### PR TITLE
fix(auth): add missing network timeouts for sso, redis, and outbound requests

### DIFF
--- a/ee/api/license.py
+++ b/ee/api/license.py
@@ -30,7 +30,9 @@ class LicenseSerializer(serializers.ModelSerializer):
         extra_kwargs = {"key": {"write_only": True}}
 
     def validate(self, data):
-        validation = requests.post("https://license.posthog.com/licenses/activate", data={"key": data["key"]})
+        validation = requests.post(
+            "https://license.posthog.com/licenses/activate", data={"key": data["key"]}, timeout=10
+        )
         resp = validation.json()
         user = self.context["request"].user
         if not validation.ok:
@@ -71,7 +73,9 @@ class LicenseViewSet(
 
     def destroy(self, request: request.Request, *args, **kwargs) -> Response:
         license = self.get_object()
-        validation = requests.post("https://license.posthog.com/licenses/deactivate", data={"key": license.key})
+        validation = requests.post(
+            "https://license.posthog.com/licenses/deactivate", data={"key": license.key}, timeout=10
+        )
         validation.raise_for_status()
 
         has_another_valid_license = License.objects.filter(valid_until__gte=now()).exclude(pk=license.pk).exists()

--- a/ee/api/sentry_stats.py
+++ b/ee/api/sentry_stats.py
@@ -24,7 +24,7 @@ def get_sentry_stats(start_time: str, end_time: str) -> tuple[dict, int]:
 
     params = {"start": start_time, "end": end_time, "sort": "freq", "utc": "true"}
 
-    response = requests.get(url=url, headers=headers, params=params).json()
+    response = requests.get(url=url, headers=headers, params=params, timeout=10).json()
 
     counts = {}
     total_count = 0
@@ -74,7 +74,7 @@ def get_tagged_issues_stats(
     for i in range(0, len(target_issues), pagination_chunk_size):
         groups = target_issues[i : i + pagination_chunk_size]
         params["groups"] = groups
-        response = requests.get(url=url, headers=headers, params=params).json()
+        response = requests.get(url=url, headers=headers, params=params, timeout=10).json()
 
         # TODO: Confirm sentry always sends this information
         for item in response:

--- a/ee/middleware.py
+++ b/ee/middleware.py
@@ -225,7 +225,7 @@ def _exchange_code_for_token(request: HttpRequest, code: str) -> dict:
         "redirect_uri": request.build_absolute_uri("/admin/oauth2/callback"),
         "grant_type": "authorization_code",
     }
-    response = requests.post(token_url, data=data)
+    response = requests.post(token_url, data=data, timeout=10)
     response.raise_for_status()
     return response.json()
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -1812,6 +1812,7 @@ def redirect_to_website(request):
                 "lastName": request.user.last_name,
             },
             headers={"Content-Type": "application/json"},
+            timeout=10,
         )
 
         if response.status_code == 200:

--- a/posthog/cdp/services/icons.py
+++ b/posthog/cdp/services/icons.py
@@ -27,6 +27,7 @@ class CDPIconsService:
                     "token": settings.LOGO_DEV_TOKEN,
                     "query": query,
                 },
+                timeout=10,
             )
             data = res.json() or []
 
@@ -52,6 +53,7 @@ class CDPIconsService:
             params={
                 "token": settings.LOGO_DEV_TOKEN,
             },
+            timeout=10,
         )
 
         return HttpResponse(res.content, content_type=res.headers["Content-Type"])

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -203,7 +203,9 @@ def _send_via_http(
                     "message_data": properties,
                 }
 
-                response = requests.post(f"{settings.CUSTOMER_IO_API_URL}/v1/send/email", headers=headers, json=payload)
+                response = requests.post(
+                    f"{settings.CUSTOMER_IO_API_URL}/v1/send/email", headers=headers, json=payload, timeout=30
+                )
 
                 if response.status_code != 200:
                     raise Exception(f"Customer.io API error: {response.status_code} - {response.text}")

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -778,6 +778,7 @@ class OauthIntegration:
                     "grant_type": "authorization_code",
                 },
                 headers={"User-Agent": "PostHog/1.0 by PostHogTeam"},
+                timeout=10,
             )
         # Pinterest uses HTTP Basic Auth for token exchange (base64-encoded client_id:client_secret)
         elif kind == "pinterest-ads":
@@ -789,6 +790,7 @@ class OauthIntegration:
                     "redirect_uri": OauthIntegration.redirect_uri(kind),
                     "grant_type": "authorization_code",
                 },
+                timeout=10,
             )
         elif kind == "tiktok-ads":
             # TikTok Ads uses JSON request body instead of form data and maps 'code' to 'auth_code'
@@ -800,6 +802,7 @@ class OauthIntegration:
                     "auth_code": params["code"],
                 },
                 headers={"Content-Type": "application/json"},
+                timeout=10,
             )
         elif kind == "stripe":
             # Stripe Apps OAuth authenticates with the developer secret key as HTTP Basic
@@ -812,6 +815,7 @@ class OauthIntegration:
                     "code": params["code"],
                     "grant_type": "authorization_code",
                 },
+                timeout=10,
             )
         else:
             redirect_uri = OauthIntegration.redirect_uri(kind)
@@ -824,6 +828,7 @@ class OauthIntegration:
                     "redirect_uri": redirect_uri,
                     "grant_type": "authorization_code",
                 },
+                timeout=10,
             )
 
         try:
@@ -853,6 +858,7 @@ class OauthIntegration:
                         "redirect_uri": OauthIntegration.redirect_uri(kind),
                         "grant_type": "authorization_code",
                     },
+                    timeout=10,
                 )
 
                 try:
@@ -887,11 +893,13 @@ class OauthIntegration:
                     oauth_config.token_info_url,
                     headers={"Authorization": f"Bearer {config['access_token']}"},
                     json={"query": oauth_config.token_info_graphql_query},
+                    timeout=10,
                 )
             else:
                 token_info_res = requests.get(
                     oauth_config.token_info_url.replace(":access_token", config["access_token"]),
                     headers={"Authorization": f"Bearer {config['access_token']}"},
+                    timeout=10,
                 )
 
             if token_info_res.status_code == 200:
@@ -1110,6 +1118,7 @@ class OauthIntegration:
                 },
                 # If I use a standard User-Agent, it will throw a 429 too many requests error
                 headers={"User-Agent": "PostHog/1.0 by PostHogTeam"},
+                timeout=10,
             )
         # Pinterest uses HTTP Basic Auth for token refresh
         elif self.integration.kind == "pinterest-ads":
@@ -1120,6 +1129,7 @@ class OauthIntegration:
                     "refresh_token": self.integration.sensitive_config["refresh_token"],
                     "grant_type": "refresh_token",
                 },
+                timeout=10,
             )
         elif self.integration.kind == "tiktok-ads":
             res = requests.post(
@@ -1131,6 +1141,7 @@ class OauthIntegration:
                     "grant_type": "refresh_token",
                 },
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=10,
             )
         elif self.integration.kind == "bing-ads":
             # Microsoft Azure AD requires scope parameter on token refresh
@@ -1143,6 +1154,7 @@ class OauthIntegration:
                     "grant_type": "refresh_token",
                     "scope": oauth_config.scope,
                 },
+                timeout=10,
             )
         elif self.integration.kind == "stripe":
             # Stripe Apps OAuth: secret as HTTP Basic username, no client_id/client_secret in body.
@@ -1153,6 +1165,7 @@ class OauthIntegration:
                     "refresh_token": self.integration.sensitive_config["refresh_token"],
                     "grant_type": "refresh_token",
                 },
+                timeout=10,
             )
         else:
             res = requests.post(
@@ -1163,6 +1176,7 @@ class OauthIntegration:
                     "refresh_token": self.integration.sensitive_config["refresh_token"],
                     "grant_type": "refresh_token",
                 },
+                timeout=10,
             )
 
         config: dict = res.json()
@@ -1401,6 +1415,7 @@ class GoogleAdsIntegration:
                 "developer-token": settings.GOOGLE_ADS_DEVELOPER_TOKEN,
                 **({"login-customer-id": parent_id} if parent_id else {}),
             },
+            timeout=10,
         )
 
         if response.status_code == 401:
@@ -1441,6 +1456,7 @@ class GoogleAdsIntegration:
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",
                 "developer-token": settings.GOOGLE_ADS_DEVELOPER_TOKEN,
             },
+            timeout=10,
         )
 
         if response.status_code == 401:
@@ -1484,6 +1500,7 @@ class GoogleAdsIntegration:
                     "developer-token": settings.GOOGLE_ADS_DEVELOPER_TOKEN,
                     **({"login-customer-id": parent_id} if parent_id else {}),
                 },
+                timeout=10,
             )
 
             if response.status_code != 200:
@@ -1940,6 +1957,7 @@ class LinkedInAdsIntegration:
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",
                 "LinkedIn-Version": "202508",
             },
+            timeout=10,
         )
 
         self._check_auth_error(response, "listing conversion rules")
@@ -1954,6 +1972,7 @@ class LinkedInAdsIntegration:
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",
                 "LinkedIn-Version": "202508",
             },
+            timeout=10,
         )
 
         self._check_auth_error(response, "listing ad accounts")
@@ -1996,6 +2015,7 @@ class ClickUpIntegration:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",
             },
+            timeout=10,
         )
 
         self._check_auth_error(response, "listing spaces")
@@ -2013,6 +2033,7 @@ class ClickUpIntegration:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",
             },
+            timeout=10,
         )
 
         self._check_auth_error(response, "listing lists")
@@ -2030,6 +2051,7 @@ class ClickUpIntegration:
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",
             },
+            timeout=10,
         )
 
         self._check_auth_error(response, "listing folders")
@@ -2044,6 +2066,7 @@ class ClickUpIntegration:
             "GET",
             "https://api.clickup.com/api/v2/team",
             headers={"Authorization": f"Bearer {self.integration.sensitive_config['access_token']}"},
+            timeout=10,
         )
 
         self._check_auth_error(response, "listing workspaces")
@@ -2247,6 +2270,7 @@ class LinearIntegration:
             "https://api.linear.app/graphql",
             headers={"Authorization": f"Bearer {self.integration.sensitive_config['access_token']}"},
             json={"query": query, "variables": variables or {}},
+            timeout=10,
         )
         return response.json()
 
@@ -2316,6 +2340,7 @@ class JiraIntegration:
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",
                 "Accept": "application/json",
             },
+            timeout=10,
         )
         body = response.json()
         projects = body.get("values", [])
@@ -2360,6 +2385,7 @@ class JiraIntegration:
                 "Content-Type": "application/json",
             },
             json=payload,
+            timeout=10,
         )
 
         issue = response.json()
@@ -2945,6 +2971,7 @@ class GitLabIntegration:
             headers={"PRIVATE-TOKEN": project_access_token},
             # disallow redirects to prevent SSRF on redirected host
             allow_redirects=False,
+            timeout=10,
         )
 
         return response.json()
@@ -2962,6 +2989,7 @@ class GitLabIntegration:
             headers={"PRIVATE-TOKEN": project_access_token},
             # disallow redirects to prevent SSRF on redirected host
             allow_redirects=False,
+            timeout=10,
         )
 
         return response.json()
@@ -3049,6 +3077,7 @@ class MetaAdsIntegration:
                 "grant_type": "fb_exchange_token",
                 "set_token_expires_in_60_days": True,
             },
+            timeout=10,
         )
 
         config: dict = res.json()

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -467,6 +467,7 @@ class RemoteConfig(UUIDTModel):
                 settings.REMOTE_CONFIG_CDN_PURGE_ENDPOINT,
                 headers={"Authorization": f"Bearer {settings.REMOTE_CONFIG_CDN_PURGE_TOKEN}"},
                 json=data,
+                timeout=10,
             )
 
             if res.status_code != 200:
@@ -491,6 +492,7 @@ class RemoteConfig(UUIDTModel):
                 settings.REMOTE_CONFIG_CDN_PURGE_ENDPOINT,
                 headers={"Authorization": f"Bearer {settings.REMOTE_CONFIG_CDN_PURGE_TOKEN}"},
                 json=data,
+                timeout=10,
             )
             if res.status_code != 200:
                 raise Exception(f"Failed to purge CDN by tag {tag}: {res.status_code} {res.text}")

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -470,6 +470,7 @@ class TestOauthIntegrationModel(BaseTest):
                 "client_secret": "hubspot-client-secret",
                 "refresh_token": "REFRESH",
             },
+            timeout=10,
         )
 
         assert integration.config["expires_in"] == 1000

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -607,6 +607,7 @@ class TestRemoteConfigCaching(_RemoteConfigBase):
                         {"url": "https://cdn2.posthog.com/array/phc_12345/config.js"},
                     ]
                 },
+                timeout=10,
             )
 
 

--- a/posthog/redis.py
+++ b/posthog/redis.py
@@ -37,7 +37,12 @@ def get_client(redis_url: Optional[str] = None) -> redis.Redis:
 
             client: Any = fakeredis.FakeRedis(server=_get_test_fake_server(redis_url))
         elif redis_url:
-            client = redis.from_url(redis_url, db=0)
+            client = redis.from_url(
+                redis_url,
+                db=0,
+                socket_timeout=settings.REDIS_SOCKET_TIMEOUT_SECONDS,
+                socket_connect_timeout=settings.REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS,
+            )
         else:
             client = None
 
@@ -135,7 +140,12 @@ def get_async_client(redis_url: Optional[str] = None):
         # Get (or create) the Redis instance for redis_url
         client = pool_map.get(redis_url)
         if client is None:
-            client = aioredis.from_url(redis_url, db=0)
+            client = aioredis.from_url(
+                redis_url,
+                db=0,
+                socket_timeout=settings.REDIS_SOCKET_TIMEOUT_SECONDS,
+                socket_connect_timeout=settings.REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS,
+            )
             pool_map[redis_url] = client
 
         return client

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -501,6 +501,13 @@ if not REDIS_URL:
         "https://posthog.com/docs/deployment/upgrading-posthog#upgrading-from-before-1011"
     )
 
+# Socket timeouts for the central Redis clients (posthog/redis.py). The connect timeout is kept
+# small so a dead node fails fast. The read timeout must comfortably exceed the largest server-side
+# blocking window on the central client, which is a 15s XREAD BLOCK (notebooks collab_stream);
+# 20s leaves margin so blocking stream reads never spuriously time out.
+REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS: float = get_from_env("REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS", 3.0, type_cast=float)
+REDIS_SOCKET_TIMEOUT_SECONDS: float = get_from_env("REDIS_SOCKET_TIMEOUT_SECONDS", 20.0, type_cast=float)
+
 # Controls whether the ZstdCompressor is used for Redis compression when writing to Redis.
 # The ZstdCompressor uses zstd compression and can cope with compressed and uncompressed reading at the same time
 USE_REDIS_COMPRESSION = get_from_env("USE_REDIS_COMPRESSION", True, type_cast=str_to_bool)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -261,6 +261,9 @@ X_FRAME_OPTIONS = "SAMEORIGIN"
 SOCIAL_AUTH_JSONFIELD_ENABLED = True
 SOCIAL_AUTH_USER_MODEL = "posthog.User"
 SOCIAL_AUTH_REDIRECT_IS_HTTPS: bool = get_from_env("SOCIAL_AUTH_REDIRECT_IS_HTTPS", not DEBUG, type_cast=str_to_bool)
+# social-auth-core reads REQUESTS_TIMEOUT in BaseAuth.request(); without it a hung self-hosted
+# GitLab/OIDC provider can block a web worker forever.
+SOCIAL_AUTH_REQUESTS_TIMEOUT: float = get_from_env("SOCIAL_AUTH_REQUESTS_TIMEOUT", 10.0, type_cast=float)
 
 SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.social_details",

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -287,6 +287,7 @@ class TestEmail(BaseTest):
                     "transactional_message_id": CUSTOMER_IO_TEMPLATE_ID_MAP["2fa_enabled"],
                     "message_data": {"utm_tags": "utm_source=posthog&utm_medium=email&utm_campaign=2fa_enabled"},
                 },
+                timeout=30,
             )
 
             mock_capture.assert_called_once_with(
@@ -333,6 +334,7 @@ class TestEmail(BaseTest):
                         "utm_tags": "utm_source=posthog&utm_medium=email&utm_campaign=2fa_enabled",
                     },
                 },
+                timeout=30,
             )
 
     @patch("posthog.email.requests.post")

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -94,8 +94,27 @@ class TestRedis(TestCase):
                 self.assertIsNot(client1, client2)
                 # Should have been called twice (once per loop)
                 self.assertEqual(mock_from_url.call_count, 2)
-                # Verify the calls were made with correct parameters
-                mock_from_url.assert_any_call("redis://mocked:6379", db=0)
+                # Socket timeouts must be passed through so a hung Redis can't block a worker forever
+                mock_from_url.assert_any_call(
+                    "redis://mocked:6379",
+                    db=0,
+                    socket_timeout=20.0,
+                    socket_connect_timeout=3.0,
+                )
+
+    def test_sync_redis_client_passes_socket_timeouts(self):
+        # Guard that the sync production client is built with socket timeouts (regression: a hung
+        # Redis node blocking a web worker indefinitely)
+        with patch("redis.from_url") as mock_from_url:
+            with self.settings(TEST=False, REDIS_URL="redis://mocked:6379"):
+                get_client()
+
+            mock_from_url.assert_called_once_with(
+                "redis://mocked:6379",
+                db=0,
+                socket_timeout=20.0,
+                socket_connect_timeout=3.0,
+            )
 
     def test_same_loop_returns_cached_client_test_mode(self):
         """In test mode, calling get_async_client twice returns the same cached instance."""

--- a/posthog/test/test_redis.py
+++ b/posthog/test/test_redis.py
@@ -2,6 +2,7 @@ import asyncio
 
 from unittest.mock import ANY, AsyncMock, patch
 
+from django.conf import settings
 from django.test.testcases import TestCase
 
 import fakeredis
@@ -98,8 +99,8 @@ class TestRedis(TestCase):
                 mock_from_url.assert_any_call(
                     "redis://mocked:6379",
                     db=0,
-                    socket_timeout=20.0,
-                    socket_connect_timeout=3.0,
+                    socket_timeout=settings.REDIS_SOCKET_TIMEOUT_SECONDS,
+                    socket_connect_timeout=settings.REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS,
                 )
 
     def test_sync_redis_client_passes_socket_timeouts(self):
@@ -112,8 +113,8 @@ class TestRedis(TestCase):
             mock_from_url.assert_called_once_with(
                 "redis://mocked:6379",
                 db=0,
-                socket_timeout=20.0,
-                socket_connect_timeout=3.0,
+                socket_timeout=settings.REDIS_SOCKET_TIMEOUT_SECONDS,
+                socket_connect_timeout=settings.REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS,
             )
 
     def test_same_loop_returns_cached_client_test_mode(self):


### PR DESCRIPTION
## Problem

Several outbound network calls in the Django backend have no timeout, so a hung upstream pins a web or celery worker forever:

- python-social-auth had no `SOCIAL_AUTH_REQUESTS_TIMEOUT`, so every SSO HTTP exchange (GitHub, GitLab, Google, SAML/OIDC) waited indefinitely. Highest risk since self-hosted GitLab/OIDC providers are third-party infrastructure we don't control.
- The central redis clients in `posthog/redis.py` passed no `socket_timeout`/`socket_connect_timeout`, so a hung Redis node blocks any worker using the shared client.
- A number of `requests.*` calls in live request paths and celery tasks also lacked `timeout=`.

## Changes

- `posthog/settings/web.py`: add `SOCIAL_AUTH_REQUESTS_TIMEOUT` (default 10s, env-overridable). social-auth-core 4.8.7 (the pinned version) reads it in `BaseAuth.request()`.
- `posthog/redis.py` + `posthog/settings/data_stores.py`: pass `socket_timeout` (default 20s) and `socket_connect_timeout` (default 3s) to both the sync and async central clients, backed by `REDIS_SOCKET_TIMEOUT_SECONDS` / `REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS` env vars.

> [!NOTE]
> The 20s read timeout was chosen after auditing all consumers of the central client for server-side blocking commands. The largest blocking window is a 15s `XREAD BLOCK` (notebooks collab stream), so 20s leaves margin. PubSub `get_message(timeout=...)` consumers wait via `select()`, not a socket read, so `socket_timeout` doesn't bound them.

- One-line `timeout=` additions to previously untimed `requests` calls: admin OIDC token exchange (`ee/middleware.py`), `/api/sentry_stats/`, all missing branches in `posthog/models/integration.py` (OAuth token exchange/refresh and Google Ads / LinkedIn / Linear / Jira API calls, matching the existing `timeout=10` in the GitHub branch), CDP icon search/proxy, squeak forum registration, Customer.io email send (30s, this one runs inside `transaction.atomic()` holding a `select_for_update` row lock), Cloudflare CDN purge, and license activate/deactivate.

## How did you test this code?

- `ruff check` and `ruff format` pass on all changed files.
- Updated `posthog/test/test_redis.py`: the existing async production-behavior test now asserts the new kwargs, and a new sync-path test guards the regression "socket timeouts get dropped and a hung Redis blocks a worker forever" (no prior test asserted the sync client's construction kwargs).
- The sandbox has no Postgres/Redis, so the Django `TestCase` suite could not run locally; the redis client wiring was verified with a standalone harness mocking `redis.from_url`/`redis.asyncio.from_url` and asserting the exact kwargs. CI should run the full suite.
- No manual testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code task). Explore subagents mapped the social-auth settings, the central redis client and its blocking-command consumers, and swept for other untimed outbound calls; an implementation subagent made the changes. The `/writing-tests` skill was invoked before touching tests.

Decisions: the redis `socket_timeout` default (20s) is driven by the largest blocking `XREAD` window found (15s) rather than an arbitrary value. `posthog/plugins/utils.py` and the unused `session_recording_api.py:stream_from` were left alone as legacy/dead code. `posthog/temporal/weekly_digest/activities.py` and `posthog/caching/redis_cluster_connection_factory.py` construct their own redis clients and are not covered by this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
