### PR TITLE
feat(workflows): add SLA breach warning template

### DIFF
--- a/products/workflows/backend/templates/__init__.py
+++ b/products/workflows/backend/templates/__init__.py
@@ -20,6 +20,7 @@ TEMPLATE_FILES = [
     "negative-survey-response.json",
     "re-engagement-workflow.json",
     "repeated-failure-alert.json",
+    "sla-approaching-alert.json",
     "support-ticket-notification.json",
     "ticket-unresolved-alert.json",
     "trial-ending-reminder.json",

--- a/products/workflows/backend/templates/sla-approaching-alert.json
+++ b/products/workflows/backend/templates/sla-approaching-alert.json
@@ -1,0 +1,148 @@
+{
+    "id": "3a9ce24c-fbde-47e3-b5c7-4d681ce553de",
+    "name": "SLA breach warning",
+    "description": "Notify your support team in Slack when a ticket is approaching its SLA deadline. Fires on the $conversation_sla_approaching event, which is emitted at the warning offsets configured on the ticket's SLA (sla_warning_minutes, e.g. 3 hours and 1 hour before breach). Add a filter on the threshold_minutes property to alert only at specific offsets.",
+    "version": 1,
+    "created_at": "2026-07-08T16:00:00.000000Z",
+    "created_by": null,
+    "updated_at": "2026-07-08T16:00:00.000000Z",
+    "trigger": {
+        "type": "event",
+        "filters": {
+            "source": "events",
+            "events": [
+                {
+                    "id": "$conversation_sla_approaching",
+                    "name": "Ticket approaching SLA breach",
+                    "type": "events"
+                }
+            ],
+            "bytecode": ["_H", 1, 32, "$conversation_sla_approaching", 32, "event", 1, 1, 11]
+        }
+    },
+    "trigger_masking": null,
+    "conversion": {
+        "filters": [],
+        "bytecode": [],
+        "window_minutes": null
+    },
+    "exit_condition": "exit_only_at_end",
+    "edges": [
+        {
+            "to": "action_function_e15de393-106a-4599-b829-c65624ad3786",
+            "from": "trigger_node",
+            "type": "continue"
+        },
+        {
+            "to": "exit_node",
+            "from": "action_function_e15de393-106a-4599-b829-c65624ad3786",
+            "type": "continue"
+        }
+    ],
+    "actions": [
+        {
+            "id": "trigger_node",
+            "name": "Ticket approaching SLA breach",
+            "description": "A ticket crossed one of its configured SLA warning thresholds.",
+            "on_error": null,
+            "created_at": 0,
+            "updated_at": 0,
+            "filters": null,
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "source": "events",
+                    "events": [
+                        {
+                            "id": "$conversation_sla_approaching",
+                            "name": "Ticket approaching SLA breach",
+                            "type": "events"
+                        }
+                    ],
+                    "bytecode": ["_H", 1, 32, "$conversation_sla_approaching", 32, "event", 1, 1, 11]
+                }
+            },
+            "output_variable": null
+        },
+        {
+            "id": "action_function_e15de393-106a-4599-b829-c65624ad3786",
+            "name": "Message in Slack channel",
+            "description": "Connect the right Slack channel and warn your support team before the SLA is breached.",
+            "on_error": null,
+            "created_at": 1783958400000,
+            "updated_at": 1783958400000,
+            "filters": null,
+            "type": "function",
+            "config": {
+                "inputs": {
+                    "slack_workspace": {
+                        "templating": "hog"
+                    },
+                    "channel": {
+                        "templating": "hog"
+                    },
+                    "icon_emoji": {
+                        "value": ":hedgehog:",
+                        "templating": "hog"
+                    },
+                    "username": {
+                        "value": "PostHog",
+                        "templating": "hog"
+                    },
+                    "blocks": {
+                        "value": [
+                            {
+                                "text": {
+                                    "text": "⏰ *Ticket #{event.properties.ticket_number} is approaching its SLA deadline*\n\n*Time remaining:* {event.properties.minutes_remaining} minutes\n*Status:* {event.properties.status}\n*Customer:* {event.properties.customer_email}",
+                                    "type": "mrkdwn"
+                                },
+                                "type": "section"
+                            },
+                            {
+                                "type": "actions",
+                                "elements": [
+                                    {
+                                        "url": "{source.url}",
+                                        "text": {
+                                            "text": "Open ticket",
+                                            "type": "plain_text"
+                                        },
+                                        "type": "button"
+                                    }
+                                ]
+                            }
+                        ],
+                        "templating": "hog"
+                    },
+                    "text": {
+                        "value": "Ticket #{event.properties.ticket_number} breaches its SLA in {event.properties.minutes_remaining} minutes",
+                        "templating": "hog"
+                    }
+                },
+                "template_id": "template-slack"
+            },
+            "output_variable": null
+        },
+        {
+            "id": "exit_node",
+            "name": "Exit",
+            "description": "User moved through the workflow without errors.",
+            "on_error": null,
+            "created_at": 0,
+            "updated_at": 0,
+            "filters": null,
+            "type": "exit",
+            "config": {
+                "reason": "Default exit"
+            },
+            "output_variable": null
+        }
+    ],
+    "abort_action": null,
+    "variables": [],
+    "billable_action_types": ["function"],
+    "image_url": "https://res.cloudinary.com/dmukukwp6/image/upload/Template_cover_11_bd57631532.jpg",
+    "tags": ["support", "support ticket", "sla", "slack"],
+    "scope": "global"
+}


### PR DESCRIPTION
## Problem

With `$conversation_sla_approaching` events landing (#69360), teams need a one-click way to turn them into Slack alerts. Part 5 (final) of the SLA series (#69339, #69345, #69354, #69360).

## Changes

New global workflow template `SLA breach warning`: triggers on `$conversation_sla_approaching` and sends a Slack message with the ticket number, minutes remaining, status, customer email, and an "Open ticket" button. The description points users at filtering on `threshold_minutes` if they only want alerts at specific offsets.

> [!NOTE]
> Functionally depends on #69360 (nothing emits the trigger event until that ships), but there is no code dependency - the template is inert until then, so this can merge independently.

Setup for a team wanting, say, 3h and 1h warnings: add `"sla_warning_minutes": [180, 60]` to the `postHogUpdateTicket` step of the workflow that sets the SLA, then create a workflow from this template.

## How did you test this code?

Existing template validation suite (`test_hog_flow_template.py`, 27 tests) passes with the new file registered, and `load_global_templates()` loads all 19 templates including this one. I (the agent) could not do an end-to-end Slack delivery test; the template was authored by cloning the structure of `support-ticket-notification.json` rather than the UI export path, so a quick open-in-editor sanity check when reviewing is worthwhile.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Structure cloned from the existing `support-ticket-notification.json` (trigger → Slack function → exit); event-property templating uses `{event.properties.*}` consistent with hog templating in CDP functions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
