### PR TITLE
chore: brand mermaid diagrams in PR guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -67,6 +67,14 @@
 - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
 - Use GitHub's rich markdown when it makes review faster, never as decoration:
   - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart LR` blocks, with the before diagram first. Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
+    - Brand the nodes with PostHog colors (mermaid can't read CSS vars, so use the hex directly). Define classes once and always pair a `fill` with an explicit text `color` so nodes stay legible on both GitHub light and dark themes:
+      ```
+      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
+      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
+      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
+      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
+      ```
+      Assign by role with `class NodeA,NodeB phBlue;`. Use `phBlue` for the primary path and agents, `phRed` for external calls and APIs, `phYellow` for entry and exit nodes, `phGray` for neutral data and artifacts. Distinguish node kinds by shape too (`{{hexagon}}` for agents, `[rect]` for steps).
   - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
   - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
   - Use fenced `diff` code blocks for config before/after.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,15 +66,15 @@
 - Do NOT claim manual testing you haven't done.
 - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
 - Use GitHub's rich markdown when it makes review faster, never as decoration:
-  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, with the before diagram first. Pick the direction that reads best (`TD` for tall pipelines, `LR` for wide request paths). Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
-    - Brand the nodes with PostHog colors (mermaid can't read CSS vars, so use the hex directly). Define classes once and always pair a `fill` with an explicit text `color` so nodes stay legible on both GitHub light and dark themes:
+  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
+    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
       ```
       classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
       classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
       classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
       classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
       ```
-      Assign by role with `class NodeA,NodeB phBlue;`. Use `phBlue` for the primary path and agents, `phRed` for external calls and APIs, `phYellow` for entry and exit nodes, `phGray` for neutral data and artifacts. Distinguish node kinds by shape too (`{{hexagon}}` for agents, `[rect]` for steps).
+      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
   - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
   - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
   - Use fenced `diff` code blocks for config before/after.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,7 +66,7 @@
 - Do NOT claim manual testing you haven't done.
 - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
 - Use GitHub's rich markdown when it makes review faster, never as decoration:
-  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart LR` blocks, with the before diagram first. Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
+  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, with the before diagram first. Pick the direction that reads best (`TD` for tall pipelines, `LR` for wide request paths). Keep them simple: a syntax error renders as an error block. Skip diagrams for trivial changes.
     - Brand the nodes with PostHog colors (mermaid can't read CSS vars, so use the hex directly). Define classes once and always pair a `fill` with an explicit text `color` so nodes stay legible on both GitHub light and dark themes:
       ```
       classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;


### PR DESCRIPTION
## Problem

- Agent-authored PR mermaid diagrams render with mermaid's default gray nodes, so they look generic and off-brand.
- The PR-template guidance told agents to add before/after diagrams but said nothing about styling them, and hard-coded `flowchart LR`.

## Changes

- Extend the mermaid bullet in `.github/pull_request_template.md` (agent-context comment) with a PostHog brand palette agents can drop in:
  - `classDef` set using canonical brand hex (blue `#1d4aff`, red `#f54e00`, yellow `#f9bd2b`) plus a neutral gray.
  - Rule: always pair `fill` with an explicit text `color` so nodes stay legible on both GitHub light and dark themes (mermaid can't read CSS vars).
  - Role mapping (primary/agents, external/APIs, entry-exit, neutral data) and a node-shape hint.
- Drop the hard-coded `LR` direction; let the agent pick `TD` (tall pipelines) or `LR` (wide request paths), whichever reads best.

Samples of what agents will now produce:

Top-down (`TD`), for a pipeline:

```mermaid
flowchart TD
    PR["PR #1234"] --> Fetch["Fetch PR data"]
    Fetch --> Diffs["PR diffs"]
    Diffs --> Review{{"Review agent"}}
    Review --> Report["Build report"]
    Report --> Publish["Publish review"]
    Publish --> Posted["Review posted"]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;

    class Review phBlue;
    class Fetch,Publish phRed;
    class PR,Posted phYellow;
    class Diffs,Report phGray;
```

Left-right (`LR`), for a request path:

```mermaid
flowchart LR
    Client["Client"] --> API["API gateway"]
    API --> Auth{{"Auth agent"}}
    Auth --> Cache["Cache"]
    Cache --> DB["Database"]
    DB --> Resp["Response"]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;

    class Auth phBlue;
    class API phRed;
    class Client,Resp phYellow;
    class Cache,DB phGray;
```

## How did you test this code?

- Docs-only change to an HTML-comment block; no runtime surface. Verified the block survives the markdown formatter (lint-staged `oxfmt`) and `hogli ci:preflight --strict` passes (markdown-format ok, branch fresh).
- Rendered both sample diagrams above to confirm the palette is valid mermaid and legible in each direction.

## Docs update

- None (guidance lives in the PR template itself).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Raúl asked to make agent-produced mermaid charts match a PostHog-branded reference image, then to stop forcing a single direction.
- I located the sole authoring guidance (PR-template comment) and the canonical brand colors in `frontend/src/styles/base.scss`, then chose the three brand colors plus a neutral gray mapped to semantic roles; skipped the reference image's green since it isn't a brand color.
- No skills invoked; markdown-only edit.
