### PR TITLE
fix(postgres): treat read-only cluster errors as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -471,6 +471,18 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "connect until the database is available again. Upgrade your provider's plan or wait "
                 "for the quota to reset, then re-enable the sync."
             ),
+            # The provider has put the cluster into read-only mode, so it rejects our read (the
+            # server-side cursor runs its SELECT inside a read/write transaction). PlanetScale's
+            # pg_readonly reports "invalid statement because cluster is read-only"; the cluster only
+            # leaves this state once the customer restores write access (free up storage, upgrade the
+            # plan), so a whole-activity retry re-reads into the same wall. Match the stable phrase and
+            # exclude the volatile leading "pg_readonly:" prefix and trailing docs URL.
+            "cluster is read-only": (
+                "Your database provider has put the database cluster into read-only mode, so it's "
+                'rejecting PostHog\'s queries ("cluster is read-only"). Providers such as PlanetScale '
+                "do this when a storage or usage limit is exceeded. Restore write access to the cluster "
+                "(for example free up storage or upgrade your plan), then re-enable the sync."
+            ),
             # A physical standby / read replica started with `hot_standby = off` refuses every
             # connection while in recovery, raising SQLSTATE 57P03 "FATAL: the database system is not
             # accepting connections / DETAIL: Hot standby mode is disabled". It will never serve read

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -503,6 +503,28 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)). The leading
+            # "pg_readonly:" prefix and trailing docs URL are volatile; "cluster is read-only" is stable.
+            "pg_readonly: invalid statement because cluster is read-only. See planetscale.com/docs/postgres/troubleshooting/readonly",
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "InternalError_: pg_readonly: invalid statement because cluster is read-only. See planetscale.com/docs/postgres/troubleshooting/readonly",
+        ],
+    )
+    def test_read_only_cluster_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Read-only cluster error should be non-retryable: {error_msg}"
+
+    def test_read_only_cluster_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = "pg_readonly: invalid statement because cluster is read-only. See planetscale.com/docs/postgres/troubleshooting/readonly"
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Read-only cluster error should surface an actionable message"
+        assert "read-only mode" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Raw psycopg message (what the activity-level check sees via str(e)). The request size
             # and memory-context name are volatile; the "out of memory" text is stable.
             'out of memory DETAIL:  Failed on request of size 12 in memory context "MessageContext".',


### PR DESCRIPTION
## Problem

Error tracking surfaced a Postgres import failure where the source cluster is in read-only mode:

> `InternalError_: pg_readonly: invalid statement because cluster is read-only. See planetscale.com/docs/postgres/troubleshooting/readonly`

Issue: https://us.posthog.com/project/2/error_tracking/019f4612-2a47-7cd3-9747-4aee85158660

The stack trace originates in this source's `get_rows` at `cursor.execute(query)`. We only issue a `SELECT`, but a server-side (named) cursor runs it inside a read/write transaction, which the provider's `pg_readonly` guard rejects while the cluster is read-only. Providers such as PlanetScale flip a cluster into read-only mode when a storage or usage limit is exceeded, and it stays that way until the customer restores write access. So retrying the whole activity just re-reads into the same rejection and burns the retry budget, and each attempt re-reports the customer-side condition as error-tracking noise.

## Changes

Add `"cluster is read-only"` to `PostgresSource.get_non_retryable_errors` with an actionable, non-sensitive message telling the customer their provider put the cluster into read-only mode and how to restore write access. This mirrors the existing sibling entries for provider-side quota conditions (`exceeded the compute time quota`, `DiskFull`).

The match is a stable substring: it deliberately excludes the volatile leading `pg_readonly:` prefix and the trailing docs URL, and it matches at both the activity layer (raw `str(e)`) and the workflow layer (Temporal-wrapped `InternalError_: ...`).

## How did you test this code?

I (Claude) couldn't run the suite in this environment (no `pytest`/`flox` available), so I validated the substring-matching logic standalone and compile-checked both files. `ruff check` and `ruff format` pass.

Added two parameterized tests in `test_postgres.py`, following the `exceeded_compute_time_quota` pattern:

- `test_read_only_cluster_is_non_retryable` - the read-only-cluster message is classified non-retryable at both the raw and Temporal-wrapped layers. Catches a regression where the entry is dropped and the error becomes retryable again, re-reading into the same read-only wall.
- `test_read_only_cluster_returns_friendly_message` - the entry surfaces an actionable message rather than `None`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from an error-tracking webhook. I (Claude) pulled the full stack trace and a representative event via the PostHog error-tracking MCP tools, confirmed the failure genuinely originates in `postgres.py:get_rows` (the top serialized frame's `code_variables` are unrelated proxy-service capture noise, but the resolved frames run through this source), and read the source and `get_non_retryable_errors`.

Decision: user/upstream error, not a fixable bug in our code. The cluster being read-only is a state of the customer's database that only they can resolve, so the right move is to stop retrying with a helpful message rather than change any query behavior. I kept the change scoped to a single dict entry plus tests, mirroring the established sibling entries. Invoked `/writing-tests` before adding the tests. Checked for duplicate open PRs (including the maintainer's own) from several angles first; none addressed this.
