### PR TITLE
fix(mcp): declare openai/widgetCSP so ChatGPT allows UI app assets

### DIFF
--- a/services/mcp/src/hono/resource-catalog.ts
+++ b/services/mcp/src/hono/resource-catalog.ts
@@ -10,7 +10,7 @@ import type {
 } from '@modelcontextprotocol/sdk/types.js'
 
 import { getPromptsFromManifest } from '@/resources'
-import { buildAppStubHtml } from '@/resources/ui-apps'
+import { buildAppStubHtml, buildUiAppResourceMeta } from '@/resources/ui-apps'
 import { UI_APPS } from '@/resources/ui-apps.generated'
 import type { Env } from '@/tools/types'
 
@@ -178,15 +178,7 @@ export class ResourceCatalog {
 
         for (const app of UI_APPS) {
             const html = buildAppStubHtml(app.appDir, baseUrl)
-
-            const uiMetadata: Record<string, unknown> = {}
-            const resourceDomains = [baseUrl]
-            const connectDomains: string[] = []
-            if (analyticsBaseUrl) {
-                connectDomains.push(analyticsBaseUrl)
-                resourceDomains.push(analyticsBaseUrl)
-            }
-            uiMetadata.csp = { connectDomains, resourceDomains }
+            const meta = buildUiAppResourceMeta(baseUrl, analyticsBaseUrl)
 
             this.uiAppResources.push({
                 name: app.name,
@@ -198,7 +190,7 @@ export class ResourceCatalog {
                 uri: app.uri,
                 mimeType: RESOURCE_MIME_TYPE,
                 text: html,
-                _meta: { ui: uiMetadata },
+                _meta: meta,
             })
         }
     }

--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -29,6 +29,43 @@ export function buildAppStubHtml(appDir: string, baseUrl: string): string {
 </body></html>`
 }
 
+export interface UiAppResourceMeta {
+    [key: string]: unknown
+    ui: McpUiResourceMeta
+    'openai/widgetCSP': {
+        connect_domains: string[]
+        resource_domains: string[]
+    }
+}
+
+/**
+ * Build the `_meta` object for a UI app resource, declaring which domains the
+ * host must allow in the app iframe's CSP.
+ *
+ * Declared in two formats: `ui.csp` per the MCP Apps spec (Claude), and
+ * `openai/widgetCSP` for ChatGPT — ChatGPT ignores `ui.csp` and only extends
+ * its iframe CSP with its own key, so without it assets on MCP_APPS_BASE_URL
+ * are blocked whenever that host differs from the connected server origin
+ * (e.g. mcp.us.posthog.com assets vs mcp.posthog.com origin).
+ */
+export function buildUiAppResourceMeta(baseUrl: string, analyticsBaseUrl: string | undefined): UiAppResourceMeta {
+    const resourceDomains: string[] = [baseUrl]
+    const connectDomains: string[] = []
+
+    if (analyticsBaseUrl) {
+        connectDomains.push(analyticsBaseUrl)
+        resourceDomains.push(analyticsBaseUrl)
+    }
+
+    return {
+        ui: { csp: { connectDomains, resourceDomains } },
+        'openai/widgetCSP': {
+            connect_domains: connectDomains,
+            resource_domains: resourceDomains,
+        },
+    }
+}
+
 /**
  * Registers UI app resources with the MCP server.
  * These resources provide interactive visualizations for tool results
@@ -66,22 +103,7 @@ function registerApp(
     { name, uri, description, appDir }: RegisterAppParams,
     baseUrl: string
 ): void {
-    const analyticsBaseUrl = context.env.POSTHOG_MCP_APPS_ANALYTICS_BASE_URL
-    const uiMetadata: McpUiResourceMeta = {}
-
-    const resourceDomains: string[] = [baseUrl]
-    const connectDomains: string[] = []
-
-    if (analyticsBaseUrl) {
-        connectDomains.push(analyticsBaseUrl)
-        resourceDomains.push(analyticsBaseUrl)
-    }
-
-    uiMetadata.csp = {
-        connectDomains,
-        resourceDomains,
-    }
-
+    const meta = buildUiAppResourceMeta(baseUrl, context.env.POSTHOG_MCP_APPS_ANALYTICS_BASE_URL)
     const html = buildAppStubHtml(appDir, baseUrl)
 
     server.registerResource(name, uri, { mimeType: RESOURCE_MIME_TYPE, description }, async (uri) => {
@@ -91,7 +113,7 @@ function registerApp(
                     uri: uri.toString(),
                     mimeType: RESOURCE_MIME_TYPE,
                     text: html,
-                    _meta: { ui: uiMetadata },
+                    _meta: meta,
                 },
             ],
         }

--- a/services/mcp/tests/unit/ui-apps.test.ts
+++ b/services/mcp/tests/unit/ui-apps.test.ts
@@ -136,6 +136,7 @@ describe('ui-apps', () => {
             const result = await handler(new URL('ui://posthog/debug.html'))
 
             expect(result.contents[0]._meta.ui.csp.resourceDomains).toContain('https://mcp.posthog.com')
+            expect(result.contents[0]._meta['openai/widgetCSP'].resource_domains).toContain('https://mcp.posthog.com')
         })
 
         it('includes analytics URL in CSP when set', async () => {
@@ -153,6 +154,8 @@ describe('ui-apps', () => {
 
             expect(result.contents[0]._meta.ui.csp.resourceDomains).toContain('https://us.i.posthog.com')
             expect(result.contents[0]._meta.ui.csp.connectDomains).toContain('https://us.i.posthog.com')
+            expect(result.contents[0]._meta['openai/widgetCSP'].resource_domains).toContain('https://us.i.posthog.com')
+            expect(result.contents[0]._meta['openai/widgetCSP'].connect_domains).toContain('https://us.i.posthog.com')
         })
 
         it('omits analytics URL from CSP when not set', async () => {
@@ -167,6 +170,8 @@ describe('ui-apps', () => {
 
             expect(result.contents[0]._meta.ui.csp.resourceDomains).toEqual(['https://mcp.posthog.com'])
             expect(result.contents[0]._meta.ui.csp.connectDomains).toEqual([])
+            expect(result.contents[0]._meta['openai/widgetCSP'].resource_domains).toEqual(['https://mcp.posthog.com'])
+            expect(result.contents[0]._meta['openai/widgetCSP'].connect_domains).toEqual([])
         })
 
         it('resource handler returns stub HTML with correct base URL', async () => {


### PR DESCRIPTION
## Problem

MCP UI apps don't render in ChatGPT. The widget iframe loads our stub HTML, but the stylesheet and script requests to `https://mcp.us.posthog.com/ui-apps/...` are blocked by ChatGPT's CSP:

> Loading the stylesheet 'https://mcp.us.posthog.com/ui-apps/query-results/styles.css' violates the following Content Security Policy directive: "style-src-elem 'self' ... https://mcp.posthog.com"

Root cause: we declare the CSP allowlist for app resources only in the [MCP Apps spec format](https://developers.openai.com/apps-sdk/build/mcp-server) (`_meta.ui.csp` with camelCase `resourceDomains`/`connectDomains`). Claude honors that key, but ChatGPT extends its iframe CSP only from its own extension key, `openai/widgetCSP` (snake_case `resource_domains`/`connect_domains`). Without it, ChatGPT allows just the connected server origin (`mcp.posthog.com`), while the stub loads assets from `MCP_APPS_BASE_URL` (`mcp.us.posthog.com` in the US deployment), so everything the widget needs gets blocked.

## Changes

- Extracted `buildUiAppResourceMeta()` in `services/mcp/src/resources/ui-apps.ts` that emits the CSP domain lists in both formats: spec `ui.csp` (Claude and future spec-compliant clients) and `openai/widgetCSP` (ChatGPT).
- Wired it into both serving paths that previously duplicated the metadata construction: the Cloudflare Worker resource registration (`registerApp`) and the Hono runtime resource catalog (`warmupUiApps`), which handles production reads.

No behavior change for Claude - the `ui.csp` payload is identical to before.

> [!NOTE]
> Needs a deploy of the MCP service to take effect. If ChatGPT tightens further, the fallback is pointing `MCP_APPS_BASE_URL` at the connected origin (`mcp.posthog.com` serves `/ui-apps/*` via the Worker's ASSETS binding), but that couples the regional runtime's HTML to the Worker's asset version, so the metadata fix is the better first move.

## How did you test this code?

- `pnpm vitest run tests/unit/ui-apps.test.ts` (15 pass) and the Hono `resource-catalog`/`mcp-protocol` suites (83 pass), plus a clean `tsc --noEmit`.
- Extended the three existing CSP assertions to check `openai/widgetCSP` mirrors the `ui.csp` domains. Regression guarded: removing the seemingly redundant ChatGPT key (it duplicates `ui.csp` and looks like cleanup bait) would silently re-break ChatGPT with no type error and no failing test.
- Not verified end-to-end in ChatGPT - that requires a production deploy of the MCP service.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy hit the CSP violation in ChatGPT and asked for a diagnosis. I (Claude Code) traced the resource metadata through `resources/ui-apps.ts` and `hono/resource-catalog.ts`, confirmed against the [Apps SDK docs](https://developers.openai.com/apps-sdk/build/mcp-server) and community reports that ChatGPT reads `openai/widgetCSP` rather than the spec's `ui.csp`, and consolidated the duplicated metadata construction into one shared builder emitting both. Skills invoked: /implementing-mcp-ui-apps, /writing-tests. Considered serving assets from the connected origin instead (works via the Worker ASSETS binding) but rejected it for version-skew reasons noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)