### PR TITLE
fix(postgres): retry connect-time recovery conflicts in offset chunking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -373,6 +373,19 @@ def _is_dropped_or_connection_limit(error: BaseException) -> bool:
     return _is_connection_dropped_error(error) or _is_connection_limit_error(error)
 
 
+def _is_recovery_conflict_error(error: BaseException) -> bool:
+    """True if the error is a Postgres hot-standby recovery conflict, at read or connect time.
+
+    A read canceled by the standby surfaces as SerializationFailure (SQLSTATE 40001), but when the
+    standby cancels the *connection's own startup* the failure comes back as a plain
+    OperationalError ("connection failed: ... FATAL: canceling statement due to conflict with
+    recovery") with no SQLSTATE-mapped subclass. Match the stable message so both are recognised.
+    """
+    if not isinstance(error, psycopg.OperationalError):
+        return False
+    return "conflict with recovery" in " ".join(str(arg) for arg in error.args)
+
+
 def _raise_if_setup_connection_broken(connection: psycopg.Connection) -> None:
     """Surface a connection dropped during metadata discovery as a retryable error.
 
@@ -3170,10 +3183,30 @@ def postgres_source(
                 floor_retries = 0
                 # Open lazily inside the loop so a recovery conflict (or connection drop) raised by
                 # the connect itself is caught by the handlers below. A hot standby can cancel the
-                # connection's own startup with "conflict with recovery" (SerializationFailure) when
-                # we reconnect mid-recovery — opening outside the loop let that escape the whole
-                # fallback even though it's the same transient condition the loop already retries.
+                # connection's own startup with "conflict with recovery" when we reconnect
+                # mid-recovery — opening outside the loop let that escape the whole fallback even
+                # though it's the same transient condition the loop already retries.
                 connection: psycopg.Connection | None = None
+
+                def handle_recovery_conflict(e: BaseException) -> None:
+                    # Shared bookkeeping for a recovery conflict hit either while reading a chunk
+                    # (SerializationFailure) or while (re)connecting for one (the standby cancels the
+                    # connection's own startup). Shrink the chunk toward the floor first; only once
+                    # stuck at the floor count down to the non-retryable abort.
+                    nonlocal chunk_size, successive_errors, floor_retries
+                    successive_errors += 1
+                    reduced_chunk_size = _next_recovery_conflict_chunk_size(chunk_size, successive_errors)
+                    if reduced_chunk_size < chunk_size:
+                        chunk_size = reduced_chunk_size
+                        logger.debug(f"Reducing chunk size to {chunk_size} to reduce load on read replica")
+                        floor_retries = 0
+                    elif chunk_size <= _MIN_RECOVERY_CONFLICT_CHUNK_SIZE:
+                        floor_retries += 1
+                        if floor_retries >= _MAX_READ_RECOVERY_CONFLICT_RETRIES:
+                            _safe_close_connection(connection)
+                            raise _recovery_conflict_abort_error(floor_retries) from e
+                    time.sleep(min(2 * successive_errors, 30))
+
                 while True:
                     try:
                         if connection is None or connection.closed:
@@ -3216,23 +3249,8 @@ def postgres_source(
                     except psycopg.errors.SerializationFailure as e:
                         if "due to conflict with recovery" not in "".join(e.args):
                             raise
-
                         logger.debug(f"SerializationFailure error: {e}. Retrying chunk at offset {offset}")
-
-                        successive_errors += 1
-                        # Shrink toward the floor first; only once stuck at the floor do we count down to
-                        # the abort.
-                        reduced_chunk_size = _next_recovery_conflict_chunk_size(chunk_size, successive_errors)
-                        if reduced_chunk_size < chunk_size:
-                            chunk_size = reduced_chunk_size
-                            logger.debug(f"Reducing chunk size to {chunk_size} to reduce load on read replica")
-                            floor_retries = 0
-                        elif chunk_size <= _MIN_RECOVERY_CONFLICT_CHUNK_SIZE:
-                            floor_retries += 1
-                            if floor_retries >= _MAX_READ_RECOVERY_CONFLICT_RETRIES:
-                                _safe_close_connection(connection)
-                                raise _recovery_conflict_abort_error(floor_retries) from e
-                        time.sleep(min(2 * successive_errors, 30))
+                        handle_recovery_conflict(e)
                     except psycopg.errors.QueryCanceled as e:
                         # A chunk hit the 10-min statement_timeout. QueryCanceled
                         # subclasses OperationalError, so this clause must precede the
@@ -3271,6 +3289,17 @@ def postgres_source(
                             ) from e
                         raise
                     except _CONNECTION_DROPPED_ERROR_TYPES as e:
+                        if _is_recovery_conflict_error(e):
+                            # A recovery conflict raised by the (re)connect itself surfaces as a plain
+                            # OperationalError ("connection failed: ... conflict with recovery"), not a
+                            # SerializationFailure, so it bypasses the handler above. Same transient
+                            # condition — drop the dead connection so the loop reopens at the same
+                            # offset, and route it through the shared recovery-conflict retry.
+                            logger.debug(f"Recovery conflict on connect ({e}). Retrying chunk at offset {offset}")
+                            _safe_close_connection(connection)
+                            connection = None
+                            handle_recovery_conflict(e)
+                            continue
                         if not _is_dropped_or_connect_timeout(e):
                             _safe_close_connection(connection)
                             raise

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2039,11 +2039,18 @@ class TestServerCursorCloseStatementTimeout:
 class TestOffsetChunkingConnectRecoveryConflict:
     """A recovery conflict raised by the connect itself in the offset-chunking fallback — a hot
     standby cancelling the new connection's startup with "conflict with recovery" — must be retried
-    in-process, not escape `get_rows`. The bootstrap connect used to run outside the retry loop, so
-    the conflict bypassed the loop's recovery-conflict handler and failed the whole sync.
+    in-process, not escape `get_rows`. It surfaces as a SerializationFailure when the standby cancels
+    a chunk read, but as a plain OperationalError ("connection failed: ... conflict with recovery")
+    when it cancels the connection's own startup — the latter bypassed the loop's SerializationFailure
+    handler and failed the whole sync.
     """
 
     _RECOVERY_CONFLICT = "canceling statement due to conflict with recovery"
+    # psycopg wraps a startup-time cancel as a plain OperationalError with no SQLSTATE-mapped subclass.
+    _CONNECT_RECOVERY_CONFLICT = (
+        'connection failed: connection to server at "localhost", port 5432 failed: '
+        "FATAL:  canceling statement due to conflict with recovery"
+    )
 
     class _NamedCursor:
         def __init__(self):
@@ -2109,7 +2116,14 @@ class TestOffsetChunkingConnectRecoveryConflict:
         def __exit__(self, *args):
             return False
 
-    def test_recovery_conflict_on_offset_chunking_connect_is_retried_in_process(self):
+    @pytest.mark.parametrize(
+        "connect_error",
+        [
+            psycopg.errors.SerializationFailure(_RECOVERY_CONFLICT),
+            psycopg.OperationalError(_CONNECT_RECOVERY_CONFLICT),
+        ],
+    )
+    def test_recovery_conflict_on_offset_chunking_connect_is_retried_in_process(self, connect_error):
         @contextmanager
         def fake_tunnel():
             yield ("localhost", 5432)
@@ -2128,7 +2142,7 @@ class TestOffsetChunkingConnectRecoveryConflict:
             # Calls 1 (setup) and 2 (initial server-cursor read) succeed; the offset-chunking
             # bootstrap connect hits the recovery conflict twice before succeeding.
             if connect_calls["n"] in (3, 4):
-                raise psycopg.errors.SerializationFailure(self._RECOVERY_CONFLICT)
+                raise connect_error
             return connection
 
         module = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres"


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError` from the Postgres data-warehouse import source failing a read-replica sync:

```
connection failed: connection to server at "<redacted host>", port 5432 failed:
FATAL:  canceling statement due to conflict with recovery
DETAIL:  User query might have needed to see row versions that must be removed.
```

Issue: https://us.posthog.com/project/2/error_tracking/019f46b1-b295-7ff1-a898-a5bdd344f44c

When reading from a hot standby, `get_rows` falls back to offset chunking after the standby cancels a read with a recovery conflict. The chunking loop already retries recovery conflicts in-process (shrink the chunk, back off, and only abort non-retryably once stuck at the floor). The stack trace shows the failure was the offset-chunking bootstrap connect itself (`_connect_with_options_fallback` → `get_connection` → `offset_chunking`), with the initial read's `SerializationFailure` chained as the cause.

The bug: a recovery conflict that cancels the *connection's own startup* comes back from psycopg as a plain `OperationalError` ("connection failed: ... conflict with recovery"), not a `SerializationFailure` (SQLSTATE 40001 only gets its mapped subclass on an established connection). So it slipped past the loop's `SerializationFailure` handler, fell through to the connection-dropped handler (which does not recognise it as a drop or connect timeout), and escaped `get_rows`, failing the whole activity. Temporal then re-ran it from offset 0 into the same conflicting replica.

The lazy-connect comment in that loop already claimed connect-time recovery conflicts were meant to be caught here, but only the `SerializationFailure` shape actually was.

## Changes

- Add `_is_recovery_conflict_error`, which recognises a recovery conflict by its stable message ("conflict with recovery") regardless of whether psycopg raised `SerializationFailure` or a bare `OperationalError`.
- In the offset-chunking loop's connection-dropped handler, detect the connect-time recovery conflict, drop the dead connection, and route it through the same in-process retry the read-time conflict uses (chunk shrink, backoff, bounded abort).
- Factor the shared recovery-conflict bookkeeping into a `handle_recovery_conflict` closure so both paths use one implementation. No change to the read-time behavior or the non-retryable abort budget.

> [!NOTE]
> Scope is deliberately narrow. Transient recovery conflicts stay retryable and self-heal in-process; a sustained conflict still ends in the existing non-retryable abort with actionable replica guidance (increase `max_standby_streaming_delay`, enable `hot_standby_feedback`, or sync from the primary). No global retry policy changed.

## How did you test this code?

Extended the existing `TestOffsetChunkingConnectRecoveryConflict` test into a parameterized test covering both connect-time shapes: the `SerializationFailure` (already handled) and the real-world plain `OperationalError` (the bug). The new `OperationalError` case reproduces the escape on master and passes with the fix.

I (Claude) ran, via `uv run pytest`:

- `TestOffsetChunkingConnectRecoveryConflict` — both parameterized cases pass with the fix.
- Confirmed the `OperationalError` case fails on master (stashing the source change): it escapes `offset_chunking` exactly as in production, while the `SerializationFailure` case still passes.
- The offset-chunking / recovery-conflict / retry unit tests in the file: 198 passed. The 6 errored tests require a live Postgres (they fail with `Name or service not known` for a real connection) and error identically on master, so they are environmental and unrelated to this change.

Regression caught: a hot-standby recovery conflict raised while (re)connecting for an offset chunk previously escaped `get_rows` and failed the whole activity. No existing test exercised the `OperationalError` shape (only the `SerializationFailure` one), so none caught it.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Pulled the issue's stack trace and a representative event via the PostHog error-tracking MCP tools, confirmed the failing frame under `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/`, and read the offset-chunking path to root-cause it. Invoked the `/writing-tests` skill before extending the test.

Considered treating this as a user/upstream error (extend `NonRetryableErrors`) but rejected it: a single recovery conflict is transient and the code already recovers from it in-process for the read-time shape, so the connect-time shape should recover the same way rather than be marked non-retryable. The sustained case still reaches the existing non-retryable abort.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
