### PR TITLE
fix(replay-vision): restore type: ignore on label accessor

### DIFF
--- a/products/replay_vision/backend/prompt_suggestions.py
+++ b/products/replay_vision/backend/prompt_suggestions.py
@@ -107,7 +107,7 @@ def _describe_reasoning(observation: ReplayObservation) -> str:
 
 def _label(observation: ReplayObservation) -> ReplayObservationLabel:
     """Typed accessor for the reverse one-to-one: guaranteed by the label__isnull=False filters here."""
-    return observation.label
+    return observation.label  # type: ignore[attr-defined]  # reverse 1:1 mypy can't resolve on a full-repo run
 
 
 def _example_line(observation: ReplayObservation) -> str:


### PR DESCRIPTION
## Problem

Master's `Python code quality` check is red for every open PR. mypy fails with:

```
products/replay_vision/backend/prompt_suggestions.py:110: error: "ReplayObservation" has no attribute "label"  [attr-defined]
```

`_label` reads the `label` reverse one-to-one on `ReplayObservation`. mypy's full-repo CI run (`mypy --cache-fine-grained .`) can't resolve that reverse relation, so the line has always needed a `# type: ignore[attr-defined]`. #65865 (an unrelated flags fix) removed it, most likely because it looked unused against a warm incremental cache where the relation did resolve. On a clean CI run it does not, so the error surfaced and took master down.

This is not caused by any one PR's diff. It reproduces on plain master and blocks unrelated PRs (e.g. #69396).

## Changes

Restore `# type: ignore[attr-defined]` on the accessor, with a short inline note on why it is needed so it is not dropped again.

```diff
-    return observation.label
+    return observation.label  # type: ignore[attr-defined]  # reverse 1:1 mypy can't resolve on a full-repo run
```

## How did you test this code?

`ruff check` and `ruff format --check` pass on the file. I (Claude, via PostHog Code) did not run the full-repo `mypy --cache-fine-grained .` locally (too slow for this environment); the fix restores the exact ignore that suppresses the reported `attr-defined` error, and the reverse relation (`ReplayObservationLabel.observation = OneToOneField(..., related_name="label")`) is real, so the accessor is correct at runtime. CI's Python code quality check on this PR is the confirming signal.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) found this while diagnosing red `Python code quality` checks on #69396. The failure was in a file that PR does not touch, so I traced it to master: `git log -S` showed #65865 removed the `# type: ignore[attr-defined]` from `prompt_suggestions.py:110`. Confirmed it reproduces on a clean full-repo mypy run (12,492 files) and is independent of any feature branch. Kim asked me to split the one-line fix into this standalone PR so master goes green for everyone rather than burying it in an unrelated feature PR. No skills were needed for a change this small.
