### PR TITLE
feat(mcp): roll out render-ui to all MCP Apps hosts, remove flag

### DIFF
--- a/ee/hogai/eval/sandboxed/cli_mcp/eval_render_ui.py
+++ b/ee/hogai/eval/sandboxed/cli_mcp/eval_render_ui.py
@@ -33,11 +33,9 @@ Not exercised here (sandbox/scope limits, not prompt gaps):
   side effects against the shared demo project.
 * **Surveys** — the hedgebox demo seeds none.
 
-``render-ui`` is registered only in ``cli`` mode AND when the ``mcp-render-ui``
-feature flag is on. The eval forces the flag on for the MCP server via the
-dev/test-only ``FEATURE_FLAG_OVERRIDES`` seam (see ``conftest.py:_mcp_server``),
-so the only remaining gate here is the mode: all cases skip under
-``--mcp-mode=tools`` (see ``conftest.py:_apply_mcp_mode``).
+``render-ui`` is registered only in ``cli`` mode and for MCP Apps hosts (the
+sandboxed eval client presents as one), so the only remaining gate here is the
+mode: all cases skip under ``--mcp-mode=tools`` (see ``conftest.py:_apply_mcp_mode``).
 
 To run a single eval:
     pytest ee/hogai/eval/sandboxed/cli_mcp/eval_render_ui.py::eval_renders_entity_ui --mcp-mode=cli

--- a/ee/hogai/eval/sandboxed/conftest.py
+++ b/ee/hogai/eval/sandboxed/conftest.py
@@ -552,11 +552,10 @@ def _mcp_server(_django_live_server, _sandbox_settings):
         # here (no POSTHOG_ANALYTICS_* config), so every flag would resolve false.
         # Force flag-gated behavior on for evals via the dev/test-only override seam
         # (honored only when NODE_ENV is explicitly development/test — set above).
-        # `mcp-render-ui` gates the render_ui umbrella tool — see eval_render_ui.py.
         # `mcp-sql-schema-discovery` routes warehouse/system-table schema discovery
         # through `system.information_schema.*` SQL instead of read-data-warehouse-schema
         # — see eval_system_table_search.py.
-        "FEATURE_FLAG_OVERRIDES": json.dumps({"mcp-render-ui": True, "mcp-sql-schema-discovery": True}),
+        "FEATURE_FLAG_OVERRIDES": json.dumps({"mcp-sql-schema-discovery": True}),
     }
 
     logger.info("Starting MCP server (Hono runtime) on port %d (API: %s)", MCP_PORT, api_url)

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -12,7 +12,6 @@ import {
 import type { RequestProperties } from '@/lib/request-properties'
 import type { McpMode } from '@/lib/utils'
 import { SQL_SCHEMA_DISCOVERY_FEATURE_FLAG } from '@/tools/posthogAiTools/readDataWarehouseSchema'
-import { RENDER_UI_FEATURE_FLAG } from '@/tools/render-ui'
 import { getRequiredFeatureFlags, getScopeGatedTools, type ScopeGatedTool } from '@/tools/toolDefinitions'
 import type { Context, Tool, Env, State, ZodObjectAny } from '@/tools/types'
 
@@ -108,14 +107,11 @@ export class RequestStateResolver {
         }
 
         const toolFlagKeys = getRequiredFeatureFlags()
-        // `mcp-render-ui` isn't a catalog tool flag, but it rides the same batched
-        // evaluation and lives in the same map so the instructions layer can gate
-        // the rendering prompt section on it (like `mcp-feedback-tool`).
         // `mcp-sql-schema-discovery` now gates the read-data-warehouse-schema tool, so
         // it already arrives via `getRequiredFeatureFlags()`; keep it listed (and dedupe)
         // since the instructions layer also reads it for SQL discovery steering — neither
         // concern should depend on the other's wiring.
-        const allFlagKeys = [...new Set([...toolFlagKeys, RENDER_UI_FEATURE_FLAG, SQL_SCHEMA_DISCOVERY_FEATURE_FLAG])]
+        const allFlagKeys = [...new Set([...toolFlagKeys, SQL_SCHEMA_DISCOVERY_FEATURE_FLAG])]
 
         const flagAnalyticsContext = await reqCtx.safelyGetAnalyticsContext(context)
         const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined
@@ -135,7 +131,6 @@ export class RequestStateResolver {
         // even when no catalog tool referenced it.
         const flagKeysForState = [...new Set([...allFlagKeys, ...Object.keys(overrides)])]
         const toolFeatureFlags = Object.fromEntries(flagKeysForState.map((k) => [k, mergedFlags[k]]))
-        const renderUiFlagEnabled = mergedFlags[RENDER_UI_FEATURE_FLAG] === true
 
         const oauthClientName = (await reqCtx.tokenCache.get('clientName')) || undefined
 
@@ -149,11 +144,9 @@ export class RequestStateResolver {
         })
 
         // `render-ui` is only meaningful for MCP Apps hosts (Claude web/desktop) that can
-        // mount its iframe. The flag is necessary but not sufficient: Claude Code and other
-        // single-exec CLI clients pool the same flag value, so the tool's advertisement and
-        // execution must also require the UI-host check — otherwise rolling the flag out to
-        // everyone leaks `render-ui` into Claude Code.
-        const renderUiEnabled = renderUiFlagEnabled && clientProfile.isClaudeUiHost()
+        // mount its iframe. Single-exec CLI clients like Claude Code can't mount it, so the
+        // tool's advertisement and execution stay gated on the UI-host check.
+        const renderUiEnabled = clientProfile.isClaudeUiHost()
 
         const { mode: resolvedMode, useSingleExec } = resolveMode({
             mode: requestContext.mode,

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -108,7 +108,7 @@ export class ToolExecutor {
         }
 
         if (toolName === 'render-ui') {
-            // render-ui is only advertised when the flag is on; reject calls otherwise.
+            // render-ui is only advertised to MCP Apps hosts; reject calls from others.
             if (!state.renderUiEnabled) {
                 toolCallsTotal.inc({ tool: toolName, status: 'error' })
                 return { content: [{ type: 'text', text: `Tool ${toolName} not found` }], isError: true }

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -27,7 +27,7 @@
  *
  * - `isClaudeUiHost()` matches Claude web/desktop and Cowork — MCP Apps hosts
  *   that render interactive UI (iframes). Used to advertise the `render-ui`
- *   tool to them, gated behind the `mcp-render-ui` flag.
+ *   tool to them.
  *
  * - `isClaudeChatHost()` matches Claude web/desktop only — the chat surfaces that
  *   report `supportsInstructions` but never surface the `instructions` payload to

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -38,9 +38,9 @@ export interface InstructionsContext {
     /** Resolved tool feature flags from `resolveToolFeatureFlags`. Used to gate
      *  prompt sections whose corresponding tool is flag-gated. */
     featureFlags?: EvaluatedFlags | undefined
-    /** Whether `render-ui` is actually available to this client (the `mcp-render-ui`
-     *  flag is on AND the client is an MCP Apps host). Gates the CLI rendering section
-     *  so it never reaches clients — like Claude Code — that can't mount the iframe. */
+    /** Whether `render-ui` is actually available to this client (i.e. the client is
+     *  an MCP Apps host). Gates the CLI rendering section so it never reaches clients —
+     *  like Claude Code — that can't mount the iframe. */
     renderUiEnabled?: boolean | undefined
 }
 

--- a/services/mcp/src/lib/posthog/flags.ts
+++ b/services/mcp/src/lib/posthog/flags.ts
@@ -42,7 +42,7 @@ export async function evaluateFeatureFlags(
 }
 
 // Env var (or Cloudflare var) holding a JSON object of flag overrides, e.g.
-// `FEATURE_FLAG_OVERRIDES={"mcp-render-ui": true, "some-flag": "variant-a"}`.
+// `FEATURE_FLAG_OVERRIDES={"mcp-sql-schema-discovery": true, "some-flag": "variant-a"}`.
 const FEATURE_FLAG_OVERRIDES_ENV = 'FEATURE_FLAG_OVERRIDES'
 
 /** Parse a JSON object of flag overrides. Non-object JSON, parse errors, and

--- a/services/mcp/src/tools/render-ui.ts
+++ b/services/mcp/src/tools/render-ui.ts
@@ -11,10 +11,6 @@ export const RENDER_UI_TOOL_NAME = 'render-ui'
 export const RENDER_UI_TOOL_TITLE = 'Render a PostHog visualization'
 export const RENDER_UI_TOOL_DESCRIPTION = RENDER_UI_PROMPT.trim()
 
-// Feature flag gating the entire `render-ui` feature: tool registration/advertisement,
-// the rendering prompt section, and the single-exec switch for Claude web/desktop.
-export const RENDER_UI_FEATURE_FLAG = 'mcp-render-ui'
-
 // Reverse of URI_MAP so a tool's `_meta.ui.resourceUri` resolves back to its app key.
 const URI_TO_APP_KEY = new Map<string, UiAppKey>(
     Object.entries(URI_MAP).map(([appKey, uri]) => [uri, appKey as UiAppKey])

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -257,24 +257,11 @@ describe('RequestStateResolver MCP client contexts', () => {
         expect(mockSessionStore.get('mcpVendorClient')).toBe('ClaudeCode')
     })
 
-    it('puts Claude web/desktop in single-exec when the render-ui flag is on', async () => {
-        vi.mocked(evaluateFeatureFlags).mockResolvedValueOnce({ 'mcp-render-ui': true })
+    it('puts Claude web/desktop in single-exec and enables render-ui', async () => {
         const props = makeProps({ mcpClientName: 'Claude Desktop', mcpVendorClient: 'ClaudeAI' })
         const result = await makeResolver().resolve(props)
 
         expect(result.renderUiEnabled).toBe(true)
-        expect(result.useSingleExec).toBe(true)
-        expect(props.mode).toBe('cli')
-    })
-
-    it('keeps Claude web/desktop in single-exec via the Claude-User user agent even when the render-ui flag is off', async () => {
-        // Anthropic clients always run in CLI (single-exec) mode, so the
-        // User-Agent-only path is single-exec regardless of the render-ui flag — the
-        // flag only gates whether the `render-ui` tool itself is advertised.
-        const props = makeProps({ mcpClientName: 'Claude Desktop', clientUserAgent: 'Claude-User' })
-        const result = await makeResolver().resolve(props)
-
-        expect(result.renderUiEnabled).toBe(false)
         expect(result.useSingleExec).toBe(true)
         expect(props.mode).toBe('cli')
     })
@@ -294,39 +281,34 @@ describe('RequestStateResolver MCP client contexts', () => {
         expect(props.mode).toBe('cli')
     })
 
-    it('does not enable render-ui for Claude Code even when the flag is on', async () => {
-        // Claude Code pools the same `mcp-render-ui` flag value as Claude web/desktop, but
-        // it isn't an MCP Apps host — it can't mount the iframe. It must stay in single-exec
-        // (it's a CLI client) while `renderUiEnabled` resolves to false, so the tool-executor
-        // never advertises or accepts `render-ui` for it.
-        vi.mocked(evaluateFeatureFlags).mockResolvedValueOnce({ 'mcp-render-ui': true })
+    it('does not enable render-ui for Claude Code', async () => {
+        // Claude Code is a single-exec CLI client but not an MCP Apps host — it can't
+        // mount the iframe. It must stay in single-exec while `renderUiEnabled` resolves
+        // to false, so the tool-executor never advertises or accepts `render-ui` for it.
         const props = makeProps({ mcpClientName: 'Anthropic/ClaudeAI', mcpVendorClient: 'ClaudeCode' })
         const result = await makeResolver().resolve(props)
 
         expect(result.renderUiEnabled).toBe(false)
         expect(result.useSingleExec).toBe(true)
-        expect(result.toolFeatureFlags?.['mcp-render-ui']).toBe(true)
     })
 
-    it('detects Claude web/desktop via the Claude-User user agent', async () => {
-        vi.mocked(evaluateFeatureFlags).mockResolvedValueOnce({ 'mcp-render-ui': true })
+    it('detects Claude web/desktop via the Claude-User user agent and enables render-ui', async () => {
         const props = makeProps({ mcpClientName: 'Claude Desktop', clientUserAgent: 'Claude-User' })
         const result = await makeResolver().resolve(props)
 
+        expect(result.renderUiEnabled).toBe(true)
         expect(result.useSingleExec).toBe(true)
         expect(props.mode).toBe('cli')
     })
 
     it('honors a dev/test flag override even when evaluation returns nothing', async () => {
         // Evaluation stays empty (analytics client disabled, as in local dev/evals);
-        // the override seam is what flips the flag on.
-        vi.mocked(resolveFeatureFlagOverrides).mockReturnValueOnce({ 'mcp-render-ui': true })
+        // the override seam is what flips a tool flag on so it reaches the tool layer.
+        vi.mocked(resolveFeatureFlagOverrides).mockReturnValueOnce({ 'mcp-sql-schema-discovery': true })
         const props = makeProps({ mcpClientName: 'Claude Desktop', mcpVendorClient: 'ClaudeAI' })
         const result = await makeResolver().resolve(props)
 
-        expect(result.renderUiEnabled).toBe(true)
-        expect(result.useSingleExec).toBe(true)
-        expect(result.toolFeatureFlags?.['mcp-render-ui']).toBe(true)
+        expect(result.toolFeatureFlags?.['mcp-sql-schema-discovery']).toBe(true)
     })
 
     it('captures consumer from a later request when initialize omitted the header', async () => {

--- a/services/mcp/tests/hono/session-mode-pool.test.ts
+++ b/services/mcp/tests/hono/session-mode-pool.test.ts
@@ -126,7 +126,7 @@ describe('Resolved mode is preserved across pooled-transport vendor flips', () =
 
         // Client caches the tools payload at init. cli mode collapses the wire
         // roster to the single `exec` umbrella tool (the sibling `render-ui` tool
-        // is gated behind the `mcp-render-ui` flag, which is off in tests).
+        // only advertises to MCP Apps hosts; Claude Code isn't one).
         const cachedTools = await clientA.listTools()
         expect(cachedTools.tools.map((t) => t.name).sort()).toEqual(['exec'])
 

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -257,7 +257,7 @@ describe('ToolExecutor', () => {
             expect(renderUiEntry.inputSchema.required).toEqual(['tool_name'])
         })
 
-        it('omits render-ui when the flag is off, even with a UI-app tool available', async () => {
+        it('omits render-ui when render-ui is disabled, even with a UI-app tool available', async () => {
             const state = makeState([uiAppTool], { useSingleExec: true, renderUiEnabled: false })
 
             const result = await executor.handleToolsList(state)
@@ -266,7 +266,7 @@ describe('ToolExecutor', () => {
     })
 
     describe('render-ui', () => {
-        it('dispatches to the render-ui payload when the flag is on', async () => {
+        it('dispatches to the render-ui payload when render-ui is enabled', async () => {
             const state = makeState([uiAppTool], { useSingleExec: true, renderUiEnabled: true })
 
             const result = (await executor.handleToolCall(
@@ -279,7 +279,7 @@ describe('ToolExecutor', () => {
             expect(result.structuredContent.app_key).toBe('survey')
         })
 
-        it('rejects a render-ui call when the flag is off', async () => {
+        it('rejects a render-ui call when render-ui is disabled', async () => {
             const state = makeState([uiAppTool], { useSingleExec: true, renderUiEnabled: false })
 
             const result = (await executor.handleToolCall(

--- a/services/mcp/tests/integration/mcp-protocol-suite.ts
+++ b/services/mcp/tests/integration/mcp-protocol-suite.ts
@@ -1605,9 +1605,9 @@ export function defineExecModeTests(
 
         it('lists the exec umbrella tool in cli mode', async () => {
             const { tools } = await client.listTools()
-            // The sibling `render-ui` tool is gated behind the `mcp-render-ui` flag,
-            // which is off in this environment (analytics client disabled), so the
-            // cli-mode roster collapses to just `exec`.
+            // The sibling `render-ui` tool only advertises to MCP Apps hosts (Claude
+            // web/desktop); this generic test client isn't one, so the cli-mode roster
+            // collapses to just `exec`.
             expect(tools.map((t) => t.name).sort()).toEqual(['exec'])
         })
 

--- a/services/mcp/tests/unit/feature-flag-overrides.test.ts
+++ b/services/mcp/tests/unit/feature-flag-overrides.test.ts
@@ -21,14 +21,14 @@ describe('resolveFeatureFlagOverrides', () => {
     })
 
     it('parses the env JSON object with boolean and variant values', () => {
-        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-render-ui': true, 'some-flag': 'variant-a' })
-        expect(resolveFeatureFlagOverrides()).toEqual({ 'mcp-render-ui': true, 'some-flag': 'variant-a' })
+        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-sql-schema-discovery': true, 'some-flag': 'variant-a' })
+        expect(resolveFeatureFlagOverrides()).toEqual({ 'mcp-sql-schema-discovery': true, 'some-flag': 'variant-a' })
     })
 
     it('lets a per-request override win over the env var', () => {
-        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-render-ui': false })
-        expect(resolveFeatureFlagOverrides(JSON.stringify({ 'mcp-render-ui': true }))).toEqual({
-            'mcp-render-ui': true,
+        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-sql-schema-discovery': false })
+        expect(resolveFeatureFlagOverrides(JSON.stringify({ 'mcp-sql-schema-discovery': true }))).toEqual({
+            'mcp-sql-schema-discovery': true,
         })
     })
 
@@ -40,13 +40,13 @@ describe('resolveFeatureFlagOverrides', () => {
 
     it('is a no-op in production, even with overrides set', () => {
         process.env.NODE_ENV = 'production'
-        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-render-ui': true })
+        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-sql-schema-discovery': true })
         expect(resolveFeatureFlagOverrides(JSON.stringify({ x: true }))).toEqual({})
     })
 
     it('fails closed when NODE_ENV is unset, even with overrides set', () => {
         delete process.env.NODE_ENV
-        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-render-ui': true })
+        process.env.FEATURE_FLAG_OVERRIDES = JSON.stringify({ 'mcp-sql-schema-discovery': true })
         expect(resolveFeatureFlagOverrides(JSON.stringify({ x: true }))).toEqual({})
     })
 

--- a/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
@@ -41,7 +41,7 @@ const STATIC_CTX: InstructionsContext = {
     metadata: STATIC_METADATA,
     tools: STATIC_TOOLS,
     queryTools: STATIC_QUERY_TOOLS,
-    featureFlags: { 'mcp-feedback-tool': true, 'mcp-render-ui': true },
+    featureFlags: { 'mcp-feedback-tool': true },
     renderUiEnabled: true,
 }
 

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -34,7 +34,7 @@ const fullCtx: InstructionsContext = {
     metadata: realisticMetadata,
     tools: realisticTools,
     queryTools: realisticQueryTools,
-    featureFlags: { 'mcp-feedback-tool': true, 'mcp-render-ui': true },
+    featureFlags: { 'mcp-feedback-tool': true },
     renderUiEnabled: true,
 }
 


### PR DESCRIPTION
## Problem

The `render-ui` umbrella tool (which lets MCP Apps hosts like Claude web/desktop render PostHog visualizations in an iframe) was gated behind the `mcp-render-ui` feature flag. The feature is ready for everyone, so the flag is now dead weight.

## Changes

Removes the `mcp-render-ui` flag and rolls `render-ui` out to every MCP Apps host.

`renderUiEnabled` now derives from the `isClaudeUiHost()` capability check alone. That check stays because it is a genuine capability gate, not a rollout gate: single-exec CLI clients like Claude Code share the same transport pool but cannot mount the iframe, so `render-ui` must never be advertised or accepted for them. `resolveMode` drops its `renderUiFlagEnabled` argument and puts Claude UI hosts into single-exec mode directly.

Also drops the now-defunct `mcp-render-ui` override from the sandboxed eval harness (`conftest.py`) and refreshes the stale comments that referenced the flag. The sandboxed eval client already presents as an MCP Apps host, so `eval_render_ui` keeps working off the mode gate alone.

> [!NOTE]
> No behavior change for Claude Code or other non-UI-host clients: they were never render-ui hosts and still are not.

## How did you test this code?

I (Claude) ran the affected suites locally after installing the `services/mcp` deps:

- `vitest run` on `protocol-types`, `feature-flag-overrides`, `instructions-formatter`, `instructions-formatter-snapshot`, `render-ui` — 45 passed
- `vitest run --config vitest.hono.config.mts` on `request-state-resolver`, `tool-executor`, `session-mode-pool` — 33 passed
- `tsgo --noEmit` shows no errors in any touched file (the only typecheck errors are pre-existing, from unbuilt `@posthog/quill` workspace packages, unrelated to this change)

The integration suite (`mcp-protocol-suite.ts`) needs a live server, which I did not stand up; my only edit there is a comment.

Test edits: the resolver/executor tests that previously mocked the flag now assert the capability-gated behavior directly. The key regression they still catch is that `render-ui` is enabled for Claude web/desktop but stays off for Claude Code. I merged two now-identical UA-detection cases and re-pointed the override-seam integration test at a still-existing flag (`mcp-sql-schema-discovery`).

## Docs update

No user-facing docs cover this internal flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Slack app) from a Slack thread. I invoked the `/writing-tests` skill before touching the test files. I traced every reference to `RENDER_UI_FEATURE_FLAG` / `mcp-render-ui` across `services/mcp` and `ee/hogai/eval`, then verified the surviving `isClaudeUiHost()` gate keeps `render-ui` away from Claude Code (which was the whole reason the flag was AND-ed with a host check rather than used alone). I chose to keep that host check rather than fully unconditionally enable the tool, since removing it would leak `render-ui` into clients that cannot render it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1783599600842199)*
