### PR TITLE
fix(web-analytics): stretch today/yesterday lazy precompute TTLs to 4h/6h

### DIFF
--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -118,9 +118,15 @@ _FILTERS_ELIGIBILITY_HASH_IGNORED_QUERY_FIELDS: frozenset[str] = frozenset(
 
 # Hourly UTC bucketing TTL schedule. Two jobs in one:
 #
-# 1. Freshness — today gets 2h (recomputing it more often buys nothing: the ~6h
-#    HogQL result cache already fronts these queries, so a cache hit never reads
-#    the precompute). Older windows get progressively longer TTLs.
+# 1. Freshness — today gets 4h and yesterday 6h. Both must comfortably outlast
+#    the eager warmer's hourly force-refresh cadence: a user read that finds the
+#    window stale pays a synchronous recompute before reading, so a TTL near the
+#    warmer period (yesterday was 1h) races it and hands users multi-second
+#    waits. Recomputing more often buys nothing anyway — the ~6h HogQL result
+#    cache already fronts these queries, so a cache hit never reads the
+#    precompute. Older windows get progressively longer TTLs. Today and
+#    yesterday must keep *distinct* TTLs or `split_ranges_by_ttl` fuses them
+#    into one 2-day job and every today-refresh recomputes yesterday too.
 # 2. Job sizing — `split_ranges_by_ttl` merges *consecutive days with the same
 #    TTL* into one job. Distinct per-week TTLs therefore force weekly job
 #    boundaries, so a 31-day warm splits into ≤7-day jobs instead of one ~24-day
@@ -128,8 +134,8 @@ _FILTERS_ELIGIBILITY_HASH_IGNORED_QUERY_FIELDS: frozenset[str] = frozenset(
 #    24-day merge is what drove the multi-hundred-million-row scans that OOM the
 #    insert on very high-traffic teams.
 LAZY_TTL_SECONDS: dict[str, int] = {
-    "0d": 2 * 60 * 60,  # today
-    "1d": 60 * 60,  # yesterday
+    "0d": 4 * 60 * 60,  # today
+    "1d": 6 * 60 * 60,  # yesterday
     "7d": 24 * 60 * 60,  # days 2–7   → one ~6d job
     "14d": 2 * 24 * 60 * 60,  # days 8–14  → one 7d job
     "21d": 4 * 24 * 60 * 60,  # days 15–21 → one 7d job

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -32,7 +32,7 @@ source of truth for freshness.
 
 Force-refresh is used deliberately. The DEFAULT execution mode gates on the
 HogQL query result cache (6h staleness), which is the wrong clock for a
-precompute warmer whose buckets expire on a much shorter TTL (2h for
+precompute warmer whose buckets expire on a much shorter TTL (4h for
 today's bucket) — it would skip tiles whose Redis result is still "fresh"
 while the precompute they feed has gone cold. Force-refresh always recomputes,
 so every tick re-enters the precompute path. Crucially it goes through `run()`

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -45,7 +45,7 @@ harmless; the user-facing replay warming is `cache_warming.py`'s job.
 Why this exists
 ---------------
 The lazy precompute path caches per-day buckets in `web_*_preaggregated`
-tables with a 2h TTL. For high-traffic teams the dashboard's main tiles
+tables with a 4h TTL on the today window. For high-traffic teams the dashboard's main tiles
 are requested constantly — there is no reason to compute them reactively.
 Running the same query set ahead of every reasonable visit keeps the
 cache perpetually warm, so user requests turn into pure reads.
@@ -312,9 +312,9 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
             # Self-check the warm actually did its job: the tile must resolve to a
             # precompute read, not fall through to raw. `preComputeStrategy == LAZY_PRECOMPUTE` is only
             # True when the read passed the lazy executor's TTL freshness filter
-            # (`created_at + TTL >= now`; per LAZY_TTL_SECONDS the TTL ranges from 2h for
+            # (`created_at + TTL >= now`; per LAZY_TTL_SECONDS the TTL ranges from 4h for
             # today's window up to 14d for the oldest windows), so True is a
-            # guarantee the precomputed value is well within the current 2h TTL. A tile
+            # guarantee the precomputed value is well within the current 4h TTL. A tile
             # that comes back `not True` warmed nothing useful — surface it loudly so a
             # stale/missing precompute or a non-precomputable breakdown can't hide.
             if getattr(response, "preComputeStrategy", None) != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE:
@@ -532,7 +532,7 @@ def web_analytics_eager_baseline_warming_job():
     # holds, delete this schedule + job. Left running (not `default_status`
     # STOPPED) so the stop is an explicit operational toggle, not a silent
     # code-deploy behavior change.
-    # Hourly. The lazy cache's 2h TTL absorbs a single missed cycle, so
+    # Hourly. The lazy cache's 4h today-TTL absorbs missed cycles, so
     # there's no need to align with shorter cadences. Offset by 5 min from
     # the top of the hour to avoid colliding with the existing
     # `web_analytics_cache_warming_schedule` (`0 * * * *`).


### PR DESCRIPTION
## Problem

The lazy precompute TTLs for the freshest windows were today = 2h, yesterday = 1h. Real user reads check `created_at + TTL >= now` and pay a synchronous recompute before reading when a window is stale. The hourly eager warmer force-refreshes on the same ~1h cadence as yesterday's TTL, so the two race: users landing in the stale gap eat a multi-second recompute instead of the ~300ms warm read. With default-on precompute reads about to expose more users to this path, the short TTLs turn a cadence hiccup (one slow warmer run, one skipped tick) directly into user-visible latency.

## Changes

- `LAZY_TTL_SECONDS`: today 2h → 4h, yesterday 1h → 6h. Generous on purpose — start wide, tighten later if freshness complaints appear. The ~6h HogQL result cache already fronts these queries, so shorter TTLs were buying no user-visible freshness anyway.
- Today and yesterday keep distinct TTLs deliberately: `split_ranges_by_ttl` merges consecutive days with the same TTL into one job, and fusing today+yesterday would make every today-refresh recompute yesterday too. Comment added recording both constraints.
- Updated the stale 2h-TTL references in the eager warmer dag's comments.

TTL is freshness metadata checked against the job table, not part of the insert AST, so this changes no job hashes and causes no cache rotation — existing jobs simply stay valid longer.

## How did you test this code?

Constant + comment change. Existing paths lazy precompute suite passes (44 passed / 9 pre-existing skips); no new tests — no behavioral branch changed, only the TTL values consumed by the existing freshness filter, which is already covered.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — internal freshness policy, documented inline.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up from production monitoring of the paths lazy precompute rollout: warm reads are now ~250–350ms, so the dominant remaining tail for real users is the synchronous stale-window recompute, and yesterday's 1h TTL racing the hourly warmer was the most likely trigger. The DRI chose 4h/6h explicitly to start generous and tighten on feedback.
