### PR TITLE
chore(experiments): stop tracking running-time-calculation auto-saves as experiment updates

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -134,11 +134,7 @@ FREEZE_EXPOSURE_MAX_UNRESOLVED_SHARE = 0.05
 # cohort id stamped into the (user-editable) flag filters can't point it at an arbitrary cohort.
 FREEZE_EXPOSURE_SNAPSHOT_NAME_PREFIX = "Exposure snapshot for experiment "
 
-# On launched experiments the frontend auto-persists a recomputed sample-size estimate, writing only
-# running_time_calculation. That's background auto-save, not a user edit, so it should not emit an
-# "experiment updated" analytics event. `_compute_changed_fields` returns a sorted/deduped list, so a
-# running-time-only write is exactly this list — an equality check skips it precisely while any
-# multi-field edit that also touches running_time_calculation is still reported.
+# Auto-saved sample-size estimate, not a user edit: skip the "experiment updated" event.
 RUNNING_TIME_ONLY_CHANGED_FIELDS = ["running_time_calculation"]
 
 

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -134,6 +134,13 @@ FREEZE_EXPOSURE_MAX_UNRESOLVED_SHARE = 0.05
 # cohort id stamped into the (user-editable) flag filters can't point it at an arbitrary cohort.
 FREEZE_EXPOSURE_SNAPSHOT_NAME_PREFIX = "Exposure snapshot for experiment "
 
+# On launched experiments the frontend auto-persists a recomputed sample-size estimate, writing only
+# running_time_calculation. That's background auto-save, not a user edit, so it should not emit an
+# "experiment updated" analytics event. `_compute_changed_fields` returns a sorted/deduped list, so a
+# running-time-only write is exactly this list — an equality check skips it precisely while any
+# multi-field edit that also touches running_time_calculation is still reported.
+RUNNING_TIME_ONLY_CHANGED_FIELDS = ["running_time_calculation"]
+
 
 class ExperimentQueryStatus(str, Enum):
     """
@@ -3034,7 +3041,7 @@ class ExperimentService:
             changed_fields = self._compute_changed_fields(
                 experiment, before_update=before_update, before_saved_metrics=before_saved_metrics
             )
-            if changed_fields:
+            if changed_fields and changed_fields != RUNNING_TIME_ONLY_CHANGED_FIELDS:
                 self._report_experiment_updated(
                     experiment, changed_fields=changed_fields, request=report_request, event_source=event_source
                 )

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -1901,6 +1901,39 @@ class TestExperimentService(APIBaseTest):
         assert self._updated_events(mock_report_user_action) == []
 
     @patch("products.experiments.backend.experiment_service.report_user_action")
+    def test_running_time_only_update_is_silent(self, mock_report_user_action):
+        # The frontend auto-persists a recomputed sample-size estimate on launched experiments,
+        # writing only running_time_calculation. That background auto-save must stay out of
+        # analytics, but the DB write itself must still land.
+        experiment = self._create_draft_experiment()
+        service = self._service()
+        service.update_experiment(
+            experiment,
+            {"running_time_calculation": {"recommended_sample_size": 4200}},
+            serializer_context=service._build_serializer_context(),
+        )
+
+        assert self._updated_events(mock_report_user_action) == []
+        experiment.refresh_from_db()
+        assert experiment.running_time_calculation == {"recommended_sample_size": 4200}
+
+    @patch("products.experiments.backend.experiment_service.report_user_action")
+    def test_running_time_change_alongside_real_edit_still_reports(self, mock_report_user_action):
+        # The skip is an exact-list match, so a genuine edit that also touches
+        # running_time_calculation must still report (a membership check would drop it).
+        experiment = self._create_draft_experiment()
+        service = self._service()
+        service.update_experiment(
+            experiment,
+            {"name": "Renamed", "running_time_calculation": {"recommended_sample_size": 4200}},
+            serializer_context=service._build_serializer_context(),
+        )
+
+        changed = self._changed_fields(mock_report_user_action)
+        assert "name" in changed
+        assert "running_time_calculation" in changed
+
+    @patch("products.experiments.backend.experiment_service.report_user_action")
     def test_update_changed_fields_multiple_at_once(self, mock_report_user_action):
         experiment = self._create_draft_experiment()
         saved_metric = self._make_saved_metric("Reusable conversion")

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -1901,39 +1901,6 @@ class TestExperimentService(APIBaseTest):
         assert self._updated_events(mock_report_user_action) == []
 
     @patch("products.experiments.backend.experiment_service.report_user_action")
-    def test_running_time_only_update_is_silent(self, mock_report_user_action):
-        # The frontend auto-persists a recomputed sample-size estimate on launched experiments,
-        # writing only running_time_calculation. That background auto-save must stay out of
-        # analytics, but the DB write itself must still land.
-        experiment = self._create_draft_experiment()
-        service = self._service()
-        service.update_experiment(
-            experiment,
-            {"running_time_calculation": {"recommended_sample_size": 4200}},
-            serializer_context=service._build_serializer_context(),
-        )
-
-        assert self._updated_events(mock_report_user_action) == []
-        experiment.refresh_from_db()
-        assert experiment.running_time_calculation == {"recommended_sample_size": 4200}
-
-    @patch("products.experiments.backend.experiment_service.report_user_action")
-    def test_running_time_change_alongside_real_edit_still_reports(self, mock_report_user_action):
-        # The skip is an exact-list match, so a genuine edit that also touches
-        # running_time_calculation must still report (a membership check would drop it).
-        experiment = self._create_draft_experiment()
-        service = self._service()
-        service.update_experiment(
-            experiment,
-            {"name": "Renamed", "running_time_calculation": {"recommended_sample_size": 4200}},
-            serializer_context=service._build_serializer_context(),
-        )
-
-        changed = self._changed_fields(mock_report_user_action)
-        assert "name" in changed
-        assert "running_time_calculation" in changed
-
-    @patch("products.experiments.backend.experiment_service.report_user_action")
     def test_update_changed_fields_multiple_at_once(self, mock_report_user_action):
         experiment = self._create_draft_experiment()
         saved_metric = self._make_saved_metric("Reusable conversion")


### PR DESCRIPTION
## Problem

The `"experiment updated"` analytics event is dominated by noise caused by `running_time_calculation`.

On launched experiments the frontend auto-persists a recomputed sample-size estimate (`persistRunningTimeEstimate` in `runningTimeLogic.ts`), which fires an `api.update(...)` carrying only `running_time_calculation`. This is background auto-save triggered on results refresh and page load, not a user editing their experiment. It currently accounts for the large majority of all `"experiment updated"` events, drowning out real edits and polluting any analysis of what people actually change.

## Changes

Remove tracking for running_time_calculation-triggered `update_experiment` calls

## How did you test this code?

No new tests: this is an internal-tracking-only change and dedicated cases would just add weight to the suite. Existing `changed_fields` coverage in `test_experiment_service.py` already exercises the `update_experiment` reporting path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marcel directed this work to cut the `running_time_calculation`-only auto-save noise out of the `"experiment updated"` event. I (Claude Code) made the one-guard change in `experiment_service.py`.

Decisions: filtered at the reporting guard, not inside `_compute_changed_fields`, since that diff is also the source of truth for other logic. Used a module-level constant with a one-line comment explaining the skip. Initially added two focused tests, then removed them at Marcel's direction since this is internal-only tracking and the cases would just bloat the suite.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
