### PR TITLE
fix(metrics): fetch attribute keys for the group-by picker

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -112,6 +112,8 @@ export const MetricsViewer = (): JSX.Element => {
         viewMode,
         statSummary,
         groupByKeys,
+        attributeKeyOptions,
+        attributeKeyOptionsLoading,
         filterGroup,
         attributeEndpointFilters,
         chartSeries,
@@ -133,6 +135,8 @@ export const MetricsViewer = (): JSX.Element => {
         setViewMode,
         setStatSummary,
         setGroupByKeys,
+        setGroupBySearch,
+        loadAttributeKeyOptions,
         setFilterGroup,
         setLiveRefresh,
         fetchQueryResults,
@@ -230,7 +234,10 @@ export const MetricsViewer = (): JSX.Element => {
                     allowCustomValues
                     value={groupByKeys}
                     onChange={setGroupByKeys}
-                    options={[]}
+                    options={attributeKeyOptions}
+                    loading={attributeKeyOptionsLoading}
+                    onInputChange={setGroupBySearch}
+                    onFocus={() => loadAttributeKeyOptions({})}
                     placeholder="Group by attribute…"
                     className="min-w-[12rem]"
                     data-attr="metrics-viewer-group-by"

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -1,3 +1,5 @@
+import { expectLogic } from 'kea-test-utils'
+
 import { NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
@@ -8,7 +10,7 @@ import {
     UniversalFiltersGroupValue,
 } from '~/types'
 
-import { metricsValuesRetrieve } from 'products/metrics/frontend/generated/api'
+import { metricsAttributesRetrieve, metricsValuesRetrieve } from 'products/metrics/frontend/generated/api'
 
 import { metricNamePickerLogic } from './metricNamePickerLogic'
 import { metricsViewerLogic, NEW_QUERY_STARTED_ERROR_MESSAGE } from './metricsViewerLogic'
@@ -16,6 +18,7 @@ import { metricsViewerLogic, NEW_QUERY_STARTED_ERROR_MESSAGE } from './metricsVi
 jest.mock('products/metrics/frontend/generated/api', () => ({
     ...jest.requireActual('products/metrics/frontend/generated/api'),
     metricsValuesRetrieve: jest.fn(),
+    metricsAttributesRetrieve: jest.fn(),
 }))
 
 const filterGroupWith = (filters: Record<string, any>[]): UniversalFiltersGroup => ({
@@ -176,5 +179,26 @@ describe('metricsViewerLogic', () => {
             ])
         )
         expect(logic.values.queryFilters).toEqual([{ key: 'env', op: 'eq', value: 'prod' }])
+    })
+
+    // The group-by picker shipped with `options={[]}` and never fetched, so it offered no
+    // attribute keys. Typing must query the attributes endpoint (scoped by search) and map
+    // `{ name }` rows into `{ key, label }` options.
+    it('group-by search fetches attribute keys and maps them into options', async () => {
+        jest.mocked(metricsAttributesRetrieve).mockResolvedValue({
+            results: [{ name: 'env' }, { name: 'service_name' }],
+            count: 2,
+        })
+        await expectLogic(logic, () => {
+            logic.actions.setGroupBySearch('e')
+        }).toDispatchActions(['loadAttributeKeyOptions', 'loadAttributeKeyOptionsSuccess'])
+        expect(metricsAttributesRetrieve).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ search: 'e' })
+        )
+        expect(logic.values.attributeKeyOptions).toEqual([
+            { key: 'env', label: 'env' },
+            { key: 'service_name', label: 'service_name' },
+        ])
     })
 })

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -19,7 +19,11 @@ import { MetricsQuery, MetricsQueryClause, MetricsQueryFilter, NodeKind } from '
 import { QueryBasedInsightModel } from '~/types'
 import { PropertyOperator, UniversalFilterValue, UniversalFiltersGroup } from '~/types'
 
-import { metricsCharacterizeCreate, metricsQueryCreate } from 'products/metrics/frontend/generated/api'
+import {
+    metricsAttributesRetrieve,
+    metricsCharacterizeCreate,
+    metricsQueryCreate,
+} from 'products/metrics/frontend/generated/api'
 import { OtelMetricTypeEnumApi } from 'products/metrics/frontend/generated/api.schemas'
 import type {
     _MetricAnomalyReportApi,
@@ -155,6 +159,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         setStatSummary: (statSummary: MetricSummary) => ({ statSummary }),
         setLiveRefresh: (liveRefresh: boolean) => ({ liveRefresh }),
         setGroupByKeys: (groupByKeys: string[]) => ({ groupByKeys }),
+        setGroupBySearch: (groupBySearch: string) => ({ groupBySearch }),
         setFilterGroup: (filterGroup: UniversalFiltersGroup) => ({ filterGroup }),
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
@@ -178,6 +183,8 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         liveRefresh: [false, { setLiveRefresh: (_, { liveRefresh }) => liveRefresh }],
         // Attribute keys to split the metric into one series each (e.g. ['service.name', 'env']).
         groupByKeys: [[] as string[], { setGroupByKeys: (_, { groupByKeys }) => groupByKeys }],
+        // Free-text search backing the group-by attribute-key autocomplete.
+        groupBySearch: ['' as string, { setGroupBySearch: (_, { groupBySearch }) => groupBySearch }],
         // The filter bar's UniversalFilters group; converted into backend matchers by `queryFilters`.
         filterGroup: [DEFAULT_UNIVERSAL_GROUP_FILTER, { setFilterGroup: (_, { filterGroup }) => filterGroup }],
         queryAbortController: [
@@ -210,6 +217,9 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         saveAsInsightFailure: ({ error }) => {
             lemonToast.error(`Failed to save insight: ${error}`)
         },
+        setGroupBySearch: () => {
+            actions.loadAttributeKeyOptions({})
+        },
         cancelInProgressQuery: ({ controller }) => {
             if (values.queryAbortController !== null) {
                 // An AbortError-named DOMException (not a bare string) is what api.ts and the global
@@ -237,6 +247,26 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         },
     })),
     loaders(({ values, actions }) => ({
+        // Backs the group-by attribute-key autocomplete. Scoped to the viewer's window so
+        // suggestions match the data on screen; debounced to match the chart fetch cadence.
+        attributeKeyOptions: [
+            [] as { key: string; label: string }[],
+            {
+                loadAttributeKeyOptions: async (_, breakpoint) => {
+                    await breakpoint(300)
+                    const dateFrom = resolveDate(values.dateFrom) ?? undefined
+                    const dateTo = resolveDate(values.dateTo) ?? undefined
+                    const response = await metricsAttributesRetrieve(String(values.currentTeamId), {
+                        search: values.groupBySearch,
+                        ...(dateFrom ? { dateFrom } : {}),
+                        ...(dateTo ? { dateTo } : {}),
+                        limit: 100,
+                    })
+                    breakpoint()
+                    return response.results.map((result) => ({ key: result.name, label: result.name }))
+                },
+            },
+        ],
         queryResults: [
             [] as MetricsViewerSeries[],
             {


### PR DESCRIPTION
## Problem

The metrics viewer's "Group by attribute" picker shipped with `options={[]}` and no fetching wired up, so it never suggested any attribute keys.
Clicking it or typing into it showed nothing and made no API request.
This is stacked on [#69248](https://github.com/PostHog/posthog/pull/69248), the filter-bar PR where that picker lives.

## Changes

- Add a debounced `attributeKeyOptions` loader in `metricsViewerLogic` that calls the generated `metricsAttributesRetrieve` endpoint, scoped to the viewer's date window, and maps `{ name }` rows into `{ key, label }` options.
- Wire the group-by `LemonInputSelect` to those options: fetch on focus and on input (`onFocus` / `onInputChange`), show a loading state, and keep `allowCustomValues` so arbitrary keys still work.

## How did you test this code?

- Added a kea logic test in `metricsViewerLogic.test.ts`: typing into group-by (`setGroupBySearch`) triggers the loader, calls the attributes endpoint with the search term, and maps the results into `{ key, label }` options. It catches the exact regression fixed here (the picker fetching nothing).
- Ran the metrics logic suite locally (15 tests, all green).
- I (Claude) did not run the app manually, so there are no screenshots.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - Frank directed this.

- Reproduced with focused Jest tests first: the filter bar's key picker already fetches `metrics/attributes` correctly, which isolated the failure to the group-by `LemonInputSelect options={[]}` that never fetched at all.
- Chose the generated `metricsAttributesRetrieve` client over a hand-rolled `api.get`, per the repo's generated-API-types guidance. Fetch is lazy (on focus) rather than primed on viewer mount, to avoid a request for users who never open group-by.
- Invoked the `/writing-tests` skill before adding the test.
- Related: a separate fix for the filter bar's value picker (it hit a bogus `api/metric_attribute/values` because `metric_attribute` was missing from `isAnyPropertyfilter`) went into the base PR #69248.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
