### PR TITLE
fix(logs): keep excluded keys out of group-by recents

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
@@ -136,6 +136,7 @@ export interface TaxonomicFilterApi {
     value?: TaxonomicFilterValue
     selectingKeyOnly?: SelectingKeyOnly
     excludedOperators?: ExcludedOperators
+    excludedProperties?: ExcludedProperties
 
     // headless-component prop bags
     rootProps: { onKeyDown: (e: React.KeyboardEvent<any>) => void }
@@ -323,6 +324,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         taxonomicGroupTypes: groupTypes,
         excludedOperators,
         selectingKeyOnly,
+        excludedProperties,
     })
 
     const groups = useMemo(() => {
@@ -580,6 +582,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         value,
         selectingKeyOnly,
         excludedOperators,
+        excludedProperties,
         rootProps: { onKeyDown },
         inputProps: {
             value: searchQuery,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
@@ -16,6 +16,7 @@ import { recentTaxonomicFiltersLogic } from 'lib/components/TaxonomicFilter/rece
 import { taxonomicFilterPinnedPropertiesLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
 import {
     ExcludedOperators,
+    ExcludedProperties,
     SelectingKeyOnly,
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroupType,
@@ -35,8 +36,9 @@ export function useTaxonomicLocalOverrides(context: {
     taxonomicGroupTypes: TaxonomicFilterGroupType[]
     excludedOperators?: ExcludedOperators
     selectingKeyOnly?: SelectingKeyOnly
+    excludedProperties?: ExcludedProperties
 }): GetLocalOverride {
-    const { taxonomicGroupTypes, excludedOperators, selectingKeyOnly } = context
+    const { taxonomicGroupTypes, excludedOperators, selectingKeyOnly, excludedProperties } = context
     const { actionsSorted } = useValues(actionsModel)
     const { recentFilterItems } = useValues(recentTaxonomicFiltersLogic)
     const { pinnedFilterItems } = useValues(taxonomicFilterPinnedPropertiesLogic)
@@ -49,8 +51,15 @@ export function useTaxonomicLocalOverrides(context: {
     // `useGroupList` memo deps and `useEffect` deps (e.g. the sole-substantive-group
     // recents promotion), where a fresh array per render means an infinite update loop.
     const contextFilteredRecentItems = useMemo(
-        () => filterRecentsForContext(recentFilterItems, taxonomicGroupTypes, excludedOperators, selectingKeyOnly),
-        [recentFilterItems, taxonomicGroupTypes, excludedOperators, selectingKeyOnly]
+        () =>
+            filterRecentsForContext(
+                recentFilterItems,
+                taxonomicGroupTypes,
+                excludedOperators,
+                selectingKeyOnly,
+                excludedProperties
+            ),
+        [recentFilterItems, taxonomicGroupTypes, excludedOperators, selectingKeyOnly, excludedProperties]
     )
 
     return useCallback(

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1502,6 +1502,50 @@ describe('infiniteListLogic', () => {
             expect(cohortValues).toEqual(expect.arrayContaining([1, 2]))
         })
 
+        it('hides a recent whose value is excluded for its source group (logs group-by drops `message`)', () => {
+            // The logs group-by picker excludes `message`, but a `message contains …` search is
+            // recorded as a recent under Log attributes — it must not leak back into the Recent tab.
+            const recentLogic = recentTaxonomicFiltersLogic.build()
+            recentLogic.mount()
+            recentLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.LogAttributes,
+                groupName: 'Log attributes',
+                value: 'message',
+                item: { name: 'message' },
+                propertyFilter: {
+                    type: PropertyFilterType.Log,
+                    key: 'message',
+                    value: 'blah',
+                    operator: PropertyOperator.IContains,
+                },
+            })
+            recentLogic.actions.recordRecentFilter({
+                groupType: TaxonomicFilterGroupType.LogAttributes,
+                groupName: 'Log attributes',
+                value: 'level',
+                item: { name: 'level' },
+            })
+
+            const listLogic = infiniteListLogic({
+                taxonomicFilterLogicKey: 'logs-group-by-recents-test',
+                listGroupType: TaxonomicFilterGroupType.RecentFilters,
+                taxonomicGroupTypes: [
+                    TaxonomicFilterGroupType.LogAttributes,
+                    TaxonomicFilterGroupType.RecentFilters,
+                ],
+                showNumericalPropsOnly: false,
+                excludedProperties: { [TaxonomicFilterGroupType.LogAttributes]: ['message'] },
+                selectingKeyOnly: true,
+            })
+            listLogic.mount()
+
+            const names = listLogic.values.contextFilteredRecentItems
+                .filter((i) => 'name' in i)
+                .map((i) => (i as { name: string }).name)
+            expect(names).not.toContain('message')
+            expect(names).toContain('level')
+        })
+
         it('preserves sourceValue on recent Persons items so the row resolves the correct distinct_id', () => {
             // Persons items are stored stripped ({name, id?}) — distinct_ids is not persisted.
             // The fix in InfiniteListRow falls back to _recentContext.sourceValue instead of

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1529,10 +1529,7 @@ describe('infiniteListLogic', () => {
             const listLogic = infiniteListLogic({
                 taxonomicFilterLogicKey: 'logs-group-by-recents-test',
                 listGroupType: TaxonomicFilterGroupType.RecentFilters,
-                taxonomicGroupTypes: [
-                    TaxonomicFilterGroupType.LogAttributes,
-                    TaxonomicFilterGroupType.RecentFilters,
-                ],
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.LogAttributes, TaxonomicFilterGroupType.RecentFilters],
                 showNumericalPropsOnly: false,
                 excludedProperties: { [TaxonomicFilterGroupType.LogAttributes]: ['message'] },
                 selectingKeyOnly: true,

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -18,6 +18,7 @@ import {
 import { legacyTaxonomicSurface } from 'lib/components/TaxonomicFilter/taxonomicFilterSurface'
 import {
     ExcludedOperators,
+    ExcludedProperties,
     InfiniteListLogicProps,
     META_GROUP_TYPES,
     QuickFilterItem,
@@ -488,12 +489,14 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 s.taxonomicGroupTypes,
                 (_, props: InfiniteListLogicProps) => props.excludedOperators,
                 (_, props: InfiniteListLogicProps) => props.selectingKeyOnly,
+                (_, props: InfiniteListLogicProps) => props.excludedProperties,
             ],
             (
                 recentFilterItems: TaxonomicDefinitionTypes[],
                 taxonomicGroupTypes: TaxonomicFilterGroupType[],
                 excludedOperators: ExcludedOperators | undefined,
-                selectingKeyOnly: boolean | undefined
+                selectingKeyOnly: boolean | undefined,
+                excludedProperties: ExcludedProperties | undefined
             ): TaxonomicDefinitionTypes[] => {
                 if (!recentFilterItems?.length) {
                     return []
@@ -501,6 +504,13 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 const availableTypes = new Set(taxonomicGroupTypes)
                 const inScope = recentFilterItems.filter((item) => {
                     if (!hasRecentContext(item) || !availableTypes.has(item._recentContext.sourceGroupType)) {
+                        return false
+                    }
+                    // A group's excluded values (e.g. `message` for the logs group-by picker) must be
+                    // dropped from the Recent tab too, not just the group's own option list — otherwise
+                    // an excluded key recorded elsewhere leaks back in as a selectable recent.
+                    const excludedValues = excludedProperties?.[item._recentContext.sourceGroupType]
+                    if (excludedValues?.length && excludedValues.includes(item._recentContext.sourceValue)) {
                         return false
                     }
                     const excludedForGroup = excludedOperators?.[item._recentContext.sourceGroupType]

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -246,8 +246,16 @@ export function TaxonomicFilterMenu({
     triggerVariant = 'button',
     defaultOpenState,
 }: TaxonomicFilterMenuProps): JSX.Element {
-    const { groups, selectItem, inputProps, searchQuery, setSearchQuery, selectingKeyOnly, excludedOperators } =
-        useTaxonomicFilterContext()
+    const {
+        groups,
+        selectItem,
+        inputProps,
+        searchQuery,
+        setSearchQuery,
+        selectingKeyOnly,
+        excludedOperators,
+        excludedProperties,
+    } = useTaxonomicFilterContext()
     const [state, setState] = useState<MenuFilterState>(() =>
         resolveInitialMenuState(defaultOpen, defaultOpenState, selected ?? null)
     )
@@ -347,11 +355,12 @@ export function TaxonomicFilterMenu({
                     recentFilterItems as TaxonomicDefinitionTypes[],
                     taxonomicGroupTypes,
                     excludedOperators,
-                    selectingKeyOnly
+                    selectingKeyOnly,
+                    excludedProperties
                 ) as ShortcutItem[],
                 groups
             ),
-        [recentFilterItems, taxonomicGroupTypes, groups, excludedOperators, selectingKeyOnly]
+        [recentFilterItems, taxonomicGroupTypes, groups, excludedOperators, selectingKeyOnly, excludedProperties]
     )
     const pinnedEntries = useMemo<MenuFilterEntry[]>(
         () =>

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
@@ -50,6 +50,14 @@ describe('suggestedContextFilters', () => {
             ).toHaveLength(1)
         })
 
+        it('drops a recent whose value is excluded for its group, keeping others', () => {
+            const items = [recent(EventProperties, 'message'), recent(EventProperties, 'plan')]
+            const out = filterRecentsForContext(items, [EventProperties], undefined, undefined, {
+                [EventProperties]: ['message'],
+            })
+            expect(names(out)).toEqual(['plan'])
+        })
+
         it('dedups by storage key and strips the property filter when selecting a key only', () => {
             const items = [
                 recent(EventProperties, 'plan', { propertyFilter: { operator: PropertyOperator.Exact } }),

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
@@ -2,6 +2,7 @@ import { expandRecentsForDisplay, hasRecentContext } from 'lib/components/Taxono
 import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
 import {
     ExcludedOperators,
+    ExcludedProperties,
     SelectingKeyOnly,
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroupType,
@@ -24,7 +25,8 @@ export function filterRecentsForContext(
     recentFilterItems: TaxonomicDefinitionTypes[],
     taxonomicGroupTypes: TaxonomicFilterGroupType[],
     excludedOperators?: ExcludedOperators,
-    selectingKeyOnly?: SelectingKeyOnly
+    selectingKeyOnly?: SelectingKeyOnly,
+    excludedProperties?: ExcludedProperties
 ): TaxonomicDefinitionTypes[] {
     if (!recentFilterItems?.length) {
         return []
@@ -32,6 +34,12 @@ export function filterRecentsForContext(
     const availableTypes = new Set(taxonomicGroupTypes)
     const inScope = recentFilterItems.filter((item) => {
         if (!hasRecentContext(item) || !availableTypes.has(item._recentContext.sourceGroupType)) {
+            return false
+        }
+        // A group's excluded values (e.g. `message` for the logs group-by picker) must be dropped
+        // from the Recent tab too, not just the group's own option list.
+        const excludedValues = excludedProperties?.[item._recentContext.sourceGroupType]
+        if (excludedValues?.length && excludedValues.includes(item._recentContext.sourceValue)) {
             return false
         }
         const excludedForGroup = excludedOperators?.[item._recentContext.sourceGroupType]

--- a/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
@@ -10,17 +10,10 @@ import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { logsGroupByLogic } from 'products/logs/frontend/components/LogsGroupBy/logsGroupByLogic'
 import { logsPatternsLogic } from 'products/logs/frontend/components/LogsPatterns/logsPatternsLogic'
-import type { GroupBySourceEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
 import { logsViewerConfigLogic } from './config/logsViewerConfigLogic'
+import { resolveGroupBySource } from './groupBySource'
 import { LogsViewerToolbar } from './LogsViewerToolbar'
-
-// Maps the picker's taxonomic group onto the group-by endpoint's source vocabulary.
-const TAXONOMIC_GROUP_TO_SOURCE: Partial<Record<TaxonomicFilterGroupType, GroupBySourceEnumApi>> = {
-    [TaxonomicFilterGroupType.Logs]: 'column',
-    [TaxonomicFilterGroupType.LogAttributes]: 'log',
-    [TaxonomicFilterGroupType.LogResourceAttributes]: 'resource',
-}
 
 export interface LogsDisplayBarProps {
     id: string
@@ -94,15 +87,21 @@ export const LogsDisplayBar = ({
                             TaxonomicFilterGroupType.LogResourceAttributes,
                         ]}
                         // `message` is not a grouping key — high-cardinality free text is the
-                        // Patterns lens's job. Excluding it also drops the message-search item.
-                        excludedProperties={{ [TaxonomicFilterGroupType.Logs]: ['message'] }}
+                        // Patterns lens's job, and the backend can't aggregate by it. Excluding it
+                        // from the Logs group drops the message-search item; excluding it from
+                        // LogAttributes keeps a `message contains …` search from leaking back in via
+                        // the Recent tab (message searches are recorded under LogAttributes).
+                        excludedProperties={{
+                            [TaxonomicFilterGroupType.Logs]: ['message'],
+                            [TaxonomicFilterGroupType.LogAttributes]: ['message'],
+                        }}
                         value={groupBy?.key}
                         onChange={(value, groupType) =>
                             // Clearing the key keeps you in the Group view (empty state) — leaving
-                            // the view is the segmented bar's job, not the picker's.
-                            setGroupBy(
-                                value ? { key: value, source: TAXONOMIC_GROUP_TO_SOURCE[groupType] ?? 'log' } : null
-                            )
+                            // the view is the segmented bar's job, not the picker's. The source is
+                            // resolved from the key so a recent (recorded under LogAttributes) still
+                            // groups by the right top-level column instead of a missing attribute.
+                            setGroupBy(value ? { key: value, source: resolveGroupBySource(value, groupType) } : null)
                         }
                         allowClear
                         placeholder="Group by"

--- a/products/logs/frontend/components/LogsViewer/groupBySource.test.ts
+++ b/products/logs/frontend/components/LogsViewer/groupBySource.test.ts
@@ -1,8 +1,11 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import type { GroupBySourceEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
-import { resolveGroupBySource } from './groupBySource'
+import { GROUPABLE_COLUMN_KEYS, resolveGroupBySource } from './groupBySource'
 
 describe('resolveGroupBySource', () => {
     // A recent for a top-level column is recorded under LogAttributes (the search bar stores it as
@@ -18,5 +21,18 @@ describe('resolveGroupBySource', () => {
         ['some.attribute', TaxonomicFilterGroupType.Logs, 'column'],
     ])('resolves %s from %s to %s', (key, groupType, expected) => {
         expect(resolveGroupBySource(key, groupType)).toBe(expected)
+    })
+
+    // GROUPABLE_COLUMN_KEYS hand-mirrors the backend `GROUPABLE_COLUMNS` dict. If the backend adds or
+    // removes a groupable column without updating the frontend set, a recent for that key would route
+    // to the wrong source and silently return no groups. Parse the backend keys and lock them in step.
+    it('stays in sync with the backend GROUPABLE_COLUMNS dict', () => {
+        const runnerPath = path.resolve(__dirname, '../../../backend/group_by_query_runner.py')
+        const source = fs.readFileSync(runnerPath, 'utf8')
+        const block = source.match(/GROUPABLE_COLUMNS[^{]*\{([^}]*)\}/)?.[1]
+        expect(block).toBeDefined()
+        const backendKeys = [...(block as string).matchAll(/["']([^"']+)["']\s*:/g)].map((m) => m[1])
+        expect(backendKeys.length).toBeGreaterThan(0)
+        expect(new Set(backendKeys)).toEqual(GROUPABLE_COLUMN_KEYS)
     })
 })

--- a/products/logs/frontend/components/LogsViewer/groupBySource.test.ts
+++ b/products/logs/frontend/components/LogsViewer/groupBySource.test.ts
@@ -29,9 +29,9 @@ describe('resolveGroupBySource', () => {
     it('stays in sync with the backend GROUPABLE_COLUMNS dict', () => {
         const runnerPath = path.resolve(__dirname, '../../../backend/group_by_query_runner.py')
         const source = fs.readFileSync(runnerPath, 'utf8')
-        const block = source.match(/GROUPABLE_COLUMNS[^{]*\{([^}]*)\}/)?.[1]
-        expect(block).toBeDefined()
-        const backendKeys = [...(block as string).matchAll(/["']([^"']+)["']\s*:/g)].map((m) => m[1])
+        const block = source.match(/GROUPABLE_COLUMNS[^{]*\{([^}]*)\}/)?.[1] ?? ''
+        const backendKeys = [...block.matchAll(/["']([^"']+)["']\s*:/g)].map((m) => m[1])
+        // Non-empty guards that the dict was actually found and parsed, not silently empty.
         expect(backendKeys.length).toBeGreaterThan(0)
         expect(new Set(backendKeys)).toEqual(GROUPABLE_COLUMN_KEYS)
     })

--- a/products/logs/frontend/components/LogsViewer/groupBySource.test.ts
+++ b/products/logs/frontend/components/LogsViewer/groupBySource.test.ts
@@ -1,0 +1,22 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import type { GroupBySourceEnumApi } from 'products/logs/frontend/generated/api.schemas'
+
+import { resolveGroupBySource } from './groupBySource'
+
+describe('resolveGroupBySource', () => {
+    // A recent for a top-level column is recorded under LogAttributes (the search bar stores it as
+    // filter type `log`), so trusting the group would send source `log` and the aggregation reads a
+    // missing attribute -> empty results. These keys must resolve to `column` regardless of group.
+    it.each<[string, TaxonomicFilterGroupType, GroupBySourceEnumApi]>([
+        ['severity_level', TaxonomicFilterGroupType.LogAttributes, 'column'],
+        ['trace_id', TaxonomicFilterGroupType.LogAttributes, 'column'],
+        ['span_id', TaxonomicFilterGroupType.LogAttributes, 'column'],
+        ['severity_level', TaxonomicFilterGroupType.Logs, 'column'],
+        ['some.attribute', TaxonomicFilterGroupType.LogAttributes, 'log'],
+        ['host.name', TaxonomicFilterGroupType.LogResourceAttributes, 'resource'],
+        ['some.attribute', TaxonomicFilterGroupType.Logs, 'column'],
+    ])('resolves %s from %s to %s', (key, groupType, expected) => {
+        expect(resolveGroupBySource(key, groupType)).toBe(expected)
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/groupBySource.ts
+++ b/products/logs/frontend/components/LogsViewer/groupBySource.ts
@@ -9,12 +9,14 @@ export const TAXONOMIC_GROUP_TO_SOURCE: Partial<Record<TaxonomicFilterGroupType,
     [TaxonomicFilterGroupType.LogResourceAttributes]: 'resource',
 }
 
-// Top-level log fields that the endpoint groups by `source: 'column'` (backend `GROUPABLE_COLUMNS`).
-// The same keys also surface in the Recent tab, where they were recorded under `LogAttributes` (the
-// search bar stores them as filter type `log`). Trusting that group would send `source: 'log'`, so
-// the aggregation reads a non-existent attribute map entry and returns nothing. Pin them to `column`
-// by key so a recent groups by the real column, matching a fresh pick from the `Logs` group.
-const GROUPABLE_COLUMN_KEYS = new Set<string>(['severity_level', 'trace_id', 'span_id'])
+// Top-level log fields that the endpoint groups by `source: 'column'` (backend `GROUPABLE_COLUMNS`
+// in `products/logs/backend/group_by_query_runner.py`). The same keys also surface in the Recent
+// tab, where they were recorded under `LogAttributes` (the search bar stores them as filter type
+// `log`). Trusting that group would send `source: 'log'`, so the aggregation reads a non-existent
+// attribute map entry and returns nothing. Pin them to `column` by key so a recent groups by the
+// real column, matching a fresh pick from the `Logs` group.
+// This mirrors the backend dict by hand; `groupBySource.test.ts` fails if the two drift apart.
+export const GROUPABLE_COLUMN_KEYS = new Set<string>(['severity_level', 'trace_id', 'span_id'])
 
 export function resolveGroupBySource(key: string, groupType: TaxonomicFilterGroupType): GroupBySourceEnumApi {
     if (GROUPABLE_COLUMN_KEYS.has(key)) {

--- a/products/logs/frontend/components/LogsViewer/groupBySource.ts
+++ b/products/logs/frontend/components/LogsViewer/groupBySource.ts
@@ -1,0 +1,24 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import type { GroupBySourceEnumApi } from 'products/logs/frontend/generated/api.schemas'
+
+// Maps the picker's taxonomic group onto the group-by endpoint's source vocabulary.
+export const TAXONOMIC_GROUP_TO_SOURCE: Partial<Record<TaxonomicFilterGroupType, GroupBySourceEnumApi>> = {
+    [TaxonomicFilterGroupType.Logs]: 'column',
+    [TaxonomicFilterGroupType.LogAttributes]: 'log',
+    [TaxonomicFilterGroupType.LogResourceAttributes]: 'resource',
+}
+
+// Top-level log fields that the endpoint groups by `source: 'column'` (backend `GROUPABLE_COLUMNS`).
+// The same keys also surface in the Recent tab, where they were recorded under `LogAttributes` (the
+// search bar stores them as filter type `log`). Trusting that group would send `source: 'log'`, so
+// the aggregation reads a non-existent attribute map entry and returns nothing. Pin them to `column`
+// by key so a recent groups by the real column, matching a fresh pick from the `Logs` group.
+const GROUPABLE_COLUMN_KEYS = new Set<string>(['severity_level', 'trace_id', 'span_id'])
+
+export function resolveGroupBySource(key: string, groupType: TaxonomicFilterGroupType): GroupBySourceEnumApi {
+    if (GROUPABLE_COLUMN_KEYS.has(key)) {
+        return 'column'
+    }
+    return TAXONOMIC_GROUP_TO_SOURCE[groupType] ?? 'log'
+}


### PR DESCRIPTION
## Problem

The logs **Group by** picker lets you pick an attribute to aggregate logs by. `message` is deliberately excluded from the picker's options: it's high-cardinality free text (that's the Patterns lens's job) and the backend can't aggregate by it under any source.

But the exclusion only covered the group's own option list, not the **Recent tab**. When you run a `message contains "blah"` search in the logs search bar, it's recorded as a recent taxonomic filter under `LogAttributes`, so it showed up in the group-by picker's Recent tab as a selectable row. Picking it set `groupBy.key = 'message'`, which the backend can't group by, so the group-by broke and returned nothing.

Raised in #team-logs.

## Changes

The Recent tab ignoring `excludedProperties` is a real, general gap in the shared TaxonomicFilter, not just a logs quirk. The fix has two parts.

**1. Make the Recent tab honor `excludedProperties`.** A recent whose recorded value is excluded for its source group is now dropped from the Recent tab, not just from the group's own option list. This is mirrored across both picker implementations:

- Legacy kea path: `contextFilteredRecentItems` in `infiniteListLogic.ts`.
- Rebuild menu path: `filterRecentsForContext` in `suggestedContextFilters.ts`, plus threading `excludedProperties` through `useTaxonomicFilter` context, `TaxonomicFilterMenu`, and `useTaxonomicLocalOverrides`.

The logs group-by picker renders through the legacy path (its `allowClear` forces the classic filter), so the legacy change is what actually fixes the reported bug; the rebuild change keeps the two paths consistent, as the shared file's own comment requires.

**2. Exclude `message` from `LogAttributes` in the logs picker.** That's the group the message recent is recorded under. `message` is never a genuine log attribute, so this only affects this picker.

Also in this PR: resolve the group-by `source` from the key. A recent for a groupable top-level column (`severity_level` / `trace_id` / `span_id`) is recorded under `LogAttributes` and would otherwise send `source: 'log'`, making the backend read a non-existent attribute map entry. Pinning those keys to `source: 'column'` lets those recents actually work, matching a fresh pick from the `Logs` group.

## How did you test this code?

Added automated tests. I (Claude) could not run the frontend toolchain in the sandbox (jest/tsgo/oxfmt aren't installed here), so these run in CI, and I have not done manual UI testing.

- `infiniteListLogic.test.ts` (legacy path, the one the logs picker uses): a `message` recent recorded under `LogAttributes` is absent from `contextFilteredRecentItems` when the picker excludes it, while a non-excluded recent survives. This is the regression guard for the reported bug.
- `suggestedContextFilters.test.ts` (rebuild pure function): a recent whose value is excluded for its group is dropped, others kept.
- `groupBySource.test.ts`: `severity_level` / `trace_id` / `span_id` resolve to `source: 'column'` from any group; genuine attributes resolve to `log` / `resource`.

Manual repro to verify once deployed: run a `message contains "blah"` search in the logs search bar, switch to **Group** mode, open the group-by picker's Recent tab. `message` should no longer appear, while other recent attributes still do.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank directed this via Slack: the logs group-by recents were surfacing `message contains '...'` and breaking group-by, with a request to keep `message` out of the picker's recents. Authored by Claude (Claude Code).

A first pass only fixed group-by `source` routing, which was a real but separate bug and didn't remove the `message` recent, so the investigation continued to the actual cause: the Recent tab never applied `excludedProperties`. Traced the selection path through both the legacy and rebuild TaxonomicFilter implementations and confirmed against the backend (`GROUPABLE_COLUMNS`) that `message` can't be grouped by any source, so excluding it from recents (rather than relabeling it) is the correct outcome.

Skills invoked: `/modifying-taxonomic-filter` (this touches the shared filter and its comment mandates mirroring behavior across both paths) and `/writing-tests`.
