### PR TITLE
fix(mcp): treat Cowork as render-ui host, gate env-context to chat

### DIFF
--- a/services/mcp/src/hono/instructions.ts
+++ b/services/mcp/src/hono/instructions.ts
@@ -110,9 +110,11 @@ export class InstructionsBuilder {
         // Claude web/desktop report `supportsInstructions` but never surface the
         // `instructions` payload to the model, so its env-context (tool domains,
         // project metadata, group types) would be lost. Keep it on the exec command
-        // description for those hosts. (Codex, which reports `supportsInstructions:
-        // false`, already gets the full env-context via the un-stripped path.)
-        const keepEnvContext = state.clientProfile.isClaudeUiHost()
+        // description for those chat hosts only — Cowork surfaces instructions
+        // normally and gets env-context through them. (Codex, which reports
+        // `supportsInstructions: false`, already gets the full env-context via the
+        // un-stripped path.)
+        const keepEnvContext = state.clientProfile.isClaudeChatHost()
         const ctx = this.buildContext(state)
         return this.formatter.buildExecCommandReference(ctx, {
             stripEnvContext: supportsInstructions,

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -28,9 +28,14 @@
  *   reliable identifier. Used to force single-exec mode regardless of the
  *   self-reported MCP client name.
  *
- * - `isClaudeUiHost()` matches Claude web and desktop — MCP Apps hosts that
- *   render interactive UI (iframes). Used to put them in single-exec mode so the
- *   `render-ui` tool is available, gated behind the `mcp-render-ui` flag.
+ * - `isClaudeUiHost()` matches Claude web/desktop and Cowork — MCP Apps hosts
+ *   that render interactive UI (iframes). Used to put them in single-exec mode so
+ *   the `render-ui` tool is available, gated behind the `mcp-render-ui` flag.
+ *
+ * - `isClaudeChatHost()` matches Claude web/desktop only — the chat surfaces that
+ *   report `supportsInstructions` but never surface the `instructions` payload to
+ *   the model. Used to keep the env-context on the exec command description for
+ *   them. Cowork surfaces instructions normally, so it is deliberately excluded.
  *
  * - `capabilities` is a feature-flag-style object describing protocol
  *   features the client actually implements (e.g. `supportsInstructions` —
@@ -162,22 +167,29 @@ export const POSTHOG_CODE_CONSUMER = 'posthog-code'
 // OAuth name without the `notion-mcp-client` self-report.
 export const VIBE_CODING_OAUTH_CLIENT_NAME_FRAGMENTS = ['lovable', 'replit', 'notion'] as const
 
-// Claude web and desktop are MCP Apps hosts that render interactive UI (iframes),
-// so the `render-ui` tool is meaningful for them. They send `x-anthropic-client:
-// ClaudeAI` (vs `ClaudeCode` for Claude Code, `Cowork` for Cowork) and
+// Claude web/desktop and Cowork are MCP Apps hosts that render interactive UI
+// (iframes), so the `render-ui` tool is meaningful for them. They send
+// `x-anthropic-client: ClaudeAI` / `Cowork` (vs `ClaudeCode` for Claude Code) and
 // `User-Agent: Claude-User`. The vendor client is authoritative when present:
-// only `ClaudeAI` is a UI host, so Cowork and Claude Code are excluded even
-// though they may share the `Claude-User` user-agent. The user-agent is a
-// fallback solely for requests that omit the vendor header. We deliberately do
-// NOT match `clientName` here — Anthropic pools transports, so Claude Code's
-// `clientInfo.name` is also `Anthropic/ClaudeAI`, and matching it would
-// misclassify Claude Code as a UI host.
-export const ANTHROPIC_UI_HOST_VENDOR_FRAGMENTS = ['claudeai'] as const
+// Claude Code is excluded even though it may share the `Claude-User` user-agent.
+// The user-agent is a fallback solely for requests that omit the vendor header.
+// We deliberately do NOT match `clientName` here — Anthropic pools transports, so
+// Claude Code's `clientInfo.name` is also `Anthropic/ClaudeAI`, and matching it
+// would misclassify Claude Code as a UI host.
+export const ANTHROPIC_UI_HOST_VENDOR_FRAGMENTS = ['claudeai', 'cowork'] as const
+
+// Claude web/desktop report `supportsInstructions` but never surface the
+// `instructions` payload to the model, so their env-context rides on the exec
+// command description instead (`keepEnvContext`). Cowork surfaces instructions
+// normally and gets env-context through them, so it is not a chat host even
+// though it is a UI host.
+export const ANTHROPIC_CHAT_HOST_VENDOR_FRAGMENTS = ['claudeai'] as const
 
 // Anthropic coding-agent surfaces that render MCP UI apps inline through the
 // single-exec `exec` tool. `ClaudeCode` and `Cowork` render UI apps on the exec
-// response itself (unlike `ClaudeAI`, which uses the separate `render-ui` tool),
-// so they get the same treatment as the PostHog Code consumer.
+// response itself (`ClaudeAI` uses the separate `render-ui` tool instead;
+// `Cowork` supports both), so they get the same treatment as the PostHog Code
+// consumer.
 export const INLINE_EXEC_UI_APP_VENDOR_FRAGMENTS = ['claudecode', 'cowork'] as const
 
 // User-Agent Anthropic clients send when they connect without the
@@ -279,13 +291,13 @@ export class MCPClientProfile {
     isClaudeUiHost(): boolean {
         // The per-request vendor client (`x-anthropic-client`) is authoritative: it
         // distinguishes the Claude surfaces that pool the same MCP transport —
-        // `ClaudeAI` (web/desktop, a UI-Apps host that renders via the separate
-        // `render-ui` tool) from `Cowork` and `ClaudeCode`, which render UI apps
-        // inline on the `exec` response instead (see `isInlineExecUiHost`) and so
-        // are not `render-ui` hosts. When it's present, trust it exclusively; only
-        // fall back to the `Claude-User` user-agent when the vendor header is absent.
-        // Otherwise a non-UI surface like Cowork — which can share the `Claude-User`
-        // user-agent with web/desktop — would be misclassified as a UI host.
+        // `ClaudeAI` (web/desktop) and `Cowork`, both `render-ui` hosts, from
+        // `ClaudeCode`, which only renders UI apps inline on the `exec` response
+        // (see `isInlineExecUiHost`). When it's present, trust it exclusively; only
+        // fall back to the `Claude-User` user-agent when the vendor header is
+        // absent. Otherwise a non-render-ui surface like Claude Code — which can
+        // share the `Claude-User` user-agent with web/desktop — would be
+        // misclassified as a UI host.
         if (this.vendorClient) {
             return matchesAnyFragment(this.vendorClient, ANTHROPIC_UI_HOST_VENDOR_FRAGMENTS)
         }
@@ -294,12 +306,24 @@ export class MCPClientProfile {
 
     isInlineExecUiHost(): boolean {
         // Anthropic coding-agent surfaces that render MCP UI apps inline through the
-        // single-exec `exec` tool (Claude Code, Cowork) — as opposed to Claude.ai
-        // web/desktop, which renders via the separate `render-ui` tool. Like PostHog
-        // Code, these hosts surface `structuredContent` to the model, so the exec
-        // UI-app branch suppresses it and re-homes the app data onto `_meta`. The
-        // per-request vendor header (`ClaudeCode` / `Cowork`) is the reliable signal.
+        // single-exec `exec` tool (Claude Code, Cowork) — Claude.ai web/desktop
+        // renders via the separate `render-ui` tool instead (Cowork supports both).
+        // Like PostHog Code, these hosts surface `structuredContent` to the model, so
+        // the exec UI-app branch suppresses it and re-homes the app data onto `_meta`.
+        // The per-request vendor header (`ClaudeCode` / `Cowork`) is the reliable signal.
         return matchesAnyFragment(this.vendorClient, INLINE_EXEC_UI_APP_VENDOR_FRAGMENTS)
+    }
+
+    isClaudeChatHost(): boolean {
+        // Same vendor-authoritative shape as `isClaudeUiHost`, narrowed to the chat
+        // surfaces (Claude web/desktop) that ignore the `instructions` payload. The
+        // `Claude-User` user-agent fallback is kept for requests without the vendor
+        // header — those are predominantly chat sessions, and keeping env-context
+        // for a misattributed surface only costs payload size, not correctness.
+        if (this.vendorClient) {
+            return matchesAnyFragment(this.vendorClient, ANTHROPIC_CHAT_HOST_VENDOR_FRAGMENTS)
+        }
+        return matchesAnyFragment(this.userAgent, ANTHROPIC_UI_HOST_USER_AGENT_FRAGMENTS)
     }
 
     get capabilities(): ClientCapabilities {

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -53,6 +53,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
             isInlineExecUiHost: vi.fn(() => false),
+            isClaudeChatHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -79,6 +79,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
             isInlineExecUiHost: vi.fn(() => false),
+            isClaudeChatHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -56,6 +56,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
             isInlineExecUiHost: vi.fn(() => false),
+            isClaudeChatHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -50,6 +50,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
             isCliModeEnabled: vi.fn(() => false),
             isClaudeUiHost: vi.fn(() => false),
             isInlineExecUiHost: vi.fn(() => false),
+            isClaudeChatHost: vi.fn(() => false),
         } as any,
         requestContext: {
             sessionId: 'sess-1',
@@ -186,30 +187,30 @@ describe('ToolExecutor', () => {
         // Env-context (active project metadata + tool-domain index) must reach the model
         // on the exec `command` for clients that don't otherwise receive the `instructions`
         // payload: Codex reports `supportsInstructions: false` so never gets it, and Claude
-        // web/desktop report `true` but silently ignore it. Claude Code strips it here
-        // because it arrives via `instructions` instead.
+        // web/desktop report `true` but silently ignore it. Claude Code and Cowork strip
+        // it here because it arrives via `instructions` instead.
         it.each([
             {
                 label: 'Claude web/desktop (ignores instructions)',
                 supportsInstructions: true,
-                isClaudeUiHost: true,
+                isClaudeChatHost: true,
                 expectEnv: true,
             },
             {
                 label: 'Codex (supportsInstructions: false)',
                 supportsInstructions: false,
-                isClaudeUiHost: false,
+                isClaudeChatHost: false,
                 expectEnv: true,
             },
             {
-                label: 'Claude Code (consumes instructions)',
+                label: 'Claude Code / Cowork (consume instructions)',
                 supportsInstructions: true,
-                isClaudeUiHost: false,
+                isClaudeChatHost: false,
                 expectEnv: false,
             },
         ])(
             'injects project metadata into the exec command for $label → $expectEnv',
-            async ({ supportsInstructions, isClaudeUiHost, expectEnv }) => {
+            async ({ supportsInstructions, isClaudeChatHost, expectEnv }) => {
                 const tools = catalog
                     .getPreBuiltEntries()
                     .slice(0, 5)
@@ -222,7 +223,9 @@ describe('ToolExecutor', () => {
                     clientProfile: {
                         capabilities: { supportsInstructions },
                         isCliModeEnabled: vi.fn(() => true),
-                        isClaudeUiHost: vi.fn(() => isClaudeUiHost),
+                        isClaudeUiHost: vi.fn(() => false),
+                        isInlineExecUiHost: vi.fn(() => false),
+                        isClaudeChatHost: vi.fn(() => isClaudeChatHost),
                     } as any,
                 })
 

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -413,16 +413,13 @@ describe('MCPClientProfile', () => {
             expect(new MCPClientProfile({ vendorClient: 'ClaudeCode' }).isClaudeUiHost()).toBe(false)
         })
 
-        it('returns false for Cowork (vendorClient: Cowork)', () => {
-            expect(new MCPClientProfile({ vendorClient: 'Cowork' }).isClaudeUiHost()).toBe(false)
+        it('returns true for Cowork (vendorClient: Cowork)', () => {
+            expect(new MCPClientProfile({ vendorClient: 'Cowork' }).isClaudeUiHost()).toBe(true)
         })
 
         it('vendor client wins over a shared Claude-User user-agent', () => {
-            // Cowork and Claude Code can share the `Claude-User` user-agent with
-            // web/desktop, but their vendor client is authoritative and excludes them.
-            expect(new MCPClientProfile({ vendorClient: 'Cowork', userAgent: 'Claude-User' }).isClaudeUiHost()).toBe(
-                false
-            )
+            // Claude Code can share the `Claude-User` user-agent with web/desktop,
+            // but its vendor client is authoritative and excludes it.
             expect(
                 new MCPClientProfile({ vendorClient: 'ClaudeCode', userAgent: 'Claude-User' }).isClaudeUiHost()
             ).toBe(false)
@@ -463,6 +460,22 @@ describe('MCPClientProfile', () => {
 
         it('is false when no vendor client is set (the user-agent is not a fallback here)', () => {
             expect(new MCPClientProfile({ userAgent: 'Claude-User' }).isInlineExecUiHost()).toBe(false)
+        })
+    })
+
+    describe('isClaudeChatHost()', () => {
+        it.each([
+            // Claude web/desktop ignore the `instructions` payload → keep env-context.
+            [{ vendorClient: 'ClaudeAI' }, true],
+            // Vendor header absent → predominantly chat sessions, keep the UA fallback.
+            [{ userAgent: 'Claude-User' }, true],
+            // Cowork surfaces instructions normally → a UI host but not a chat host.
+            [{ vendorClient: 'Cowork' }, false],
+            [{ vendorClient: 'Cowork', userAgent: 'Claude-User' }, false],
+            [{ vendorClient: 'ClaudeCode', userAgent: 'Claude-User' }, false],
+            [{}, false],
+        ])('resolves %j to %s', (input, expected) => {
+            expect(new MCPClientProfile(input).isClaudeChatHost()).toBe(expected)
         })
     })
 


### PR DESCRIPTION
## Problem

Cowork renders MCP UI apps, but the MCP server's UI-host detection (`isClaudeUiHost()`) only matched the `ClaudeAI` vendor header. In practice this made the advertised tool list nondeterministic for Cowork sessions. The first `tools/list` on a pooled Anthropic transport usually arrives before any request has carried `x-anthropic-client: Cowork`, so it hits the `Claude-User` user-agent fallback and gets `[exec, render-ui]`, while a refetch after the session is vendor-pinned drops back to `[exec]`. MCP analytics for the last week showed roughly 80% of Cowork sessions on the 2-tool list and the rest on the 1-tool list, decided purely by header timing.

On top of that, Cowork was inheriting the Claude web/desktop env-context workaround. Claude chat reports `supportsInstructions` but never surfaces the `instructions` payload to the model, so we embed the env-context (project metadata, tool domains, group types) in the exec `command` schema description for those hosts. Cowork surfaces instructions normally, so for it this only bloated the exec tool entry, and the entry's size scales with org size.

## Changes

- `ANTHROPIC_UI_HOST_VENDOR_FRAGMENTS` now includes `cowork`, so Cowork deterministically gets `render-ui` advertised (still gated behind the `mcp-render-ui` flag). Claude Code stays excluded.
- New `MCPClientProfile.isClaudeChatHost()` matching the `ClaudeAI` vendor only (same `Claude-User` UA fallback for vendor-less requests). `keepEnvContext` in the instructions builder now keys off it instead of `isClaudeUiHost()`, so Claude web/desktop keep the embedded env-context and Cowork gets it via `instructions` like other clients.
- Comments updated where they described Cowork as a non-render-ui host; `isInlineExecUiHost()` (#69030) is untouched — Cowork now supports both rendering paths.

## How did you test this code?

Automated tests only (I didn't run a live Cowork session):

- `services/mcp` unit suite (2081 tests) and hono suite (293 tests) pass.
- Flipped the `isClaudeUiHost()` Cowork assertions — they now pin that Cowork is a UI host, guarding against re-excluding it.
- New parameterized `isClaudeChatHost()` cases pin the split no existing test covered: ClaudeAI keeps env-context, Cowork does not (even when sharing the `Claude-User` UA), UA-fallback stays chat.
- Re-keyed the existing exec env-context injection matrix in `tool-executor.test.ts` from `isClaudeUiHost` to `isClaudeChatHost`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — server-side client detection, no user-facing docs describe this behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy directed this via Claude Code after we traced a report of a Cowork session claiming the PostHog MCP exposes only `render-ui`. I (Claude) queried MCP analytics (`$mcp_tools_list` / `$mcp_tool_call` events) to establish that Cowork's advertised list flapped between 1 and 2 tools depending on whether the vendor header had pinned the session yet, and that the affected session had received `[exec, render-ui]` with exec then disappearing client-side. Skills invoked: /writing-tests. Decisions: kept the `Claude-User` UA fallback in the new chat-host predicate since vendor-less requests are predominantly chat and misattribution only costs payload size; resolved a merge with #69030 (inline-exec UI hosts) by keeping both predicates — Cowork is both an inline-exec UI host and a render-ui host. The client-side dropping of the exec tool in Cowork is not addressed here; shrinking the exec entry is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)