### PR TITLE
chore(experiments): add A/A dogfood flag to validate freeze exposure

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -315,6 +315,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_END_MODAL_CONCLUSION_FIRST: 'experiments-end-modal-conclusion-first', // owner: @ruby.c #team-experiments
     EXPERIMENTS_EXCLUDED_VARIANTS: 'experiments-excluded-variants', // owner: @rodrigoi #team-experiments
+    EXPERIMENTS_FREEZE_EXPOSURE_AA_TEST: 'experiments-freeze-exposure-aa-test', // owner: @mp-hog #team-experiments multivariate=control,test, dogfood A/A used to validate the freeze-exposure lifecycle action
     EXPERIMENTS_METRICS_RECALCULATION: 'experiments-metrics-recalculation', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments

--- a/frontend/src/scenes/AuthenticatedShell.tsx
+++ b/frontend/src/scenes/AuthenticatedShell.tsx
@@ -46,6 +46,9 @@ export default function AuthenticatedShell({ children }: { children: React.React
                 {featureFlags[FEATURE_FLAGS.EXPERIMENTS_DW_AA_TEST] === 'test' && (
                     <div data-attr="experiments-dw-aa-test-variant" className="hidden" />
                 )}
+                {featureFlags[FEATURE_FLAGS.EXPERIMENTS_FREEZE_EXPOSURE_AA_TEST] === 'test' && (
+                    <div data-attr="experiments-freeze-exposure-aa-test-variant" className="hidden" />
+                )}
             </div>
             <ToastContainer
                 autoClose={6000}


### PR DESCRIPTION
## Problem

A/A feature flag to validate the freeze-exposure action ([#63838](https://github.com/PostHog/posthog/pull/63838))

## Changes

Adds `experiments-freeze-exposure-aa-test` (`control`/`test`) and reads it in `AuthenticatedShell`, mirroring `EXPERIMENTS_DW_AA_TEST`. Authenticated surface = fast exposure and every exposed user has a person profile, which the freeze scan needs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
