### PR TITLE
docs(stamphog): note that vendored copies in other repos need re-syncing

### DIFF
--- a/.stamphog/README.md
+++ b/.stamphog/README.md
@@ -2,6 +2,7 @@
 
 Declarative policy for the stamphog PR-approval merge gate (`tools/pr-approval-agent/`).
 The engine loads these files from the checked-out working tree at run time.
+Engine and policy are vendored into other repos (see the note in `tools/pr-approval-agent/README.md`), so format changes here need those copies re-synced too.
 
 ## What lives here
 

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -3,6 +3,9 @@
 AI-assisted PR approval for PostHog.
 Deterministic safety gates first, then Claude reviews for showstoppers.
 
+> [!NOTE]
+> This directory (together with `.stamphog/`) is vendored into other repos — e.g. [MLHog](https://github.com/PostHog/MLHog/tree/master/tools/pr-approval-agent) — each documenting its intentional local changes in its own copy of this README. When you change the engine or policy format here, those copies stay stale until someone re-syncs them, so give the owning teams a heads-up (or re-sync yourself: diff, re-copy, re-apply their documented local changes).
+
 ## Usage
 
 Add the `stamphog` label to a non-draft PR.


### PR DESCRIPTION
StampHog is now vendored into other repos (e.g. [MLHog](https://github.com/PostHog/MLHog/tree/master/tools/pr-approval-agent), just re-synced in [MLHog#53](https://github.com/PostHog/MLHog/pull/53)), and those copies silently go stale when the engine or policy format changes here.

Adds a short note to `tools/pr-approval-agent/README.md` and a one-liner to `.stamphog/README.md` so anyone changing stamphog knows downstream copies need a heads-up or a re-sync.

Docs only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)