### PR TITLE
fix(experiments): read flag config from the flag in mcp results tool and ui apps

### DIFF
--- a/products/experiments/mcp/apps/ExperimentListView.tsx
+++ b/products/experiments/mcp/apps/ExperimentListView.tsx
@@ -64,10 +64,10 @@ export function ExperimentListView({ data, onExperimentClick }: ExperimentListVi
                             ),
                     },
                     {
-                        key: 'parameters' as keyof ExperimentData,
+                        key: 'feature_flag' as keyof ExperimentData,
                         header: 'Variants',
                         render: (row): ReactNode => {
-                            const variants = row.parameters?.feature_flag_variants
+                            const variants = row.feature_flag?.filters?.multivariate?.variants
                             if (!variants || variants.length === 0) {
                                 return <span className="text-muted-foreground">&mdash;</span>
                             }

--- a/products/experiments/mcp/apps/ExperimentView.tsx
+++ b/products/experiments/mcp/apps/ExperimentView.tsx
@@ -11,7 +11,7 @@ export interface ExperimentViewProps {
 
 export function ExperimentView({ experiment }: ExperimentViewProps): ReactElement {
     const status = getStatus(experiment)
-    const variants = experiment.parameters?.feature_flag_variants ?? []
+    const variants = experiment.feature_flag?.filters?.multivariate?.variants ?? []
 
     const variantColumns: DataTableColumn<ExperimentVariant>[] = [
         { key: 'key', header: 'Key', sortable: true },

--- a/products/experiments/mcp/apps/Experiments.stories.tsx
+++ b/products/experiments/mcp/apps/Experiments.stories.tsx
@@ -33,11 +33,18 @@ const runningExperiment: ExperimentData = {
     feature_flag_key: 'onboarding-v2-experiment',
     start_date: '2025-11-01T10:00:00Z',
     created_at: '2025-10-28T09:00:00Z',
-    parameters: {
-        feature_flag_variants: [
-            { key: 'control', name: 'Current flow', split_percent: 50 },
-            { key: 'test', name: 'Simplified flow', split_percent: 50 },
-        ],
+    feature_flag: {
+        id: 101,
+        key: 'onboarding-v2-experiment',
+        filters: {
+            groups: [{ rollout_percentage: 100 }],
+            multivariate: {
+                variants: [
+                    { key: 'control', name: 'Current flow', rollout_percentage: 50 },
+                    { key: 'test', name: 'Simplified flow', rollout_percentage: 50 },
+                ],
+            },
+        },
     },
     metrics: [{ kind: 'primary', event: 'user_activated', math: 'total' }],
     _posthogUrl: 'https://us.posthog.com/project/1/experiments/1',
@@ -52,12 +59,19 @@ const completedExperiment: ExperimentData = {
     start_date: '2025-09-01T10:00:00Z',
     end_date: '2025-10-01T10:00:00Z',
     created_at: '2025-08-28T09:00:00Z',
-    parameters: {
-        feature_flag_variants: [
-            { key: 'control', name: 'Get started', split_percent: 34 },
-            { key: 'test-a', name: 'Start free trial', split_percent: 33 },
-            { key: 'test-b', name: 'Try it now', split_percent: 33 },
-        ],
+    feature_flag: {
+        id: 102,
+        key: 'pricing-cta-test',
+        filters: {
+            groups: [{ rollout_percentage: 100 }],
+            multivariate: {
+                variants: [
+                    { key: 'control', name: 'Get started', rollout_percentage: 34 },
+                    { key: 'test-a', name: 'Start free trial', rollout_percentage: 33 },
+                    { key: 'test-b', name: 'Try it now', rollout_percentage: 33 },
+                ],
+            },
+        },
     },
     conclusion: 'significant',
     conclusion_comment: 'test-a outperformed control by 12% on conversion rate.',
@@ -70,11 +84,18 @@ const draftExperiment: ExperimentData = {
     description: 'Should new users default to dark mode?',
     feature_flag_key: 'dark-mode-default',
     created_at: '2025-12-01T09:00:00Z',
-    parameters: {
-        feature_flag_variants: [
-            { key: 'control', split_percent: 50 },
-            { key: 'test', split_percent: 50 },
-        ],
+    feature_flag: {
+        id: 103,
+        key: 'dark-mode-default',
+        filters: {
+            groups: [{ rollout_percentage: 100 }],
+            multivariate: {
+                variants: [
+                    { key: 'control', rollout_percentage: 50 },
+                    { key: 'test', rollout_percentage: 50 },
+                ],
+            },
+        },
     },
 }
 

--- a/products/experiments/mcp/apps/utils.ts
+++ b/products/experiments/mcp/apps/utils.ts
@@ -24,7 +24,11 @@ export interface ExperimentData {
     created_at?: string
     updated_at?: string
     feature_flag?: {
+        id?: number
+        key?: string
+        name?: string
         filters?: {
+            groups?: { rollout_percentage?: number | null }[]
             multivariate?: {
                 variants?: ExperimentVariant[]
             } | null

--- a/products/experiments/mcp/apps/utils.ts
+++ b/products/experiments/mcp/apps/utils.ts
@@ -23,10 +23,13 @@ export interface ExperimentData {
     archived?: boolean
     created_at?: string
     updated_at?: string
-    parameters?: {
-        feature_flag_variants?: ExperimentVariant[]
-        [key: string]: unknown
-    }
+    feature_flag?: {
+        filters?: {
+            multivariate?: {
+                variants?: ExperimentVariant[]
+            } | null
+        } | null
+    } | null
     metrics?: ExperimentMetric[]
     metrics_secondary?: ExperimentMetric[]
     filters?: Record<string, unknown>

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -563,6 +563,7 @@ tools:
                 - name
                 - description
                 - feature_flag_key
+                - feature_flag
                 - start_date
                 - end_date
                 - archived

--- a/services/mcp/src/schema/experiments.ts
+++ b/services/mcp/src/schema/experiments.ts
@@ -4,12 +4,31 @@ const ExperimentType = ['web', 'product'] as const
 
 const ExperimentConclusion = ['won', 'lost', 'inconclusive', 'stopped_early', 'invalid'] as const
 
+// The flag's native variant shape (filters.multivariate.variants). This is the source
+// of truth for an experiment's variants — the deprecated parameters.feature_flag_variants
+// projection just echoes it. looseObject so unknown filter/variant keys survive parsing:
+// the exposure query forwards the whole feature_flag object to the backend, so narrowing
+// filters here would strip groups/payloads/etc. before the query is sent.
+const FeatureFlagVariantSchema = z.looseObject({
+    key: z.string(),
+    name: z.string().nullish(),
+    rollout_percentage: z.number().nullish(),
+})
+
+const FeatureFlagFiltersSchema = z.looseObject({
+    multivariate: z
+        .looseObject({
+            variants: z.array(FeatureFlagVariantSchema).nullish(),
+        })
+        .nullish(),
+})
+
 const FeatureFlagSchema = z.object({
     id: z.number(),
     key: z.string(),
     name: z.string(),
     description: z.string().nullish(),
-    filters: z.any().nullish(),
+    filters: FeatureFlagFiltersSchema.nullish(),
     active: z.boolean(),
     tags: z.array(z.string()).optional(),
     updated_at: z.string().nullish(),
@@ -361,7 +380,7 @@ export function transformExperimentResults(input: {
             | 'draft'
             | 'running'
             | 'completed',
-        variants: experiment.parameters?.feature_flag_variants || [],
+        variants: experiment.feature_flag?.filters?.multivariate?.variants ?? [],
     }
 
     const buildRows = (

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -573,6 +573,7 @@ const experimentList = (): ToolBase<
                         'name',
                         'description',
                         'feature_flag_key',
+                        'feature_flag',
                         'start_date',
                         'end_date',
                         'archived',

--- a/services/mcp/tests/unit/experiments-results-transform.test.ts
+++ b/services/mcp/tests/unit/experiments-results-transform.test.ts
@@ -88,6 +88,31 @@ describe('transformExperimentResults', () => {
         })
     })
 
+    it('reads variants from the linked flag, not the deprecated parameters projection', () => {
+        const experiment = makeExperiment({
+            feature_flag: {
+                id: 9,
+                key: 'k',
+                name: 'k',
+                active: true,
+                filters: { multivariate: { variants: [{ key: 'control' }, { key: 'test' }] } },
+            },
+            // Stale projection echo: must be ignored now that the flag is the source of truth.
+            parameters: { feature_flag_variants: [{ key: 'old-control' }] },
+        })
+
+        const result = transformExperimentResults({
+            experiment,
+            exposures: baseExposures,
+            primaryMetricEntries: [],
+            secondaryMetricEntries: [],
+            primaryMetricsResults: [],
+            secondaryMetricsResults: [],
+        })
+
+        expect(result.experiment.variants.map((v) => v.key)).toEqual(['control', 'test'])
+    })
+
     it('treats inline and shared metrics as one ordered surface and tags the source on each', () => {
         const experiment = makeExperiment({
             metrics: [],


### PR DESCRIPTION
## Problem

Phase 5 of the experiment flag-config cleanup. After #68867, the linked feature flag is the source of truth for an experiment's flag config, and `parameters.feature_flag_variants` is just a deprecated read projection that echoes it. The MCP surface still read variants from that projection in three places: the results tool transform and the two experiment UI apps. This keeps the projection alive as a hard dependency and teaches the old shape.

## Changes

Switch the internal MCP readers to read variants from the flag itself (`feature_flag.filters.multivariate.variants`), so the deprecated projection is no longer on the internal read path.

- `services/mcp/src/schema/experiments.ts`: `transformExperimentResults` (the `experiment-results-get` tool) now sources `variants` from the linked flag. The hand-written `ExperimentSchema` now types `feature_flag.filters.multivariate.variants` via a `looseObject` filters schema, so unknown filter keys still survive parsing (the exposure query forwards the whole `feature_flag` object to the backend, so narrowing filters would strip `groups`/`payloads`/etc.).
- MCP UI apps (`products/experiments/mcp/apps/`): the detail view (`ExperimentView`), list view (`ExperimentListView`), and shared `ExperimentData` type read variants from the flag instead of `parameters`.
- `products/experiments/mcp/tools.yaml`: add `feature_flag` to the `experiment-list` tool response include list so the list view has the flag to read from (the detail tool `experiment-get` already returns the full object). Regenerated `services/mcp/src/tools/generated/experiments.ts`.

Out of scope (per the plan): the backend read projection stays, and nothing under `products/experiments/backend` is touched. External API readers still get the projection.

> [!NOTE]
> `split_percent` is only ever set on the deprecated projection, never on the flag's native variants. The UI apps already fall back to `rollout_percentage` when it is absent, so the displayed split is unchanged.

## How did you test this code?

Automated tests I (Claude) actually ran, all passing:

- `services/mcp` unit suites: `experiments-results-transform.test.ts`, `experiments-schema-cast.test.ts`, `tool-filtering.test.ts`, `tool-schema-snapshots.test.ts`, `generate-tools.test.ts`.
- Added one focused case to `experiments-results-transform.test.ts`: it asserts the results transform reads variants from the linked flag and ignores a stale `parameters.feature_flag_variants` echo. No existing test set variants at all, so nothing guarded against the reader being reverted to the projection or the flag path being mistyped.
- `pnpm run typecheck` (tsgo) clean, which also covers the UI apps via the generated MCP dispatch entry points.

I did not exercise the tools against a live MCP client.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implements Phase 5 (retire the read projection - internal reader switches) of the experiment flag-config post-#68867 cleanup plan. This PR does only the internal-reader switches; the read projection itself is deliberately kept for external API consumers.

Authored by Claude Code (Opus). Skills invoked while producing this PR: `/writing-tests` (before adding the transform test).

One decision worth flagging for review: I kept the flag `filters` schema as a `looseObject` rather than a narrow object. A narrow schema would strip unknown filter keys, and the exposure-query path re-parses the `feature_flag` object before forwarding it to the backend query endpoint, so narrowing would silently drop `groups`/`multivariate.override_property_values`/`payloads`. Loose keeps the parse faithful while still typing the one field the readers need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
