### PR TITLE
feat(data-warehouse): implement decagon import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -125,6 +125,7 @@ the row lists both.
 | culture_amp             | HTTP                        | requests                                                        | ✅                          |
 | customer_io             | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
 | datadog                 | HTTP                        | requests                                                        | ✅                          |
+| decagon                 | HTTP                        | requests                                                        | ✅                          |
 | deel                    | HTTP                        | requests                                                        | ✅                          |
 | delighted               | HTTP                        | requests                                                        | ✅                          |
 | devin_ai                | HTTP                        | requests                                                        | ✅                          |
@@ -472,7 +473,6 @@ doesn't conflict with concurrent PRs.
 - datorama
 - db2
 - dbt
-- decagon
 - deepgram
 - deputy
 - display_video_360

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/canonical_descriptions.py
@@ -1,0 +1,23 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "conversations": {
+        "description": (
+            "A conversation between a user and a Decagon AI agent, including every message, "
+            "the customer satisfaction rating, tags, and metadata attached to the conversation."
+        ),
+        "docs_url": "https://docs.decagon.ai/api/exporting-conversations",
+        "columns": {
+            "conversation_id": "Unique identifier for the conversation.",
+            "user_id": "Identifier of the end user who had the conversation.",
+            "created_at": "Timestamp at which the conversation was created.",
+            "destination": "Channel the conversation was handled on (e.g. AI).",
+            "messages": "All messages in the conversation; each message has text, a role (USER or AI), and a created_at timestamp.",
+            "csat_rating": "Customer satisfaction rating the user gave the conversation, if any.",
+            "tags": "Tags applied to the conversation; each tag has a name and a level.",
+            "metadata": "Custom metadata attached to the conversation (e.g. user attributes).",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
@@ -1,0 +1,169 @@
+import time
+import dataclasses
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.settings import DECAGON_ENDPOINTS
+
+DECAGON_BASE_URL = "https://api.decagon.ai"
+
+REQUEST_TIMEOUT_SECONDS = 60
+
+# Decagon enforces a hard limit of 1 request/second across all API endpoints and
+# automatically IP-bans gross violators, so requests are spaced client-side rather
+# than relying on 429 backoff alone.
+MIN_SECONDS_BETWEEN_REQUESTS = 1.0
+
+
+class DecagonRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class DecagonResumeConfig:
+    # The next-page export cursor returned by Decagon (`next_page_cursor`).
+    cursor: str
+
+
+class RequestThrottle:
+    """Spaces consecutive requests at least `min_interval` seconds apart."""
+
+    def __init__(self, min_interval: float = MIN_SECONDS_BETWEEN_REQUESTS) -> None:
+        self._min_interval = min_interval
+        self._last_request_at: Optional[float] = None
+
+    def wait(self) -> None:
+        if self._last_request_at is not None:
+            remaining = self._min_interval - (time.monotonic() - self._last_request_at)
+            if remaining > 0:
+                time.sleep(remaining)
+        self._last_request_at = time.monotonic()
+
+
+def _get_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+
+
+def validate_credentials(api_key: str) -> bool:
+    """Probe the export endpoint (the only one this source calls) to confirm the key works."""
+    try:
+        response = make_tracked_session().get(
+            f"{DECAGON_BASE_URL}/conversation/export",
+            headers=_get_headers(api_key),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[DecagonResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = DECAGON_ENDPOINTS[endpoint]
+    headers = _get_headers(api_key)
+    url = f"{DECAGON_BASE_URL}{config.path}"
+    session = make_tracked_session()
+    throttle = RequestThrottle()
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    cursor: Optional[str] = resume_config.cursor if resume_config else None
+    if cursor:
+        logger.debug(f"Decagon: resuming {endpoint} from saved cursor")
+
+    @retry(
+        retry=retry_if_exception_type((DecagonRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(5),
+        # The 1 rps limit means a 429 needs a generous backoff, not a quick retry.
+        wait=wait_exponential_jitter(initial=2, max=60),
+        reraise=True,
+    )
+    def fetch_page(params: dict[str, str]) -> dict[str, Any]:
+        throttle.wait()
+        response = session.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise DecagonRetryableError(f"Decagon API error (retryable): status={response.status_code}, url={url}")
+
+        if not response.ok:
+            logger.error(f"Decagon API error: status={response.status_code}, body={response.text}, url={url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    # A conversation that receives new messages re-enters the export stream on a later
+    # page, so a single walk can emit the same conversation twice. Full-refresh writes
+    # are plain appends (no primary-key merge), so re-emissions are skipped client-side;
+    # the next sync picks up the newer version.
+    seen_ids: set[str] = set()
+
+    while True:
+        # An omitted cursor starts the stream at the oldest conversations.
+        params = {"cursor": cursor} if cursor else {}
+        data = fetch_page(params)
+
+        items = data.get(config.data_key) or []
+        next_cursor = data.get("next_page_cursor")
+
+        fresh: list[dict[str, Any]] = []
+        for item in items:
+            item_id = item.get("conversation_id")
+            if item_id is not None:
+                if item_id in seen_ids:
+                    continue
+                seen_ids.add(item_id)
+            fresh.append(item)
+
+        if fresh:
+            yield fresh
+            # Save state only after yielding, so a crash re-yields the last batch rather
+            # than skipping it (the duplicate rows a resumed re-yield can produce are
+            # bounded to one page and cleaned up by the next full refresh).
+            if next_cursor:
+                resumable_source_manager.save_state(DecagonResumeConfig(cursor=str(next_cursor)))
+
+        # `next_page_cursor` is null once the stream is exhausted. Also stop if the
+        # server ever returns the cursor we just used, to guard against spinning on
+        # one page forever.
+        if not next_cursor or str(next_cursor) == cursor:
+            break
+
+        cursor = str(next_cursor)
+
+
+def decagon_source(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[DecagonResumeConfig],
+) -> SourceResponse:
+    config = DECAGON_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime",
+        partition_format="month",
+        partition_keys=[config.partition_key],
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
@@ -57,7 +57,7 @@ def _get_headers(api_key: str) -> dict[str, str]:
 def validate_credentials(api_key: str) -> bool:
     """Probe the export endpoint (the only one this source calls) to confirm the key works."""
     try:
-        response = make_tracked_session().get(
+        response = make_tracked_session(redact_values=(api_key,)).get(
             f"{DECAGON_BASE_URL}/conversation/export",
             headers=_get_headers(api_key),
             timeout=REQUEST_TIMEOUT_SECONDS,
@@ -76,7 +76,7 @@ def get_rows(
     config = DECAGON_ENDPOINTS[endpoint]
     headers = _get_headers(api_key)
     url = f"{DECAGON_BASE_URL}{config.path}"
-    session = make_tracked_session()
+    session = make_tracked_session(redact_values=(api_key,))
     throttle = RequestThrottle()
 
     resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
@@ -120,11 +120,13 @@ def get_rows(
 
         fresh: list[dict[str, Any]] = []
         for item in items:
-            item_id = item.get("conversation_id")
-            if item_id is not None:
-                if item_id in seen_ids:
-                    continue
-                seen_ids.add(item_id)
+            # Direct access on purpose: conversation_id is the primary key, so a row
+            # without one should fail the sync loudly rather than land in the warehouse
+            # unkeyed and undeduplicatable.
+            item_id = item["conversation_id"]
+            if item_id in seen_ids:
+                continue
+            seen_ids.add(item_id)
             fresh.append(item)
 
         if fresh:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/settings.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+from products.warehouse_sources.backend.types import IncrementalField
+
+
+@dataclass
+class DecagonEndpointConfig:
+    name: str
+    path: str
+    # Top-level key in the JSON response that holds the list of rows
+    # (e.g. `{"conversations": [...]}` -> `"conversations"`).
+    data_key: str
+    primary_keys: list[str]
+    incremental_fields: list[IncrementalField]
+    # Stable datetime field used for partitioning. Must never change for a row
+    # (so `created_at`, never `updated_at`).
+    partition_key: str
+
+
+# Decagon's syncable surface is a single stream: /conversation/export returns
+# conversations with their messages, CSAT ratings, tags, and metadata, paginated
+# with a `cursor` request param and a `next_page_cursor` response field (null once
+# exhausted, up to 100 conversations per page). There is no server-side timestamp
+# filter, so the stream is full refresh only — the export cursor is an opaque
+# stream position, not a durable watermark our incremental machinery can use.
+DECAGON_ENDPOINTS: dict[str, DecagonEndpointConfig] = {
+    "conversations": DecagonEndpointConfig(
+        name="conversations",
+        path="/conversation/export",
+        data_key="conversations",
+        primary_keys=["conversation_id"],
+        incremental_fields=[],
+        partition_key="created_at",
+    ),
+}
+
+ENDPOINTS = tuple(DECAGON_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in DECAGON_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
@@ -1,19 +1,42 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.decagon import (
+    DecagonResumeConfig,
+    decagon_source,
+    validate_credentials as validate_decagon_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import DecagonSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class DecagonSource(SimpleSource[DecagonSourceConfig]):
+class DecagonSource(ResumableSource[DecagonSourceConfig, DecagonResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.DECAGON
@@ -24,8 +47,93 @@ class DecagonSource(SimpleSource[DecagonSourceConfig]):
             name=SchemaExternalDataSourceType.DECAGON,
             category=DataWarehouseSourceCategory.CUSTOMER_SUPPORT,
             label="Decagon",
+            caption="""Enter a Decagon API key to pull your Decagon conversations into the PostHog Data warehouse.
+
+You can find your API key on the **Developer** page of the [Decagon dashboard](https://decagon.ai/).
+""",
             iconPath="/static/services/decagon.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/decagon",
             keywords=["ai agents", "customer support", "conversations", "csat"],
-            fields=cast(list[FieldType], []),
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
             unreleasedSource=True,
+            releaseStatus=ReleaseStatus.ALPHA,
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized": (
+                "Decagon rejected the API key. Generate a new key on the Developer page of the "
+                "Decagon dashboard and reconnect."
+            ),
+            "403 Client Error: Forbidden": (
+                "The Decagon API key does not have access to the conversation export. Check the key "
+                "on the Developer page of the Decagon dashboard and reconnect."
+            ),
+        }
+
+    def get_schemas(
+        self,
+        config: DecagonSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
+                supports_append=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+            )
+            for endpoint in ENDPOINTS
+        ]
+
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+
+        return schemas
+
+    def validate_credentials(
+        self, config: DecagonSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_decagon_credentials(config.api_key):
+            return True, None
+
+        return False, "Invalid Decagon API key"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[DecagonResumeConfig]:
+        return ResumableSourceManager[DecagonResumeConfig](inputs, DecagonResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: DecagonSourceConfig,
+        resumable_source_manager: ResumableSourceManager[DecagonResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return decagon_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon.py
@@ -1,0 +1,188 @@
+import json
+from typing import Any
+
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+from requests import HTTPError, Response
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.decagon import (
+    DECAGON_BASE_URL,
+    DecagonResumeConfig,
+    decagon_source,
+    get_rows,
+    validate_credentials,
+)
+
+DECAGON_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.decagon.decagon"
+
+
+def _make_response(body: dict[str, Any], status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+def _conversation(conversation_id: str) -> dict[str, Any]:
+    return {"conversation_id": conversation_id, "created_at": "2026-01-01T00:00:00Z"}
+
+
+class TestValidateCredentials:
+    @parameterized.expand(
+        [
+            ("ok", 200, True),
+            ("unauthorized", 401, False),
+            ("forbidden", 403, False),
+            ("server_error", 500, False),
+        ]
+    )
+    def test_status_code_mapping(self, _name: str, status_code: int, expected: bool) -> None:
+        with patch(f"{DECAGON_MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.return_value = _make_response({}, status_code=status_code)
+            assert validate_credentials("key") is expected
+
+    def test_network_error_returns_invalid(self) -> None:
+        with patch(f"{DECAGON_MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.side_effect = Exception("boom")
+            assert validate_credentials("key") is False
+
+    def test_probes_export_endpoint_with_bearer_auth(self) -> None:
+        with patch(f"{DECAGON_MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.return_value = _make_response({}, status_code=200)
+            validate_credentials("secret-key")
+            args, kwargs = mock_session.return_value.get.call_args
+            assert args[0] == f"{DECAGON_BASE_URL}/conversation/export"
+            assert kwargs["headers"]["Authorization"] == "Bearer secret-key"
+
+
+class TestGetRows:
+    def _drive(self, manager: MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[list[str]]]:
+        """Drive get_rows with a mocked session; return (params sent per page, ids yielded per batch)."""
+        sent_params: list[dict[str, Any]] = []
+        response_iter = iter(responses)
+
+        def fake_get(_url: str, *, params: dict[str, Any], **_kwargs: Any) -> Response:
+            sent_params.append(dict(params or {}))
+            return next(response_iter)
+
+        with (
+            patch(f"{DECAGON_MODULE}.make_tracked_session") as mock_session,
+            patch(f"{DECAGON_MODULE}.time.sleep"),
+        ):
+            mock_session.return_value.get.side_effect = fake_get
+            batches = list(
+                get_rows(
+                    api_key="key",
+                    endpoint="conversations",
+                    logger=MagicMock(),
+                    resumable_source_manager=manager,
+                )
+            )
+        yielded_ids = [[item["conversation_id"] for item in batch] for batch in batches]
+        return sent_params, yielded_ids
+
+    def _fresh_manager(self) -> MagicMock:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+        return manager
+
+    def test_paginates_with_cursor_and_saves_state_after_each_yield(self) -> None:
+        manager = self._fresh_manager()
+        responses = [
+            _make_response({"conversations": [_conversation("c1")], "next_page_cursor": "cur-1"}),
+            _make_response({"conversations": [_conversation("c2")], "next_page_cursor": "cur-2"}),
+            _make_response({"conversations": [_conversation("c3")], "next_page_cursor": None}),
+        ]
+        sent_params, yielded_ids = self._drive(manager, responses)
+
+        # First request omits the cursor (starts at the oldest conversations).
+        assert sent_params == [{}, {"cursor": "cur-1"}, {"cursor": "cur-2"}]
+        assert yielded_ids == [["c1"], ["c2"], ["c3"]]
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [DecagonResumeConfig(cursor="cur-1"), DecagonResumeConfig(cursor="cur-2")]
+
+    def test_resume_seeds_cursor_from_saved_state(self) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = DecagonResumeConfig(cursor="cur-resumed")
+
+        responses = [_make_response({"conversations": [_conversation("c9")], "next_page_cursor": None})]
+        sent_params, yielded_ids = self._drive(manager, responses)
+
+        assert sent_params == [{"cursor": "cur-resumed"}]
+        assert yielded_ids == [["c9"]]
+
+    def test_terminal_single_page_does_not_save_state(self) -> None:
+        manager = self._fresh_manager()
+        responses = [_make_response({"conversations": [_conversation("c1")], "next_page_cursor": None})]
+        self._drive(manager, responses)
+        manager.save_state.assert_not_called()
+
+    def test_deduplicates_conversations_that_reappear_in_later_pages(self) -> None:
+        # A conversation that receives new messages re-enters the export stream, so the
+        # same conversation_id can appear on multiple pages of a single walk.
+        manager = self._fresh_manager()
+        responses = [
+            _make_response({"conversations": [_conversation("c1"), _conversation("c2")], "next_page_cursor": "cur-1"}),
+            _make_response({"conversations": [_conversation("c2"), _conversation("c3")], "next_page_cursor": None}),
+        ]
+        _, yielded_ids = self._drive(manager, responses)
+        assert yielded_ids == [["c1", "c2"], ["c3"]]
+
+    def test_stops_when_server_repeats_the_same_cursor(self) -> None:
+        manager = self._fresh_manager()
+        responses = [
+            _make_response({"conversations": [_conversation("c1")], "next_page_cursor": "cur-1"}),
+            _make_response({"conversations": [_conversation("c2")], "next_page_cursor": "cur-1"}),
+        ]
+        sent_params, yielded_ids = self._drive(manager, responses)
+        assert len(sent_params) == 2
+        assert yielded_ids == [["c1"], ["c2"]]
+
+    def test_empty_page_with_cursor_continues_without_yielding(self) -> None:
+        manager = self._fresh_manager()
+        responses = [
+            _make_response({"conversations": [], "next_page_cursor": "cur-1"}),
+            _make_response({"conversations": [_conversation("c1")], "next_page_cursor": None}),
+        ]
+        sent_params, yielded_ids = self._drive(manager, responses)
+        assert sent_params == [{}, {"cursor": "cur-1"}]
+        assert yielded_ids == [["c1"]]
+
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500)])
+    def test_retryable_status_is_retried_then_succeeds(self, _name: str, status_code: int) -> None:
+        manager = self._fresh_manager()
+        responses = [
+            _make_response({}, status_code=status_code),
+            _make_response({"conversations": [_conversation("c1")], "next_page_cursor": None}),
+        ]
+        _, yielded_ids = self._drive(manager, responses)
+        assert yielded_ids == [["c1"]]
+
+    def test_unauthorized_raises_without_retry(self) -> None:
+        manager = self._fresh_manager()
+        response_401 = _make_response({"detail": "Invalid Authorization token."}, status_code=401)
+        response_401.url = f"{DECAGON_BASE_URL}/conversation/export"
+        try:
+            self._drive(manager, [response_401])
+            raise AssertionError("expected HTTPError")
+        except HTTPError as e:
+            assert e.response.status_code == 401
+
+
+class TestDecagonSource:
+    def test_source_response_shape(self) -> None:
+        response = decagon_source(
+            api_key="key",
+            endpoint="conversations",
+            logger=MagicMock(),
+            resumable_source_manager=MagicMock(spec=ResumableSourceManager),
+        )
+        assert response.name == "conversations"
+        assert response.primary_keys == ["conversation_id"]
+        assert response.partition_keys == ["created_at"]
+        assert response.partition_mode == "datetime"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
@@ -1,0 +1,95 @@
+from typing import Any
+
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.decagon import DecagonResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.source import DecagonSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import DecagonSourceConfig
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+def _make_inputs(**overrides: Any) -> mock.MagicMock:
+    inputs = mock.MagicMock()
+    inputs.schema_name = overrides.get("schema_name", "conversations")
+    return inputs
+
+
+class TestDecagonSource:
+    def setup_method(self) -> None:
+        self.source = DecagonSource()
+        self.team_id = 123
+        self.config = DecagonSourceConfig(api_key="decagon-test-key")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.DECAGON
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+
+        assert config.name.value == "Decagon"
+        assert config.label == "Decagon"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert len(config.fields) == 1
+
+        api_key_field = config.fields[0]
+        assert isinstance(api_key_field, SourceFieldInputConfig)
+        assert api_key_field.name == "api_key"
+        assert api_key_field.type == SourceFieldInputConfigType.PASSWORD
+        assert api_key_field.required is True
+
+    def test_get_schemas_is_full_refresh_only(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {s.name for s in schemas} == set(ENDPOINTS)
+        conversations = next(s for s in schemas if s.name == "conversations")
+        # /conversation/export has no server-side timestamp filter, so incremental
+        # sync must never be advertised for it.
+        assert conversations.supports_incremental is False
+        assert conversations.supports_append is False
+        assert conversations.incremental_fields == []
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        assert [s.name for s in self.source.get_schemas(self.config, self.team_id, names=["conversations"])] == [
+            "conversations"
+        ]
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    def test_non_retryable_errors_cover_auth_failures(self) -> None:
+        errors = self.source.get_non_retryable_errors()
+        assert "401 Client Error: Unauthorized" in errors
+        assert "403 Client Error: Forbidden" in errors
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.decagon.source.validate_decagon_credentials"
+    )
+    def test_validate_credentials(self, mock_validate: mock.MagicMock) -> None:
+        mock_validate.return_value = True
+        assert self.source.validate_credentials(self.config, self.team_id) == (True, None)
+
+        mock_validate.return_value = False
+        is_valid, message = self.source.validate_credentials(self.config, self.team_id)
+        assert is_valid is False
+        assert message is not None
+
+        mock_validate.assert_called_with(self.config.api_key)
+
+    def test_get_resumable_source_manager_bound_to_resume_config(self) -> None:
+        manager = self.source.get_resumable_source_manager(_make_inputs())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is DecagonResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.decagon.source.decagon_source")
+    def test_source_for_pipeline_passes_arguments(self, mock_decagon_source: mock.MagicMock) -> None:
+        inputs = _make_inputs(schema_name="conversations")
+        manager = mock.MagicMock(spec=ResumableSourceManager)
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        _, kwargs = mock_decagon_source.call_args
+        assert kwargs["api_key"] == self.config.api_key
+        assert kwargs["endpoint"] == "conversations"
+        assert kwargs["resumable_source_manager"] is manager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -986,7 +986,7 @@ class DbtSourceConfig(config.Config):
 
 @config.config
 class DecagonSourceConfig(config.Config):
-    pass
+    api_key: str
 
 
 @config.config


### PR DESCRIPTION
## Problem

The Decagon warehouse source exists only as a scaffolded stub (from #69517): registered enum, empty fields, no sync logic. Users of Decagon's AI customer support agents can't pull their conversation history (messages, CSAT ratings, tags, metadata) into the PostHog Data warehouse to analyze support quality alongside product data.

## Why

Decagon's conversation export is exactly the kind of historical business data the warehouse is for, and Decagon ships a first-party Fivetran connector for the same export, which validates the warehouse-sync use case.

## Changes

Implements the Decagon source end-to-end, following the standard `source.py` / `settings.py` / `decagon.py` split:

- **One stream, `conversations`**, backed by `GET /conversation/export` - Decagon's only data-export endpoint (other documented endpoints are action-oriented, e.g. sending outbound messages). It returns conversations with all messages, CSAT ratings, tags, and metadata.
- **`ResumableSource`**: the export's `next_page_cursor` is persisted after each yielded batch, so Temporal can resume a long backfill mid-stream instead of restarting.
- **Full refresh only.** The export API has no server-side timestamp filter, so `supports_incremental` is not advertised. Conversations that receive new messages re-enter the export stream; a walk dedupes re-emissions by `conversation_id` and the next refresh picks up the newer version.
- **Client-side throttling at 1 request/second.** Decagon enforces a hard 1 rps limit across all endpoints with automatic IP banning for gross violations, so the client spaces requests itself rather than relying on 429 backoff (429/5xx still retry with a generous exponential backoff).
- All HTTP goes through `make_tracked_session()`. Bearer API key auth, `validate_credentials` probes the export endpoint, `get_non_retryable_errors` covers 401/403.
- `lists_tables_without_credentials = True` (static endpoint catalog) plus `canonical_descriptions.py`, so the posthog.com doc can render the Supported tables section.
- Stays behind `unreleasedSource=True` with `releaseStatus=ALPHA`.
- `SOURCES.md`: moved `decagon` from Scaffolded to Implemented (HTTP / requests / tracked ✅).
- Regenerated `DecagonSourceConfig` (`api_key`).

> [!NOTE]
> Based on #69517 (the scaffold branch), so this PR targets that branch and will retarget to master when it merges. No icon added: I couldn't obtain a logo legitimately in this environment (no Logo.dev API key), so `iconPath` keeps the scaffolded path and relies on the missing-icon fallback.

**Known uncertainty:** Decagon's API reference is gated behind a customer access code, so the exact response field names (`conversation_id`, `created_at`, `csat_rating`, ...) were confirmed from search-indexed copies of the official docs plus unauthenticated probes of the live API (base URL, endpoint, GET method, and Bearer auth semantics all verified; a real customer key is needed to confirm the full payload). The row-parsing surface is deliberately tiny (one `data_key`, one primary key) to keep any correction small. This is noted in code comments and the source stays unreleased/alpha.

**Docs:** no posthog.com checkout was available in this environment, so the user-facing doc (written per the documenting-warehouse-sources skill) needs to land in the posthog.com repo as `contents/docs/cdp/sources/decagon.md`. `docsUrl` already points at `https://posthog.com/docs/cdp/sources/decagon`.

<details>
<summary>Drafted posthog.com doc content</summary>

```markdown
---
title: Linking Decagon as a source
sidebar: Docs
showTitle: true
availability: { free: full, selfServe: full, enterprise: full }
sourceId: Decagon
beta: true
---

import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
import SyncModes from "../_snippets/sync-modes.mdx"
import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
import AlphaRelease from "../_snippets/alpha-release.mdx"

<AlphaRelease />

The Decagon connector syncs your Decagon AI agent conversations, including every message, customer satisfaction (CSAT) rating, tags, and metadata, into the PostHog Data warehouse, so you can analyze support quality alongside your product data.

## Prerequisites

- A Decagon account with API access.
- A Decagon API key, generated on the **Developer** page of your Decagon dashboard.

## Adding a data source

<SourceSetupIntro />

You'll need your Decagon API key, which you can find on the **Developer** page of the Decagon dashboard.

## Sync modes

<SyncModes />

Decagon's conversation export has no server-side timestamp filter, so the conversations table syncs as a full refresh. Conversations that receive new messages reappear in the export stream and are picked up on the next sync.

## Configuration

<SourceParameters />

## Supported tables

<SourceTables />

## Troubleshooting

Decagon enforces a rate limit of 1 request per second across all API endpoints. The connector throttles itself to stay under this limit, so accounts with a lot of conversation history can take a while to complete their first sync.

<TroubleshootingLink />
```

</details>

## How did you test this code?

- `hogli test products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/` - 24 passed. The two new modules catch regressions no existing test covers: `test_decagon.py` pins the cursor walk (first request cursor-less, state saved only after a yield, dedup of re-exported conversations, stop on null/repeated cursor, 429/5xx retry vs 401 fail-fast) and `test_decagon_source.py` pins the source contract (full-refresh-only schemas, credential validation, resume-config binding).
- `hogli test .../sources/common/test/test_source_config_generator.py` - 15 passed (generated config in sync).
- `ruff check` / `ruff format` clean on all changed files.
- Verified `get_documented_tables()` renders the credential-free table catalog for the public docs API.
- I could not run a live sync: Decagon has no self-serve signup, so no API key was available. Unauthenticated curl probes confirmed the endpoint, method, and auth behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Doc drafted above, needs to land in the posthog.com repo (this repo only carries `docsUrl` and the table catalog).

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Built with PostHog Code (Claude Code) as a batch task to implement the scaffolded `decagon` source from #69517.
- Skills invoked: `implementing-warehouse-sources`, `writing-tests`, `documenting-warehouse-sources`.
- Decisions: chose `ResumableSource` over `SimpleSource` because the export cursor is persistable; shipped full refresh instead of incremental because the API exposes no server-side timestamp filter (the export cursor is an opaque stream position, not a durable watermark); modeled the transport on the `square` source (closest shape: single-token REST, cursor pagination, tracked session, tenacity retries); added client-side 1 rps throttling because of Decagon's IP-ban enforcement; skipped the icon rather than committing a placeholder.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
