### PR TITLE
chore(ci): adopt zizmor for workflow security auditing

### DIFF
--- a/.github/actions/setup-emsdk/action.yml
+++ b/.github/actions/setup-emsdk/action.yml
@@ -53,7 +53,8 @@ runs:
           shell: bash
           env:
               EMSDK_VERSION: ${{ inputs.version }}
-          run: |
+          # writes its own install paths, no untrusted input
+          run: | # zizmor: ignore[github-env]
               set -euo pipefail
 
               VERSION="$EMSDK_VERSION"

--- a/.github/actions/setup-protoc/action.yml
+++ b/.github/actions/setup-protoc/action.yml
@@ -62,6 +62,7 @@ runs:
 
         - name: Add protoc to PATH
           shell: bash
-          run: |
+          # writes its own install path, no untrusted input
+          run: | # zizmor: ignore[github-env]
               echo "$RUNNER_TEMP/protoc/bin" >> "$GITHUB_PATH"
               "$RUNNER_TEMP/protoc/bin/protoc" --version

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -67,7 +67,8 @@ runs:
 
         - name: Configure sccache
           shell: bash
-          run: |
+          # writes its own install path, no untrusted input
+          run: | # zizmor: ignore[github-env]
               echo "$RUNNER_TEMP/sccache" >> "$GITHUB_PATH"
               for i in 1 2 3; do
                 if "$RUNNER_TEMP/sccache/sccache" --start-server; then

--- a/.github/actions/setup-sqlx-cli/action.yml
+++ b/.github/actions/setup-sqlx-cli/action.yml
@@ -47,6 +47,7 @@ runs:
 
         - name: Add sqlx-cli to PATH
           shell: bash
-          run: |
+          # writes its own install path, no untrusted input
+          run: | # zizmor: ignore[github-env]
               echo "$RUNNER_TEMP/sqlx-cli/bin" >> "$GITHUB_PATH"
               "$RUNNER_TEMP/sqlx-cli/bin/sqlx" --version

--- a/.github/workflows/build-hogql-parser-npm.yml
+++ b/.github/workflows/build-hogql-parser-npm.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
     contents: read
-    pull-requests: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -16,6 +15,9 @@ concurrency:
 
 jobs:
     check-package-version:
+        permissions:
+            contents: read
+            pull-requests: write
         name: Check npm package version
         runs-on: ubuntu-24.04
         timeout-minutes: 5

--- a/.github/workflows/build-hogql-parser-rs.yml
+++ b/.github/workflows/build-hogql-parser-rs.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
     contents: read
-    pull-requests: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -16,6 +15,9 @@ concurrency:
 
 jobs:
     check-version:
+        permissions:
+            contents: read
+            pull-requests: write
         name: Check version legitimacy
         runs-on: ubuntu-22.04
         timeout-minutes: 5
@@ -23,7 +25,7 @@ jobs:
             parser-release-needed: ${{ steps.version.outputs.parser-release-needed }}
             local-version: ${{ steps.version.outputs.local-version }}
         steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
                   filter: blob:none
@@ -123,14 +125,14 @@ jobs:
                       target: x86_64
 
         steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: '3.12.10' # 3.12.11/.12 binaries lag on macOS
 
             - name: Build wheel via maturin
-              uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.3
+              uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.1
               with:
                   command: build
                   target: ${{ matrix.target }}
@@ -146,7 +148,7 @@ jobs:
 
             - name: Build sdist (linux x86_64 manylinux only)
               if: matrix.os == 'ubuntu-22.04' && matrix.target == 'x86_64' && matrix.manylinux == '2_28'
-              uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.3
+              uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.1
               with:
                   command: sdist
                   args: --out dist --manifest-path rust/hogql/parser/Cargo.toml
@@ -198,7 +200,7 @@ jobs:
                   client-id: ${{ secrets.GH_APP_POSTHOG_TESTS_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_TESTS_PRIVATE_KEY }}
 
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   token: ${{ steps.app-token.outputs.token }}
@@ -213,9 +215,8 @@ jobs:
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
               with:
                   version: '0.11.14'
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
+                  # No cache in the publish job: restored caches can poison published artifacts
+                  enable-cache: false
 
             - name: Update hogql-parser-rs in requirements
               shell: bash

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
     contents: read
-    pull-requests: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -16,6 +15,9 @@ concurrency:
 
 jobs:
     check-version:
+        permissions:
+            contents: read
+            pull-requests: write
         name: Check version legitimacy
         runs-on: ubuntu-22.04
         timeout-minutes: 5
@@ -203,9 +205,8 @@ jobs:
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
-                  enable-cache: true
-                  cache-dependency-glob: uv.lock
-                  save-cache: ${{ github.ref == 'refs/heads/master' }}
+                  # No cache in the publish job: restored caches can poison published artifacts
+                  enable-cache: false
 
             - name: Update hogql-parser in requirements
               shell: bash

--- a/.github/workflows/ci-agent-container.yml
+++ b/.github/workflows/ci-agent-container.yml
@@ -36,6 +36,10 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     changes:
         runs-on: ubuntu-24.04

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -14,6 +14,10 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     changes:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -68,7 +68,7 @@ env:
 
 permissions:
     contents: read
-    pull-requests: write
+    pull-requests: read
 
 jobs:
     # Job to decide if we should run backend ci
@@ -3093,7 +3093,7 @@ jobs:
                   version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
             - name: Download junit artifacts
               if: github.run_attempt == '1' && steps.timing-reporter.outputs.available == 'true'
-              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
               with:
                   path: ./junit-artifacts
                   pattern: junit-results-*

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -593,7 +593,7 @@ jobs:
               run: pnpm --filter=@posthog/playwright exec playwright install chromium --with-deps
 
             - name: Wait for PostHog to be ready
-              uses: iFaxity/wait-on-action@1fe019e0475491e9e8c4f421b6914ccc3ed8f99c # v1.2.1
+              uses: iFaxity/wait-on-action@1fe019e0475491e9e8c4f421b6914ccc3ed8f99c # untagged: post-v1.2.1 with dependency security bumps
               with:
                   resource: http://localhost:8000
                   timeout: 180000

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -18,7 +18,7 @@ concurrency:
 
 permissions:
     contents: read
-    pull-requests: write
+    pull-requests: read
     actions: read
 
 env:
@@ -331,6 +331,10 @@ jobs:
               run: pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc "**/*.{md,mdx}"
 
     frontend-bundle-size:
+        permissions:
+            contents: read
+            pull-requests: write
+            actions: read
         name: Frontend bundle size
         needs: [changes]
         if: needs.changes.outputs.frontend_code == 'true' && github.event_name != 'merge_group'

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -20,8 +20,7 @@ concurrency:
 
 permissions:
     contents: read
-    pull-requests: write
-    deployments: write
+    pull-requests: read
 
 jobs:
     # Determine if we should run based on changed files or preview label
@@ -95,6 +94,10 @@ jobs:
                       core.setOutput('label_removed', labelRemoved.toString());
 
     wait-for-docker-image:
+        permissions:
+            contents: read
+            pull-requests: write
+            deployments: write
         name: Wait for Docker image build
         needs: changes
         runs-on: ubuntu-24.04
@@ -330,6 +333,10 @@ jobs:
                       });
 
     hobby-test:
+        permissions:
+            contents: read
+            pull-requests: write
+            deployments: write
         runs-on: ubuntu-24.04
         timeout-minutes: 90
         name: Setup DO Hobby Instance and test
@@ -348,6 +355,7 @@ jobs:
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
               with:
                   version: '0.11.14' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: false
             - name: Set environment variables from previous job
               run: |
                   echo "PREVIEW_MODE=${{ github.event_name == 'pull_request' && needs.wait-for-docker-image.outputs.preview-mode || 'false' }}" >> $GITHUB_ENV

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -16,6 +16,10 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+    contents: read
+    pull-requests: read
+
 jobs:
     # Job to decide if we should run backend ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details

--- a/.github/workflows/ci-lint-workflows.yml
+++ b/.github/workflows/ci-lint-workflows.yml
@@ -5,6 +5,7 @@ on:
         paths:
             - .github/workflows/**
             - .github/actions/**
+            - .github/zizmor.yml
             - services/**
             - tools/hogli-commands/hogli_commands/workflow_lint/**
             - hogli.yaml
@@ -41,3 +42,12 @@ jobs:
 
             - name: Lint workflows
               run: ./bin/hogli lint:workflows
+
+            # Security audit of workflows and composite actions. Offline mode skips
+            # the audits that need the GitHub API (ref/tag drift, known-vulnerable
+            # actions) to stay off the shared per-repo rate-limit bucket; run those
+            # locally per the header comment in .github/zizmor.yml.
+            - name: Run zizmor
+              env:
+                  ZIZMOR_OFFLINE: 'true'
+              run: uvx zizmor==1.26.1 --config .github/zizmor.yml --min-severity low --no-progress --format github .github/

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -11,7 +11,7 @@ concurrency:
 
 permissions:
     contents: read
-    pull-requests: write
+    pull-requests: read
 
 jobs:
     changes:
@@ -49,6 +49,9 @@ jobs:
                         - '.github/workflows/ci-mcp-ui-apps.yml'
 
     build-and-report:
+        permissions:
+            contents: read
+            pull-requests: write
         name: Build and validate UI Apps
         runs-on: ubuntu-latest
         timeout-minutes: 10

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -545,7 +545,7 @@ jobs:
                   python -m granian --interface asgi posthog.asgi:application --host 0.0.0.0 --port 8000 --workers 1 &> /tmp/server.log &
 
             - name: Wait for PostHog to be ready
-              uses: iFaxity/wait-on-action@1fe019e0475491e9e8c4f421b6914ccc3ed8f99c # v1.2.1
+              uses: iFaxity/wait-on-action@1fe019e0475491e9e8c4f421b6914ccc3ed8f99c # untagged: post-v1.2.1 with dependency security bumps
               with:
                   resource: http://localhost:8000
                   timeout: 180000

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -21,6 +21,11 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+    contents: read
+    pull-requests: read
+    actions: read
+
 jobs:
     # Job to decide if we should run nodejs services ci
     # See https://github.com/dorny/paths-filter#conditional-execution for more details

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -402,7 +402,7 @@ jobs:
                   cd ../ && ./bin/download-mmdb
 
             - name: Install cargo-binstall
-              uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # main
+              uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # v1.12.5
 
             - name: Install cargo-nextest
               # --force: Swatinem/rust-cache restores ~/.cargo/.crates2.json but not the
@@ -410,7 +410,8 @@ jobs:
               # installed") and leave no `cargo nextest` binary.
               run: cargo binstall --no-confirm --force cargo-nextest@0.9.140
 
-            - name: Run cargo test
+            # matrix.packages is computed from repo code, not untrusted input
+            - name: Run cargo test # zizmor: ignore[template-injection]
               env:
                   RUST_BACKTRACE: 1
                   # Set up dual database environment for feature-flags service
@@ -540,7 +541,7 @@ jobs:
               run: cargo check --all-features
 
             - name: Install cargo-binstall
-              uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # main
+              uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # v1.12.5
 
             - name: Install cargo-shear
               # --force is required: Swatinem/rust-cache restores ~/.cargo/.crates2.json

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -449,7 +449,8 @@ jobs:
               run: find frontend/__snapshots__ -name '*.png' -delete 2>/dev/null || true
 
             # Capture-only: VR is the gate for visual changes, jest just captures screenshots
-            - name: Run @storybook/test-runner
+            # matrix/needs values are workflow-defined, not untrusted input
+            - name: Run @storybook/test-runner # zizmor: ignore[template-injection]
               id: test-runner
               shell: bash
               env:
@@ -917,7 +918,7 @@ jobs:
                   fetch-depth: 1
                   persist-credentials: false
             - name: Download JUnit artifacts
-              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
+              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
               continue-on-error: true
               with:
                   path: ./junit-artifacts

--- a/.github/workflows/ci-survey-sdk-check.yml
+++ b/.github/workflows/ci-survey-sdk-check.yml
@@ -13,10 +13,12 @@ concurrency:
 
 permissions:
     contents: read
-    pull-requests: write
 
 jobs:
     check-sdk-requirements:
+        permissions:
+            contents: read
+            pull-requests: write
         name: Check for SDK version requirements
         runs-on: ubuntu-24.04
         timeout-minutes: 5

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -18,6 +18,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: depot-ubuntu-latest

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -32,11 +32,12 @@ on:
                 type: number
                 default: 7
 
-permissions:
-    deployments: write
+permissions: {}
 
 jobs:
     cleanup-hobby-preview:
+        permissions:
+            deployments: write
         name: Cleanup hobby preview droplets
         runs-on: ubuntu-24.04
         timeout-minutes: 5

--- a/.github/workflows/publish-hogli.yml
+++ b/.github/workflows/publish-hogli.yml
@@ -38,6 +38,7 @@ jobs:
             - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.14'
+                  enable-cache: false
 
             - name: Verify tag matches package version
               shell: bash

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -33,6 +33,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+    contents: read
+
 jobs:
     affected:
         name: compute affected images

--- a/.github/workflows/terragrunt-posthog.yaml
+++ b/.github/workflows/terragrunt-posthog.yaml
@@ -1,9 +1,7 @@
 name: Terragrunt PostHog
 
 permissions:
-    id-token: write
     contents: read
-    pull-requests: write
 
 on:
     pull_request:
@@ -23,6 +21,9 @@ concurrency:
 
 jobs:
     setup:
+        permissions:
+            contents: read
+            pull-requests: write
         runs-on: ubuntu-22.04
         timeout-minutes: 15
         outputs:
@@ -69,6 +70,10 @@ jobs:
                   issue: '${{ github.event.number }}'
 
     terragrunt:
+        permissions:
+            contents: read
+            id-token: write
+            pull-requests: write
         if: needs.setup.outputs.matrix_data != '[]'
         needs: [setup]
         name: ${{ matrix.service_name }}
@@ -99,7 +104,7 @@ jobs:
 
             - name: Plan Terraform ${{ matrix.working_dir }}
               if: github.ref != 'refs/heads/master'
-              uses: PostHog/terragrunt-action@8ca7875a6786a8eb884dd53d7c360f0aa5947bfb # v4.3.1
+              uses: PostHog/terragrunt-action@8ca7875a6786a8eb884dd53d7c360f0aa5947bfb # fork master: v4.3.1 plus pinned internal refs
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -120,7 +125,7 @@ jobs:
 
             - name: Apply Terraform ${{ matrix.working_dir }}
               if: github.ref == 'refs/heads/master'
-              uses: PostHog/terragrunt-action@8ca7875a6786a8eb884dd53d7c360f0aa5947bfb # v4.3.1
+              uses: PostHog/terragrunt-action@8ca7875a6786a8eb884dd53d7c360f0aa5947bfb # fork master: v4.3.1 plus pinned internal refs
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,50 @@
+# zizmor - GitHub Actions security auditor: https://docs.zizmor.sh
+# CI runs it in ci-lint-workflows.yml (offline, --min-severity low).
+# Full run with online audits (ref/tag drift, known-vulnerable actions):
+#   uvx zizmor --gh-token "$(gh auth token)" .github/
+
+rules:
+    artipacked:
+        # `persist-credentials: false` hardening across ~200 checkout steps.
+        # Some workflows push with the persisted credentials, so this needs a
+        # per-workflow burn-down rather than a mass fix.
+        disable: true
+
+    github-app:
+        # `permission-*` scoping on every create-github-app-token call (~84 sites).
+        # Requires auditing each app's installed permissions first; separate burn-down.
+        disable: true
+
+    dangerous-triggers:
+        # Deliberately hardened usages: each one only runs code checked out from
+        # master and passes untrusted PR fields via env, never interpolation. See
+        # the security comments in each workflow before changing them.
+        ignore:
+            - auto-assign-labels.yml
+            - auto-assign-reviewers.yml
+            - pr-posthog-js-reviewer.yml
+            - ci-alerts-devex.yml
+
+    excessive-permissions:
+        # Every job in this workflow posts reviews or comments, so the
+        # workflow-level write grant is genuinely workflow-wide.
+        ignore:
+            - pr-approval-agent.yml
+
+    # release.yml and release-cli.yml are derived from cargo-dist's generated
+    # workflow; the flagged expansions and images come from the dist plan JSON,
+    # which is repo-controlled.
+    template-injection:
+        ignore:
+            - release.yml
+            - release-cli.yml
+    unpinned-images:
+        ignore:
+            - release.yml
+            - release-cli.yml
+    adhoc-packages:
+        # Exact-version `npm install -g npm@x` upgrades needed for OIDC trusted
+        # publishing; release-cli.yml is cargo-dist derived (see above).
+        ignore:
+            - publish-quill-npm.yml
+            - release-cli.yml


### PR DESCRIPTION
## Problem

- We lint workflows with actionlint, pinact, and custom hogli checks, but nothing audits them for security issues: permission scope, cache poisoning in publish jobs, or pin/comment drift.
- A zizmor run surfaced real findings, including 13 action pins whose version comments don't match the pinned SHA.

## Changes

- Add [zizmor](https://docs.zizmor.sh) (pinned, offline) to the `Lint workflows` CI job, gating on findings of low severity and up.
- Add `.github/zizmor.yml`: `artipacked` (~200 checkouts) and `github-app` (~84 token mints) disabled as tracked follow-up burn-downs, plus justified ignores for the already-hardened `pull_request_target` workflows.
- Fix 13 pin comment drifts (e.g. maturin-action commented `v1.49.3` but pinned to `v1.49.1`, cargo-binstall commented `main` but is `v1.12.5`).
- Least-privilege permissions: add missing `permissions:` blocks to 6 workflows, demote workflow-level `pull-requests`/`deployments`/`id-token: write` into the jobs that need them in 8 more.
- Disable uv caches in PyPI publish jobs and the hobby droplet job (cache poisoning surface).

## How did you test this code?

- `zizmor` exits 0 both offline (CI mode) and online with a GH token.
- `actionlint`, `hogli lint:workflows`, and `hogli ci:preflight` all pass.
- Negative test: removing a `permissions:` block makes the gate fail as expected.
- Verified each pin drift against the GitHub API (tag -> commit SHA) before correcting the comment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). I asked whether we use zizmor and whether we should; Claude validated the findings against the GitHub API before proposing adoption, then did the burn-down.
- Key decisions: run offline in CI to stay off the shared API rate-limit bucket, block from day one since findings are fixed here, and defer the two noisy audits (`artipacked`, `github-app`) to follow-ups rather than mass-ignoring inline.
- Skill invoked: `/gating-production-deploys` (to avoid breaking CD gating while moving permissions).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
