### PR TITLE
fix(subscriptions): freeze post-fix HogQL in the AI query plan

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -197,7 +197,7 @@ async def generate_ai_report(
             else:
                 spec = await _plan(team=team, user=user, prompt=prompt, window=window, trace_id=trace_correlation_id)
                 freshly_planned = True
-            rendered_results, failed_count, diagnostics, final_step_hogql = await _execute_plan(
+            rendered_results, failed_count, diagnostics = await _execute_plan(
                 spec, team, user, window, trace_correlation_id
             )
             report = await _synthesize(spec, rendered_results, team, user, trace_correlation_id)
@@ -230,7 +230,6 @@ async def generate_ai_report(
             report = _all_queries_failed_notice(total_steps) + report
         plan_to_persist = _plan_to_freeze(
             spec.plan,
-            final_step_hogql=final_step_hogql,
             freshly_planned=freshly_planned,
             failed_count=failed_count,
             total_steps=total_steps,
@@ -247,31 +246,26 @@ async def generate_ai_report(
 def _plan_to_freeze(
     plan: QueryPlan,
     *,
-    final_step_hogql: list[str],
     freshly_planned: bool,
     failed_count: int,
     total_steps: int,
     trace_correlation_id: Optional[Union[int, str]],
 ) -> Optional[dict]:
+    # Steps already carry their final HogQL by this point — see the write-back in `run_step`.
     # Never freeze a plan the next delivery is better off re-planning: an all-failed plan would replay
     # broken HogQL forever, and a step without any window placeholder would scan unbounded every run.
     if not freshly_planned:
         return None
     if total_steps and failed_count >= total_steps:
         return None
-    # Freeze each step's final HogQL (post any fix-LLM rewrite) — freezing the planner's original would
-    # replay the broken query and re-run the fix LLM on every reused delivery.
-    frozen_plan = plan.model_copy(deep=True)
-    for step, final_hogql in zip(frozen_plan.steps, final_step_hogql, strict=True):
-        step.hogql = final_hogql
-    if not all(any(token in step.hogql for token in WINDOW_PLACEHOLDERS) for step in frozen_plan.steps):
+    if not all(any(token in step.hogql for token in WINDOW_PLACEHOLDERS) for step in plan.steps):
         logger.warning(
             "ai_report.plan_missing_window_placeholder_not_frozen",
             trace_correlation_id=trace_correlation_id,
         )
         return None
     # Versioned envelope: bumping AI_QUERY_PLAN_VERSION lazily re-plans every frozen subscription.
-    return {"version": AI_QUERY_PLAN_VERSION, "plan": frozen_plan.model_dump()}
+    return {"version": AI_QUERY_PLAN_VERSION, "plan": plan.model_dump()}
 
 
 async def _plan(
@@ -313,7 +307,7 @@ async def _execute_plan(
     user: User,
     window: ReportWindow,
     trace_correlation_id: Optional[Union[int, str]],
-) -> tuple[list[str], int, list[QueryStepDiagnostic], list[str]]:
+) -> tuple[list[str], int, list[QueryStepDiagnostic]]:
     try:
         return await _run_steps(spec, team, user, window, trace_correlation_id)
     except Exception as exc:
@@ -383,7 +377,7 @@ async def _run_steps(
     user: User,
     window: ReportWindow,
     trace_correlation_id: Optional[Union[int, str]],
-) -> tuple[list[str], int, list[QueryStepDiagnostic], list[str]]:
+) -> tuple[list[str], int, list[QueryStepDiagnostic]]:
     executor = AssistantQueryExecutor(team, datetime.now(tz=UTC), user=user)
     # Cap simultaneous ClickHouse scans per report; excess steps queue until a slot frees.
     step_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_STEPS)
@@ -395,12 +389,10 @@ async def _run_steps(
         max(_MIN_STEP_RESULT_CHARS, _SYNTHESIS_RESULTS_CHAR_BUDGET // len(spec.plan.steps)),
     )
 
-    async def run_step(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic, str]:
+    async def run_step(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic]:
         # `current_hogql` keeps the window-agnostic form (the `{{date_range}}` placeholder) so it round-trips
         # through the fix LLM unchanged; the run's fresh bounds are substituted into `executable_hogql` on
         # every attempt. The diagnostic records the executed SQL (placeholder resolved) for debugging.
-        # The third element is the window-agnostic HogQL the caller should freeze: the post-fix form for a
-        # step that succeeded, the planner's original for a step that failed (so a broken rewrite isn't kept).
         current_hogql = step.hogql
         last_exc: Optional[BaseException] = None
         # planner output — strip framing markers so it can't break the <query_results> envelope
@@ -416,10 +408,13 @@ async def _run_steps(
                 )
                 # result values are attacker-influenceable (public project tokens) — strip framing markers
                 safe_formatted = strip_llm_framing_markers(formatted, per_step_cap)
+                # Write the succeeding query (post any fix-LLM rewrite, still window-agnostic) back onto
+                # the step so `_plan_to_freeze` freezes what actually ran — a no-op unless the fix LLM
+                # rewrote it. A failed step keeps the planner's original, never a broken rewrite.
+                step.hogql = current_hogql
                 return (
                     f"### {safe_description}\n\n{safe_formatted}",
                     QueryStepDiagnostic(description=safe_description, hogql=executable_hogql, ok=True, error_type=None),
-                    current_hogql,
                 )
             except Exception as exc:
                 last_exc = exc
@@ -468,20 +463,18 @@ async def _run_steps(
                 error_type=type_name,
                 human_readable_error=_safe_error_message(last_exc) if last_exc is not None else None,
             ),
-            step.hogql,
         )
 
-    async def run_step_bounded(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic, str]:
+    async def run_step_bounded(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic]:
         # Hold a slot for the whole step (query + any fix/rerun) so concurrent ClickHouse load stays bounded.
         async with step_semaphore:
             return await run_step(step)
 
     step_results = await asyncio.gather(*(run_step_bounded(step) for step in spec.plan.steps))
-    rendered = [text for text, _, _ in step_results]
-    diagnostics = [diag for _, diag, _ in step_results]
-    final_hogql = [hogql for _, _, hogql in step_results]
+    rendered = [text for text, _ in step_results]
+    diagnostics = [diag for _, diag in step_results]
     failed_count = sum(1 for diag in diagnostics if not diag.ok)
-    return rendered, failed_count, diagnostics, final_hogql
+    return rendered, failed_count, diagnostics
 
 
 async def _arequest_hogql_fix(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/report_pipeline.py
@@ -197,7 +197,7 @@ async def generate_ai_report(
             else:
                 spec = await _plan(team=team, user=user, prompt=prompt, window=window, trace_id=trace_correlation_id)
                 freshly_planned = True
-            rendered_results, failed_count, diagnostics = await _execute_plan(
+            rendered_results, failed_count, diagnostics, final_step_hogql = await _execute_plan(
                 spec, team, user, window, trace_correlation_id
             )
             report = await _synthesize(spec, rendered_results, team, user, trace_correlation_id)
@@ -230,6 +230,7 @@ async def generate_ai_report(
             report = _all_queries_failed_notice(total_steps) + report
         plan_to_persist = _plan_to_freeze(
             spec.plan,
+            final_step_hogql=final_step_hogql,
             freshly_planned=freshly_planned,
             failed_count=failed_count,
             total_steps=total_steps,
@@ -246,6 +247,7 @@ async def generate_ai_report(
 def _plan_to_freeze(
     plan: QueryPlan,
     *,
+    final_step_hogql: list[str],
     freshly_planned: bool,
     failed_count: int,
     total_steps: int,
@@ -257,14 +259,19 @@ def _plan_to_freeze(
         return None
     if total_steps and failed_count >= total_steps:
         return None
-    if not all(any(token in step.hogql for token in WINDOW_PLACEHOLDERS) for step in plan.steps):
+    # Freeze each step's final HogQL (post any fix-LLM rewrite) — freezing the planner's original would
+    # replay the broken query and re-run the fix LLM on every reused delivery.
+    frozen_plan = plan.model_copy(deep=True)
+    for step, final_hogql in zip(frozen_plan.steps, final_step_hogql, strict=True):
+        step.hogql = final_hogql
+    if not all(any(token in step.hogql for token in WINDOW_PLACEHOLDERS) for step in frozen_plan.steps):
         logger.warning(
             "ai_report.plan_missing_window_placeholder_not_frozen",
             trace_correlation_id=trace_correlation_id,
         )
         return None
     # Versioned envelope: bumping AI_QUERY_PLAN_VERSION lazily re-plans every frozen subscription.
-    return {"version": AI_QUERY_PLAN_VERSION, "plan": plan.model_dump()}
+    return {"version": AI_QUERY_PLAN_VERSION, "plan": frozen_plan.model_dump()}
 
 
 async def _plan(
@@ -306,7 +313,7 @@ async def _execute_plan(
     user: User,
     window: ReportWindow,
     trace_correlation_id: Optional[Union[int, str]],
-) -> tuple[list[str], int, list[QueryStepDiagnostic]]:
+) -> tuple[list[str], int, list[QueryStepDiagnostic], list[str]]:
     try:
         return await _run_steps(spec, team, user, window, trace_correlation_id)
     except Exception as exc:
@@ -376,7 +383,7 @@ async def _run_steps(
     user: User,
     window: ReportWindow,
     trace_correlation_id: Optional[Union[int, str]],
-) -> tuple[list[str], int, list[QueryStepDiagnostic]]:
+) -> tuple[list[str], int, list[QueryStepDiagnostic], list[str]]:
     executor = AssistantQueryExecutor(team, datetime.now(tz=UTC), user=user)
     # Cap simultaneous ClickHouse scans per report; excess steps queue until a slot frees.
     step_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_STEPS)
@@ -388,10 +395,12 @@ async def _run_steps(
         max(_MIN_STEP_RESULT_CHARS, _SYNTHESIS_RESULTS_CHAR_BUDGET // len(spec.plan.steps)),
     )
 
-    async def run_step(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic]:
+    async def run_step(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic, str]:
         # `current_hogql` keeps the window-agnostic form (the `{{date_range}}` placeholder) so it round-trips
         # through the fix LLM unchanged; the run's fresh bounds are substituted into `executable_hogql` on
         # every attempt. The diagnostic records the executed SQL (placeholder resolved) for debugging.
+        # The third element is the window-agnostic HogQL the caller should freeze: the post-fix form for a
+        # step that succeeded, the planner's original for a step that failed (so a broken rewrite isn't kept).
         current_hogql = step.hogql
         last_exc: Optional[BaseException] = None
         # planner output — strip framing markers so it can't break the <query_results> envelope
@@ -410,6 +419,7 @@ async def _run_steps(
                 return (
                     f"### {safe_description}\n\n{safe_formatted}",
                     QueryStepDiagnostic(description=safe_description, hogql=executable_hogql, ok=True, error_type=None),
+                    current_hogql,
                 )
             except Exception as exc:
                 last_exc = exc
@@ -458,18 +468,20 @@ async def _run_steps(
                 error_type=type_name,
                 human_readable_error=_safe_error_message(last_exc) if last_exc is not None else None,
             ),
+            step.hogql,
         )
 
-    async def run_step_bounded(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic]:
+    async def run_step_bounded(step: QueryPlanStep) -> tuple[str, QueryStepDiagnostic, str]:
         # Hold a slot for the whole step (query + any fix/rerun) so concurrent ClickHouse load stays bounded.
         async with step_semaphore:
             return await run_step(step)
 
     step_results = await asyncio.gather(*(run_step_bounded(step) for step in spec.plan.steps))
-    rendered = [text for text, _ in step_results]
-    diagnostics = [diag for _, diag in step_results]
+    rendered = [text for text, _, _ in step_results]
+    diagnostics = [diag for _, diag, _ in step_results]
+    final_hogql = [hogql for _, _, hogql in step_results]
     failed_count = sum(1 for diag in diagnostics if not diag.ok)
-    return rendered, failed_count, diagnostics
+    return rendered, failed_count, diagnostics, final_hogql
 
 
 async def _arequest_hogql_fix(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -45,8 +45,9 @@ _ALL_FAILED_RUN = (
     ["### s0\n\n_Query failed to run (ExposedHogQLError)_"],
     1,
     [QueryStepDiagnostic("s0", "SELECT bad", False, "ExposedHogQLError")],
+    ["SELECT count() FROM events WHERE {{date_range}}"],
 )
-_OK_RUN = (["### s\n\nok"], 0, [QueryStepDiagnostic("s", "SELECT count() FROM events", True, None)])
+_OK_RUN = (["### s\n\nok"], 0, [QueryStepDiagnostic("s", "SELECT count() FROM events", True, None)], ["SELECT 1"])
 
 
 def _spec(steps: int = 1) -> EnrichedPromptSpec:
@@ -112,6 +113,7 @@ async def test_successful_report_emits_slo_success(
             QueryStepDiagnostic(description="s0", hogql="SELECT 1", ok=True, error_type=None),
             QueryStepDiagnostic(description="s1", hogql="SELECT 2", ok=True, error_type=None),
         ],
+        ["SELECT 1", "SELECT 2"],
     )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
@@ -139,6 +141,7 @@ async def test_degraded_report_still_synthesizes(
         ["### s0\n\n_Query failed to run (ExposedHogQLError) — metric not computed, not empty data._"],
         1,
         [QueryStepDiagnostic(description="s0", hogql="SELECT bad", ok=False, error_type="ExposedHogQLError")],
+        ["SELECT 1"],
     )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Weekly report")
 
@@ -171,6 +174,7 @@ async def test_synthesis_failure_wrapped_with_stage(
         ["### s0\n\nok"],
         0,
         [QueryStepDiagnostic(description="s0", hogql="SELECT 1", ok=True, error_type=None)],
+        ["SELECT 1"],
     )
     mock_chat.return_value.invoke.side_effect = RuntimeError("synth boom")
 
@@ -225,7 +229,7 @@ async def test_request_hogql_fix_returns_none_on_wrong_type(mock_chat: MagicMock
 @patch(f"{_RP}.AssistantQueryExecutor")
 async def test_run_steps_non_retryable_error_degrades_to_placeholder(mock_executor_cls: MagicMock) -> None:
     mock_executor_cls.return_value.arun_and_format_query = AsyncMock(side_effect=RuntimeError("boom"))
-    rendered, failed, diagnostics = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
+    rendered, failed, diagnostics, _ = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
     assert failed == 1
     assert "Query failed to run" in rendered[0]
     assert diagnostics[0].ok is False
@@ -263,6 +267,7 @@ async def test_synthesis_prompt_carries_the_failure_marker(
         ["### s0\n\nfailed"],
         1,
         [QueryStepDiagnostic(description="s0", hogql="SELECT bad", ok=False, error_type="ExposedHogQLError")],
+        ["SELECT 1"],
     )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
@@ -282,13 +287,17 @@ async def test_run_steps_retries_then_succeeds(mock_executor_cls: MagicMock, moc
         side_effect=[ExposedHogQLError("bad query"), ("formatted table", None)]
     )
     mock_fix.return_value = "SELECT fixed"
-    rendered, failed, diagnostics = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
+    rendered, failed, diagnostics, final_hogql = await _run_steps(
+        _spec(steps=1), MagicMock(), MagicMock(), _test_window(), None
+    )
     assert failed == 0
     assert "formatted table" in rendered[0]
     mock_fix.assert_awaited_once()
     # The diagnostic tracks the fixed query (current_hogql), not the original SELECT 1.
     assert diagnostics[0].ok is True
     assert diagnostics[0].hogql == "SELECT fixed"
+    # The freezable form is the post-fix query — freezing the original would re-run the fix every reuse.
+    assert final_hogql == ["SELECT fixed"]
 
 
 @patch(f"{_RP}._arequest_hogql_fix", new_callable=AsyncMock)
@@ -300,7 +309,7 @@ async def test_run_steps_breaks_early_when_fix_returns_same_query(
     # degrade rather than burn the retry budget on an identical query.
     mock_executor_cls.return_value.arun_and_format_query = AsyncMock(side_effect=ExposedHogQLError("bad query"))
     mock_fix.return_value = "SELECT 1"  # identical to QueryPlanStep.hogql in _spec()
-    rendered, failed, diagnostics = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
+    rendered, failed, diagnostics, _ = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
     assert failed == 1
     assert "Query failed to run" in rendered[0]
     # Executor ran exactly once (no rerun of the identical fixed query); the fix was requested once.
@@ -392,7 +401,7 @@ async def test_frozen_plan_reused_skips_planner_and_event_selection(
     # NEITHER LLM pass the live path uses — build_enriched_prompt wraps both the planner and the
     # event-selection model, so asserting it's never called proves both are skipped.
     mock_frozen.return_value = _spec(steps=1)
-    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)])
+    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)], ["SELECT 1"])
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
     result = await generate_ai_report(
@@ -417,12 +426,63 @@ async def test_unfrozen_run_returns_plan_to_persist(
     # dict is what build_frozen_prompt validates back on reuse, so this guards the persist↔reuse contract.
     spec = _spec_with_window_placeholder()
     mock_bep.return_value = spec
-    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)])
+    mock_run.return_value = (
+        ["### s0\n\nok"],
+        0,
+        [QueryStepDiagnostic("s0", "SELECT 1", True, None)],
+        [spec.plan.steps[0].hogql],
+    )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
     result = await generate_ai_report(team=MagicMock(), user=MagicMock(), prompt="x", window=_test_window())
 
     assert result.plan_to_persist == {"version": AI_QUERY_PLAN_VERSION, "plan": spec.plan.model_dump()}
+
+
+@pytest.mark.parametrize(
+    "fixed_hogql,expected_frozen_hogql",
+    [
+        # The fix LLM rewrote the step and the rerun succeeded: the frozen plan must carry the post-fix
+        # query, or every reused delivery replays the broken original and re-bills the fix LLM.
+        pytest.param(
+            "SELECT uniq(person_id) FROM events WHERE {{date_range}}",
+            "SELECT uniq(person_id) FROM events WHERE {{date_range}}",
+            id="post_fix_hogql_is_frozen",
+        ),
+        # The fixer stripped the window placeholder: the guard applies to the post-fix text, so nothing
+        # is frozen — freezing it would cement an unbounded scan.
+        pytest.param("SELECT uniq(person_id) FROM events", None, id="fix_without_placeholder_not_frozen"),
+    ],
+)
+@patch(_SLO_CAPTURE)
+@patch(f"{_RP}.MaxChatOpenAI")
+@patch(f"{_RP}._arequest_hogql_fix", new_callable=AsyncMock)
+@patch(f"{_RP}.AssistantQueryExecutor")
+@patch(f"{_RP}.build_enriched_prompt")
+async def test_freeze_carries_post_fix_hogql(
+    mock_bep: MagicMock,
+    mock_executor_cls: MagicMock,
+    mock_fix: AsyncMock,
+    mock_chat: MagicMock,
+    _mock_capture: MagicMock,
+    fixed_hogql: str,
+    expected_frozen_hogql: str | None,
+) -> None:
+    mock_bep.return_value = _spec_with_window_placeholder()
+    mock_executor_cls.return_value.arun_and_format_query = AsyncMock(
+        side_effect=[ExposedHogQLError("bad query"), ("formatted table", None)]
+    )
+    mock_fix.return_value = fixed_hogql
+    mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
+
+    result = await generate_ai_report(team=MagicMock(), user=MagicMock(), prompt="x", window=_test_window())
+
+    if expected_frozen_hogql is None:
+        assert result.plan_to_persist is None
+    else:
+        assert result.plan_to_persist is not None
+        assert result.plan_to_persist["version"] == AI_QUERY_PLAN_VERSION
+        assert result.plan_to_persist["plan"]["steps"][0]["hogql"] == expected_frozen_hogql
 
 
 @patch(f"{_RP}.AssistantQueryExecutor")
@@ -500,7 +560,12 @@ async def test_invalid_stored_plan_self_heals_by_replanning(
     # A stored plan that no longer validates (e.g. QueryPlan schema changed) must re-plan live, not fail
     # the delivery — otherwise a schema change would auto-disable every frozen subscription.
     mock_bep.return_value = _spec_with_window_placeholder()
-    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)])
+    mock_run.return_value = (
+        ["### s0\n\nok"],
+        0,
+        [QueryStepDiagnostic("s0", "SELECT 1", True, None)],
+        ["SELECT count() FROM events WHERE {{date_range}}"],
+    )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
     result = await generate_ai_report(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -45,9 +45,8 @@ _ALL_FAILED_RUN = (
     ["### s0\n\n_Query failed to run (ExposedHogQLError)_"],
     1,
     [QueryStepDiagnostic("s0", "SELECT bad", False, "ExposedHogQLError")],
-    ["SELECT count() FROM events WHERE {{date_range}}"],
 )
-_OK_RUN = (["### s\n\nok"], 0, [QueryStepDiagnostic("s", "SELECT count() FROM events", True, None)], ["SELECT 1"])
+_OK_RUN = (["### s\n\nok"], 0, [QueryStepDiagnostic("s", "SELECT count() FROM events", True, None)])
 
 
 def _spec(steps: int = 1) -> EnrichedPromptSpec:
@@ -113,7 +112,6 @@ async def test_successful_report_emits_slo_success(
             QueryStepDiagnostic(description="s0", hogql="SELECT 1", ok=True, error_type=None),
             QueryStepDiagnostic(description="s1", hogql="SELECT 2", ok=True, error_type=None),
         ],
-        ["SELECT 1", "SELECT 2"],
     )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
@@ -141,7 +139,6 @@ async def test_degraded_report_still_synthesizes(
         ["### s0\n\n_Query failed to run (ExposedHogQLError) — metric not computed, not empty data._"],
         1,
         [QueryStepDiagnostic(description="s0", hogql="SELECT bad", ok=False, error_type="ExposedHogQLError")],
-        ["SELECT 1"],
     )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Weekly report")
 
@@ -174,7 +171,6 @@ async def test_synthesis_failure_wrapped_with_stage(
         ["### s0\n\nok"],
         0,
         [QueryStepDiagnostic(description="s0", hogql="SELECT 1", ok=True, error_type=None)],
-        ["SELECT 1"],
     )
     mock_chat.return_value.invoke.side_effect = RuntimeError("synth boom")
 
@@ -229,7 +225,7 @@ async def test_request_hogql_fix_returns_none_on_wrong_type(mock_chat: MagicMock
 @patch(f"{_RP}.AssistantQueryExecutor")
 async def test_run_steps_non_retryable_error_degrades_to_placeholder(mock_executor_cls: MagicMock) -> None:
     mock_executor_cls.return_value.arun_and_format_query = AsyncMock(side_effect=RuntimeError("boom"))
-    rendered, failed, diagnostics, _ = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
+    rendered, failed, diagnostics = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
     assert failed == 1
     assert "Query failed to run" in rendered[0]
     assert diagnostics[0].ok is False
@@ -267,7 +263,6 @@ async def test_synthesis_prompt_carries_the_failure_marker(
         ["### s0\n\nfailed"],
         1,
         [QueryStepDiagnostic(description="s0", hogql="SELECT bad", ok=False, error_type="ExposedHogQLError")],
-        ["SELECT 1"],
     )
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
@@ -287,17 +282,16 @@ async def test_run_steps_retries_then_succeeds(mock_executor_cls: MagicMock, moc
         side_effect=[ExposedHogQLError("bad query"), ("formatted table", None)]
     )
     mock_fix.return_value = "SELECT fixed"
-    rendered, failed, diagnostics, final_hogql = await _run_steps(
-        _spec(steps=1), MagicMock(), MagicMock(), _test_window(), None
-    )
+    spec = _spec(steps=1)
+    rendered, failed, diagnostics = await _run_steps(spec, MagicMock(), MagicMock(), _test_window(), None)
     assert failed == 0
     assert "formatted table" in rendered[0]
     mock_fix.assert_awaited_once()
     # The diagnostic tracks the fixed query (current_hogql), not the original SELECT 1.
     assert diagnostics[0].ok is True
     assert diagnostics[0].hogql == "SELECT fixed"
-    # The freezable form is the post-fix query — freezing the original would re-run the fix every reuse.
-    assert final_hogql == ["SELECT fixed"]
+    # Proves the in-place write-back; test_freeze_carries_post_fix_hogql covers the guard -> freeze path.
+    assert spec.plan.steps[0].hogql == "SELECT fixed"
 
 
 @patch(f"{_RP}._arequest_hogql_fix", new_callable=AsyncMock)
@@ -309,7 +303,7 @@ async def test_run_steps_breaks_early_when_fix_returns_same_query(
     # degrade rather than burn the retry budget on an identical query.
     mock_executor_cls.return_value.arun_and_format_query = AsyncMock(side_effect=ExposedHogQLError("bad query"))
     mock_fix.return_value = "SELECT 1"  # identical to QueryPlanStep.hogql in _spec()
-    rendered, failed, diagnostics, _ = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
+    rendered, failed, diagnostics = await _run_steps(_spec(steps=1), MagicMock(), MagicMock(), _test_window(), None)
     assert failed == 1
     assert "Query failed to run" in rendered[0]
     # Executor ran exactly once (no rerun of the identical fixed query); the fix was requested once.
@@ -401,7 +395,7 @@ async def test_frozen_plan_reused_skips_planner_and_event_selection(
     # NEITHER LLM pass the live path uses — build_enriched_prompt wraps both the planner and the
     # event-selection model, so asserting it's never called proves both are skipped.
     mock_frozen.return_value = _spec(steps=1)
-    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)], ["SELECT 1"])
+    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)])
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
     result = await generate_ai_report(
@@ -426,12 +420,7 @@ async def test_unfrozen_run_returns_plan_to_persist(
     # dict is what build_frozen_prompt validates back on reuse, so this guards the persist↔reuse contract.
     spec = _spec_with_window_placeholder()
     mock_bep.return_value = spec
-    mock_run.return_value = (
-        ["### s0\n\nok"],
-        0,
-        [QueryStepDiagnostic("s0", "SELECT 1", True, None)],
-        [spec.plan.steps[0].hogql],
-    )
+    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)])
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
     result = await generate_ai_report(team=MagicMock(), user=MagicMock(), prompt="x", window=_test_window())
@@ -560,12 +549,7 @@ async def test_invalid_stored_plan_self_heals_by_replanning(
     # A stored plan that no longer validates (e.g. QueryPlan schema changed) must re-plan live, not fail
     # the delivery — otherwise a schema change would auto-disable every frozen subscription.
     mock_bep.return_value = _spec_with_window_placeholder()
-    mock_run.return_value = (
-        ["### s0\n\nok"],
-        0,
-        [QueryStepDiagnostic("s0", "SELECT 1", True, None)],
-        ["SELECT count() FROM events WHERE {{date_range}}"],
-    )
+    mock_run.return_value = (["### s0\n\nok"], 0, [QueryStepDiagnostic("s0", "SELECT 1", True, None)])
     mock_chat.return_value.invoke.return_value = MagicMock(content="# Report")
 
     result = await generate_ai_report(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_report_pipeline.py
@@ -31,6 +31,7 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.spec_genera
 )
 
 _RP = "products.exports.backend.temporal.subscriptions.ai_subscription.report_pipeline"
+_SG = "products.exports.backend.temporal.subscriptions.ai_subscription.spec_generator"
 # slo_operation emits through posthoganalytics.capture; patch that boundary to inspect the SLO events.
 _SLO_CAPTURE = "posthog.slo.events.posthoganalytics.capture"
 
@@ -468,10 +469,35 @@ async def test_freeze_carries_post_fix_hogql(
 
     if expected_frozen_hogql is None:
         assert result.plan_to_persist is None
-    else:
-        assert result.plan_to_persist is not None
-        assert result.plan_to_persist["version"] == AI_QUERY_PLAN_VERSION
-        assert result.plan_to_persist["plan"]["steps"][0]["hogql"] == expected_frozen_hogql
+        return
+    assert result.plan_to_persist is not None
+    assert result.plan_to_persist["version"] == AI_QUERY_PLAN_VERSION
+    assert result.plan_to_persist["plan"]["steps"][0]["hogql"] == expected_frozen_hogql
+
+    # Round trip — the payoff the freeze exists for: reusing the frozen plan runs the fixed query
+    # first try, so the fix LLM is never invoked again (the pre-fix bug re-billed it every delivery).
+    mock_fix.reset_mock()
+
+    # Succeed only for the fixed query: a regression that froze the pre-fix original would fail here,
+    # re-invoke the fixer, and trip the assert_not_awaited below.
+    async def _reuse_execute(query):
+        if "uniq(person_id)" not in query.query:
+            raise ExposedHogQLError("bad query")
+        return ("formatted table", None)
+
+    reuse_executor = AsyncMock(side_effect=_reuse_execute)
+    mock_executor_cls.return_value.arun_and_format_query = reuse_executor
+    with patch(f"{_SG}.build_context_blob", return_value="c"):
+        reused = await generate_ai_report(
+            team=MagicMock(),
+            user=MagicMock(),
+            prompt="x",
+            window=_test_window(),
+            ai_query_plan=result.plan_to_persist,
+        )
+    mock_fix.assert_not_awaited()
+    reuse_executor.assert_awaited_once()  # fixed query succeeds on the first attempt, no retry
+    assert reused.plan_to_persist is None  # nothing new to freeze on a reused run
 
 
 @patch(f"{_RP}.AssistantQueryExecutor")


### PR DESCRIPTION
## Problem

AI subscription reports freeze a query plan (`Subscription.ai_query_plan`) on the first delivery so later runs skip the planner LLM and produce consistent results. But the frozen plan stored the planner's *original* per-step HogQL — and a step can succeed only after the fix LLM (`_arequest_hogql_fix`) rewrites its query mid-run.

Freezing the pre-fix form means every reused delivery replays the known-broken query, fails, and re-bills the fix LLM for the same repair — the exact repetition the frozen plan exists to avoid. Determinism is also only partial: the fixer re-rolls each run and may not produce the same rewrite twice.

Found during review of the (now closed) #66824.

## Changes

- `run_step` writes each succeeding step's **final window-agnostic HogQL** (post any fix-LLM rewrite) back onto its plan step, so `_plan_to_freeze` freezes what actually ran. A failed step never reaches the write-back and keeps the planner's original — a broken rewrite is never kept. Synthesis reads only the plan's intent, so the in-place update has no other readers. (An earlier revision threaded this through widened return tuples; a review pass simplified it to the write-back.)
- The existing fail-safe now applies to the **post-fix** text: if the fixer stripped the `{{date_range}}`-style window placeholder, nothing is frozen (freezing it would cement an unbounded scan) and the next run re-plans — same degradation semantics as today.

```mermaid
flowchart LR
    P[planner HogQL] --> E{executes?}
    E -- yes --> F[freeze as-is]
    E -- no --> X[fix LLM rewrite] --> R{rerun succeeds?}
    R -- yes --> G[freeze POST-fix HogQL]
    R -- no --> O[keep original, step degrades]
    G --> H{placeholder still present?}
    H -- no --> N[do not freeze - re-plan next run]
```

## How did you test this code?

I'm an agent (Claude Code via PostHog Code). Automated tests only — no manual testing claimed.

- New parameterized test `test_freeze_carries_post_fix_hogql` (through the public `generate_ai_report`): (a) a step fixed by the fix LLM freezes the post-fix HogQL, not the original — catches the regression where reused plans replay broken queries; (b) a fixer output without the window placeholder freezes nothing — pins the fail-safe to the post-fix text.
- Extended `test_run_steps_retries_then_succeeds` to assert the freezable form is the fixed query.
- Full touched suite green locally: `test_report_pipeline.py` 30/30. Existing tests updated only mechanically for the widened `_run_steps`/`_execute_plan` return tuple; none encoded the old pre-fix freezing behavior.
- `ruff check` / `ruff format` clean. (Local DB-fixture errors in unrelated test files reproduce identically on clean master — pre-existing environment staleness, not this change.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the freeze internals; behavior change is cost/consistency only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Code) in an isolated worktree, directed by @vdekrijger.
- Origin: review finding on #66824 (closed in favor of this upstream fix — improving planner/frozen-plan quality beats maintaining owner-facing plan-editing escape hatches).
- Key decision: failed steps keep the planner's original HogQL in the frozen plan rather than a possibly-broken rewrite; the placeholder fail-safe intentionally moved to the post-fix text.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
