### PR TITLE
fix(dashboards): keep inline code innermost in text card markdown

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.test.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.test.ts
@@ -124,6 +124,34 @@ describe('textCardMarkdown', () => {
         expect(roundTripDoc).not.toEqual(richDoc)
     })
 
+    it.each([
+        ['bold', 'bold'],
+        ['italic', 'italic'],
+        ['strike', 'strike'],
+    ])('keeps inline code innermost when a text node is also %s', (_name, markType) => {
+        const doc: JSONContent = {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        { type: 'text', text: 'before ' },
+                        { type: 'text', text: "ai_product='signals'", marks: [{ type: markType }, { type: 'code' }] },
+                        { type: 'text', text: ' after' },
+                    ],
+                },
+            ],
+        }
+
+        const markdown = textCardDocToMarkdown(doc)
+        // The code span's backticks must sit inside the surrounding mark, e.g. **`code`** — not
+        // the malformed **`code**` that @tiptap/markdown emits when code is not innermost.
+        expect(markdown).toContain("`ai_product='signals'`")
+        // Round-trips cleanly, so the controlled editor no longer resets while typing near this span.
+        expect(isTextCardMarkdownRoundTripSafe(markdown)).toBe(true)
+        expect(markdownToTextCardDoc(markdown)).toEqual(markdownToTextCardDoc(textCardDocToMarkdown(markdownToTextCardDoc(markdown))))
+    })
+
     it('supports underline markdown round-trip', () => {
         const markdown = '++underlined++'
         const doc = markdownToTextCardDoc(markdown)

--- a/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.test.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.test.ts
@@ -124,33 +124,31 @@ describe('textCardMarkdown', () => {
         expect(roundTripDoc).not.toEqual(richDoc)
     })
 
-    it.each([
-        ['bold', 'bold'],
-        ['italic', 'italic'],
-        ['strike', 'strike'],
-    ])('keeps inline code innermost when a text node is also %s', (_name, markType) => {
-        const doc: JSONContent = {
-            type: 'doc',
-            content: [
-                {
-                    type: 'paragraph',
-                    content: [
-                        { type: 'text', text: 'before ' },
-                        { type: 'text', text: "ai_product='signals'", marks: [{ type: markType }, { type: 'code' }] },
-                        { type: 'text', text: ' after' },
-                    ],
-                },
-            ],
-        }
+    it.each(['bold', 'italic', 'strike'])(
+        'keeps inline code innermost when a text node is also %s',
+        (markType) => {
+            const doc: JSONContent = {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            { type: 'text', text: 'before ' },
+                            { type: 'text', text: "ai_product='signals'", marks: [{ type: markType }, { type: 'code' }] },
+                            { type: 'text', text: ' after' },
+                        ],
+                    },
+                ],
+            }
 
-        const markdown = textCardDocToMarkdown(doc)
-        // The code span's backticks must sit inside the surrounding mark, e.g. **`code`** — not
-        // the malformed **`code**` that @tiptap/markdown emits when code is not innermost.
-        expect(markdown).toContain("`ai_product='signals'`")
-        // Round-trips cleanly, so the controlled editor no longer resets while typing near this span.
-        expect(isTextCardMarkdownRoundTripSafe(markdown)).toBe(true)
-        expect(markdownToTextCardDoc(markdown)).toEqual(markdownToTextCardDoc(textCardDocToMarkdown(markdownToTextCardDoc(markdown))))
-    })
+            const markdown = textCardDocToMarkdown(doc)
+            // The code span's backticks must sit inside the surrounding mark, e.g. **`code`** — not
+            // the malformed **`code**` that @tiptap/markdown emits when code is not innermost.
+            expect(markdown).toContain("`ai_product='signals'`")
+            // Round-trips cleanly, so the controlled editor no longer resets while typing near this span.
+            expect(isTextCardMarkdownRoundTripSafe(markdown)).toBe(true)
+        }
+    )
 
     it('supports underline markdown round-trip', () => {
         const markdown = '++underlined++'

--- a/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.test.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.test.ts
@@ -124,31 +124,28 @@ describe('textCardMarkdown', () => {
         expect(roundTripDoc).not.toEqual(richDoc)
     })
 
-    it.each(['bold', 'italic', 'strike'])(
-        'keeps inline code innermost when a text node is also %s',
-        (markType) => {
-            const doc: JSONContent = {
-                type: 'doc',
-                content: [
-                    {
-                        type: 'paragraph',
-                        content: [
-                            { type: 'text', text: 'before ' },
-                            { type: 'text', text: "ai_product='signals'", marks: [{ type: markType }, { type: 'code' }] },
-                            { type: 'text', text: ' after' },
-                        ],
-                    },
-                ],
-            }
-
-            const markdown = textCardDocToMarkdown(doc)
-            // The code span's backticks must sit inside the surrounding mark, e.g. **`code`** — not
-            // the malformed **`code**` that @tiptap/markdown emits when code is not innermost.
-            expect(markdown).toContain("`ai_product='signals'`")
-            // Round-trips cleanly, so the controlled editor no longer resets while typing near this span.
-            expect(isTextCardMarkdownRoundTripSafe(markdown)).toBe(true)
+    it.each(['bold', 'italic', 'strike'])('keeps inline code innermost when a text node is also %s', (markType) => {
+        const doc: JSONContent = {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        { type: 'text', text: 'before ' },
+                        { type: 'text', text: "ai_product='signals'", marks: [{ type: markType }, { type: 'code' }] },
+                        { type: 'text', text: ' after' },
+                    ],
+                },
+            ],
         }
-    )
+
+        const markdown = textCardDocToMarkdown(doc)
+        // The code span's backticks must sit inside the surrounding mark, e.g. **`code`** — not
+        // the malformed **`code**` that @tiptap/markdown emits when code is not innermost.
+        expect(markdown).toContain("`ai_product='signals'`")
+        // Round-trips cleanly, so the controlled editor no longer resets while typing near this span.
+        expect(isTextCardMarkdownRoundTripSafe(markdown)).toBe(true)
+    })
 
     it('supports underline markdown round-trip', () => {
         const markdown = '++underlined++'

--- a/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.ts
@@ -92,23 +92,20 @@ const markdownManager = new MarkdownManager({
     extensions: TEXT_CARD_MARKDOWN_EXTENSIONS,
 })
 
-// @tiptap/markdown closes a text node's marks in array order, so when `code` is not the
+// @tiptap/markdown 3.20.x closes a text node's marks in array order, so when `code` is not the
 // innermost mark it emits malformed markdown (e.g. **`snippet**` instead of **`snippet`**).
 // That broke the round trip and made the controlled editor reset itself while typing. Force
 // `code` innermost (first in the marks array) so its backticks always sit inside bold/italic/strike.
+// Fixed upstream in @tiptap/markdown >= 3.27.3; remove this once the tiptap suite is bumped.
 function withCodeMarkInnermost(doc: JSONContent): JSONContent {
     const visit = (node: JSONContent): JSONContent => {
-        let next = node
         const marks = node.marks
-        if (marks && marks.length > 1 && marks.some((mark) => mark.type === 'code')) {
-            const code = marks.filter((mark) => mark.type === 'code')
-            const others = marks.filter((mark) => mark.type !== 'code')
-            next = { ...node, marks: [...code, ...others] }
-        }
-        if (next.content) {
-            next = { ...next, content: next.content.map(visit) }
-        }
-        return next
+        const codeIndex = marks ? marks.findIndex((mark) => mark.type === 'code') : -1
+        const next =
+            marks && codeIndex > 0
+                ? { ...node, marks: [marks[codeIndex], ...marks.slice(0, codeIndex), ...marks.slice(codeIndex + 1)] }
+                : node
+        return next.content ? { ...next, content: next.content.map(visit) } : next
     }
     return visit(doc)
 }

--- a/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.ts
@@ -92,6 +92,31 @@ const markdownManager = new MarkdownManager({
     extensions: TEXT_CARD_MARKDOWN_EXTENSIONS,
 })
 
+// @tiptap/markdown closes a text node's marks in array order, so when `code` is not the
+// innermost mark it emits malformed markdown (e.g. **`snippet**` instead of **`snippet`**).
+// That broke the round trip and made the controlled editor reset itself while typing. Force
+// `code` innermost (first in the marks array) so its backticks always sit inside bold/italic/strike.
+function withCodeMarkInnermost(doc: JSONContent): JSONContent {
+    const visit = (node: JSONContent): JSONContent => {
+        let next = node
+        const marks = node.marks
+        if (marks && marks.length > 1 && marks.some((mark) => mark.type === 'code')) {
+            const code = marks.filter((mark) => mark.type === 'code')
+            const others = marks.filter((mark) => mark.type !== 'code')
+            next = { ...node, marks: [...code, ...others] }
+        }
+        if (next.content) {
+            next = { ...next, content: next.content.map(visit) }
+        }
+        return next
+    }
+    return visit(doc)
+}
+
+function serializeTextCardDoc(doc: JSONContent): string {
+    return markdownManager.serialize(withCodeMarkInnermost(doc))
+}
+
 const EMPTY_DOC_CONTENT: JSONContent['content'] = [{ type: 'paragraph' }]
 
 export const EMPTY_TEXT_CARD_DOC: JSONContent = {
@@ -155,7 +180,7 @@ export function textCardDocToMarkdown(doc: JSONContent): string {
             return ''
         }
 
-        const markdown = markdownManager.serialize(doc).trimEnd()
+        const markdown = serializeTextCardDoc(doc).trimEnd()
         if (!markdown) {
             return ''
         }
@@ -173,7 +198,7 @@ export function isTextCardMarkdownRoundTripSafe(markdown: string | null | undefi
     try {
         const expanded = expandFlattenedMarkdownTables(markdown)
         const originalDoc = markdownManager.parse(expanded) as JSONContent
-        const roundTripDoc = markdownManager.parse(markdownManager.serialize(originalDoc).trimEnd()) as JSONContent
+        const roundTripDoc = markdownManager.parse(serializeTextCardDoc(originalDoc).trimEnd()) as JSONContent
         return JSON.stringify(originalDoc) === JSON.stringify(roundTripDoc)
     } catch {
         return false

--- a/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardMarkdown.ts
@@ -96,7 +96,7 @@ const markdownManager = new MarkdownManager({
 // innermost mark it emits malformed markdown (e.g. **`snippet**` instead of **`snippet`**).
 // That broke the round trip and made the controlled editor reset itself while typing. Force
 // `code` innermost (first in the marks array) so its backticks always sit inside bold/italic/strike.
-// Fixed upstream in @tiptap/markdown >= 3.27.3; remove this once the tiptap suite is bumped.
+// Fixed upstream in @tiptap/markdown >= 3.20.4; remove this once the tiptap suite is bumped.
 function withCodeMarkInnermost(doc: JSONContent): JSONContent {
     const visit = (node: JSONContent): JSONContent => {
         const marks = node.marks


### PR DESCRIPTION
## Problem

On dashboards, editing a text card whose content mixes **bold** (or _italic_/~~strike~~) with an inline `code` snippet was broken: typing after such a span did nothing, or edits were lost. Reported for a card whose bold run ends in an inline-code snippet right before an em dash — the em dash was a red herring.

Root cause is in markdown serialization. `@tiptap/markdown` closes a text node's marks in array order, so a run that is both bold and inline `code` was written as `` **`snippet**` `` instead of `` **`snippet`** `` when `code` was not the innermost mark. That markdown is malformed, so it no longer round-trips (`docToMarkdown` → `markdownToDoc` → `docToMarkdown` diverges). The rich text card editor is controlled and re-syncs on mismatch, so it reset its own content on edits near that span, discarding what the user typed.

## Changes

Normalize the doc so the `code` mark is always innermost (first in the marks array) before serializing to markdown, in `textCardMarkdown.ts`. This restores valid markdown (`` **`snippet`** ``) and a stable round trip, so the editor stops resetting. Applied to both `textCardDocToMarkdown` and the round-trip-safety check that picks the rich vs legacy editor.

## How did you test this code?

- Added parameterized cases to `textCardMarkdown.test.ts` covering a text node that is `code` plus each of bold/italic/strike — asserting the backticks stay inside the surrounding mark and the result round-trips. This guards exactly the regression fixed here; existing tests only covered each mark in isolation, never a combined bold+code node.
- Reproduced the original failure and verified the fix outside the repo by driving the real editor (matching `@tiptap/markdown` version and the production extension set) in a headless browser against the affected card's actual content: before, every keystroke near the bold+code span forced a content reset; after, editing is clean with the markdown preserved.
- I (the agent) did not run the repo's Jest suite or typecheck in this environment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a support thread. Skills invoked: `/writing-tests`. The investigation first ruled out several plausible-but-wrong causes (the controlled-sync reset loop in the abstract, a Base UI modal focus trap, the WordArt extension added the same day) by reproducing them faithfully in a headless browser and finding they all worked, before isolating the real defect to mark-ordering in the markdown serializer. Chose to normalize at serialization time rather than patch the third-party library or loosen the editor's re-sync.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783598295096019?thread_ts=1783598295.096019&cid=C0ACRAMJUAG)*
