### PR TITLE
fix(slack): gate link unfurls in unapproved external channels

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1909,6 +1909,16 @@ def route_posthog_code_event_to_relevant_region(
         ):
             return _proxy_event_and_return_route(request, other_domain)
         if event_type == "link_shared":
+            # Mirror the app_mention gate: don't unfurl project data into an unapproved externally
+            # shared channel. A paste isn't an explicit invocation, so suppress without prompting.
+            channel_id = event.get("channel") if isinstance(event.get("channel"), str) else None
+            if (
+                is_ext_shared_channel
+                and channel_id
+                and not _channel_is_approved(local_match.integration_id, channel_id)
+            ):
+                logger.info("slack_link_unfurl_channel_unapproved", slack_team_id=slack_team_id, channel=channel_id)
+                return ROUTE_HANDLED_LOCALLY
             handle_posthog_link_unfurl(event, local_match)
         return ROUTE_HANDLED_LOCALLY
     return _route_to_other_region_or_drop(request, slack_team_id, proxied=proxied, other_domain=other_domain)

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -2,14 +2,24 @@ import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
+from django.test import TestCase, override_settings
+from django.test.client import RequestFactory
+from django.utils import timezone
+
 from parameterized import parameterized
 
+from posthog.helpers.slack_scopes import REQUIRED_SLACK_SCOPES
 from posthog.models.comment import Comment
 from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
 
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.product_analytics.backend.models.insight import Insight
+from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
+from products.slack_app.backend.models import SlackChannel
+from products.slack_app.backend.services.slack_auth import write_auth_state_ok
 from products.slack_app.backend.slack_link_unfurl import (
     _insight_resource_label,
     handle_posthog_link_unfurl,
@@ -342,3 +352,61 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
 
         text = self._unfurl_text(mock_client.chat_unfurl.call_args.kwargs["unfurls"][url])
         assert ">>>" not in text
+
+
+@override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+class TestLinkUnfurlChannelGate(TestCase):
+    SLACK_TEAM_ID = "TGate01"
+    CHANNEL_ID = "C_EXT"
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.organization = Organization.objects.create(name="Gate Org")
+        self.team = Team.objects.create(organization=self.organization, name="Gate Team")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id=self.SLACK_TEAM_ID,
+            config={"scope": ",".join(sorted(REQUIRED_SLACK_SCOPES))},
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+        # load_integrations calls auth.test on cache miss; pre-seed ok so the resolver short-circuits.
+        write_auth_state_ok(self.integration.id, bot_user_id=None)
+
+    def _event(self) -> dict:
+        return {
+            "type": "link_shared",
+            "channel": self.CHANNEL_ID,
+            "user": "U_SHARER",
+            "message_ts": "1.2",
+            "links": [{"url": "https://us.posthog.com/support/tickets/1"}],
+        }
+
+    def _route(self, *, is_ext_shared_channel: bool) -> str:
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
+        return route_posthog_code_event_to_relevant_region(
+            request, self._event(), self.SLACK_TEAM_ID, is_ext_shared_channel=is_ext_shared_channel
+        )
+
+    @parameterized.expand(
+        [
+            ("ext_unapproved", True, False, False),
+            ("ext_approved", True, True, True),
+            ("internal_channel", False, False, True),
+        ]
+    )
+    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
+    def test_unfurl_gated_on_external_channel_approval(
+        self, _name: str, is_ext_shared: bool, approved: bool, expect_unfurled: bool, mock_unfurl: MagicMock
+    ) -> None:
+        if approved:
+            SlackChannel.objects.create(
+                slack_workspace_id=self.SLACK_TEAM_ID,
+                slack_channel_id=self.CHANNEL_ID,
+                approved_at=timezone.now(),
+            )
+
+        result = self._route(is_ext_shared_channel=is_ext_shared)
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        assert mock_unfurl.called is expect_unfurled


### PR DESCRIPTION
## Problem

The `link_shared` unfurl path posts PostHog project data into a Slack channel without the external-channel approval gate that the `app_mention` flow already enforces. An org member can paste a link into an unapproved, externally shared Slack Connect channel and the bot unfurls project data to every participant, including external (cross-workspace) users.

The missing gate pre-dates support tickets — insight and dashboard names already unfurled ungated. Follow-up to #67083, which raised the stakes: ticket unfurls include requester identity and the opening support message (customer data), and tickets have no per-resource access-control check.

Flagged in review on #67083 after it merged, so this lands as a follow-up.

## Changes

Gate the whole unfurl in the router, mirroring the `app_mention` gate: in an externally shared, unapproved channel, suppress the unfurl. The approval state reuses the existing `_channel_is_approved` lookup keyed by the integration's workspace id, exactly as `app_mention` does.

Unlike `app_mention`, a passive link paste is not an explicit invocation, so this suppresses silently rather than posting an approval prompt. Internal channels and approved external channels are unaffected.

## How did you test this code?

Added `TestLinkUnfurlChannelGate` in `test_link_unfurl.py`: a routing-level test parameterized over the three channel states (external+unapproved, external+approved, internal), asserting the unfurl handler is invoked only when allowed. This guards the exact regression the fix addresses — no existing test covered external-channel gating on the `link_shared` path (the only prior ext-shared test covers `member_joined_channel` onboarding).

3/3 cases pass. Note: a ClickHouse "table is in readonly mode" error appears in local test teardown, but it is environmental — the untouched pre-existing class in the same file shows the identical teardown error, and these tests only touch Postgres. `ruff check` and `ruff format` clean; pre-push preflight passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A. No user-facing docs for this internal behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Luke flagged the review comment on #67083 and asked whether it was valid; I traced both event paths and confirmed the `link_shared` branch of `route_posthog_code_event_to_relevant_region` never consulted `is_ext_shared_channel` (the flag is in scope, just unused), while `app_mention` did.

Decisions:

- Chose to gate the entire unfurl rather than only suppress rich ticket details. The leak and its fix are the same mechanism, and gating everything also closes the pre-existing insight/dashboard leak in one move, consistent with `app_mention`.
- Placed the check in the router next to the existing `app_mention` gate rather than inside `handle_posthog_link_unfurl`, so the security decision lives with its sibling and reuses `_channel_is_approved`.
- Suppress silently instead of prompting for approval, since a paste is passive.
- Invoked `/writing-tests` before adding the test to confirm it targets a real regression at the cheapest level (routing `TestCase`, no ClickHouse).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
