### PR TITLE
fix(google_sheets): treat 404 entity-not-found reads as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -47,6 +47,12 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             # `str(SpreadsheetNotFound)` is otherwise just `<Response [404]>`, with nothing to match.
             # Retrying cannot recover.
             "Spreadsheet not found": "Import failed: the Google Sheet could not be found. It may have been deleted or moved. Please check the spreadsheet URL and that it is shared with our service account.",
+            # The values-read calls (`get_all_values`/`get_all_records`) hit the Sheets API directly and
+            # gspread does NOT wrap their 404 into `SpreadsheetNotFound` — it raises the raw `APIError`,
+            # whose `str()` is "APIError: [404]: Requested entity was not found." (Google's stable 404
+            # text). So the sheet/worksheet vanishing mid-read bypasses the `SpreadsheetNotFound` branch
+            # above and would be retried forever. The 404 is deterministic — retrying cannot recover.
+            "Requested entity was not found": "Import failed: the Google Sheet or worksheet could not be found. It may have been deleted or moved, or is no longer shared with our service account. Please check the spreadsheet URL and its sharing settings.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -440,6 +440,17 @@ def test_permission_error_is_non_retryable():
     assert any(key in error_msg for key in non_retryable_errors)
 
 
+def test_api_error_404_entity_not_found_is_non_retryable():
+    """The values-read calls raise a raw gspread APIError (not SpreadsheetNotFound) on a 404, whose
+    `str()` is "APIError: [404]: Requested entity was not found." The framework matches non-retryable
+    keys as substrings of that string, so a deleted/moved/unshared sheet hit mid-read must match a
+    key — otherwise the deterministic 404 gets retried forever."""
+    error = _api_error(404, "Requested entity was not found.", "NOT_FOUND")
+    non_retryable_errors = GoogleSheetsSource().get_non_retryable_errors()
+
+    assert any(key in str(error) for key in non_retryable_errors)
+
+
 @pytest.mark.parametrize(
     "call_site",
     [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -427,25 +427,20 @@ def test_google_sheets_source_reads_blank_cells_as_null():
     mock_worksheet.get_all_records.assert_called_once_with(default_blank=None)
 
 
-def test_permission_error_is_non_retryable():
-    """The message we re-raise from gspread's bare PermissionError must be a
-    substring match for one of the source's non-retryable error keys, otherwise
-    we'd retry a 403 forever."""
-    source = GoogleSheetsSource()
-    non_retryable_errors = source.get_non_retryable_errors()
-
-    raised = PermissionError(_PERMISSION_DENIED_MESSAGE)
-    error_msg = str(raised)
-
-    assert any(key in error_msg for key in non_retryable_errors)
-
-
-def test_api_error_404_entity_not_found_is_non_retryable():
-    """The values-read calls raise a raw gspread APIError (not SpreadsheetNotFound) on a 404, whose
-    `str()` is "APIError: [404]: Requested entity was not found." The framework matches non-retryable
-    keys as substrings of that string, so a deleted/moved/unshared sheet hit mid-read must match a
-    key — otherwise the deterministic 404 gets retried forever."""
-    error = _api_error(404, "Requested entity was not found.", "NOT_FOUND")
+@pytest.mark.parametrize(
+    "error",
+    [
+        # gspread's bare 403 PermissionError, re-raised with a stable message.
+        pytest.param(PermissionError(_PERMISSION_DENIED_MESSAGE), id="permission_denied"),
+        # Values-read 404s stay a raw APIError (not SpreadsheetNotFound), so str() is
+        # "APIError: [404]: Requested entity was not found." — a deleted/moved/unshared sheet hit mid-read.
+        pytest.param(_api_error(404, "Requested entity was not found.", "NOT_FOUND"), id="entity_not_found_404"),
+    ],
+)
+def test_error_string_matches_a_non_retryable_key(error):
+    """The framework classifies non-retryable errors by substring-matching `str(exc)` against the
+    source's keys. Each error the source surfaces for a permanent failure must match a key, otherwise
+    a deterministic 403/404 gets retried forever."""
     non_retryable_errors = GoogleSheetsSource().get_non_retryable_errors()
 
     assert any(key in str(error) for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

Error tracking surfaced a repeating `APIError: [404]: Requested entity was not found.` from the Google Sheets import source: [issue 019f4661](https://us.posthog.com/project/2/error_tracking/019f4661-f40a-7e32-b573-dc2585f5e68a).

The stack originates squarely in this source's code, during schema discovery:

```
sync_new_schemas_activity
  → google_sheets/source.py get_schemas
    → google_sheets.py get_schema_incremental_fields   # worksheet.get_all_values("1:2")
      → gspread values_get → APIError [404] Requested entity was not found.
```

The source already converts the Sheets API 404 raised by `open_by_url` into a `SpreadsheetNotFound` with a stable "Spreadsheet not found" message that `get_non_retryable_errors` matches. But the values-read calls (`get_all_values` / `get_all_records`) hit the API directly and gspread does **not** wrap their 404 into `SpreadsheetNotFound`. It raises the raw `APIError`, whose `str()` is `APIError: [404]: Requested entity was not found.` That string matches none of the source's non-retryable keys, so a sheet or worksheet that was deleted, moved, or unshared mid-read gets retried forever instead of failing fast.

## Changes

This is a user/upstream condition, not a bug in our code: a 404 entity-not-found from the Sheets API is deterministic and retrying can never recover. So I extended `GoogleSheetsSource.get_non_retryable_errors` with a key matching Google's stable `Requested entity was not found` text (no volatile URL, id, or timestamp in it), mapped to an actionable message telling the customer the sheet or worksheet is gone or no longer shared.

Scoped strictly to this error: no change to retry policy, timeouts, or the inline transient-error backoff (a 404 was already not retried inline; this only stops the wasteful Temporal-level retries).

## How did you test this code?

Added `test_api_error_404_entity_not_found_is_non_retryable`, which builds the exact raw gspread `APIError [404]` shape that reaches the framework's substring matcher and asserts one of the source's non-retryable keys is a substring of its string form. It guards against the deterministic 404 being retried forever if the key is ever dropped, and mirrors the existing `test_permission_error_is_non_retryable` pattern. No existing test covered the raw-`APIError` values-read path (only the `SpreadsheetNotFound` open path).

Ran the full source test module locally: `49 passed`. Ran `ruff check` and `ruff format --check` on both changed files: clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking webhook by an agent (Claude, Claude Code). Pulled the full stack trace and a representative event via the PostHog error-tracking MCP tools to confirm the failure originates in the google_sheets source (not just serialized log context), read the source and its shared `google_sheets.py` helper, and confirmed the framework matches `get_non_retryable_errors` keys as substrings of the exception string. Considered re-raising the raw 404 as `SpreadsheetNotFound` to reuse the existing key, but that adds a conversion layer where the raw message is already stable and matchable, so I matched the message directly instead. Invoked the `/writing-tests` skill before adding the regression test. Checked open PRs (including the maintainer's own) for a duplicate; none address this read-path 404.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
