### PR TITLE
feat(dashboards): attach existing insights at dashboard creation

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -524,6 +524,54 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         instance = Dashboard.objects.get(id=response_data["id"])
         self.assertEqual(instance.name, "My new dashboard")
 
+    def test_create_dashboard_with_insight_ids_attaches_insights_as_tiles(self):
+        insight_one_id, _ = self.dashboard_api.create_insight({"name": "insight one"})
+        insight_two_id, _ = self.dashboard_api.create_insight({"name": "insight two"})
+
+        # a repeated ID must not produce a duplicate tile
+        _, response_data = self.dashboard_api.create_dashboard(
+            {"name": "dashboard with insights", "insight_ids": [insight_one_id, insight_two_id, insight_one_id]}
+        )
+
+        self.assertEqual(
+            sorted(tile["insight"]["id"] for tile in response_data["tiles"]),
+            sorted([insight_one_id, insight_two_id]),
+        )
+
+    @parameterized.expand(["nonexistent", "soft_deleted", "other_team"])
+    def test_create_dashboard_with_invalid_insight_id_creates_nothing(self, case: str) -> None:
+        valid_insight_id, _ = self.dashboard_api.create_insight({"name": "valid insight"})
+        if case == "nonexistent":
+            invalid_id = 999999
+        elif case == "soft_deleted":
+            invalid_id, _ = self.dashboard_api.create_insight({"name": "deleted insight"})
+            Insight.objects.filter(id=invalid_id).update(deleted=True)
+        else:
+            other_team = Team.objects.create(organization=self.organization)
+            invalid_id = Insight.objects.create(team=other_team, name="other team insight").id
+
+        dashboard_count_before = Dashboard.objects.count()
+        _, response = self.dashboard_api.create_dashboard(
+            {"name": "should not be created", "insight_ids": [valid_insight_id, invalid_id]},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
+        self.assertIn(str(invalid_id), response["detail"])
+        self.assertEqual(Dashboard.objects.count(), dashboard_count_before)
+
+    def test_create_dashboard_with_insight_ids_overlapping_duplicated_dashboard(self):
+        source_dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "source"})
+        insight_id, _ = self.dashboard_api.create_insight(
+            {"name": "shared insight", "dashboards": [source_dashboard_id]}
+        )
+
+        _, response_data = self.dashboard_api.create_dashboard(
+            {"name": "copy", "use_dashboard": source_dashboard_id, "insight_ids": [insight_id]}
+        )
+
+        insight_tiles = [tile for tile in response_data["tiles"] if tile["insight"] is not None]
+        self.assertEqual([tile["insight"]["id"] for tile in insight_tiles], [insight_id])
+
     def test_update_dashboard(self):
         dashboard = Dashboard.objects.create(
             team=self.team,

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1221,6 +1221,12 @@ class DashboardSerializer(DashboardMetadataSerializer):
         required=False,
         help_text="ID of an existing dashboard to duplicate.",
     )
+    insight_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        write_only=True,
+        required=False,
+        help_text="Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates.",
+    )
     delete_insights = serializers.BooleanField(
         write_only=True,
         required=False,
@@ -1236,6 +1242,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             "tiles",
             "use_template",
             "use_dashboard",
+            "insight_ids",
             "delete_insights",
             "_create_in_folder",
         ]
@@ -1268,6 +1275,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
         )
         use_template: str = validated_data.pop("use_template", None)
         use_dashboard: int = validated_data.pop("use_dashboard", None)
+        insight_ids: list[int] | None = validated_data.pop("insight_ids", None)
         validated_data.pop("delete_insights", None)  # not used during creation
         validated_data = self._update_creation_mode(validated_data, use_template, use_dashboard)
         tags = validated_data.pop("tags", None)  # tags are created separately below as global tag relationships
@@ -1285,6 +1293,31 @@ class DashboardSerializer(DashboardMetadataSerializer):
             # so the caller must have at least viewer access to the source — mirrors the copy_tile/move_tile checks.
             if not user_access_control.check_access_level_for_object(existing_dashboard, "viewer"):
                 raise exceptions.PermissionDenied("You don't have permission to view the source dashboard.")
+
+        # Resolve insights to attach before creating anything: create() runs in autocommit,
+        # so failing any later would leave an orphaned dashboard behind.
+        insights_to_attach: list[Insight] = []
+        if insight_ids:
+            unique_insight_ids = list(dict.fromkeys(insight_ids))
+            insights_by_id = {
+                insight.id: insight
+                for insight in Insight.objects.filter(id__in=unique_insight_ids, team_id=team_id, deleted=False)
+            }
+            missing_ids = [str(insight_id) for insight_id in unique_insight_ids if insight_id not in insights_by_id]
+            if missing_ids:
+                raise serializers.ValidationError({"insight_ids": f"Insights not found: {', '.join(missing_ids)}"})
+            insights_to_attach = [insights_by_id[insight_id] for insight_id in unique_insight_ids]
+            for insight in insights_to_attach:
+                # Attaching renders the insight on the new dashboard, so the caller must have viewer
+                # access to each insight — an insight can be restricted independently of its dashboards.
+                if not user_access_control.check_access_level_for_object(insight, "viewer"):
+                    raise exceptions.PermissionDenied(f"You don't have permission to view insight: {insight.id}")
+            check_count_limit(
+                team=team,
+                key=LimitKey.MAX_INSIGHTS_PER_DASHBOARD,
+                current_count=len(insights_to_attach) - 1,
+                user=request.user,
+            )
 
         request_filters = request.data.get("filters")
         if request_filters:
@@ -1344,6 +1377,25 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 else:
                     existing_tile.copy_to_dashboard(dashboard)
 
+        for insight in insights_to_attach:
+            # get_or_create: duplicating via use_dashboard may already have linked this insight to the new dashboard
+            DashboardTile.objects_including_soft_deleted.get_or_create(
+                insight=insight,
+                dashboard=dashboard,
+                defaults={"team_id": dashboard.team_id, "last_refresh": now()},
+            )
+            report_user_action(
+                request.user,
+                "dashboard tile added",
+                {
+                    "tile_type": "insight",
+                    "insight_type": _get_insight_type(insight),
+                    "dashboard_id": dashboard.id,
+                },
+                team=dashboard.team,
+                request=request,
+            )
+
         # Manual tag creation since this create method doesn't call super()
         self._attempt_set_tags(tags, dashboard)
 
@@ -1356,6 +1408,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 "template_key": use_template,
                 "duplicated": bool(use_dashboard),
                 "duplicated_from_dashboard_id": use_dashboard,
+                "attached_insights_count": len(insights_to_attach),
             },
             team=dashboard.team,
             request=request,
@@ -1504,6 +1557,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             )
 
         validated_data.pop("use_template", None)  # Remove attribute if present
+        validated_data.pop("insight_ids", None)  # attach-at-creation only, per the field's contract
 
         being_undeleted = instance.deleted and "deleted" in validated_data and not validated_data["deleted"]
         if being_undeleted:

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -374,6 +374,8 @@ export interface DashboardApi {
      * @nullable
      */
     use_dashboard?: number | null
+    /** Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates. */
+    insight_ids?: number[]
     /** When deleting, also delete insights that are only on this dashboard. */
     delete_insights?: boolean
     _create_in_folder?: string

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -159,6 +159,12 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
             .optional()
             .describe('Template key to create the dashboard from a predefined template.'),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
+        insight_ids: zod
+            .array(zod.number())
+            .optional()
+            .describe(
+                'Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates.'
+            ),
         delete_insights: zod
             .boolean()
             .default(dashboardsCreateBodyDeleteInsightsDefault)
@@ -206,6 +212,12 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
             .optional()
             .describe('Template key to create the dashboard from a predefined template.'),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
+        insight_ids: zod
+            .array(zod.number())
+            .optional()
+            .describe(
+                'Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates.'
+            ),
         delete_insights: zod
             .boolean()
             .default(dashboardsUpdateBodyDeleteInsightsDefault)
@@ -2626,6 +2638,12 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
             .optional()
             .describe('Template key to create the dashboard from a predefined template.'),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
+        insight_ids: zod
+            .array(zod.number())
+            .optional()
+            .describe(
+                'Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates.'
+            ),
         delete_insights: zod
             .boolean()
             .default(dashboardsCreateFromTemplateJsonCreateBodyDeleteInsightsDefault)
@@ -2669,6 +2687,12 @@ export const DashboardsCreateUnlistedDashboardCreateBody = /* @__PURE__ */ zod
             .optional()
             .describe('Template key to create the dashboard from a predefined template.'),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
+        insight_ids: zod
+            .array(zod.number())
+            .optional()
+            .describe(
+                'Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates.'
+            ),
         delete_insights: zod
             .boolean()
             .default(dashboardsCreateUnlistedDashboardCreateBodyDeleteInsightsDefault)

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -21,12 +21,13 @@ tools:
         enrich_url: '{id}'
         title: Create dashboard
         description: >
-            Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
-            from a template or duplicate an existing dashboard. This tool cannot attach insights — insights join a
-            dashboard through their own `dashboards` field, so when building a dashboard of insights, create the
-            dashboard first and pass its ID in `dashboards` on each insight-create (or add existing insights by
-            appending it via insight-update). The returned tiles omit insight results to save context — use
-            dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see
+            Create a new dashboard. Provide a name and optional description, tags, and pinned status. Attach existing
+            saved insights as tiles at creation by passing their numeric IDs in `insight_ids` — when building a
+            dashboard of insights, create the insights first, then create the dashboard with all their IDs in one call
+            instead of patching each insight afterwards. (If the dashboard already exists, add insights to it via the
+            `dashboards` field on insight-create or insight-update.) Can also create from a template or duplicate an
+            existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to
+            fetch the actual data for each insight. To add widget tiles after creation, see
             dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.
         exclude_params:
             - creation_mode
@@ -292,6 +293,7 @@ tools:
             add new widget tiles to this dashboard, use dashboard-widgets-batch-add instead. The returned tiles omit
             insight results to save context — use dashboard-insights-run to fetch the actual data for each insight.
         exclude_params:
+            - insight_ids
             - creation_mode
             - effective_restriction_level
             - effective_privilege_level

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -22,9 +22,12 @@ tools:
         title: Create dashboard
         description: >
             Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create
-            from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context
-            — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation,
-            see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.
+            from a template or duplicate an existing dashboard. This tool cannot attach insights — insights join a
+            dashboard through their own `dashboards` field, so when building a dashboard of insights, create the
+            dashboard first and pass its ID in `dashboards` on each insight-create (or add existing insights by
+            appending it via insight-update). The returned tiles omit insight results to save context — use
+            dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see
+            dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.
         exclude_params:
             - creation_mode
             - effective_restriction_level

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -83,8 +83,10 @@ tools:
         description: >
             Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel /
             query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save.
-            Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if
-            you want to see the computed results.
+            Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards
+            with insight-update. If the insight is destined for a dashboard, create the dashboard first
+            (dashboard-create) and pass its ID in `dashboards`. Returns insight metadata only — after creating, call the
+            insight-query tool with the returned `short_id` if you want to see the computed results.
         exclude_params:
             - query
         include_params:

--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -84,9 +84,10 @@ tools:
             Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel /
             query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save.
             Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards
-            with insight-update. If the insight is destined for a dashboard, create the dashboard first
-            (dashboard-create) and pass its ID in `dashboards`. Returns insight metadata only — after creating, call the
-            insight-query tool with the returned `short_id` if you want to see the computed results.
+            with insight-update. To place the insight on a dashboard: pass the dashboard's ID in `dashboards` if it
+            already exists, or create the insights first and attach them all at once via `insight_ids` on
+            dashboard-create. Returns insight metadata only — after creating, call the insight-query tool with the
+            returned `short_id` if you want to see the computed results.
         exclude_params:
             - query
         include_params:

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1836,7 +1836,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. This tool cannot attach insights — insights join a dashboard through their own `dashboards` field, so when building a dashboard of insights, create the dashboard first and pass its ID in `dashboards` on each insight-create (or add existing insights by appending it via insight-update). The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Attach existing saved insights as tiles at creation by passing their numeric IDs in `insight_ids` — when building a dashboard of insights, create the insights first, then create the dashboard with all their IDs in one call instead of patching each insight afterwards. (If the dashboard already exists, add insights to it via the `dashboards` field on insight-create or insight-update.) Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -4294,7 +4294,7 @@
         }
     },
     "insight-create": {
-        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards with insight-update. If the insight is destined for a dashboard, create the dashboard first (dashboard-create) and pass its ID in `dashboards`. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
+        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards with insight-update. To place the insight on a dashboard: pass the dashboard's ID in `dashboards` if it already exists, or create the insights first and attach them all at once via `insight_ids` on dashboard-create. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
         "category": "Product analytics",
         "feature": "product_analytics",
         "summary": "Create insight",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1836,7 +1836,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. This tool cannot attach insights — insights join a dashboard through their own `dashboards` field, so when building a dashboard of insights, create the dashboard first and pass its ID in `dashboards` on each insight-create (or add existing insights by appending it via insight-update). The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -4294,7 +4294,7 @@
         }
     },
     "insight-create": {
-        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
+        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards with insight-update. If the insight is destined for a dashboard, create the dashboard first (dashboard-create) and pass its ID in `dashboards`. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
         "category": "Product analytics",
         "feature": "product_analytics",
         "summary": "Create insight",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1866,7 +1866,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. This tool cannot attach insights — insights join a dashboard through their own `dashboards` field, so when building a dashboard of insights, create the dashboard first and pass its ID in `dashboards` on each insight-create (or add existing insights by appending it via insight-update). The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -4576,7 +4576,7 @@
         }
     },
     "insight-create": {
-        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
+        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards with insight-update. If the insight is destined for a dashboard, create the dashboard first (dashboard-create) and pass its ID in `dashboards`. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
         "category": "Product analytics",
         "feature": "product_analytics",
         "summary": "Create insight",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1866,7 +1866,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "dashboard-create": {
-        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. This tool cannot attach insights — insights join a dashboard through their own `dashboards` field, so when building a dashboard of insights, create the dashboard first and pass its ID in `dashboards` on each insight-create (or add existing insights by appending it via insight-update). The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
+        "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Attach existing saved insights as tiles at creation by passing their numeric IDs in `insight_ids` — when building a dashboard of insights, create the insights first, then create the dashboard with all their IDs in one call instead of patching each insight afterwards. (If the dashboard already exists, add insights to it via the `dashboards` field on insight-create or insight-update.) Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard",
@@ -4576,7 +4576,7 @@
         }
     },
     "insight-create": {
-        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards with insight-update. If the insight is destined for a dashboard, create the dashboard first (dashboard-create) and pass its ID in `dashboards`. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
+        "description": "Create a new saved insight from a name and query definition. Test queries with query-trends / query-funnel / query-retention / query-paths / query-stickiness / query-lifecycle first to confirm the shape, then save. Set `name`, `description`, `tags`, and `dashboards` here at creation instead of patching them in afterwards with insight-update. To place the insight on a dashboard: pass the dashboard's ID in `dashboards` if it already exists, or create the insights first and attach them all at once via `insight_ids` on dashboard-create. Returns insight metadata only — after creating, call the insight-query tool with the returned `short_id` if you want to see the computed results.",
         "category": "Product analytics",
         "feature": "product_analytics",
         "summary": "Create insight",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14956,6 +14956,8 @@ export namespace Schemas {
          * @nullable
          */
       use_dashboard?: number | null;
+      /** Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates. */
+      insight_ids?: number[];
       /** When deleting, also delete insights that are only on this dashboard. */
       delete_insights?: boolean;
       _create_in_folder?: string;

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -73,6 +73,12 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
             .optional()
             .describe('Template key to create the dashboard from a predefined template.'),
         use_dashboard: zod.number().nullish().describe('ID of an existing dashboard to duplicate.'),
+        insight_ids: zod
+            .array(zod.number())
+            .optional()
+            .describe(
+                'Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates.'
+            ),
         delete_insights: zod
             .boolean()
             .default(dashboardsCreateBodyDeleteInsightsDefault)

--- a/services/mcp/src/templates/sections/examples.md
+++ b/services/mcp/src/templates/sections/examples.md
@@ -50,9 +50,9 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Search saved insights related to revenue (the `execute-sql` tool against `system.insights` — check `execute-sql` for SQL guidance)
 3. Validate promising insights by reading their query schemas (the `insight-get` tool)
 4. Retrieve the taxonomy and understand available revenue-related events and properties (the `read-data-schema` tool)
-5. Create the dashboard first, with a name and description (the `dashboard-create` tool — it cannot attach insights itself)
-6. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
-7. Save each new insight with `name`, `description`, and `dashboards: [<dashboard_id>]` set at creation (the `insight-create` tool); attach existing insights by appending the dashboard ID to their `dashboards` list (the `insight-update` tool)
+5. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
+6. Save each new insight with `name` and `description` set at creation (the `insight-create` tool)
+7. Create the dashboard, attaching both existing and newly created insights in one call via `insight_ids` (the `dashboard-create` tool)
 8. Analyze the created dashboard and provide a concise summary of metrics
 *Begins working on the first task*
 <reasoning>
@@ -60,6 +60,6 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Finding existing insights requires both listing (to discover insights with different naming) and searching.
 3. Promising insights must be validated by reading their schemas to check if they match the user's intent.
 4. New insights should only be created when no existing insight matches the requirement.
-5. Creating the dashboard before saving insights lets every new insight be assigned via `dashboards` at creation — one call per insight instead of a create-then-update pair.
+5. Attaching insights via `insight_ids` at dashboard creation wires the whole dashboard in one call — no per-insight update calls afterwards.
 </reasoning>
 </example>

--- a/services/mcp/src/templates/sections/examples.md
+++ b/services/mcp/src/templates/sections/examples.md
@@ -50,14 +50,16 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Search saved insights related to revenue (the `execute-sql` tool against `system.insights` — check `execute-sql` for SQL guidance)
 3. Validate promising insights by reading their query schemas (the `insight-get` tool)
 4. Retrieve the taxonomy and understand available revenue-related events and properties (the `read-data-schema` tool)
-5. Create new insights only for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
-6. Create a new dashboard with both existing and newly created insights (the `dashboard-create` tool)
-7. Analyze the created dashboard and provide a concise summary of metrics
+5. Create the dashboard first, with a name and description (the `dashboard-create` tool — it cannot attach insights itself)
+6. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
+7. Save each new insight with `name`, `description`, and `dashboards: [<dashboard_id>]` set at creation (the `insight-create` tool); attach existing insights by appending the dashboard ID to their `dashboards` list (the `insight-update` tool)
+8. Analyze the created dashboard and provide a concise summary of metrics
 *Begins working on the first task*
 <reasoning>
 1. The user requested creating a dashboard. This is a complex task that requires multiple steps to complete.
 2. Finding existing insights requires both listing (to discover insights with different naming) and searching.
 3. Promising insights must be validated by reading their schemas to check if they match the user's intent.
 4. New insights should only be created when no existing insight matches the requirement.
+5. Creating the dashboard before saving insights lets every new insight be assigned via `dashboards` at creation — one call per insight instead of a create-then-update pair.
 </reasoning>
 </example>

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -73,6 +73,9 @@ const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUr
         if (params.use_dashboard !== undefined) {
             body['use_dashboard'] = params.use_dashboard
         }
+        if (params.insight_ids !== undefined) {
+            body['insight_ids'] = params.insight_ids
+        }
         if (params.delete_insights !== undefined) {
             body['delete_insights'] = params.delete_insights
         }

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -424,14 +424,16 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Search saved insights related to revenue (the `execute-sql` tool against `system.insights` — check `execute-sql` for SQL guidance)
 3. Validate promising insights by reading their query schemas (the `insight-get` tool)
 4. Retrieve the taxonomy and understand available revenue-related events and properties (the `read-data-schema` tool)
-5. Create new insights only for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
-6. Create a new dashboard with both existing and newly created insights (the `dashboard-create` tool)
-7. Analyze the created dashboard and provide a concise summary of metrics
+5. Create the dashboard first, with a name and description (the `dashboard-create` tool — it cannot attach insights itself)
+6. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
+7. Save each new insight with `name`, `description`, and `dashboards: [<dashboard_id>]` set at creation (the `insight-create` tool); attach existing insights by appending the dashboard ID to their `dashboards` list (the `insight-update` tool)
+8. Analyze the created dashboard and provide a concise summary of metrics
 *Begins working on the first task*
 <reasoning>
 1. The user requested creating a dashboard. This is a complex task that requires multiple steps to complete.
 2. Finding existing insights requires both listing (to discover insights with different naming) and searching.
 3. Promising insights must be validated by reading their schemas to check if they match the user's intent.
 4. New insights should only be created when no existing insight matches the requirement.
+5. Creating the dashboard before saving insights lets every new insight be assigned via `dashboards` at creation — one call per insight instead of a create-then-update pair.
 </reasoning>
 </example>

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -424,9 +424,9 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Search saved insights related to revenue (the `execute-sql` tool against `system.insights` — check `execute-sql` for SQL guidance)
 3. Validate promising insights by reading their query schemas (the `insight-get` tool)
 4. Retrieve the taxonomy and understand available revenue-related events and properties (the `read-data-schema` tool)
-5. Create the dashboard first, with a name and description (the `dashboard-create` tool — it cannot attach insights itself)
-6. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
-7. Save each new insight with `name`, `description`, and `dashboards: [<dashboard_id>]` set at creation (the `insight-create` tool); attach existing insights by appending the dashboard ID to their `dashboards` list (the `insight-update` tool)
+5. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
+6. Save each new insight with `name` and `description` set at creation (the `insight-create` tool)
+7. Create the dashboard, attaching both existing and newly created insights in one call via `insight_ids` (the `dashboard-create` tool)
 8. Analyze the created dashboard and provide a concise summary of metrics
 *Begins working on the first task*
 <reasoning>
@@ -434,6 +434,6 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Finding existing insights requires both listing (to discover insights with different naming) and searching.
 3. Promising insights must be validated by reading their schemas to check if they match the user's intent.
 4. New insights should only be created when no existing insight matches the requirement.
-5. Creating the dashboard before saving insights lets every new insight be assigned via `dashboards` at creation — one call per insight instead of a create-then-update pair.
+5. Attaching insights via `insight_ids` at dashboard creation wires the whole dashboard in one call — no per-insight update calls afterwards.
 </reasoning>
 </example>

--- a/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
@@ -288,9 +288,9 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Search saved insights related to revenue (the `execute-sql` tool against `system.insights` — check `execute-sql` for SQL guidance)
 3. Validate promising insights by reading their query schemas (the `insight-get` tool)
 4. Retrieve the taxonomy and understand available revenue-related events and properties (the `read-data-schema` tool)
-5. Create the dashboard first, with a name and description (the `dashboard-create` tool — it cannot attach insights itself)
-6. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
-7. Save each new insight with `name`, `description`, and `dashboards: [<dashboard_id>]` set at creation (the `insight-create` tool); attach existing insights by appending the dashboard ID to their `dashboards` list (the `insight-update` tool)
+5. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
+6. Save each new insight with `name` and `description` set at creation (the `insight-create` tool)
+7. Create the dashboard, attaching both existing and newly created insights in one call via `insight_ids` (the `dashboard-create` tool)
 8. Analyze the created dashboard and provide a concise summary of metrics
 *Begins working on the first task*
 <reasoning>
@@ -298,6 +298,6 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Finding existing insights requires both listing (to discover insights with different naming) and searching.
 3. Promising insights must be validated by reading their schemas to check if they match the user's intent.
 4. New insights should only be created when no existing insight matches the requirement.
-5. Creating the dashboard before saving insights lets every new insight be assigned via `dashboards` at creation — one call per insight instead of a create-then-update pair.
+5. Attaching insights via `insight_ids` at dashboard creation wires the whole dashboard in one call — no per-insight update calls afterwards.
 </reasoning>
 </example>

--- a/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
@@ -288,14 +288,16 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 2. Search saved insights related to revenue (the `execute-sql` tool against `system.insights` — check `execute-sql` for SQL guidance)
 3. Validate promising insights by reading their query schemas (the `insight-get` tool)
 4. Retrieve the taxonomy and understand available revenue-related events and properties (the `read-data-schema` tool)
-5. Create new insights only for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
-6. Create a new dashboard with both existing and newly created insights (the `dashboard-create` tool)
-7. Analyze the created dashboard and provide a concise summary of metrics
+5. Create the dashboard first, with a name and description (the `dashboard-create` tool — it cannot attach insights itself)
+6. Test queries for metrics not covered by existing insights (the `query-trends` tool or appropriate query tool)
+7. Save each new insight with `name`, `description`, and `dashboards: [<dashboard_id>]` set at creation (the `insight-create` tool); attach existing insights by appending the dashboard ID to their `dashboards` list (the `insight-update` tool)
+8. Analyze the created dashboard and provide a concise summary of metrics
 *Begins working on the first task*
 <reasoning>
 1. The user requested creating a dashboard. This is a complex task that requires multiple steps to complete.
 2. Finding existing insights requires both listing (to discover insights with different naming) and searching.
 3. Promising insights must be validated by reading their schemas to check if they match the user's intent.
 4. New insights should only be created when no existing insight matches the requirement.
+5. Creating the dashboard before saving insights lets every new insight be assigned via `dashboards` at creation — one call per insight instead of a create-then-update pair.
 </reasoning>
 </example>

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
@@ -24,6 +24,13 @@
         "description": {
             "type": "string"
         },
+        "insight_ids": {
+            "description": "Only used when creating a dashboard: IDs of existing saved insights to add to the new dashboard as tiles. Each insight must belong to the same project and be visible to you. Ignored on updates.",
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
         "name": {
             "anyOf": [
                 {


### PR DESCRIPTION
## TL;DR

Agents using the PostHog MCP kept creating an insight and then immediately updating it, most often just to put it on a dashboard. Now `dashboard-create` accepts `insight_ids`, so a whole dashboard of existing insights is wired in one call, and the MCP instructions teach that flow: save insights first, then create the dashboard with all their IDs.

## Problem

MCP session analysis (see the linked Slack thread) found that the most common follow-up to insight-create is an insight-update, with dashboard assignment leading by a wide margin. Two causes:

- The dashboards API had no way to attach existing insights at dashboard creation. Insights join dashboards only through their own `dashboards` field, so placing N existing insights on a new dashboard took N insight-update calls.
- The MCP server's canonical "Building a dashboard" example told agents to attach insights "with the `dashboard-create` tool", which could not attach insights, and neither tool description mentioned the working alternative.

Agents follow the example, hit the wall, and fall back to one insight-update per insight. Dashboard-first ordering (create dashboard, then pass its ID in `dashboards` on each insight-create) avoids the updates but fights how agents naturally work: iterate on insights first, assemble the dashboard last.

Raised in #team-analytics-platform: https://posthog.slack.com/archives/C09BDQLM8KA/p1783544972399209?thread_ts=1783544923.850079&cid=C09BDQLM8KA

## Changes

API (`products/dashboards/backend/api/dashboard.py`):

- New write-only `insight_ids` field on dashboard create: existing saved insights are attached to the new dashboard as tiles, in one call.
- Insights are resolved and validated before the dashboard row is created, so a bad ID cannot leave an orphaned dashboard behind (create runs in autocommit).
- Per-insight checks mirror the existing attach paths: same team, not deleted, viewer access on each insight (an insight can be restricted independently of its dashboards), plus the max-insights-per-dashboard count-limit event.
- Tiles are created with `get_or_create` so overlap with `use_dashboard` duplication cannot violate the unique (dashboard, insight) constraint. Each attach fires the same "dashboard tile added" analytics event as the insight-side path, and "dashboard created" now carries `attached_insights_count` so adoption of the one-call flow is measurable.
- On updates the field is ignored (popped like `use_template`), and the `dashboard-update` MCP tool excludes it so agents never see a no-op param.

MCP guidance (prompt-only):

- `dashboard-create` and `insight-create` tool descriptions now describe the one-call flow and when to use `dashboards` vs `insight_ids`.
- The "Building a dashboard" example in the server instructions teaches: test queries, save insights with `name` and `description` set, then create the dashboard attaching everything via `insight_ids`.

Generated artifacts (OpenAPI types, MCP tool definition JSONs, instruction snapshots) are regenerated and auto-committed by the check-openapi-types CI job, as it did for the first commit on this branch.

## How did you test this code?

Added three tests to `posthog/api/test/dashboards/test_dashboard.py`:

- `test_create_dashboard_with_insight_ids_attaches_insights_as_tiles` – wiring guard for the new field, and locks that a repeated ID yields one tile instead of a unique-constraint 500.
- `test_create_dashboard_with_invalid_insight_id_creates_nothing` (parameterized: nonexistent, soft-deleted, other-team) – locks fail-fast-before-create; moving validation after `Dashboard.objects.create` would orphan dashboards on error, and the other-team case guards project scoping.
- `test_create_dashboard_with_insight_ids_overlapping_duplicated_dashboard` – guards the `get_or_create` against an IntegrityError 500 when `use_dashboard` duplication already linked the same insight.

I (or, actually Claude) could not run the Django test suite in the sandbox this was authored in (no dev environment); both changed Python files pass a syntax compile check and the YAML definitions parse. CI runs the suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

API reference docs are generated from the OpenAPI spec; the new field's `help_text` flows through automatically.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) from a request to fix the create-then-update pattern surfaced in the Slack thread above. The first commit was prompt-only (teach dashboard-first ordering); the author then pointed out the better fix is letting `dashboard-create` attach insights directly, so this now adds the `insight_ids` API capability and re-teaches the instructions around it. Invoked /improving-drf-endpoints, /implementing-mcp-tools, and /writing-tests while producing this PR. The attach semantics deliberately mirror `InsightSerializer`'s existing dashboard-attach path (permission checks, tile creation, analytics events) rather than inventing new ones; a separate batch "add insights to existing dashboard" endpoint was considered and left out of scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
