### PR TITLE
feat(taxonomic-filter): promote committed selection to top of legacy lists

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -464,7 +464,10 @@ export const InfiniteListRow = ({
 
     const normalizedValue = typeof itemValue === 'number' && typeof value === 'string' ? Number(value) : value
 
-    const isSelected = listGroupType === groupType && itemValue === normalizedValue
+    // On the aggregated Suggested filters tab, a row's own group (via `itemGroup`) is the
+    // source group it was promoted from, not `listGroupType` — compare against that so a
+    // cross-group promoted row still gets the selected treatment.
+    const isSelected = (itemGroup?.type ?? listGroupType) === groupType && itemValue === normalizedValue
 
     const isHighlighted = rowIndex === highlightedIndex && isActiveTab
 

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1267,6 +1267,15 @@ describe('infiniteListLogic', () => {
                 false
             )
         })
+
+        it('does not synthesize a blank row for an empty-string selection', async () => {
+            // '' round-trips through `getValue` for name/value-keyed groups, so without the
+            // empty-string guard a blank, clickable synthetic row would land at row 0 and
+            // re-commit '' on click.
+            const listLogic = mountSuggestedList({ value: '', groupType: TaxonomicFilterGroupType.Events })
+            await expectLogic(listLogic).toFinishAllListeners()
+            expect(listLogic.values.results.some((item) => (item as { value?: unknown })?.value === '')).toBe(false)
+        })
     })
 
     describe('contextFilteredRecentItems', () => {

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1199,6 +1199,43 @@ describe('infiniteListLogic', () => {
             expect((logic.values.results[1] as { name?: string })?.name).toBe('search term')
         })
 
+        it('statically inserts the committed selection while its row is not yet loaded', async () => {
+            logic = logicWith({ value: 'zzz custom event', groupType: TaxonomicFilterGroupType.Events })
+            await expectLogic(logic).toDispatchActions(['loadRemoteItemsSuccess'])
+            expect((logic.values.results[0] as { name?: string })?.name).toBe('All events')
+            expect(logic.values.results[1]).toMatchObject({
+                name: 'zzz custom event',
+                group: TaxonomicFilterGroupType.Events,
+            })
+            // the synthetic is counted so the windowed loader's row math stays consistent:
+            // 1 local ("All events") + 156 remote + 1 synthetic
+            expect(logic.values.items.count).toBe(158)
+        })
+
+        it('hands off from the synthetic row to the real row once its page loads, without duplicating it', async () => {
+            // 'misc-150-generated' sits past the first page (100 rows) of the 156-row mock list
+            logic = logicWith({ value: 'misc-150-generated', groupType: TaxonomicFilterGroupType.Events })
+            await expectLogic(logic).toDispatchActions(['loadRemoteItemsSuccess'])
+            expect(logic.values.results[1]).toMatchObject({
+                name: 'misc-150-generated',
+                group: TaxonomicFilterGroupType.Events,
+            })
+
+            // scrolling to the hole after the loaded page must fetch the true remote offset
+            // (display index minus local rows minus the synthetic), completing the list
+            await expectLogic(logic, () =>
+                logic.actions.onRowsRendered({ startIndex: 90, stopIndex: 110, overscanStopIndex: 130 })
+            ).toDispatchActions(['loadRemoteItems', 'loadRemoteItemsSuccess'])
+
+            const results = logic.values.results
+            expect(logic.values.items.count).toBe(157)
+            expect(results).toHaveLength(157)
+            expect(results.every((item) => item != null)).toBe(true)
+            // the real row (it has an id; the synthetic doesn't) floats, the synthetic is gone
+            expect(results[1]).toMatchObject({ name: 'misc-150-generated', id: 'uuid-150-foobar' })
+            expect(results.filter((item) => (item as { name?: string })?.name === 'misc-150-generated')).toHaveLength(1)
+        })
+
         it('leaves relevance ordering alone while searching', async () => {
             logic = logicWith({ value: 'other event', groupType: TaxonomicFilterGroupType.Events })
             await expectLogic(logic).toDispatchActions(['loadRemoteItemsSuccess'])

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1234,30 +1234,32 @@ describe('infiniteListLogic', () => {
             expect(results.filter((item) => (item as { name?: string })?.name === 'event1')).toHaveLength(1)
         })
 
-        it('prepends a synthetic selected row keyed by the raw value on the suggested list when the selection is not visible', async () => {
-            const listLogic = mountSuggestedList({ value: '$pageview', groupType: TaxonomicFilterGroupType.Events })
-            await expectLogic(listLogic).toFinishAllListeners()
-            expect(listLogic.values.results[0]).toMatchObject({
-                name: '$pageview',
-                group: TaxonomicFilterGroupType.Events,
-            })
-        })
-
-        it('prepends a synthetic row for a name-keyed property group so the round-trip guard still passes', async () => {
-            const listLogic = mountSuggestedList({
+        it.each([
+            {
+                description: 'default events group',
+                taxonomicGroupTypes: undefined,
+                value: '$pageview',
+                groupType: TaxonomicFilterGroupType.Events,
+            },
+            {
+                description: 'name-keyed property group, so the round-trip guard still passes',
                 taxonomicGroupTypes: [
                     TaxonomicFilterGroupType.EventProperties,
                     TaxonomicFilterGroupType.SuggestedFilters,
                 ],
                 value: '$browser',
                 groupType: TaxonomicFilterGroupType.EventProperties,
-            })
-            await expectLogic(listLogic).toFinishAllListeners()
-            expect(listLogic.values.results[0]).toMatchObject({
-                name: '$browser',
-                group: TaxonomicFilterGroupType.EventProperties,
-            })
-        })
+            },
+        ])(
+            'prepends a synthetic selected row keyed by the raw value when the selection is not visible ($description)',
+            async ({ taxonomicGroupTypes, value, groupType }) => {
+                const listLogic = mountSuggestedList(
+                    taxonomicGroupTypes ? { taxonomicGroupTypes, value, groupType } : { value, groupType }
+                )
+                await expectLogic(listLogic).toFinishAllListeners()
+                expect(listLogic.values.results[0]).toMatchObject({ name: String(value), group: groupType })
+            }
+        )
 
         it('skips the synthetic row for id-keyed groups where only the raw id could render', async () => {
             const listLogic = mountSuggestedList({

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1192,11 +1192,11 @@ describe('infiniteListLogic', () => {
                 ...props,
             })
 
-        it('floats the selected value to the top of its own group list when idle', async () => {
+        it('floats the selected value above the group list when idle, without displacing a leading catch-all row', async () => {
             logic = logicWith({ value: 'search term', groupType: TaxonomicFilterGroupType.Events })
             await expectLogic(logic).toDispatchActions(['loadRemoteItemsSuccess'])
-            expect((logic.values.results[0] as { name?: string })?.name).toBe('search term')
-            expect((logic.values.results[1] as { name?: string })?.name).toBe('All events')
+            expect((logic.values.results[0] as { name?: string })?.name).toBe('All events')
+            expect((logic.values.results[1] as { name?: string })?.name).toBe('search term')
         })
 
         it('leaves relevance ordering alone while searching', async () => {
@@ -1234,11 +1234,11 @@ describe('infiniteListLogic', () => {
             expect(results.filter((item) => (item as { name?: string })?.name === 'event1')).toHaveLength(1)
         })
 
-        it('prepends a synthetic selected row on the suggested list when the selection is not visible', async () => {
+        it('prepends a synthetic selected row with a friendly label on the suggested list when the selection is not visible', async () => {
             const listLogic = mountSuggestedList({ value: '$pageview', groupType: TaxonomicFilterGroupType.Events })
             await expectLogic(listLogic).toFinishAllListeners()
             expect(listLogic.values.results[0]).toMatchObject({
-                name: '$pageview',
+                name: 'Pageview',
                 group: TaxonomicFilterGroupType.Events,
             })
         })
@@ -1251,6 +1251,21 @@ describe('infiniteListLogic', () => {
             })
             await expectLogic(listLogic).toFinishAllListeners()
             expect(listLogic.values.results).toEqual([])
+        })
+
+        it('does not synthesize a row when groupType is the meta Suggested filters group itself', async () => {
+            // Callers like ActionFilterRow open the popover with `groupType={SuggestedFilters}`
+            // while `value` is the real committed event/action — that meta type must never be
+            // treated as the selection's source group, or the synthetic row round-trips through
+            // the wrong group and `onChange` can't map it back to a real entity type.
+            const listLogic = mountSuggestedList({
+                value: 'some_event',
+                groupType: TaxonomicFilterGroupType.SuggestedFilters,
+            })
+            await expectLogic(listLogic).toFinishAllListeners()
+            expect(listLogic.values.results.some((item) => (item as { name?: string })?.name === 'some_event')).toBe(
+                false
+            )
         })
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1234,12 +1234,28 @@ describe('infiniteListLogic', () => {
             expect(results.filter((item) => (item as { name?: string })?.name === 'event1')).toHaveLength(1)
         })
 
-        it('prepends a synthetic selected row with a friendly label on the suggested list when the selection is not visible', async () => {
+        it('prepends a synthetic selected row keyed by the raw value on the suggested list when the selection is not visible', async () => {
             const listLogic = mountSuggestedList({ value: '$pageview', groupType: TaxonomicFilterGroupType.Events })
             await expectLogic(listLogic).toFinishAllListeners()
             expect(listLogic.values.results[0]).toMatchObject({
-                name: 'Pageview',
+                name: '$pageview',
                 group: TaxonomicFilterGroupType.Events,
+            })
+        })
+
+        it('prepends a synthetic row for a name-keyed property group so the round-trip guard still passes', async () => {
+            const listLogic = mountSuggestedList({
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.EventProperties,
+                    TaxonomicFilterGroupType.SuggestedFilters,
+                ],
+                value: '$browser',
+                groupType: TaxonomicFilterGroupType.EventProperties,
+            })
+            await expectLogic(listLogic).toFinishAllListeners()
+            expect(listLogic.values.results[0]).toMatchObject({
+                name: '$browser',
+                group: TaxonomicFilterGroupType.EventProperties,
             })
         })
 

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1176,6 +1176,84 @@ describe('infiniteListLogic', () => {
         )
     })
 
+    describe('committed selection promotion', () => {
+        beforeEach(() => {
+            localStorage.clear()
+        })
+
+        afterEach(() => {
+            localStorage.clear()
+        })
+
+        const mountSuggestedList = (props: Record<string, any>): ReturnType<typeof infiniteListLogic.build> =>
+            logicWith({
+                listGroupType: TaxonomicFilterGroupType.SuggestedFilters,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.SuggestedFilters],
+                ...props,
+            })
+
+        it('floats the selected value to the top of its own group list when idle', async () => {
+            logic = logicWith({ value: 'search term', groupType: TaxonomicFilterGroupType.Events })
+            await expectLogic(logic).toDispatchActions(['loadRemoteItemsSuccess'])
+            expect((logic.values.results[0] as { name?: string })?.name).toBe('search term')
+            expect((logic.values.results[1] as { name?: string })?.name).toBe('All events')
+        })
+
+        it('leaves relevance ordering alone while searching', async () => {
+            logic = logicWith({ value: 'other event', groupType: TaxonomicFilterGroupType.Events })
+            await expectLogic(logic).toDispatchActions(['loadRemoteItemsSuccess'])
+            await expectLogic(logic, () => logic.actions.setSearchQuery('event')).toDispatchActions([
+                'loadRemoteItemsSuccess',
+            ])
+            const names = logic.values.results.map((item) => (item as { name?: string })?.name)
+            expect(names).toContain('other event')
+            expect(names.indexOf('other event')).toBeGreaterThan(0)
+        })
+
+        it('floats a matching recent to the top of the suggested list without duplicating it', async () => {
+            const recentLogic = recentTaxonomicFiltersLogic.build()
+            recentLogic.mount()
+            recentLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Events,
+                groupName: 'Events',
+                value: 'event1',
+                item: { name: 'event1' },
+            })
+            recentLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.Events,
+                groupName: 'Events',
+                value: 'test event',
+                item: { name: 'test event' },
+            })
+
+            const listLogic = mountSuggestedList({ value: 'event1', groupType: TaxonomicFilterGroupType.Events })
+            await expectLogic(listLogic).toFinishAllListeners()
+
+            const results = listLogic.values.results
+            expect(hasRecentContext(results[0]) && results[0]._recentContext.sourceValue).toBe('event1')
+            expect(results.filter((item) => (item as { name?: string })?.name === 'event1')).toHaveLength(1)
+        })
+
+        it('prepends a synthetic selected row on the suggested list when the selection is not visible', async () => {
+            const listLogic = mountSuggestedList({ value: '$pageview', groupType: TaxonomicFilterGroupType.Events })
+            await expectLogic(listLogic).toFinishAllListeners()
+            expect(listLogic.values.results[0]).toMatchObject({
+                name: '$pageview',
+                group: TaxonomicFilterGroupType.Events,
+            })
+        })
+
+        it('skips the synthetic row for id-keyed groups where only the raw id could render', async () => {
+            const listLogic = mountSuggestedList({
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Cohorts, TaxonomicFilterGroupType.SuggestedFilters],
+                value: 5,
+                groupType: TaxonomicFilterGroupType.Cohorts,
+            })
+            await expectLogic(listLogic).toFinishAllListeners()
+            expect(listLogic.values.results).toEqual([])
+        })
+    })
+
     describe('contextFilteredRecentItems', () => {
         // Generic wrapper around hasRecentContext so .filter() preserves the input type
         // (the production type guard uses `unknown` which TS can't narrow through Array.filter).

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -1170,13 +1170,10 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             // `undefined` and the round-trip below fails — keeping their raw ids
                             // out of the list, which is the intent.
                             const sourceGroup = taxonomicGroups.find((g: TaxonomicFilterGroup) => g.type === groupType)
-                            // Keep `name` as the raw key: consumers persist `item.name` verbatim
-                            // (e.g. ActionFilterRow, universalFiltersLogic), so baking a friendly
-                            // label in here would corrupt the saved value on a no-op re-pick, and
-                            // it would defeat the round-trip guard below for name-keyed groups
-                            // (EventProperties/PersonProperties/SessionProperties `getValue`
-                            // reads `.name`). The renderer already prettifies raw keys at render
-                            // time via PropertyKeyInfo/getCoreFilterDefinition.
+                            // `name` stays the raw key, matching how real rows in name/value-keyed
+                            // groups are shaped: it round-trips through `getValue` below, and
+                            // consumers that persist `item.name` verbatim don't get a friendly
+                            // label baked in. Renderers already prettify raw keys at render time.
                             const synthetic = {
                                 name: String(value),
                                 value,

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -30,6 +30,7 @@ import {
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 import {
     buildUrlContainsShortcut,
@@ -992,6 +993,22 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 })
             },
         ],
+        // The list's own group plus the committed selection, bundled into one input so
+        // `items` stays within kea's 16-entry `SelectorTuple` cap (every extra input on
+        // `items` also lengthens typegen for downstream logics, per the note on
+        // `dedupedTopMatches`).
+        selectionPromotionContext: [
+            (s) => [s.group, s.groupType, s.value],
+            (
+                group,
+                groupType,
+                value
+            ): {
+                group: TaxonomicFilterGroup | undefined
+                groupType: TaxonomicFilterGroupType | undefined
+                value: TaxonomicFilterValue | undefined
+            } => ({ group, groupType, value }),
+        ],
         items: [
             (s) => [
                 s.remoteItems,
@@ -1007,9 +1024,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 s.isSoleSubstantiveGroup,
                 s.soleGroupHasGetValue,
                 s.taxonomicGroups,
-                s.group,
-                s.groupType,
-                s.value,
+                s.selectionPromotionContext,
                 (_, props: InfiniteListLogicProps) => props.collapseUrlsToContainsRow,
             ],
             (
@@ -1026,11 +1041,10 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 isSoleSubstantiveGroup,
                 soleGroupHasGetValue,
                 taxonomicGroups,
-                group,
-                groupType,
-                value,
+                selectionPromotionContext,
                 collapseUrlsToContainsRow
             ) => {
+                const { group, groupType, value } = selectionPromotionContext
                 // Collapse URL groups to a single "URL contains <query>" shortcut row
                 // (mirrors the rebuild menu's `COLLAPSED_TO_CONTAINS_ROW`). Only once
                 // the remote fetch for the *current* query has returned at least one
@@ -1176,7 +1190,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             }
                             const itemGroup = getItemGroup(item, taxonomicGroups, group)
                             return (
-                                groupItemKey(itemGroup?.type ?? listGroupType, itemGroup?.getValue?.(item)) ===
+                                groupItemKey(itemGroup?.type ?? listGroupType, itemGroup?.getValue?.(item) ?? null) ===
                                 selectionKey
                             )
                         })

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -42,7 +42,16 @@ import {
     pinnedSourceKey,
     recentSourceKey,
 } from 'lib/components/TaxonomicFilter/utils/floatRecentPinned'
-import { floatToFront } from 'lib/components/TaxonomicFilter/utils/floatToFront'
+// Move the element at `index` to `offset` (0, or 1 to preserve a leading catch-all row),
+// preserving the order of everything else. Legacy-only: unlike the rebuild's `floatToFront`
+// (which always floats to the very first row), the legacy own-group/suggested float must not
+// displace a leading null-valued aggregate row — see the invariant in `floatRecentPinned.ts`.
+function floatToOffset<T>(list: T[], index: number, offset: number): T[] {
+    if (index <= offset) {
+        return list
+    }
+    return [...list.slice(0, offset), list[index], ...list.slice(offset, index), ...list.slice(index + 1)]
+}
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
@@ -1112,11 +1121,32 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     orderedBase = combinedResults
                 }
                 // Mirrors the rebuild menu's Combobox idle promotion: with no search query,
-                // the committed selection floats to the very first row so the user can see
-                // at a glance what is currently picked. While searching, relevance wins.
+                // the committed selection floats above the rest of the list so the user can
+                // see at a glance what is currently picked. A leading null-valued catch-all
+                // row (e.g. "All events") keeps its place, per the invariant in
+                // floatRecentPinned.ts — so the float targets index 1 when one is present.
+                // While searching, relevance wins.
                 let syntheticSelectedCount = 0
-                if (!searchQuery && value != null && groupType && !DATA_WAREHOUSE_GROUP_TYPES.includes(groupType)) {
+                if (
+                    !searchQuery &&
+                    value != null &&
+                    groupType &&
+                    !META_GROUP_TYPES.has(groupType) &&
+                    !DATA_WAREHOUSE_GROUP_TYPES.includes(groupType)
+                ) {
                     const selectionKey = groupItemKey(groupType, value)
+                    // A leading catch-all row (e.g. "All events") is a real, non-recent/pinned
+                    // group option whose `getValue` resolves to `null` — not merely a recent/
+                    // pinned row whose stripped shape happens to leave `getValue` undefined.
+                    const leadingItem = orderedBase[0]
+                    const leadingCatchAllOffset =
+                        leadingItem != null &&
+                        !isSkeletonItem(leadingItem) &&
+                        !hasRecentContext(leadingItem) &&
+                        !hasPinnedContext(leadingItem) &&
+                        getItemGroup(leadingItem, taxonomicGroups, group)?.getValue?.(leadingItem) === null
+                            ? 1
+                            : 0
                     if (isSuggested && selectionKey) {
                         // The aggregated list is fully client-side (recents/pinned prefixes),
                         // so both floating and prepending are safe here.
@@ -1124,10 +1154,15 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             (item) =>
                                 item != null &&
                                 !isSkeletonItem(item) &&
-                                (recentSourceKey(item) === selectionKey || pinnedSourceKey(item) === selectionKey)
+                                (recentSourceKey(item) === selectionKey ||
+                                    pinnedSourceKey(item) === selectionKey ||
+                                    groupItemKey(
+                                        getItemGroup(item, taxonomicGroups, group)?.type ?? listGroupType,
+                                        getItemGroup(item, taxonomicGroups, group)?.getValue?.(item)
+                                    ) === selectionKey)
                         )
                         if (selectedIndex >= 0) {
-                            orderedBase = floatToFront(orderedBase, selectedIndex)
+                            orderedBase = floatToOffset(orderedBase, selectedIndex, leadingCatchAllOffset)
                         } else {
                             // The selection isn't among the visible recents/pinned — prepend a
                             // synthetic row (shaped like a top match, so `getItemGroup` resolves
@@ -1136,13 +1171,17 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             // same value: id-keyed groups (actions, cohorts) would render the
                             // raw id, which would confuse more than it clarifies.
                             const sourceGroup = taxonomicGroups.find((g: TaxonomicFilterGroup) => g.type === groupType)
+                            const friendlyLabel = getCoreFilterDefinition(String(value), groupType)?.label
                             const synthetic = {
-                                name: String(value),
+                                name: friendlyLabel ?? String(value),
                                 value,
                                 group: groupType,
                             } as unknown as TaxonomicDefinitionTypes
                             if (sourceGroup?.getValue?.(synthetic) === value) {
-                                orderedBase = [synthetic, ...orderedBase]
+                                orderedBase =
+                                    leadingCatchAllOffset > 0
+                                        ? [orderedBase[0], synthetic, ...orderedBase.slice(1)]
+                                        : [synthetic, ...orderedBase]
                                 syntheticSelectedCount = 1
                             }
                         }
@@ -1157,10 +1196,10 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         // remote-offset mapping. When the selection is paginated past (not
                         // loaded yet), we leave the list alone for the same reason.
                         if (
-                            selectedIndex > 0 &&
+                            selectedIndex > leadingCatchAllOffset &&
                             orderedBase.slice(0, selectedIndex).every((item) => item != null && !isSkeletonItem(item))
                         ) {
-                            orderedBase = floatToFront(orderedBase, selectedIndex)
+                            orderedBase = floatToOffset(orderedBase, selectedIndex, leadingCatchAllOffset)
                         }
                     }
                 }

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -1121,6 +1121,10 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 if (
                     !searchQuery &&
                     value != null &&
+                    // An empty string is not a real committed selection: it round-trips through
+                    // `getValue` for name/value-keyed groups and would otherwise float a blank,
+                    // clickable synthetic row that re-commits `''` on click. `0`/`false` are kept.
+                    value !== '' &&
                     groupType &&
                     !META_GROUP_TYPES.has(groupType) &&
                     !DATA_WAREHOUSE_GROUP_TYPES.includes(groupType)
@@ -1160,9 +1164,11 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             // The selection isn't among the visible recents/pinned — prepend a
                             // synthetic row (shaped like a top match, so `getItemGroup` resolves
                             // its source group) so the user can still verify what's picked.
-                            // Only when the source group round-trips the synthetic back to the
-                            // same value: id-keyed groups (actions, cohorts) would render the
-                            // raw id, which would confuse more than it clarifies.
+                            // Guarded on the source group round-tripping the synthetic back to the
+                            // committed value: id-keyed groups (actions, cohorts) read `.id`, which
+                            // the `{ name, value, group }` shape lacks, so `getValue` returns
+                            // `undefined` and the round-trip below fails — keeping their raw ids
+                            // out of the list, which is the intent.
                             const sourceGroup = taxonomicGroups.find((g: TaxonomicFilterGroup) => g.type === groupType)
                             const friendlyLabel = getCoreFilterDefinition(String(value), groupType)?.label
                             const synthetic = {

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -42,16 +42,7 @@ import {
     pinnedSourceKey,
     recentSourceKey,
 } from 'lib/components/TaxonomicFilter/utils/floatRecentPinned'
-// Move the element at `index` to `offset` (0, or 1 to preserve a leading catch-all row),
-// preserving the order of everything else. Legacy-only: unlike the rebuild's `floatToFront`
-// (which always floats to the very first row), the legacy own-group/suggested float must not
-// displace a leading null-valued aggregate row — see the invariant in `floatRecentPinned.ts`.
-function floatToOffset<T>(list: T[], index: number, offset: number): T[] {
-    if (index <= offset) {
-        return list
-    }
-    return [...list.slice(0, offset), list[index], ...list.slice(offset, index), ...list.slice(index + 1)]
-}
+import { floatToFront } from 'lib/components/TaxonomicFilter/utils/floatToFront'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
@@ -1150,19 +1141,21 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     if (isSuggested && selectionKey) {
                         // The aggregated list is fully client-side (recents/pinned prefixes),
                         // so both floating and prepending are safe here.
-                        const selectedIndex = orderedBase.findIndex(
-                            (item) =>
-                                item != null &&
-                                !isSkeletonItem(item) &&
-                                (recentSourceKey(item) === selectionKey ||
-                                    pinnedSourceKey(item) === selectionKey ||
-                                    groupItemKey(
-                                        getItemGroup(item, taxonomicGroups, group)?.type ?? listGroupType,
-                                        getItemGroup(item, taxonomicGroups, group)?.getValue?.(item)
-                                    ) === selectionKey)
-                        )
+                        const selectedIndex = orderedBase.findIndex((item) => {
+                            if (item == null || isSkeletonItem(item)) {
+                                return false
+                            }
+                            if (recentSourceKey(item) === selectionKey || pinnedSourceKey(item) === selectionKey) {
+                                return true
+                            }
+                            const itemGroup = getItemGroup(item, taxonomicGroups, group)
+                            return (
+                                groupItemKey(itemGroup?.type ?? listGroupType, itemGroup?.getValue?.(item)) ===
+                                selectionKey
+                            )
+                        })
                         if (selectedIndex >= 0) {
-                            orderedBase = floatToOffset(orderedBase, selectedIndex, leadingCatchAllOffset)
+                            orderedBase = floatToFront(orderedBase, selectedIndex, leadingCatchAllOffset)
                         } else {
                             // The selection isn't among the visible recents/pinned — prepend a
                             // synthetic row (shaped like a top match, so `getItemGroup` resolves
@@ -1195,11 +1188,16 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         // position would desync the windowed loader's display-index ->
                         // remote-offset mapping. When the selection is paginated past (not
                         // loaded yet), we leave the list alone for the same reason.
-                        if (
-                            selectedIndex > leadingCatchAllOffset &&
-                            orderedBase.slice(0, selectedIndex).every((item) => item != null && !isSkeletonItem(item))
-                        ) {
-                            orderedBase = floatToOffset(orderedBase, selectedIndex, leadingCatchAllOffset)
+                        const rowsAboveSelectionLoaded = (): boolean => {
+                            for (let i = 0; i < selectedIndex; i++) {
+                                if (orderedBase[i] == null || isSkeletonItem(orderedBase[i])) {
+                                    return false
+                                }
+                            }
+                            return true
+                        }
+                        if (selectedIndex > leadingCatchAllOffset && rowsAboveSelectionLoaded()) {
+                            orderedBase = floatToFront(orderedBase, selectedIndex, leadingCatchAllOffset)
                         }
                     }
                 }

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -1045,6 +1045,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     const results = hasMatch ? [buildUrlContainsShortcut(trimmed, listGroupType)] : []
                     return {
                         results,
+                        syntheticSelectedCount: 0,
                         count: results.length,
                         searchQuery: remoteItems.searchQuery,
                         queryChanged: remoteItems.queryChanged,
@@ -1112,11 +1113,13 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     orderedBase = combinedResults
                 }
                 // Mirrors the rebuild menu's Combobox idle promotion: with no search query,
-                // the committed selection floats above the rest of the list so the user can
-                // see at a glance what is currently picked. A leading null-valued catch-all
-                // row (e.g. "All events") keeps its place, per the invariant in
-                // floatRecentPinned.ts — so the float targets index 1 when one is present.
-                // While searching, relevance wins.
+                // the committed selection leads the list so the user can see at a glance
+                // what is currently picked — floated in place when the real row is loaded,
+                // otherwise statically inserted as a synthetic row (the selection is known
+                // at open; there's no need to wait for the loader). A leading null-valued
+                // catch-all row (e.g. "All events") keeps its place, per the invariant in
+                // floatRecentPinned.ts — so the selection targets index 1 when one is
+                // present. While searching, relevance wins.
                 let syntheticSelectedCount = 0
                 if (
                     !searchQuery &&
@@ -1142,6 +1145,25 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         getItemGroup(leadingItem, taxonomicGroups, group)?.getValue?.(leadingItem) === null
                             ? 1
                             : 0
+                    // The synthetic stand-in for a selection whose real row isn't loaded —
+                    // shaped like a top match, so `getItemGroup` resolves its source group.
+                    // Only usable when the source group round-trips it back to the committed
+                    // value: id-keyed groups (actions, cohorts) read `.id`, which the
+                    // `{ name, value, group }` shape lacks, so `getValue` returns `undefined`
+                    // and the round-trip fails — keeping their raw ids out of the list, which
+                    // is the intent. `name` stays the raw key, matching how real rows in
+                    // name/value-keyed groups are shaped: it round-trips through `getValue`,
+                    // and consumers that persist `item.name` verbatim don't get a friendly
+                    // label baked in. Renderers already prettify raw keys at render time.
+                    const sourceGroup = taxonomicGroups.find((g: TaxonomicFilterGroup) => g.type === groupType)
+                    const synthetic = {
+                        name: String(value),
+                        value,
+                        group: groupType,
+                    } as unknown as TaxonomicDefinitionTypes
+                    const syntheticRoundTrips = sourceGroup?.getValue?.(synthetic) === value
+                    const insertSynthetic = (list: typeof orderedBase): typeof orderedBase =>
+                        leadingCatchAllOffset > 0 ? [list[0], synthetic, ...list.slice(1)] : [synthetic, ...list]
                     if (isSuggested) {
                         // The aggregated list is fully client-side (recents/pinned prefixes),
                         // so both floating and prepending are safe here.
@@ -1160,53 +1182,44 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         })
                         if (selectedIndex >= 0) {
                             orderedBase = floatToFront(orderedBase, selectedIndex, leadingCatchAllOffset)
-                        } else {
-                            // The selection isn't among the visible recents/pinned — prepend a
-                            // synthetic row (shaped like a top match, so `getItemGroup` resolves
-                            // its source group) so the user can still verify what's picked.
-                            // Guarded on the source group round-tripping the synthetic back to the
-                            // committed value: id-keyed groups (actions, cohorts) read `.id`, which
-                            // the `{ name, value, group }` shape lacks, so `getValue` returns
-                            // `undefined` and the round-trip below fails — keeping their raw ids
-                            // out of the list, which is the intent.
-                            const sourceGroup = taxonomicGroups.find((g: TaxonomicFilterGroup) => g.type === groupType)
-                            // `name` stays the raw key, matching how real rows in name/value-keyed
-                            // groups are shaped: it round-trips through `getValue` below, and
-                            // consumers that persist `item.name` verbatim don't get a friendly
-                            // label baked in. Renderers already prettify raw keys at render time.
-                            const synthetic = {
-                                name: String(value),
-                                value,
-                                group: groupType,
-                            } as unknown as TaxonomicDefinitionTypes
-                            if (sourceGroup?.getValue?.(synthetic) === value) {
-                                orderedBase =
-                                    leadingCatchAllOffset > 0
-                                        ? [orderedBase[0], synthetic, ...orderedBase.slice(1)]
-                                        : [synthetic, ...orderedBase]
-                                syntheticSelectedCount = 1
-                            }
+                        } else if (syntheticRoundTrips) {
+                            orderedBase = insertSynthetic(orderedBase)
+                            syntheticSelectedCount = 1
                         }
-                    } else if (!isSuggested && groupType === listGroupType && group?.getValue) {
+                    } else if (groupType === listGroupType && group?.getValue) {
                         const getValue = group.getValue
                         const selectedIndex = orderedBase.findIndex(
                             (item) => item != null && !isSkeletonItem(item) && getValue(item) === value
                         )
-                        // Floating shifts every row above the selection down by one, so it is
-                        // only safe when those rows are all loaded — a hole changing display
-                        // position would desync the windowed loader's display-index ->
-                        // remote-offset mapping. When the selection is paginated past (not
-                        // loaded yet), we leave the list alone for the same reason.
-                        const rowsAboveSelectionLoaded = (): boolean => {
-                            for (let i = 0; i < selectedIndex; i++) {
-                                if (orderedBase[i] == null || isSkeletonItem(orderedBase[i])) {
-                                    return false
-                                }
+                        if (selectedIndex === -1) {
+                            // The selection isn't among the loaded rows (first page still in
+                            // flight, or paginated past it) — insert the synthetic stand-in
+                            // rather than waiting for the loader. Once the page carrying the
+                            // real row lands, the `findIndex` above starts matching, the
+                            // synthetic drops out, and the float below takes over: the loaded
+                            // copy is the dedupe. The loader's display-index -> remote-offset
+                            // mapping stays exact because `onRowsRendered` subtracts
+                            // `syntheticSelectedCount` alongside `localItems.count`.
+                            if (syntheticRoundTrips) {
+                                orderedBase = insertSynthetic(orderedBase)
+                                syntheticSelectedCount = 1
                             }
-                            return true
-                        }
-                        if (selectedIndex > leadingCatchAllOffset && rowsAboveSelectionLoaded()) {
-                            orderedBase = floatToFront(orderedBase, selectedIndex, leadingCatchAllOffset)
+                        } else {
+                            // Floating shifts every row above the selection down by one, so it
+                            // is only safe when those rows are all loaded — a hole changing
+                            // display position would desync the windowed loader's
+                            // display-index -> remote-offset mapping.
+                            const rowsAboveSelectionLoaded = (): boolean => {
+                                for (let i = 0; i < selectedIndex; i++) {
+                                    if (orderedBase[i] == null || isSkeletonItem(orderedBase[i])) {
+                                        return false
+                                    }
+                                }
+                                return true
+                            }
+                            if (selectedIndex > leadingCatchAllOffset && rowsAboveSelectionLoaded()) {
+                                orderedBase = floatToFront(orderedBase, selectedIndex, leadingCatchAllOffset)
+                            }
                         }
                     }
                 }
@@ -1217,6 +1230,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 const orderedResults = shortcutItems.length ? [...shortcutItems, ...otherItems] : orderedBase
                 return {
                     results: orderedResults,
+                    syntheticSelectedCount,
                     count:
                         syntheticSelectedCount +
                         keywordShortcutItems.length +
@@ -1322,7 +1336,11 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     }
                 }
                 if (loadFrom !== null) {
-                    const offset = (loadFrom || startIndex) - values.localItems.count
+                    // The synthetic selected row (when present) sits before the remote block,
+                    // so it shifts every remote row's display index by one — subtract it along
+                    // with the local rows to recover the true remote offset.
+                    const offset =
+                        (loadFrom || startIndex) - values.localItems.count - (values.items.syntheticSelectedCount ?? 0)
                     actions.loadRemoteItems({ offset, limit: values.limit })
                 }
             }

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -42,6 +42,7 @@ import {
     pinnedSourceKey,
     recentSourceKey,
 } from 'lib/components/TaxonomicFilter/utils/floatRecentPinned'
+import { floatToFront } from 'lib/components/TaxonomicFilter/utils/floatToFront'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
@@ -120,6 +121,14 @@ export interface RowInfo {
  */
 export const NO_ITEM_SELECTED = -1
 
+// Data-warehouse tabs keep their own committed-selection affordance (the pinned,
+// auto-expanded row via `getInitialPinnedRowIndex`), so they are excluded from
+// the generic selection-promotion below.
+const DATA_WAREHOUSE_GROUP_TYPES: TaxonomicFilterGroupType[] = [
+    TaxonomicFilterGroupType.DataWarehouse,
+    TaxonomicFilterGroupType.DataWarehouseSourceTables,
+]
+
 export function getInitialPinnedRowIndex({
     results,
     taxonomicGroups,
@@ -137,15 +146,11 @@ export function getInitialPinnedRowIndex({
     value: string | number | null | undefined
     isActiveTab: boolean
 }): number | null {
-    const dataWarehouseGroupTypes: TaxonomicFilterGroupType[] = [
-        TaxonomicFilterGroupType.DataWarehouse,
-        TaxonomicFilterGroupType.DataWarehouseSourceTables,
-    ]
     if (
         !isActiveTab ||
-        !dataWarehouseGroupTypes.includes(listGroupType) ||
+        !DATA_WAREHOUSE_GROUP_TYPES.includes(listGroupType) ||
         groupType === undefined ||
-        !dataWarehouseGroupTypes.includes(groupType) ||
+        !DATA_WAREHOUSE_GROUP_TYPES.includes(groupType) ||
         value == null
     ) {
         return null
@@ -1002,6 +1007,9 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 s.isSoleSubstantiveGroup,
                 s.soleGroupHasGetValue,
                 s.taxonomicGroups,
+                s.group,
+                s.groupType,
+                s.value,
                 (_, props: InfiniteListLogicProps) => props.collapseUrlsToContainsRow,
             ],
             (
@@ -1018,6 +1026,9 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 isSoleSubstantiveGroup,
                 soleGroupHasGetValue,
                 taxonomicGroups,
+                group,
+                groupType,
+                value,
                 collapseUrlsToContainsRow
             ) => {
                 // Collapse URL groups to a single "URL contains <query>" shortcut row
@@ -1100,6 +1111,59 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 } else {
                     orderedBase = combinedResults
                 }
+                // Mirrors the rebuild menu's Combobox idle promotion: with no search query,
+                // the committed selection floats to the very first row so the user can see
+                // at a glance what is currently picked. While searching, relevance wins.
+                let syntheticSelectedCount = 0
+                if (!searchQuery && value != null && groupType && !DATA_WAREHOUSE_GROUP_TYPES.includes(groupType)) {
+                    const selectionKey = groupItemKey(groupType, value)
+                    if (isSuggested && selectionKey) {
+                        // The aggregated list is fully client-side (recents/pinned prefixes),
+                        // so both floating and prepending are safe here.
+                        const selectedIndex = orderedBase.findIndex(
+                            (item) =>
+                                item != null &&
+                                !isSkeletonItem(item) &&
+                                (recentSourceKey(item) === selectionKey || pinnedSourceKey(item) === selectionKey)
+                        )
+                        if (selectedIndex >= 0) {
+                            orderedBase = floatToFront(orderedBase, selectedIndex)
+                        } else {
+                            // The selection isn't among the visible recents/pinned — prepend a
+                            // synthetic row (shaped like a top match, so `getItemGroup` resolves
+                            // its source group) so the user can still verify what's picked.
+                            // Only when the source group round-trips the synthetic back to the
+                            // same value: id-keyed groups (actions, cohorts) would render the
+                            // raw id, which would confuse more than it clarifies.
+                            const sourceGroup = taxonomicGroups.find((g: TaxonomicFilterGroup) => g.type === groupType)
+                            const synthetic = {
+                                name: String(value),
+                                value,
+                                group: groupType,
+                            } as unknown as TaxonomicDefinitionTypes
+                            if (sourceGroup?.getValue?.(synthetic) === value) {
+                                orderedBase = [synthetic, ...orderedBase]
+                                syntheticSelectedCount = 1
+                            }
+                        }
+                    } else if (!isSuggested && groupType === listGroupType && group?.getValue) {
+                        const getValue = group.getValue
+                        const selectedIndex = orderedBase.findIndex(
+                            (item) => item != null && !isSkeletonItem(item) && getValue(item) === value
+                        )
+                        // Floating shifts every row above the selection down by one, so it is
+                        // only safe when those rows are all loaded — a hole changing display
+                        // position would desync the windowed loader's display-index ->
+                        // remote-offset mapping. When the selection is paginated past (not
+                        // loaded yet), we leave the list alone for the same reason.
+                        if (
+                            selectedIndex > 0 &&
+                            orderedBase.slice(0, selectedIndex).every((item) => item != null && !isSkeletonItem(item))
+                        ) {
+                            orderedBase = floatToFront(orderedBase, selectedIndex)
+                        }
+                    }
+                }
                 // The "URL contains <query>" shortcut leads the aggregated SuggestedFilters list —
                 // ahead of recents/pinned/top-matches — so a URL search surfaces the contains
                 // suggestion first. Everything else keeps its existing order.
@@ -1108,6 +1172,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 return {
                     results: orderedResults,
                     count:
+                        syntheticSelectedCount +
                         keywordShortcutItems.length +
                         recentPrefix.length +
                         pinnedPrefix.length +

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -1142,7 +1142,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         getItemGroup(leadingItem, taxonomicGroups, group)?.getValue?.(leadingItem) === null
                             ? 1
                             : 0
-                    if (isSuggested && selectionKey) {
+                    if (isSuggested) {
                         // The aggregated list is fully client-side (recents/pinned prefixes),
                         // so both floating and prepending are safe here.
                         const selectedIndex = orderedBase.findIndex((item) => {
@@ -1170,9 +1170,15 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             // `undefined` and the round-trip below fails — keeping their raw ids
                             // out of the list, which is the intent.
                             const sourceGroup = taxonomicGroups.find((g: TaxonomicFilterGroup) => g.type === groupType)
-                            const friendlyLabel = getCoreFilterDefinition(String(value), groupType)?.label
+                            // Keep `name` as the raw key: consumers persist `item.name` verbatim
+                            // (e.g. ActionFilterRow, universalFiltersLogic), so baking a friendly
+                            // label in here would corrupt the saved value on a no-op re-pick, and
+                            // it would defeat the round-trip guard below for name-keyed groups
+                            // (EventProperties/PersonProperties/SessionProperties `getValue`
+                            // reads `.name`). The renderer already prettifies raw keys at render
+                            // time via PropertyKeyInfo/getCoreFilterDefinition.
                             const synthetic = {
-                                name: friendlyLabel ?? String(value),
+                                name: String(value),
                                 value,
                                 group: groupType,
                             } as unknown as TaxonomicDefinitionTypes

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -54,6 +54,7 @@ import {
     partitionContainsShortcuts,
     urlContainsRowLabel,
 } from '../utils/collapsedContainsRow'
+import { floatToFront } from '../utils/floatToFront'
 import { promoteMatchingBy } from '../utils/promoteProperties'
 import { MenuFilterHeader } from './Header'
 import { MatchedValueBadge } from './MatchedValueBadge'
@@ -151,15 +152,6 @@ function entryLabelMatchesSelection(entry: MenuFilterEntry, selected: MenuFilter
  *  selection means we must not also prepend a synthetic placeholder. */
 function entryMatchesSelection(entry: MenuFilterEntry, selected: MenuFilterEntry): boolean {
     return entryValueMatchesSelection(entry, selected) || entryLabelMatchesSelection(entry, selected)
-}
-
-/** Move the element at `index` to the front, preserving the order of the rest.
- *  No-op when `index <= 0` (already first, or not found via `findIndex` -> -1). */
-function floatToFront<T>(list: T[], index: number): T[] {
-    if (index <= 0) {
-        return list
-    }
-    return [list[index], ...list.slice(0, index), ...list.slice(index + 1)]
 }
 
 function fuseMatchEntries(entries: MenuFilterEntry[], query: string): MenuFilterEntry[] {

--- a/frontend/src/lib/components/TaxonomicFilter/utils/floatToFront.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/floatToFront.ts
@@ -2,7 +2,7 @@
  *  catch-all row), preserving the order of everything else.
  *  No-op when `index <= offset` (already in place, or not found via `findIndex` -> -1).
  *  Shared by the rebuild menu's `Combobox` and the legacy `infiniteListLogic`
- *  so the committed-selection promotion behaves identically across surfaces. */
+ *  for the committed-selection promotion; callers choose the offset per surface. */
 export function floatToFront<T>(list: T[], index: number, offset = 0): T[] {
     if (index <= offset) {
         return list

--- a/frontend/src/lib/components/TaxonomicFilter/utils/floatToFront.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/floatToFront.ts
@@ -1,10 +1,11 @@
-/** Move the element at `index` to the front, preserving the order of the rest.
- *  No-op when `index <= 0` (already first, or not found via `findIndex` -> -1).
+/** Move the element at `index` to `offset` (0 by default, or 1 to preserve a leading
+ *  catch-all row), preserving the order of everything else.
+ *  No-op when `index <= offset` (already in place, or not found via `findIndex` -> -1).
  *  Shared by the rebuild menu's `Combobox` and the legacy `infiniteListLogic`
  *  so the committed-selection promotion behaves identically across surfaces. */
-export function floatToFront<T>(list: T[], index: number): T[] {
-    if (index <= 0) {
+export function floatToFront<T>(list: T[], index: number, offset = 0): T[] {
+    if (index <= offset) {
         return list
     }
-    return [list[index], ...list.slice(0, index), ...list.slice(index + 1)]
+    return [...list.slice(0, offset), list[index], ...list.slice(offset, index), ...list.slice(index + 1)]
 }

--- a/frontend/src/lib/components/TaxonomicFilter/utils/floatToFront.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/floatToFront.ts
@@ -1,0 +1,10 @@
+/** Move the element at `index` to the front, preserving the order of the rest.
+ *  No-op when `index <= 0` (already first, or not found via `findIndex` -> -1).
+ *  Shared by the rebuild menu's `Combobox` and the legacy `infiniteListLogic`
+ *  so the committed-selection promotion behaves identically across surfaces. */
+export function floatToFront<T>(list: T[], index: number): T[] {
+    if (index <= 0) {
+        return list
+    }
+    return [list[index], ...list.slice(0, index), ...list.slice(index + 1)]
+}


### PR DESCRIPTION
## Problem

When a taxonomic filter picker (e.g. the series subject button in an insight, `data-attr="trend-element-subject-0"`) is reopened with an existing selection, the rebuild menu floats the committed selection to the very first row so the user can verify at a glance what is currently picked. Neither legacy surface (`legacy-control`, `legacy-pill`) does this — the selection is only indicated by a checkmark somewhere down the list, if it is visible at all.

## Changes

Mirrors the rebuild's idle selection promotion into the legacy data layer (`infiniteListLogic`'s `items` selector), active only when there is no search query — while searching, relevance ordering wins, exactly as in the rebuild:

- On a group's own tab (the opening surface for `legacy-control`), the committed selection leads the list from the moment the picker opens: a synthetic row is inserted statically while the real row's page hasn't loaded (the selection is known at open — no need to wait for the loader), and once the real row loads the synthetic drops out and the real row floats in its place (the loaded copy is the dedupe). The float only reorders when every row above the selection is loaded, and the windowed loader's display-index → remote-offset mapping subtracts the synthetic prefix, so pagination stays exact. The selection sits below a leading catch-all row ("All events" stays at position 0).
- On the aggregated Suggested filters tab (the opening surface for `legacy-pill`), a matching recent/pinned row floats to the top; if the selection isn't among the visible recents/pinned, a synthetic row (shaped like a top match) is prepended. The synthetic row is only used when the source group round-trips it to the same value, so id-keyed groups (actions, cohorts) never render a raw id.
- Data-warehouse tabs are excluded — they keep their existing pinned/auto-expanded row affordance.
- Extracted the rebuild's `floatToFront` helper into `utils/floatToFront.ts`, now shared by the rebuild `Combobox` and legacy `infiniteListLogic`, so the promotion behavior can't silently diverge between arms.

No telemetry payloads changed.

## How did you test this code?

Ran the full TaxonomicFilter jest suites locally (`frontend/src/lib/components/TaxonomicFilter/`, including `menu/`, `headless/`, `utils/`) — 400+ tests pass. Could not run `hogli ci:preflight` or the full `tsgo` typecheck meaningfully in the sandbox (no python; the checkout lacks CI-generated artifacts so `tsgo` reports thousands of pre-existing errors on master too — the errors in touched files match that pre-existing class).

New tests in `infiniteListLogic.test.ts`, each catching a regression no existing test covers:
- idle selection floats to row 0 on its own group tab (guards the float being dropped or reordered behind other prefixes)
- promotion is skipped while searching (guards selection hijacking relevance ordering)
- a matching recent floats on the Suggested tab without duplication (guards the dedupe against the synthetic row)
- a synthetic row is prepended when the selection isn't visible (guards the paginated-past case)
- id-keyed groups skip the synthetic row (guards raw cohort/action ids leaking into the list)

I was not able to manually verify the three surfaces in a browser; screenshots to follow from a human run if needed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal UI ordering behavior, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (PostHog Code cloud task) at @pauldambra's request. Skills invoked: `/modifying-taxonomic-filter`, `/writing-tests`.
- Per the taxonomic-filter skill, ordering/promotion changes need explicit human sign-off — this change was explicitly requested by the owner of the legacy surfaces, and intentionally mirrors an existing rebuild behavior rather than introducing a new ordering.
- Initially the own-group tab only floated the selection when its row was already loaded (to avoid touching the windowed loader's offset math); per review direction the synthetic row is now inserted statically on paginated tabs too, with the offset math compensating for the prefix — matching the rebuild's prepend-when-missing behavior.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

