### PR TITLE
feat(pulse): execute queries through the query performance proxy

### DIFF
--- a/posthog/api/query_performance_proxy.py
+++ b/posthog/api/query_performance_proxy.py
@@ -1,7 +1,8 @@
 """OAuth-gated ClickHouse passthrough for query-performance autoresearch.
 
-Stub: route + M2M auth only. The execution layer that forwards SQL to the
-``autoresearch`` ClickHouse user will be added in a follow-up PR.
+Forwards SQL to the restricted ``autoresearch`` ClickHouse user on the test
+cluster. Fails closed (503) when the cluster is not configured; never routes
+to the main app ClickHouse.
 """
 
 from __future__ import annotations
@@ -14,6 +15,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.auth import OAuthAccessTokenAuthentication
+from posthog.clickhouse.test_cluster_client import (
+    TestClusterNotConfigured,
+    TestClusterQueryError,
+    execute_on_test_cluster,
+)
 from posthog.permissions import APIScopePermission
 
 MAX_SQL_LENGTH = 64 * 1024
@@ -57,22 +63,31 @@ class QueryPerformanceProxyViewSet(viewsets.ViewSet):
         responses={200: ExecuteTestClusterResponseSerializer},
         summary="Run a read-only query against the autoresearch test cluster",
         description=(
-            "Stub for the autoresearch ClickHouse passthrough. Auth + scope are wired up; "
-            "execution lands in a follow-up PR. Currently returns an empty response."
+            "Forwards SQL to the restricted autoresearch ClickHouse user for query-performance "
+            "analysis (query_log_archive and related tables). Read-only; row and time limited."
         ),
     )
     @action(detail=False, methods=["POST"], url_path="execute-test")
     def execute_test(self, request: Request) -> Response:
         serializer = ExecuteTestClusterRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        try:
+            out = execute_on_test_cluster(serializer.validated_data["sql"])
+        except TestClusterNotConfigured:
+            return Response(
+                {"detail": "Test cluster is not configured on this instance."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        except TestClusterQueryError as err:
+            return Response({"detail": str(err)}, status=status.HTTP_400_BAD_REQUEST)
         return Response(
             {
-                "result": [],
-                "query_id": None,
-                "elapsed_ms": None,
-                "rows_read": None,
-                "bytes_read": None,
-                "rows_returned": 0,
+                "result": out.result,
+                "query_id": out.query_id,
+                "elapsed_ms": out.elapsed_ms,
+                "rows_read": out.rows_read,
+                "bytes_read": out.bytes_read,
+                "rows_returned": len(out.result),
             },
             status=status.HTTP_200_OK,
         )

--- a/posthog/api/test/test_query_performance_proxy.py
+++ b/posthog/api/test/test_query_performance_proxy.py
@@ -1,0 +1,127 @@
+from datetime import timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
+
+from posthog.api.query_performance_proxy import MAX_SQL_LENGTH, ExecuteTestClusterRequestSerializer
+from posthog.clickhouse.test_cluster_client import (
+    TestClusterNotConfigured,
+    TestClusterQueryError,
+    TestClusterResult,
+    execute_on_test_cluster,
+)
+from posthog.models.oauth import OAuthAccessToken, OAuthApplication
+
+
+class TestExecuteTestClusterRequestSerializer(SimpleTestCase):
+    def test_missing_sql_is_invalid(self):
+        serializer = ExecuteTestClusterRequestSerializer(data={})
+        assert not serializer.is_valid()
+        assert "sql" in serializer.errors
+
+    def test_oversized_sql_is_invalid(self):
+        serializer = ExecuteTestClusterRequestSerializer(data={"sql": "S" * (MAX_SQL_LENGTH + 1)})
+        assert not serializer.is_valid()
+        assert serializer.errors["sql"][0].code == "max_length"
+
+
+class BaseQueryPerformanceProxyTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.oauth_application = OAuthApplication.objects.create(
+            name="Test OAuth App",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            organization=self.organization,
+            user=self.user,
+        )
+        self.access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=self.oauth_application,
+            token="pha_test_query_perf_proxy_token",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="clickhouse_test_cluster_perf:read",
+        )
+
+    def _post_execute(self, data: dict):
+        return self.client.post(
+            "/api/query_performance_proxy/execute-test/",
+            data,
+            format="json",
+            headers={"authorization": f"Bearer {self.access_token.token}"},
+        )
+
+
+class TestExecuteTestCluster(BaseQueryPerformanceProxyTest):
+    def test_returns_503_when_test_cluster_unconfigured(self):
+        with self.settings(CLICKHOUSE_TEST_CLUSTER_HOST=""):
+            response = self._post_execute({"sql": "SELECT 1"})
+        assert response.status_code == 503
+        assert "not configured" in response.json()["detail"]
+
+    def test_invalid_request_body_returns_400(self):
+        response = self._post_execute({})
+        assert response.status_code == 400
+
+    @patch("posthog.api.query_performance_proxy.execute_on_test_cluster")
+    def test_forwards_sql_and_returns_rows_with_stats(self, execute):
+        execute.return_value = TestClusterResult(
+            result=[[1, "a"]], query_id="qid-1", elapsed_ms=12.5, rows_read=100, bytes_read=2048
+        )
+        response = self._post_execute({"sql": "SELECT team_id, lc_kind FROM query_log_archive LIMIT 1"})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["result"] == [[1, "a"]]
+        assert body["query_id"] == "qid-1"
+        assert body["elapsed_ms"] == 12.5
+        assert body["rows_read"] == 100
+        assert body["bytes_read"] == 2048
+        assert body["rows_returned"] == 1
+        execute.assert_called_once_with("SELECT team_id, lc_kind FROM query_log_archive LIMIT 1")
+
+    @patch("posthog.api.query_performance_proxy.execute_on_test_cluster")
+    def test_clickhouse_error_returns_400_with_message(self, execute):
+        execute.side_effect = TestClusterQueryError("Syntax error: failed at position 1")
+        response = self._post_execute({"sql": "SELEC 1"})
+        assert response.status_code == 400
+        assert "Syntax error" in response.json()["detail"]
+
+
+class TestExecuteOnTestCluster(TestCase):
+    def test_raises_not_configured_when_host_unset(self):
+        with self.settings(CLICKHOUSE_TEST_CLUSTER_HOST=""):
+            with self.assertRaises(TestClusterNotConfigured):
+                execute_on_test_cluster("SELECT 1")
+
+    @patch("posthog.clickhouse.test_cluster_client.SyncClient")
+    def test_builds_readonly_client_and_canonicalizes_rows(self, client_cls):
+        instance = client_cls.return_value
+        instance.execute.return_value = [(1, "x")]
+        instance.last_query = MagicMock(elapsed=0.0125, progress=MagicMock(rows=100, bytes=2048))
+        with self.settings(CLICKHOUSE_TEST_CLUSTER_HOST="test-ch", CLICKHOUSE_TEST_CLUSTER_USER="autoresearch"):
+            out = execute_on_test_cluster("SELECT 1")
+        assert out.result == [[1, "x"]]
+        assert out.query_id is not None and out.query_id.startswith("pulse-autoresearch-")
+        assert out.elapsed_ms == 12.5
+        assert out.rows_read == 100
+        assert out.bytes_read == 2048
+        _, kwargs = client_cls.call_args
+        assert kwargs["user"] == "autoresearch"
+        assert kwargs["settings"]["readonly"] == 1
+        assert kwargs["settings"]["max_execution_time"] == 60
+        assert kwargs["settings"]["max_result_rows"] == 10_000
+        instance.disconnect.assert_called_once()
+
+    @patch("posthog.clickhouse.test_cluster_client.SyncClient")
+    def test_driver_error_raises_query_error_and_disconnects(self, client_cls):
+        instance = client_cls.return_value
+        instance.execute.side_effect = Exception("DB::Exception: Syntax error")
+        with self.settings(CLICKHOUSE_TEST_CLUSTER_HOST="test-ch"):
+            with self.assertRaises(TestClusterQueryError):
+                execute_on_test_cluster("SELEC 1")
+        instance.disconnect.assert_called_once()

--- a/posthog/clickhouse/test_cluster_client.py
+++ b/posthog/clickhouse/test_cluster_client.py
@@ -1,0 +1,85 @@
+"""Client for the autoresearch test ClickHouse cluster.
+
+Deliberately separate from the main-cluster pooled clients: this connects with the
+restricted ``autoresearch`` user, whose server-side grants (read-only, query-log
+tables only) are the enforcement layer. Fails closed when unconfigured.
+"""
+
+import uuid
+import dataclasses
+
+from django.conf import settings
+
+from clickhouse_driver import Client as SyncClient
+
+QUERY_SETTINGS: dict[str, int] = {
+    # Defense in depth on top of the restricted user's server-side grants.
+    "readonly": 1,
+    "max_execution_time": 60,
+    "max_result_rows": 10_000,
+    "result_overflow_mode": 1,  # break: truncate instead of erroring at the cap
+}
+
+
+class TestClusterNotConfigured(Exception):
+    pass
+
+
+class TestClusterQueryError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class TestClusterResult:
+    result: list[list[object]]
+    query_id: str | None
+    elapsed_ms: float | None
+    rows_read: int | None
+    bytes_read: int | None
+
+
+def _canonicalize(value: object) -> object:
+    """JSON-safe positional values: UUIDs/datetimes/etc. become strings."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
+def execute_on_test_cluster(sql: str) -> TestClusterResult:
+    if not settings.CLICKHOUSE_TEST_CLUSTER_HOST:
+        raise TestClusterNotConfigured("CLICKHOUSE_TEST_CLUSTER_HOST is not set")
+    query_id = f"pulse-autoresearch-{uuid.uuid4()}"
+    client = SyncClient(
+        host=settings.CLICKHOUSE_TEST_CLUSTER_HOST,
+        database=settings.CLICKHOUSE_TEST_CLUSTER_DATABASE or "default",
+        user=settings.CLICKHOUSE_TEST_CLUSTER_USER,
+        password=settings.CLICKHOUSE_TEST_CLUSTER_PASSWORD,
+        secure=settings.CLICKHOUSE_TEST_CLUSTER_SECURE,
+        ca_certs=settings.CLICKHOUSE_TEST_CLUSTER_CA,
+        verify=settings.CLICKHOUSE_TEST_CLUSTER_VERIFY,
+        settings=dict(QUERY_SETTINGS),
+    )
+    try:
+        rows = client.execute(sql, query_id=query_id)
+    except Exception as err:  # clickhouse_driver raises driver-specific ServerException etc.
+        raise TestClusterQueryError(str(err)) from err
+    finally:
+        last_query = getattr(client, "last_query", None)
+        client.disconnect()
+    elapsed_ms: float | None = None
+    rows_read: int | None = None
+    bytes_read: int | None = None
+    if last_query is not None:
+        elapsed = getattr(last_query, "elapsed", None)
+        elapsed_ms = elapsed * 1000 if elapsed is not None else None
+        progress = getattr(last_query, "progress", None)
+        if progress is not None:
+            rows_read = getattr(progress, "rows", None)
+            bytes_read = getattr(progress, "bytes", None)
+    return TestClusterResult(
+        result=[[_canonicalize(v) for v in row] for row in rows],
+        query_id=query_id,
+        elapsed_ms=elapsed_ms,
+        rows_read=rows_read,
+        bytes_read=bytes_read,
+    )

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -743,10 +743,11 @@ class TestOAuthAccessTokenAPIScopePermission(BaseTest):
     def test_allows_explicit_scope_for_internal_viewset(self):
         self.access_token.scope = "clickhouse_test_cluster_perf:read"
         self.access_token.save()
+        # Test cluster is unconfigured here: 503 proves the scope check passed and the action ran.
         response = self._do_request(
             "/api/query_performance_proxy/execute-test/", method="POST", data={"sql": "SELECT 1"}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 503)
 
     def test_forbids_wildcard_scope_for_internal_required_scope_on_public_viewset(self):
         """Regression: when a viewset's `scope_object` is public (e.g. `signal_scout`) but a


### PR DESCRIPTION
## Problem

The query performance proxy viewset shipped as a stub — auth and the M2M scope wired, but `execute_test` returning empty. The pulse agent engine's first internal mission (query-performance analysis) needs it to actually execute, safely.

## Changes

- **Test-cluster client** (`posthog/clickhouse/test_cluster_client.py`): connects with dedicated `CLICKHOUSE_TEST_CLUSTER_*` settings (default-unset), enforces `readonly=1` in connection settings as defense-in-depth on top of the restricted database user, bounds execution time, returns rows plus basic stats.
- **Proxy execution**: `execute_test` validates the request via the declared serializer and runs through the client. **Fail-closed**: when the cluster settings are unconfigured the endpoint returns 503 with a clear detail — it never falls back to the main app ClickHouse.
- Existing auth/scope behavior unchanged (staff + M2M scope), verified by the existing tests plus new ones.

Local dev can point the settings at the dev ClickHouse with a readonly user. Production requires the restricted user to be provisioned — an ops prerequisite for prod rollout, not a code dependency.

## How did you test this code?

Proxy tests + permissions + full pulse suite green. New tests cover: unconfigured settings → 503 (fail-closed), configured (client boundary mocked) → rows returned, readonly and timeout asserted on the connection call, serializer validation rejects malformed SQL requests, and scope enforcement intact.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal/staff surface — no docs yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code) from an approved plan (pulse query-perf mission, task 1). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`. Chain position: stacks on the agent-engine PR; the MCP tool exposure and the query-perf mission skill follow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*