### PR TITLE
feat(logs): make every configured column reorderable, removable, and resizable

### DIFF
--- a/products/logs/frontend/components/LogsViewer/config/LogsColumnConfigurator.tsx
+++ b/products/logs/frontend/components/LogsViewer/config/LogsColumnConfigurator.tsx
@@ -48,16 +48,27 @@ function SelectedColumnRow({ column }: { column: LogsColumnConfig }): JSX.Elemen
     const { id } = useValues(logsViewerLogic)
     const { editingColumnId } = useValues(logsColumnConfiguratorLogic({ id }))
     const { updateDraftColumn, removeDraftColumn, setEditingColumnId } = useActions(logsColumnConfiguratorLogic({ id }))
-    const { setNodeRef, attributes, transform, transition, listeners } = useSortable({ id: column.id })
+    const { setNodeRef, attributes, transform, transition, listeners } = useSortable({
+        id: column.id,
+        disabled: column.type === 'message',
+    })
 
     const isEditing = editingColumnId === column.id
 
     return (
         <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }} {...attributes}>
             <div className="flex items-center justify-start px-2 py-1 my-1 rounded bg-accent-highlight-secondary">
-                <span {...listeners} className="pr-2 text-secondary cursor-move">
-                    <SortableDragIcon />
-                </span>
+                {column.type === 'message' ? (
+                    <Tooltip title="Message is always the last column">
+                        <span className="pr-2 text-muted">
+                            <SortableDragIcon />
+                        </span>
+                    </Tooltip>
+                ) : (
+                    <span {...listeners} className="pr-2 text-secondary cursor-move">
+                        <SortableDragIcon />
+                    </span>
+                )}
                 <span className="truncate">{columnLabel(column)}</span>
                 {column.type === 'custom' && column.name && column.expression && column.expression !== column.name && (
                     <span className="ml-2 text-xs text-muted font-mono truncate">{column.expression}</span>

--- a/products/logs/frontend/components/LogsViewer/config/columns.test.ts
+++ b/products/logs/frontend/components/LogsViewer/config/columns.test.ts
@@ -1,6 +1,6 @@
 import { AttributeColumnConfig } from 'products/logs/frontend/types'
 
-import { columnsToCustomColumns, LogsColumnConfig, migrateAttributeColumns } from './columns'
+import { columnsToCustomColumns, LogsColumnConfig, migrateAttributeColumns, normalizeColumns } from './columns'
 
 describe('logs column config', () => {
     describe('columnsToCustomColumns', () => {
@@ -51,6 +51,27 @@ describe('logs column config', () => {
         it('escapes quotes and backslashes so keys cannot break out of the expression string', () => {
             const [migrated] = migrateAttributeColumns({ "we'ird\\key": { order: 0 } })
             expect(migrated.expression).toContain("we\\'ird\\\\key")
+        })
+    })
+
+    describe('normalizeColumns', () => {
+        it('pins message columns last, preserving relative order of the rest', () => {
+            const columns: LogsColumnConfig[] = [
+                { id: 'm', type: 'message' },
+                { id: 't', type: 'timestamp' },
+                { id: 'c', type: 'custom', expression: 'attributes.a' },
+            ]
+            expect(normalizeColumns(columns).map((c) => c.id)).toEqual(['t', 'c', 'm'])
+        })
+
+        it('is identity when message is already last or absent', () => {
+            const alreadyLast: LogsColumnConfig[] = [
+                { id: 't', type: 'timestamp' },
+                { id: 'm', type: 'message' },
+            ]
+            expect(normalizeColumns(alreadyLast).map((c) => c.id)).toEqual(['t', 'm'])
+            const noMessage: LogsColumnConfig[] = [{ id: 't', type: 'timestamp' }]
+            expect(normalizeColumns(noMessage)).toBe(noMessage)
         })
     })
 })

--- a/products/logs/frontend/components/LogsViewer/config/columns.test.ts
+++ b/products/logs/frontend/components/LogsViewer/config/columns.test.ts
@@ -64,12 +64,14 @@ describe('logs column config', () => {
             expect(normalizeColumns(columns).map((c) => c.id)).toEqual(['t', 'c', 'm'])
         })
 
-        it('is identity when message is already last or absent', () => {
+        it('returns the same reference when message is already last or absent', () => {
+            // Identity matters: reducers call this on every mutation, and a fresh array in the
+            // steady state would defeat referential-equality checks downstream
             const alreadyLast: LogsColumnConfig[] = [
                 { id: 't', type: 'timestamp' },
                 { id: 'm', type: 'message' },
             ]
-            expect(normalizeColumns(alreadyLast).map((c) => c.id)).toEqual(['t', 'm'])
+            expect(normalizeColumns(alreadyLast)).toBe(alreadyLast)
             const noMessage: LogsColumnConfig[] = [{ id: 't', type: 'timestamp' }]
             expect(normalizeColumns(noMessage)).toBe(noMessage)
         })

--- a/products/logs/frontend/components/LogsViewer/config/columns.ts
+++ b/products/logs/frontend/components/LogsViewer/config/columns.ts
@@ -45,6 +45,16 @@ export const DEFAULT_LOGS_COLUMNS: LogsColumnConfig[] = [
     { id: 'message', type: 'message' },
 ]
 
+/**
+ * Message is pinned to the end: it's the flex fill column, and the row FAB (whose scroll
+ * buttons drive the message cell) anchors to the row's right edge. Stable within each partition.
+ */
+export function normalizeColumns(columns: LogsColumnConfig[]): LogsColumnConfig[] {
+    const rest = columns.filter((column) => column.type !== 'message')
+    const message = columns.filter((column) => column.type === 'message')
+    return message.length > 0 ? [...rest, ...message] : columns
+}
+
 export function columnLabel(column: LogsColumnConfig): string {
     if (column.name) {
         return column.name

--- a/products/logs/frontend/components/LogsViewer/config/columns.ts
+++ b/products/logs/frontend/components/LogsViewer/config/columns.ts
@@ -47,12 +47,20 @@ export const DEFAULT_LOGS_COLUMNS: LogsColumnConfig[] = [
 
 /**
  * Message is pinned to the end: it's the flex fill column, and the row FAB (whose scroll
- * buttons drive the message cell) anchors to the row's right edge. Stable within each partition.
+ * buttons drive the message cell) anchors to the row's right edge.
  */
+export function isPinnedColumn(column: LogsColumnConfig): boolean {
+    return column.type === 'message'
+}
+
+/** Sort pinned columns last, stable otherwise. Returns the input untouched when already normalized. */
 export function normalizeColumns(columns: LogsColumnConfig[]): LogsColumnConfig[] {
-    const rest = columns.filter((column) => column.type !== 'message')
-    const message = columns.filter((column) => column.type === 'message')
-    return message.length > 0 ? [...rest, ...message] : columns
+    const firstPinnedIndex = columns.findIndex(isPinnedColumn)
+    if (firstPinnedIndex === -1 || columns.slice(firstPinnedIndex).every(isPinnedColumn)) {
+        return columns
+    }
+    const rest = columns.filter((column) => !isPinnedColumn(column))
+    return [...rest, ...columns.filter(isPinnedColumn)]
 }
 
 export function columnLabel(column: LogsColumnConfig): string {

--- a/products/logs/frontend/components/LogsViewer/config/logsColumnConfiguratorLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsColumnConfiguratorLogic.test.ts
@@ -31,7 +31,8 @@ describe('logsColumnConfiguratorLogic', () => {
     it('draft edits do not touch the applied columns until applyDraft', async () => {
         const before = configLogic.values.columns
         logic.actions.addDraftColumn({ type: 'custom' })
-        const draftId = logic.values.draft[logic.values.draft.length - 1].id
+        // Normalization pins message last, so the new custom column sits just before it
+        const draftId = logic.values.draft.find((c) => c.type === 'custom')!.id
         logic.actions.updateDraftColumn(draftId, { expression: 'attributes.http.url' })
 
         // Still uncommitted — this is what keeps per-keystroke edits from firing logs queries
@@ -42,7 +43,9 @@ describe('logsColumnConfiguratorLogic', () => {
         }).toFinishAllListeners()
 
         expect(configLogic.values.columns).toHaveLength(before.length + 1)
-        expect(configLogic.values.columns.at(-1)?.expression).toBe('attributes.http.url')
+        expect(configLogic.values.columns.find((c) => c.type === 'custom')?.expression).toBe('attributes.http.url')
+        // Message stays pinned last through apply
+        expect(configLogic.values.columns.at(-1)?.type).toBe('message')
         expect(logic.values.isOpen).toBe(false)
     })
 
@@ -68,10 +71,15 @@ describe('logsColumnConfiguratorLogic', () => {
         expect(configLogic.values.columns).toEqual(before)
     })
 
-    it('moveDraftColumn reorders by index', () => {
+    it('moveDraftColumn reorders by index but keeps message pinned last', () => {
         logic.actions.addDraftColumn({ type: 'custom', expression: 'attributes.a' })
+        // Draft is [timestamp, custom, message] after normalization
         const ids = logic.values.draft.map((c) => c.id)
+        logic.actions.moveDraftColumn(0, 1)
+        expect(logic.values.draft.map((c) => c.id)).toEqual([ids[1], ids[0], ids[2]])
+
+        // Dragging a column onto/past message re-normalizes message back to the end
         logic.actions.moveDraftColumn(0, 2)
-        expect(logic.values.draft.map((c) => c.id)).toEqual([ids[1], ids[2], ids[0]])
+        expect(logic.values.draft.at(-1)?.type).toBe('message')
     })
 })

--- a/products/logs/frontend/components/LogsViewer/config/logsColumnConfiguratorLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsColumnConfiguratorLogic.ts
@@ -4,7 +4,7 @@ import { uuid } from 'lib/utils/dom'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 
-import { LogsColumnConfig } from './columns'
+import { LogsColumnConfig, normalizeColumns } from './columns'
 import type { logsColumnConfiguratorLogicType } from './logsColumnConfiguratorLogicType'
 
 export interface LogsColumnConfiguratorLogicProps {
@@ -58,10 +58,10 @@ export const logsColumnConfiguratorLogic = kea<logsColumnConfiguratorLogicType>(
         draft: [
             [] as LogsColumnConfig[],
             {
-                setDraft: (_, { draft }) => draft,
+                setDraft: (_, { draft }) => normalizeColumns(draft),
                 updateDraftColumn: (state, { id, patch }) =>
                     state.map((column) => (column.id === id ? { ...column, ...patch } : column)),
-                addDraftColumn: (state, { column }) => [...state, { ...column, id: uuid() }],
+                addDraftColumn: (state, { column }) => normalizeColumns([...state, { ...column, id: uuid() }]),
                 removeDraftColumn: (state, { id }) => state.filter((column) => column.id !== id),
                 moveDraftColumn: (state, { fromIndex, toIndex }) => {
                     if (fromIndex === toIndex || !state[fromIndex] || toIndex < 0 || toIndex >= state.length) {
@@ -70,7 +70,7 @@ export const logsColumnConfiguratorLogic = kea<logsColumnConfiguratorLogicType>(
                     const next = [...state]
                     const [moved] = next.splice(fromIndex, 1)
                     next.splice(toIndex, 0, moved)
-                    return next
+                    return normalizeColumns(next)
                 },
             },
         ],

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -8,6 +8,7 @@ import {
     DEFAULT_LOGS_COLUMNS,
     LogsColumnConfig,
     migrateAttributeColumns,
+    normalizeColumns,
 } from 'products/logs/frontend/components/LogsViewer/config/columns'
 import { LogsViewerConfig, LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
 import type { GroupBySourceEnumApi } from 'products/logs/frontend/generated/api.schemas'
@@ -118,8 +119,8 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
             DEFAULT_LOGS_COLUMNS,
             { persist: true },
             {
-                setColumns: (_, { columns }) => columns,
-                addColumn: (state, { column }) => [...state, column],
+                setColumns: (_, { columns }) => normalizeColumns(columns),
+                addColumn: (state, { column }) => normalizeColumns([...state, column]),
                 removeColumn: (state, { id }) => state.filter((column) => column.id !== id),
                 setColumnWidth: (state, { id, width }) =>
                     state.map((column) => (column.id === id ? { ...column, width } : column)),
@@ -131,7 +132,7 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
                     }
                     const next = [...state]
                     ;[next[index], next[targetIndex]] = [next[targetIndex], next[index]]
-                    return next
+                    return normalizeColumns(next)
                 },
             },
         ],

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -619,7 +619,7 @@ describe('logsViewerLogic', () => {
 
         it.each<['left' | 'right', string, string[]]>([
             ['left', 'c1', ['c1', 'timestamp', 'message']],
-            ['right', 'c1', ['timestamp', 'message', 'c1']],
+            ['right', 'c1', ['timestamp', 'c1', 'message']], // message pinned last, so a no-op
             ['left', 'timestamp', ['timestamp', 'c1', 'message']], // first, no-op
             ['right', 'message', ['timestamp', 'c1', 'message']], // last, no-op
             ['left', 'missing', ['timestamp', 'c1', 'message']], // unknown id, no-op

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -103,7 +103,9 @@ export function LogRow({
                     isPrettified={isPrettified}
                     onTogglePin={onTogglePin}
                     onTogglePrettify={onTogglePrettify}
-                    showScrollButtons={!wrapBody}
+                    // Scroll buttons drive the message cell's inner scroll — pointless without
+                    // a message column (the flex column) or when wrapping already shows everything
+                    showScrollButtons={!wrapBody && columns.some((col) => col.sizing.type === 'flex')}
                 />
             </div>
             {isExpanded && <ExpandedLogContent log={log} />}

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -17,6 +17,7 @@ export interface LogRowProps {
     pinned: boolean
     showPinnedWithOpacity: boolean
     wrapBody: boolean
+    hasMessageColumn: boolean
     onTogglePin: (log: ParsedLogMessage) => void
     onClick?: () => void
     rowWidth?: number
@@ -41,6 +42,7 @@ export function LogRow({
     pinned,
     showPinnedWithOpacity,
     wrapBody,
+    hasMessageColumn,
     onTogglePin,
     onClick,
     rowWidth,
@@ -104,8 +106,8 @@ export function LogRow({
                     onTogglePin={onTogglePin}
                     onTogglePrettify={onTogglePrettify}
                     // Scroll buttons drive the message cell's inner scroll — pointless without
-                    // a message column (the flex column) or when wrapping already shows everything
-                    showScrollButtons={!wrapBody && columns.some((col) => col.sizing.type === 'flex')}
+                    // a message column or when wrapping already shows everything
+                    showScrollButtons={!wrapBody && hasMessageColumn}
                 />
             </div>
             {isExpanded && <ExpandedLogContent log={log} />}

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -209,16 +209,18 @@ export function VirtualizedLogsList({
     // pinned controls column is a configured column; there are no special cases here.
     const columns = useMemo(() => {
         const rendering = { tzLabelFormat, orderBy, onChangeOrderBy, wrapBody, prettifyJson, flexWidthRef }
+        // Move bounds range over movable columns only — message is pinned last and never swaps
+        const movable = columnConfigs.filter((config) => config.type !== 'message')
         return [
             createControlsColumn({ dataSourceRef }),
-            ...columnConfigs.map((config, index) =>
+            ...columnConfigs.map((config) =>
                 createConfiguredColumn({
                     config,
                     alias: aliasById.get(config.id),
                     callbacks: { onResize: setColumnWidth, onRemove: removeColumn, onMove: moveColumn },
                     rendering,
-                    isFirst: index === 0,
-                    isLast: index === columnConfigs.length - 1,
+                    isFirst: movable.indexOf(config) === 0,
+                    isLast: movable.length > 0 && movable.indexOf(config) === movable.length - 1,
                 })
             ),
         ]

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -12,6 +12,7 @@ import { AutoSizer } from 'lib/components/AutoSizer'
 import { SizeProps } from 'lib/components/AutoSizer/AutoSizer'
 import { TZLabelProps } from 'lib/components/TZLabel'
 
+import { isPinnedColumn } from 'products/logs/frontend/components/LogsViewer/config/columns'
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { logDetailsModalLogic } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
@@ -62,6 +63,7 @@ interface LogsListRowProps {
     showPinnedWithOpacity: boolean
     disableCursor: boolean
     wrapBody: boolean
+    hasMessageColumn: boolean
     togglePinLog: (log: ParsedLogMessage) => void
     handleLogRowClick: (log: ParsedLogMessage, index: number) => void
     rowWidth?: number
@@ -85,6 +87,7 @@ function LogsListRow({
     showPinnedWithOpacity,
     disableCursor,
     wrapBody,
+    hasMessageColumn,
     togglePinLog,
     handleLogRowClick,
     rowWidth,
@@ -120,6 +123,7 @@ function LogsListRow({
                 pinned={!!pinnedLogs[log.uuid]}
                 showPinnedWithOpacity={showPinnedWithOpacity}
                 wrapBody={wrapBody}
+                hasMessageColumn={hasMessageColumn}
                 onTogglePin={togglePinLog}
                 onClick={() => handleLogRowClick(log, index)}
                 rowWidth={rowWidth}
@@ -209,8 +213,8 @@ export function VirtualizedLogsList({
     // pinned controls column is a configured column; there are no special cases here.
     const columns = useMemo(() => {
         const rendering = { tzLabelFormat, orderBy, onChangeOrderBy, wrapBody, prettifyJson, flexWidthRef }
-        // Move bounds range over movable columns only — message is pinned last and never swaps
-        const movable = columnConfigs.filter((config) => config.type !== 'message')
+        // Move bounds range over movable columns only — pinned columns sort last and never swap
+        const movable = columnConfigs.filter((config) => !isPinnedColumn(config))
         return [
             createControlsColumn({ dataSourceRef }),
             ...columnConfigs.map((config) =>
@@ -219,8 +223,8 @@ export function VirtualizedLogsList({
                     alias: aliasById.get(config.id),
                     callbacks: { onResize: setColumnWidth, onRemove: removeColumn, onMove: moveColumn },
                     rendering,
-                    isFirst: movable.indexOf(config) === 0,
-                    isLast: movable.length > 0 && movable.indexOf(config) === movable.length - 1,
+                    isFirst: config === movable[0],
+                    isLast: config === movable[movable.length - 1],
                 })
             ),
         ]
@@ -303,6 +307,7 @@ export function VirtualizedLogsList({
             showPinnedWithOpacity,
             disableCursor,
             wrapBody,
+            hasMessageColumn: columnConfigs.some((config) => config.type === 'message'),
             togglePinLog,
             handleLogRowClick,
             rowWidth,
@@ -317,6 +322,7 @@ export function VirtualizedLogsList({
         [
             dataSource,
             columns,
+            columnConfigs,
             cursorIndex,
             expandedLogIds,
             pinnedLogs,

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -18,8 +18,6 @@ import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/lo
 import {
     createConfiguredColumn,
     createControlsColumn,
-    createMessageColumn,
-    createTimestampColumn,
 } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
 import {
     LOG_ROW_HEADER_HEIGHT,
@@ -207,26 +205,22 @@ export function VirtualizedLogsList({
     }, [columnConfigs, customColumnAliases])
 
     // Columns memoized on structural deps only — per-row state (selection,
-    // expansion, prettify) is read from kea inside cell components.
+    // expansion, prettify) is read from kea inside cell components. Everything after the
+    // pinned controls column is a configured column; there are no special cases here.
     const columns = useMemo(() => {
-        const managed = columnConfigs.filter((config) => config.type !== 'timestamp' && config.type !== 'message')
+        const rendering = { tzLabelFormat, orderBy, onChangeOrderBy, wrapBody, prettifyJson, flexWidthRef }
         return [
             createControlsColumn({ dataSourceRef }),
-            ...columnConfigs.map((config) => {
-                if (config.type === 'timestamp') {
-                    return createTimestampColumn({ tzLabelFormat, orderBy, onChangeOrderBy })
-                }
-                if (config.type === 'message') {
-                    return createMessageColumn({ wrapBody, prettifyJson, flexWidthRef })
-                }
-                return createConfiguredColumn({
+            ...columnConfigs.map((config, index) =>
+                createConfiguredColumn({
                     config,
                     alias: aliasById.get(config.id),
                     callbacks: { onResize: setColumnWidth, onRemove: removeColumn, onMove: moveColumn },
-                    isFirst: managed.indexOf(config) === 0,
-                    isLast: managed.indexOf(config) === managed.length - 1,
+                    rendering,
+                    isFirst: index === 0,
+                    isLast: index === columnConfigs.length - 1,
                 })
-            }),
+            ),
         ]
     }, [
         tzLabelFormat,

--- a/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
@@ -147,54 +147,20 @@ export function createControlsColumn(params: {
     }
 }
 
-export function createTimestampColumn(params: {
-    tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
-    orderBy?: LogsOrderBy
-    onChangeOrderBy?: (orderBy: LogsOrderBy) => void
-}): VirtualizedTableColumn<ParsedLogMessage> {
-    const { tzLabelFormat, orderBy, onChangeOrderBy } = params
-
-    return {
-        key: 'timestamp',
-        title: 'Timestamp',
-        sizing: { type: 'fixed', width: TIMESTAMP_WIDTH },
-        render: (log) => (
-            <div className="flex items-center shrink-0" style={{ width: TIMESTAMP_WIDTH }}>
-                <span className="text-xs text-muted font-mono">
-                    <TZLabel time={log.timestamp} {...tzLabelFormat} timestampStyle="absolute" />
-                </span>
-            </div>
-        ),
-        renderHeader: () => (
-            <div
-                className="flex items-center justify-between pr-3 gap-1 h-full border-r"
-                style={{ width: TIMESTAMP_WIDTH, flexShrink: 0 }}
-            >
-                Timestamp
-                <LemonButton
-                    size="xsmall"
-                    className="h-full"
-                    icon={orderBy === 'latest' ? <IconArrowDown /> : <IconArrowUp />}
-                    tooltip={
-                        orderBy === 'latest'
-                            ? 'Showing latest first. Click to show earliest first (reloads).'
-                            : 'Showing earliest first. Click to show latest first (reloads).'
-                    }
-                    onClick={() => {
-                        const newOrderBy = orderBy === 'latest' ? 'earliest' : 'latest'
-                        onChangeOrderBy?.(newOrderBy)
-                    }}
-                    disabled={!orderBy || !onChangeOrderBy}
-                />
-            </div>
-        ),
-    }
-}
-
 export interface ConfiguredColumnCallbacks {
     onResize?: (id: string, width: number) => void
     onRemove?: (id: string) => void
     onMove?: (id: string, direction: 'left' | 'right') => void
+}
+
+/** Presentation context shared by every configured column, resolved once per table render. */
+export interface ConfiguredColumnRendering {
+    tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
+    orderBy?: LogsOrderBy
+    onChangeOrderBy?: (orderBy: LogsOrderBy) => void
+    wrapBody: boolean
+    prettifyJson: boolean
+    flexWidthRef: RefObject<number | undefined | null>
 }
 
 /** Read a server-computed custom column value off the raw row by its canonical alias. */
@@ -206,42 +172,156 @@ function customColumnValue(log: ParsedLogMessage, alias: string | undefined): st
     return value == null ? '' : String(value)
 }
 
+function ColumnHeaderMenu({
+    config,
+    callbacks,
+    isFirst,
+    isLast,
+}: {
+    config: LogsColumnConfig
+    callbacks: ConfiguredColumnCallbacks
+    isFirst: boolean
+    isLast: boolean
+}): JSX.Element | null {
+    const { onRemove, onMove } = callbacks
+    if (!onRemove && !onMove) {
+        return null
+    }
+    return (
+        <LemonMenu
+            items={[
+                onMove
+                    ? {
+                          label: 'Move left',
+                          icon: <IconArrowLeft />,
+                          disabledReason: isFirst ? 'Already at the start' : undefined,
+                          onClick: () => onMove(config.id, 'left'),
+                      }
+                    : null,
+                onMove
+                    ? {
+                          label: 'Move right',
+                          icon: <IconArrowRight />,
+                          disabledReason: isLast ? 'Already at the end' : undefined,
+                          onClick: () => onMove(config.id, 'right'),
+                      }
+                    : null,
+                onRemove
+                    ? {
+                          label: 'Remove column',
+                          icon: <IconTrash />,
+                          status: 'danger' as const,
+                          onClick: () => onRemove(config.id),
+                      }
+                    : null,
+            ]}
+        >
+            <LemonButton size="xsmall" noPadding icon={<IconEllipsis className="text-muted" />} className="shrink-0" />
+        </LemonMenu>
+    )
+}
+
+function TimestampSortButton({
+    orderBy,
+    onChangeOrderBy,
+}: Pick<ConfiguredColumnRendering, 'orderBy' | 'onChangeOrderBy'>): JSX.Element {
+    return (
+        <LemonButton
+            size="xsmall"
+            className="h-full"
+            icon={orderBy === 'latest' ? <IconArrowDown /> : <IconArrowUp />}
+            tooltip={
+                orderBy === 'latest'
+                    ? 'Showing latest first. Click to show earliest first (reloads).'
+                    : 'Showing earliest first. Click to show latest first (reloads).'
+            }
+            onClick={() => onChangeOrderBy?.(orderBy === 'latest' ? 'earliest' : 'latest')}
+            disabled={!orderBy || !onChangeOrderBy}
+        />
+    )
+}
+
 /**
- * Generic resizable column driven by a LogsColumnConfig: built-in types resolve client-side
- * from row fields via the registry; custom columns read the server-computed value keyed by
- * `alias`. Custom values render through AttributeCell so the special-case renderers
- * (PersonDisplay for distinct-id keys, ViewRecordingButton for session-id keys) keep working.
+ * The single column factory: every configured column — built-in or custom — renders through
+ * here, so all of them are reorderable, removable, and resizable. Message is the one layout
+ * exception (the flex fill column, so no resizer). Type differences are confined to the cell
+ * renderer (timestamp -> TZLabel, message -> MessageCell, rest -> AttributeCell, which keeps
+ * the PersonDisplay / ViewRecordingButton special cases) plus timestamp's sort toggle.
  */
 export function createConfiguredColumn(params: {
     config: LogsColumnConfig
     alias?: string
     callbacks: ConfiguredColumnCallbacks
+    rendering: ConfiguredColumnRendering
     isFirst: boolean
     isLast: boolean
 }): VirtualizedTableColumn<ParsedLogMessage> {
-    const { config, alias, callbacks, isFirst, isLast } = params
-    const { onResize, onRemove, onMove } = callbacks
+    const { config, alias, callbacks, rendering, isFirst, isLast } = params
     const title = columnLabel(config)
-    const width = config.width ?? DEFAULT_ATTRIBUTE_COLUMN_WIDTH
+
+    if (config.type === 'message') {
+        return {
+            key: `col:${config.id}`,
+            title,
+            sizing: { type: 'flex', minWidth: MESSAGE_MIN_WIDTH },
+            render: (log) => (
+                <MessageColumnCell
+                    log={log}
+                    wrapBody={rendering.wrapBody}
+                    prettifyJson={rendering.prettifyJson}
+                    flexWidthRef={rendering.flexWidthRef}
+                />
+            ),
+            renderHeader: () => (
+                <div
+                    className="flex items-center justify-between px-1 gap-1"
+                    style={getMessageStyle(rendering.flexWidthRef.current ?? undefined)}
+                >
+                    <span className="truncate" title={title}>
+                        {title}
+                    </span>
+                    <ColumnHeaderMenu config={config} callbacks={callbacks} isFirst={isFirst} isLast={isLast} />
+                </div>
+            ),
+        }
+    }
+
+    const width = config.width ?? (config.type === 'timestamp' ? TIMESTAMP_WIDTH : DEFAULT_ATTRIBUTE_COLUMN_WIDTH)
     const totalWidth = width + RESIZER_HANDLE_WIDTH
 
     const semanticKey = config.type === 'custom' ? (config.name ?? config.expression ?? '') : config.type
-    const getValue =
-        config.type === 'custom'
-            ? (log: ParsedLogMessage): string => customColumnValue(log, alias)
-            : LOGS_COLUMN_REGISTRY[config.type].getValue
+    const renderValue =
+        config.type === 'timestamp'
+            ? (log: ParsedLogMessage): JSX.Element => (
+                  <div className="flex items-center shrink-0" style={{ width: totalWidth }}>
+                      <span className="text-xs text-muted font-mono">
+                          <TZLabel time={log.timestamp} {...rendering.tzLabelFormat} timestampStyle="absolute" />
+                      </span>
+                  </div>
+              )
+            : (log: ParsedLogMessage): JSX.Element => (
+                  <AttributeCell
+                      attributeKey={semanticKey}
+                      value={
+                          config.type === 'custom'
+                              ? customColumnValue(log, alias)
+                              : LOGS_COLUMN_REGISTRY[config.type].getValue(log)
+                      }
+                      width={totalWidth}
+                  />
+              )
 
     return {
         key: `col:${config.id}`,
         title,
         sizing: { type: 'resizable', width, minWidth: MIN_ATTRIBUTE_COLUMN_WIDTH },
-        render: (log) => <AttributeCell attributeKey={semanticKey} value={getValue(log)} width={totalWidth} />,
+        render: renderValue,
         renderHeader: () => (
             <ResizableElement
                 defaultWidth={totalWidth}
                 minWidth={MIN_ATTRIBUTE_COLUMN_WIDTH + RESIZER_HANDLE_WIDTH}
                 maxWidth={Infinity}
-                onResize={(newWidth) => onResize?.(config.id, newWidth - RESIZER_HANDLE_WIDTH)}
+                onResize={(newWidth) => callbacks.onResize?.(config.id, newWidth - RESIZER_HANDLE_WIDTH)}
                 className="flex items-center h-full shrink-0 group/header"
                 innerClassName="h-full"
             >
@@ -249,67 +329,12 @@ export function createConfiguredColumn(params: {
                     <span className="truncate flex-1" title={title}>
                         {title}
                     </span>
-                    {(onRemove || onMove) && (
-                        <LemonMenu
-                            items={[
-                                onMove
-                                    ? {
-                                          label: 'Move left',
-                                          icon: <IconArrowLeft />,
-                                          disabledReason: isFirst ? 'Already at the start' : undefined,
-                                          onClick: () => onMove(config.id, 'left'),
-                                      }
-                                    : null,
-                                onMove
-                                    ? {
-                                          label: 'Move right',
-                                          icon: <IconArrowRight />,
-                                          disabledReason: isLast ? 'Already at the end' : undefined,
-                                          onClick: () => onMove(config.id, 'right'),
-                                      }
-                                    : null,
-                                onRemove
-                                    ? {
-                                          label: 'Remove column',
-                                          icon: <IconTrash />,
-                                          status: 'danger' as const,
-                                          onClick: () => onRemove(config.id),
-                                      }
-                                    : null,
-                            ]}
-                        >
-                            <LemonButton
-                                size="xsmall"
-                                noPadding
-                                icon={<IconEllipsis className="text-muted" />}
-                                className="shrink-0"
-                            />
-                        </LemonMenu>
+                    {config.type === 'timestamp' && (
+                        <TimestampSortButton orderBy={rendering.orderBy} onChangeOrderBy={rendering.onChangeOrderBy} />
                     )}
+                    <ColumnHeaderMenu config={config} callbacks={callbacks} isFirst={isFirst} isLast={isLast} />
                 </div>
             </ResizableElement>
-        ),
-    }
-}
-
-export function createMessageColumn(params: {
-    wrapBody: boolean
-    prettifyJson: boolean
-    flexWidthRef: RefObject<number | undefined | null>
-}): VirtualizedTableColumn<ParsedLogMessage> {
-    const { wrapBody, prettifyJson, flexWidthRef } = params
-
-    return {
-        key: 'message',
-        title: 'Message',
-        sizing: { type: 'flex', minWidth: MESSAGE_MIN_WIDTH },
-        render: (log) => (
-            <MessageColumnCell log={log} wrapBody={wrapBody} prettifyJson={prettifyJson} flexWidthRef={flexWidthRef} />
-        ),
-        renderHeader: () => (
-            <div className="flex items-center px-1" style={getMessageStyle(flexWidthRef.current ?? undefined)}>
-                Message
-            </div>
         ),
     }
 }

--- a/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
@@ -260,6 +260,8 @@ export function createConfiguredColumn(params: {
     const title = columnLabel(config)
 
     if (config.type === 'message') {
+        // Pinned to the end (see normalizeColumns) — removable, but never movable
+        const messageCallbacks = { ...callbacks, onMove: undefined }
         return {
             key: `col:${config.id}`,
             title,
@@ -280,7 +282,7 @@ export function createConfiguredColumn(params: {
                     <span className="truncate" title={title}>
                         {title}
                     </span>
-                    <ColumnHeaderMenu config={config} callbacks={callbacks} isFirst={isFirst} isLast={isLast} />
+                    <ColumnHeaderMenu config={config} callbacks={messageCallbacks} isFirst={isFirst} isLast={isLast} />
                 </div>
             ),
         }

--- a/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
@@ -260,8 +260,6 @@ export function createConfiguredColumn(params: {
     const title = columnLabel(config)
 
     if (config.type === 'message') {
-        // Pinned to the end (see normalizeColumns) — removable, but never movable
-        const messageCallbacks = { ...callbacks, onMove: undefined }
         return {
             key: `col:${config.id}`,
             title,
@@ -282,7 +280,13 @@ export function createConfiguredColumn(params: {
                     <span className="truncate" title={title}>
                         {title}
                     </span>
-                    <ColumnHeaderMenu config={config} callbacks={messageCallbacks} isFirst={isFirst} isLast={isLast} />
+                    {/* Pinned to the end (see normalizeColumns) — removable, but never movable */}
+                    <ColumnHeaderMenu
+                        config={config}
+                        callbacks={{ ...callbacks, onMove: undefined }}
+                        isFirst={isFirst}
+                        isLast={isLast}
+                    />
                 </div>
             ),
         }


### PR DESCRIPTION
## Problem

Stacked on #69275. After the rendering cutover, timestamp and message were still special-cased in the table assembly: fixed-width timestamp, flex message, neither movable nor removable, with their own factories bypassing the configured-column path. The table should be composed purely from the configured column list — one factory, uniform capabilities.

## Changes

- `createTimestampColumn` and `createMessageColumn` are gone. `createConfiguredColumn` is now the single factory for everything after the pinned controls column; the assembly in `VirtualizedLogsList` is one loop over the config list with no type checks.
- Timestamp becomes resizable (default width unchanged at 180px), keeps its sort toggle, and gains the same move/remove header menu as every other column.
- Message stays the flex fill column — the one layout exception, so it has no resizer — but is now reorderable and removable via its header menu.
- Message is pinned to the end of the table: it's the flex fill column, and the row FAB — whose scroll buttons drive the message cell's inner horizontal scroll — anchors to the row's right edge, so a mid-table message column would render wrong and scroll the wrong cell. `normalizeColumns` sorts message-type columns last after every mutation (applied state and configurator draft), the modal shows message as non-draggable with a tooltip, message's header menu drops its move actions, and the FAB scroll buttons hide when no message column exists.
- Type differences are confined to the cell renderer: TZLabel for timestamp, MessageCell for message, AttributeCell for everything else (preserving the PersonDisplay / ViewRecordingButton special cases). The header menu, resizer, and sort toggle are small extracted components composed per type.
- Also regenerates the stale `logsViewerDataLogicType` left behind by the earlier expression-keyed alias change.

Since the columns state and configurator modal already handle arbitrary orderings and removals of built-ins, no logic changes were needed — this closes the gap where the table couldn't render what the configurator could already express (e.g. message before timestamp, or a table with no message column).

## How did you test this code?

Automated: full logs frontend sweep, 436 tests across 23 suites, all passing. New `normalizeColumns` tests lock in the pinned-message invariant (a mutation path dropping normalization would drift message mid-table and break the FAB); the move/draft tests are updated to the pinned semantics. Otherwise the existing `moveColumn`/`removeColumn`/width tests and configurator draft tests already cover the state transitions that drive it, and column composition itself is exercised by the existing rendering tests. Typecheck clean for logs files. I did not manually drive the table; the branch is on Jon's preview stack.

## Docs update

None — behavior gated behind the same `logs-column-configuration` flag as the configurator.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jon directed this: all columns should be resizable/configurable, with the whole table composed from configured columns. I (Claude, via PostHog Code) kept message as flex rather than resizable — it's the fill column, and giving it a fixed width would leave dead space or overflow; reorder/remove still work on it. Timestamp's sort toggle stays attached to the timestamp column type rather than becoming a generic sortable-column concept, since logs ordering is timestamp-only server-side.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


