### PR TITLE
fix(pipedrive): clearer error when company domain is a full URL

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/pipedrive.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/pipedrive.py
@@ -23,6 +23,14 @@ MAX_RETRIES = 5
 
 _SUBDOMAIN_RE = re.compile(r"^[a-z0-9-]+$")
 
+# Never reflects the raw input back: it can be a full URL or website domain the user pasted by
+# mistake, and echoing it gives no guidance on what a valid value looks like.
+_INVALID_COMPANY_DOMAIN_ERROR = (
+    "Invalid Pipedrive company domain. Enter just your Pipedrive subdomain — the part before "
+    ".pipedrive.com (for example, enter 'acme' for acme.pipedrive.com) — not a full URL or your "
+    "website's domain."
+)
+
 
 class PipedriveRetryableError(Exception):
     pass
@@ -47,7 +55,7 @@ def normalize_company_domain(raw: str) -> str:
     domain = domain.split("/")[0]
     domain = domain.removesuffix(".pipedrive.com")
     if not _SUBDOMAIN_RE.match(domain):
-        raise ValueError(f"Invalid Pipedrive company domain: {raw!r}")
+        raise ValueError(_INVALID_COMPANY_DOMAIN_ERROR)
     return domain
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive.py
@@ -48,6 +48,13 @@ class TestNormalizeCompanyDomain:
         with pytest.raises(ValueError):
             normalize_company_domain(raw)
 
+    def test_rejection_message_guides_without_echoing_input(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            normalize_company_domain("https://secret-subdomain.example.com/")
+        message = str(exc_info.value)
+        assert "secret-subdomain" not in message
+        assert "pipedrive.com" in message
+
     def test_base_url_is_pinned_to_pipedrive(self) -> None:
         assert base_url("mycompany") == "https://mycompany.pipedrive.com"
         assert base_url("https://MyCompany.pipedrive.com") == "https://mycompany.pipedrive.com"


### PR DESCRIPTION
## Problem

The Pipedrive source's company-domain field expects a bare subdomain (the part before `.pipedrive.com`). When a user pasted a full URL or their own website's domain instead, validation rejected it with a message that just said the value was invalid and echoed the raw input straight back. That gives the user nothing to act on and reflects whatever they typed (which can be an arbitrary URL) back into the error.

We saw real source-creation failures of exactly this shape: users entering a website domain rather than their Pipedrive subdomain.

## Changes

Replace the message with an actionable one that tells the user to enter just their Pipedrive subdomain (for example `acme` for `acme.pipedrive.com`), and stop reflecting the pasted input back. This mirrors the pattern the Postgres and MySQL sources already use for the "pasted a URL in the host field" case (`_HOST_IS_URL_ERROR`).

Behavior is otherwise unchanged: the same inputs are still rejected, and outbound traffic stays pinned to `*.pipedrive.com`.

## How did you test this code?

I'm an agent and did not do manual testing. I ran the existing Pipedrive unit tests plus one new pure-function case:

- Added `test_rejection_message_guides_without_echoing_input` to `TestNormalizeCompanyDomain`. It guards the regression this PR fixes: that the rejection message does not echo the user's raw input back and does point them at the expected `pipedrive.com` subdomain format. No existing test asserted anything about the message text (they only checked that a `ValueError` was raised).
- `pytest` over `test_pipedrive.py::TestNormalizeCompanyDomain` and `test_pipedrive_source.py` — 37 passed.
- `ruff check` / `ruff format` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (PostHog Code) while triaging a batch of data-warehouse source-creation failures. Invoked the `/writing-tests` skill before adding the test to apply the value gate.

I considered whether this warranted a code change at all, since a "your domain is invalid" message is borderline user-misconfiguration. What tipped it: the message reflected raw user input and the codebase already has a dedicated, friendlier message for the analogous "pasted a URL" case on the SQL sources, so aligning Pipedrive with that pattern is a small, consistent improvement. I put the fix in `normalize_company_domain` (the single place the value is validated) so both the setup-validation path and the sync path get the clearer message.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
