### PR TITLE
feat(insights): add "show values on series" toggle for SQL charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5978,6 +5978,10 @@ snapshots:
         hash: v1.k794b7964.d4921e1d896775d1f98056f5bc1c57c9b7ca0be8951e14a0f3229e7b77dc2472.W3I3GvNATojXlZJp04S-XFH3DfLBUNb7lJ1-lr-rW9g
     scenes-app-insights-side-panel-actions--unsaved-insight--light:
         hash: v1.k794b7964.1509a0b35b8b28d5a721d77a7f1ae7e166057624f7db16331216264e581e2f6e.V-NDMPceHNP8iL5m7RVrATBNmdh4zjdetX_KW6UQg5g
+    scenes-app-insights-sqllinechart--sql-bar-chart-value-labels-quill--dark:
+        hash: v1.k794b7964.52d791fc7eb98cf6dcd1a5bee6b116b602ac0a12eb00ce9e91bff37507f287ee.97PQFvm6wL2rjbzNZ-7-ie9sXB6RUpuS7j_aqEeCmCE
+    scenes-app-insights-sqllinechart--sql-bar-chart-value-labels-quill--light:
+        hash: v1.k794b7964.7b8d49b9b0520e77193d4daa6ac01ab65a68b2317ce647bbdf1d68a8765da8ad.IvWMtHjUu9iH5XiCPh77GgiSYJGtT5ERO_opo82cDe0
     scenes-app-insights-sqllinechart--sql-line-chart--dark:
         hash: v1.k794b7964.de80c9b4dac120fbbaca7e49026f65cdb77e19c4a53f734a3840c53a5573218c.CWJMQGhmxj5sAShfvws2pIRo9cBU8K7GILzcPsmkXhI
     scenes-app-insights-sqllinechart--sql-line-chart--light:

--- a/frontend/src/mocks/fixtures/api/projects/team_id/insights/sqlBarChartValueLabels.json
+++ b/frontend/src/mocks/fixtures/api/projects/team_id/insights/sqlBarChartValueLabels.json
@@ -1,0 +1,135 @@
+{
+  "id": 24,
+  "short_id": "qJ3UMv9L",
+  "name": "SQL with value labels",
+  "derived_name": null,
+  "filters": {},
+  "query": {
+    "kind": "DataVisualizationNode",
+    "source": {
+      "kind": "HogQLQuery",
+      "query": "SELECT\n    toStartOfMonth(timestamp) AS month,\n    countIf(event = '$pageview') AS pageviews,\n    countIf(event = 'signed_up') AS signups\nFROM events\nGROUP BY month\nORDER BY month"
+    },
+    "display": "ActionsBar",
+    "chartSettings": {
+      "xAxis": {
+        "column": "month"
+      },
+      "yAxis": [
+        {
+          "column": "pageviews",
+          "settings": {
+            "formatting": {
+              "prefix": "",
+              "suffix": ""
+            }
+          }
+        },
+        {
+          "column": "signups",
+          "settings": {
+            "formatting": {
+              "prefix": "",
+              "suffix": ""
+            }
+          }
+        }
+      ],
+      "showValuesOnSeries": true
+    },
+    "tableSettings": {
+      "columns": [
+        {
+          "column": "month",
+          "settings": {
+            "formatting": {
+              "prefix": "",
+              "suffix": ""
+            }
+          }
+        },
+        {
+          "column": "pageviews",
+          "settings": {
+            "formatting": {
+              "prefix": "",
+              "suffix": ""
+            }
+          }
+        },
+        {
+          "column": "signups",
+          "settings": {
+            "formatting": {
+              "prefix": "",
+              "suffix": ""
+            }
+          }
+        }
+      ]
+    }
+  },
+  "order": null,
+  "deleted": false,
+  "dashboards": [],
+  "dashboard_tiles": [],
+  "last_refresh": "2026-03-04T16:10:59.052768Z",
+  "cache_target_age": "2026-03-04T22:10:59.052768Z",
+  "next_allowed_client_refresh": "2026-03-04T16:11:59.052768Z",
+  "result": [
+    ["2021-10-01", 340, 120],
+    ["2021-11-01", 520, 210],
+    ["2021-12-01", 610, 260],
+    ["2022-01-01", 480, 190],
+    ["2022-02-01", 720, 310],
+    ["2022-03-01", 890, 400]
+  ],
+  "hasMore": false,
+  "columns": ["month", "pageviews", "signups"],
+  "created_at": "2026-03-04T16:11:08.460573Z",
+  "created_by": {
+    "id": 1,
+    "uuid": "019c66e6-fd77-0000-a6bb-509ac38f988e",
+    "distinct_id": "otSl3FZiAxw3Vv8GUTeWtZcV3mdpR0lH9pprZmBRKXd",
+    "first_name": "Employee 427",
+    "last_name": "",
+    "email": "test@posthog.com",
+    "is_email_verified": null,
+    "hedgehog_config": null,
+    "role_at_organization": "engineering"
+  },
+  "description": null,
+  "updated_at": "2026-03-04T16:11:08.460609Z",
+  "favorited": false,
+  "saved": true,
+  "last_modified_at": "2026-03-04T16:11:08.456506Z",
+  "last_modified_by": {
+    "id": 1,
+    "uuid": "019c66e6-fd77-0000-a6bb-509ac38f988e",
+    "distinct_id": "otSl3FZiAxw3Vv8GUTeWtZcV3mdpR0lH9pprZmBRKXd",
+    "first_name": "Employee 427",
+    "last_name": "",
+    "email": "test@posthog.com",
+    "is_email_verified": null,
+    "hedgehog_config": null,
+    "role_at_organization": "engineering"
+  },
+  "is_sample": false,
+  "effective_restriction_level": 21,
+  "effective_privilege_level": 37,
+  "user_access_level": "manager",
+  "timezone": "UTC",
+  "is_cached": true,
+  "query_status": null,
+  "hogql": "SELECT\n    toStartOfMonth(timestamp) AS month,\n    countIf(equals(event, '$pageview')) AS pageviews,\n    countIf(equals(event, 'signed_up')) AS signups\nFROM\n    events\nGROUP BY\n    month\nORDER BY\n    month ASC\nLIMIT 101\nOFFSET 0",
+  "types": [
+    ["month", "Date"],
+    ["pageviews", "UInt64"],
+    ["signups", "UInt64"]
+  ],
+  "resolved_date_range": null,
+  "alerts": [],
+  "last_viewed_at": "2026-03-04T16:11:30.018817Z",
+  "tags": [],
+  "filters_hash": "cache_1_eb04b61fff884f29a4c74600aea3684fb7769ff1fa6e0d4e59865ee187c3b58c"
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -384,10 +384,22 @@ const LegacyLineGraph = ({
                         backgroundColor: (context) => {
                             return (context.dataset.borderColor as string) || 'black'
                         },
-                        display: () => {
-                            return false
+                        // Read the raw value from ySeriesData rather than the (possibly percent-scaled in
+                        // stacked-100 mode) dataset value, so labels match the tooltip and hide on nulls.
+                        display: (context) => {
+                            if (!chartSettings.showValuesOnSeries) {
+                                return false
+                            }
+                            return ySeriesData?.[context.datasetIndex]?.data[context.dataIndex] != null
                         },
-                        formatter: () => {},
+                        formatter: (_value, context) => {
+                            const series = ySeriesData?.[context.datasetIndex]
+                            const formatted = formatDataWithSettings(
+                                series?.data[context.dataIndex] ?? null,
+                                series?.settings
+                            )
+                            return typeof formatted === 'object' ? null : formatted
+                        },
                         borderWidth: 2,
                         borderRadius: 4,
                         borderColor: 'white',

--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -174,6 +174,14 @@ export const DisplayTab = (): JSX.Element => {
                                                 updateChartSettings({ showNullsAsZero: value })
                                             }}
                                         />
+                                        <LemonSwitch
+                                            className="flex-1 w-full"
+                                            label="Show values on series"
+                                            checked={chartSettings.showValuesOnSeries ?? false}
+                                            onChange={(value) => {
+                                                updateChartSettings({ showValuesOnSeries: value })
+                                            }}
+                                        />
                                         <div className="flex flex-col gap-1">
                                             <LemonLabel>X-axis label</LemonLabel>
                                             <LemonInput

--- a/frontend/src/scenes/insights/stories/SQLLineChart.stories.tsx
+++ b/frontend/src/scenes/insights/stories/SQLLineChart.stories.tsx
@@ -7,6 +7,7 @@ import { createInsightStory } from 'scenes/insights/__mocks__/createInsightScene
 
 import { mswDecorator } from '~/mocks/browser'
 
+import __sqlBarChartValueLabels from '../../../mocks/fixtures/api/projects/team_id/insights/sqlBarChartValueLabels.json'
 import __sqlLineChart from '../../../mocks/fixtures/api/projects/team_id/insights/sqlLineChart.json'
 import __sqlLineChartBreakdown from '../../../mocks/fixtures/api/projects/team_id/insights/sqlLineChartBreakdown.json'
 import __sqlLineChartTrendLine from '../../../mocks/fixtures/api/projects/team_id/insights/sqlLineChartTrendLine.json'
@@ -64,6 +65,18 @@ SQLLineChartBreakdown.parameters = {
 
 export const SQLLineChartTrendLineQuill: Story = createInsightStory(__sqlLineChartTrendLine as any)
 SQLLineChartTrendLineQuill.parameters = {
+    ...meta.parameters,
+    featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_SQL_CHARTS],
+    testOptions: {
+        ...meta.parameters?.testOptions,
+        waitForSelector: '.DataVisualization canvas',
+    },
+}
+
+// The legacy chart.js SQL renderer does not paint in the visual-regression harness (a pre-existing gap
+// that also affects the SQL line stories above), so this story targets the quill renderer, which does.
+export const SQLBarChartValueLabelsQuill: Story = createInsightStory(__sqlBarChartValueLabels as any)
+SQLBarChartValueLabelsQuill.parameters = {
     ...meta.parameters,
     featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_SQL_CHARTS],
     testOptions: {


### PR DESCRIPTION
## Problem

Insights driven by SQL had no way to show value labels on their bar and line charts, even though every other insight type exposes that option. The natural home for it (visualization → settings cog → Display sub-tab) simply had no such toggle.

## Changes

- Add a "Show values on series" switch to the Display sub-tab (General section). It writes `chartSettings.showValuesOnSeries`, the field the schema already defined.
- Make the legacy chart.js renderer honor it. The `datalabels` plugin was hardcoded to `display: () => false`; it now shows a label per point, formatted through the same `formatDataWithSettings` path as the tooltip (respects per-column prefix/suffix/decimals, hides on nulls).
- Storybook: a small 2-series bar chart fixture plus one story on the quill renderer.

No schema change was needed. `ChartSettings.showValuesOnSeries` already existed in both the TS and Python schemas.

> [!NOTE]
> **Flag interaction.** SQL charts render through two engines behind `product-analytics-quill-sql-charts` (owner: #team-data-tools): legacy chart.js when off, `@posthog/quill-charts` when on. The new engine already read `showValuesOnSeries` (via `buildValueLabelsConfig`), but nothing in the UI ever set it, so the plumbing was effectively dead. Flipping the flag alone does not surface value labels. This PR adds the missing toggle (works on both engines) and fixes the legacy engine to consume it, so the option behaves the same regardless of where an org sits in the rollout.

> [!WARNING]
> **Legacy renderer isn't visual-regression tested.** The legacy chart.js SQL renderer paints blank in the Storybook visual-regression harness. This is pre-existing and not caused by this PR: the existing `SQLLineChart` / `SQLLineChartBreakdown` stories hit it too. I diagnosed it with throwaway CI stories (bar+labels, bar+no-labels, line+labels): all three legacy variants snapshot blank while the quill variant renders, so it is the renderer, not the chart type or the value-label drawing. I confirmed the legacy fix works by rendering it against the exact CI production Storybook bundle locally (value labels draw correctly). The Storybook story therefore targets the quill renderer, which snapshots cleanly. The legacy path stays covered by the adapter unit tests and the manual capture below.

## How did you test this code?

- Rendered the value-labels output against the exact CI production Storybook bundle (downloaded the `storybook-build` artifact, served it, drove it with Playwright). Both engines draw value labels correctly.
- `pnpm --filter=@posthog/frontend typescript:check` clean for the edited files (pre-existing stale-typegen errors elsewhere are unrelated).
- `format` and `hogli ci:preflight --strict` clean.
- I (Claude) could not exercise the live in-app toggle: the insight mock harness doesn't mount the editable visualization controls. The toggle uses the identical `updateChartSettings(...)` pattern as its sibling switches in the same file.

<details>
<summary>Legacy chart.js renderer with value labels (rendered against the CI bundle)</summary>

Bars show `340 / 120 / 520 / 210 / ...` labels; verified in both light and dark. Not attached inline since visual-regression baselines are generated in CI, not committed.

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this per-chart setting, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Code, Opus) built this end to end at Xander's direction. The quill renderer already had value-label support wired and tested but no UI ever set the flag, so it never showed. I chose to both surface the toggle and fix the legacy renderer rather than depend on the flag rollout, so behavior is consistent during and after the migration. When the legacy story snapshotted blank in CI, I pushed temporary diagnostic stories to isolate the cause (renderer, not chart type or value labels), confirmed the fix against the exact CI bundle, then dropped the legacy/diagnostic stories and kept the quill story. No repo skills were required (isolated frontend chart change).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
