### PR TITLE
fix(phrocs): make r (re)run procs in any state, not just running or crashed

### DIFF
--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -312,21 +312,17 @@ func (m *Model) updateProcKeys() {
 	if p.IsStandby() {
 		m.keys.Start.SetEnabled(true)
 		m.keys.Stop.SetEnabled(false)
-		m.keys.Restart.SetEnabled(false)
+		m.keys.Restart.SetEnabled(true)
 		m.keys.ClearLogs.SetEnabled(false)
 		return
 	}
-	// Snapshot status once so running/crashed are derived from the same
-	// observation — avoids a second trip through the proc mutex and any
-	// chance of inconsistency between the two reads.
-	st := p.Status()
-	running := st.IsRunning()
-	crashed := st == process.StatusCrashed
+	running := p.Status().IsRunning()
 	m.keys.Start.SetEnabled(!running)
 	m.keys.Stop.SetEnabled(running)
-	// `r` doubles as "restart a running proc" and "kick a crashed proc back to
-	// life" — both express the same user intent of "rerun this thing".
-	m.keys.Restart.SetEnabled(running || crashed)
+	// `r` always has work to do — restart a running proc, or (re)run one
+	// that crashed, finished, was stopped, or never started. One key, one
+	// intent: "run this thing", regardless of what state it's in.
+	m.keys.Restart.SetEnabled(true)
 	m.keys.ClearLogs.SetEnabled(running)
 }
 
@@ -519,11 +515,18 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		if p := m.activeProc(); p != nil {
 			send := m.mgr.Send()
 			switch {
+			case p.IsStandby():
+				if real, ok := m.promoteStandby(); ok {
+					m.dbg("restart: promoted standby proc=%s", real.Name)
+					go func() { _ = real.Start(send) }()
+				}
 			case p.IsRunning():
 				m.dbg("restart: proc=%s", p.Name)
 				go p.Restart(send)
-			case p.Status() == process.StatusCrashed:
-				m.dbg("restart (from crashed): proc=%s", p.Name)
+			default:
+				// Crashed, finished, stopped, or never started — `r` means
+				// "run it (again)", so one-shot tasks rerun on a keypress.
+				m.dbg("restart (from %s): proc=%s", p.Status(), p.Name)
 				go func() { _ = p.Start(send) }()
 			}
 		}

--- a/tools/phrocs/internal/tui/restart_failed_test.go
+++ b/tools/phrocs/internal/tui/restart_failed_test.go
@@ -244,10 +244,9 @@ func waitRunning(t *testing.T, p *process.Process, send func(tea.Msg)) {
 }
 
 // TestUpdateProcKeys_RestartBindingGating verifies the `r` (Restart) binding
-// is enabled in exactly the states where it has meaningful work: a running
-// proc (existing behavior) or a crashed proc (new behavior). Never-started,
-// cleanly-exited, and manually-stopped procs are all the user's chosen end-
-// state and must leave `r` disabled.
+// is enabled in every proc state — running procs restart, everything else
+// (never-started, crashed, cleanly-exited one-shots, manually-stopped) starts.
+// `r` is the universal "run this thing" key.
 func TestUpdateProcKeys_RestartBindingGating(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -259,7 +258,7 @@ func TestUpdateProcKeys_RestartBindingGating(t *testing.T) {
 			setup: func(t *testing.T) Model {
 				return readyModel(t, "backend")
 			},
-			wantEnabled: false,
+			wantEnabled: true,
 		},
 		{
 			name: "running proc",
@@ -286,7 +285,7 @@ func TestUpdateProcKeys_RestartBindingGating(t *testing.T) {
 				runUntilStatus(t, findProc(t, m, "oneshot"), m.mgr.Send(), process.StatusDone)
 				return m
 			},
-			wantEnabled: false,
+			wantEnabled: true,
 		},
 		{
 			name: "manually stopped",
@@ -297,7 +296,7 @@ func TestUpdateProcKeys_RestartBindingGating(t *testing.T) {
 				p.Stop()
 				return m
 			},
-			wantEnabled: false,
+			wantEnabled: true,
 		},
 	}
 
@@ -312,36 +311,49 @@ func TestUpdateProcKeys_RestartBindingGating(t *testing.T) {
 	}
 }
 
-// ── `r` keypress on a crashed proc actually restarts it ─────────────────────────
+// ── `r` keypress on a non-running proc actually (re)starts it ────────────────────
 
-func TestHandleNormalKey_RestartKeyRevivesCrashedProc(t *testing.T) {
-	// End-to-end check that pressing `r` on a crashed proc kicks off Start
-	// (not just that the binding is enabled). We use `sleep 30` as the shell
-	// — once the second start fires, the proc should be running again.
-	m := modelWithProcs(t, map[string]string{"flaky": "exit 1"})
-	runUntilStatus(t, findProc(t, m, "flaky"), m.mgr.Send(), process.StatusCrashed)
-
-	// Swap the shell to a long-running command so the post-`r` start lands on
-	// a process that won't immediately crash again — lets us observe the
-	// running state without races.
-	p := findProc(t, m, "flaky")
-	p.Cfg.Shell = "sleep 30"
-	t.Cleanup(func() { p.Stop() })
-
-	m.updateProcKeys()
-	if !m.keys.Restart.Enabled() {
-		t.Fatal("precondition: Restart binding should be enabled on a crashed proc")
+// End-to-end check that pressing `r` kicks off Start on procs in terminal
+// states (not just that the binding is enabled). Covers the crashed case and
+// the finished one-shot case ("migrate postgres"-style tasks that exit 0).
+func TestHandleNormalKey_RestartKeyRerunsTerminalProc(t *testing.T) {
+	cases := []struct {
+		name   string
+		shell  string
+		target process.Status
+	}{
+		{name: "crashed", shell: "exit 1", target: process.StatusCrashed},
+		{name: "finished one-shot", shell: "true", target: process.StatusDone},
 	}
 
-	next, _ := m.Update(keypress('r'))
-	_ = next
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := modelWithProcs(t, map[string]string{"task": tc.shell})
+			runUntilStatus(t, findProc(t, m, "task"), m.mgr.Send(), tc.target)
 
-	deadline := time.After(2 * time.Second)
-	for !p.IsRunning() {
-		select {
-		case <-deadline:
-			t.Fatalf("crashed proc never restarted (status: %s)", p.Status())
-		case <-time.After(20 * time.Millisecond):
-		}
+			// Swap the shell to a long-running command so the post-`r` start
+			// lands on a process that won't immediately exit again — lets us
+			// observe the running state without races.
+			p := findProc(t, m, "task")
+			p.Cfg.Shell = "sleep 30"
+			t.Cleanup(func() { p.Stop() })
+
+			m.updateProcKeys()
+			if !m.keys.Restart.Enabled() {
+				t.Fatalf("precondition: Restart binding should be enabled on a %s proc", tc.name)
+			}
+
+			next, _ := m.Update(keypress('r'))
+			_ = next
+
+			deadline := time.After(2 * time.Second)
+			for !p.IsRunning() {
+				select {
+				case <-deadline:
+					t.Fatalf("%s proc never restarted (status: %s)", tc.name, p.Status())
+				case <-time.After(20 * time.Millisecond):
+				}
+			}
+		})
 	}
 }

--- a/tools/phrocs/internal/tui/standby_test.go
+++ b/tools/phrocs/internal/tui/standby_test.go
@@ -272,8 +272,9 @@ func TestShowAll_cursorPreservedOnToggle(t *testing.T) {
 // ── Key enablement ──────────────────────────────────────────────────────────────
 
 func TestShowAll_keyEnablementByProcState(t *testing.T) {
-	// Expected key enablement for each process state. Ensures standby processes
-	// only expose Start, while other states follow the running/stopped rules.
+	// Expected key enablement for each process state. `r` is enabled in every
+	// state (it acts as start on standby/stopped procs); Stop stays gated on
+	// running.
 	cases := []struct {
 		name        string
 		procName    string // name of the process to focus on (from readyShowAllModel)
@@ -281,8 +282,8 @@ func TestShowAll_keyEnablementByProcState(t *testing.T) {
 		wantStop    bool
 		wantRestart bool
 	}{
-		{name: "standby", procName: "capture", wantStart: true},
-		{name: "stopped", procName: "backend", wantStart: true},
+		{name: "standby", procName: "capture", wantStart: true, wantRestart: true},
+		{name: "stopped", procName: "backend", wantStart: true, wantRestart: true},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Problem

In the phrocs TUI (`hogli start` / `bin/start`), pressing `r` on a one-shot task like `migrate postgres` did nothing once the task had finished. The Restart binding was only enabled for procs that were currently running or crashed, so procs in done, stopped, never-started, or standby states silently ignored the key. That made `r` unreliable as the "just do the thing" key.

**Why:** you should be able to select any entry in the sidebar and press `r` to run it — refresh, restart, start, rerun — without first checking what state it's in.

## Changes

`r` now always acts on the selected proc:

- running → restart (unchanged)
- crashed → start (unchanged)
- done / stopped / never started → start, so finished one-shot tasks rerun on a keypress
- standby → promote to a real proc and start (same as `s`)

`s` (start), `x` (stop), and `R` (restart all failed) are untouched — `R` still only touches crashed procs and won't rerun clean exits or undo manual stops.

## How did you test this code?

Automated tests only (no manual TUI run in this environment):

- Extended `TestUpdateProcKeys_RestartBindingGating` so the clean-exit, manually-stopped, and never-started cases now assert the binding is enabled — these previously asserted the opposite, catching a regression back to the old gating.
- Generalized the crashed-proc end-to-end test into `TestHandleNormalKey_RestartKeyRerunsTerminalProc`, adding a finished one-shot (`exit 0`) case that verifies a real `r` keypress spawns the process again — the exact reported symptom.
- Updated `TestShowAll_keyEnablementByProcState` for standby/stopped procs.

Ran `go build ./...`, `go vet`, and the full `go test ./...` suite in `tools/phrocs` — all green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The README's footer diagram (`r restart`) and standby docs remain accurate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code). Located the `r` handling in `tools/phrocs/internal/tui/keys.go`, traced the process status model (`pending/running/stopped/done/crashed/standby`), and widened both the key-enablement gate (`updateProcKeys`) and the keypress handler. Considered leaving standby procs on `s` only, but included them so `r` is uniformly "run this thing" in every state. No skills invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
