### PR TITLE
feat(customer-analytics): add value suggestions endpoint for account custom properties

### DIFF
--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -799,6 +799,14 @@ def get_custom_property_definition(
     return _to_custom_property_definition_view(definition, references)
 
 
+def list_custom_property_value_suggestions(team_id: int, definition_id: str, search: str | None) -> list[str]:
+    """Suggested filter values for a custom property — see the logic function for the per-type
+    behavior. Empty for unknown definitions."""
+    return _custom_property_values_logic.list_custom_property_value_suggestions(
+        team_id=team_id, definition_id=definition_id, search=search
+    )
+
+
 def create_custom_property_definition(
     *,
     team_id: int,

--- a/products/customer_analytics/backend/facade/hogql.py
+++ b/products/customer_analytics/backend/facade/hogql.py
@@ -154,8 +154,14 @@ def _account_notebooks_select() -> ast.SelectQuery | ast.SelectSetQuery:
 
 # A custom property value is stored across four typed columns (exactly one non-null per row);
 # coalesce them to a single string so any display type round-trips through one column.
+# Booleans render as 'true'/'false' explicitly: the federated read maps PostgreSQL boolean to
+# UInt8, so toString() would yield '1'/'0' — which filters and value suggestions don't speak.
+# The isNull guard keeps non-boolean rows falling through the coalesce (ClickHouse if()
+# treats a NULL condition as false, which would otherwise coalesce them to 'false').
 _COALESCED_VALUE = (
-    "coalesce(cpv.value_str, toString(cpv.value_num), toString(cpv.value_bool), toString(cpv.value_datetime))"
+    "coalesce(cpv.value_str, toString(cpv.value_num),"
+    " if(isNull(cpv.value_bool), NULL, if(cpv.value_bool, 'true', 'false')),"
+    " toString(cpv.value_datetime))"
 )
 
 

--- a/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from posthog.test.base import ClickhouseTestMixin, NonAtomicBaseTest
 
 from django.test import override_settings
@@ -472,6 +474,53 @@ class TestAccountsQueryRunner(ClickhouseTestMixin, NonAtomicBaseTest):
             search="match",
             filterExpression="JSONExtract(properties, 'score', 'Nullable(Int64)') < 50",
         )
+        self.assertEqual(names, ["Match"])
+
+    def test_filter_expression_can_reference_a_custom_property_not_in_select(self):
+        definition = create_custom_property_definition(team_id=self.team.id, name="Plan")
+        match = create_account(team_id=self.team.id, name="Enterprise co")
+        create_account(team_id=self.team.id, name="No value")
+        CustomPropertyValue.objects.unscoped().create(
+            team_id=self.team.id, account=match, definition=definition, value_str="enterprise"
+        )
+        # The custom-property filter UI compiles to filterExpression fragments like this, and the
+        # filtered property is usually not a selected column — the WHERE reference alone must
+        # expand the custom_properties lazy join.
+        names = self._names(filterExpression=f"accounts.custom_properties.values.`{definition.id}` = 'enterprise'")
+        self.assertEqual(names, ["Enterprise co"])
+
+    @parameterized.expand(
+        [
+            (
+                "boolean",
+                {"value_bool": True},
+                {"value_bool": False},
+                "accounts.custom_properties.values.`{id}` = 'true'",
+            ),
+            (
+                "datetime",
+                {"value_datetime": datetime(2026, 1, 10, tzinfo=UTC)},
+                {"value_datetime": datetime(2026, 6, 10, tzinfo=UTC)},
+                "parseDateTimeBestEffort(accounts.custom_properties.values.`{id}`) < parseDateTimeBestEffort('2026-03-01')",
+            ),
+        ]
+    )
+    def test_typed_custom_property_filter_expression_round_trips(
+        self, display_type, match_value, other_value, expression_template
+    ):
+        # These are the exact predicate shapes the filter UI compiles; they must match against
+        # the coalesced string column as it comes back through the federated read (where e.g.
+        # a PostgreSQL boolean arrives as UInt8, not as 'true'/'false').
+        definition = create_custom_property_definition(team_id=self.team.id, name="Prop", display_type=display_type)
+        match = create_account(team_id=self.team.id, name="Match")
+        other = create_account(team_id=self.team.id, name="Other")
+        CustomPropertyValue.objects.unscoped().create(
+            team_id=self.team.id, account=match, definition=definition, **match_value
+        )
+        CustomPropertyValue.objects.unscoped().create(
+            team_id=self.team.id, account=other, definition=definition, **other_value
+        )
+        names = self._names(filterExpression=expression_template.format(id=definition.id))
         self.assertEqual(names, ["Match"])
 
     def test_custom_property_value_round_trips_through_a_selected_alias(self):

--- a/products/customer_analytics/backend/logic/custom_property_values.py
+++ b/products/customer_analytics/backend/logic/custom_property_values.py
@@ -169,6 +169,50 @@ def list_active_custom_property_values(*, team_id: int, account_id: str | UUID) 
     )
 
 
+VALUE_SUGGESTIONS_LIMIT = 50
+
+
+def list_custom_property_value_suggestions(*, team_id: int, definition_id: str | UUID, search: str | None) -> list[str]:
+    """Suggested filter values for a custom property: a select's option labels, a boolean's
+    true/false, otherwise distinct active values across the team's accounts. Empty when the
+    definition doesn't exist — suggestions are best-effort, not an error surface."""
+    try:
+        definition = CustomPropertyDefinition.objects.for_team(team_id).get(id=definition_id)
+    except (CustomPropertyDefinition.DoesNotExist, ValidationError, ValueError):
+        return []
+
+    needle = (search or "").strip().lower()
+
+    if definition.display_type == DisplayType.SELECT:
+        labels = [str(option.get("label") or "") for option in definition.options or []]
+        return [label for label in labels if needle in label.lower()][:VALUE_SUGGESTIONS_LIMIT]
+    if definition.data_type == DataType.BOOLEAN:
+        return [value for value in ("true", "false") if needle in value]
+    if definition.data_type == DataType.DATETIME:
+        # Date filters render a date picker, not text suggestions.
+        return []
+
+    column = "value_num" if definition.data_type == DataType.NUMERIC else "value_str"
+    queryset = CustomPropertyValue.objects.for_team(team_id).filter(definition_id=definition.id, is_deleted=False)
+    if needle and column == "value_str":
+        queryset = queryset.filter(value_str__icontains=needle)
+    values = (
+        queryset.exclude(**{f"{column}__isnull": True})
+        .values_list(column, flat=True)
+        .distinct()
+        .order_by(column)[:VALUE_SUGGESTIONS_LIMIT]
+    )
+    if column == "value_num":
+        formatted = [_format_numeric_suggestion(value) for value in values]
+        return [value for value in formatted if needle in value] if needle else formatted
+    return list(values)
+
+
+def _format_numeric_suggestion(value: float) -> str:
+    # Match ClickHouse toString(Float64), which renders integral floats without a trailing ".0".
+    return str(int(value)) if value == int(value) else str(value)
+
+
 def _assert_account_in_team(*, team_id: int, account_id: str | UUID) -> None:
     if not Account.objects.for_team(team_id).filter(id=account_id).exists():
         raise Account.DoesNotExist(f"Account {account_id} not found for team {team_id}")

--- a/products/customer_analytics/backend/logic/custom_property_values.py
+++ b/products/customer_analytics/backend/logic/custom_property_values.py
@@ -185,7 +185,7 @@ def list_custom_property_value_suggestions(*, team_id: int, definition_id: str |
 
     if definition.display_type == DisplayType.SELECT:
         labels = [str(option.get("label") or "") for option in definition.options or []]
-        return [label for label in labels if needle in label.lower()][:VALUE_SUGGESTIONS_LIMIT]
+        return [label for label in labels if label and needle in label.lower()][:VALUE_SUGGESTIONS_LIMIT]
     if definition.data_type == DataType.BOOLEAN:
         return [value for value in ("true", "false") if needle in value]
     if definition.data_type == DataType.DATETIME:
@@ -196,20 +196,27 @@ def list_custom_property_value_suggestions(*, team_id: int, definition_id: str |
     queryset = CustomPropertyValue.objects.for_team(team_id).filter(definition_id=definition.id, is_deleted=False)
     if needle and column == "value_str":
         queryset = queryset.filter(value_str__icontains=needle)
-    values = (
-        queryset.exclude(**{f"{column}__isnull": True})
-        .values_list(column, flat=True)
-        .distinct()
-        .order_by(column)[:VALUE_SUGGESTIONS_LIMIT]
-    )
-    if column == "value_num":
-        formatted = [_format_numeric_suggestion(value) for value in values]
-        return [value for value in formatted if needle in value] if needle else formatted
-    return list(values)
+    values = queryset.exclude(**{f"{column}__isnull": True}).values_list(column, flat=True).distinct().order_by(column)
+    if column == "value_str":
+        return list(values[:VALUE_SUGGESTIONS_LIMIT])
+    # The needle matches the *formatted* numeric string, which the database can't compute — filter
+    # in Python and stop once the limit fills, instead of slicing the queryset before filtering.
+    suggestions: list[str] = []
+    for value in values.iterator():
+        formatted = _format_numeric_suggestion(value)
+        if formatted is None or needle not in formatted:
+            continue
+        suggestions.append(formatted)
+        if len(suggestions) == VALUE_SUGGESTIONS_LIMIT:
+            break
+    return suggestions
 
 
-def _format_numeric_suggestion(value: float) -> str:
-    # Match ClickHouse toString(Float64), which renders integral floats without a trailing ".0".
+def _format_numeric_suggestion(value: float) -> str | None:
+    # Integral floats render without a trailing ".0", matching how the filter column displays
+    # them. Non-finite values can't pass write-path coercion; skip a stray row rather than crash.
+    if not math.isfinite(value):
+        return None
     return str(int(value)) if value == int(value) else str(value)
 
 

--- a/products/customer_analytics/backend/logic/custom_property_values.py
+++ b/products/customer_analytics/backend/logic/custom_property_values.py
@@ -215,18 +215,20 @@ def list_custom_property_value_suggestions(*, team_id: int, definition_id: str |
 
     if needle:
         queryset = queryset.filter(value_str__icontains=needle)
-    return list(
+    string_values = (
         queryset.exclude(value_str__isnull=True)
         .values_list("value_str", flat=True)
         .distinct()
         .order_by("value_str")[:VALUE_SUGGESTIONS_LIMIT]
     )
+    return [value for value in string_values if value is not None]
 
 
-def _format_numeric_suggestion(value: float) -> str | None:
+def _format_numeric_suggestion(value: float | None) -> str | None:
     # Integral floats render without a trailing ".0", matching how the filter column displays
     # them. Non-finite values can't pass write-path coercion; skip a stray row rather than crash.
-    if not math.isfinite(value):
+    # None only occurs in the type, not at runtime — the caller excludes null rows.
+    if value is None or not math.isfinite(value):
         return None
     return str(int(value)) if value == int(value) else str(value)
 

--- a/products/customer_analytics/backend/logic/custom_property_values.py
+++ b/products/customer_analytics/backend/logic/custom_property_values.py
@@ -192,24 +192,35 @@ def list_custom_property_value_suggestions(*, team_id: int, definition_id: str |
         # Date filters render a date picker, not text suggestions.
         return []
 
-    column = "value_num" if definition.data_type == DataType.NUMERIC else "value_str"
     queryset = CustomPropertyValue.objects.for_team(team_id).filter(definition_id=definition.id, is_deleted=False)
-    if needle and column == "value_str":
+
+    if definition.data_type == DataType.NUMERIC:
+        numeric_values = (
+            queryset.exclude(value_num__isnull=True)
+            .values_list("value_num", flat=True)
+            .distinct()
+            .order_by("value_num")
+        )
+        # The needle matches the *formatted* numeric string, which the database can't compute —
+        # filter in Python and stop once the limit fills, instead of slicing the queryset first.
+        suggestions: list[str] = []
+        for value in numeric_values.iterator():
+            formatted = _format_numeric_suggestion(value)
+            if formatted is None or needle not in formatted:
+                continue
+            suggestions.append(formatted)
+            if len(suggestions) == VALUE_SUGGESTIONS_LIMIT:
+                break
+        return suggestions
+
+    if needle:
         queryset = queryset.filter(value_str__icontains=needle)
-    values = queryset.exclude(**{f"{column}__isnull": True}).values_list(column, flat=True).distinct().order_by(column)
-    if column == "value_str":
-        return list(values[:VALUE_SUGGESTIONS_LIMIT])
-    # The needle matches the *formatted* numeric string, which the database can't compute — filter
-    # in Python and stop once the limit fills, instead of slicing the queryset before filtering.
-    suggestions: list[str] = []
-    for value in values.iterator():
-        formatted = _format_numeric_suggestion(value)
-        if formatted is None or needle not in formatted:
-            continue
-        suggestions.append(formatted)
-        if len(suggestions) == VALUE_SUGGESTIONS_LIMIT:
-            break
-    return suggestions
+    return list(
+        queryset.exclude(value_str__isnull=True)
+        .values_list("value_str", flat=True)
+        .distinct()
+        .order_by("value_str")[:VALUE_SUGGESTIONS_LIMIT]
+    )
 
 
 def _format_numeric_suggestion(value: float) -> str | None:

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -517,6 +517,27 @@ class CustomPropertyValueSerializer(serializers.Serializer):
     )
 
 
+class CustomPropertyValueSuggestionSerializer(serializers.Serializer):
+    """One suggested filter value for a custom property."""
+
+    name = serializers.CharField(read_only=True, help_text="A suggested value for the custom property.")
+
+
+class CustomPropertyValueSuggestionsResponseSerializer(serializers.Serializer):
+    """Response shape of the custom property value-suggestions endpoint.
+
+    Matches the contract of the shared property-values picker (``propertyDefinitionsModel``
+    on the frontend), which expects ``{results: [{name}], refreshing}``.
+    """
+
+    results = CustomPropertyValueSuggestionSerializer(
+        many=True, read_only=True, help_text="Suggested values matching the search input."
+    )
+    refreshing = serializers.BooleanField(
+        read_only=True, help_text="Always false — present for compatibility with the property-values consumer."
+    )
+
+
 class AccountRelationshipDefinitionSerializer(DataclassSerializer):
     """A team-defined account relationship type (CSM, Onboarding manager, ...)."""
 

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -47,6 +47,7 @@ from products.customer_analytics.backend.presentation.views.serializers import (
     CustomPropertySourceSerializer,
     CustomPropertySourceUpdateSerializer,
     CustomPropertyValueSerializer,
+    CustomPropertyValueSuggestionsResponseSerializer,
     CustomPropertyValueWriteSerializer,
 )
 
@@ -221,6 +222,33 @@ class CustomPropertyDefinitionViewSet(
         if definition is None:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         return Response(CustomPropertyDefinitionSerializer(instance=definition).data)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="key",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Id of the custom property definition to suggest values for.",
+            ),
+            OpenApiParameter(
+                name="value",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Case-insensitive substring to narrow the suggestions.",
+            ),
+        ],
+        responses={200: CustomPropertyValueSuggestionsResponseSerializer},
+    )
+    @action(methods=["GET"], detail=False, pagination_class=None)
+    def values(self, request: Request, *args, **kwargs) -> Response:
+        key = request.GET.get("key")
+        if not key:
+            return Response({"results": [], "refreshing": False})
+        suggestions = api.list_custom_property_value_suggestions(self.team_id, key, request.GET.get("value"))
+        return Response({"results": [{"name": value} for value in suggestions], "refreshing": False})
 
     def create(self, request: Request, *args, **kwargs) -> Response:
         serializer = CustomPropertyDefinitionSerializer(data=request.data)

--- a/products/customer_analytics/backend/test/test_custom_property_values.py
+++ b/products/customer_analytics/backend/test/test_custom_property_values.py
@@ -18,6 +18,7 @@ from products.customer_analytics.backend.facade import (
     contracts,
 )
 from products.customer_analytics.backend.logic.custom_property_values import (
+    VALUE_SUGGESTIONS_LIMIT,
     CustomPropertyDefinitionNotFound,
     CustomPropertyValueConflict,
     InvalidCustomPropertyValue,
@@ -289,7 +290,10 @@ class TestListCustomPropertyValueSuggestions(BaseTest):
 
     def test_select_returns_option_labels_filtered_by_search(self):
         definition = create_custom_property_definition(
-            team_id=self.team.id, name="Tier", display_type=DisplayType.SELECT, options=SELECT_OPTIONS
+            team_id=self.team.id,
+            name="Tier",
+            display_type=DisplayType.SELECT,
+            options=[*SELECT_OPTIONS, {"id": "opt-3", "color": "preset-3"}],  # unlabeled option must not suggest
         )
         assert self._suggestions(definition.id) == ["Enterprise", "Startup"]
         assert self._suggestions(definition.id, search="ENT") == ["Enterprise"]
@@ -317,6 +321,36 @@ class TestListCustomPropertyValueSuggestions(BaseTest):
         self._set(definition, 10.0)
         self._set(definition, 2.5, account=other_account)
         assert self._suggestions(definition.id) == ["2.5", "10"]
+
+    def test_numeric_search_matches_values_beyond_the_limit_window(self):
+        definition = create_custom_property_definition(
+            team_id=self.team.id, name="Seats", display_type=DisplayType.NUMBER
+        )
+        accounts = Account.objects.unscoped().bulk_create(
+            Account(team_id=self.team.id, name=f"Account {i}") for i in range(VALUE_SUGGESTIONS_LIMIT + 10)
+        )
+        CustomPropertyValue.objects.unscoped().bulk_create(
+            CustomPropertyValue(team_id=self.team.id, account=account, definition=definition, value_num=float(i))
+            for i, account in enumerate(accounts)
+        )
+        # The match sorts after the first VALUE_SUGGESTIONS_LIMIT values — the search must not be
+        # applied to a pre-sliced window.
+        assert self._suggestions(definition.id, search=str(VALUE_SUGGESTIONS_LIMIT + 5)) == [
+            str(VALUE_SUGGESTIONS_LIMIT + 5)
+        ]
+
+    def test_non_finite_numeric_rows_are_skipped(self):
+        definition = create_custom_property_definition(
+            team_id=self.team.id, name="Seats", display_type=DisplayType.NUMBER
+        )
+        # Write-path coercion rejects non-finite values, so plant a stray row directly; it must be
+        # skipped rather than crash the suggestions.
+        stray_account = create_account(team_id=self.team.id, name="Stray", external_id="stray-ext")
+        CustomPropertyValue.objects.unscoped().create(
+            team_id=self.team.id, account=stray_account, definition=definition, value_num=float("inf")
+        )
+        self._set(definition, 7.0)
+        assert self._suggestions(definition.id) == ["7"]
 
     @parameterized.expand([("unknown_uuid", str(uuid4())), ("malformed", "not-a-uuid")])
     def test_unknown_definition_returns_empty(self, _name, definition_id):

--- a/products/customer_analytics/backend/test/test_custom_property_values.py
+++ b/products/customer_analytics/backend/test/test_custom_property_values.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from posthog.test.base import BaseTest
@@ -285,7 +285,7 @@ class TestListCustomPropertyValueSuggestions(BaseTest):
             value=value,
         )
 
-    def _suggestions(self, definition_id: object, search: str | None = None) -> list[str]:
+    def _suggestions(self, definition_id: str | UUID, search: str | None = None) -> list[str]:
         return list_custom_property_value_suggestions(team_id=self.team.id, definition_id=definition_id, search=search)
 
     def test_select_returns_option_labels_filtered_by_search(self):

--- a/products/customer_analytics/backend/test/test_custom_property_values.py
+++ b/products/customer_analytics/backend/test/test_custom_property_values.py
@@ -22,6 +22,7 @@ from products.customer_analytics.backend.logic.custom_property_values import (
     CustomPropertyValueConflict,
     InvalidCustomPropertyValue,
     list_active_custom_property_values,
+    list_custom_property_value_suggestions,
     set_account_custom_properties_by_id,
     set_custom_property_value,
 )
@@ -268,6 +269,58 @@ class TestSetAccountCustomPropertiesById(BaseTest):
                 team_id=self.team.id, account_id=self.account.id, properties={str(seats.id): "not a number"}
             )
         assert exc_info.value.field == str(seats.id)
+
+
+class TestListCustomPropertyValueSuggestions(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.account = create_account(team_id=self.team.id)
+
+    def _set(self, definition: CustomPropertyDefinition, value: object, account: Account | None = None) -> None:
+        set_custom_property_value(
+            team_id=self.team.id,
+            account_id=(account or self.account).id,
+            definition_id=definition.id,
+            value=value,
+        )
+
+    def _suggestions(self, definition_id: object, search: str | None = None) -> list[str]:
+        return list_custom_property_value_suggestions(team_id=self.team.id, definition_id=definition_id, search=search)
+
+    def test_select_returns_option_labels_filtered_by_search(self):
+        definition = create_custom_property_definition(
+            team_id=self.team.id, name="Tier", display_type=DisplayType.SELECT, options=SELECT_OPTIONS
+        )
+        assert self._suggestions(definition.id) == ["Enterprise", "Startup"]
+        assert self._suggestions(definition.id, search="ENT") == ["Enterprise"]
+
+    def test_text_returns_distinct_active_values_only(self):
+        definition = create_custom_property_definition(team_id=self.team.id, name="Region")
+        other_account = create_account(team_id=self.team.id, name="Other", external_id="other-ext")
+        self._set(definition, "emea")
+        self._set(definition, "apac")  # supersedes "emea" — the soft-deleted row must not suggest
+        self._set(definition, "amer", account=other_account)
+        assert self._suggestions(definition.id) == ["amer", "apac"]
+        assert self._suggestions(definition.id, search="ap") == ["apac"]
+
+    def test_boolean_suggests_true_false(self):
+        definition = create_custom_property_definition(
+            team_id=self.team.id, name="Active", display_type=DisplayType.BOOLEAN
+        )
+        assert self._suggestions(definition.id) == ["true", "false"]
+
+    def test_numeric_values_render_like_clickhouse_tostring(self):
+        definition = create_custom_property_definition(
+            team_id=self.team.id, name="Seats", display_type=DisplayType.NUMBER
+        )
+        other_account = create_account(team_id=self.team.id, name="Other2", external_id="other-ext-2")
+        self._set(definition, 10.0)
+        self._set(definition, 2.5, account=other_account)
+        assert self._suggestions(definition.id) == ["2.5", "10"]
+
+    @parameterized.expand([("unknown_uuid", str(uuid4())), ("malformed", "not-a-uuid")])
+    def test_unknown_definition_returns_empty(self, _name, definition_id):
+        assert self._suggestions(definition_id) == []
 
 
 class TestCustomPropertyValueFacade(BaseTest):

--- a/products/customer_analytics/backend/test/test_views.py
+++ b/products/customer_analytics/backend/test/test_views.py
@@ -1544,6 +1544,26 @@ class TestCustomPropertyDefinitionViewSet(APIBaseTest):
         payload.update(overrides)
         return self.client.post(self.endpoint_base, payload, format="json")
 
+    def test_values_returns_suggestions_envelope(self):
+        created = self._create(
+            name="Tier",
+            display_type="select",
+            is_big_number=False,
+            options=[
+                {"label": "Enterprise", "color": "preset-1"},
+                {"label": "Startup", "color": "preset-2"},
+            ],
+        )
+        definition_id = created.json()["id"]
+
+        response = self.client.get(f"{self.endpoint_base}values/?key={definition_id}&value=ent")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"results": [{"name": "Enterprise"}], "refreshing": False})
+
+        missing_key = self.client.get(f"{self.endpoint_base}values/")
+        self.assertEqual(missing_key.status_code, status.HTTP_200_OK)
+        self.assertEqual(missing_key.json(), {"results": [], "refreshing": False})
+
     def test_create_success(self):
         response = self._create()
 

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -625,6 +625,27 @@ export interface PatchedCustomPropertyDefinitionApi {
     readonly references?: readonly CustomPropertyReferenceApi[]
 }
 
+/**
+ * One suggested filter value for a custom property.
+ */
+export interface CustomPropertyValueSuggestionApi {
+    /** A suggested value for the custom property. */
+    readonly name: string
+}
+
+/**
+ * Response shape of the custom property value-suggestions endpoint.
+ *
+ * Matches the contract of the shared property-values picker (``propertyDefinitionsModel``
+ * on the frontend), which expects ``{results: [{name}], refreshing}``.
+ */
+export interface CustomPropertyValueSuggestionsResponseApi {
+    /** Suggested values matching the search input. */
+    readonly results: readonly CustomPropertyValueSuggestionApi[]
+    /** Always false — present for compatibility with the property-values consumer. */
+    readonly refreshing: boolean
+}
+
 export interface PaginatedCustomPropertySourceListApi {
     count: number
     /** @nullable */
@@ -1008,6 +1029,17 @@ export type CustomPropertyDefinitionsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+}
+
+export type CustomPropertyDefinitionsValuesRetrieveParams = {
+    /**
+     * Id of the custom property definition to suggest values for.
+     */
+    key: string
+    /**
+     * Case-insensitive substring to narrow the suggestions.
+     */
+    value?: string
 }
 
 export type CustomPropertySourcesListParams = {

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -21,10 +21,12 @@ import type {
     AccountsRelationshipsListParams,
     CustomPropertyDefinitionApi,
     CustomPropertyDefinitionsListParams,
+    CustomPropertyDefinitionsValuesRetrieveParams,
     CustomPropertySourceApi,
     CustomPropertySourceUpdateApi,
     CustomPropertySourcesListParams,
     CustomPropertyValueApi,
+    CustomPropertyValueSuggestionsResponseApi,
     CustomPropertyValueWriteApi,
     CustomerJourneyApi,
     CustomerJourneysListParams,
@@ -610,6 +612,39 @@ export const customPropertyDefinitionsDestroy = async (
         ...options,
         method: 'DELETE',
     })
+}
+
+export const getCustomPropertyDefinitionsValuesRetrieveUrl = (
+    projectId: string,
+    params: CustomPropertyDefinitionsValuesRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/custom_property_definitions/values/?${stringifiedParams}`
+        : `/api/projects/${projectId}/custom_property_definitions/values/`
+}
+
+export const customPropertyDefinitionsValuesRetrieve = async (
+    projectId: string,
+    params: CustomPropertyDefinitionsValuesRetrieveParams,
+    options?: RequestInit
+): Promise<CustomPropertyValueSuggestionsResponseApi> => {
+    return apiMutator<CustomPropertyValueSuggestionsResponseApi>(
+        getCustomPropertyDefinitionsValuesRetrieveUrl(projectId, params),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
 }
 
 export const getCustomPropertySourcesListUrl = (projectId: string, params?: CustomPropertySourcesListParams) => {

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -339,6 +339,9 @@ tools:
     custom-property-definitions-update:
         operation: custom_property_definitions_update
         enabled: false
+    custom-property-definitions-values-retrieve:
+        operation: custom_property_definitions_values_retrieve
+        enabled: false
     custom-property-sources-create:
         operation: custom_property_sources_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14787,6 +14787,27 @@ export namespace Schemas {
       readonly created_by_id: number | null;
     }
 
+    /**
+     * One suggested filter value for a custom property.
+     */
+    export interface CustomPropertyValueSuggestion {
+      /** A suggested value for the custom property. */
+      readonly name: string;
+    }
+
+    /**
+     * Response shape of the custom property value-suggestions endpoint.
+     *
+     * Matches the contract of the shared property-values picker (``propertyDefinitionsModel``
+     * on the frontend), which expects ``{results: [{name}], refreshing}``.
+     */
+    export interface CustomPropertyValueSuggestionsResponse {
+      /** Suggested values matching the search input. */
+      readonly results: readonly CustomPropertyValueSuggestion[];
+      /** Always false — present for compatibility with the property-values consumer. */
+      readonly refreshing: boolean;
+    }
+
     export interface CustomPropertyValueWrite {
       /** UUID of the custom property definition whose value to set for this account. */
       definition: string;
@@ -58259,6 +58280,17 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type EnvironmentsCustomPropertyDefinitionsValuesRetrieveParams = {
+    /**
+     * Id of the custom property definition to suggest values for.
+     */
+    key: string;
+    /**
+     * Case-insensitive substring to narrow the suggestions.
+     */
+    value?: string;
+    };
+
     export type EnvironmentsCustomerJourneysListParams = {
     /**
      * Number of results to return per page.
@@ -64452,6 +64484,17 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    };
+
+    export type CustomPropertyDefinitionsValuesRetrieveParams = {
+    /**
+     * Id of the custom property definition to suggest values for.
+     */
+    key: string;
+    /**
+     * Case-insensitive substring to narrow the suggestions.
+     */
+    value?: string;
     };
 
     export type CustomPropertySourcesListParams = {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Part 1/3 of custom property filters for the accounts list (split from #69415). The filter UI needs value suggestions per custom property, and the lazy join's boolean coalescing breaks typed filtering.

## Changes

- Add `GET custom_property_definitions/values/?key=<id>&value=<search>`: select → option labels, boolean → true/false, text/numeric → distinct active values (soft-deleted and other teams excluded)
- Coalesce boolean custom property values to 'true'/'false' in the lazy join (the federated read maps PostgreSQL boolean to UInt8, so toString() yields '1'/'0')
- Exclude the new endpoint from MCP tools
- Add query-runner tests proving a WHERE-only reference expands the custom-properties lazy join and that typed predicates round-trip

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests: suggestions logic (select labels, soft-delete + team isolation, numeric formatting), endpoint envelope, and query-runner lazy-join/typed round-trip tests — 83 passing.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code); split out of #69415 by layer. Skills invoked: /improving-drf-endpoints, /writing-tests. The endpoint response shape ({results: [{name}], refreshing}) matches the shared property-values picker contract on the frontend, which lands in the follow-up PRs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
