### PR TITLE
fix(notebooks): keep scene when deleting a note from the side panel

### DIFF
--- a/frontend/src/scenes/notebooks/NotebookMenu.tsx
+++ b/frontend/src/scenes/notebooks/NotebookMenu.tsx
@@ -18,7 +18,7 @@ import { notebooksModel } from '~/models/notebooksModel'
 import { isMarkdownNotebookContent } from './Notebook/markdownNotebookV2'
 import { NotebookLogicProps, notebookLogic } from './Notebook/notebookLogic'
 
-export function NotebookMenu({ shortId }: NotebookLogicProps): JSX.Element {
+export function NotebookMenu({ shortId, inPanel }: NotebookLogicProps & { inPanel?: boolean }): JSX.Element {
     const { notebook, showHistory, isLocalOnly, content } = useValues(notebookLogic({ shortId }))
     const { openShareModal, duplicateNotebook, exportJSON, downloadMarkdown, copyMarkdown, setShowHistory } =
         useActions(notebookLogic({ shortId }))
@@ -78,7 +78,11 @@ export function NotebookMenu({ shortId }: NotebookLogicProps): JSX.Element {
                             <ButtonPrimitive
                                 onClick={() => {
                                     notebooksModel.actions.deleteNotebook(shortId, notebook?.title)
-                                    router.actions.push(urls.notebooks())
+                                    // In the side panel the deleted notebook is swapped for the
+                                    // scratchpad in place, so we stay on the current scene.
+                                    if (!inPanel) {
+                                        router.actions.push(urls.notebooks())
+                                    }
                                 }}
                                 menuItem
                                 variant="danger"

--- a/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
+++ b/frontend/src/scenes/notebooks/NotebookPanel/NotebookPanel.tsx
@@ -68,7 +68,7 @@ export function NotebookPanel(): JSX.Element | null {
                             <div className="flex-1" />
                             <div className="flex items-center gap-1">
                                 {selectedNotebook && <NotebookPresence shortId={selectedNotebook} />}
-                                <NotebookMenu shortId={selectedNotebook} />
+                                <NotebookMenu shortId={selectedNotebook} inPanel />
                                 {contentWidthHasEffect && (
                                     <NotebookExpandButton
                                         size="small"


### PR DESCRIPTION
## Problem

Deleting an account note from the notebook side panel (e.g. on the Customer analytics accounts view at `/customer_analytics/accounts#panel=notebook`) navigated the user away to the notebooks list instead of leaving them where they were. Raised in [this Slack thread](https://posthog.slack.com/archives/C08GGECGJF4/p1783581643326579?thread_ts=1783581643.326579&cid=C08GGECGJF4).

## Changes

`NotebookMenu` is shared between the full-page notebook scene and the side panel. Its delete handler unconditionally ran `router.actions.push(urls.notebooks())`, which is right for the full page but wrong in the panel: `notebooksModel.deleteNotebook` already swaps the deleted notebook for the scratchpad in place, so the panel stays open on the current scene.

I added an `inPanel` prop to `NotebookMenu` and pass it from `NotebookPanel`. When set, the post-delete navigation is skipped, so deleting a note keeps you on the accounts list (or whatever scene the panel is open over).

## How did you test this code?

I (the agent) did not run the app. The change is a small conditional guard around an existing navigation call; no automated tests were added or run. The existing `NotebookMenu.test.tsx` covers menu rendering.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread. Traced the bug to `NotebookMenu.tsx` sharing one delete handler across the full-page scene and the side panel, confirmed `notebooksModel` already handles the panel case by swapping in the scratchpad notebook, and gated the navigation on a new `inPanel` prop rather than duplicating the delete logic.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08GGECGJF4/p1783581643326579?thread_ts=1783581643.326579&cid=C08GGECGJF4)*
