### PR TITLE
fix(insights): resolve group-property breakdown on retention

### DIFF
--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -3920,6 +3920,61 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             ),
         )
 
+    def test_retention_with_breakdown_with_group_properties(self):
+        create_group_type_mapping_without_created_at(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+        create_group(
+            team_id=self.team.pk, group_type_index=0, group_key="org:finance", properties={"industry": "finance"}
+        )
+        create_group(
+            team_id=self.team.pk, group_type_index=0, group_key="org:tech", properties={"industry": "technology"}
+        )
+
+        create_person(team=self.team, distinct_ids=["person1"])
+        create_person(team=self.team, distinct_ids=["person2"])
+
+        _create_events(
+            self.team,
+            [
+                # finance org
+                ("person1", _date(0), {"$group_0": "org:finance"}),
+                ("person1", _date(1), {"$group_0": "org:finance"}),
+                ("person1", _date(3), {"$group_0": "org:finance"}),
+                # technology org
+                ("person2", _date(0), {"$group_0": "org:tech"}),
+                ("person2", _date(1), {"$group_0": "org:tech"}),
+            ],
+        )
+
+        # Breaking down by a group property must resolve the events->groups join
+        # (chain group_0, not groups_0), otherwise the query fails to resolve.
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(5, hour=0)},
+                "retentionFilter": {"totalIntervals": 6, "period": "Day"},
+                "breakdownFilter": {"breakdowns": [{"property": "industry", "type": "group", "group_type_index": 0}]},
+            }
+        )
+
+        breakdown_values = {c.get("breakdown_value") for c in result}
+        self.assertEqual(breakdown_values, {"finance", "technology"})
+
+        finance_cohorts = pluck([c for c in result if c.get("breakdown_value") == "finance"], "values", "count")
+        self.assertEqual(
+            finance_cohorts,
+            pad(
+                [
+                    [1, 1, 0, 1, 0, 0],
+                    [1, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                ]
+            ),
+        )
+
     def test_dwh_variant_breakdown_event_property_per_value_parity(self):
         # Tracer bullet: the variant must mirror the legacy per-value cohort semantics
         # for event-property breakdowns. person1 starts "clothing" then returns with a

--- a/posthog/hogql_queries/insights/retention/test/test_retention_utils.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_utils.py
@@ -24,6 +24,12 @@ class TestBreakdownExtractExpr(SimpleTestCase):
         expr = breakdown_extract_expr("industry", "group", group_type_index=cast(int, 1.0))
         self.assertEqual(_chain(expr), ["group_1", "properties", "industry"])
 
+    def test_group_breakdown_virtual_property_skips_properties_key(self) -> None:
+        # Virtual group properties are expression fields on the groups table, so the
+        # chain must be `group_{index}.$virt_x`, not `group_{index}.properties.$virt_x`.
+        expr = breakdown_extract_expr("$virt_revenue", "group", group_type_index=0)
+        self.assertEqual(_chain(expr), ["group_0", "$virt_revenue"])
+
     def test_group_breakdown_without_index_raises_clear_error(self) -> None:
         # A missing index must fail loudly rather than emit an unresolvable `group_None` field.
         with self.assertRaises(ValueError):

--- a/posthog/hogql_queries/insights/retention/test/test_retention_utils.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_utils.py
@@ -1,0 +1,30 @@
+from typing import cast
+
+from django.test import SimpleTestCase
+
+from posthog.hogql import ast
+
+from posthog.hogql_queries.insights.retention.utils import breakdown_extract_expr
+
+
+def _chain(expr: ast.Expr) -> list:
+    # breakdown_extract_expr wraps the field in ifNull(toString(<field>), '')
+    to_string = cast(ast.Call, cast(ast.Call, expr).args[0])
+    return cast(ast.Field, to_string.args[0]).chain
+
+
+class TestBreakdownExtractExpr(SimpleTestCase):
+    def test_group_breakdown_uses_events_lazy_join_chain(self) -> None:
+        # Group properties are read via the events table lazy join `group_{index}`,
+        # not a standalone `groups_{index}` table.
+        expr = breakdown_extract_expr("industry", "group", group_type_index=0)
+        self.assertEqual(_chain(expr), ["group_0", "properties", "industry"])
+
+    def test_group_breakdown_coerces_float_index(self) -> None:
+        expr = breakdown_extract_expr("industry", "group", group_type_index=cast(int, 1.0))
+        self.assertEqual(_chain(expr), ["group_1", "properties", "industry"])
+
+    def test_group_breakdown_without_index_raises_clear_error(self) -> None:
+        # A missing index must fail loudly rather than emit an unresolvable `group_None` field.
+        with self.assertRaises(ValueError):
+            breakdown_extract_expr("industry", "group", group_type_index=None)

--- a/posthog/hogql_queries/insights/retention/utils.py
+++ b/posthog/hogql_queries/insights/retention/utils.py
@@ -31,9 +31,9 @@ def breakdown_extract_expr(property_name: str, breakdown_type: str, group_type_i
         elif breakdown_type == "group":
             if property_name.startswith("$virt_"):
                 # Virtual properties exist as expression fields on the groups table
-                properties_chain = [f"groups_{group_type_index}", property_name]
+                properties_chain = [f"group_{group_type_index}", property_name]
             else:
-                properties_chain = [f"groups_{group_type_index}", "properties", property_name]
+                properties_chain = [f"group_{group_type_index}", "properties", property_name]
         else:
             # Default to event properties
             properties_chain = ["events", "properties", property_name]

--- a/posthog/hogql_queries/insights/retention/utils.py
+++ b/posthog/hogql_queries/insights/retention/utils.py
@@ -29,11 +29,14 @@ def breakdown_extract_expr(property_name: str, breakdown_type: str, group_type_i
         elif breakdown_type == "data_warehouse_person_property":
             properties_chain = ["person", *property_name.split(".")]
         elif breakdown_type == "group":
+            if group_type_index is None:
+                raise ValueError("group_type_index is required for group breakdowns")
+            group_index = int(group_type_index)
             if property_name.startswith("$virt_"):
                 # Virtual properties exist as expression fields on the groups table
-                properties_chain = [f"group_{group_type_index}", property_name]
+                properties_chain = [f"group_{group_index}", property_name]
             else:
-                properties_chain = [f"group_{group_type_index}", "properties", property_name]
+                properties_chain = [f"group_{group_index}", "properties", property_name]
         else:
             # Default to event properties
             properties_chain = ["events", "properties", property_name]


### PR DESCRIPTION
## Problem

Adding a **group** breakdown to a retention insight errors out with `Validation error: Unable to resolve field: groups_0`. Event- and person-property breakdowns work fine — only group-property breakdowns fail, so retention can't be segmented by a group (e.g. organization) property at all.

Reported from a [Slack thread](https://posthog.slack.com/archives/C0A2AHK6CN8/p1783601341559609).

## Changes

`breakdown_extract_expr` (retention) built the group property chain as `groups_{group_type_index}`, but there is no such field. Group properties are reached from the `events` table through its lazy join named `group_{group_type_index}` (singular) — the same chain trends' `get_properties_chain` already uses. Dropping the stray `s` lets the join resolve.

- Fix the property chain in `posthog/hogql_queries/insights/retention/utils.py` (both the `$virt_` and the regular-property branch).
- Add `test_retention_with_breakdown_with_group_properties` covering a group-property breakdown end to end.

## How did you test this code?

Reproduced the failure against a live project before the fix (retention + `breakdown_type: "group"` → `Unable to resolve field: groups_0`); an equivalent event-property breakdown returned data, isolating the bug to the group chain.

Added `test_retention_with_breakdown_with_group_properties` — it catches a regression no existing retention test did: none exercised `breakdown_type: "group"` on a group property (existing coverage is event, person, cohort, and `event_metadata` only), so a revert to `groups_{index}` would otherwise ship uncaught.

**Manually verified locally** (Python/ClickHouse/Postgres stack):

- Ran the ClickHouse-backed test: `test_retention_with_breakdown_with_group_properties` **passes** on this branch. Reverting the fix (`group_` back to `groups_`) makes it **fail with the exact reported error** (`Unable to resolve field: groups_0`), so the test genuinely catches the regression rather than just passing.
- End-to-end in the app: seeded an `organization` group type, two groups, and group-tagged events, then ran a retention insight broken down by a group property through the query API. On this branch it resolves into segmented rows (finance / technology); on `master` the same query errors with `Unable to resolve field: groups_0`.

Changed files also pass `ruff check`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent from a Slack thread. The user hit the error on a retention insight and asked for the fix. The agent reproduced it live via the PostHog MCP tools (created a temp insight with the exact query, confirmed the error, verified an event-property breakdown worked, then deleted the temp insight), traced the unresolved `groups_0` field to `breakdown_extract_expr`, and confirmed the correct chain against the `events` table schema (`group_0` lazy join) and trends' `get_properties_chain`. Invoked the `/writing-tests` skill before adding the test.

