### PR TITLE
fix(data-warehouse): retry Shopify token endpoint 5xx locally

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
@@ -309,12 +309,18 @@ def normalize_store_id(raw: str) -> str:
     # connect/read timeout) surfaces from `post` as requests ConnectionError/Timeout — SSLError
     # is a ConnectionError. A connection dropped mid-response surfaces as ChunkedEncodingError,
     # which is a RequestException rather than a ConnectionError, so it must be listed explicitly.
-    # The adapter's own urllib3 retries back off for only ~1.5s, too short to ride out a
-    # multi-second blip. Minting a token is idempotent, so reissue with backoff rather than failing
-    # the whole import. 4xx/5xx are raised as plain Exceptions below and so are untouched here —
-    # auth failures still fail fast.
+    # A 429/5xx returns a completed response and is raised as ShopifyRetryableError below, so it
+    # is listed here too. The adapter's own urllib3 retries back off for only ~1.5s, too short to
+    # ride out a multi-second blip. Minting a token is idempotent, so reissue with backoff rather
+    # than failing the whole import. 4xx auth failures are raised as plain Exceptions and so are
+    # untouched here — they still fail fast.
     retry=retry_if_exception_type(
-        (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.exceptions.ChunkedEncodingError)
+        (
+            ShopifyRetryableError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+        )
     ),
     stop=stop_after_attempt(5),
     wait=_shopify_backoff,
@@ -332,10 +338,13 @@ def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, sho
     if not access_res.ok:
         # A 4xx means the app credentials are invalid/revoked (e.g. the app was
         # uninstalled) — re-auth is the only fix, so surface a non-retryable message.
-        # 429 (rate limit) and 5xx are transient and stay retryable via the generic message.
         if 400 <= access_res.status_code < 500 and access_res.status_code != 429:
             raise Exception(f"{SHOPIFY_ACCESS_TOKEN_AUTH_ERROR} (HTTP {access_res.status_code})")
-        raise Exception(f"Failed to retrieve Shopify access token: {access_res}")
+        # 429 (rate limit) and 5xx (e.g. a 502 Bad Gateway from Shopify's edge) are transient —
+        # retry locally with backoff instead of failing the import, mirroring the GraphQL path.
+        raise ShopifyRetryableError(
+            f"Failed to retrieve Shopify access token: {access_res.status_code} {access_res.reason}"
+        )
     return access_res.json()["access_token"]
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -5,15 +5,17 @@ from requests.exceptions import ChunkedEncodingError, SSLError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
+    ShopifyRetryableError,
     _get_shopify_access_token,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.source import ShopifySource
 
 
-def _mock_response(status_code: int, ok: bool, json_data: dict | None = None) -> mock.MagicMock:
+def _mock_response(status_code: int, ok: bool, json_data: dict | None = None, reason: str = "") -> mock.MagicMock:
     response = mock.MagicMock()
     response.status_code = status_code
     response.ok = ok
+    response.reason = reason
     response.json.return_value = json_data or {}
     return response
 
@@ -43,17 +45,39 @@ def test_get_access_token_4xx_is_non_retryable(status_code):
     )
 
 
-@pytest.mark.parametrize("status_code", [429, 500, 502, 503])
-def test_get_access_token_transient_stays_retryable(status_code):
-    with _patched_token_call(_mock_response(status_code, ok=False)):
-        with pytest.raises(Exception) as exc_info:
+@pytest.mark.parametrize(
+    "status_code,reason",
+    [(429, "Too Many Requests"), (500, "Internal Server Error"), (502, "Bad Gateway"), (503, "Service Unavailable")],
+)
+@mock.patch("tenacity.nap.time.sleep")
+def test_get_access_token_transient_retries_then_reraises(_mock_sleep, status_code, reason):
+    # A 429/5xx on the token endpoint (e.g. the 502 Bad Gateway seen in production) is transient,
+    # so it must retry locally with backoff and, if it never recovers, reraise a retryable error
+    # rather than a non-retryable one.
+    post = mock.MagicMock(return_value=_mock_response(status_code, ok=False, reason=reason))
+    with _patched_token_post(post):
+        with pytest.raises(ShopifyRetryableError) as exc_info:
             _get_shopify_access_token("store", "client-id", "client-secret")
-
+    assert post.call_count == 5
     error_message = str(exc_info.value)
     patterns = ShopifySource().get_non_retryable_errors()
     assert not any(pattern in error_message for pattern in patterns), (
         f"transient token error '{error_message}' should remain retryable"
     )
+
+
+@mock.patch("tenacity.nap.time.sleep")
+def test_get_access_token_retries_5xx_then_succeeds(_mock_sleep):
+    # A transient 502 followed by a healthy response should mint the token, not fail the import.
+    post = mock.MagicMock(
+        side_effect=[
+            _mock_response(502, ok=False, reason="Bad Gateway"),
+            _mock_response(200, ok=True, json_data={"access_token": "tok"}),
+        ]
+    )
+    with _patched_token_post(post):
+        assert _get_shopify_access_token("store", "client-id", "client-secret") == "tok"
+    assert post.call_count == 2
 
 
 def test_get_access_token_success_returns_token():


### PR DESCRIPTION
## Problem

Error tracking flagged a live failure on the Shopify data-warehouse import source:

> `Exception: Failed to retrieve Shopify access token: <Response [502]>`

raised at `_get_shopify_access_token` in `products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py`.

The 502 is a transient Bad Gateway from Shopify's OAuth token endpoint. The token endpoint's local `@retry` only covered connection and timeout exceptions, not a completed 5xx HTTP response. So a 502 fell through to a plain `Exception` that wasn't retried locally, failed the whole import, and surfaced this as an error-tracking event. This is inconsistent with the GraphQL request path (`_make_paginated_shopify_request`), which already retries 5xx locally via `ShopifyRetryableError`.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f46a0-abf1-7d71-a72b-04c1bb921950

## Changes

For a 429 or 5xx response from the token endpoint, raise `ShopifyRetryableError` instead of a plain `Exception`, and add it to the retry decorator's exception set. Transient token-endpoint blips now retry locally with backoff, matching the GraphQL path. 4xx auth failures (invalid or revoked credentials) still raise the non-retryable message and fail fast.

The reraised message uses the stable status code and reason (e.g. `502 Bad Gateway`) rather than the volatile `<Response [502]>` repr, and carries no URL or credential.

## How did you test this code?

Automated tests only (I, Claude, did not run this against live Shopify):

- Reworked `test_get_access_token_transient_retries_then_reraises` (429/500/502/503) to assert the token endpoint now retries 5 times with backoff and reraises a retryable error, guarding the 502 that was failing without a local retry.
- Added `test_get_access_token_retries_5xx_then_succeeds` for the 502-then-200 recovery path, so a transient blip mints the token instead of failing the import.
- Existing 4xx-is-non-retryable and connection/TLS-retry cases still pass.

Ran the full shopify source test suite (95 passed) plus `ruff check` and `ruff format --check` on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (PostHog Code). Confirmed the issue via the error-tracking MCP tools (stack frame at `shopify.py:338`, single occurrence, 502 status), then read the source to locate the gap: the token endpoint retried connection or timeout errors locally but not 5xx responses, even though the module's comment claimed 5xx "stay retryable". Judged this a fixable fragility rather than a user/upstream error (a 502 is transient infra, so it stays retryable, not added to `NonRetryableErrors`), and scoped the fix to align the token path with the existing GraphQL 5xx handling. Invoked the `/writing-tests` skill before touching the test file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
