### PR TITLE
chore(cdp): remove the self-loop guard mode flag

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -147,7 +147,6 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_FETCH_RETRIES'
         | 'CDP_FETCH_BACKOFF_BASE_MS'
         | 'CDP_FETCH_BACKOFF_MAX_MS'
-        | 'CDP_SELF_LOOP_GUARD_MODE'
         | 'CDP_EMAIL_TRACKING_URL'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_PRODUCER'
@@ -416,7 +415,6 @@ export function createCdpCoreServices(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
-            selfLoopGuardMode: config.CDP_SELF_LOOP_GUARD_MODE,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
         hogInputsService,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -216,10 +216,9 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_FETCH_RETRIES: 3,
         CDP_FETCH_BACKOFF_BASE_MS: 1000,
         CDP_FETCH_BACKOFF_MAX_MS: 30000,
-        // Observe-only by default. Values: 'disabled' | 'warn' | 'enforce'. 'warn' detects
-        // and emits cdp_self_loop_guard_total without blocking; 'enforce' bounds true loops
-        // at SELF_LOOP_MAX_DEPTH hops. Roll out warn -> enforce per environment.
-        CDP_SELF_LOOP_GUARD_MODE: 'warn',
+        // Values: 'disabled' | 'enforce'. 'enforce' bounds true event-forwarding loops at
+        // SELF_LOOP_MAX_DEPTH hops; 'disabled' is an emergency kill switch.
+        CDP_SELF_LOOP_GUARD_MODE: 'enforce',
         CDP_OVERFLOW_QUEUE_ENABLED: false,
         HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC: KAFKA_APP_METRICS_2,
         HOG_FUNCTION_MONITORING_APP_METRICS_PRODUCER: WARPSTREAM_INGESTION_PRODUCER,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -18,7 +18,6 @@ import {
     WARPSTREAM_CYCLOTRON_PRODUCER,
     WARPSTREAM_INGESTION_PRODUCER,
 } from './outputs/producers'
-import { SelfLoopGuardMode } from './services/self-loop-guard'
 import { CyclotronJobQueueKind, CyclotronJobQueueSource } from './types'
 
 // CdpConfig intersects ClickhouseConfig so any consumer reading
@@ -96,7 +95,6 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_FETCH_RETRIES: number
     CDP_FETCH_BACKOFF_BASE_MS: number
     CDP_FETCH_BACKOFF_MAX_MS: number
-    CDP_SELF_LOOP_GUARD_MODE: SelfLoopGuardMode
     CDP_OVERFLOW_QUEUE_ENABLED: boolean
     HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC: string
     HOG_FUNCTION_MONITORING_APP_METRICS_PRODUCER: CdpProducerName
@@ -216,9 +214,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_FETCH_RETRIES: 3,
         CDP_FETCH_BACKOFF_BASE_MS: 1000,
         CDP_FETCH_BACKOFF_MAX_MS: 30000,
-        // Values: 'disabled' | 'enforce'. 'enforce' bounds true event-forwarding loops at
-        // SELF_LOOP_MAX_DEPTH hops; 'disabled' is an emergency kill switch.
-        CDP_SELF_LOOP_GUARD_MODE: 'enforce',
         CDP_OVERFLOW_QUEUE_ENABLED: false,
         HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC: KAFKA_APP_METRICS_2,
         HOG_FUNCTION_MONITORING_APP_METRICS_PRODUCER: WARPSTREAM_INGESTION_PRODUCER,

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -544,7 +544,6 @@ export function createHogTransformerService(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
-            selfLoopGuardMode: config.CDP_SELF_LOOP_GUARD_MODE,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
         hogInputsService,

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -75,7 +75,6 @@ describe('Hog Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,
@@ -2026,10 +2025,6 @@ describe('Hog Executor', () => {
                 } as any)
             }
 
-            const setMode = (mode: 'disabled' | 'enforce'): void => {
-                ;(executor as any).config.selfLoopGuardMode = mode
-            }
-
             const ownTokenCaptureBody = (): string =>
                 JSON.stringify({ api_key: OWN_TOKEN, event: 'replicated', distinct_id: 'u1', properties: {} })
 
@@ -2066,7 +2061,6 @@ describe('Hog Executor', () => {
             }
 
             it('fails open: a team lookup error never breaks the fetch', async () => {
-                setMode('enforce')
                 jest.spyOn(hub.teamManager, 'getTeam').mockRejectedValue(new Error('db unavailable'))
                 const invocation = await createFetchInvocation({
                     url: INGEST_URL,
@@ -2091,7 +2085,6 @@ describe('Hog Executor', () => {
                 { case: 'mid-chain under the cap', depth: 2, stampedTo: 3 },
                 { case: 'the last hop under the cap', depth: 9, stampedTo: 10 },
             ])('enforce: allows + stamps the next hop ($case)', async ({ depth, stampedTo }) => {
-                setMode('enforce')
                 mockOwnTeam()
                 const invocation = await createFetchInvocation({
                     url: INGEST_URL,
@@ -2116,7 +2109,6 @@ describe('Hog Executor', () => {
             // depth for a DIFFERENT function is treated as depth 0 here, so a legitimately
             // running destination is never blocked by an unrelated deep chain.
             it('enforce: does NOT block when the high depth belongs to another function', async () => {
-                setMode('enforce')
                 mockOwnTeam()
                 const invocation = await createFetchInvocation({
                     url: INGEST_URL,
@@ -2138,7 +2130,6 @@ describe('Hog Executor', () => {
             })
 
             it('enforce: breaks the chain once it reaches the cap', async () => {
-                setMode('enforce')
                 mockOwnTeam()
                 const invocation = await createFetchInvocation({
                     url: INGEST_URL,
@@ -2162,7 +2153,6 @@ describe('Hog Executor', () => {
             })
 
             it('enforce: leaves a normal external fetch untouched', async () => {
-                setMode('enforce')
                 mockOwnTeam()
                 const invocation = await createFetchInvocation({
                     url: `${baseUrl}/test`,

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -2026,7 +2026,7 @@ describe('Hog Executor', () => {
                 } as any)
             }
 
-            const setMode = (mode: 'disabled' | 'warn' | 'enforce'): void => {
+            const setMode = (mode: 'disabled' | 'enforce'): void => {
                 ;(executor as any).config.selfLoopGuardMode = mode
             }
 
@@ -2065,56 +2065,8 @@ describe('Hog Executor', () => {
                 return metric.values.find((v) => v.labels.mode === mode && v.labels.action === action)?.value ?? 0
             }
 
-            // The detected count is the production signal that drives the enforce decision,
-            // so assert it actually moves - not just the human-facing log.
-            const readDetectedCount = (): Promise<number> => readActionCount('warn', 'detected')
-
-            it('detects a self-referential ingest fetch and logs + meters it without blocking (warn)', async () => {
-                setMode('warn')
-                mockOwnTeam()
-                const invocation = await createFetchInvocation({
-                    url: INGEST_URL,
-                    method: 'POST',
-                    body: ownTokenCaptureBody(),
-                })
-                ;(fetch as jest.Mock).mockImplementationOnce(() =>
-                    Promise.resolve({ status: 200, headers: {}, text: () => Promise.resolve('ok') })
-                )
-                const detectedBefore = await readDetectedCount()
-
-                const result = await executor.executeFetch(invocation)
-
-                // Observe-only: the fetch still happens and nothing errors.
-                expect(result.error).toBeUndefined()
-                expect(cleanLogs(result.logs.map((l) => l.message))).toEqual(
-                    expect.arrayContaining([expect.stringContaining('can form an event-forwarding loop')])
-                )
-                expect(await readDetectedCount()).toBe(detectedBefore + 1)
-            })
-
-            it('does not flag a normal external fetch even with the project token in the body', async () => {
-                setMode('warn')
-                mockOwnTeam()
-                const invocation = await createFetchInvocation({
-                    url: `${baseUrl}/test`,
-                    method: 'POST',
-                    body: ownTokenCaptureBody(),
-                })
-                mockRequest.mockClear()
-                const detectedBefore = await readDetectedCount()
-
-                const result = await executor.executeFetch(invocation)
-
-                expect(result.error).toBeUndefined()
-                expect(mockRequest).toHaveBeenCalled()
-                expect(cleanLogs(result.logs.map((l) => l.message))).not.toEqual(
-                    expect.arrayContaining([expect.stringContaining('event-forwarding loop')])
-                )
-                expect(await readDetectedCount()).toBe(detectedBefore)
-            })
-
             it('fails open: a team lookup error never breaks the fetch', async () => {
-                setMode('warn')
+                setMode('enforce')
                 jest.spyOn(hub.teamManager, 'getTeam').mockRejectedValue(new Error('db unavailable'))
                 const invocation = await createFetchInvocation({
                     url: INGEST_URL,

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -820,8 +820,7 @@ export class HogExecutorService {
         // ingest-URL check gates the team lookup so external fetches (the common case) pay
         // nothing, and the whole block fails open - the guard must never break a destination
         // it was only meant to protect.
-        const guardMode = this.config.selfLoopGuardMode
-        if (guardMode !== 'disabled' && isPostHogIngestUrl(params.url)) {
+        if (this.config.selfLoopGuardMode === 'enforce' && isPostHogIngestUrl(params.url)) {
             try {
                 const team = await this.asyncContext.teamManager.getTeam(invocation.teamId)
                 if (team && isSelfReferentialIngestFetch({ url: params.url, body: params.body, team })) {
@@ -831,15 +830,9 @@ export class HogExecutorService {
                     const functionId = invocation.hogFunction.id
                     const depth = getSelfLoopDepth(invocation.state.globals.event?.properties, functionId)
 
-                    if (guardMode === 'warn') {
-                        selfLoopGuardCounter.inc({ mode: guardMode, action: 'detected' })
-                        addLog(
-                            'warn',
-                            `This fetch targets a PostHog ingestion endpoint using this project's own API key, which can form an event-forwarding loop. To capture an event back into this project use the 'postHogCapture' helper, or to enrich incoming events use a transformation.`
-                        )
-                    } else if (depth >= SELF_LOOP_MAX_DEPTH) {
-                        // enforce, this destination has re-fed itself to the cap - break it.
-                        selfLoopGuardCounter.inc({ mode: guardMode, action: 'blocked' })
+                    if (depth >= SELF_LOOP_MAX_DEPTH) {
+                        // This destination has re-fed itself to the cap - break it.
+                        selfLoopGuardCounter.inc({ mode: 'enforce', action: 'blocked' })
                         addLog(
                             'error',
                             `Refusing to fetch a PostHog ingestion endpoint using this project's own API key - this destination's event-forwarding loop has already repeated ${SELF_LOOP_MAX_DEPTH} times. To capture an event back into this project use the 'postHogCapture' helper, or to enrich incoming events use a transformation.`
@@ -847,11 +840,10 @@ export class HogExecutorService {
                         result.error = new Error('Self-referential event-forwarding loop blocked at max depth')
                         result.finished = true
                         return result
-                    } else {
-                        // enforce, under the cap - stamp this destination's next hop and proceed.
-                        selfLoopGuardCounter.inc({ mode: guardMode, action: 'allowed_with_counter' })
-                        params.body = injectSelfLoopDepth(params.body, functionId, depth + 1)
                     }
+                    // Under the cap - stamp this destination's next hop and proceed.
+                    selfLoopGuardCounter.inc({ mode: 'enforce', action: 'allowed_with_counter' })
+                    params.body = injectSelfLoopDepth(params.body, functionId, depth + 1)
                 }
             } catch (err) {
                 logger.warn('🦔', '[HogExecutor] Self-loop guard skipped due to an internal error', {

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -37,7 +37,6 @@ import { EmailService } from './messaging/email.service'
 import { RecipientTokensService } from './messaging/recipient-tokens.service'
 import {
     SELF_LOOP_MAX_DEPTH,
-    SelfLoopGuardMode,
     getSelfLoopDepth,
     injectSelfLoopDepth,
     isPostHogIngestUrl,
@@ -57,7 +56,6 @@ export interface HogExecutorConfig {
     fetchRetries: number
     fetchBackoffBaseMs: number
     fetchBackoffMaxMs: number
-    selfLoopGuardMode: SelfLoopGuardMode
 }
 
 export interface HogExecutorAsyncContext {
@@ -820,7 +818,7 @@ export class HogExecutorService {
         // ingest-URL check gates the team lookup so external fetches (the common case) pay
         // nothing, and the whole block fails open - the guard must never break a destination
         // it was only meant to protect.
-        if (this.config.selfLoopGuardMode === 'enforce' && isPostHogIngestUrl(params.url)) {
+        if (isPostHogIngestUrl(params.url)) {
             try {
                 const team = await this.asyncContext.teamManager.getTeam(invocation.teamId)
                 if (team && isSelfReferentialIngestFetch({ url: params.url, body: params.body, team })) {

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -66,7 +66,6 @@ describe('HogFunctionHandler', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -85,7 +85,6 @@ describe('Hogflow Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,

--- a/nodejs/src/cdp/services/self-loop-guard.ts
+++ b/nodejs/src/cdp/services/self-loop-guard.ts
@@ -7,13 +7,9 @@ import { Team } from '../../types'
 // A destination that fetches one of PostHog's own ingestion endpoints, authenticating
 // as its own project, re-enters the event pipeline. If that re-ingested event then
 // re-triggers the same destination, the chain forms an event-forwarding loop that
-// doubles traffic on every hop.
-//
-// - 'enforce' (default): bound the loop by counting how many times *this specific
-//   destination* has re-fed the pipeline - allow the first SELF_LOOP_MAX_DEPTH hops,
-//   then break it.
-// - 'disabled': no-op emergency kill switch.
-export type SelfLoopGuardMode = 'disabled' | 'enforce'
+// doubles traffic on every hop. The guard bounds the loop by counting how many times
+// *this specific destination* has re-fed the pipeline - allowing the first
+// SELF_LOOP_MAX_DEPTH hops, then breaking it.
 
 // Event property carrying the self-loop depth *per hog function*, keyed by function id:
 //   { "<functionId>": <hops this destination has re-fed itself> }

--- a/nodejs/src/cdp/services/self-loop-guard.ts
+++ b/nodejs/src/cdp/services/self-loop-guard.ts
@@ -9,11 +9,11 @@ import { Team } from '../../types'
 // re-triggers the same destination, the chain forms an event-forwarding loop that
 // doubles traffic on every hop.
 //
-// - 'disabled': no-op.
-// - 'warn': detect the shape and emit a metric, but never block (observe-only).
-// - 'enforce': bound the loop by counting how many times *this specific destination* has
-//   re-fed the pipeline - allow the first SELF_LOOP_MAX_DEPTH hops, then break it.
-export type SelfLoopGuardMode = 'disabled' | 'warn' | 'enforce'
+// - 'enforce' (default): bound the loop by counting how many times *this specific
+//   destination* has re-fed the pipeline - allow the first SELF_LOOP_MAX_DEPTH hops,
+//   then break it.
+// - 'disabled': no-op emergency kill switch.
+export type SelfLoopGuardMode = 'disabled' | 'enforce'
 
 // Event property carrying the self-loop depth *per hog function*, keyed by function id:
 //   { "<functionId>": <hops this destination has re-fed itself> }

--- a/nodejs/src/cdp/templates/test/test-helpers.ts
+++ b/nodejs/src/cdp/templates/test/test-helpers.ts
@@ -211,7 +211,6 @@ export class TemplateTester {
                 fetchRetries: config.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
-                selfLoopGuardMode: config.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: undefined as any, siteUrl: config.SITE_URL },
             hogInputsService,


### PR DESCRIPTION
## Problem

The CDP self-loop guard shipped with a three-value mode (`disabled` | `warn` | `enforce`). `warn` was an observe-only phase for the rollout: detect self-referential ingest loops and meter them without blocking. Enforce has since been the permanent, fleet-wide behavior and has run clean in both regions. That makes the mode config dead scaffolding, and the kill switch is no longer wanted, so the whole flag can go.

## Changes

The guard now runs **unconditionally**. There is no mode config at all.

- Removed `CDP_SELF_LOOP_GUARD_MODE` (config type + default) and the `SelfLoopGuardMode` type.
- Removed the `selfLoopGuardMode` field from `HogExecutorConfig` and dropped the plumbing from every construction site (`cdp-services.ts`, `hog-transformer.service.ts`, and the test helpers).
- The guard gate is now just `if (isPostHogIngestUrl(...))`; the per-function depth cap always enforces.
- The guard core is untouched: `isSelfReferentialIngestFetch`, the per-function depth counter keyed by `hogFunction.id`, `SELF_LOOP_MAX_DEPTH`, the fails-open `try/catch`, the input hardenings, and the customer-facing block error log.
- The `cdp_self_loop_guard_total{mode="enforce"}` metric label is preserved, so the existing block alert keeps working.

> [!NOTE]
> Removing the flag means the guard can no longer be disabled via config. If it ever misfired, the remedy is a revert + redeploy rather than flipping a value. Given enforce has run clean with zero blocks, that tradeoff is intentional.

The leftover `CDP_SELF_LOOP_GUARD_MODE: "enforce"` override in `charts/shared/cdp/common.yaml` is now inert: `overrideWithEnv` only reads env vars that match a known config key, so an unknown one is ignored. No startup impact in any deploy order. It is cosmetic cleanup for a follow-up.

## How did you test this code?

Because prod already runs `enforce`, the executed guard path is unchanged by this PR: it deletes a gate condition that was already always-true and a config key nothing else reads. So there is no runtime behavior delta to observe.

CI is green on the head commit, including the jobs I could not run in this environment (the sandbox blocks a dependency install and `hogli` is not importable, so no local `tsc`/`jest`):

- **Node.js Build** (compile) and **Node.js Code quality** (typecheck + lint/format) pass, confirming no dangling reference to the removed type/field.
- **Node.js Tests 1-3** and the **Node.js Tests Pass** gate pass, covering the self-loop guard tests.

Test changes: dropped the two `warn`-specific cases and the mode-setting test helper. Kept the coverage that catches real regressions: the depth-cap allow-and-stamp path (including hop 0), cross-function isolation (a deep chain for a different function must not trip this one), block-at-cap, and the bypass hardenings (negative/non-finite/array depth). `self-loop-guard.test.ts` was already mode-agnostic (it exercises the pure functions), so it needed no change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs reference this env var, so nothing to update. Internal config change only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus). Two commits, in order: first flip the code default from `warn` to `enforce` while keeping `disabled` as a kill switch, then a follow-up that removes the flag entirely once we decided the kill switch was no longer needed. I invoked the `/writing-tests` skill before touching tests to keep the diff to dropping dead `warn` coverage rather than adding bloat.

One decision worth flagging for review: I checked how config loads before removing the key, since charts still sets `CDP_SELF_LOOP_GUARD_MODE`. `overrideWithEnv` iterates the known config keys and ignores any env var without a match, so the leftover charts value cannot crash startup and the removal is safe in any deploy order. That is why the charts line is left as a separate cosmetic cleanup instead of being bundled here.

Session: https://claude.ai/code/session_01QabnP7KMVAtdKubHdAncPb