### PR TITLE
feat: hide disabled eaf from ac settings list

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6735,9 +6735,9 @@ snapshots:
     scenes-app-settings-authentication-domains--one-unverified-domain--light:
         hash: v1.k794b7964.b1ae6dbc8feb673159fcc13f4a8fd5ee856c63ad1204e839a1b55ef70d109c81.W5sqRIJDHcdkKlYg4ghfwpbKS2FmlQKF_N-1C83h9Mg
     scenes-app-settings-environment--settings-environment-access-control--dark:
-        hash: v1.k794b7964.5bdb625b2aa06881aa45de062d90db4a79c1d5db3a98d19bd32732ca7bbf131d.c-3ldkVa3GNd3un6_Kz92eUf4lDgv_J9gRENX6TzpHI
+        hash: v1.k794b7964.84afcca498a07bd34d2ba2fc6c8906c831567ac76f0d5fcc6a041f87df0a9d98.mHktwkt-98SEYkZVBlvJ4hVz77VfQxAwrdzNx6bBE1A
     scenes-app-settings-environment--settings-environment-access-control--light:
-        hash: v1.k794b7964.5c5044164897f6364215a0895d4b5ad61512f876a7a8960e0e515ca096ff6331.6B9W_QyrpxTnrwOjIWXdpDxc-7JlvDA6KOMec3_sYbE
+        hash: v1.k794b7964.27d524965b859d455ad62bbaf86630247708d73d365539ce88ec63d3028620dc.YTYagSQOfdDbSKRVICZ8CaILwAFf_jcuryf8TnB0vEw
     scenes-app-settings-environment--settings-environment-autocapture--dark:
         hash: v1.k794b7964.2183cf0082a1556d6df553572df4ab3813c96288a8b9a80e669c005908230c3e.-ybX8d6KyxaSa-yJDVccZm2CkK8Fl8qLSbw9jGhSIx4
     scenes-app-settings-environment--settings-environment-autocapture--light:

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlTable.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControlTable.tsx
@@ -8,7 +8,7 @@ import { fullName } from 'lib/utils/strings'
 
 import { APIScopeObject } from '~/types'
 
-import { getEntryId, isMemberEntry, isRoleEntry } from './helpers'
+import { getAccessSummaryTags, getEntryId, isMemberEntry, isRoleEntry } from './helpers'
 import { AccessControlSettingsEntry, AccessControlsTab } from './types'
 
 const MAX_VISIBLE_RESOURCE_TAGS = 3
@@ -64,11 +64,12 @@ export interface AccessControlTableProps {
     entries: AccessControlSettingsEntry[]
     loading: boolean
     canEditAny: boolean
+    visibleResources: Set<APIScopeObject>
     onEdit: (entry: AccessControlSettingsEntry) => void
 }
 
 export function AccessControlTable(props: AccessControlTableProps): JSX.Element {
-    const columns = getColumns(props.activeTab, props.canEditAny, props.onEdit)
+    const columns = getColumns(props.activeTab, props.canEditAny, props.visibleResources, props.onEdit)
 
     return (
         <LemonTable
@@ -94,18 +95,14 @@ export function AccessControlTable(props: AccessControlTableProps): JSX.Element 
     )
 }
 
-function AccessSummary({ entry }: { entry: AccessControlSettingsEntry }): JSX.Element {
-    const tags: { resource: string; level: string }[] = []
-
-    if (entry.project.effective_access_level !== null) {
-        tags.push({ resource: 'project', level: entry.project.effective_access_level })
-    }
-
-    for (const [resource, resourceEntry] of Object.entries(entry.resources)) {
-        if (resourceEntry.effective_access_level !== null) {
-            tags.push({ resource, level: resourceEntry.effective_access_level })
-        }
-    }
+function AccessSummary({
+    entry,
+    visibleResources,
+}: {
+    entry: AccessControlSettingsEntry
+    visibleResources: Set<APIScopeObject>
+}): JSX.Element {
+    const tags = getAccessSummaryTags(entry, visibleResources)
 
     if (tags.length === 0) {
         return <span className="text-muted">No access configured</span>
@@ -137,6 +134,7 @@ function AccessSummary({ entry }: { entry: AccessControlSettingsEntry }): JSX.El
 function getColumns(
     activeTab: AccessControlsTab,
     canEditAny: boolean,
+    visibleResources: Set<APIScopeObject>,
     onEdit: (entry: AccessControlSettingsEntry) => void
 ): LemonTableColumns<AccessControlSettingsEntry> {
     const scopeColumns = getScopeColumnsForTab(activeTab)
@@ -147,7 +145,7 @@ function getColumns(
             title: 'Access',
             key: 'resource',
             render: function RenderResource(_: any, entry: AccessControlSettingsEntry) {
-                return <AccessSummary entry={entry} />
+                return <AccessSummary entry={entry} visibleResources={visibleResources} />
             },
         },
         {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/AccessControls.tsx
@@ -30,6 +30,7 @@ export function AccessControls({ projectId }: { projectId: string }): JSX.Elemen
         filteredMembers,
         canEdit,
         loading,
+        visibleResourceKeySet,
     } = useValues(logic)
 
     const { setActiveTab, setSearchText, setFilters, openRuleModal } = useActions(logic)
@@ -75,6 +76,7 @@ export function AccessControls({ projectId }: { projectId: string }): JSX.Elemen
                                 entries={activeTab === 'roles' ? filteredRoles : filteredMembers}
                                 loading={loading}
                                 canEditAny={canEdit}
+                                visibleResources={visibleResourceKeySet}
                                 onEdit={(entry) => openRuleModal({ scopeType, entry, projectId })}
                             />
                         </div>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
 
 import api from 'lib/api'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { captureAccessControlEvent, pluralizeResource } from 'lib/utils/accessControlUtils'
 import { toSentenceCase } from 'lib/utils/strings'
 import { membersLogic } from 'scenes/organization/membersLogic'
@@ -13,13 +14,14 @@ import {
     AccessControlDefaultsResponse,
     AccessControlLevel,
     AccessControlMembersResponse,
+    AccessControlResourceType,
     AccessControlRolesResponse,
     AvailableFeature,
     OrganizationMemberType,
 } from '~/types'
 
 import { accessControlLogic } from '../accessControlLogic'
-import { resourcesAccessControlLogic } from '../resourcesAccessControlLogic'
+import { isResourceRolledOut, resourcesAccessControlLogic } from '../resourcesAccessControlLogic'
 import { roleAccessControlLogic } from '../roleAccessControlLogic'
 import type { accessControlsLogicType } from './accessControlsLogicType'
 import {
@@ -51,7 +53,11 @@ function getEffectiveLevel(entry: AccessControlSettingsEntry, resourceKey: APISc
     return entry.resources[resourceKey]?.effective_access_level ?? null
 }
 
-function matchesFilters(entry: AccessControlSettingsEntry, filters: AccessControlFilters): boolean {
+function matchesFilters(
+    entry: AccessControlSettingsEntry,
+    filters: AccessControlFilters,
+    visibleResources: Set<APIScopeObject>
+): boolean {
     const hasResourceFilter = filters.resourceKeys.length > 0
     const hasLevelFilter = filters.ruleLevels.length > 0
 
@@ -68,7 +74,10 @@ function matchesFilters(entry: AccessControlSettingsEntry, filters: AccessContro
     }
 
     if (hasLevelFilter) {
-        const allKeys = ['project', ...Object.keys(entry.resources)] as APIScopeObject[]
+        const allKeys = [
+            'project',
+            ...Object.keys(entry.resources).filter((k) => visibleResources.has(k as APIScopeObject)),
+        ] as APIScopeObject[]
         return filters.ruleLevels.some((rl) => allKeys.some((k) => getEffectiveLevel(entry, k) === rl))
     }
 
@@ -115,6 +124,8 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
             ['roles'],
             resourcesAccessControlLogic,
             ['resources'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
     })),
 
@@ -208,13 +219,15 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
         ],
 
         resourceKeys: [
-            (s) => [s.defaults, s.resources],
-            (defaults, resources): { key: APIScopeObject; label: string }[] => {
+            (s) => [s.defaults, s.resources, s.featureFlags],
+            (defaults, resources, featureFlags): { key: APIScopeObject; label: string }[] => {
                 if (defaults) {
-                    return Object.keys(defaults.resource_access_levels).map((resource) => ({
-                        key: resource as APIScopeObject,
-                        label: toSentenceCase(pluralizeResource(resource as APIScopeObject)),
-                    }))
+                    return Object.keys(defaults.resource_access_levels)
+                        .filter((resource) => isResourceRolledOut(resource as AccessControlResourceType, featureFlags))
+                        .map((resource) => ({
+                            key: resource as APIScopeObject,
+                            label: toSentenceCase(pluralizeResource(resource as APIScopeObject)),
+                        }))
                 }
                 // Fallback to list of all resources while loading
                 return resources.map((resource) => ({
@@ -229,6 +242,11 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
             (resourceKeys): { key: APIScopeObject; label: string }[] => {
                 return [{ key: 'project' as APIScopeObject, label: 'Project' }, ...resourceKeys]
             },
+        ],
+
+        visibleResourceKeySet: [
+            (s) => [s.resourceKeys],
+            (resourceKeys): Set<APIScopeObject> => new Set(resourceKeys.map((r) => r.key)),
         ],
 
         ruleOptions: [
@@ -252,8 +270,8 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
         ],
 
         filteredRoles: [
-            (s) => [s.rolesData, s.searchText, s.filters, s.canUseRoles],
-            (rolesData, searchText, filters, canUseRoles): AccessControlRoleEntry[] => {
+            (s) => [s.rolesData, s.searchText, s.filters, s.canUseRoles, s.visibleResourceKeySet],
+            (rolesData, searchText, filters, canUseRoles, visibleResourceKeySet): AccessControlRoleEntry[] => {
                 if (!canUseRoles || !rolesData) {
                     return []
                 }
@@ -265,14 +283,14 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
                     if (search.length > 0 && !role.role_name.toLowerCase().includes(search)) {
                         return false
                     }
-                    return matchesFilters(role, filters)
+                    return matchesFilters(role, filters, visibleResourceKeySet)
                 })
             },
         ],
 
         filteredMembers: [
-            (s) => [s.membersData, s.searchText, s.filters],
-            (membersData, searchText, filters): AccessControlMemberEntry[] => {
+            (s) => [s.membersData, s.searchText, s.filters, s.visibleResourceKeySet],
+            (membersData, searchText, filters, visibleResourceKeySet): AccessControlMemberEntry[] => {
                 if (!membersData) {
                     return []
                 }
@@ -292,7 +310,7 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
                     ) {
                         return false
                     }
-                    return matchesFilters(member, filters)
+                    return matchesFilters(member, filters, visibleResourceKeySet)
                 })
             },
         ],

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/helpers.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/helpers.test.ts
@@ -1,0 +1,57 @@
+import { APIScopeObject, AccessControlLevel, EffectiveAccessControlEntry } from '~/types'
+
+import { getAccessSummaryTags } from './helpers'
+import { AccessControlRoleEntry } from './types'
+
+const makeEffectiveEntry = (
+    level: AccessControlLevel | null,
+    overrides?: Partial<EffectiveAccessControlEntry>
+): EffectiveAccessControlEntry => ({
+    access_level: level,
+    effective_access_level: level,
+    inherited_access_level: null,
+    inherited_access_level_reason: null,
+    minimum: AccessControlLevel.None,
+    maximum: AccessControlLevel.Manager,
+    ...overrides,
+})
+
+describe('helpers', () => {
+    describe('getAccessSummaryTags', () => {
+        const roleEntry: AccessControlRoleEntry = {
+            role_id: 'role-1',
+            role_name: 'Engineer',
+            project: makeEffectiveEntry(AccessControlLevel.Admin),
+            resources: {
+                dashboard: makeEffectiveEntry(AccessControlLevel.Editor),
+                tracing: makeEffectiveEntry(AccessControlLevel.Viewer),
+                insight: makeEffectiveEntry(null),
+            },
+        }
+
+        it('includes the project tag and visible resources with an effective access level', () => {
+            const visibleResources = new Set<APIScopeObject>(['dashboard', 'tracing', 'insight'])
+            expect(getAccessSummaryTags(roleEntry, visibleResources)).toEqual([
+                { resource: 'project', level: AccessControlLevel.Admin },
+                { resource: 'dashboard', level: AccessControlLevel.Editor },
+                { resource: 'tracing', level: AccessControlLevel.Viewer },
+            ])
+        })
+
+        it('omits a resource with an effective access level if its product is not rolled out', () => {
+            const visibleResources = new Set<APIScopeObject>(['dashboard'])
+            expect(getAccessSummaryTags(roleEntry, visibleResources)).toEqual([
+                { resource: 'project', level: AccessControlLevel.Admin },
+                { resource: 'dashboard', level: AccessControlLevel.Editor },
+            ])
+        })
+
+        it('omits the project tag when there is no effective project access', () => {
+            const entry = { ...roleEntry, project: makeEffectiveEntry(null) }
+            const visibleResources = new Set<APIScopeObject>(['dashboard'])
+            expect(getAccessSummaryTags(entry, visibleResources)).toEqual([
+                { resource: 'dashboard', level: AccessControlLevel.Editor },
+            ])
+        })
+    })
+})

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/helpers.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/helpers.ts
@@ -52,6 +52,32 @@ export function isMemberEntry(entry: AccessControlSettingsEntry): entry is Acces
     return 'organization_membership_id' in entry
 }
 
+export interface AccessSummaryTag {
+    resource: string
+    level: string
+}
+
+/** Builds the "Access" column tags for a role/member entry, excluding resources whose
+ * product isn't rolled out to the current user even if a stale access level exists for it. */
+export function getAccessSummaryTags(
+    entry: AccessControlSettingsEntry,
+    visibleResources: Set<APIScopeObject>
+): AccessSummaryTag[] {
+    const tags: AccessSummaryTag[] = []
+
+    if (entry.project.effective_access_level !== null) {
+        tags.push({ resource: 'project', level: entry.project.effective_access_level })
+    }
+
+    for (const [resource, resourceEntry] of Object.entries(entry.resources)) {
+        if (resourceEntry.effective_access_level !== null && visibleResources.has(resource as APIScopeObject)) {
+            tags.push({ resource, level: resourceEntry.effective_access_level })
+        }
+    }
+
+    return tags
+}
+
 export function getEntryId(entry: AccessControlSettingsEntry): string {
     if (isRoleEntry(entry)) {
         return entry.role_id

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.test.ts
@@ -1,0 +1,20 @@
+import { AccessControlResourceType } from '~/types'
+
+import { isResourceRolledOut, RESOURCE_ROLLOUT_FLAG_REQUIREMENTS } from './resourcesAccessControlLogic'
+
+describe('resourcesAccessControlLogic', () => {
+    describe('isResourceRolledOut', () => {
+        it('is always rolled out for resources with no rollout flag requirement', () => {
+            expect(isResourceRolledOut(AccessControlResourceType.Dashboard, {})).toBe(true)
+        })
+
+        it.each(Object.entries(RESOURCE_ROLLOUT_FLAG_REQUIREMENTS))(
+            'hides %s until its rollout flag is enabled',
+            (resource, flag) => {
+                expect(isResourceRolledOut(resource as AccessControlResourceType, {})).toBe(false)
+                expect(isResourceRolledOut(resource as AccessControlResourceType, { [flag]: false })).toBe(false)
+                expect(isResourceRolledOut(resource as AccessControlResourceType, { [flag]: true })).toBe(true)
+            }
+        )
+    })
+})

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.ts
@@ -4,7 +4,8 @@ import { loaders } from 'kea-loaders'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { captureAccessControlEvent } from 'lib/utils/accessControlUtils'
 import { membersLogic } from 'scenes/organization/membersLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -40,6 +41,23 @@ const RESOURCE_FEATURE_REQUIREMENTS: Partial<Record<AccessControlResourceType, A
     [AccessControlResourceType.ActivityLog]: AvailableFeature.AUDIT_LOGS,
 }
 
+// Resources whose underlying product is still gated behind a rollout feature flag - hide the row
+// until the user has that product rolled out or has opted in, matching the product's own nav gating.
+export const RESOURCE_ROLLOUT_FLAG_REQUIREMENTS: Partial<Record<AccessControlResourceType, string>> = {
+    [AccessControlResourceType.CustomerAnalytics]: FEATURE_FLAGS.CUSTOMER_ANALYTICS,
+    [AccessControlResourceType.Endpoint]: FEATURE_FLAGS.ENDPOINTS,
+    [AccessControlResourceType.RevenueAnalytics]: FEATURE_FLAGS.REVENUE_ANALYTICS,
+    [AccessControlResourceType.Tracing]: FEATURE_FLAGS.TRACING,
+}
+
+export function isResourceRolledOut(
+    resource: AccessControlResourceType,
+    featureFlags: Record<string, boolean | string | undefined>
+): boolean {
+    const requiredFlag = RESOURCE_ROLLOUT_FLAG_REQUIREMENTS[resource]
+    return !requiredFlag || !!featureFlags[requiredFlag]
+}
+
 export const resourcesAccessControlLogic = kea<resourcesAccessControlLogicType>([
     path(['scenes', 'accessControl', 'resourcesAccessControlLogic']),
     connect(() => ({
@@ -52,6 +70,8 @@ export const resourcesAccessControlLogic = kea<resourcesAccessControlLogicType>(
             ['sortedMembers'],
             userLogic,
             ['hasAvailableFeature'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
     })),
     actions({
@@ -288,11 +308,12 @@ export const resourcesAccessControlLogic = kea<resourcesAccessControlLogicType>(
         ],
 
         resources: [
-            (s) => [s.hasAvailableFeature],
-            (hasAvailableFeature): APIScopeObject[] => {
+            (s) => [s.hasAvailableFeature, s.featureFlags],
+            (hasAvailableFeature, featureFlags): APIScopeObject[] => {
                 const allResources = [
                     AccessControlResourceType.Action,
                     AccessControlResourceType.ActivityLog,
+                    AccessControlResourceType.CustomerAnalytics,
                     AccessControlResourceType.Dashboard,
                     AccessControlResourceType.EarlyAccessFeature,
                     AccessControlResourceType.Endpoint,
@@ -310,14 +331,16 @@ export const resourcesAccessControlLogic = kea<resourcesAccessControlLogicType>(
                     AccessControlResourceType.Survey,
                     AccessControlResourceType.WebAnalytics,
                     AccessControlResourceType.Workflow,
+                    AccessControlResourceType.Tracing,
                 ]
 
                 return allResources.filter((resource) => {
                     const requiredFeature = RESOURCE_FEATURE_REQUIREMENTS[resource]
-                    if (!requiredFeature) {
-                        return true
+                    if (requiredFeature && !hasAvailableFeature(requiredFeature)) {
+                        return false
                     }
-                    return hasAvailableFeature(requiredFeature)
+
+                    return isResourceRolledOut(resource, featureFlags)
                 })
             },
         ],


### PR DESCRIPTION
## Problem

Some users may not have access to a product, but have the option to configure access control rules for it. This will only get increasingly more confusing as we expand support to products which have not been released yet.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add logic to hide any products which have not been released yet by checking if the feature flag for the product is enabled. This is handled through a product -> feature flag map which will need to be updated whenever we add access control support for unreleased products in the future.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually + test

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
