### PR TITLE
feat(logs): mirror logs-ingestion prometheus metrics into the metrics product

### DIFF
--- a/nodejs/src/common/internal-metrics-exporter.test.ts
+++ b/nodejs/src/common/internal-metrics-exporter.test.ts
@@ -1,0 +1,199 @@
+import { Counter, Gauge, Histogram, Registry } from 'prom-client'
+
+import { parseJSON } from '~/common/utils/json-parse'
+
+import {
+    InternalMetricsExporter,
+    buildOtlpMetricsPayload,
+    internalMetricsConfigFromEnv,
+} from './internal-metrics-exporter'
+
+describe('internal-metrics-exporter', () => {
+    let registry: Registry
+
+    beforeEach(() => {
+        registry = new Registry()
+    })
+
+    describe('buildOtlpMetricsPayload', () => {
+        const build = async (): Promise<ReturnType<typeof buildOtlpMetricsPayload>> =>
+            buildOtlpMetricsPayload(await registry.getMetricsAsJSON(), {
+                serviceName: 'test-service',
+                startTimeMs: 1700000000000,
+                nowMs: 1700000060000,
+            })
+
+        it('converts counters to cumulative monotonic sums with label attributes', async () => {
+            const counter = new Counter({
+                name: 'orders_total',
+                help: 'orders',
+                labelNames: ['plan'],
+                registers: [registry],
+            })
+            counter.inc({ plan: 'free' }, 3)
+            counter.inc({ plan: 'pro' }, 5)
+
+            const payload = await build()
+            const metric = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0]
+            expect(metric.name).toBe('orders_total')
+            expect(metric.sum.aggregationTemporality).toBe(2)
+            expect(metric.sum.isMonotonic).toBe(true)
+            const points = metric.sum.dataPoints
+            expect(points).toHaveLength(2)
+            const byPlan = Object.fromEntries(
+                points.map((p: any) => [p.attributes.find((a: any) => a.key === 'plan').value.stringValue, p.asDouble])
+            )
+            expect(byPlan).toEqual({ free: 3, pro: 5 })
+            expect(points[0].startTimeUnixNano).toBe('1700000000000000000')
+            expect(points[0].timeUnixNano).toBe('1700000060000000000')
+        })
+
+        it('converts gauges to gauge data points', async () => {
+            const gauge = new Gauge({ name: 'queue_depth', help: 'depth', registers: [registry] })
+            gauge.set(17)
+
+            const payload = await build()
+            const metric = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0]
+            expect(metric.gauge.dataPoints[0].asDouble).toBe(17)
+        })
+
+        it('converts histograms: cumulative le buckets become per-bucket counts, +Inf becomes the overflow bucket', async () => {
+            const hist = new Histogram({
+                name: 'latency_ms',
+                help: 'latency',
+                buckets: [10, 50, 100],
+                registers: [registry],
+            })
+            hist.observe(5) // le=10
+            hist.observe(40) // le=50
+            hist.observe(45) // le=50
+            hist.observe(2000) // +Inf overflow
+
+            const payload = await build()
+            const metric = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0]
+            const dp = metric.histogram.dataPoints[0]
+            expect(metric.histogram.aggregationTemporality).toBe(2)
+            expect(dp.explicitBounds).toEqual([10, 50, 100])
+            expect(dp.bucketCounts).toEqual([1, 2, 0, 1])
+            expect(dp.count).toBe(4)
+            expect(dp.sum).toBeCloseTo(5 + 40 + 45 + 2000)
+        })
+
+        it('splits histogram label sets into separate data points', async () => {
+            const hist = new Histogram({
+                name: 'latency_ms',
+                help: 'latency',
+                labelNames: ['route'],
+                buckets: [10],
+                registers: [registry],
+            })
+            hist.observe({ route: '/a' }, 5)
+            hist.observe({ route: '/b' }, 20)
+
+            const payload = await build()
+            const dps = payload!.resourceMetrics[0].scopeMetrics[0].metrics[0].histogram.dataPoints
+            expect(dps).toHaveLength(2)
+            const byRoute = Object.fromEntries(
+                dps.map((p: any) => [
+                    p.attributes.find((a: any) => a.key === 'route').value.stringValue,
+                    p.bucketCounts,
+                ])
+            )
+            expect(byRoute).toEqual({ '/a': [1, 0], '/b': [0, 1] })
+        })
+
+        it('attaches service.name as a resource attribute and returns null when there are no metrics', async () => {
+            expect(await build()).toBeNull()
+
+            new Gauge({ name: 'g', help: 'g', registers: [registry] }).set(1)
+            const payload = await build()
+            expect(payload!.resourceMetrics[0].resource.attributes).toContainEqual({
+                key: 'service.name',
+                value: { stringValue: 'test-service' },
+            })
+        })
+    })
+
+    describe('InternalMetricsExporter', () => {
+        beforeEach(() => {
+            jest.useFakeTimers()
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        it('posts the registry as OTLP JSON on the configured interval', async () => {
+            const gauge = new Gauge({ name: 'depth', help: 'depth', registers: [registry] })
+            gauge.set(42)
+            const fetchMock = jest.fn().mockResolvedValue({ status: 200 })
+
+            const exporter = new InternalMetricsExporter(
+                { host: 'https://us.i.posthog.com', token: 'phc_test', intervalSeconds: 15, serviceName: 'svc' },
+                registry,
+                fetchMock as any
+            )
+            exporter.start()
+
+            await jest.advanceTimersByTimeAsync(15000)
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            const [url, init] = fetchMock.mock.calls[0]
+            expect(url).toBe('https://us.i.posthog.com/i/v1/metrics?token=phc_test')
+            expect(init.method).toBe('POST')
+            const body = parseJSON(init.body)
+            expect(body.resourceMetrics[0].scopeMetrics[0].metrics[0].name).toBe('depth')
+
+            await jest.advanceTimersByTimeAsync(15000)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+
+            exporter.stop()
+            await jest.advanceTimersByTimeAsync(60000)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('survives fetch failures and keeps exporting', async () => {
+            new Gauge({ name: 'depth', help: 'depth', registers: [registry] }).set(1)
+            const fetchMock = jest.fn().mockRejectedValue(new Error('offline'))
+
+            const exporter = new InternalMetricsExporter(
+                { host: 'https://us.i.posthog.com', token: 'phc_test', intervalSeconds: 15, serviceName: 'svc' },
+                registry,
+                fetchMock as any
+            )
+            exporter.start()
+            await jest.advanceTimersByTimeAsync(30000)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+            exporter.stop()
+        })
+    })
+
+    describe('internalMetricsConfigFromEnv', () => {
+        it('is disabled without a token and enabled with one', () => {
+            expect(internalMetricsConfigFromEnv({})).toBeNull()
+
+            const config = internalMetricsConfigFromEnv({
+                POSTHOG_INTERNAL_METRICS_TOKEN: 'phc_x',
+                POSTHOG_INTERNAL_METRICS_HOST: 'https://us.i.posthog.com',
+                POSTHOG_INTERNAL_METRICS_SERVICE_NAME: 'plugin-server',
+                POSTHOG_INTERNAL_METRICS_INTERVAL_SECONDS: '30',
+            })
+            expect(config).toEqual({
+                token: 'phc_x',
+                host: 'https://us.i.posthog.com',
+                serviceName: 'plugin-server',
+                intervalSeconds: 30,
+            })
+        })
+
+        it('uses the caller default service name only when the env var is unset', () => {
+            const env = { POSTHOG_INTERNAL_METRICS_TOKEN: 'phc_x' }
+            expect(internalMetricsConfigFromEnv(env, 'logs-ingestion')?.serviceName).toBe('logs-ingestion')
+            expect(
+                internalMetricsConfigFromEnv(
+                    { ...env, POSTHOG_INTERNAL_METRICS_SERVICE_NAME: 'override' },
+                    'logs-ingestion'
+                )?.serviceName
+            ).toBe('override')
+        })
+    })
+})

--- a/nodejs/src/common/internal-metrics-exporter.ts
+++ b/nodejs/src/common/internal-metrics-exporter.ts
@@ -1,0 +1,294 @@
+import { Registry, register as globalRegistry } from 'prom-client'
+
+import { logger } from '~/common/utils/logger'
+import { FetchResponse, internalFetch } from '~/common/utils/request'
+
+/**
+ * Exports this process's prom-client metrics into the PostHog Metrics product
+ * (dogfooding): every interval, the registry is snapshotted, converted to an
+ * OTLP/JSON `ExportMetricsServiceRequest`, and POSTed to `/i/v1/metrics`. The
+ * Prometheus scrape endpoint keeps working untouched — this is an additive sink,
+ * off unless `POSTHOG_INTERNAL_METRICS_TOKEN` is set, with a real per-service `service.name`.
+ *
+ * Prometheus counters/histograms are cumulative, so data points are exported
+ * with cumulative temporality and a fixed process-start `startTimeUnixNano` —
+ * the metrics read path diffs cumulative series with counter-reset handling.
+ */
+
+export interface InternalMetricsConfig {
+    host: string
+    token: string
+    serviceName: string
+    intervalSeconds: number
+}
+
+interface OtlpKeyValue {
+    key: string
+    value: { stringValue: string }
+}
+
+interface OtlpNumberDataPoint {
+    attributes: OtlpKeyValue[]
+    startTimeUnixNano: string
+    timeUnixNano: string
+    asDouble: number
+}
+
+interface OtlpHistogramDataPoint {
+    attributes: OtlpKeyValue[]
+    startTimeUnixNano: string
+    timeUnixNano: string
+    count: number
+    sum: number
+    bucketCounts: number[]
+    explicitBounds: number[]
+}
+
+interface OtlpMetric {
+    name: string
+    sum?: { aggregationTemporality: number; isMonotonic: boolean; dataPoints: OtlpNumberDataPoint[] }
+    gauge?: { dataPoints: OtlpNumberDataPoint[] }
+    histogram?: { aggregationTemporality: number; dataPoints: OtlpHistogramDataPoint[] }
+}
+
+interface OtlpMetricsPayload {
+    resourceMetrics: Array<{
+        resource: { attributes: OtlpKeyValue[] }
+        scopeMetrics: Array<{ scope: { name: string }; metrics: OtlpMetric[] }>
+    }>
+}
+
+const OTLP_TEMPORALITY_CUMULATIVE = 2
+
+// Shape of `registry.getMetricsAsJSON()` entries — declared locally because
+// prom-client doesn't export its MetricObjectWithValues internals.
+interface PromMetric {
+    name: string
+    type: string
+    values: Array<{ value: number; labels: Record<string, string | number>; metricName?: string }>
+}
+
+function msToUnixNano(ms: number): string {
+    return String(ms) + '000000'
+}
+
+function toAttributes(labels: Record<string, string | number>): OtlpKeyValue[] {
+    return Object.entries(labels).map(([key, value]) => ({ key, value: { stringValue: String(value) } }))
+}
+
+function labelsKey(labels: Record<string, string | number>): string {
+    return JSON.stringify(Object.entries(labels).sort(([a], [b]) => (a < b ? -1 : 1)))
+}
+
+function convertHistogram(metric: PromMetric, startNano: string, nowNano: string): OtlpHistogramDataPoint[] {
+    // prom-client emits one entry per (label set, le) bucket with CUMULATIVE
+    // counts, plus `<name>_sum` and `<name>_count` entries per label set.
+    // Group by the label set without `le`, then de-cumulate the buckets.
+    interface SeriesAccumulator {
+        labels: Record<string, string | number>
+        buckets: Array<{ le: number; cumulative: number }>
+        sum: number
+        count: number
+    }
+    const series = new Map<string, SeriesAccumulator>()
+
+    for (const entry of metric.values) {
+        const { le, ...rest } = entry.labels as Record<string, string | number> & { le?: string | number }
+        const key = labelsKey(rest)
+        let acc = series.get(key)
+        if (!acc) {
+            acc = { labels: rest, buckets: [], sum: 0, count: 0 }
+            series.set(key, acc)
+        }
+        if (entry.metricName?.endsWith('_sum')) {
+            acc.sum = entry.value
+        } else if (entry.metricName?.endsWith('_count')) {
+            acc.count = entry.value
+        } else if (le !== undefined) {
+            acc.buckets.push({ le: le === '+Inf' ? Infinity : Number(le), cumulative: entry.value })
+        }
+    }
+
+    const dataPoints: OtlpHistogramDataPoint[] = []
+    for (const acc of series.values()) {
+        acc.buckets.sort((a, b) => a.le - b.le)
+        const explicitBounds = acc.buckets.filter((b) => Number.isFinite(b.le)).map((b) => b.le)
+        const bucketCounts: number[] = []
+        let previous = 0
+        for (const bucket of acc.buckets) {
+            bucketCounts.push(bucket.cumulative - previous)
+            previous = bucket.cumulative
+        }
+        dataPoints.push({
+            attributes: toAttributes(acc.labels),
+            startTimeUnixNano: startNano,
+            timeUnixNano: nowNano,
+            count: acc.count,
+            sum: acc.sum,
+            bucketCounts,
+            explicitBounds,
+        })
+    }
+    return dataPoints
+}
+
+export function buildOtlpMetricsPayload(
+    promMetrics: PromMetric[],
+    options: { serviceName: string; startTimeMs: number; nowMs: number }
+): OtlpMetricsPayload | null {
+    const startNano = msToUnixNano(options.startTimeMs)
+    const nowNano = msToUnixNano(options.nowMs)
+    const metrics: OtlpMetric[] = []
+
+    for (const metric of promMetrics) {
+        if (metric.values.length === 0) {
+            continue
+        }
+        if (metric.type === 'counter') {
+            metrics.push({
+                name: metric.name,
+                sum: {
+                    aggregationTemporality: OTLP_TEMPORALITY_CUMULATIVE,
+                    isMonotonic: true,
+                    dataPoints: metric.values.map((v) => ({
+                        attributes: toAttributes(v.labels),
+                        startTimeUnixNano: startNano,
+                        timeUnixNano: nowNano,
+                        asDouble: v.value,
+                    })),
+                },
+            })
+        } else if (metric.type === 'gauge') {
+            metrics.push({
+                name: metric.name,
+                gauge: {
+                    dataPoints: metric.values.map((v) => ({
+                        attributes: toAttributes(v.labels),
+                        startTimeUnixNano: startNano,
+                        timeUnixNano: nowNano,
+                        asDouble: v.value,
+                    })),
+                },
+            })
+        } else if (metric.type === 'histogram') {
+            const dataPoints = convertHistogram(metric, startNano, nowNano)
+            if (dataPoints.length > 0) {
+                metrics.push({
+                    name: metric.name,
+                    histogram: { aggregationTemporality: OTLP_TEMPORALITY_CUMULATIVE, dataPoints },
+                })
+            }
+        }
+        // Summaries are skipped: prom-client summaries are rare here and the
+        // quantile representation doesn't round-trip losslessly.
+    }
+
+    if (metrics.length === 0) {
+        return null
+    }
+
+    return {
+        resourceMetrics: [
+            {
+                resource: {
+                    attributes: toAttributes({ 'service.name': options.serviceName }),
+                },
+                scopeMetrics: [{ scope: { name: 'posthog-nodejs-internal-metrics' }, metrics }],
+            },
+        ],
+    }
+}
+
+export function internalMetricsConfigFromEnv(
+    env: Record<string, string | undefined>,
+    defaultServiceName: string = 'posthog-nodejs'
+): InternalMetricsConfig | null {
+    const token = env.POSTHOG_INTERNAL_METRICS_TOKEN
+    if (!token) {
+        return null
+    }
+    return {
+        token,
+        host: env.POSTHOG_INTERNAL_METRICS_HOST || 'https://us.i.posthog.com',
+        serviceName: env.POSTHOG_INTERNAL_METRICS_SERVICE_NAME || defaultServiceName,
+        intervalSeconds: Number(env.POSTHOG_INTERNAL_METRICS_INTERVAL_SECONDS) || 15,
+    }
+}
+
+export class InternalMetricsExporter {
+    private timer?: NodeJS.Timeout
+    private readonly startTimeMs = Date.now()
+
+    constructor(
+        private readonly config: InternalMetricsConfig,
+        private readonly registry: Registry = globalRegistry,
+        private readonly fetchImpl: (
+            url: string,
+            options: { method: string; headers: Record<string, string>; body: string }
+        ) => Promise<Pick<FetchResponse, 'status'>> = internalFetch
+    ) {}
+
+    start(): void {
+        if (this.timer) {
+            return
+        }
+        this.timer = setInterval(() => void this.exportOnce(), this.config.intervalSeconds * 1000)
+        this.timer.unref?.()
+        const { token: _token, ...safeConfig } = this.config
+        logger.info('📈', 'Internal metrics exporter started', safeConfig)
+    }
+
+    stop(): void {
+        if (this.timer) {
+            clearInterval(this.timer)
+            this.timer = undefined
+        }
+    }
+
+    private async exportOnce(): Promise<void> {
+        try {
+            const promMetrics = (await this.registry.getMetricsAsJSON()) as unknown as PromMetric[]
+            const payload = buildOtlpMetricsPayload(promMetrics, {
+                serviceName: this.config.serviceName,
+                startTimeMs: this.startTimeMs,
+                nowMs: Date.now(),
+            })
+            if (!payload) {
+                return
+            }
+            const url = `${this.config.host}/i/v1/metrics?token=${encodeURIComponent(this.config.token)}`
+            const response = await this.fetchImpl(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            })
+            if (response.status < 200 || response.status >= 300) {
+                logger.warn('📈', 'Internal metrics export failed', { status: response.status })
+            }
+        } catch (error) {
+            // Metrics export must never take a service down with it.
+            logger.warn('📈', 'Internal metrics export errored', { error })
+        }
+    }
+}
+
+let exporter: InternalMetricsExporter | undefined
+
+/** Starts the exporter once per process if `POSTHOG_INTERNAL_METRICS_TOKEN` is set. */
+export function startInternalMetricsExporterFromEnv(defaultServiceName?: string): void {
+    if (exporter) {
+        return
+    }
+    const config = internalMetricsConfigFromEnv(process.env, defaultServiceName)
+    if (!config) {
+        return
+    }
+    exporter = new InternalMetricsExporter(config)
+    exporter.start()
+}
+
+/** Stops and clears the process-wide exporter (server shutdown). */
+export function stopInternalMetricsExporter(): void {
+    exporter?.stop()
+    exporter = undefined
+}

--- a/nodejs/src/servers/ingestion-logs-server.ts
+++ b/nodejs/src/servers/ingestion-logs-server.ts
@@ -1,5 +1,6 @@
 import { defaultConfig, overrideConfigWithEnv } from '~/common/config/config'
 import { createPosthogRedisConnectionConfig } from '~/common/config/redis-pools'
+import { startInternalMetricsExporterFromEnv, stopInternalMetricsExporter } from '~/common/internal-metrics-exporter'
 import { KafkaProducerRegistry } from '~/common/outputs/kafka-producer-registry'
 import { QuotaLimiting } from '~/common/services/quota-limiting.service'
 import { PostgresRouter } from '~/common/utils/db/postgres'
@@ -121,6 +122,10 @@ export class IngestionLogsServer implements NodeServer {
 
         const readyServices = await Promise.all(serviceLoaders.map((loader) => loader()))
         this.lifecycle.services.push(...readyServices)
+
+        // Dogfooding: also ship this process's prometheus metrics to the PostHog
+        // Metrics product. No-op unless POSTHOG_INTERNAL_METRICS_TOKEN is set.
+        startInternalMetricsExporterFromEnv('logs-ingestion')
     }
 
     private getCleanupResources(): CleanupResources {
@@ -129,6 +134,7 @@ export class IngestionLogsServer implements NodeServer {
             redisPools: [this.posthogRedisPool].filter(Boolean) as RedisPool[],
             postgres: this.postgres,
             additionalCleanup: async () => {
+                stopInternalMetricsExporter()
                 await this.producerRegistry?.disconnectAll()
             },
         }


### PR DESCRIPTION
## Problem

The logs pipeline should dogfood the Metrics product so we validate metrics ingest and querying with real production workloads. The Rust edge (capture-logs) already dual-ships its internal metrics (#68693, #68694, #68695), but the Node.js logs-ingestion consumer only exposes Prometheus for the infra scrape, and the scrape collector path loses the per-service `service.name`, so its metrics can't be usefully filtered in the Metrics UI.

## Changes

Adds an internal metrics exporter that mirrors the process's prom-client registry into the Metrics product, wired into the logs-ingestion server only:

- `nodejs/src/common/internal-metrics-exporter.ts`: on an interval (default 15s), snapshots the prom-client global registry, converts counters, gauges, and histograms to an OTLP/JSON `ExportMetricsServiceRequest` (cumulative temporality with a fixed process-start time, so counter `rate()`/`increase()` work on the read path), and POSTs it to `/i/v1/metrics`. Prometheus histograms' cumulative `le` buckets are de-cumulated into OTLP per-bucket counts with `+Inf` as the overflow bucket.
- `nodejs/src/servers/ingestion-logs-server.ts`: starts the exporter with default `service.name` `logs-ingestion` and stops it on shutdown.

The Prometheus scrape endpoint is untouched, so VictoriaMetrics keeps receiving everything it does today. The exporter is a no-op unless `POSTHOG_INTERNAL_METRICS_TOKEN` is set (plus optional `POSTHOG_INTERNAL_METRICS_HOST`, `POSTHOG_INTERNAL_METRICS_SERVICE_NAME`, `POSTHOG_INTERNAL_METRICS_INTERVAL_SECONDS`), so rollout is a per-deployment env change in charts. Export failures are logged and never propagate, and the interval timer is unref'd so it can't hold the process open.

> [!NOTE]
> This is the Node.js leg of the logs-pipeline dogfooding series: capture-logs (Rust, open stack above), logs-ingestion (this PR), and the logs alerting Temporal worker (next PR).

## How did you test this code?

`jest src/common/internal-metrics-exporter.test.ts` (9 tests, all passing). The conversion tests catch regressions in histogram de-cumulation (cumulative le buckets to per-bucket counts, +Inf overflow), label-set splitting into separate data points, and counter/gauge temporality encoding, none covered by existing tests since this converter is new. The exporter tests use fake timers and a mocked fetch to lock in the interval loop, the failure-resilience path (an offline endpoint must not stop future exports), and the env gate defaulting. Also ran eslint and prettier on the changed files. I could not run the full nodejs typecheck locally (pre-existing unrelated `@posthog/replay-anonymizer` resolution failures in my env); CI covers it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal dogfooding only, no user-facing docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /writing-tests. The exporter module and its tests are restored from #69428 (closed), which mirrored the registry for every nodejs server mode via the common router; per the direction change there, this PR scopes the wiring to the logs-ingestion server only and parameterizes the default service name, so adoption stays per-service. Considered producing Kafka metric rows directly like capture-logs does, but POSTing OTLP to the public endpoint was chosen deliberately: it exercises the same ingest path customers use, which is the point of dogfooding.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*