### PR TITLE
chore(skills): add skill-count guidance to writing-skills

### DIFF
--- a/.agents/skills/writing-skills/SKILL.md
+++ b/.agents/skills/writing-skills/SKILL.md
@@ -39,6 +39,15 @@ it's about how an experienced person would approach a job using those tools.
 Ask: "If a customer asked an agent to do X with my feature, would the agent know the right approach?"
 If not, write a skill.
 
+### How many is too many?
+
+Skill count is a budgeted, shared resource — agents pick from a list of _all_ skill descriptions, and many harnesses truncate that list once it grows long, so every extra skill makes the others less likely to fire.
+Prefer a small set of focused skills, each with rich `references/`, over many thin ones:
+
+- **New trigger → new skill.** A skill earns its own entry point only when its "when to use it" is clearly distinct from every existing skill.
+- **More detail → `references/`, not a new skill.** Another failure mode, SDK variant, or query catalog is depth on an existing job — add it to that skill's `references/` instead of spending a new slot.
+- **Consolidate near-duplicate siblings.** Skills sharing a diagnosis, bug class, or trigger should be one skill with references, not two.
+
 ## Key rules
 
 - **Name**: lowercase kebab-case, prefer gerund form (`analyzing-llm-traces`, not `llm-analytics`). Never prefix with `posthog-*`.

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -73,6 +73,18 @@ Additional signals that a skill is the right answer even when tool prompts are a
 
 Don't write a skill for something the agent already one-shots from generic knowledge. A few real examples from review: `creating-isolated-project` or `finding-experiments` were unnecessary — the agent can do it without help. `setting-up-reverse-proxy` was the right call — the agent failed at it, and the skill needed to ship code snippets it couldn't derive. The bar is PostHog-specific judgement that a smart generalist agent wouldn't have, not project setup it can already handle.
 
+### How many skills is too many?
+
+A common worry when shipping a set of skills is "am I adding too many?" — and it's the right worry. Skill count is a budgeted, shared resource, not a free axis to expand. Agents pick skills from a list of _all_ available descriptions, and many harnesses **truncate that list** once it grows long. Every extra skill dilutes discovery for every other skill, so a bloated set makes each individual skill _less_ likely to fire, not more.
+
+So the number of skills is a cost to weigh, not just the content of each one. Before adding another skill, decide whether you have a genuinely new job-to-be-done or just more detail for a job you've already covered:
+
+- **New trigger → new skill.** A skill earns its own entry point only when it has a distinct trigger an agent would match against on its own. If you can't write a description whose "when to use it" is clearly different from an existing skill's, it isn't a separate skill.
+- **More detail → `references/`, not a new skill.** When the extra material is depth on an existing workflow (another failure mode, an SDK-specific variant, a longer query catalog), add it to that skill's [`references/`](#progressive-disclosure) rather than spinning up a sibling. The entry point stays lean and the detail loads on demand — you get coverage without spending a skill slot.
+- **Consolidate near-duplicate siblings.** If two skills share the same diagnosis, bug class, or trigger and differ only in a detail, merge them into one skill with references. Splitting the same job across two files adds a slot for no discovery benefit — reviewers will (and should) push back on it.
+
+The rule of thumb: prefer a small set of focused skills, each with rich `references/`, over a large set of thin ones. Reach for a reference file first; add a whole new skill only when the job and its trigger are genuinely distinct.
+
 ### Referencing MCP tools in skills
 
 When a skill references an MCP tool, use the `posthog:` namespace prefix


### PR DESCRIPTION
## Problem

When shipping a set of skills, authors hit a recurring question with no clear answer in our docs: "am I adding too many skills here?" Skill count is a budgeted, shared resource — agents choose from a list of _all_ skill descriptions, and many harnesses truncate that list once it grows long, so every extra skill dilutes discovery for the rest. The writing-skills guidance covered when to write _a_ skill but not how to weigh the total number, nor how `references/` is the alternative to proliferating near-duplicate skills.

## Changes

- Add a "How many skills is too many?" section to the writing-skills handbook doc: skill count is a cost to weigh, new-trigger → new skill, more-detail → `references/`, and consolidate near-duplicate siblings.
- Surface a short version of the same rule in the `writing-skills` SKILL.md pointer so agents get it without loading the full doc.

## How did you test this code?

Markdown-only change (no skill frontmatter or file-structure changes), so skill lint is unaffected. `hogli`/`flox` weren't available in this environment to run `hogli lint:skills`; the edits touch only prose in an existing SKILL.md and its handbook doc.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Docs are updated in this PR (the handbook page is the change).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread to capture guidance that came up while reviewing an ingestion-warnings skills PR: an author's concern about adding too many skills, and the point that harnesses truncate long skill lists so `references/` is preferred over proliferating skills. Skills invoked: /writing-skills. Content added to both the handbook source of truth and the thin SKILL.md pointer that references it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1783588928661309?thread_ts=1783588928.661309&cid=C09SK2PAGKF)*
