### PR TITLE
fix(data-modeling): exclude deleted saved queries from freshness scheduling

### DIFF
--- a/products/data_modeling/backend/logic/node_frequency.py
+++ b/products/data_modeling/backend/logic/node_frequency.py
@@ -140,7 +140,7 @@ class FrequencyGraph:
 
 def build_frequency_graph(dag: DAG) -> FrequencyGraph:
     """Extract the freshness graph for a DAG: schedulable nodes, edges, targets, source floors."""
-    nodes = list(Node.objects.filter(dag=dag))
+    nodes = list(Node.objects.filter(dag=dag).exclude(saved_query__deleted=True))
     edges = [
         (str(source_id), str(target_id))
         for source_id, target_id in Edge.objects.filter(dag=dag).values_list("source_id", "target_id")
@@ -175,7 +175,12 @@ def seed_targets(dag: DAG) -> dict[str, timedelta]:
     the preview overlays these in memory, and a backfill can persist them.
     """
     seeds: dict[str, timedelta] = {}
-    for node in Node.objects.filter(dag=dag).exclude(type=NodeType.TABLE).select_related("saved_query"):
+    for node in (
+        Node.objects.filter(dag=dag)
+        .exclude(type=NodeType.TABLE)
+        .exclude(saved_query__deleted=True)
+        .select_related("saved_query")
+    ):
         interval = None
         if node.saved_query is not None and node.saved_query.sync_frequency_interval is not None:
             interval = node.saved_query.sync_frequency_interval


### PR DESCRIPTION
## Problem

The per-node freshness scheduler (shipped in #67395) pulls every node in a DAG without checking whether the node's saved query is soft-deleted. Soft-deleted saved queries leave behind `POSTHOG_DELETED_*` nodes with a null `sync_frequency_interval`. In `seed_targets` those nodes fall through to the DAG-cadence fallback and get seeded a target, and in `build_frequency_graph` they stay in the schedulable set. So they land in a cadence tier.

I found this running `preview_freshness_schedules --seed` against a real blocked team: four tombstoned nodes showed up in the 1-day tier. `execute_dag` has no deleted-node skip (it only skips suspended, upstream-failed, and ephemeral nodes), so once the write path (#67554) goes live those tiers would try to materialize tombstones.

## Changes

- `build_frequency_graph` and `seed_targets` (`logic/node_frequency.py`) now `.exclude(saved_query__deleted=True)`. Table source nodes have no saved query, so they are unaffected.

No edge filtering needed: `compute_effective_cadences` already guards every edge traversal with `if child in nodes` / `if parent in nodes`, so edges pointing at an excluded node are ignored.

This is read-only preview + reconcile-input logic. It changes nothing until a DAG is actually reconciled, and the effect is simply that deleted saved queries stop being scheduled.

## How did you test this code?

I (Claude) did not add an automated test for this per the author's call. Verified `ruff check` / `ruff format` clean on the touched file, and confirmed against the live preview output that the excluded nodes were the `POSTHOG_DELETED_*` tombstones (saved query `deleted=True`, null interval).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude (Claude Code) while previewing the freshness-target migration on real blocked teams via the deployed `preview_freshness_schedules` command. Traced the tombstone-in-tier symptom to the missing `deleted` filter in the two graph-input functions, confirmed `execute_dag` has no compensating skip, and confirmed the effective-cadence pass tolerates dangling edges so no edge filtering is required. Raised as a standalone fix off master rather than folding into the write-path PR (#67554).
