### PR TITLE
fix(frontend): exclude @posthog/brand from vite pre-bundling

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -135,7 +135,11 @@ export default defineConfig(({ mode }) => {
         },
         optimizeDeps: {
             include: ['react', 'react-dom', 'buffer'],
-            exclude: ['snappy-wasm'], // Don't pre-bundle snappy-wasm so WASM file stays with JS
+            // snappy-wasm: don't pre-bundle so the WASM file stays with the JS.
+            // @posthog/brand: its PNG stubs resolve assets via `new URL(..., import.meta.url)`,
+            // which pre-bundling rewrites to .vite/deps/ where the images don't exist — hoggie
+            // art silently 404s in dev serve (production builds are unaffected).
+            exclude: ['snappy-wasm', '@posthog/brand'],
         },
     }
 })


### PR DESCRIPTION
## Problem

Hoggie illustrations loaded through `pngHoggie` (`@posthog/brand/hoggies/png/*`) never render in local dev. The package's stubs resolve their image with `new URL('./<name>.png', import.meta.url)`, and Vite's dependency pre-bundling relocates the module to `node_modules/.vite/deps/`, where the relative PNG path 404s. Decorative images (`alt=""`, lazy) fail silently, so every default-hog `ProductIntroduction` empty state ships artless in dev. Production builds are unaffected (Rollup's asset-import-meta-url handling processes dependencies too). Surfaces using `customHog` inline SVGs never hit this, which is why it went unnoticed.

## Changes

Add `@posthog/brand` to `optimizeDeps.exclude`, next to `snappy-wasm` which is excluded for the same class of reason. Excluded deps are served from their real location, where `import.meta.url` resolves correctly.

## How did you test this code?

Traced the failing resolution: the installed package's `dist/generated/hoggies/png/construction-2.{mjs,png}` both exist, and the stub's `new URL` is the only dev-serve-incompatible piece. Config-only change; no automated test applies.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code — found while testing the prompts empty state (#69646), whose default hog art didn't render locally.