### PR TITLE
feat(workflows): suggest account properties as output variables

### DIFF
--- a/nodejs/src/cdp/async-functions/customer_analytics.ts
+++ b/nodejs/src/cdp/async-functions/customer_analytics.ts
@@ -75,6 +75,10 @@ registerAsyncFunction('postHogGetAccount', {
                     CSM: [{ user_id: 1, email: 'csm@example.com' }],
                     'Account executive': [{ user_id: 2, email: 'ae@example.com' }],
                 },
+                custom_properties: {
+                    Plan: 'enterprise',
+                    'MRR (net)': 1234,
+                },
             },
         }
     },

--- a/products/customer_analytics/backend/COMPROMISES.md
+++ b/products/customer_analytics/backend/COMPROMISES.md
@@ -62,6 +62,22 @@ Cutover checklist — when done, the sync and this section are deleted:
 - [ ] Delete `sync_from_account_properties` + call sites; strip the three role keys from
       `AccountProperties`
 
+## External account `custom_properties` payload
+
+- **Every definition is emitted, unbounded.** `_to_external_account` includes every team
+  custom property definition keyed by name (`null` when unset) so workflow result paths are
+  deterministic. The hogflow executor caps all workflow variables at 5 KB of JSON combined and
+  the Get account node's default `account` variable stores the whole response body, so a team
+  with enough definitions (roughly 100–150 at typical name lengths, fewer with long names or
+  populated values) makes every Get account step throw and drop its variables — even in
+  workflows that never touch custom properties. If this bites: stop emitting unset definitions
+  as `null`, or drop the whole-body default variable in favor of path-scoped ones.
+- **Output variable suggestions read one page.** The workflow editor's suggestion chips fetch
+  custom property and relationship definitions without pagination (default page size 100), so
+  definitions past the first page silently never appear as suggestions — the value still exists
+  in the payload and can be mapped by hand. Follow `next` pages in
+  `getOutputMappingSuggestions` (workflows frontend registry) if teams that large show up.
+
 ## Tech debt
 
 - **Account property writes have no single choke point.** `Account._properties` is mutated from four

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -16,6 +16,7 @@ Do NOT:
 """
 
 from collections.abc import Iterable
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, cast
 from uuid import UUID
 
@@ -256,6 +257,10 @@ def _to_external_account(account: Account) -> contracts.ExternalAccount:
     ``properties`` is the exact ``model_dump(mode="json")`` of the validated
     pydantic properties and ``tags`` the sorted tag names — byte-identical to
     what the CDP worker consumed before this moved behind the facade.
+
+    ``custom_properties`` includes every team definition keyed by name, with the
+    account's active value (scalar) or ``None`` when unset, so workflow result
+    paths are deterministic regardless of whether the property has been set.
     """
     relationships: dict[str, list[dict]] = {}
     for relationship in (
@@ -268,6 +273,19 @@ def _to_external_account(account: Account) -> contracts.ExternalAccount:
         relationships.setdefault(relationship.definition.name, []).append(
             {"user_id": relationship.user.id, "email": relationship.user.email}
         )
+
+    definitions = list(CustomPropertyDefinition.objects.for_team(account.team_id).values("id", "name"))
+    active_values = {
+        row.definition_id: row
+        for row in _custom_property_values_logic.list_active_custom_property_values(
+            team_id=account.team_id, account_id=account.id
+        )
+    }
+    custom_properties: dict[str, float | bool | str | None] = {
+        defn["name"]: _scalar_value(active_values[defn["id"]]) if defn["id"] in active_values else None
+        for defn in definitions
+    }
+
     return contracts.ExternalAccount(
         id=str(account.id),
         external_id=account.external_id,
@@ -275,7 +293,18 @@ def _to_external_account(account: Account) -> contracts.ExternalAccount:
         properties=account.properties.model_dump(mode="json"),
         tags=sorted(account.tagged_items.values_list("tag__name", flat=True)),
         relationships=relationships,
+        custom_properties=custom_properties,
     )
+
+
+def _scalar_value(row: "CustomPropertyValue") -> float | bool | str | None:
+    """Return the row's value as a JSON-safe scalar; datetimes become ISO strings."""
+    v = _custom_property_values_logic.value_of(row)
+    if isinstance(v, datetime):
+        return v.isoformat()
+    if isinstance(v, float | bool | str):
+        return v
+    return None
 
 
 def _get_external_account_by_external_id(team_id: int, external_id: str) -> Account | None:

--- a/products/customer_analytics/backend/facade/contracts.py
+++ b/products/customer_analytics/backend/facade/contracts.py
@@ -135,6 +135,11 @@ class ExternalAccount:
     consumes stays byte-identical to the pre-facade response — a validated
     pydantic pass-through, not a re-typed projection. ``id`` is the stringified
     UUID, matching the wire shape.
+
+    ``custom_properties`` contains every team-defined custom property definition
+    keyed by definition name, with the account's current scalar value (or ``None``
+    when unset). Every definition is present so result paths are deterministic even
+    when a property hasn't been set on this account yet.
     """
 
     id: str
@@ -143,6 +148,7 @@ class ExternalAccount:
     properties: dict
     tags: list[str] = field(default_factory=list)
     relationships: dict[str, list[dict]] = field(default_factory=dict)
+    custom_properties: dict[str, float | bool | str | None] = field(default_factory=dict)
 
 
 class ExternalAccountUpdateError(Enum):

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -103,6 +103,7 @@ def _external_account_body(account: contracts.ExternalAccount) -> dict[str, Any]
         "properties": account.properties,
         "tags": account.tags,
         "relationships": account.relationships,
+        "custom_properties": account.custom_properties,
     }
 
 

--- a/products/customer_analytics/backend/test/test_external.py
+++ b/products/customer_analytics/backend/test/test_external.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from uuid import uuid4
 
 from posthog.test.base import APIBaseTest
@@ -123,6 +124,32 @@ class TestExternalAccountAPI(APIBaseTest):
         self.assertEqual(
             response.json()["relationships"],
             {"CSM": [{"user_id": self.user.id, "email": self.user.email}]},
+        )
+
+    def test_get_account_returns_custom_properties(self):
+        plan = create_custom_property_definition(team_id=self.team.id, name="Plan", display_type=DisplayType.TEXT)
+        create_custom_property_definition(team_id=self.team.id, name="Seats", display_type=DisplayType.NUMBER)
+        renewal = create_custom_property_definition(
+            team_id=self.team.id, name="Renewal", display_type=DisplayType.DATETIME
+        )
+        CustomPropertyValue.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            account=self.account,
+            definition=plan,
+            value_str="enterprise",
+        )
+        CustomPropertyValue.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            account=self.account,
+            definition=renewal,
+            value_datetime=datetime(2026, 7, 1, 12, 0, tzinfo=UTC),
+        )
+
+        response = self._get()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["custom_properties"],
+            {"Plan": "enterprise", "Seats": None, "Renewal": "2026-07-01T12:00:00+00:00"},
         )
 
     def test_does_not_leak_accounts_from_other_team(self):

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -141,10 +141,17 @@ export type HogFlowEditorActionMetrics = {
     filtered: number
 }
 
+export type OutputMappingSuggestion = {
+    key: string
+    result_path: string
+    label: string
+}
+
 export type CreateActionType = Pick<HogFlowAction, 'type' | 'config' | 'name' | 'description'> & {
     branchEdges?: number
     output_variable?: HogFlowAction['output_variable']
     getDefaultInputs?: () => Record<string, CyclotronInputType> | undefined
+    getOutputMappingSuggestions?: () => Promise<OutputMappingSuggestion[]>
 }
 
 export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -33,9 +33,8 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
     const { selectedNode, workflow, categories, categoriesLoading } = useValues(hogFlowEditorLogic)
     const { setWorkflowAction, setMode } = useActions(hogFlowEditorLogic)
     const { logicProps } = useValues(workflowLogic)
-    const { mappings, pendingPath, testLoading, testError, testResultData, shakePickButton } = useValues(
-        hogFlowOutputMappingLogic(logicProps)
-    )
+    const { mappings, pendingPath, testLoading, testError, testResultData, shakePickButton, pendingSuggestions } =
+        useValues(hogFlowOutputMappingLogic(logicProps))
     const {
         setSelectedActionId,
         setMappings,
@@ -46,6 +45,7 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
         assignPendingPathToMapping,
         cancelPendingPath,
         runOutputTest,
+        applySuggestion,
     } = useActions(hogFlowOutputMappingLogic(logicProps))
 
     useEffect(() => {
@@ -237,6 +237,24 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
                                                     </LemonField.Pure>
                                                 </div>
                                             ))}
+                                            {pendingSuggestions.length > 0 && (
+                                                <div className="w-full">
+                                                    <p className="text-xs text-secondary mb-1">Suggested</p>
+                                                    <div className="flex flex-wrap gap-1">
+                                                        {pendingSuggestions.map((suggestion) => (
+                                                            <LemonButton
+                                                                key={suggestion.key}
+                                                                size="xsmall"
+                                                                type="secondary"
+                                                                icon={<IconPlus />}
+                                                                onClick={() => applySuggestion(suggestion)}
+                                                            >
+                                                                {suggestion.label}
+                                                            </LemonButton>
+                                                        ))}
+                                                    </div>
+                                                </div>
+                                            )}
                                             <div className="flex gap-2 w-full">
                                                 <LemonButton
                                                     icon={<IconPlus />}

--- a/products/workflows/frontend/Workflows/hogflows/panel/hogFlowOutputMappingLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/hogFlowOutputMappingLogic.ts
@@ -1,9 +1,12 @@
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
 
 import { WorkflowLogicProps, sanitizeWorkflow, workflowLogic } from '../../workflowLogic'
+import { OutputMappingSuggestion } from '../hogFlowEditorLogic'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
+import { getRegisteredActionNodeCategories } from '../registry/actions/actionNodeRegistry'
 import type { HogflowTestResult } from '../steps/types'
 import type { HogFlowAction } from '../types'
 import type { hogFlowOutputMappingLogicType } from './hogFlowOutputMappingLogicType'
@@ -63,8 +66,38 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
         setTestError: (error: string | null) => ({ error }),
         setTestResultData: (data: unknown | null) => ({ data }),
         setShakePickButton: (shake: boolean) => ({ shake }),
+        applySuggestion: (suggestion: OutputMappingSuggestion) => ({ suggestion }),
     }),
+    loaders(({ values }) => ({
+        suggestions: {
+            __default: [] as OutputMappingSuggestion[],
+            loadSuggestions: async (): Promise<OutputMappingSuggestion[]> => {
+                const { selectedNode } = values
+                if (!selectedNode) {
+                    return []
+                }
+                const templateId = selectedNode.data?.config?.template_id
+                if (!templateId) {
+                    return []
+                }
+                const nodeDef = getRegisteredActionNodeCategories()
+                    .flatMap((c) => c.nodes)
+                    .find((n) => n.config?.template_id === templateId)
+                if (!nodeDef?.getOutputMappingSuggestions) {
+                    return []
+                }
+                try {
+                    return await nodeDef.getOutputMappingSuggestions()
+                } catch {
+                    return []
+                }
+            },
+        },
+    })),
     reducers({
+        suggestions: {
+            setSelectedActionId: () => [],
+        },
         selectedActionId: [
             null as string | null,
             {
@@ -125,6 +158,14 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
     }),
     selectors({
         selectedAction: [(s) => [s.selectedNode], (selectedNode) => selectedNode?.data ?? null],
+        pendingSuggestions: [
+            (s) => [s.suggestions, s.mappings],
+            (suggestions, mappings): OutputMappingSuggestion[] => {
+                const usedResultPaths = new Set(mappings.map((m) => m.result_path).filter(Boolean))
+                const usedKeys = new Set(mappings.map((m) => m.key).filter(Boolean))
+                return suggestions.filter((s) => !usedResultPaths.has(s.result_path) && !usedKeys.has(s.key))
+            },
+        ],
     }),
     listeners(({ actions, values, props }) => {
         const persistMappings = (newMappings: OutputMapping[]): void => {
@@ -151,6 +192,7 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
                 const selectedNode = values.selectedNode
                 if (selectedNode) {
                     actions.initMappings(normalizeOutputVariable(selectedNode.data.output_variable))
+                    actions.loadSuggestions()
                 }
             },
             setMappings: ({ mappings }) => {
@@ -187,6 +229,21 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
                 if (!values.shakePickButton) {
                     actions.setShakePickButton(true)
                     setTimeout(() => actions.setShakePickButton(false), 1000)
+                }
+            },
+            applySuggestion: ({ suggestion }) => {
+                const newMappings = [...values.mappings, { key: suggestion.key, result_path: suggestion.result_path }]
+                actions.setMappings(newMappings)
+
+                const { workflow } = values
+                const existingVars = workflow.variables ?? []
+                if (!existingVars.some((v) => v.key === suggestion.key)) {
+                    workflowLogic(props).actions.setWorkflowInfo({
+                        variables: [
+                            ...existingVars,
+                            { key: suggestion.key, label: suggestion.label, type: 'string' as const, default: '' },
+                        ],
+                    })
                 }
             },
             runOutputTest: async () => {

--- a/products/workflows/frontend/Workflows/hogflows/panel/hogFlowOutputMappingLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/hogFlowOutputMappingLogic.ts
@@ -76,13 +76,14 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
                 if (!selectedNode) {
                     return []
                 }
-                const templateId = selectedNode.data?.config?.template_id
+                const config = selectedNode.data?.config
+                const templateId = config && 'template_id' in config ? config.template_id : undefined
                 if (!templateId) {
                     return []
                 }
                 const nodeDef = getRegisteredActionNodeCategories()
                     .flatMap((c) => c.nodes)
-                    .find((n) => n.config?.template_id === templateId)
+                    .find((n) => 'template_id' in n.config && n.config.template_id === templateId)
                 if (!nodeDef?.getOutputMappingSuggestions) {
                     return []
                 }
@@ -195,7 +196,7 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
                 const selectedNode = values.selectedNode
                 if (selectedNode) {
                     actions.initMappings(normalizeOutputVariable(selectedNode.data.output_variable))
-                    actions.loadSuggestions()
+                    actions.loadSuggestions({})
                 }
             },
             setMappings: ({ mappings }) => {

--- a/products/workflows/frontend/Workflows/hogflows/panel/hogFlowOutputMappingLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/hogFlowOutputMappingLogic.ts
@@ -71,7 +71,7 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
     loaders(({ values }) => ({
         suggestions: {
             __default: [] as OutputMappingSuggestion[],
-            loadSuggestions: async (): Promise<OutputMappingSuggestion[]> => {
+            loadSuggestions: async (_, breakpoint): Promise<OutputMappingSuggestion[]> => {
                 const { selectedNode } = values
                 if (!selectedNode) {
                     return []
@@ -86,11 +86,14 @@ export const hogFlowOutputMappingLogic = kea<hogFlowOutputMappingLogicType>([
                 if (!nodeDef?.getOutputMappingSuggestions) {
                     return []
                 }
+                let suggestions: OutputMappingSuggestion[]
                 try {
-                    return await nodeDef.getOutputMappingSuggestions()
+                    suggestions = await nodeDef.getOutputMappingSuggestions()
                 } catch {
-                    return []
+                    suggestions = []
                 }
+                breakpoint()
+                return suggestions
             },
         },
     })),

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
@@ -3,7 +3,12 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { GroupType, GroupTypeIndex } from '~/types'
 
 import { getRegisteredActionNodeCategories } from './actionNodeRegistry'
-import { buildAccountExternalIdInputs } from './customer_analytics'
+import {
+    buildAccountExternalIdInputs,
+    buildAccountOutputSuggestions,
+    customPropertyResultPath,
+    slugifyName,
+} from './customer_analytics'
 
 const groupTypesMap = (...entries: [GroupTypeIndex, string][]): Map<GroupTypeIndex, GroupType> =>
     new Map(entries.map(([index, groupType]) => [index, { group_type: groupType, group_type_index: index }]))
@@ -88,6 +93,47 @@ describe('customer analytics action registry', () => {
             expect(typeof node?.getDefaultInputs).toBe('function')
         }
     )
+
+    describe('slugifyName', () => {
+        it.each([
+            ['Plan', 'plan'],
+            ['MRR (net)', 'mrr_net'],
+            ['ARR (net)', 'arr_net'],
+            ['my_property', 'my_property'],
+            ['  spaces  ', 'spaces'],
+            ['a--b', 'a_b'],
+        ])('slugifies %s → %s', (input, expected) => {
+            expect(slugifyName(input)).toBe(expected)
+        })
+    })
+
+    describe('customPropertyResultPath', () => {
+        it.each([
+            ['Plan', 'custom_properties.Plan'],
+            ['my_prop', 'custom_properties.my_prop'],
+            ['ARR123', 'custom_properties.ARR123'],
+            ['MRR (net)', 'custom_properties["MRR (net)"]'],
+            ['has space', 'custom_properties["has space"]'],
+            ['with"quote', 'custom_properties["with\\"quote"]'],
+        ])('builds result path for %s → %s', (name, expected) => {
+            expect(customPropertyResultPath(name)).toBe(expected)
+        })
+    })
+
+    describe('buildAccountOutputSuggestions', () => {
+        it('namespaces relationships and dedupes colliding keys', () => {
+            const suggestions = buildAccountOutputSuggestions(['Plan', 'MRR (net)', 'MRR net'], ['Plan', 'CSM'])
+            expect(suggestions.map((s) => s.key)).toEqual([
+                'account_plan',
+                'account_mrr_net',
+                'account_relationship_plan',
+                'account_relationship_csm',
+            ])
+            expect(suggestions.find((s) => s.key === 'account_relationship_csm')?.result_path).toBe(
+                'relationships["CSM"]'
+            )
+        })
+    })
 
     describe('buildAccountExternalIdInputs', () => {
         it('builds a name-based group key expression from the account group type index', () => {

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
@@ -1,9 +1,15 @@
 import { FEATURE_FLAGS } from 'lib/constants'
+import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { groupsModel } from '~/models/groupsModel'
 import { GroupType, GroupTypeIndex } from '~/types'
 
+import {
+    accountRelationshipDefinitionsList,
+    customPropertyDefinitionsList,
+} from 'products/customer_analytics/frontend/generated/api'
+import { OutputMappingSuggestion } from 'products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic'
 import { registerActionNodeCategory } from 'products/workflows/frontend/Workflows/hogflows/registry/actions/actionNodeRegistry'
 import { CyclotronInputType } from 'products/workflows/frontend/Workflows/hogflows/steps/types'
 
@@ -31,6 +37,63 @@ const getAccountExternalIdDefaultInputs = (): Record<string, CyclotronInputType>
         groupsModel.findMounted()?.values.groupTypes ?? new Map()
     )
 
+/** Slugify a definition name to a safe variable key suffix: lowercase, non-alphanumeric → `_`, collapse and trim. */
+export const slugifyName = (name: string): string =>
+    name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '')
+
+/** Build a lodash-get-compatible result_path for a custom property name.
+ * Names matching /^[A-Za-z0-9_]+$/ use dot notation; others use bracket notation with `"` escaped. */
+export const customPropertyResultPath = (name: string): string => {
+    if (/^[A-Za-z0-9_]+$/.test(name)) {
+        return `custom_properties.${name}`
+    }
+    const escaped = name.replace(/"/g, '\\"')
+    return `custom_properties["${escaped}"]`
+}
+
+/** Assemble suggestions from definition names, deduped by variable key (first wins on slug collisions). */
+export const buildAccountOutputSuggestions = (
+    customPropertyNames: string[],
+    relationshipNames: string[]
+): OutputMappingSuggestion[] => {
+    const suggestions = [
+        ...customPropertyNames.map((name) => ({
+            key: `account_${slugifyName(name)}`,
+            result_path: customPropertyResultPath(name),
+            label: name,
+        })),
+        ...relationshipNames.map((name) => ({
+            key: `account_relationship_${slugifyName(name)}`,
+            result_path: `relationships["${name.replace(/"/g, '\\"')}"]`,
+            label: `${name} (relationship)`,
+        })),
+    ]
+    const seenKeys = new Set<string>()
+    return suggestions.filter((s) => !seenKeys.has(s.key) && !!seenKeys.add(s.key))
+}
+
+const getOutputMappingSuggestions = async (): Promise<OutputMappingSuggestion[]> => {
+    const projectId = String(projectLogic.findMounted()?.values.currentProjectId ?? '')
+    if (!projectId) {
+        return []
+    }
+    try {
+        const [customPropsResponse, relDefsResponse] = await Promise.all([
+            customPropertyDefinitionsList(projectId),
+            accountRelationshipDefinitionsList(projectId),
+        ])
+        return buildAccountOutputSuggestions(
+            (customPropsResponse.results ?? []).map((defn) => defn.name),
+            (relDefsResponse.results ?? []).map((defn) => defn.name)
+        )
+    } catch {
+        return []
+    }
+}
+
 registerActionNodeCategory({
     label: 'Customer analytics',
     featureFlag: FEATURE_FLAGS.CUSTOMER_ANALYTICS_CSP,
@@ -41,6 +104,7 @@ registerActionNodeCategory({
             description: 'Fetch a Customer analytics account into a workflow variable.',
             config: { template_id: 'template-posthog-get-account', inputs: {} },
             getDefaultInputs: getAccountExternalIdDefaultInputs,
+            getOutputMappingSuggestions,
             output_variable: [
                 { key: 'account', result_path: null, label: 'Account' },
                 { key: 'account_relationships', result_path: 'relationships', label: 'Relationships' },


### PR DESCRIPTION
## Problem

There is no easy way to add custom property or relationship variables to a Get account workflow node without running a live test or hand-typing result paths.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Closes https://github.com/PostHog/posthog/issues/69417

## Changes

- Add `custom_properties` to the external account payload (contract, facade, view, nodejs mock) -- every team definition keyed by name, `null` when unset
- Extend `CreateActionType` with `getOutputMappingSuggestions` for node-level suggestion hooks
- Implement suggestions on the Get account node -- fetches custom property and relationship definitions and builds the correct dot or bracket `result_path`
- Add `suggestions` loader and `applySuggestion` action to `hogFlowOutputMappingLogic`
- Render suggestion chips in the output variables panel; clicking creates the mapping and workflow variable in one step

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Python: `hogli test products/customer_analytics/backend/test/test_external.py` (36 pass; new test catches missing/null `custom_properties` in GET response)
Frontend: `pnpm --filter=@posthog/frontend exec jest .../customer_analytics.test.ts --forceExit` (24 pass; new cases cover dot vs bracket path and slug edge cases)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by a Claude sonnet sub-agent orchestrated in a PostHog Code session. Skills invoked: `/writing-tests`, `/writing-kea-logics`.

The bracket-path rule (`custom_properties["name"]` for names containing non-alphanumeric chars) exists because lodash `get` -- used at runtime in `trackActionResult` -- supports quoted bracket notation, so paths like `custom_properties["MRR (net)"]` resolve correctly. Names matching `/^[A-Za-z0-9_]+$/` use the shorter dot form. Suggestions are best-effort (fetch failure returns `[]`) to avoid blocking panel render when the definitions API is slow.

Orchestrator review pass added on top: datetime custom property values serialize as ISO strings (instead of being dropped to null), relationship suggestion keys are namespaced `account_relationship_<slug>` and deduped against slug collisions, and stale suggestions reset when switching nodes.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
