### PR TITLE
fix(tasks): bind wizard PRs to their run via a server-generated head branch

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -17,7 +17,6 @@ Functions that bridge to those heavy surfaces import them lazily inside the func
 
 import re
 import logging
-import secrets
 from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Literal
@@ -64,7 +63,7 @@ from products.tasks.backend.models import (
     TaskThreadMessage,
     TaskThreadMessageMention,
 )
-from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIX, build_wizard_pr_agent_prompt
+from products.tasks.backend.prompts import build_wizard_pr_agent_prompt, generate_wizard_head_branch
 from products.tasks.backend.visibility import task_control_q, task_run_visibility_q, task_visibility_q
 
 from . import contracts
@@ -771,7 +770,7 @@ def create_wizard_cloud_run(
     opened PR back to this run by branch + repository — wizard PRs are bot-authored, which the
     agent-side PR attribution cannot match.
     """
-    head_branch = f"{WIZARD_HEAD_BRANCH_PREFIX}{secrets.token_hex(3)}"
+    head_branch = generate_wizard_head_branch()
     prompt = build_wizard_pr_agent_prompt(head_branch)
     return create_and_run_task(
         team=team,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -64,7 +64,7 @@ from products.tasks.backend.models import (
     TaskThreadMessage,
     TaskThreadMessageMention,
 )
-from products.tasks.backend.prompts import build_wizard_pr_agent_prompt
+from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIX, build_wizard_pr_agent_prompt
 from products.tasks.backend.visibility import task_control_q, task_run_visibility_q, task_visibility_q
 
 from . import contracts
@@ -771,7 +771,7 @@ def create_wizard_cloud_run(
     opened PR back to this run by branch + repository — wizard PRs are bot-authored, which the
     agent-side PR attribution cannot match.
     """
-    head_branch = f"posthog/instrumentation-{secrets.token_hex(3)}"
+    head_branch = f"{WIZARD_HEAD_BRANCH_PREFIX}{secrets.token_hex(3)}"
     prompt = build_wizard_pr_agent_prompt(head_branch)
     return create_and_run_task(
         team=team,
@@ -1465,6 +1465,7 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
         "sandbox_ttl_seconds",
         "inactivity_timeout_seconds",
         "wizard_config",
+        "wizard_head_branch",
         "use_modal_directory_resume_snapshots",
         "snapshot_external_id",
         "snapshot_kind",
@@ -3737,6 +3738,12 @@ def run_task(
         extra_state = extra_state or {}
         extra_state["resume_from_run_id"] = str(resume_from_run_id)
         extra_state.update(prev_state.resume_snapshot_carry_state())
+
+        # The resumed agent still pushes the head branch baked into the original prompt, so the
+        # PR webhook must be able to match this run, not the terminal predecessor.
+        prev_wizard_head_branch = (previous_run.state or {}).get("wizard_head_branch")
+        if prev_wizard_head_branch:
+            extra_state["wizard_head_branch"] = prev_wizard_head_branch
 
         if prev_state.sandbox_environment_id and sandbox_environment_id is None:
             sandbox_environment_id = prev_state.sandbox_environment_id

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -17,6 +17,7 @@ Functions that bridge to those heavy surfaces import them lazily inside the func
 
 import re
 import logging
+import secrets
 from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Literal
@@ -63,7 +64,7 @@ from products.tasks.backend.models import (
     TaskThreadMessage,
     TaskThreadMessageMention,
 )
-from products.tasks.backend.prompts import WIZARD_PR_AGENT_PROMPT
+from products.tasks.backend.prompts import build_wizard_pr_agent_prompt
 from products.tasks.backend.visibility import task_control_q, task_run_visibility_q, task_visibility_q
 
 from . import contracts
@@ -765,11 +766,17 @@ def create_wizard_cloud_run(
 
     ``user_id`` is the person going through onboarding; it becomes the task's ``created_by`` so the
     run is explicitly attributed to them.
+
+    The PR head branch is generated here (not by the agent) so the GitHub PR webhook can bind the
+    opened PR back to this run by branch + repository — wizard PRs are bot-authored, which the
+    agent-side PR attribution cannot match.
     """
+    head_branch = f"posthog/instrumentation-{secrets.token_hex(3)}"
+    prompt = build_wizard_pr_agent_prompt(head_branch)
     return create_and_run_task(
         team=team,
         title="Set up PostHog",
-        description=WIZARD_PR_AGENT_PROMPT,
+        description=prompt,
         origin_product=Task.OriginProduct.ONBOARDING,
         user_id=user_id,
         repository=repository,
@@ -777,10 +784,11 @@ def create_wizard_cloud_run(
         mode="background",
         branch=branch,
         wizard_config={},
+        wizard_head_branch=head_branch,
         posthog_mcp_scopes="read_only",
         # The agent server boots idle; this is the message that actually kicks it off once ready
         # (delivered by forward_pending_user_message). Without it the run stalls after "Started agent".
-        pending_user_message=WIZARD_PR_AGENT_PROMPT,
+        pending_user_message=prompt,
     )
 
 

--- a/products/tasks/backend/migrations/0054_taskrun_wizard_branch_idx.py
+++ b/products/tasks/backend/migrations/0054_taskrun_wizard_branch_idx.py
@@ -1,0 +1,23 @@
+import django.db.models.fields.json
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("tasks", "0053_sandboxcustomimage_build_log"),
+    ]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="taskrun",
+            index=models.Index(
+                django.db.models.fields.json.KeyTransform("wizard_head_branch", "state"),
+                name="task_run_wizard_branch_idx",
+                condition=models.Q(state__wizard_head_branch__isnull=False),
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0053_sandboxcustomimage_build_log
+0054_taskrun_wizard_branch_idx

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -432,6 +432,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         sandbox_timeout_seconds: int | None = None,
         inactivity_timeout_seconds: int | None = None,
         wizard_config: dict | None = None,
+        wizard_head_branch: str | None = None,
         pending_user_message: str | None = None,
         custom_image_builder_id: str | None = None,
         custom_image_id: str | None = None,
@@ -599,6 +600,13 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             # Wizard runs must boot the agent only after the wizard step.
             extra_state["overlap_clone_boot_enabled"] = False
 
+        # Server-generated head branch the agent is instructed to push to, so the GitHub PR
+        # webhook can bind the opened PR back to this run (webhooks.find_task_run). Kept out of
+        # TaskRun.branch, which means "branch to check out at provisioning" — not "branch the
+        # agent will create".
+        if wizard_head_branch:
+            extra_state["wizard_head_branch"] = wizard_head_branch
+
         # The first message handed to the agent once its server is ready (forward_pending_user_message
         # reads it from run state). Without it a background run boots the agent idle — it never gets a
         # prompt and just sits there while relay_sandbox_events waits for events that never come.
@@ -688,6 +696,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         inactivity_timeout_seconds: int | None = None,
         ai_stage: str | None = None,
         wizard_config: dict | None = None,
+        wizard_head_branch: str | None = None,
         pending_user_message: str | None = None,
         custom_image_builder_id: str | None = None,
         custom_image_id: str | None = None,
@@ -718,6 +727,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             inactivity_timeout_seconds=inactivity_timeout_seconds,
             ai_stage=ai_stage,
             wizard_config=wizard_config,
+            wizard_head_branch=wizard_head_branch,
             pending_user_message=pending_user_message,
             custom_image_builder_id=custom_image_builder_id,
             custom_image_id=custom_image_id,

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1028,6 +1028,13 @@ class TaskRun(models.Model):
                 name="task_run_output_pr_url_idx",
                 condition=models.Q(output__pr_url__isnull=False),
             ),
+            # Same shape for the wizard-run webhook leg `filter(state__wizard_head_branch=...)`;
+            # only wizard runs carry the key, so the index stays tiny.
+            models.Index(
+                KeyTransform("wizard_head_branch", "state"),
+                name="task_run_wizard_branch_idx",
+                condition=models.Q(state__wizard_head_branch__isnull=False),
+            ),
             # Time-range scans over runs (default ordering, recent-runs lookups, and the
             # signals outcome-billing query that buckets PR runs into a period).
             models.Index(fields=["created_at"], name="task_run_created_at_idx"),
@@ -1434,6 +1441,18 @@ class TaskRun(models.Model):
         backend decides grouping granularity by picking a phase id (e.g.
         `"setup"`, `"pr_create"`).
         """
+        event = self.build_progress_event(step, status, label, group, detail)
+        self.append_log([event])
+        self.publish_stream_event(event)
+
+    def build_progress_event(
+        self,
+        step: str,
+        status: str,
+        label: str,
+        group: str,
+        detail: Optional[str] = None,
+    ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "sessionId": str(self.id),
             "step": step,
@@ -1443,7 +1462,7 @@ class TaskRun(models.Model):
         }
         if detail is not None:
             params["detail"] = detail
-        event = {
+        return {
             "type": "notification",
             "timestamp": django_timezone.now().isoformat(),
             "notification": {
@@ -1452,8 +1471,6 @@ class TaskRun(models.Model):
                 "params": params,
             },
         }
-        self.append_log([event])
-        self.publish_stream_event(event)
 
     def emit_sandbox_output(self, stdout: str, stderr: str, exit_code: int) -> None:
         """Emit sandbox execution output as ACP notification."""

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -5,6 +5,10 @@ Shell efficiency: optimize for the fewest shell round trips.
 - Read multiple files at once.
 - Never rerun a command solely to reproduce output you already have."""
 
+# Sentinel swapped for the run's server-generated head branch by build_wizard_pr_agent_prompt.
+# A .replace() sentinel (not str.format) because the prompt body is full of literal braces.
+WIZARD_HEAD_BRANCH_PLACEHOLDER = "<wizard-head-branch>"
+
 WIZARD_PR_AGENT_PROMPT = f"""
 # Context
 
@@ -58,9 +62,9 @@ are actually in the repository.
 
 ## Step 2 - Commit the wizard's changes to a new branch
 
-1. Create a branch named `posthog/instrumentation-<random-short-sha>`, where
-   `<random-short-sha>` is a random 6-character hex string you generate (NOT the HEAD
-   commit SHA). Its only purpose is to keep this branch from clashing with an existing branch.
+1. Create a branch named exactly `{WIZARD_HEAD_BRANCH_PLACEHOLDER}`. This name was
+   pre-generated for this run and PostHog uses it to link the pull request back to the
+   setup progress — do NOT choose a different branch name.
 2. Look at `git log` to learn this repository's commit message convention.
 3. Commit the wizard's changes in that style; the message should resemble the concept of
    "Add PostHog to codebase". For example, in a repo using conventional commits:
@@ -72,11 +76,11 @@ are actually in the repository.
 4. Do NOT commit `posthog-setup-report.md` or `.posthog-events.json` - they are local reference
    only. Leave them untracked or exclude them from staging.
 
-**Checkpoint:** the commit exists on `posthog/instrumentation-<random-short-sha>` and
+**Checkpoint:** the commit exists on `{WIZARD_HEAD_BRANCH_PLACEHOLDER}` and
 contains neither reference file:
 
 ```bash
-git rev-parse --abbrev-ref HEAD          # prints: posthog/instrumentation-<random-short-sha>
+git rev-parse --abbrev-ref HEAD          # prints: {WIZARD_HEAD_BRANCH_PLACEHOLDER}
 git show --stat HEAD                     # lists the wizard's files
 git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' && echo "FAIL: forbidden files committed" || echo "OK: no forbidden files"
 # expected: OK: no forbidden files (the grep finding nothing is the pass case)
@@ -255,3 +259,13 @@ unrelated to the integration and documented in a PR comment.
 
 {SHELL_EFFICIENCY_INSTRUCTION}
 """
+
+
+def build_wizard_pr_agent_prompt(head_branch: str) -> str:
+    """The wizard PR agent prompt with the run's server-generated head branch baked in.
+
+    The branch must be known before the agent runs so the GitHub PR webhook can bind the
+    opened PR back to the TaskRun (see webhooks.find_task_run); letting the agent invent
+    the name made that binding impossible.
+    """
+    return WIZARD_PR_AGENT_PROMPT.replace(WIZARD_HEAD_BRANCH_PLACEHOLDER, head_branch)

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -1,3 +1,5 @@
+import secrets
+
 SHELL_EFFICIENCY_INSTRUCTION = """\
 Shell efficiency: optimize for the fewest shell round trips.
 - Batch related commands into one Bash invocation using `&&` (e.g. `npm run typecheck && npm run lint && npm test`).
@@ -10,6 +12,13 @@ Shell efficiency: optimize for the fewest shell round trips.
 WIZARD_HEAD_BRANCH_PLACEHOLDER = "<wizard-head-branch>"
 
 WIZARD_HEAD_BRANCH_PREFIX = "posthog/instrumentation-"
+
+
+def generate_wizard_head_branch() -> str:
+    """A unique PR head branch for a wizard run; the random suffix only prevents
+    collisions with existing branches in the user's repo."""
+    return f"{WIZARD_HEAD_BRANCH_PREFIX}{secrets.token_hex(3)}"
+
 
 WIZARD_PR_AGENT_PROMPT = f"""
 # Context

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -9,6 +9,8 @@ Shell efficiency: optimize for the fewest shell round trips.
 # A .replace() sentinel (not str.format) because the prompt body is full of literal braces.
 WIZARD_HEAD_BRANCH_PLACEHOLDER = "<wizard-head-branch>"
 
+WIZARD_HEAD_BRANCH_PREFIX = "posthog/instrumentation-"
+
 WIZARD_PR_AGENT_PROMPT = f"""
 # Context
 

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -18,7 +18,7 @@ from products.tasks.backend.facade import (
     warm as warm_facade,
 )
 from products.tasks.backend.models import SandboxCustomImage, SandboxEnvironment, Task, TaskRun
-from products.tasks.backend.prompts import WIZARD_PR_AGENT_PROMPT
+from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PLACEHOLDER, build_wizard_pr_agent_prompt
 
 FACADE_MODULES = [
     "products.tasks.backend.facade.api",
@@ -449,7 +449,16 @@ class TestFacadeReadsAndMappers(TestCase):
         run = TaskRun.objects.get(task_id=created.task_id)
         # The agent server boots idle; forward_pending_user_message only kicks it off if the run state
         # carries the prompt. Without this the cloud wizard stalls right after "Started agent".
-        self.assertEqual(run.state.get("pending_user_message"), WIZARD_PR_AGENT_PROMPT)
+        head_branch = run.state.get("wizard_head_branch")
+        # Server-generated head branch: the GitHub PR webhook binds the opened PR back to this
+        # run by matching it (wizard PRs are bot-authored, so agent-side attribution can't).
+        # Losing the state key or leaving the placeholder untemplated in the prompt silently
+        # unbinds every wizard PR again.
+        assert head_branch is not None
+        self.assertRegex(head_branch, r"^posthog/instrumentation-[0-9a-f]{6}$")
+        self.assertEqual(run.state.get("pending_user_message"), build_wizard_pr_agent_prompt(head_branch))
+        self.assertIn(f"`{head_branch}`", run.state["pending_user_message"])
+        self.assertNotIn(WIZARD_HEAD_BRANCH_PLACEHOLDER, run.state["pending_user_message"])
         # The agent-server self-delivers pending_user_message the moment it boots, so an
         # overlap-clone-boot launch (before run_wizard) burns the prompt on an untouched repo
         # and the run never opens a PR. Wizard runs must pin the overlap boot off.

--- a/products/tasks/backend/tests/test_migration_0050.py
+++ b/products/tasks/backend/tests/test_migration_0050.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from posthog.test.base import TestMigrations
+from posthog.test.base import NonAtomicTestMigrations
 
 
-class BackfillThreadMessageMentionsMigrationTest(TestMigrations):
+class BackfillThreadMessageMentionsMigrationTest(NonAtomicTestMigrations):
     """0050 indexes mentions already stored inline in existing thread messages. The backfill
     must mirror write-time extraction: org members only, self-mentions skipped, created_at
     copied from the message.
@@ -11,6 +11,8 @@ class BackfillThreadMessageMentionsMigrationTest(TestMigrations):
 
     migrate_from = "0049_taskthreadmessagemention"
     migrate_to = "0050_backfill_thread_message_mentions"
+
+    CLASS_DATA_LEVEL_SETUP = False
 
     @property
     def app(self) -> str:

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -754,12 +754,26 @@ class TestFindTaskRun(TestCase):
             task=self.task,
             team=self.team,
             status=TaskRun.Status.IN_PROGRESS,
+            branch="main",
             state={"wizard_head_branch": "posthog/instrumentation-ab12cd"},
         )
         result = find_task_run(branch="posthog/instrumentation-ab12cd", repository="posthog/posthog")
         self.assertEqual(result, wizard_run)
         # Same branch name from a foreign repository must not be attributed to this run.
         self.assertIsNone(find_task_run(branch="posthog/instrumentation-ab12cd", repository="acme/other"))
+        # The run's `branch` column holds the checkout base, so a same-repo PR whose head
+        # ref equals it must not claim the wizard run through the plain branch leg.
+        self.assertIsNone(find_task_run(branch="main", repository="posthog/posthog"))
+
+    def test_wizard_head_branch_leg_ignores_terminal_runs(self):
+        # A reopened/re-PR'd wizard branch months later must not fire events on a dead run.
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"wizard_head_branch": "posthog/instrumentation-dead00"},
+        )
+        self.assertIsNone(find_task_run(branch="posthog/instrumentation-dead00", repository="posthog/posthog"))
 
     def test_returns_none_when_no_match(self):
         result = find_task_run(pr_url="https://github.com/posthog/posthog/pull/999")

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -746,6 +746,21 @@ class TestFindTaskRun(TestCase):
         )
         self.assertEqual(result, branch_run)
 
+    def test_finds_wizard_run_by_state_head_branch(self):
+        # Wizard cloud runs never have the PR head branch in TaskRun.branch (that column is
+        # the checkout base); the server-generated head branch lives in run state. Dropping
+        # this match leg silently unbinds every wizard PR from its run again.
+        wizard_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            state={"wizard_head_branch": "posthog/instrumentation-ab12cd"},
+        )
+        result = find_task_run(branch="posthog/instrumentation-ab12cd", repository="posthog/posthog")
+        self.assertEqual(result, wizard_run)
+        # Same branch name from a foreign repository must not be attributed to this run.
+        self.assertIsNone(find_task_run(branch="posthog/instrumentation-ab12cd", repository="acme/other"))
+
     def test_returns_none_when_no_match(self):
         result = find_task_run(pr_url="https://github.com/posthog/posthog/pull/999")
         self.assertIsNone(result)

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -232,6 +232,36 @@ class TestGitHubPRWebhook(TestCase):
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_opened_backfills_pr_url_on_wizard_head_branch_match(self, mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="main",
+            state={"wizard_head_branch": "posthog/instrumentation-ab12cd"},
+            output={},
+        )
+        pr_url = "https://github.com/posthog/posthog/pull/778"
+        payload = {
+            "action": "opened",
+            "pull_request": {
+                "html_url": pr_url,
+                "merged": False,
+                "head": {"ref": "posthog/instrumentation-ab12cd", "repo": {"full_name": "posthog/posthog"}},
+            },
+            "repository": {"full_name": "posthog/posthog"},
+        }
+
+        response = self._make_webhook_request(payload)
+        self.assertEqual(response.status_code, 200)
+
+        run.refresh_from_db()
+        assert run.output is not None
+        self.assertEqual(run.output["pr_url"], pr_url)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
     def test_pr_opened_from_fork_does_not_backfill_pr_url(self, mock_capture, mock_get_secret):
         mock_get_secret.return_value = self.webhook_secret
         run = TaskRun.objects.create(

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -44,6 +44,16 @@ def find_task_run(
         if task_run:
             return task_run
 
+        # Wizard cloud runs push to a server-generated head branch stored in run state —
+        # TaskRun.branch holds the checkout (base) branch, so the leg above can't match them.
+        task_run = (
+            TaskRun.objects.filter(state__wizard_head_branch=branch, task__repository__iexact=repository)
+            .select_related(*TASK_RUN_SELECT_RELATED)
+            .first()
+        )
+        if task_run:
+            return task_run
+
     return None
 
 
@@ -158,7 +168,16 @@ def _record_run_pr_url(task_run: TaskRun, pr_url: str) -> None:
     ``output.pr_url`` stays empty, so inbox notifications, the CI follow-up loop,
     and later webhook lookups never resolve the PR.
     """
-    _record_run_output_field(task_run, "pr_url", pr_url, "github_pr_webhook_record_pr_url_failed")
+    if not _record_run_output_field(task_run, "pr_url", pr_url, "github_pr_webhook_record_pr_url_failed"):
+        return
+    # Surface the PR to any live UI: without these the output write is invisible until the
+    # client refetches the run (the onboarding progress modal streams, it doesn't poll).
+    # Tolerant for the same reason as the write itself — GitHub retries webhook 5xx.
+    try:
+        task_run.emit_progress_event("pr", "completed", "Opened pull request", "setup", detail=pr_url)
+        task_run.publish_stream_state_event()
+    except Exception:
+        logger.warning("github_pr_webhook_pr_events_failed", run_id=str(task_run.id), exc_info=True)
 
 
 def _record_run_pr_merged(task_run: TaskRun) -> None:
@@ -171,26 +190,29 @@ def _record_run_pr_merged(task_run: TaskRun) -> None:
     _record_run_output_field(task_run, "pr_merged", True, "github_pr_webhook_record_pr_merged_failed")
 
 
-def _record_run_output_field(task_run: TaskRun, key: str, value: str | bool, failure_log_event: str) -> None:
+def _record_run_output_field(task_run: TaskRun, key: str, value: str | bool, failure_log_event: str) -> bool:
     """Idempotently merge ``{key: value}`` into a run's ``output`` JSON under a row lock.
 
-    Tolerant: a failure here must not fail the webhook (GitHub retries 5xx, and the event is
-    already handled).
+    Returns True only when this call performed the write, so callers can fire follow-on
+    side effects exactly once. Tolerant: a failure here must not fail the webhook (GitHub
+    retries 5xx, and the event is already handled).
     """
     if isinstance(task_run.output, dict) and task_run.output.get(key):
-        return
+        return False
     try:
         with transaction.atomic():
             locked = TaskRun.objects.select_for_update().get(id=task_run.id)
             output = locked.output if isinstance(locked.output, dict) else {}
             if output.get(key):
-                return
+                return False
             locked.output = {**output, key: value}
             locked.save(update_fields=["output", "updated_at"])
         # Keep the in-memory instance consistent for the rest of this request.
         task_run.output = locked.output
+        return True
     except Exception:
         logger.warning(failure_log_event, run_id=str(task_run.id), exc_info=True)
+        return False
 
 
 # Nulled on external PRs so their schema matches task-originated PR events.

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -15,6 +15,7 @@ from posthog.models.team.team import Team
 
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
 from products.tasks.backend.models import TaskRun
+from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIX
 
 logger = structlog.get_logger(__name__)
 
@@ -36,23 +37,38 @@ def find_task_run(
     # (e.g. "main") gets attributed to whichever TaskRun shares that branch.
     repository = repository.strip() if repository else None
     if branch and repository:
+        # Wizard runs are excluded here: their `branch` column holds the checkout (base)
+        # branch, so a same-repo PR whose head ref equals the base (e.g. "main") would
+        # otherwise claim the run before the dedicated leg below is consulted.
         task_run = (
-            TaskRun.objects.filter(branch=branch, task__repository__iexact=repository)
+            TaskRun.objects.filter(
+                branch=branch,
+                task__repository__iexact=repository,
+                state__wizard_head_branch__isnull=True,
+            )
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
         if task_run:
             return task_run
 
-        # Wizard cloud runs push to a server-generated head branch stored in run state —
-        # TaskRun.branch holds the checkout (base) branch, so the leg above can't match them.
-        task_run = (
-            TaskRun.objects.filter(state__wizard_head_branch=branch, task__repository__iexact=repository)
-            .select_related(*TASK_RUN_SELECT_RELATED)
-            .first()
-        )
-        if task_run:
-            return task_run
+        # Wizard cloud runs push to a server-generated head branch stored in run state.
+        # The prefix check keeps this leg off the hot path for ordinary PR webhooks, and
+        # terminal runs are excluded so a reopened branch can't fire events on a dead run
+        # (post-merge events for bound runs resolve via the pr_url leg above).
+        if branch.startswith(WIZARD_HEAD_BRANCH_PREFIX):
+            task_run = (
+                TaskRun.objects.filter(
+                    state__wizard_head_branch=branch,
+                    task__repository__iexact=repository,
+                    task__deleted=False,
+                )
+                .exclude(status__in=(TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED))
+                .select_related(*TASK_RUN_SELECT_RELATED)
+                .first()
+            )
+            if task_run:
+                return task_run
 
     return None
 
@@ -170,11 +186,15 @@ def _record_run_pr_url(task_run: TaskRun, pr_url: str) -> None:
     """
     if not _record_run_output_field(task_run, "pr_url", pr_url, "github_pr_webhook_record_pr_url_failed"):
         return
-    # Surface the PR to any live UI: without these the output write is invisible until the
-    # client refetches the run (the onboarding progress modal streams, it doesn't poll).
-    # Tolerant for the same reason as the write itself — GitHub retries webhook 5xx.
+    # Publish-only (no append_log): the S3 run log has a live writer — the agent is streaming
+    # log batches at exactly this moment — and append_log's read-modify-write would race it.
+    # Tolerant: a stream hiccup must not fail the webhook; clients recover on refetch.
     try:
-        task_run.emit_progress_event("pr", "completed", "Opened pull request", "setup", detail=pr_url)
+        for event in (
+            task_run.build_progress_event("pr", "completed", "Opened pull request", "setup", detail=pr_url),
+            task_run.build_progress_event("ci", "in_progress", "Keeping CI green", "setup"),
+        ):
+            task_run.publish_stream_event(event)
         task_run.publish_stream_state_event()
     except Exception:
         logger.warning("github_pr_webhook_pr_events_failed", run_id=str(task_run.id), exc_info=True)


### PR DESCRIPTION
## Problem

Onboarding wizard cloud runs open their PR on the user's repo, but the run never learns about it: `output.pr_url` stays empty, the onboarding progress UI sits on "Opening a pull request" forever, and nothing downstream (Slack update, PR-ready notifications, CI follow-up) can fire.

Both existing PR-discovery mechanisms structurally miss for these runs:

- The agent-side PR attribution compares the PR author against the sandbox's GitHub login. Wizard runs are bot-authorship: the PR is authored by the GitHub App (`posthog[bot]`, rendered as `app/posthog` by `gh pr view --json author`), and the installation token has no user context — the identity guard can never pass, and it fails silently.
- The GitHub `pull_request` webhook backstop matches `TaskRun.branch` against the PR head ref, but for wizard runs `branch` holds the checkout (base) branch; the head branch was invented by the agent mid-run and never reported back. Even on a match, the recorder wrote `output` without publishing stream/progress events, so a live UI would not advance.

Verified against a prod wizard run: PR opened at 21:26 UTC, run stuck on "Opening a pull request" until the sandbox's 6h TTL killed it.

## Changes

- `create_wizard_cloud_run` now generates the PR head branch server-side (`posthog/instrumentation-<6-hex>`), templates it into the wizard PR agent prompt (the agent is instructed to use exactly that branch), and persists it in run state as `wizard_head_branch`. Deliberately not written to `TaskRun.branch`, which means "branch to check out at provisioning".
- `WIZARD_PR_AGENT_PROMPT` gains a `<wizard-head-branch>` sentinel and a `build_wizard_pr_agent_prompt(head_branch)` builder (`.replace()` rather than `str.format` — the prompt body is full of literal braces).
- `webhooks.find_task_run` gets a third match leg: `state.wizard_head_branch` + repository, so GitHub's (retried) webhook delivery deterministically binds the opened PR to the run.
- `_record_run_pr_url` now emits the `pr` progress step and publishes the stream state event when it performs the write (idempotent — `_record_run_output_field` reports whether it wrote), so the onboarding modal advances live instead of waiting for a refetch.

This is deliberately server-side and webhook-driven: it works regardless of sandbox health, agent-server deploy lag, or the bot-authorship identity mismatch (which needs a separate fix in the agent-server for the whole bot-authored class).

## How did you test this code?

- Extended `test_create_wizard_cloud_run_seeds_pending_user_message`: asserts `wizard_head_branch` is seeded in the expected format, the prompt is templated with it, and no placeholder leaks — catches a regression where the state key or templating is dropped, silently unbinding every wizard PR again.
- Added `test_finds_wizard_run_by_state_head_branch` to `TestFindTaskRun`: the state-branch match leg works and stays repository-scoped (no cross-repo attribution) — no existing test covered the wizard-run webhook path.
- Ran `products/tasks/backend/tests/test_webhooks.py` and `test_facade.py` locally: 80 passed.
- Not tested by the agent: an end-to-end prod wizard run through GitHub webhook delivery.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal run-binding mechanics; no user-facing API or documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code (Fable 5), continuing the investigation tracked in GROW-136 (follow-up to #69455). Root cause established by a multi-agent investigation: GitHub-side evidence (PR author `app/posthog` reproduced live), agent-server code reading in the companion repo, prod log forensics, and an adversarial synthesis pass that refuted the alternative explanations (recency window, sandbox network policy, token scopes).
- Skills invoked: /writing-tests.
- Chose the webhook-binding approach over fixing the agent-side identity guard because it is posthog-only, rides GitHub's retried delivery, and is independent of sandbox lifetime; the agent-server guard fix (bot-login normalization) is tracked separately as it needs the companion repo plus a sandbox image rollout.
