### PR TITLE
fix(batch-import): assume migration iam role before customer's role

### DIFF
--- a/rust/batch-import-worker/src/config.rs
+++ b/rust/batch-import-worker/src/config.rs
@@ -94,7 +94,8 @@ pub struct Config {
     // Dedicated cross-account role for managed-migration S3 imports. Customer trust
     // policies reference this role's ARN (not the worker's own identity), so the worker
     // role-chains through it: ambient creds -> managed-migrations role -> customer role.
-    // When unset (local dev, self-hosted) customer roles are assumed directly.
+    // Required for IAM-role-auth jobs; when unset they fail with a contact-support error
+    // (the customer hop can never succeed without it). Key-auth jobs don't need it.
     #[envconfig(from = "MANAGED_MIGRATIONS_ROLE_ARN")]
     pub managed_migrations_role_arn: Option<String>,
 

--- a/rust/batch-import-worker/src/config.rs
+++ b/rust/batch-import-worker/src/config.rs
@@ -91,6 +91,13 @@ pub struct Config {
     #[envconfig(from = "CAPTURE_URL", default = "http://localhost:3307")]
     pub capture_url: String,
 
+    // Dedicated cross-account role for managed-migration S3 imports. Customer trust
+    // policies reference this role's ARN (not the worker's own identity), so the worker
+    // role-chains through it: ambient creds -> managed-migrations role -> customer role.
+    // When unset (local dev, self-hosted) customer roles are assumed directly.
+    #[envconfig(from = "MANAGED_MIGRATIONS_ROLE_ARN")]
+    pub managed_migrations_role_arn: Option<String>,
+
     // Dedicated root for temp files created during job processing. Swept on
     // every startup to reclaim space leaked by non-graceful pod terminations.
     #[envconfig(from = "STAGING_DIR", default = "/tmp/batch-import-worker")]

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -262,11 +262,19 @@ impl SourceConfig {
                 // may have been deleted, for example.
                 config.create_source(secrets, !is_restarting).await?,
             )),
-            SourceConfig::S3(config) => Ok(Box::new(config.create_source(secrets).await?)),
+            SourceConfig::S3(config) => Ok(Box::new(
+                config
+                    .create_source(
+                        secrets,
+                        context.config.managed_migrations_role_arn.as_deref(),
+                    )
+                    .await?,
+            )),
             SourceConfig::S3Gzip(config) => Ok(Box::new(
                 config
                     .create_gzip_source(
                         secrets,
+                        context.config.managed_migrations_role_arn.as_deref(),
                         staging_dir,
                         staging_max_bytes,
                         staging_backend,
@@ -509,6 +517,7 @@ impl S3SourceConfig {
         &self,
         role_arn: &str,
         external_id: &str,
+        managed_migrations_role_arn: Option<&str>,
     ) -> Result<aws_config::sts::AssumeRoleProvider, Error> {
         if self.endpoint_url.is_some() {
             return Err(Error::from(UserError::new(
@@ -516,14 +525,38 @@ impl S3SourceConfig {
             )));
         }
 
-        let provider = aws_config::sts::AssumeRoleProvider::builder(role_arn)
+        let mut builder = aws_config::sts::AssumeRoleProvider::builder(role_arn)
             .session_name("posthog-batch-import")
             .external_id(external_id)
             .region(Region::new(self.region.clone()))
             .session_length(Duration::from_secs(3600))
-            .policy(self.session_policy())
-            .build()
-            .await;
+            .policy(self.session_policy());
+
+        // Customer trust policies reference the dedicated managed-migrations role, not the
+        // worker's own identity, so chain through it: ambient creds -> managed-migrations
+        // role -> customer role.
+        if let Some(intermediate_arn) = managed_migrations_role_arn {
+            let intermediate = aws_config::sts::AssumeRoleProvider::builder(intermediate_arn)
+                .session_name("posthog-batch-import")
+                .region(Region::new(self.region.clone()))
+                .build()
+                .await;
+            // An unassumable intermediate role is a PostHog deployment problem, so fail with
+            // an internal error rather than the customer-facing trust-policy message below.
+            intermediate.provide_credentials().await.map_err(|e| {
+                Error::msg(format!(
+                    "Failed to assume managed-migrations role {intermediate_arn}: {e}"
+                ))
+            })?;
+            let chain_config = aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(self.region.clone()))
+                .credentials_provider(intermediate)
+                .load()
+                .await;
+            builder = builder.configure(&chain_config);
+        }
+
+        let provider = builder.build().await;
 
         // Fail fast so a misconfigured trust policy pauses the job with an actionable
         // message instead of surfacing as an opaque S3 error mid-import.
@@ -539,6 +572,7 @@ impl S3SourceConfig {
     async fn build_s3_config(
         &self,
         secrets: &JobSecrets,
+        managed_migrations_role_arn: Option<&str>,
     ) -> Result<aws_sdk_s3::config::Builder, Error> {
         let mut builder = aws_sdk_s3::config::Builder::new()
             .region(Region::new(self.region.clone()))
@@ -559,8 +593,10 @@ impl S3SourceConfig {
             S3Auth::Role {
                 role_arn,
                 external_id,
-            } => builder
-                .credentials_provider(self.assume_role_credentials(role_arn, external_id).await?),
+            } => builder.credentials_provider(
+                self.assume_role_credentials(role_arn, external_id, managed_migrations_role_arn)
+                    .await?,
+            ),
             S3Auth::Keys {
                 access_key_id_key,
                 secret_access_key_key,
@@ -588,13 +624,25 @@ impl S3SourceConfig {
         Ok(builder)
     }
 
-    async fn build_client(&self, secrets: &JobSecrets) -> Result<aws_sdk_s3::Client, Error> {
-        let builder = self.build_s3_config(secrets).await?;
+    async fn build_client(
+        &self,
+        secrets: &JobSecrets,
+        managed_migrations_role_arn: Option<&str>,
+    ) -> Result<aws_sdk_s3::Client, Error> {
+        let builder = self
+            .build_s3_config(secrets, managed_migrations_role_arn)
+            .await?;
         Ok(aws_sdk_s3::Client::from_conf(builder.build()))
     }
 
-    pub async fn create_source(&self, secrets: &JobSecrets) -> Result<S3Source, Error> {
-        let client = self.build_client(secrets).await?;
+    pub async fn create_source(
+        &self,
+        secrets: &JobSecrets,
+        managed_migrations_role_arn: Option<&str>,
+    ) -> Result<S3Source, Error> {
+        let client = self
+            .build_client(secrets, managed_migrations_role_arn)
+            .await?;
 
         Ok(S3Source::new(
             client,
@@ -606,12 +654,15 @@ impl S3SourceConfig {
     pub async fn create_gzip_source(
         &self,
         secrets: &JobSecrets,
+        managed_migrations_role_arn: Option<&str>,
         staging_dir: PathBuf,
         staging_max_bytes: u64,
         staging_backend: Option<Arc<dyn StagingBackend>>,
         staged_plaintext_max_bytes: u64,
     ) -> Result<GzipS3Source, Error> {
-        let client = self.build_client(secrets).await?;
+        let client = self
+            .build_client(secrets, managed_migrations_role_arn)
+            .await?;
 
         let remote_staging = staging_backend.map(|backend| RemoteStaging {
             backend,
@@ -1057,7 +1108,7 @@ mod tests {
             serde_json::json!({"endpoint_url": "https://acct123.r2.cloudflarestorage.com"}),
         );
         let err = config
-            .build_s3_config(&empty_secrets())
+            .build_s3_config(&empty_secrets(), None)
             .await
             .unwrap_err()
             .to_string();
@@ -1069,7 +1120,7 @@ mod tests {
         let mut config = role_auth_config(serde_json::json!({}));
         config.external_id = None;
         let err = config
-            .build_s3_config(&empty_secrets())
+            .build_s3_config(&empty_secrets(), None)
             .await
             .unwrap_err()
             .to_string();
@@ -1090,7 +1141,7 @@ mod tests {
         secrets.insert("ak".to_string(), Value::String("key-id".to_string()));
         secrets.insert("sk".to_string(), Value::String("key-secret".to_string()));
         let secrets = JobSecrets { secrets };
-        assert!(config.build_s3_config(&secrets).await.is_ok());
+        assert!(config.build_s3_config(&secrets, None).await.is_ok());
     }
 
     #[tokio::test]
@@ -1104,7 +1155,7 @@ mod tests {
         }"#;
         let config: S3SourceConfig = serde_json::from_str(json).unwrap();
         let err = config
-            .build_s3_config(&empty_secrets())
+            .build_s3_config(&empty_secrets(), None)
             .await
             .unwrap_err()
             .to_string();
@@ -1123,7 +1174,7 @@ mod tests {
         for patch in cases {
             let config = role_auth_config(patch.clone());
             let err = config
-                .build_s3_config(&empty_secrets())
+                .build_s3_config(&empty_secrets(), None)
                 .await
                 .unwrap_err()
                 .to_string();
@@ -1146,7 +1197,7 @@ mod tests {
         }"#;
         let config: S3SourceConfig = serde_json::from_str(json).unwrap();
         let err = config
-            .build_s3_config(&empty_secrets())
+            .build_s3_config(&empty_secrets(), None)
             .await
             .unwrap_err()
             .to_string();
@@ -1158,7 +1209,7 @@ mod tests {
         let json = r#"{"bucket": "b", "prefix": "p", "region": "us-east-1"}"#;
         let config: S3SourceConfig = serde_json::from_str(json).unwrap();
         let err = config
-            .build_s3_config(&empty_secrets())
+            .build_s3_config(&empty_secrets(), None)
             .await
             .unwrap_err()
             .to_string();

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -534,27 +534,43 @@ impl S3SourceConfig {
 
         // Customer trust policies reference the dedicated managed-migrations role, not the
         // worker's own identity, so chain through it: ambient creds -> managed-migrations
-        // role -> customer role.
-        if let Some(intermediate_arn) = managed_migrations_role_arn {
-            let intermediate = aws_config::sts::AssumeRoleProvider::builder(intermediate_arn)
-                .session_name("posthog-batch-import")
-                .region(Region::new(self.region.clone()))
-                .build()
-                .await;
-            // An unassumable intermediate role is a PostHog deployment problem, so fail with
-            // an internal error rather than the customer-facing trust-policy message below.
-            intermediate.provide_credentials().await.map_err(|e| {
-                Error::msg(format!(
-                    "Failed to assume managed-migrations role {intermediate_arn}: {e}"
+        // role -> customer role. Without that role configured the customer hop can never
+        // succeed, so fail the job up front rather than attempting a direct assume that
+        // would pause it with a message wrongly blaming the customer's trust policy.
+        let Some(intermediate_arn) = managed_migrations_role_arn else {
+            return Err(Error::from(UserError::new(
+                "The PostHog import service is missing its cross-account role configuration, \
+                 so it cannot use IAM role authentication. This is not a problem with your S3 \
+                 or IAM setup. Please contact PostHog support.",
+            )));
+        };
+
+        let intermediate = aws_config::sts::AssumeRoleProvider::builder(intermediate_arn)
+            .session_name("posthog-batch-import")
+            .region(Region::new(self.region.clone()))
+            .build()
+            .await;
+        // An unassumable intermediate role is a PostHog deployment problem, so surface the
+        // same contact-support message as the missing-ARN case above rather than the
+        // customer-facing trust-policy message below. The ARN and STS error stay in the
+        // inner error chain for logs and status_message.
+        intermediate.provide_credentials().await.map_err(|e| {
+            Error::from(e)
+                .context(format!(
+                    "Failed to assume managed-migrations role {intermediate_arn}"
                 ))
-            })?;
-            let chain_config = aws_config::defaults(BehaviorVersion::latest())
-                .region(Region::new(self.region.clone()))
-                .credentials_provider(intermediate)
-                .load()
-                .await;
-            builder = builder.configure(&chain_config);
-        }
+                .context(UserError::new(
+                    "PostHog's import service could not authenticate with its own cross-account \
+                     role, so it cannot use IAM role authentication. This is not a problem with \
+                     your S3 or IAM setup. Please contact PostHog support.",
+                ))
+        })?;
+        let chain_config = aws_config::defaults(BehaviorVersion::latest())
+            .region(Region::new(self.region.clone()))
+            .credentials_provider(intermediate)
+            .load()
+            .await;
+        builder = builder.configure(&chain_config);
 
         let provider = builder.build().await;
 
@@ -1113,6 +1129,17 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("IAM role authentication only works with AWS S3"));
+    }
+
+    #[tokio::test]
+    async fn test_build_s3_config_rejects_role_auth_without_managed_migrations_role() {
+        let config = role_auth_config(serde_json::json!({}));
+        let err = config
+            .build_s3_config(&empty_secrets(), None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("contact PostHog support"), "got: {err}");
     }
 
     #[tokio::test]

--- a/rust/batch-import-worker/tests/s3_gzip_minio_integration_test.rs
+++ b/rust/batch-import-worker/tests/s3_gzip_minio_integration_test.rs
@@ -108,7 +108,7 @@ async fn test_s3_gzip_minio_integration() {
 
     let _staging = tempfile::TempDir::new().expect("create staging dir");
     let source = s3_config
-        .create_gzip_source(&secrets, _staging.path().to_path_buf(), 0, None, 0)
+        .create_gzip_source(&secrets, None, _staging.path().to_path_buf(), 0, None, 0)
         .await
         .expect("create gzip source");
     source.prepare_for_job().await.expect("prepare for job");


### PR DESCRIPTION
## Problem

The IAM role provisioned for managed migrations used for cross-account auth will not be the ISRA for the batch import worker service. The batch import worker needs to assume the IAM role before it tries to assume the customer's role.

## Changes

- env var for configuring the managed migration IAM role ARN for a paritcular environment
- adds a step to assume the managed migration role in the role assumption flow
- if assuming the role of the configured IAM doesn't work or the IAM arn isn't configured, surface a user error that tells the user to contact support, as this is an us issue not a configuration issue.

## How did you test this code?

Added unit tests to cover the error logic

Will need to hook up django/frontend before i can fully test e2e

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
