### PR TITLE
feat(max): support ? prefix in #panel=max deep links as explicit pre-load

### DIFF
--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -87,6 +87,22 @@ describe('maxLogic', () => {
         })
     })
 
+    it('strips the pre-load prefix without setting autoRun for #panel=max:?Foo', async () => {
+        // `?` is the documented "pre-load only" modifier — the prefix must not leak into the question text
+        sidePanelStateLogic.mount()
+        await expectLogic(sidePanelStateLogic, () => {
+            sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max, '?Foo')
+        }).toDispatchActions(['openSidePanel'])
+
+        logic = maxLogic({ panelId: SIDE_PANEL_PANEL_ID })
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            autoRun: false,
+            question: 'Foo',
+        })
+    })
+
     it('does not reset conversation when 404 occurs during active message generation', async () => {
         router.actions.push('', {}, { panel: 'max' })
         sidePanelStateLogic.mount()

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -97,9 +97,9 @@ function parseCommandString(options: string): ParsedCommand {
         remaining = colonIndex === -1 ? '' : remaining.slice(colonIndex + 1)
     }
 
-    // Handle auto-run prefix
+    // Handle question prefixes: `!` auto-runs the question, `?` explicitly pre-loads it (same as no prefix)
     const autoRun = remaining.startsWith('!')
-    if (autoRun) {
+    if (autoRun || remaining.startsWith('?')) {
         remaining = remaining.slice(1)
     }
 


### PR DESCRIPTION
## Problem

PostHog AI deep links use `#panel=max:<question>` to pre-load a question into the composer and `#panel=max:!<question>` to auto-run it (added in #31909). Marketing has also been sharing links with a `?` prefix as the explicit "pre-load only" form, e.g. `https://app.posthog.com/#panel=max:?What%20changed%20across%20my%20product%20this%20week%3F`, but the parser never handled `?` - the question arrived in the composer with a literal leading `?` glued to it.

Refs #69246

## Changes

- `parseCommandString` in `maxLogic` now strips a leading `?` the same way it strips `!`, minus the auto-run. Bare questions keep working unchanged, and the `mode=` prefix composes with it as before.
- Since #69246 routes the new side panel composer through the same `parseCommandString`, the `?` form carries over to the new view once that lands.

## How did you test this code?

- Added one jest case asserting `#panel=max:?Foo` pre-loads `Foo` with `autoRun: false` - catches a regression where the prefix leaks into the question text or accidentally auto-runs; the existing cases only cover the bare and `!` forms.
- `maxLogic.test.ts` full suite: 40/40 passing. oxlint and oxfmt clean. Full `typescript:check` couldn't run meaningfully in this environment (kea typegen artifacts absent repo-wide); the change adds no new actions or type signatures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

A companion PR documents the deep-link contract on the wizard-and-docs handbook page in posthog.com.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude) while investigating why `#panel=max:!...` / `#panel=max:?...` links stopped working. Root cause of the breakage is separate: with `phai-sandbox-mode` on, the side panel renders the new composer which doesn't read the panel option string - #69246 (already open) fixes that. This PR only closes the gap that `?` was never an actual modifier: the original contract from #31909 was bare = pre-load, `!` = auto-run.
- Skills invoked: /writing-tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
