### PR TITLE
chore(toolbar): cut remaining app-zone edges and shrink the deny list

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -329,10 +329,7 @@
                                     "!~/scenes/urls",
                                     "!scenes/product-tours/stepUtils",
                                     "!scenes/product-tours/constants",
-                                    "!scenes/product-tours/editor/generateStepHtml",
-                                    "!scenes/experiments/experimentStatus",
-                                    "!scenes/experiments/utils",
-                                    "!~/scenes/experiments/utils"
+                                    "!scenes/product-tours/editor/generateStepHtml"
                                 ],
                                 "message": "The toolbar ships to customer pages and must not depend on app scenes. Import from lib/, or fetch via toolbarFetch. The listed exceptions are the toolbar's intentional seams; the full transitive boundary is enforced by frontend/bin/check-toolbar-graph.mjs."
                             },

--- a/frontend/bin/check-toolbar-graph.mjs
+++ b/frontend/bin/check-toolbar-graph.mjs
@@ -29,9 +29,8 @@ const ENTRY = 'src/toolbar/index.tsx'
 
 const APP_ZONE = [/^src\/products/, /^src\/scenes\//, /^src\/layout\//, /^src\/models\//, /^\.\.\/products\//]
 
-// Packages the toolbar never renders and must not appear in its graph at all. monaco-editor and
-// chart.js are denied at resolve time in toolbar-config.mjs; mermaid and hls.js have no import
-// path into the toolbar, and this guards against one being reintroduced.
+// Packages the toolbar never renders and must not appear in its graph at all. None have an
+// import path into the toolbar today; this guard fails the build if a change reintroduces one.
 const FORBIDDEN_PACKAGES = [
     'node_modules/monaco-editor/',
     'node_modules/chart.js/',
@@ -42,7 +41,7 @@ const FORBIDDEN_PACKAGES = [
 // Ratchet policy: when an edge is cut, lower the budget to lock it in; raise it only as a
 // conscious, reviewed decision in the PR that needs it. There is headroom for churn, but any
 // reintroduced leak jumps the graph back toward ~100 MiB and fails loudly.
-const TOTAL_INPUT_BYTES_BUDGET = 14_800_000
+const TOTAL_INPUT_BYTES_BUDGET = 14_400_000
 
 function fail(message) {
     console.error(`\n❌ ${message}`)

--- a/frontend/bin/check-toolbar-size.mjs
+++ b/frontend/bin/check-toolbar-size.mjs
@@ -16,7 +16,7 @@ const MAX_FILE_BYTES = 10_000_000
 // 2. Eager-set budget: the entry plus everything statically imported from it — the bytes every
 //    toolbar load fetches before any feature runs. Ratchet policy: when an edge is cut, lower the
 //    budget to lock it in; raise it only as a conscious, reviewed decision in the PR that needs it.
-const MAX_EAGER_BYTES = 1_700_000
+const MAX_EAGER_BYTES = 1_650_000
 
 // 3. The loader is injected on every customer page that enables the toolbar and must stay tiny.
 const MAX_LOADER_BYTES = 20_000

--- a/frontend/bin/toolbar-graph-baseline.json
+++ b/frontend/bin/toolbar-graph-baseline.json
@@ -1,11 +1,6 @@
 {
     "//": "Toolbar -> app-zone import edges that exist today, enforced by bin/check-toolbar-graph.mjs. These are the toolbar's intentional seams into app code. Do not add entries; delete an entry if you cut its edge.",
     "edges": [
-        "src/lib/components/PropertyKeyInfo.tsx -> src/scenes/surveys/surveyQuestionLabelsLogic.ts",
-        "src/taxonomy/helpers.ts -> src/scenes/surveys/surveyQuestionLabelsLogic.ts",
-        "src/taxonomy/taxonomy.tsx -> src/scenes/web-analytics/tabs/marketing-analytics/utils.ts",
-        "src/toolbar/experiments/experimentsTabLogic.tsx -> src/scenes/experiments/experimentStatus.ts",
-        "src/toolbar/experiments/experimentsTabLogic.tsx -> src/scenes/experiments/utils.ts",
         "src/toolbar/product-tours/ProductToursSidebar.tsx -> src/scenes/product-tours/stepUtils.tsx",
         "src/toolbar/product-tours/StepCard.tsx -> src/scenes/product-tours/stepUtils.tsx",
         "src/toolbar/product-tours/productToursLogic.ts -> src/scenes/product-tours/constants.ts",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1,8 +1,8 @@
 import { DataColorToken } from 'lib/colors'
 // eslint-disable-next-line import/no-cycle
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { ConversionGoalSchema } from 'scenes/web-analytics/tabs/marketing-analytics/utils'
 
+import { ConversionGoalSchema } from '~/taxonomy/marketingAnalytics'
 import {
     AnyFilterLike,
     AnyGroupScopeFilter,

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
@@ -13,16 +13,15 @@ import {
     NodeKind,
 } from '~/queries/schema/schema-general'
 import { isDataWarehouseNode } from '~/queries/utils'
-import { conversionGoalPopoverFields } from '~/taxonomy/taxonomy'
-import { ActionFilter, BaseMathType, AnyDataWarehouseFilter, EntityTypes, FilterType, PropertyMathType } from '~/types'
-
 import {
     ConversionGoalSchema,
     DISTINCT_ID_FIELD_SCHEMA_FIELD,
     TIMESTAMP_FIELD_SCHEMA_FIELD,
     UTM_CAMPAIGN_NAME_SCHEMA_FIELD,
     UTM_SOURCE_NAME_SCHEMA_FIELD,
-} from '../../../utils'
+} from '~/taxonomy/marketingAnalytics'
+import { conversionGoalPopoverFields } from '~/taxonomy/taxonomy'
+import { ActionFilter, BaseMathType, AnyDataWarehouseFilter, EntityTypes, FilterType, PropertyMathType } from '~/types'
 
 interface ConversionGoalDropdownProps {
     value: ConversionGoalFilter

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/common/ConversionGoalDropdown.tsx
@@ -138,7 +138,8 @@ export function ConversionGoalDropdown({
                     // Override the schema with the schema from the data warehouse
                     if (data_warehouse?.[0]?.type === EntityTypes.DATA_WAREHOUSE) {
                         const dwNode = data_warehouse[0] as AnyDataWarehouseFilter &
-                            Record<ConversionGoalSchema, string>
+                            Record<ConversionGoalSchema, string> &
+                            Partial<Pick<DataWarehouseNode, 'id_field' | 'dw_source_type'>>
                         const schema = dwNode
                         const overrideSchema: Record<ConversionGoalSchema, string> = {
                             utm_campaign_name: schema[UTM_CAMPAIGN_NAME_SCHEMA_FIELD],

--- a/frontend/src/taxonomy/marketingAnalytics.ts
+++ b/frontend/src/taxonomy/marketingAnalytics.ts
@@ -1,16 +1,14 @@
-import { MarketingAnalyticsSchemaField } from '~/queries/schema/schema-general'
-
 export const UTM_CAMPAIGN_NAME_SCHEMA_FIELD = 'utm_campaign_name'
 export const UTM_SOURCE_NAME_SCHEMA_FIELD = 'utm_source_name'
 export const DISTINCT_ID_FIELD_SCHEMA_FIELD = 'distinct_id_field'
 export const TIMESTAMP_FIELD_SCHEMA_FIELD = 'timestamp_field'
 
-export const MARKETING_ANALYTICS_CONVERSION_GOAL_SCHEMA: Record<string, MarketingAnalyticsSchemaField> = {
+export const MARKETING_ANALYTICS_CONVERSION_GOAL_SCHEMA = {
     // UTM fields are required for conversion goals to properly track attribution
     [UTM_CAMPAIGN_NAME_SCHEMA_FIELD]: { type: ['string'], required: true, isCurrency: false },
     [UTM_SOURCE_NAME_SCHEMA_FIELD]: { type: ['string'], required: true, isCurrency: false },
     [TIMESTAMP_FIELD_SCHEMA_FIELD]: { type: ['datetime', 'date', 'string'], required: true, isCurrency: false },
     [DISTINCT_ID_FIELD_SCHEMA_FIELD]: { type: ['string'], required: false, isCurrency: false },
-}
+} as const
 
 export type ConversionGoalSchema = keyof typeof MARKETING_ANALYTICS_CONVERSION_GOAL_SCHEMA

--- a/frontend/src/taxonomy/marketingAnalytics.ts
+++ b/frontend/src/taxonomy/marketingAnalytics.ts
@@ -1,14 +1,18 @@
-export const UTM_CAMPAIGN_NAME_SCHEMA_FIELD = 'utm_campaign_name'
-export const UTM_SOURCE_NAME_SCHEMA_FIELD = 'utm_source_name'
-export const DISTINCT_ID_FIELD_SCHEMA_FIELD = 'distinct_id_field'
-export const TIMESTAMP_FIELD_SCHEMA_FIELD = 'timestamp_field'
+export const UTM_CAMPAIGN_NAME_SCHEMA_FIELD = 'utm_campaign_name' as const
+export const UTM_SOURCE_NAME_SCHEMA_FIELD = 'utm_source_name' as const
+export const DISTINCT_ID_FIELD_SCHEMA_FIELD = 'distinct_id_field' as const
+export const TIMESTAMP_FIELD_SCHEMA_FIELD = 'timestamp_field' as const
 
-export const MARKETING_ANALYTICS_CONVERSION_GOAL_SCHEMA = {
+// KLUDGE: This should ideally be a union of the strings above,
+// however the backend is pretty borked and assumes it's a string everywhere
+// and migrating away from this is not trivial
+export type ConversionGoalSchema = string
+type ConversionGoalSchemaType = { type: string[]; required: boolean; isCurrency: boolean }
+
+export const MARKETING_ANALYTICS_CONVERSION_GOAL_SCHEMA: Record<ConversionGoalSchema, ConversionGoalSchemaType> = {
     // UTM fields are required for conversion goals to properly track attribution
     [UTM_CAMPAIGN_NAME_SCHEMA_FIELD]: { type: ['string'], required: true, isCurrency: false },
     [UTM_SOURCE_NAME_SCHEMA_FIELD]: { type: ['string'], required: true, isCurrency: false },
     [TIMESTAMP_FIELD_SCHEMA_FIELD]: { type: ['datetime', 'date', 'string'], required: true, isCurrency: false },
     [DISTINCT_ID_FIELD_SCHEMA_FIELD]: { type: ['string'], required: false, isCurrency: false },
-} as const
-
-export type ConversionGoalSchema = keyof typeof MARKETING_ANALYTICS_CONVERSION_GOAL_SCHEMA
+}

--- a/frontend/src/taxonomy/taxonomy.tsx
+++ b/frontend/src/taxonomy/taxonomy.tsx
@@ -1,9 +1,6 @@
-import { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
-import {
-    UTM_CAMPAIGN_NAME_SCHEMA_FIELD,
-    UTM_SOURCE_NAME_SCHEMA_FIELD,
-} from 'scenes/web-analytics/tabs/marketing-analytics/utils'
+import type { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
 
+import { UTM_CAMPAIGN_NAME_SCHEMA_FIELD, UTM_SOURCE_NAME_SCHEMA_FIELD } from '~/taxonomy/marketingAnalytics'
 import { CoreFilterDefinition } from '~/types'
 
 import coreFilterDefinitionsByGroup from './core-filter-definitions-by-group.json'

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -4,9 +4,7 @@ import { subscriptions } from 'kea-subscriptions'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { EXPERIMENT_TARGET_SELECTOR } from 'lib/utils/actions'
-import { isLaunched } from 'scenes/experiments/experimentStatus'
 
-import { percentageDistribution } from '~/scenes/experiments/utils'
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { experimentsLogic } from '~/toolbar/experiments/experimentsLogic'
 import {
@@ -20,7 +18,7 @@ import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { WebExperiment, WebExperimentDraftType, WebExperimentForm } from '~/toolbar/types'
 import { urls } from '~/toolbar/urls'
-import { elementToQuery, joinWithUiHost } from '~/toolbar/utils'
+import { elementToQuery, isLaunched, joinWithUiHost, percentageDistribution } from '~/toolbar/utils'
 import { Experiment, ExperimentIdType } from '~/types'
 
 import type { experimentsTabLogicType } from './experimentsTabLogicType'

--- a/frontend/src/toolbar/shims/shims.test.ts
+++ b/frontend/src/toolbar/shims/shims.test.ts
@@ -5,6 +5,7 @@ import { initKeaTests } from '~/test/init'
 import { featureFlagLogic, getFeatureFlagPayload } from './featureFlagLogic'
 import { membersLogic } from './membersLogic'
 import { sceneLogic } from './sceneLogic'
+import { surveyQuestionLabelsLogic } from './surveyQuestionLabelsLogic'
 import { isAuthenticatedTeam, teamLogic } from './teamLogic'
 import { userLogic } from './userLogic'
 
@@ -20,6 +21,7 @@ describe('toolbar shims', () => {
             ['sceneLogic', sceneLogic, { sceneConfig: null }],
             ['teamLogic', teamLogic, { currentTeam: null, timezone: 'UTC', weekStartDay: 0 }],
             ['featureFlagLogic', featureFlagLogic, { featureFlags: {} }],
+            ['surveyQuestionLabelsLogic', surveyQuestionLabelsLogic, { surveyQuestionLabels: {} }],
         ])('%s provides expected defaults', (_name, logic, expected) => {
             logic.mount()
             expectLogic(logic).toMatchValues(expected)
@@ -53,6 +55,7 @@ describe('toolbar shims', () => {
         sceneLogic.mount()
         teamLogic.mount()
         featureFlagLogic.mount()
+        surveyQuestionLabelsLogic.mount()
 
         expect(fetchSpy).not.toHaveBeenCalled()
     })

--- a/frontend/src/toolbar/shims/surveyQuestionLabelsLogic.ts
+++ b/frontend/src/toolbar/shims/surveyQuestionLabelsLogic.ts
@@ -1,0 +1,20 @@
+import { kea, path, reducers } from 'kea'
+
+import type { surveyQuestionLabelsLogicType } from './surveyQuestionLabelsLogicType'
+
+// Toolbar shim — survey question labels come from an authenticated endpoint the toolbar can't
+// reach on customer pages (lib/api is denied), so the labels are always empty here. Consumers
+// (PropertyKeyInfo, taxonomy helpers) fall back to their generic labels.
+export interface SurveyQuestionLabel {
+    surveyId: string
+    surveyName: string
+    questionText: string
+    questionIndex: number
+}
+
+export const surveyQuestionLabelsLogic = kea<surveyQuestionLabelsLogicType>([
+    path(['toolbar', 'shims', 'surveyQuestionLabelsLogic']),
+    reducers({
+        surveyQuestionLabels: [{} as Record<string, SurveyQuestionLabel>, {}],
+    }),
+])

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -8,7 +8,7 @@ import { toolbarLogger } from '~/toolbar/toolbarLogger'
 import { captureToolbarException } from '~/toolbar/toolbarPosthogJS'
 import { ActionStepForm, ElementRect } from '~/toolbar/types'
 import { finder } from '~/toolbar/vendor/finder'
-import { ActionStepType } from '~/types'
+import { Experiment, ActionStepType, ExperimentStatus } from '~/types'
 
 import { ActionStepPropertyKey } from './actions/ActionStep'
 
@@ -733,6 +733,47 @@ export function makeNavigateWrapper(onNavigate: () => void, patchKey: string): (
             unwrapReplaceState?.()
         }
     }
+}
+
+// Toolbar-owned copy of the app's experiment variant-split helper. Duplicated rather than
+// imported from scenes/experiments/utils, which drags 37KB and app-only modules into the
+// customer-facing bundle for this one pure function.
+export function percentageDistribution(variantCount: number): number[] {
+    const basePercentage = Math.floor(100 / variantCount)
+    const percentages = new Array(variantCount).fill(basePercentage)
+
+    // try to equally distribute `remaining` across variants
+    let remaining = 100 - basePercentage * variantCount
+    for (let i = 0; remaining > 0; i++, remaining--) {
+        percentages[i] += 1
+    }
+
+    return percentages
+}
+
+// Toolbar-owned copy of the app's experiment status helpers. Duplicated rather than imported
+// from scenes/experiments/experimentStatus so the toolbar bundle doesn't reach into the app
+// scene zone for these two pure functions.
+type ExperimentStatusInput = Pick<Experiment, 'status' | 'start_date' | 'end_date'> | null | undefined
+
+function getExperimentStatus(experiment: ExperimentStatusInput): ExperimentStatus {
+    if (!experiment) {
+        return ExperimentStatus.Draft
+    }
+    if (experiment.status) {
+        return experiment.status
+    }
+    if (experiment.end_date) {
+        return ExperimentStatus.Stopped
+    }
+    if (experiment.start_date) {
+        return ExperimentStatus.Running
+    }
+    return ExperimentStatus.Draft
+}
+
+export function isLaunched(experiment: ExperimentStatusInput): boolean {
+    return getExperimentStatus(experiment) !== ExperimentStatus.Draft
 }
 
 export function joinWithUiHost(uiHost: string, path: string): string {

--- a/frontend/toolbar-config.mjs
+++ b/frontend/toolbar-config.mjs
@@ -26,6 +26,9 @@ const shimmedModules = {
     'scenes/sceneLogic': 'src/toolbar/shims/sceneLogic.ts',
     'scenes/teamLogic': 'src/toolbar/shims/teamLogic.ts',
     'lib/logic/featureFlagLogic': 'src/toolbar/shims/featureFlagLogic.ts',
+    // Survey question labels load from an authenticated endpoint the toolbar can't reach, so
+    // the shim keeps its shared consumers (PropertyKeyInfo, taxonomy helpers) out of the app zone.
+    'scenes/surveys/surveyQuestionLabelsLogic': 'src/toolbar/shims/surveyQuestionLabelsLogic.ts',
     // Not a kea shim: the toolbar's parity-tested urls duplicate (see src/toolbar/urls.ts).
     // Toolbar code imports it directly; this entry covers lib/ components shared with the
     // app (TZLabel, Link, HeatmapEventsPanel), whose scenes/urls import would otherwise pull
@@ -44,29 +47,9 @@ const deniedPaths = [
     'scenes/session-recordings/player/snapshot-processing/DecompressionWorkerManager.ts',
 ]
 
-// Heavy third-party libraries the toolbar never renders but which would otherwise leak in
-// transitively through the shared scene graph. Denying them at resolve time keeps them out of
-// the artifact set entirely; bin/check-toolbar-graph.mjs asserts their absence.
-const deniedThirdPartyPackages = [
-    // chart.js + its annotation plugin (via Sparkline). Charts in the toolbar go through the
-    // already-denied LineGraph.
-    /^chart\.js(\/|$)/,
-    /^chartjs-plugin-annotation(\/|$)/,
-]
-
-const deniedPatterns = [
-    /monaco/,
-    /scenes\/insights\/filters\/ActionFilter/,
-    /lib\/components\/CodeSnippet/,
-    /scenes\/session-recordings\/player/,
-    /queries\/schema-guard/,
-    /queries\/schema.json/,
-    /queries\/QueryEditor\/QueryEditor/,
-    /scenes\/billing/,
-    /scenes\/data-warehouse/,
-    /LineGraph/,
-    ...deniedThirdPartyPackages,
-]
+// PayGateMini (shipped in the toolbar) imports scenes/billing, which we can't bundle because it
+// pulls in chart.js, monaco, and the rest of the app's billing scene graph.
+const deniedPatterns = [/scenes\/billing/]
 
 /**
  * The toolbar shares lib/ code with the main app, and that code reaches app-only modules
@@ -78,11 +61,10 @@ const deniedPatterns = [
  *   contracts, and the parity-tested urls duplicate). These are intentional injection points:
  *   the toolbar genuinely needs different answers (its own team context, no scene routing)
  *   than the app.
- * - Denied modules get replaced with an inert proxy. Every deny is load-bearing: without them
- *   PayGateMini pulls in scenes/billing (re-inlining the app scene graph), and even with
- *   billing denied the lib-zone paths (CodeSnippet -> monaco, Sparkline/LineGraph -> chart.js,
- *   the replay player, the query schema) balloon the eager set. A deny can only be retired
- *   once its import path is cut at the source.
+ * - Denied modules get replaced with an inert proxy. The deny list is kept minimal: only the
+ *   paths a toolbar-shipped module actually reaches today (chiefly PayGateMini -> scenes/billing)
+ *   need cutting here. Regressions that reintroduce heavier dependencies are caught by the guard
+ *   scripts rather than pre-emptively denied.
  *
  * The enforced invariants live in bin/check-toolbar-size.mjs (eager-chunk budget, per-file
  * CloudFront limit), bin/check-toolbar-graph.mjs (boundary edges, forbidden packages, source


### PR DESCRIPTION
## Problem

After the cleanup, the toolbar still held 10 import edges into the app scene graph. Most were accidental: a 9-line pure function pulled in a 37KB module (and a denied dependency), and a handful of shared helpers reached into `scenes/` for constants and an inert kea logic. The deny list had also grown to 11 patterns, only one of which still does anything.

## Changes

Cuts the toolbar's crossing edges from **10 to 5** (only the product-tours seams remain, kept intentionally). No toolbar behavior change.

| Edge | Fix |
| --- | --- |
| `experimentsTabLogic → scenes/experiments/utils` + `→ experimentStatus` | Duplicate the two pure helpers (`percentageDistribution`, `isLaunched`) into `toolbar/utils.ts`. `utils.ts` also dragged in the denied `ActionFilterRow` and 37KB, all for one 9-line function. |
| `taxonomy → scenes/web-analytics/.../marketing-analytics/utils` | Move the conversion-goal constants to `taxonomy/marketingAnalytics.ts`. `taxonomy/` is outside the app zone, so the edge disappears; app consumers repoint to the new home. |
| `PropertyKeyInfo → surveyQuestionLabelsLogic` + `helpers.ts → surveyQuestionLabelsLogic` | Shim `surveyQuestionLabelsLogic`. Its loader calls the denied `lib/api`, so it was already inert in the toolbar. The shim returns empty labels, which is exactly what the real logic produced there. |

Also:

- **Trim `deniedPatterns` from 11 patterns to 1.** Only `scenes/billing` (via `PayGateMini`) is load-bearing today. Removing all patterns and rebuilding proved billing is the sole one that re-enters (+3 MiB, +2 edges); the rest were dormant. The heavy-package guards (monaco, chart.js, mermaid, hls.js) already live in `check-toolbar-graph.mjs`'s `FORBIDDEN_PACKAGES`, and anything else is caught by the crossing-edge baseline and byte budgets.
- **Ratchet budgets** to lock in the wins: graph 14.8 → 14.4 MB (measured 13.47 MiB), eager 1.7 → 1.65 MB (measured 1.53 MB).

> [!NOTE]
> `percentageDistribution` and `isLaunched` are now duplicated in the toolbar. They are tiny, pure, and stable; duplicating avoids dragging the app's experiment graph into a customer-facing bundle.

## How did you test this code?

I (Claude) rebuilt the toolbar after each cut and ran the three guards (`check-toolbar-graph`, `check-toolbar-size`, `check-toolbar-csp-eval`) - all green at 5 edges / 13.47 MiB / eager 1.53 MB / CSP clean. Ran the affected Jest suites: `toolbar/shims/shims.test.ts` (incl. the new `surveyQuestionLabelsLogic` default), `toolbar/utils.test.ts`, `toolbar/experiments/experimentsTabLogic.test.ts` - all pass. Ran a full `build:esbuild` (exit 0) to confirm the marketing-analytics move compiles app-side. Whole-app `typescript:check` surfaces only pre-existing stale-kea-typegen errors in unrelated files (navigation-3000, workflows), none in files this PR touches. No manual browser testing was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8), directed by @rafaeelaudibert. Second of two PRs closing out the toolbar migration, stacked on the cleanup PR.

Decisions along the way: for the experiments and survey edges I first considered leaf-extraction (the earlier migration pattern), but the human preferred straight duplication for the pure functions since they are trivial and stable. The survey logic became a shim rather than a duplicate because it is stateful and already inert in the toolbar (denied `lib/api`), so a shim is behavior-identical and matches the existing shim pattern. The deny-list trim was driven empirically (emptied `deniedPatterns`, rebuilt, watched what re-entered) rather than reasoned, which is why it lands at billing-only. The `surveyQuestionLabelsLogicType.ts` file is gitignored (kea-typegen output) like the other shim types, so it is regenerated in CI and not committed.
