### PR TITLE
feat(surveys): show current response count next to completion limit

### DIFF
--- a/frontend/src/scenes/surveys/HostedSurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/HostedSurveyEdit.tsx
@@ -32,13 +32,14 @@ import { sanitizeSurveyAppearance, validateSurveyAppearance } from 'scenes/surve
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
-import { Survey, SurveyQuestion, SurveyQuestionType, SurveyType } from '~/types'
+import { Survey, SurveyEventName, SurveyQuestion, SurveyQuestionType, SurveyType } from '~/types'
 
 import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
 import { defaultSurveyFieldValues, NewSurvey, SurveyQuestionLabel } from './constants'
 import { CopySurveyLink } from './CopySurveyLink'
 import { HostedSurveyCanvas } from './hosted-canvas/HostedSurveyCanvas'
 import { HostedSurveySettingsPanel } from './hosted-canvas/HostedSurveySettingsPanel'
+import { SurveyResponsesLimitProgress } from './SurveyEdit'
 import { surveyLogic } from './surveyLogic'
 import { SurveyResponsesCollection } from './SurveyResponsesCollection'
 import { AddQuestionButton } from './wizard/AddQuestionButton'
@@ -400,8 +401,16 @@ function HostedSurveyEditorHeader({
 }
 
 export function HostedSurveyEdit({ id }: { id: string }): JSX.Element {
-    const { survey, selectedPageIndex, hasBranchingLogic, surveyErrors, surveyLoading, editingLanguage } =
-        useValues(surveyLogic)
+    const {
+        survey,
+        selectedPageIndex,
+        hasBranchingLogic,
+        surveyErrors,
+        surveyLoading,
+        editingLanguage,
+        processedSurveyStats,
+        surveyBaseStatsLoading,
+    } = useValues(surveyLogic)
     const {
         deleteBranchingLogic,
         editingSurvey,
@@ -683,6 +692,14 @@ export function HostedSurveyEdit({ id }: { id: string }): JSX.Element {
                                             responses
                                         </div>
                                     </LemonField.Pure>
+                                    <SurveyResponsesLimitProgress
+                                        survey={survey}
+                                        limit={survey.responses_limit ?? null}
+                                        responsesReceived={
+                                            processedSurveyStats?.[SurveyEventName.SENT]?.total_count ?? 0
+                                        }
+                                        loading={surveyBaseStatsLoading && !processedSurveyStats}
+                                    />
                                     <SurveyResponsesCollection />
                                 </div>
                             ),

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -30,6 +30,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LemonRadio, LemonRadioOption } from 'lib/lemon-ui/LemonRadio'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
@@ -57,6 +58,8 @@ import {
     PropertyFilterType,
     PropertyOperator,
     RatingSurveyQuestion,
+    Survey,
+    SurveyEventName,
     SurveyMatchType,
     SurveyQuestion,
     SurveyQuestionType,
@@ -65,7 +68,13 @@ import {
 } from '~/types'
 
 import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
-import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
+import {
+    NEW_SURVEY,
+    NewSurvey,
+    SURVEY_TYPE_LABEL_MAP,
+    SurveyMatchTypeLabels,
+    defaultSurveyFieldValues,
+} from './constants'
 import { COMMON_LANGUAGES, getBaseLanguage, getSurveyLanguageName } from './language'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { SurveyAppearancePreview } from './SurveyAppearancePreview'
@@ -76,8 +85,51 @@ import { DataCollectionType, SurveyEditSection, surveyLogic } from './surveyLogi
 import { surveysLogic } from './surveysLogic'
 import { canUseSurveyWizard } from './utils'
 
+export function SurveyResponsesLimitProgress({
+    survey,
+    limit,
+    responsesReceived,
+    loading,
+}: {
+    survey: Survey | NewSurvey
+    limit: number | null
+    responsesReceived: number
+    loading: boolean
+}): JSX.Element | null {
+    // Response counts are only meaningful for a saved survey that has started collecting responses.
+    if (survey.id === NEW_SURVEY.id || !survey.start_date) {
+        return null
+    }
+
+    if (loading) {
+        return <span className="text-secondary text-xs ml-1">Loading current responses…</span>
+    }
+
+    const hasLimit = typeof limit === 'number' && limit > 0
+    const percentage = hasLimit ? Math.min(100, Math.round((responsesReceived / limit) * 100)) : 0
+
+    return (
+        <div className="flex flex-col gap-1 max-w-100 ml-1">
+            <div className="text-secondary text-xs">
+                {hasLimit ? (
+                    <>
+                        <b>{responsesReceived.toLocaleString()}</b> of <b>{limit.toLocaleString()}</b> responses
+                        received so far ({percentage}%)
+                    </>
+                ) : (
+                    <>
+                        <b>{responsesReceived.toLocaleString()}</b> responses received so far
+                    </>
+                )}
+            </div>
+            {hasLimit && <LemonProgress percent={percentage} />}
+        </div>
+    )
+}
+
 function SurveyCompletionConditions(): JSX.Element {
-    const { survey, dataCollectionType, isAdaptiveLimitFFEnabled } = useValues(surveyLogic)
+    const { survey, dataCollectionType, isAdaptiveLimitFFEnabled, processedSurveyStats, surveyBaseStatsLoading } =
+        useValues(surveyLogic)
     const { setSurveyValue, resetSurveyResponseLimits, resetSurveyAdaptiveSampling, setDataCollectionType } =
         useActions(surveyLogic)
     const [visible, setVisible] = useState(false)
@@ -202,27 +254,35 @@ function SurveyCompletionConditions(): JSX.Element {
                 <LemonField name="responses_limit" className="ml-5">
                     {({ onChange, value }) => {
                         return (
-                            <div className="flex flex-row gap-2 items-center">
-                                Stop the survey once
-                                <LemonInput
-                                    type="number"
-                                    data-attr="survey-responses-limit-input"
-                                    size="small"
-                                    min={1}
-                                    value={value || NaN}
-                                    onChange={(newValue) => {
-                                        if (newValue && newValue > 0) {
-                                            onChange(newValue)
-                                        } else {
-                                            onChange(null)
-                                        }
-                                    }}
-                                    className="w-16"
-                                />{' '}
-                                responses are received.
-                                <Tooltip title="This is a rough guideline, not an absolute one, so the survey might receive slightly more responses than the limit specifies.">
-                                    <IconInfo />
-                                </Tooltip>
+                            <div className="flex flex-col gap-2">
+                                <div className="flex flex-row gap-2 items-center">
+                                    Stop the survey once
+                                    <LemonInput
+                                        type="number"
+                                        data-attr="survey-responses-limit-input"
+                                        size="small"
+                                        min={1}
+                                        value={value || NaN}
+                                        onChange={(newValue) => {
+                                            if (newValue && newValue > 0) {
+                                                onChange(newValue)
+                                            } else {
+                                                onChange(null)
+                                            }
+                                        }}
+                                        className="w-16"
+                                    />{' '}
+                                    responses are received.
+                                    <Tooltip title="This is a rough guideline, not an absolute one, so the survey might receive slightly more responses than the limit specifies.">
+                                        <IconInfo />
+                                    </Tooltip>
+                                </div>
+                                <SurveyResponsesLimitProgress
+                                    survey={survey}
+                                    limit={value}
+                                    responsesReceived={processedSurveyStats?.[SurveyEventName.SENT]?.total_count ?? 0}
+                                    loading={surveyBaseStatsLoading && !processedSurveyStats}
+                                />
                             </div>
                         )
                     }}


### PR DESCRIPTION
## Problem

The survey editor lets you stop a survey once it reaches a set number of completed responses, but it never shows how many responses the survey currently has. That makes it hard to tell how close a survey is to being cut off. This adds that count at a glance.

## Changes

Next to the "Stop the survey once N responses are received" option, the editor now shows how many responses have been received so far and a progress bar toward the limit. It's rendered for both the standard survey editor and the hosted survey editor, and only appears for saved surveys that have already started collecting responses (nothing shown while drafting a new survey). The count reuses the survey's existing "survey sent" stats already loaded by the editor.

## How did you test this code?

Automated: ran the frontend TypeScript check (`typescript:check`) against the changed scenes after regenerating the survey logic typegen — the new component and edits type-clean. Ran `format` (oxlint + oxfmt). I did not manually exercise the UI in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1783576411507989). The response count is derived from the editor's already-loaded `processedSurveyStats` (the `survey sent` total), so no new queries were added. A small `SurveyResponsesLimitProgress` component was factored out of `SurveyEdit` and reused in `HostedSurveyEdit` to keep the two editors consistent. It renders nothing for unsaved/not-yet-started surveys, where a count would be meaningless.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1783576411507989)*
