### PR TITLE
fix(exports): teach AI subscription planner and fixer the $group_N key

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
@@ -222,6 +222,11 @@ Joined data available WITHOUT writing a JOIN (the engine joins these automatical
   available for this project are listed in <project_context>.
 - Group / account properties: `group_<index>.properties.<name>` (e.g. `group_0.properties.name`).
   The index-to-type mapping for this project is listed in <project_context>.
+  To COUNT or aggregate the groups/accounts themselves (not a property of theirs), use the raw
+  group-key column `$group_<index>` — note the leading `$` — e.g. `uniq($group_0)` for distinct
+  accounts, or `uniqIf($group_2, event = 'signup')`. Bare `group_<index>` without a trailing
+  `.properties.<name>` is NOT a scalar column: used on its own it fails with
+  "Field not found: group_<index>". Reach for `$group_<index>` whenever you want the account itself.
 - Session attributes: `session.$session_duration` (seconds), `session.$pageview_count`,
   `session.$channel_type`, `session.$entry_pathname`, `session.$is_bounce`, `session.$end_timestamp`.
 Reference these as plain columns inside a single `FROM events` SELECT — never write `JOIN` for them.
@@ -237,6 +242,14 @@ Breakdown by a person property (USE the dotted path, NOT a JOIN):
   GROUP BY plan
   ORDER BY event_count DESC
   LIMIT 50
+
+Count distinct groups/accounts (the account itself, via the raw `$`-prefixed key — never bare
+`group_N`, which is only valid as `group_N.properties.<name>`):
+  SELECT
+    uniq($group_2) AS accounts,
+    uniqIf($group_2, event = 'signup') AS accounts_signed_up
+  FROM events
+  WHERE {{date_range}}
 
 First-EVER occurrence of an event per user, landing in the window (e.g. "users whose first ever
 'Dashboard created' falls in the window", broken down by a property of that first event). "First ever" needs each
@@ -335,6 +348,11 @@ rewrite MUST follow the same HogQL syntax constraints used by the planner:
   UNNEST, or ARRAY JOIN on subqueries.
 - No JOINs of any kind, including self-joins on `event`. Use conditional aggregation instead
   (ClickHouse rejects HogQL's null-safe join keys).
+- Schema note for "Field not found: group_<index>": to count or aggregate a group/account, the raw
+  group-key column is `$group_<index>` with a leading `$` (e.g. `uniq($group_2)`,
+  `uniqIf($group_2, cond)`). A bare `group_<index>` is only valid as `group_<index>.properties.<name>`;
+  used as a scalar it does not resolve — replace it with `$group_<index>`. The same `$`-prefixed form
+  applies to person/session keys only via their documented paths, so do not add `$` elsewhere.
 - Time window: PRESERVE the original query's window tokens (`{{date_range}}`,
   `{{compare_date_range}}`, `{{window_start}}`, `{{window_end}}`) or literal `toDateTime('…')` bounds
   verbatim — those are the report's fixed analysis window. Do NOT introduce `now()` /

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
@@ -243,7 +243,7 @@ Breakdown by a person property (USE the dotted path, NOT a JOIN):
   LIMIT 50
 
 Count distinct groups/accounts (the account itself, via the raw `$`-prefixed key, never bare
-`group_N`, which is only valid as `group_N.properties.<name>`):
+`group_<index>`, which is only valid as `group_<index>.properties.<name>`):
   SELECT
     uniq($group_2) AS accounts,
     uniqIf($group_2, event = 'signup') AS accounts_signed_up

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
@@ -223,10 +223,9 @@ Joined data available WITHOUT writing a JOIN (the engine joins these automatical
 - Group / account properties: `group_<index>.properties.<name>` (e.g. `group_0.properties.name`).
   The index-to-type mapping for this project is listed in <project_context>.
   To COUNT or aggregate the groups/accounts themselves (not a property of theirs), use the raw
-  group-key column `$group_<index>` — note the leading `$` — e.g. `uniq($group_0)` for distinct
-  accounts, or `uniqIf($group_2, event = 'signup')`. Bare `group_<index>` without a trailing
-  `.properties.<name>` is NOT a scalar column: used on its own it fails with
-  "Field not found: group_<index>". Reach for `$group_<index>` whenever you want the account itself.
+  group-key column `$group_<index>` (leading `$`). A bare `group_<index>` without a trailing
+  `.properties.<name>` is NOT a scalar column and fails with "Field not found: group_<index>". See
+  the count-distinct-accounts pattern below.
 - Session attributes: `session.$session_duration` (seconds), `session.$pageview_count`,
   `session.$channel_type`, `session.$entry_pathname`, `session.$is_bounce`, `session.$end_timestamp`.
 Reference these as plain columns inside a single `FROM events` SELECT — never write `JOIN` for them.
@@ -243,7 +242,7 @@ Breakdown by a person property (USE the dotted path, NOT a JOIN):
   ORDER BY event_count DESC
   LIMIT 50
 
-Count distinct groups/accounts (the account itself, via the raw `$`-prefixed key — never bare
+Count distinct groups/accounts (the account itself, via the raw `$`-prefixed key, never bare
 `group_N`, which is only valid as `group_N.properties.<name>`):
   SELECT
     uniq($group_2) AS accounts,
@@ -351,7 +350,7 @@ rewrite MUST follow the same HogQL syntax constraints used by the planner:
 - Schema note for "Field not found: group_<index>": to count or aggregate a group/account, the raw
   group-key column is `$group_<index>` with a leading `$` (e.g. `uniq($group_2)`,
   `uniqIf($group_2, cond)`). A bare `group_<index>` is only valid as `group_<index>.properties.<name>`;
-  used as a scalar it does not resolve — replace it with `$group_<index>`. The same `$`-prefixed form
+  used as a scalar it does not resolve; replace it with `$group_<index>`. The same `$`-prefixed form
   applies to person/session keys only via their documented paths, so do not add `$` elsewhere.
 - Time window: PRESERVE the original query's window tokens (`{{date_range}}`,
   `{{compare_date_range}}`, `{{window_start}}`, `{{window_end}}`) or literal `toDateTime('…')` bounds

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -504,8 +504,9 @@ def build_context_blob(team: Team, window: ReportWindow, relevant_events: Sequen
     group_labels = _group_type_labels(team)
     if group_labels:
         lines.append(
-            "- Group/account types (reference as group_<index>.properties.<name>, no JOIN needed): "
-            + ", ".join(group_labels)
+            "- Group/account types (properties via group_<index>.properties.<name>; count/aggregate "
+            "the account itself via the raw key $group_<index>, e.g. uniq($group_2) — never bare "
+            "group_<index>; no JOIN needed): " + ", ".join(group_labels)
         )
     return "\n".join(lines)
 

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -87,7 +87,7 @@ WINDOW_PLACEHOLDERS = (
 )
 # Bumping invalidates every frozen plan (they lazily re-plan on next delivery), so prompt/harness
 # improvements reach existing subscriptions instead of only new ones.
-AI_QUERY_PLAN_VERSION = 1
+AI_QUERY_PLAN_VERSION = 2
 
 
 DEFAULT_PLANNER_MODEL = "gpt-4.1"

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -505,7 +505,7 @@ def build_context_blob(team: Team, window: ReportWindow, relevant_events: Sequen
     if group_labels:
         lines.append(
             "- Group/account types (properties via group_<index>.properties.<name>; count/aggregate "
-            "the account itself via the raw key $group_<index>, e.g. uniq($group_2) — never bare "
+            "the account itself via the raw key $group_<index>, e.g. uniq($group_2), never bare "
             "group_<index>; no JOIN needed): " + ", ".join(group_labels)
         )
     return "\n".join(lines)

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -666,7 +666,10 @@ class TestContextBlob(APIBaseTest):
         assert "dormant_event" in blob
         assert "Person properties (reference as person.properties.<name>" in blob
         assert "plan" in blob
-        assert "Group/account types (reference as group_<index>.properties.<name>" in blob
+        assert "properties via group_<index>.properties.<name>" in blob
+        # the raw group-key aggregation hint must be present so the planner counts accounts with
+        # $group_<index> rather than a bare group_<index> that fails with "Field not found"
+        assert "$group_<index>" in blob
         assert "group_0 = organization" in blob
 
     @parameterized.expand(


### PR DESCRIPTION
## Problem

AI subscription ("prompt subscription") report queries that count or aggregate groups/accounts have been failing with `Field not found: group_N`, degrading the metric to "could not be computed (query failed)" in the delivered report.

Root cause: the planner prompt, the project context blob, and the HogQL auto-fixer prompt only ever documented `group_<index>.properties.<name>` (the property-access form). Nothing told the model that referencing the account *itself* — to count or aggregate it — needs the raw group-key column `$group_<index>` (leading `$`). So the planner reached for a bare `group_<index>` as a scalar (e.g. `uniqIf(group_2, ...)`), which does not resolve.

The auto-fixer loop is not broken mechanically: it executes each candidate query for real and forwards the resolution error to the LLM. But it carried no schema signal for this specific mistake, so a rewrite could reproduce the same error until retries were exhausted.

## Changes

Add the `$group_<index>` guidance in the three places the model reads:

- **Planner prompt** (`prompts.py`) — the "joined data available" section now distinguishes property access (`group_<index>.properties.<name>`) from counting/aggregating the account itself (`$group_<index>`), plus a new count-distinct-accounts reference pattern.
- **Fixer prompt** (`prompts.py`) — a targeted note keyed on the exact `Field not found: group_N` error, so a repair attempt knows to swap the bare identifier for `$group_<index>`.
- **Project context blob** (`spec_generator.py`) — the per-project group-type line now carries the `$group_<index>` aggregation form alongside the existing labels.

## How did you test this code?

- Reproduced the failure and confirmed the fix shape against a live project: bare `uniq(group_2)` returns `Field not found: group_2`, while `uniq($group_2)` resolves correctly.
- Updated the existing `build_context_blob` test to assert the group line now teaches `$group_<index>` (guards against the hint silently disappearing).
- Byte-compiled the edited modules. I (the agent) could not run the full Django test suite here — no local DB/env — so I did not run `test_spec_generator.py` end to end; a reviewer or CI should.

No new brittle prompt-wording tests were added: the change is prompt/context string content, so I extended the one existing behavioral assertion rather than adding change-detector tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread investigating a failed subscription report. Traced the AI-subscription report pipeline (`products/exports/backend/temporal/subscriptions/ai_subscription/`) to confirm the fixer executes queries for real and forwards errors, then located the missing `$group_N` guidance as the actual gap. Invoked the `/writing-tests` skill before touching tests, which steered this toward extending the existing `build_context_blob` assertion instead of adding wording-scraping tests.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1783588265082319?thread_ts=1783588265.082319&cid=C09BDQLM8KA)*
