### PR TITLE
fix(funnels): hide baseline from chart when toggled off with compare enabled

### DIFF
--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -1786,5 +1786,38 @@ describe('funnelDataLogic', () => {
                 .map((b) => getVisibilityKey(b.breakdown_value))
             expect(breakdownValues).toEqual(['Chrome', 'Chrome', 'Safari', 'Safari'])
         })
+
+        it('hides both periods of the baseline when its legend entry is hidden', async () => {
+            const insight: Partial<InsightModel> = {
+                filters: { insight: InsightType.FUNNELS },
+                result: funnelResultStepsBreakdownCompare.result as InsightModel['result'],
+            }
+            await expectLogic(logic, () => {
+                const query: FunnelsQuery = {
+                    ...stepsQuery,
+                    funnelsFilter: { ...stepsQuery.funnelsFilter, hiddenLegendBreakdowns: ['Baseline'] },
+                }
+                logic.actions.updateQuerySource(query)
+                builtDataNodeLogic.actions.loadDataSuccess(insight)
+            }).toFinishAllListeners()
+
+            // The synthesized baseline pair takes a separate path than the value bars, so it must be
+            // hidden too; the values keep their baseline-shifted orders (hence colors) while the
+            // baseline is merely hidden.
+            const visibleValues = logic.values.visibleStepsWithConversionMetrics[0].nested_breakdown?.map((b) => [
+                getVisibilityKey(b.breakdown_value),
+                b.compare_label,
+                b.order,
+            ])
+            expect(visibleValues).toEqual([
+                ['Chrome', 'current', 1],
+                ['Chrome', 'previous', 1],
+                ['Safari', 'current', 2],
+                ['Safari', 'previous', 2],
+            ])
+
+            // The table still lists both baseline rows (just unchecked), so they can be toggled back on.
+            expect(logic.values.flattenedBreakdowns.filter((b) => b.isBaseline)).toHaveLength(2)
+        })
     })
 })

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -537,13 +537,20 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                 // and per-value orders (both periods of a value share one order, hence one color).
                 if (isBreakdownCompareFunnel) {
                     const baselineRows = flattenedBreakdowns.filter((b) => b.isBaseline)
+                    // Offset stays 1 while the baseline is merely hidden, so the remaining values keep
+                    // their color positions when the baseline is toggled — same as the plain-breakdown
+                    // path, which assigns orders before filtering.
                     const baselineOffset = baselineRows.length > 0 ? 1 : 0
                     // Size each baseline bar by its period's share of the larger period (the larger fills,
                     // the smaller is proportionally shorter) — matching how the value and pure-compare bars
                     // are scaled, so the previous baseline isn't drawn at full height.
                     const compareBasis = Math.max(0, ...baselineRows.map((row) => row.steps?.[0]?.count ?? 0))
+                    const visibleBaselineRows = baselineRows.filter(
+                        (row) =>
+                            isOnlySeries || !hiddenLegendBreakdowns?.includes(getVisibilityKey(row.breakdown_value))
+                    )
                     return steps.map((step, stepIndex) => {
-                        const baselineEntries = baselineRows
+                        const baselineEntries = visibleBaselineRows
                             .map((row) => row.steps?.[stepIndex])
                             .filter((s): s is FunnelStepWithConversionMetrics => s != null)
                             .map((s) => ({


### PR DESCRIPTION
## TL;DR

In a steps funnel that has both a breakdown and "Compare against previous period" turned on, unchecking the "Baseline" row in the results table did nothing, the baseline bars stayed in the chart. Now they disappear like every other unchecked row.

## Problem

The detailed results table below a funnel lets you toggle series on and off. With a breakdown plus compare enabled, the Baseline checkbox updated the persisted `hiddenLegendBreakdowns` filter correctly, but the chart kept drawing the baseline pair. Without compare, the same toggle worked.

Root cause: the `visibleStepsWithConversionMetrics` selector in `funnelDataLogic.ts` has a dedicated breakdown + compare branch that builds the baseline bars straight from `flattenedBreakdowns` and prepends them to `nested_breakdown` without ever consulting `hiddenLegendBreakdowns`. Only the real breakdown values got that filter. The plain-breakdown branch filters the baseline like any other entry, which is why it worked there.

## Changes

- `frontend/src/scenes/funnels/funnelDataLogic.ts`: apply the same hidden-legend guard to the baseline rows that the value entries already get, so an unchecked Baseline is excluded from the chart. The color offset stays derived from the unfiltered baseline rows, so the remaining values keep their color positions while the baseline is merely hidden (matching the plain-breakdown path, which assigns orders before filtering).
- `frontend/src/scenes/funnels/funnelDataLogic.test.ts`: one regression test for hiding Baseline in the breakdown + compare case.

## How did you test this code?

- `hogli test frontend/src/scenes/funnels/funnelDataLogic.test.ts` — all 74 tests pass.
- The new test catches a regression no existing test did: the suite already covered hiding a real breakdown value (Chrome) with compare on, but the synthesized baseline flows through a separate code path (`baselineEntries` vs `valueEntries`), which is exactly where this bug lived. It asserts the baseline pair is dropped from the chart, the remaining values keep their shifted orders (color stability), and the table still lists the baseline rows so they can be toggled back on.
- I (or, actually Claude) did not manually verify this in the browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected, this restores documented toggle behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Explored the funnel visibility code paths with read-only subagents, pinpointed the missing filter in the breakdown + compare branch of `visibleStepsWithConversionMetrics`, and mirrored the guard the plain-breakdown branch already applies.
- Skills invoked: `/writing-tests`.
- One decision worth noting: the color offset (`baselineOffset`) intentionally stays at 1 while the baseline is hidden, so toggling it doesn't reshuffle the other series' colors, consistent with the non-compare behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
