### PR TITLE
fix(mcp): respect project test account filter default in query tools

### DIFF
--- a/services/mcp/src/lib/instructions.ts
+++ b/services/mcp/src/lib/instructions.ts
@@ -43,6 +43,11 @@ export function buildActiveEnvironmentContextPrompt(
     }
     if (project) {
         lines.push(`Project timezone: ${project.timezone ?? 'UTC'}.`)
+        if (project.test_account_filters_default_checked) {
+            lines.push(
+                'This project filters out internal and test users by default. `query-*` tools apply this automatically when `filterTestAccounts` is omitted; when composing queries for other tools (e.g. insight-create), set `filterTestAccounts: true` unless the user asks to include internal/test data.'
+            )
+        }
         const poeValue = project.person_on_events_querying_enabled as string | boolean | null | undefined
         if (poeValue === true || poeValue === 'true') {
             lines.push(

--- a/services/mcp/src/schema/query.ts
+++ b/services/mcp/src/schema/query.ts
@@ -167,7 +167,9 @@ const AnyEntityNode = EventsNode
 // Base query interface
 const InsightsQueryBase = z.object({
     dateRange: DateRange.optional(),
-    filterTestAccounts: z.boolean().optional().default(false),
+    // No hard default: omission lets the project's "Filter out internal and test
+    // users" default setting apply, matching UI behavior for new insights.
+    filterTestAccounts: z.boolean().optional(),
     properties: z
         .union([z.array(AnyPropertyFilter), PropertyGroupFilter])
         .optional()

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -23,6 +23,34 @@ interface QueryWrapperConfig<T extends ZodObjectAny> {
     urlPrefix?: string
 }
 
+const TEST_ACCOUNT_FILTER_FIELD = 'filterTestAccounts'
+
+function hasTestAccountFilterField(schema: ZodObjectAny): schema is z.ZodObject<z.ZodRawShape> {
+    return schema instanceof z.ZodObject && TEST_ACCOUNT_FILTER_FIELD in schema.shape
+}
+
+/**
+ * The generated query schemas hard-default `filterTestAccounts` to `false`, which
+ * silently ignores the project's "Filter out internal and test users" default
+ * (`test_account_filters_default_checked`) that the UI applies to every new
+ * insight. Stripping the schema default lets an omitted value survive validation
+ * as `undefined`, so the handler can fill in the project default instead. An
+ * explicit `filterTestAccounts` from the caller always wins.
+ */
+function withoutTestAccountFilterDefault<T extends ZodObjectAny>(schema: T): T {
+    if (!hasTestAccountFilterField(schema)) {
+        return schema
+    }
+    return schema.extend({
+        [TEST_ACCOUNT_FILTER_FIELD]: z.coerce
+            .boolean()
+            .optional()
+            .describe(
+                'Exclude internal and test users by applying the respective filters. When omitted, follows the project\'s "Filter out internal and test users" default setting.'
+            ),
+    }) as unknown as T
+}
+
 function buildInsightUrl(
     kind: 'InsightVizNode' | 'DataTableNode',
     query: Record<string, unknown>,
@@ -37,12 +65,16 @@ function buildInsightUrl(
 }
 
 export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperConfig<T>): () => ToolBase<T> {
+    // Both the advertised tool schema and the handler's re-parse must use the
+    // stripped schema — parsing with the original would re-apply the `false`
+    // default and make omission indistinguishable from an explicit `false`.
+    const schema = withoutTestAccountFilterDefault(config.schema)
     return () => ({
         name: config.name,
-        schema: config.schema,
+        schema,
         handler: async (context: Context, rawParams: z.infer<T>) => {
             const projectId = await context.stateManager.getProjectId()
-            const params = config.schema.parse(rawParams)
+            const params = schema.parse(rawParams)
             // `output_format` is a tool-level control, not part of the query body. Strip it before
             // POSTing so it doesn't leak into the backend `kind: ...Query` payload.
             const { output_format: callerOutputFormat, ...queryParams } = params as typeof params & {
@@ -51,6 +83,14 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
             const query: Record<string, unknown> = {
                 ...queryParams,
                 kind: config.kind,
+            }
+            if (hasTestAccountFilterField(schema) && query[TEST_ACCOUNT_FILTER_FIELD] === undefined) {
+                const project = await context.stateManager.getCachedOrFetchProject().catch(() => undefined)
+                // Only inject `true`: when the project default is unchecked the field
+                // stays omitted and the backend's own `false` default applies.
+                if (project?.test_account_filters_default_checked) {
+                    query[TEST_ACCOUNT_FILTER_FIELD] = true
+                }
             }
             const baseUrl = context.api.getProjectBaseUrl(projectId)
             const effectiveOutputFormat = callerOutputFormat ?? config.outputFormat

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -30,15 +30,26 @@ function hasTestAccountFilterField(schema: ZodObjectAny): schema is z.ZodObject<
 }
 
 /**
- * The generated query schemas hard-default `filterTestAccounts` to `false`, which
+ * Most generated query schemas hard-default `filterTestAccounts` to `false`, which
  * silently ignores the project's "Filter out internal and test users" default
  * (`test_account_filters_default_checked`) that the UI applies to every new
  * insight. Stripping the schema default lets an omitted value survive validation
  * as `undefined`, so the handler can fill in the project default instead. An
  * explicit `filterTestAccounts` from the caller always wins.
+ *
+ * Only a `false` default is stripped: a schema that defaults the field to `true`
+ * (e.g. AssistantTracesQuery) is an intentional stricter product default, and
+ * replacing it would flip its queries to unfiltered on projects where the
+ * setting is unchecked.
  */
 function withoutTestAccountFilterDefault<T extends ZodObjectAny>(schema: T): T {
     if (!hasTestAccountFilterField(schema)) {
+        return schema
+    }
+    // `ZodRawShape` values are typed as core `$ZodType`, which hides `safeParse`.
+    const field = schema.shape[TEST_ACCOUNT_FILTER_FIELD] as z.ZodType
+    const omittedValue = field.safeParse(undefined)
+    if (!omittedValue.success || omittedValue.data !== false) {
         return schema
     }
     return schema.extend({

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -53,7 +53,9 @@ function withoutTestAccountFilterDefault<T extends ZodObjectAny>(schema: T): T {
         return schema
     }
     return schema.extend({
-        [TEST_ACCOUNT_FILTER_FIELD]: z.coerce
+        // Strict boolean, not `z.coerce.boolean()`: coercion turns the string
+        // `"false"` into `true`, which would silently flip query semantics.
+        [TEST_ACCOUNT_FILTER_FIELD]: z
             .boolean()
             .optional()
             .describe(

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-funnel.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-funnel.json
@@ -81,8 +81,7 @@
             "description": "Date range for the query"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the respective filters",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "funnelsFilter": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-lifecycle.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-lifecycle.json
@@ -51,8 +51,7 @@
             "description": "Date range for the query"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the respective filters",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "interval": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-traces-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-traces-list.json
@@ -43,7 +43,8 @@
             "type": "boolean"
         },
         "filterTestAccounts": {
-            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
+            "default": true,
+            "description": "Exclude internal and test users by applying the respective filters.",
             "type": "boolean"
         },
         "groupKey": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-traces-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-traces-list.json
@@ -43,8 +43,7 @@
             "type": "boolean"
         },
         "filterTestAccounts": {
-            "default": true,
-            "description": "Exclude internal and test users by applying the respective filters.",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "groupKey": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-paths.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-paths.json
@@ -51,8 +51,7 @@
             "description": "Date range for the query"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the respective filters",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "kind": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-retention.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-retention.json
@@ -51,8 +51,7 @@
             "description": "Date range for the query"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the respective filters",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "kind": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness.json
@@ -66,8 +66,7 @@
             "description": "Date range for the query"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the respective filters",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "interval": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
@@ -145,8 +145,7 @@
             "description": "Date range for the query"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the respective filters",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "interval": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-overview.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-overview.json
@@ -90,8 +90,7 @@
             "type": "boolean"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the team's test-account filter.",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "kind": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-stats.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-stats.json
@@ -121,8 +121,7 @@
             "type": "boolean"
         },
         "filterTestAccounts": {
-            "default": false,
-            "description": "Exclude internal and test users by applying the team's test-account filter.",
+            "description": "Exclude internal and test users by applying the respective filters. When omitted, follows the project's \"Filter out internal and test users\" default setting.",
             "type": "boolean"
         },
         "includeAvgTimeOnPage": {

--- a/services/mcp/tests/unit/instructions.test.ts
+++ b/services/mcp/tests/unit/instructions.test.ts
@@ -296,6 +296,18 @@ describe('buildActiveEnvironmentContextPrompt', () => {
         expect(buildActiveEnvironmentContextPrompt(undefined, undefined, undefined)).toBeUndefined()
     })
 
+    it.each([
+        ['checked', true, true],
+        ['unchecked', false, false],
+        ['unset', undefined, false],
+    ])('surfaces the test account filter default only when %s', (_name, testAccountFiltersDefaultChecked, expected) => {
+        const result = buildActiveEnvironmentContextPrompt(user, org, {
+            ...project,
+            test_account_filters_default_checked: testAccountFiltersDefaultChecked,
+        } as CachedProject)
+        expect((result ?? '').includes('filters out internal and test users by default')).toBe(expected)
+    })
+
     it('still renders an "Unknown" project when org is present but project is missing', () => {
         // The org branch is unchanged — only the no-org branch was added.
         const result = buildActiveEnvironmentContextPrompt(user, org, undefined)

--- a/services/mcp/tests/unit/query-wrapper-factory.test.ts
+++ b/services/mcp/tests/unit/query-wrapper-factory.test.ts
@@ -307,16 +307,20 @@ describe('createQueryWrapper output_format handling', () => {
 })
 
 describe('createQueryWrapper filterTestAccounts project default', () => {
-    // Mirrors the generated wrapper schemas, whose hard `.default(false)` the
-    // factory must strip so omission can follow the project setting.
-    const schemaWithFilter = z.object({
-        series: z.array(z.object({ kind: z.string(), event: z.string() })),
-        filterTestAccounts: z.coerce
-            .boolean()
-            .describe('Exclude internal and test users by applying the respective filters')
-            .default(false)
-            .optional(),
-    })
+    // Mirrors the generated wrapper schemas: most default `filterTestAccounts`
+    // to false (which the factory must strip so omission can follow the project
+    // setting), AssistantTracesQuery to true (an intentional stricter default
+    // the factory must keep).
+    function makeSchema(schemaDefault: boolean): z.ZodObject<z.ZodRawShape> {
+        return z.object({
+            series: z.array(z.object({ kind: z.string(), event: z.string() })),
+            filterTestAccounts: z.coerce
+                .boolean()
+                .describe('Exclude internal and test users by applying the respective filters')
+                .default(schemaDefault)
+                .optional(),
+        })
+    }
     const series = [{ kind: 'EventsNode', event: '$pageview' }]
 
     function createMockContext(
@@ -338,14 +342,22 @@ describe('createQueryWrapper filterTestAccounts project default', () => {
     }
 
     it.each([
-        ['omitted follows a checked project default', {}, true, true],
-        ['omitted stays unset when the project default is unchecked', {}, false, undefined],
-        ['explicit false wins over a checked project default', { filterTestAccounts: false }, true, false],
-        ['explicit true wins over an unchecked project default', { filterTestAccounts: true }, false, true],
-    ] as const)('%s', async (_name, inputExtra, projectDefault, expected) => {
+        ['omitted follows a checked project default', false, {}, true, true],
+        ['omitted stays unset when the project default is unchecked', false, {}, false, undefined],
+        ['explicit false wins over a checked project default', false, { filterTestAccounts: false }, true, false],
+        ['explicit true wins over an unchecked project default', false, { filterTestAccounts: true }, false, true],
+        ['an intentional true schema default survives an unchecked project default', true, {}, false, true],
+        [
+            'explicit false wins over an intentional true schema default',
+            true,
+            { filterTestAccounts: false },
+            true,
+            false,
+        ],
+    ] as const)('%s', async (_name, schemaDefault, inputExtra, projectDefault, expected) => {
         const runQuery = vi.fn().mockResolvedValue({ results: [] })
         const context = createMockContext(runQuery, projectDefault)
-        const tool = createQueryWrapper({ name: 'test', schema: schemaWithFilter, kind: 'TrendsQuery' })()
+        const tool = createQueryWrapper({ name: 'test', schema: makeSchema(schemaDefault), kind: 'TrendsQuery' })()
 
         // Validate through the tool's advertised schema first, exactly like the
         // executor does — this is where a hard default would clobber omission.

--- a/services/mcp/tests/unit/query-wrapper-factory.test.ts
+++ b/services/mcp/tests/unit/query-wrapper-factory.test.ts
@@ -366,6 +366,18 @@ describe('createQueryWrapper filterTestAccounts project default', () => {
         expect(runQuery.mock.calls[0]![0].query.filterTestAccounts).toBe(expected)
     })
 
+    it.each(['false', 'true'])(
+        'rejects the string %j rather than coercing it to a boolean',
+        (stringValue) => {
+            const tool = createQueryWrapper({ name: 'test', schema: makeSchema(false), kind: 'TrendsQuery' })()
+
+            // The generated schemas use z.coerce.boolean(), which would turn "false"
+            // into true; the stripped replacement must be a strict boolean so a
+            // malformed value is rejected instead of silently flipping filtering.
+            expect(tool.schema.safeParse({ series, filterTestAccounts: stringValue }).success).toBe(false)
+        }
+    )
+
     it('does not inject the field into schemas that lack it', async () => {
         const runQuery = vi.fn().mockResolvedValue({ results: [] })
         const context = createMockContext(runQuery, true)

--- a/services/mcp/tests/unit/query-wrapper-factory.test.ts
+++ b/services/mcp/tests/unit/query-wrapper-factory.test.ts
@@ -306,6 +306,68 @@ describe('createQueryWrapper output_format handling', () => {
     })
 })
 
+describe('createQueryWrapper filterTestAccounts project default', () => {
+    // Mirrors the generated wrapper schemas, whose hard `.default(false)` the
+    // factory must strip so omission can follow the project setting.
+    const schemaWithFilter = z.object({
+        series: z.array(z.object({ kind: z.string(), event: z.string() })),
+        filterTestAccounts: z.coerce
+            .boolean()
+            .describe('Exclude internal and test users by applying the respective filters')
+            .default(false)
+            .optional(),
+    })
+    const series = [{ kind: 'EventsNode', event: '$pageview' }]
+
+    function createMockContext(
+        runQuery: ReturnType<typeof vi.fn>,
+        testAccountFiltersDefaultChecked: boolean | undefined
+    ): Context {
+        return {
+            api: {
+                query: vi.fn().mockReturnValue({ runQuery }),
+                getProjectBaseUrl: vi.fn().mockReturnValue('http://localhost:8010/project/1'),
+            },
+            stateManager: {
+                getProjectId: vi.fn().mockResolvedValue('1'),
+                getCachedOrFetchProject: vi
+                    .fn()
+                    .mockResolvedValue({ test_account_filters_default_checked: testAccountFiltersDefaultChecked }),
+            },
+        } as unknown as Context
+    }
+
+    it.each([
+        ['omitted follows a checked project default', {}, true, true],
+        ['omitted stays unset when the project default is unchecked', {}, false, undefined],
+        ['explicit false wins over a checked project default', { filterTestAccounts: false }, true, false],
+        ['explicit true wins over an unchecked project default', { filterTestAccounts: true }, false, true],
+    ] as const)('%s', async (_name, inputExtra, projectDefault, expected) => {
+        const runQuery = vi.fn().mockResolvedValue({ results: [] })
+        const context = createMockContext(runQuery, projectDefault)
+        const tool = createQueryWrapper({ name: 'test', schema: schemaWithFilter, kind: 'TrendsQuery' })()
+
+        // Validate through the tool's advertised schema first, exactly like the
+        // executor does — this is where a hard default would clobber omission.
+        await tool.handler(context, tool.schema.parse({ series, ...inputExtra }))
+
+        expect(runQuery.mock.calls[0]![0].query.filterTestAccounts).toBe(expected)
+    })
+
+    it('does not inject the field into schemas that lack it', async () => {
+        const runQuery = vi.fn().mockResolvedValue({ results: [] })
+        const context = createMockContext(runQuery, true)
+        const schemaWithoutFilter = z.object({
+            series: z.array(z.object({ kind: z.string(), event: z.string() })),
+        })
+        const tool = createQueryWrapper({ name: 'test', schema: schemaWithoutFilter, kind: 'WebOverviewQuery' })()
+
+        await tool.handler(context, tool.schema.parse({ series }))
+
+        expect(runQuery.mock.calls[0]![0].query).not.toHaveProperty('filterTestAccounts')
+    })
+})
+
 describe('createQueryWrapper actors dispatch', () => {
     function createMockContext(): Context {
         return {


### PR DESCRIPTION
## TL;DR (eli5)

PostHog projects have a setting that says "hide internal and test users from insights by default". The PostHog UI honors it whenever you build a new insight, but the MCP query tools quietly forced it off unless the agent remembered to turn it on. Now, when an agent runs a query without saying either way, the MCP follows the project setting, just like the UI. If the agent explicitly asks to include or exclude test accounts, that always wins.

## Problem

The MCP's generated query wrapper schemas hard-default `filterTestAccounts` to `false`, so agent-run queries ignored the project's `test_account_filters_default_checked` setting that the UI applies to every new insight. Agents and the UI could report different numbers for the same question, with test-account noise silently included.

## Changes

- `createQueryWrapper` strips the hard `.default(false)` on `filterTestAccounts` from the generated schemas at registration, so an omitted value survives both validation gates as `undefined` instead of being coerced to `false`.
- When the field is omitted and the project has `test_account_filters_default_checked` enabled, the handler injects `filterTestAccounts: true` (matching `setTestAccountFilterForNewInsight` in the UI). Explicit values from the caller always win. When the project default is unchecked the field stays omitted and the backend default applies, as before.
- The active environment prompt now surfaces the setting so agents apply it on surfaces where injection can't reach (e.g. `insight-create`, dashboard queries).
- Removed the same hard default from the handwritten `schema/query.ts` insight base schema.
- Tool schema snapshots regenerated: the `query-*` tools now describe the project-default behavior instead of advertising `default: false`.

> [!NOTE]
> Behavior change: in projects with "Filter out internal and test users" enabled by default, `query-*` MCP tool calls that omit `filterTestAccounts` now exclude test accounts, matching what the same query shows in the UI.

## How did you test this code?

- `services/mcp` unit suite (2083 tests, all passing), including regenerated tool-schema snapshots.
- New parameterized cases in `query-wrapper-factory.test.ts` drive input through `tool.schema.parse` exactly like the executor does, catching the regression where a re-added hard default (or a handler re-parse against the original schema) makes omission indistinguishable from explicit `false`. One case guards against injecting the field into query kinds whose schema lacks it.
- New cases in `instructions.test.ts` lock in that the environment prompt surfaces the setting only when enabled.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference the MCP `filterTestAccounts` default.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) from a finding that the MCP hard-defaults `filterTestAccounts: false` while the UI respects the project default. Skills invoked: /implementing-mcp-tools, /writing-tests. Considered patching the codegen for `query-wrappers.ts` instead, but transforming the schema in the wrapper factory keeps generated files untouched and covers every wrapper uniformly; also considered prompt-only guidance, but deterministic injection matches UI behavior without relying on the agent to comply, with the prompt line covering the remaining surfaces.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
