### PR TITLE
perf(hogql): fetch warehouse catalog narrowly in cache fingerprint

### DIFF
--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -1,127 +1,11 @@
-import contextlib
-from collections.abc import Iterator
-from contextvars import ContextVar
 from typing import TYPE_CHECKING, Optional
 
-from django.core.signals import request_finished, request_started
-from django.db.models.signals import post_delete, post_save
-from django.dispatch import receiver
-
-from celery.signals import task_postrun, task_prerun
 from pydantic import BaseModel
 
 from posthog.schema import DataWarehouseNode, FunnelsDataWarehouseNode, LifecycleDataWarehouseNode
 
 if TYPE_CHECKING:
     from posthog.models import Team
-
-# Scoped memoization for `_warehouse_and_view_names`. The cache fingerprint runs before any
-# cache lookup — on every run of every query, including cache hits — and a single request or
-# task can fingerprint many HogQL queries (e.g. a dashboard with N SQL tiles), each of which
-# would otherwise issue an identical catalog lookup. We cache the name sets keyed by team_id
-# for the lifetime of a scope and discard the cache when the scope closes.
-#
-# The ContextVar defaults to ``None`` which means "no scope active — do not cache". This is
-# critical: the catalog partitions the query cache key (a security boundary), so a
-# thread-lifetime cache could fingerprint against a stale catalog after tables changed.
-# Scopes are opened at HTTP request boundaries (`request_started` / `request_finished`) and
-# Celery task boundaries (`task_prerun` / `task_postrun`); callers outside those boundaries
-# (Temporal activities, management commands, scripts) simply pay the query cost.
-_warehouse_names_cache_var: ContextVar[Optional[dict[int, tuple[set[str], set[str]]]]] = ContextVar(
-    "queried_warehouse_names_cache", default=None
-)
-
-
-@contextlib.contextmanager
-def warehouse_names_cache_scope() -> Iterator[None]:
-    """Open a memoization scope for the warehouse catalog lookup backing
-    `queried_access_controlled_resources`.
-
-    Use this to bracket any non-HTTP, non-Celery code path that fingerprints several
-    queries for the same team (e.g. scripts or tests that want the per-request behavior
-    without going through the signal plumbing).
-    """
-    token = _warehouse_names_cache_var.set({})
-    try:
-        yield
-    finally:
-        _warehouse_names_cache_var.reset(token)
-
-
-@receiver(request_started)
-@receiver(task_prerun)
-def _open_warehouse_names_cache_scope(**_kwargs: object) -> None:
-    _warehouse_names_cache_var.set({})
-
-
-@receiver(request_finished)
-@receiver(task_postrun)
-def _close_warehouse_names_cache_scope(**_kwargs: object) -> None:
-    _warehouse_names_cache_var.set(None)
-
-
-# Lazy string senders keep the warehouse models off this module's import path (it is imported
-# by query_runner at module scope). Bulk writes (queryset.update / bulk_create) bypass these
-# signals, but the flows that bulk-write catalog rows run in Temporal, where no scope is active.
-@receiver(post_save, sender="warehouse_sources.DataWarehouseTable")
-@receiver(post_delete, sender="warehouse_sources.DataWarehouseTable")
-@receiver(post_save, sender="warehouse_sources.ExternalDataSource")
-@receiver(post_delete, sender="warehouse_sources.ExternalDataSource")
-@receiver(post_save, sender="data_modeling.DataWarehouseSavedQuery")
-@receiver(post_delete, sender="data_modeling.DataWarehouseSavedQuery")
-def _invalidate_warehouse_names_cache_on_change(**_kwargs: object) -> None:
-    # The cached names derive from table and view rows plus each table's source (the prefixed
-    # form), so any write to those invalidates the current scope's cache.
-    cache = _warehouse_names_cache_var.get()
-    if cache is not None:
-        cache.clear()
-
-
-def _warehouse_and_view_names(team: "Team") -> tuple[set[str], set[str]]:
-    """All queryable warehouse table names and saved-query (view) names for the team,
-    memoized per request/task scope keyed by team_id.
-
-    External tables are queryable under BOTH their raw name and the prefixed
-    source_type.prefix.table key (see database.py schema build), so both forms are included —
-    otherwise a denied user could read an allowed user's cached rows via the raw name.
-    """
-    # Deferred to break the query_runner -> this module -> hogql import cycle.
-    from posthog.hogql.database.database import get_data_warehouse_table_name  # noqa: PLC0415
-
-    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery  # noqa: PLC0415
-    from products.warehouse_sources.backend.facade.models import DataWarehouseTable  # noqa: PLC0415
-
-    cache = _warehouse_names_cache_var.get()
-    if cache is not None and (cached := cache.get(team.pk)) is not None:
-        return cached
-
-    warehouse_table_names: set[str] = set()
-    tables = (
-        DataWarehouseTable.objects.filter(team_id=team.pk)
-        .exclude(deleted=True)
-        .select_related("external_data_source")
-        # Exactly the fields get_data_warehouse_table_name reads (pks are always fetched).
-        # This runs on the hot path even on cache hits, so the wide `columns` schema JSON must
-        # stay in Postgres; a field missing here would silently defer-load per row instead.
-        .only(
-            "name",
-            "external_data_source__source_type",
-            "external_data_source__prefix",
-            "external_data_source__access_method",
-        )
-    )
-    for table in tables:
-        warehouse_table_names.add(table.name)
-        warehouse_table_names.add(get_data_warehouse_table_name(table.external_data_source, table.name))
-
-    view_names = set(
-        DataWarehouseSavedQuery.objects.filter(team_id=team.pk).exclude(deleted=True).values_list("name", flat=True)
-    )
-
-    result = (warehouse_table_names, view_names)
-    if cache is not None:
-        cache[team.pk] = result
-    return result
 
 
 def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str]]:
@@ -134,10 +18,14 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
     short-circuits the schema strip that would otherwise raise "You don't have access to table")."""
 
     # Deferred to break the query_runner -> this module -> hogql import cycle.
+    from posthog.hogql.database.database import get_data_warehouse_table_name  # noqa: PLC0415
     from posthog.hogql.database.schema.system import access_controlled_system_tables  # noqa: PLC0415
     from posthog.hogql.errors import BaseHogQLError  # noqa: PLC0415
     from posthog.hogql.metadata import get_table_names  # noqa: PLC0415
     from posthog.hogql.parser import parse_select  # noqa: PLC0415
+
+    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+    from products.warehouse_sources.backend.facade.models import DataWarehouseTable  # noqa: PLC0415
 
     # Raw HogQL is the only query that references system.* and warehouse tables by name
     if getattr(query, "kind", None) == "HogQLQuery":
@@ -159,10 +47,35 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
         # cache key by AnalyticsQueryRunner._get_object_access_restrictions.
         non_system_names = table_names - set(system_scopes)
         if non_system_names:
-            warehouse_table_names, view_names = _warehouse_and_view_names(team)
+            # External tables are queryable under BOTH their raw name and the prefixed
+            # source_type.prefix.table key (see database.py schema build), so match either form —
+            # otherwise a denied user could read an allowed user's cached rows via the raw name.
+            warehouse_table_names: set[str] = set()
+            for table in (
+                DataWarehouseTable.objects.filter(team_id=team.pk)
+                .exclude(deleted=True)
+                .select_related("external_data_source")
+                # Exactly the fields get_data_warehouse_table_name reads (pks are always fetched).
+                # The fingerprint runs on every query run, even on cache hits, so the wide `columns`
+                # schema JSON must stay in Postgres; a field missing here would silently defer-load
+                # per row instead.
+                .only(
+                    "name",
+                    "external_data_source__source_type",
+                    "external_data_source__prefix",
+                    "external_data_source__access_method",
+                )
+            ):
+                warehouse_table_names.add(table.name)
+                warehouse_table_names.add(get_data_warehouse_table_name(table.external_data_source, table.name))
             if non_system_names & warehouse_table_names:
                 scopes.add("warehouse_table")
 
+            view_names = set(
+                DataWarehouseSavedQuery.objects.filter(team_id=team.pk)
+                .exclude(deleted=True)
+                .values_list("name", flat=True)
+            )
             if non_system_names & view_names:
                 scopes.add("warehouse_view")
                 # A non-materialized view re-resolves to its underlying warehouse tables at execution.

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -54,6 +54,11 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
             for table in (
                 DataWarehouseTable.objects.filter(team_id=team.pk)
                 .exclude(deleted=True)
+                # The default manager eager-loads created_by and prefetches externaldataschema_set;
+                # neither is used here, and a select_related("created_by") left in place makes the
+                # .only() below raise FieldError (created_by would be deferred AND traversed).
+                .select_related(None)
+                .prefetch_related(None)
                 .select_related("external_data_source")
                 # Exactly the fields get_data_warehouse_table_name reads (pks are always fetched).
                 # The fingerprint runs on every query run, even on cache hits, so the wide `columns`

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -1,11 +1,127 @@
+import contextlib
+from collections.abc import Iterator
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Optional
 
+from django.core.signals import request_finished, request_started
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from celery.signals import task_postrun, task_prerun
 from pydantic import BaseModel
 
 from posthog.schema import DataWarehouseNode, FunnelsDataWarehouseNode, LifecycleDataWarehouseNode
 
 if TYPE_CHECKING:
     from posthog.models import Team
+
+# Scoped memoization for `_warehouse_and_view_names`. The cache fingerprint runs before any
+# cache lookup — on every run of every query, including cache hits — and a single request or
+# task can fingerprint many HogQL queries (e.g. a dashboard with N SQL tiles), each of which
+# would otherwise issue an identical catalog lookup. We cache the name sets keyed by team_id
+# for the lifetime of a scope and discard the cache when the scope closes.
+#
+# The ContextVar defaults to ``None`` which means "no scope active — do not cache". This is
+# critical: the catalog partitions the query cache key (a security boundary), so a
+# thread-lifetime cache could fingerprint against a stale catalog after tables changed.
+# Scopes are opened at HTTP request boundaries (`request_started` / `request_finished`) and
+# Celery task boundaries (`task_prerun` / `task_postrun`); callers outside those boundaries
+# (Temporal activities, management commands, scripts) simply pay the query cost.
+_warehouse_names_cache_var: ContextVar[Optional[dict[int, tuple[set[str], set[str]]]]] = ContextVar(
+    "queried_warehouse_names_cache", default=None
+)
+
+
+@contextlib.contextmanager
+def warehouse_names_cache_scope() -> Iterator[None]:
+    """Open a memoization scope for the warehouse catalog lookup backing
+    `queried_access_controlled_resources`.
+
+    Use this to bracket any non-HTTP, non-Celery code path that fingerprints several
+    queries for the same team (e.g. scripts or tests that want the per-request behavior
+    without going through the signal plumbing).
+    """
+    token = _warehouse_names_cache_var.set({})
+    try:
+        yield
+    finally:
+        _warehouse_names_cache_var.reset(token)
+
+
+@receiver(request_started)
+@receiver(task_prerun)
+def _open_warehouse_names_cache_scope(**_kwargs: object) -> None:
+    _warehouse_names_cache_var.set({})
+
+
+@receiver(request_finished)
+@receiver(task_postrun)
+def _close_warehouse_names_cache_scope(**_kwargs: object) -> None:
+    _warehouse_names_cache_var.set(None)
+
+
+# Lazy string senders keep the warehouse models off this module's import path (it is imported
+# by query_runner at module scope). Bulk writes (queryset.update / bulk_create) bypass these
+# signals, but the flows that bulk-write catalog rows run in Temporal, where no scope is active.
+@receiver(post_save, sender="warehouse_sources.DataWarehouseTable")
+@receiver(post_delete, sender="warehouse_sources.DataWarehouseTable")
+@receiver(post_save, sender="warehouse_sources.ExternalDataSource")
+@receiver(post_delete, sender="warehouse_sources.ExternalDataSource")
+@receiver(post_save, sender="data_modeling.DataWarehouseSavedQuery")
+@receiver(post_delete, sender="data_modeling.DataWarehouseSavedQuery")
+def _invalidate_warehouse_names_cache_on_change(**_kwargs: object) -> None:
+    # The cached names derive from table and view rows plus each table's source (the prefixed
+    # form), so any write to those invalidates the current scope's cache.
+    cache = _warehouse_names_cache_var.get()
+    if cache is not None:
+        cache.clear()
+
+
+def _warehouse_and_view_names(team: "Team") -> tuple[set[str], set[str]]:
+    """All queryable warehouse table names and saved-query (view) names for the team,
+    memoized per request/task scope keyed by team_id.
+
+    External tables are queryable under BOTH their raw name and the prefixed
+    source_type.prefix.table key (see database.py schema build), so both forms are included —
+    otherwise a denied user could read an allowed user's cached rows via the raw name.
+    """
+    # Deferred to break the query_runner -> this module -> hogql import cycle.
+    from posthog.hogql.database.database import get_data_warehouse_table_name  # noqa: PLC0415
+
+    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery  # noqa: PLC0415
+    from products.warehouse_sources.backend.facade.models import DataWarehouseTable  # noqa: PLC0415
+
+    cache = _warehouse_names_cache_var.get()
+    if cache is not None and (cached := cache.get(team.pk)) is not None:
+        return cached
+
+    warehouse_table_names: set[str] = set()
+    tables = (
+        DataWarehouseTable.objects.filter(team_id=team.pk)
+        .exclude(deleted=True)
+        .select_related("external_data_source")
+        # Exactly the fields get_data_warehouse_table_name reads (pks are always fetched).
+        # This runs on the hot path even on cache hits, so the wide `columns` schema JSON must
+        # stay in Postgres; a field missing here would silently defer-load per row instead.
+        .only(
+            "name",
+            "external_data_source__source_type",
+            "external_data_source__prefix",
+            "external_data_source__access_method",
+        )
+    )
+    for table in tables:
+        warehouse_table_names.add(table.name)
+        warehouse_table_names.add(get_data_warehouse_table_name(table.external_data_source, table.name))
+
+    view_names = set(
+        DataWarehouseSavedQuery.objects.filter(team_id=team.pk).exclude(deleted=True).values_list("name", flat=True)
+    )
+
+    result = (warehouse_table_names, view_names)
+    if cache is not None:
+        cache[team.pk] = result
+    return result
 
 
 def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str]]:
@@ -18,14 +134,10 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
     short-circuits the schema strip that would otherwise raise "You don't have access to table")."""
 
     # Deferred to break the query_runner -> this module -> hogql import cycle.
-    from posthog.hogql.database.database import get_data_warehouse_table_name  # noqa: PLC0415
     from posthog.hogql.database.schema.system import access_controlled_system_tables  # noqa: PLC0415
     from posthog.hogql.errors import BaseHogQLError  # noqa: PLC0415
     from posthog.hogql.metadata import get_table_names  # noqa: PLC0415
     from posthog.hogql.parser import parse_select  # noqa: PLC0415
-
-    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
-    from products.warehouse_sources.backend.facade.models import DataWarehouseTable  # noqa: PLC0415
 
     # Raw HogQL is the only query that references system.* and warehouse tables by name
     if getattr(query, "kind", None) == "HogQLQuery":
@@ -47,25 +159,10 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
         # cache key by AnalyticsQueryRunner._get_object_access_restrictions.
         non_system_names = table_names - set(system_scopes)
         if non_system_names:
-            # External tables are queryable under BOTH their raw name and the prefixed
-            # source_type.prefix.table key (see database.py schema build), so match either form —
-            # otherwise a denied user could read an allowed user's cached rows via the raw name.
-            warehouse_table_names: set[str] = set()
-            for table in (
-                DataWarehouseTable.objects.filter(team_id=team.pk)
-                .exclude(deleted=True)
-                .select_related("external_data_source")
-            ):
-                warehouse_table_names.add(table.name)
-                warehouse_table_names.add(get_data_warehouse_table_name(table.external_data_source, table.name))
+            warehouse_table_names, view_names = _warehouse_and_view_names(team)
             if non_system_names & warehouse_table_names:
                 scopes.add("warehouse_table")
 
-            view_names = set(
-                DataWarehouseSavedQuery.objects.filter(team_id=team.pk)
-                .exclude(deleted=True)
-                .values_list("name", flat=True)
-            )
             if non_system_names & view_names:
                 scopes.add("warehouse_view")
                 # A non-materialized view re-resolves to its underlying warehouse tables at execution.

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -54,11 +54,6 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
             for table in (
                 DataWarehouseTable.objects.filter(team_id=team.pk)
                 .exclude(deleted=True)
-                # The default manager eager-loads created_by and prefetches externaldataschema_set;
-                # neither is used here, and a select_related("created_by") left in place makes the
-                # .only() below raise FieldError (created_by would be deferred AND traversed).
-                .select_related(None)
-                .prefetch_related(None)
                 .select_related("external_data_source")
                 # Exactly the fields get_data_warehouse_table_name reads (pks are always fetched).
                 # The fingerprint runs on every query run, even on cache hits, so the wide `columns`

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -55,10 +55,6 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
                 DataWarehouseTable.objects.filter(team_id=team.pk)
                 .exclude(deleted=True)
                 .select_related("external_data_source")
-                # Exactly the fields get_data_warehouse_table_name reads (pks are always fetched).
-                # The fingerprint runs on every query run, even on cache hits, so the wide `columns`
-                # schema JSON must stay in Postgres; a field missing here would silently defer-load
-                # per row instead.
                 .only(
                     "name",
                     "external_data_source__source_type",

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -54,6 +54,10 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
             for table in (
                 DataWarehouseTable.objects.filter(team_id=team.pk)
                 .exclude(deleted=True)
+                # clear the manager's created_by/schema eager-loads: select_related chains additively,
+                # so without this the .only() below raises FieldError (created_by deferred + traversed)
+                .select_related(None)
+                .prefetch_related(None)
                 .select_related("external_data_source")
                 .only(
                     "name",

--- a/posthog/hogql_queries/test/test_access_controlled_resources.py
+++ b/posthog/hogql_queries/test/test_access_controlled_resources.py
@@ -17,6 +17,7 @@ from posthog.hogql.database.database import get_data_warehouse_table_name
 from posthog.hogql_queries.access_controlled_resources import (
     _references_data_warehouse,
     queried_access_controlled_resources,
+    warehouse_names_cache_scope,
 )
 
 from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
@@ -133,6 +134,46 @@ class TestQueriedAccessControlledResources(BaseTest):
             HogQLQuery(query="select 1 from my_warehouse_table, system.notebooks"), self.team
         )
         assert result == {"warehouse_table", "notebook"}
+
+    def test_catalog_lookup_is_memoized_within_scope_and_fetches_narrowly(self):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="s",
+            connection_id="c",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.STRIPE,
+            prefix="myprefix",
+        )
+        table = self._create_warehouse_table("stripe_customers")
+        table.external_data_source = source
+        table.save()
+
+        query = HogQLQuery(query="select * from stripe_customers")
+        with warehouse_names_cache_scope():
+            # One query each for tables and views. A third means the .only() field list no
+            # longer covers what get_data_warehouse_table_name reads, i.e. a per-row defer-load.
+            with self.assertNumQueries(2):
+                assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
+            with self.assertNumQueries(0):
+                assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
+
+    def test_catalog_writes_invalidate_the_scope_cache(self):
+        query = HogQLQuery(query="select * from fresh_table")
+        with warehouse_names_cache_scope():
+            assert queried_access_controlled_resources(query, self.team) == set()
+            # post_save must clear the scope cache, or this table would be fingerprinted as
+            # nonexistent (unpartitioned cache key) for the rest of the request.
+            self._create_warehouse_table("fresh_table")
+            assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
+
+    def test_catalog_lookup_is_uncached_outside_a_scope(self):
+        self._create_warehouse_table("my_warehouse_table")
+        query = HogQLQuery(query="select * from my_warehouse_table")
+        queried_access_controlled_resources(query, self.team)
+        # No scope is active, so nothing may be cached: a cache outliving the request/task
+        # scope could fingerprint against a stale catalog after access-relevant rows change.
+        with self.assertNumQueries(2):
+            assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
 
     def test_warehouse_table_of_another_team_not_matched(self):
         from posthog.models import Team

--- a/posthog/hogql_queries/test/test_access_controlled_resources.py
+++ b/posthog/hogql_queries/test/test_access_controlled_resources.py
@@ -148,8 +148,9 @@ class TestQueriedAccessControlledResources(BaseTest):
         table.save()
 
         query = HogQLQuery(query="select * from stripe_customers")
-        # One query each for tables and views. A third means the .only() field list no longer
-        # covers what get_data_warehouse_table_name reads, i.e. rows silently defer-load per row.
+        # One query each for tables and views. A third means either the .only() field list no
+        # longer covers what get_data_warehouse_table_name reads (rows silently defer-load per
+        # row) or the default manager's externaldataschema_set prefetch leaked back in.
         with self.assertNumQueries(2):
             assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
 

--- a/posthog/hogql_queries/test/test_access_controlled_resources.py
+++ b/posthog/hogql_queries/test/test_access_controlled_resources.py
@@ -17,7 +17,6 @@ from posthog.hogql.database.database import get_data_warehouse_table_name
 from posthog.hogql_queries.access_controlled_resources import (
     _references_data_warehouse,
     queried_access_controlled_resources,
-    warehouse_names_cache_scope,
 )
 
 from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
@@ -135,7 +134,7 @@ class TestQueriedAccessControlledResources(BaseTest):
         )
         assert result == {"warehouse_table", "notebook"}
 
-    def test_catalog_lookup_is_memoized_within_scope_and_fetches_narrowly(self):
+    def test_catalog_fetch_loads_only_name_fields(self):
         source = ExternalDataSource.objects.create(
             team=self.team,
             source_id="s",
@@ -149,29 +148,8 @@ class TestQueriedAccessControlledResources(BaseTest):
         table.save()
 
         query = HogQLQuery(query="select * from stripe_customers")
-        with warehouse_names_cache_scope():
-            # One query each for tables and views. A third means the .only() field list no
-            # longer covers what get_data_warehouse_table_name reads, i.e. a per-row defer-load.
-            with self.assertNumQueries(2):
-                assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
-            with self.assertNumQueries(0):
-                assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
-
-    def test_catalog_writes_invalidate_the_scope_cache(self):
-        query = HogQLQuery(query="select * from fresh_table")
-        with warehouse_names_cache_scope():
-            assert queried_access_controlled_resources(query, self.team) == set()
-            # post_save must clear the scope cache, or this table would be fingerprinted as
-            # nonexistent (unpartitioned cache key) for the rest of the request.
-            self._create_warehouse_table("fresh_table")
-            assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
-
-    def test_catalog_lookup_is_uncached_outside_a_scope(self):
-        self._create_warehouse_table("my_warehouse_table")
-        query = HogQLQuery(query="select * from my_warehouse_table")
-        queried_access_controlled_resources(query, self.team)
-        # No scope is active, so nothing may be cached: a cache outliving the request/task
-        # scope could fingerprint against a stale catalog after access-relevant rows change.
+        # One query each for tables and views. A third means the .only() field list no longer
+        # covers what get_data_warehouse_table_name reads, i.e. rows silently defer-load per row.
         with self.assertNumQueries(2):
             assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
 


### PR DESCRIPTION
## Problem

Since #61686, computing a HogQL query's cache fingerprint calls `queried_access_controlled_resources` to work out whether the query reads any warehouse tables or views, so denied objects can partition the cache key.
That check resolves warehouse names by loading **every** non-deleted `DataWarehouseTable` row for the team as full model rows, including the wide `columns` schema JSON, even though the only fields it uses are the ones that make up the table's queryable names.
Because the model's default manager eager-loads relations, each fetch also joins in the creator's full user row and issues a second query prefetching every table's `externaldataschema_set`, none of which is read here.

The fingerprint runs before the cache is consulted, so this happens on every run of every HogQL query, including cache hits, and a dashboard GET with N SQL tiles pays it N times per request.
On projects with large warehouse catalogs this made `refresh=force_cache` dashboard loads roughly an order of magnitude slower, with almost all of the time spent shipping schema JSON out of Postgres only to throw it away.
The entitlement gate added in #66066 doesn't help orgs that do have the access control feature.

## Changes

The catalog lookup now clears the default manager's eager-loads (`select_related(None)` / `prefetch_related(None)`), re-adds only `external_data_source`, and restricts the fetch with `.only("name", "external_data_source__source_type", "external_data_source__prefix", "external_data_source__access_method")`, exactly the fields `get_data_warehouse_table_name` reads.
The compiled statement selects just table id/name/fk plus those four source columns: no `columns` JSON, no user join, no schema prefetch.
Views already fetched names via `values_list`.

Clearing the manager defaults is required, not just nice: leaving the manager's `select_related("created_by")` in place makes the `.only()` raise `FieldError` (created_by would be deferred and traversed at once).

Scope resolution behavior is unchanged: same names matched, both raw and prefixed forms, same fail-closed handling.
Memoizing the lookup per request (a dashboard load still runs it once per tile) is deliberately left for a separate change.

## How did you test this code?

Added one test to `test_access_controlled_resources.py`: with an external-source-backed table present, a fingerprint issues exactly 2 queries (tables + views).
It guards the regressions this PR is exposed to: a field access outside the `.only()` list silently defer-loading per row, or the manager's schema prefetch leaking back in as a third query.
No existing test could catch either, and the prefixed-name fixture exercises every source field the helper touches.

> [!NOTE]
> Draft-mode CI skips the Django test matrix (test selection reported `SELECT_OUTCOME: skipped`), so that test has not yet executed in CI; it will run when this PR is marked ready for review.
> As a stand-in, I verified the queryset compiles and is narrow without a database by rendering `str(qs.query)` under `django.setup()`. That check is what caught the `FieldError` conflict with the default manager's `select_related("created_by")`, fixed in the last commit.

The existing tests in this file cover the unchanged scope-resolution behavior (raw name, prefixed name, view, cross-team isolation).
`ruff` and `hogli ci:preflight --fix` pass.
The sandbox this was authored in has no Postgres/ClickHouse, so the Django suite can't run locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal performance change, no user-facing behavior or documented workflow touched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session), directed by @thmsobrmlr.
The session first root-caused a dashboard-load slowdown to the per-tile catalog dump introduced in #61686 using internal query telemetry, then implemented the fix.
Skills invoked: `/writing-tests`.

Decisions along the way:

- An earlier revision of this PR also memoized the catalog per request/Celery-task scope (ContextVar plus signal receivers, mirroring `get_restricted_properties_for_team`). Thomas asked for the narrow fetch to land on its own, so that was stripped back out; the branch history shows both steps.
- Kept ORM instances with `.only()` instead of `values_list` so `get_data_warehouse_table_name` is reused unchanged rather than reimplemented.
- The first push of the `.only()` version would have raised `FieldError` on every HogQL fingerprint because of the default manager's `select_related("created_by")`. Draft CI never ran the test that catches it; a no-database SQL-compile check during the CI-feedback pass did, leading to the `select_related(None)` / `prefetch_related(None)` fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
