### PR TITLE
feat(cdp): shadow-execute event filters on the rust hogvm

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -35,6 +35,7 @@ import { isNonFailureStatus } from '../utils/non-failure-status-codes'
 import { HogInputsService } from './hog-inputs.service'
 import { EmailService } from './messaging/email.service'
 import { RecipientTokensService } from './messaging/recipient-tokens.service'
+import type { FilterShadowCapturer } from './rust-vm-filter-shadow'
 import {
     SELF_LOOP_MAX_DEPTH,
     SelfLoopGuardMode,
@@ -264,7 +265,8 @@ export class HogExecutorService {
 
     async buildHogFunctionInvocations(
         hogFunctions: HogFunctionType[],
-        triggerGlobals: HogFunctionInvocationGlobals
+        triggerGlobals: HogFunctionInvocationGlobals,
+        filterShadow?: FilterShadowCapturer
     ): Promise<{
         invocations: CyclotronJobInvocationHogFunction[]
         metrics: MinimalAppMetric[]
@@ -286,6 +288,7 @@ export class HogExecutorService {
                 fn: hogFunction,
                 filters,
                 filterGlobals,
+                shadow: filterShadow,
             })
 
             // Add any generated metrics and logs to our collections

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
@@ -20,7 +20,6 @@ const config = {
     CDP_RATE_LIMITER_TTL: 60,
     CDP_OVERFLOW_QUEUE_ENABLED: true,
     CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE: 0,
-    MMDB_FILE_LOCATION: '../share/GeoLite2-City.mmdb',
 }
 
 function makeHogFunction(overrides: Partial<HogFunctionType> = {}): HogFunctionType {

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
@@ -19,6 +19,8 @@ const config = {
     CDP_RATE_LIMITER_REFILL_RATE: 10,
     CDP_RATE_LIMITER_TTL: 60,
     CDP_OVERFLOW_QUEUE_ENABLED: true,
+    CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE: 0,
+    MMDB_FILE_LOCATION: '../share/GeoLite2-City.mmdb',
 }
 
 function makeHogFunction(overrides: Partial<HogFunctionType> = {}): HogFunctionType {

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
@@ -21,12 +21,15 @@ import { HogFunctionManagerService } from './managers/hog-function-manager.servi
 import { HogFunctionMonitoringService } from './monitoring/hog-function-monitoring.service'
 import { HogMaskerService } from './monitoring/hog-masker.service'
 import { HogWatcherService, HogWatcherState } from './monitoring/hog-watcher.service'
+import { RustVmFilterShadow } from './rust-vm-filter-shadow'
 
 export interface HogFunctionInvocationPipelineConfig {
     CDP_RATE_LIMITER_BUCKET_SIZE: number
     CDP_RATE_LIMITER_REFILL_RATE: number
     CDP_RATE_LIMITER_TTL: number
     CDP_OVERFLOW_QUEUE_ENABLED: boolean
+    CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE: number
+    MMDB_FILE_LOCATION: string
 }
 
 export interface HogFunctionInvocationPipelineDeps {
@@ -55,6 +58,7 @@ export interface BuildHogFunctionInvocationsOptions {
 export class HogFunctionInvocationPipeline {
     private hogRateLimiter: KeyedRateLimiterService
     private hogRateLimiterMirror: KeyedRateLimiterService | null
+    private rustVmFilterShadow: RustVmFilterShadow
 
     constructor(
         private config: HogFunctionInvocationPipelineConfig,
@@ -70,6 +74,10 @@ export class HogFunctionInvocationPipeline {
         this.hogRateLimiterMirror = deps.valkeyShadow
             ? new KeyedRateLimiterService(rateLimiterConfig, deps.valkeyShadow.writer)
             : null
+        this.rustVmFilterShadow = new RustVmFilterShadow({
+            sampleRate: config.CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE,
+            mmdbPath: config.MMDB_FILE_LOCATION,
+        })
     }
 
     @instrumented('cdpConsumer.handleEachBatch.queueMatchingFunctions')
@@ -91,7 +99,8 @@ export class HogFunctionInvocationPipeline {
 
                     const { invocations, metrics, logs } = await this.deps.hogExecutor.buildHogFunctionInvocations(
                         teamHogFunctions,
-                        globals
+                        globals,
+                        this.rustVmFilterShadow
                     )
 
                     this.deps.hogFunctionMonitoringService.queueAppMetrics(metrics, 'hog_function')
@@ -228,6 +237,11 @@ export class HogFunctionInvocationPipeline {
         })
 
         this.deps.hogFunctionMonitoringService.queueAppMetrics(triggeredInvocationsMetrics, 'hog_function')
+
+        // Off the hot path: shadow-execute this batch's sampled filters on the Rust HogVM and
+        // compare. Fire-and-forget via mirrorCall so it can never throw into or delay the primary
+        // pipeline; the shadow guards against overlapping flushes internally.
+        void mirrorCall('hogvm.rust-filter-shadow-flush', () => this.rustVmFilterShadow.flush(), 5000)
 
         return notMaskedInvocations
     }

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
@@ -29,7 +29,6 @@ export interface HogFunctionInvocationPipelineConfig {
     CDP_RATE_LIMITER_TTL: number
     CDP_OVERFLOW_QUEUE_ENABLED: boolean
     CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE: number
-    MMDB_FILE_LOCATION: string
 }
 
 export interface HogFunctionInvocationPipelineDeps {
@@ -76,7 +75,6 @@ export class HogFunctionInvocationPipeline {
             : null
         this.rustVmFilterShadow = new RustVmFilterShadow({
             sampleRate: config.CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE,
-            mmdbPath: config.MMDB_FILE_LOCATION,
         })
     }
 
@@ -237,11 +235,6 @@ export class HogFunctionInvocationPipeline {
         })
 
         this.deps.hogFunctionMonitoringService.queueAppMetrics(triggeredInvocationsMetrics, 'hog_function')
-
-        // Off the hot path: shadow-execute this batch's sampled filters on the Rust HogVM and
-        // compare. Fire-and-forget via mirrorCall so it can never throw into or delay the primary
-        // pipeline; the shadow guards against overlapping flushes internally.
-        void mirrorCall('hogvm.rust-filter-shadow-flush', () => this.rustVmFilterShadow.flush(), 5000)
 
         return notMaskedInvocations
     }

--- a/nodejs/src/cdp/services/rust-vm-filter-shadow.test.ts
+++ b/nodejs/src/cdp/services/rust-vm-filter-shadow.test.ts
@@ -118,6 +118,30 @@ describe('RustVmFilterShadow', () => {
             expect(await outcomeCounts()).toEqual({ match: 2, result_mismatch: 1 })
         })
 
+        it('dispatches distinct-bytecode groups concurrently, not one after another', async () => {
+            const filterA: HogBytecode = ['_H', 1, 29]
+            const filterB: HogBytecode = ['_H', 1, 30]
+            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true), filterA))
+            shadow.capture(capture('fn-b', { uuid: 'b1' }, node(true), filterB))
+
+            // Each native batch stays pending until we release it. A serial flush would await the
+            // first before dispatching the second, so only one call would exist at the checkpoint;
+            // concurrent dispatch means both are in flight before either resolves.
+            const releases: Array<() => void> = []
+            mockHogvmNode.executeBatch.mockImplementation(
+                () => new Promise((resolve) => releases.push(() => resolve([{ result: true, durationUs: 5 }])))
+            )
+
+            const flushed = shadow.flush()
+            await Promise.resolve()
+
+            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(2)
+
+            releases.forEach((release) => release())
+            await flushed
+            expect(await outcomeCounts()).toEqual({ match: 2 })
+        })
+
         it('a failing rust batch resolves the flush, counts rust_error, and does not affect other groups', async () => {
             const filterA: HogBytecode = ['_H', 1, 29]
             const filterB: HogBytecode = ['_H', 1, 30]

--- a/nodejs/src/cdp/services/rust-vm-filter-shadow.test.ts
+++ b/nodejs/src/cdp/services/rust-vm-filter-shadow.test.ts
@@ -1,0 +1,191 @@
+import { init } from '@posthog/hogvm-node'
+
+import { HogBytecode } from '~/cdp/types'
+
+import {
+    FilterShadowCapturedInvocation,
+    FilterShadowNodeResult,
+    FilterShadowOutcome,
+    RustVmFilterShadow,
+    classifyFilterShadowOutcome,
+    filterShadowComparison,
+} from './rust-vm-filter-shadow'
+
+jest.mock('@posthog/hogvm-node', () => ({
+    init: jest.fn(),
+    executeBatch: jest.fn(),
+}))
+
+const mockHogvmNode = jest.mocked(jest.requireMock<typeof import('@posthog/hogvm-node')>('@posthog/hogvm-node'))
+
+// A trivially-matching filter program; grouping keys off the array reference, so tests that want
+// two groups pass two distinct arrays and tests that want one group reuse the same reference.
+const MATCH_BYTECODE: HogBytecode = ['_H', 1, 29]
+
+const node = (match: boolean, error?: string): FilterShadowNodeResult => ({ match, error, durationMs: 1 })
+
+const capture = (
+    functionId: string,
+    globals: Record<string, unknown>,
+    nodeResult: FilterShadowNodeResult,
+    bytecode: HogBytecode = MATCH_BYTECODE
+): FilterShadowCapturedInvocation => ({
+    functionId,
+    teamId: 1,
+    bytecode,
+    globalsJson: JSON.stringify(globals),
+    node: nodeResult,
+})
+
+async function outcomeCounts(): Promise<Record<string, number>> {
+    const data = await filterShadowComparison.get()
+    return Object.fromEntries(data.values.map((v) => [v.labels.outcome, v.value]))
+}
+
+describe('RustVmFilterShadow', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        filterShadowComparison.reset()
+    })
+
+    describe('classifyFilterShadowOutcome', () => {
+        it.each<
+            [
+                string,
+                FilterShadowNodeResult,
+                { result?: unknown; error?: string; durationUs: number } | undefined,
+                FilterShadowOutcome,
+            ]
+        >([
+            ['both matched', node(true), { result: true, durationUs: 1 }, 'match'],
+            ['both did not match', node(false), { result: false, durationUs: 1 }, 'match'],
+            ['node matched, rust did not', node(true), { result: false, durationUs: 1 }, 'result_mismatch'],
+            ['node did not match, rust did', node(false), { result: true, durationUs: 1 }, 'result_mismatch'],
+            // A non-boolean rust result is a non-match, exactly as the node filtering treats it.
+            ['rust returns non-boolean truthy', node(false), { result: 1, durationUs: 1 }, 'match'],
+            ['rust non-boolean vs node match', node(true), { result: 1, durationUs: 1 }, 'result_mismatch'],
+            ['both errored', node(false, 'boom'), { error: 'Division by zero', durationUs: 1 }, 'match'],
+            ['node ok, rust errored', node(true), { error: 'Division by zero', durationUs: 1 }, 'status_mismatch'],
+            ['node errored, rust ok', node(false, 'boom'), { result: false, durationUs: 1 }, 'status_mismatch'],
+            [
+                'unsupported host function',
+                node(true),
+                { error: 'Native call failed: unsupported_ext_fn:geoipLookup', durationUs: 1 },
+                'skipped_unsupported',
+            ],
+            [
+                'host function missing from rust vm',
+                node(true),
+                { error: 'Unknown Global sendEmail', durationUs: 1 },
+                'skipped_unsupported',
+            ],
+            ['missing rust result', node(true), undefined, 'rust_error'],
+        ])('%s', (_name, nodeResult, rust, expected) => {
+            expect(classifyFilterShadowOutcome(nodeResult, rust)).toEqual(expected)
+        })
+    })
+
+    describe('flush', () => {
+        let shadow: RustVmFilterShadow
+
+        beforeEach(() => {
+            shadow = new RustVmFilterShadow({ sampleRate: 1, mmdbPath: '/dev/null' })
+        })
+
+        it('groups captures by bytecode reference across functions, pairing rust results by index', async () => {
+            const filterA: HogBytecode = ['_H', 1, 29]
+            const filterB: HogBytecode = ['_H', 1, 30]
+            // Two different functions share filterA -> one batch; fn-b also has a distinct mapping
+            // filter (filterB) -> a separate batch.
+            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true), filterA))
+            shadow.capture(capture('fn-b', { uuid: 'b1' }, node(true), filterA))
+            shadow.capture(capture('fn-b', { uuid: 'b2' }, node(false), filterB))
+
+            // Rust returns true for every event; filterA's node(true) captures agree, filterB's
+            // node(false) capture diverges.
+            mockHogvmNode.executeBatch.mockImplementation((_program, events) =>
+                Promise.resolve((events as unknown[]).map(() => ({ result: true, durationUs: 5 })))
+            )
+
+            await shadow.flush()
+
+            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(2)
+            expect(mockHogvmNode.executeBatch.mock.calls[0][0]).toBe(filterA)
+            expect(mockHogvmNode.executeBatch.mock.calls[0][1]).toEqual([{ uuid: 'a1' }, { uuid: 'b1' }])
+            expect(mockHogvmNode.executeBatch.mock.calls[1][0]).toBe(filterB)
+            expect(mockHogvmNode.executeBatch.mock.calls[1][1]).toEqual([{ uuid: 'b2' }])
+            // filterA: node(true) vs rust true twice = 2 matches. filterB: node(false) vs rust true = mismatch.
+            expect(await outcomeCounts()).toEqual({ match: 2, result_mismatch: 1 })
+        })
+
+        it('a failing rust batch resolves the flush, counts rust_error, and does not affect other groups', async () => {
+            const filterA: HogBytecode = ['_H', 1, 29]
+            const filterB: HogBytecode = ['_H', 1, 30]
+            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true), filterA))
+            shadow.capture(capture('fn-b', { uuid: 'b1' }, node(true), filterB))
+
+            mockHogvmNode.executeBatch
+                .mockRejectedValueOnce(new Error('napi exploded'))
+                .mockResolvedValueOnce([{ result: true, durationUs: 5 }])
+
+            await expect(shadow.flush()).resolves.toBeUndefined()
+            expect(await outcomeCounts()).toEqual({ rust_error: 1, match: 1 })
+        })
+
+        it('a flush while a native batch is still running drops its captures instead of stacking', async () => {
+            let resolveBatch: (results: unknown[]) => void = () => {}
+            mockHogvmNode.executeBatch.mockImplementationOnce(
+                () => new Promise((resolve) => (resolveBatch = resolve as (results: unknown[]) => void))
+            )
+
+            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true)))
+            const firstFlush = shadow.flush()
+
+            shadow.capture(capture('fn-a', { uuid: 'a2' }, node(true)))
+            await shadow.flush()
+
+            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(1)
+            expect(await outcomeCounts()).toEqual({ dropped: 1 })
+
+            resolveBatch([{ result: true, durationUs: 5 }])
+            await firstFlush
+            expect(await outcomeCounts()).toEqual({ dropped: 1, match: 1 })
+        })
+
+        it('filters calling nondeterministic stl fns are skipped at capture, not compared', async () => {
+            // CALL_GLOBAL now() — relative-date filters legitimately differ between executions.
+            shadow.capture(capture('fn-date', { uuid: 'a' }, node(true), ['_H', 1, 2, 'now', 0, 38]))
+            // A string literal that merely contains a fn name (preceded by STRING op 32) must not skip.
+            shadow.capture(capture('fn-str', { uuid: 'b' }, node(true), ['_H', 1, 32, 'now', 29]))
+
+            mockHogvmNode.executeBatch.mockResolvedValue([{ result: true, durationUs: 5 }])
+            await shadow.flush()
+
+            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(1)
+            expect(await outcomeCounts()).toEqual({ skipped_nondeterministic: 1, match: 1 })
+        })
+
+        it('captures beyond the buffer cap are counted as dropped, not as rust errors', async () => {
+            for (let i = 0; i < 10_001; i++) {
+                shadow.capture(capture('fn-a', { uuid: 'a' }, node(true)))
+            }
+            expect(await outcomeCounts()).toEqual({ dropped: 1 })
+        })
+
+        it('flush drains the buffer, so a second flush does nothing', async () => {
+            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true)))
+            mockHogvmNode.executeBatch.mockResolvedValue([{ result: true, durationUs: 5 }])
+
+            await shadow.flush()
+            await shadow.flush()
+
+            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    it('a zero sample rate never captures nor loads the native module', () => {
+        const shadow = new RustVmFilterShadow({ sampleRate: 0, mmdbPath: '/dev/null' })
+        expect(shadow.shouldCapture()).toEqual(false)
+        expect(init).not.toHaveBeenCalled()
+    })
+})

--- a/nodejs/src/cdp/services/rust-vm-filter-shadow.test.ts
+++ b/nodejs/src/cdp/services/rust-vm-filter-shadow.test.ts
@@ -1,10 +1,6 @@
-import { init } from '@posthog/hogvm-node'
-
 import { HogBytecode } from '~/cdp/types'
 
 import {
-    FilterShadowCapturedInvocation,
-    FilterShadowNodeResult,
     FilterShadowOutcome,
     RustVmFilterShadow,
     classifyFilterShadowOutcome,
@@ -12,30 +8,12 @@ import {
 } from './rust-vm-filter-shadow'
 
 jest.mock('@posthog/hogvm-node', () => ({
-    init: jest.fn(),
     executeBatch: jest.fn(),
 }))
 
 const mockHogvmNode = jest.mocked(jest.requireMock<typeof import('@posthog/hogvm-node')>('@posthog/hogvm-node'))
 
-// A trivially-matching filter program; grouping keys off the array reference, so tests that want
-// two groups pass two distinct arrays and tests that want one group reuse the same reference.
-const MATCH_BYTECODE: HogBytecode = ['_H', 1, 29]
-
-const node = (match: boolean, error?: string): FilterShadowNodeResult => ({ match, error, durationMs: 1 })
-
-const capture = (
-    functionId: string,
-    globals: Record<string, unknown>,
-    nodeResult: FilterShadowNodeResult,
-    bytecode: HogBytecode = MATCH_BYTECODE
-): FilterShadowCapturedInvocation => ({
-    functionId,
-    teamId: 1,
-    bytecode,
-    globalsJson: JSON.stringify(globals),
-    node: nodeResult,
-})
+const BYTECODE: HogBytecode = ['_H', 1, 29]
 
 async function outcomeCounts(): Promise<Record<string, number>> {
     const data = await filterShadowComparison.get()
@@ -50,166 +28,70 @@ describe('RustVmFilterShadow', () => {
 
     describe('classifyFilterShadowOutcome', () => {
         it.each<
-            [
-                string,
-                FilterShadowNodeResult,
-                { result?: unknown; error?: string; durationUs: number } | undefined,
-                FilterShadowOutcome,
-            ]
+            [string, boolean, { result?: unknown; error?: string; durationUs: number } | undefined, FilterShadowOutcome]
         >([
-            ['both matched', node(true), { result: true, durationUs: 1 }, 'match'],
-            ['both did not match', node(false), { result: false, durationUs: 1 }, 'match'],
-            ['node matched, rust did not', node(true), { result: false, durationUs: 1 }, 'result_mismatch'],
-            ['node did not match, rust did', node(false), { result: true, durationUs: 1 }, 'result_mismatch'],
-            // A non-boolean rust result is a non-match, exactly as the node filtering treats it.
-            ['rust returns non-boolean truthy', node(false), { result: 1, durationUs: 1 }, 'match'],
-            ['rust non-boolean vs node match', node(true), { result: 1, durationUs: 1 }, 'result_mismatch'],
-            ['both errored', node(false, 'boom'), { error: 'Division by zero', durationUs: 1 }, 'match'],
-            ['node ok, rust errored', node(true), { error: 'Division by zero', durationUs: 1 }, 'status_mismatch'],
-            ['node errored, rust ok', node(false, 'boom'), { result: false, durationUs: 1 }, 'status_mismatch'],
-            [
-                'unsupported host function',
-                node(true),
-                { error: 'Native call failed: unsupported_ext_fn:geoipLookup', durationUs: 1 },
-                'skipped_unsupported',
-            ],
-            [
-                'host function missing from rust vm',
-                node(true),
-                { error: 'Unknown Global sendEmail', durationUs: 1 },
-                'skipped_unsupported',
-            ],
-            ['missing rust result', node(true), undefined, 'rust_error'],
-        ])('%s', (_name, nodeResult, rust, expected) => {
-            expect(classifyFilterShadowOutcome(nodeResult, rust)).toEqual(expected)
+            ['both matched', true, { result: true, durationUs: 1 }, 'match'],
+            ['both did not match', false, { result: false, durationUs: 1 }, 'match'],
+            ['node matched, rust did not', true, { result: false, durationUs: 1 }, 'mismatch'],
+            ['node did not match, rust did', false, { result: true, durationUs: 1 }, 'mismatch'],
+            // A non-boolean rust result is treated as a non-match, exactly as Node filtering treats it.
+            ['rust non-boolean vs node no-match', false, { result: 1, durationUs: 1 }, 'match'],
+            ['rust non-boolean vs node match', true, { result: 1, durationUs: 1 }, 'mismatch'],
+            ['rust errored', true, { error: 'Division by zero', durationUs: 1 }, 'error'],
+            ['missing rust result', true, undefined, 'error'],
+        ])('%s', (_name, nodeMatch, rust, expected) => {
+            expect(classifyFilterShadowOutcome(nodeMatch, rust)).toEqual(expected)
         })
     })
 
-    describe('flush', () => {
+    describe('compare', () => {
         let shadow: RustVmFilterShadow
 
         beforeEach(() => {
-            shadow = new RustVmFilterShadow({ sampleRate: 1, mmdbPath: '/dev/null' })
+            shadow = new RustVmFilterShadow({ sampleRate: 1 })
         })
 
-        it('groups captures by bytecode reference across functions, pairing rust results by index', async () => {
-            const filterA: HogBytecode = ['_H', 1, 29]
-            const filterB: HogBytecode = ['_H', 1, 30]
-            // Two different functions share filterA -> one batch; fn-b also has a distinct mapping
-            // filter (filterB) -> a separate batch.
-            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true), filterA))
-            shadow.capture(capture('fn-b', { uuid: 'b1' }, node(true), filterA))
-            shadow.capture(capture('fn-b', { uuid: 'b2' }, node(false), filterB))
-
-            // Rust returns true for every event; filterA's node(true) captures agree, filterB's
-            // node(false) capture diverges.
-            mockHogvmNode.executeBatch.mockImplementation((_program, events) =>
-                Promise.resolve((events as unknown[]).map(() => ({ result: true, durationUs: 5 })))
-            )
-
-            await shadow.flush()
-
-            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(2)
-            expect(mockHogvmNode.executeBatch.mock.calls[0][0]).toBe(filterA)
-            expect(mockHogvmNode.executeBatch.mock.calls[0][1]).toEqual([{ uuid: 'a1' }, { uuid: 'b1' }])
-            expect(mockHogvmNode.executeBatch.mock.calls[1][0]).toBe(filterB)
-            expect(mockHogvmNode.executeBatch.mock.calls[1][1]).toEqual([{ uuid: 'b2' }])
-            // filterA: node(true) vs rust true twice = 2 matches. filterB: node(false) vs rust true = mismatch.
-            expect(await outcomeCounts()).toEqual({ match: 2, result_mismatch: 1 })
-        })
-
-        it('dispatches distinct-bytecode groups concurrently, not one after another', async () => {
-            const filterA: HogBytecode = ['_H', 1, 29]
-            const filterB: HogBytecode = ['_H', 1, 30]
-            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true), filterA))
-            shadow.capture(capture('fn-b', { uuid: 'b1' }, node(true), filterB))
-
-            // Each native batch stays pending until we release it. A serial flush would await the
-            // first before dispatching the second, so only one call would exist at the checkpoint;
-            // concurrent dispatch means both are in flight before either resolves.
-            const releases: Array<() => void> = []
-            mockHogvmNode.executeBatch.mockImplementation(
-                () => new Promise((resolve) => releases.push(() => resolve([{ result: true, durationUs: 5 }])))
-            )
-
-            const flushed = shadow.flush()
-            await Promise.resolve()
-
-            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(2)
-
-            releases.forEach((release) => release())
-            await flushed
-            expect(await outcomeCounts()).toEqual({ match: 2 })
-        })
-
-        it('a failing rust batch resolves the flush, counts rust_error, and does not affect other groups', async () => {
-            const filterA: HogBytecode = ['_H', 1, 29]
-            const filterB: HogBytecode = ['_H', 1, 30]
-            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true), filterA))
-            shadow.capture(capture('fn-b', { uuid: 'b1' }, node(true), filterB))
-
-            mockHogvmNode.executeBatch
-                .mockRejectedValueOnce(new Error('napi exploded'))
-                .mockResolvedValueOnce([{ result: true, durationUs: 5 }])
-
-            await expect(shadow.flush()).resolves.toBeUndefined()
-            expect(await outcomeCounts()).toEqual({ rust_error: 1, match: 1 })
-        })
-
-        it('a flush while a native batch is still running drops its captures instead of stacking', async () => {
-            let resolveBatch: (results: unknown[]) => void = () => {}
-            mockHogvmNode.executeBatch.mockImplementationOnce(
-                () => new Promise((resolve) => (resolveBatch = resolve as (results: unknown[]) => void))
-            )
-
-            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true)))
-            const firstFlush = shadow.flush()
-
-            shadow.capture(capture('fn-a', { uuid: 'a2' }, node(true)))
-            await shadow.flush()
-
-            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(1)
-            expect(await outcomeCounts()).toEqual({ dropped: 1 })
-
-            resolveBatch([{ result: true, durationUs: 5 }])
-            await firstFlush
-            expect(await outcomeCounts()).toEqual({ dropped: 1, match: 1 })
-        })
-
-        it('filters calling nondeterministic stl fns are skipped at capture, not compared', async () => {
-            // CALL_GLOBAL now() — relative-date filters legitimately differ between executions.
-            shadow.capture(capture('fn-date', { uuid: 'a' }, node(true), ['_H', 1, 2, 'now', 0, 38]))
-            // A string literal that merely contains a fn name (preceded by STRING op 32) must not skip.
-            shadow.capture(capture('fn-str', { uuid: 'b' }, node(true), ['_H', 1, 32, 'now', 29]))
-
-            mockHogvmNode.executeBatch.mockResolvedValue([{ result: true, durationUs: 5 }])
-            await shadow.flush()
-
-            expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(1)
-            expect(await outcomeCounts()).toEqual({ skipped_nondeterministic: 1, match: 1 })
-        })
-
-        it('captures beyond the buffer cap are counted as dropped, not as rust errors', async () => {
-            for (let i = 0; i < 10_001; i++) {
-                shadow.capture(capture('fn-a', { uuid: 'a' }, node(true)))
-            }
-            expect(await outcomeCounts()).toEqual({ dropped: 1 })
-        })
-
-        it('flush drains the buffer, so a second flush does nothing', async () => {
-            shadow.capture(capture('fn-a', { uuid: 'a1' }, node(true)))
+        it('runs the same bytecode + globals on the rust vm and records a match', async () => {
             mockHogvmNode.executeBatch.mockResolvedValue([{ result: true, durationUs: 5 }])
 
-            await shadow.flush()
-            await shadow.flush()
+            await shadow.compare(BYTECODE, { uuid: 'e1' }, true, 2)
 
             expect(mockHogvmNode.executeBatch).toHaveBeenCalledTimes(1)
+            expect(mockHogvmNode.executeBatch.mock.calls[0][0]).toBe(BYTECODE)
+            expect(mockHogvmNode.executeBatch.mock.calls[0][1]).toEqual([{ uuid: 'e1' }])
+            expect(await outcomeCounts()).toEqual({ match: 1 })
         })
-    })
 
-    it('a zero sample rate never captures nor loads the native module', () => {
-        const shadow = new RustVmFilterShadow({ sampleRate: 0, mmdbPath: '/dev/null' })
-        expect(shadow.shouldCapture()).toEqual(false)
-        expect(init).not.toHaveBeenCalled()
+        it('counts a divergent boolean as a mismatch', async () => {
+            mockHogvmNode.executeBatch.mockResolvedValue([{ result: false, durationUs: 5 }])
+
+            await shadow.compare(BYTECODE, { uuid: 'e1' }, true, 2)
+
+            expect(await outcomeCounts()).toEqual({ mismatch: 1 })
+        })
+
+        it('counts a rust execution error as error, not a mismatch', async () => {
+            mockHogvmNode.executeBatch.mockResolvedValue([{ error: 'Division by zero', durationUs: 5 }])
+
+            await shadow.compare(BYTECODE, { uuid: 'e1' }, true, 2)
+
+            expect(await outcomeCounts()).toEqual({ error: 1 })
+        })
+
+        it('swallows a rejected native call as error instead of throwing', async () => {
+            mockHogvmNode.executeBatch.mockRejectedValue(new Error('napi exploded'))
+
+            await expect(shadow.compare(BYTECODE, { uuid: 'e1' }, true, 2)).resolves.toBeUndefined()
+            expect(await outcomeCounts()).toEqual({ error: 1 })
+        })
+
+        it('does nothing and never loads the native module when sampling is disabled', async () => {
+            const disabled = new RustVmFilterShadow({ sampleRate: 0 })
+
+            await disabled.compare(BYTECODE, { uuid: 'e1' }, true, 2)
+
+            expect(mockHogvmNode.executeBatch).not.toHaveBeenCalled()
+            expect(await outcomeCounts()).toEqual({})
+        })
     })
 })

--- a/nodejs/src/cdp/services/rust-vm-filter-shadow.ts
+++ b/nodejs/src/cdp/services/rust-vm-filter-shadow.ts
@@ -230,8 +230,8 @@ export class RustVmFilterShadow {
         }
 
         // Group by bytecode reference: the hog function manager caches functions, so every event
-        // that ran the same filter shares the exact same bytecode array. Grouping lets each group
-        // run as one parallel rust batch, which is where the rayon win shows up.
+        // that ran the same filter shares the exact same bytecode array. Each group runs as one
+        // rust batch that fans its events out over rayon (`parallel: true`).
         const byBytecode = new Map<HogBytecode, FilterShadowCapturedInvocation[]>()
         for (const item of items) {
             const group = byBytecode.get(item.bytecode)
@@ -242,50 +242,62 @@ export class RustVmFilterShadow {
             }
         }
 
-        for (const [bytecode, group] of byBytecode.entries()) {
-            filterShadowFlushSize.observe({ scope: 'bytecode' }, group.length)
-            let rustResults: RustExecResult[] = []
-            const stopTimer = filterShadowBatchDuration.startTimer()
-            try {
-                rustResults = await module_.executeBatch(
-                    bytecode,
-                    group.map((item) => parseJSON(item.globalsJson)),
-                    { parallel: true, maxSteps: RUST_MAX_STEPS }
-                )
-            } catch (error) {
-                logger.warn('🦀', 'Rust HogVM filter shadow batch failed', {
-                    functionId: group[0].functionId,
-                    error: String(error),
-                })
-            } finally {
-                stopTimer()
-            }
+        // Run the groups concurrently, not one after another: each `executeBatch` is a napi
+        // AsyncTask off the JS event loop, so distinct filters execute in parallel with each other
+        // while every group also fans its own events out over rayon internally. This is where the
+        // full parallelism the shadow is measuring actually happens.
+        await Promise.all(
+            Array.from(byBytecode.entries()).map(([bytecode, group]) => this.executeGroup(module_, bytecode, group))
+        )
+    }
 
-            let mismatchLogged = false
-            group.forEach((item, index) => {
-                const rust: RustExecResult | undefined = rustResults[index]
-                filterShadowExecutionDuration.observe({ vm: 'node' }, item.node.durationMs)
-                if (rust) {
-                    filterShadowExecutionDuration.observe({ vm: 'rust' }, rust.durationUs / 1000)
-                }
-                const outcome = classifyFilterShadowOutcome(item.node, rust)
-                filterShadowComparison.inc({ outcome })
-                // One example per bytecode group per flush is enough to identify a diverging filter
-                // without flooding the logs; replay its bytecode offline for the actual diff.
-                if ((outcome === 'result_mismatch' || outcome === 'status_mismatch') && !mismatchLogged) {
-                    mismatchLogged = true
-                    logger.warn('🦀', 'Rust HogVM filter shadow divergence', {
-                        outcome,
-                        functionId: item.functionId,
-                        teamId: item.teamId,
-                        nodeMatch: item.node.match,
-                        nodeError: item.node.error,
-                        rustResult: rust?.result,
-                        rustError: rust?.error,
-                    })
-                }
+    private async executeGroup(
+        module_: HogvmNodeModule,
+        bytecode: HogBytecode,
+        group: FilterShadowCapturedInvocation[]
+    ): Promise<void> {
+        filterShadowFlushSize.observe({ scope: 'bytecode' }, group.length)
+        let rustResults: RustExecResult[] = []
+        const stopTimer = filterShadowBatchDuration.startTimer()
+        try {
+            rustResults = await module_.executeBatch(
+                bytecode,
+                group.map((item) => parseJSON(item.globalsJson)),
+                { parallel: true, maxSteps: RUST_MAX_STEPS }
+            )
+        } catch (error) {
+            logger.warn('🦀', 'Rust HogVM filter shadow batch failed', {
+                functionId: group[0].functionId,
+                error: String(error),
             })
+        } finally {
+            stopTimer()
         }
+
+        let mismatchLogged = false
+        group.forEach((item, index) => {
+            const rust: RustExecResult | undefined = rustResults[index]
+            filterShadowExecutionDuration.observe({ vm: 'node' }, item.node.durationMs)
+            if (rust) {
+                filterShadowExecutionDuration.observe({ vm: 'rust' }, rust.durationUs / 1000)
+            }
+            const outcome = classifyFilterShadowOutcome(item.node, rust)
+            filterShadowComparison.inc({ outcome })
+            // One example per bytecode group per flush is enough to identify a diverging filter
+            // without flooding the logs; replay its bytecode offline for the actual diff.
+            if ((outcome === 'result_mismatch' || outcome === 'status_mismatch') && !mismatchLogged) {
+                mismatchLogged = true
+                logger.warn('🦀', 'Rust HogVM filter shadow divergence', {
+                    outcome,
+                    functionId: item.functionId,
+                    teamId: item.teamId,
+                    nodeMatch: item.node.match,
+                    nodeError: item.node.error,
+                    rustResult: rust?.result,
+                    rustError: rust?.error,
+                })
+            }
+        })
     }
 
     private getModule(): HogvmNodeModule | null {

--- a/nodejs/src/cdp/services/rust-vm-filter-shadow.ts
+++ b/nodejs/src/cdp/services/rust-vm-filter-shadow.ts
@@ -1,21 +1,15 @@
 import { Counter, Histogram } from 'prom-client'
 
 import { HogBytecode } from '~/cdp/types'
-import { parseJSON } from '~/common/utils/json-parse'
 import { logger } from '~/common/utils/logger'
 
-import { KNOWN_BOT_IP_LIST, KNOWN_BOT_UA_LIST } from '../hog-transformations/bots/bots'
-
 /**
- * Shadow-executes sampled filter (bytecode) evaluations on the Rust HogVM (via the
- * `@posthog/hogvm-node` napi addon) to compare latency and correctness against the Node VM used by
- * the CDP events consumer to find matching hog functions. The Node result stays authoritative:
- * captures buffer in memory and execute per batch off the hot path, results are discarded after
- * comparison, and any failure only surfaces as a metric or log.
- *
- * The real win from the Rust VM is that a batch of events sharing the same filter bytecode can be
- * fanned out over a rayon thread pool, so the flush groups by bytecode and executes each group as a
- * single parallel batch.
+ * Shadow-executes sampled filter evaluations on the Rust HogVM (via the `@posthog/hogvm-node` napi
+ * addon) to compare latency and correctness against the Node VM the CDP events consumer uses to
+ * find matching hog functions. Filters are pure Hog (no host functions), so there's no setup: for a
+ * sampled filter run we hand the same bytecode + globals to the Rust VM off the JS event loop,
+ * record how long each VM took, and compare the boolean match. The Node result stays authoritative
+ * — nothing here can affect it, and every failure is swallowed into a metric or log.
  *
  * The native addon is optional — if it isn't built for this environment the shadow disables itself.
  */
@@ -23,32 +17,12 @@ import { KNOWN_BOT_IP_LIST, KNOWN_BOT_UA_LIST } from '../hog-transformations/bot
 // The Rust VM budgets steps, not wall-clock time; generous so it never trips before the Node VM's
 // timeout would.
 const RUST_MAX_STEPS = 1_000_000
-// STL functions whose output legitimately differs between two executions — filters using relative
-// dates (now/today) are common, so programs calling them can never be compared and are skipped at
-// capture time.
-const NONDETERMINISTIC_FNS = new Set(['randomFloat', 'generateUUIDv4', 'now', 'today'])
-const CALL_GLOBAL_OP = 2
-// Safety cap so a stalled flush can't grow the buffer unboundedly.
-const MAX_BUFFER_SIZE = 10_000
 
-export const filterShadowExecutionDuration = new Histogram({
-    name: 'hogvm_filter_shadow_execution_duration_ms',
-    help: 'Per-invocation hog filter execution duration for shadow-sampled events, by VM',
+export const filterShadowDuration = new Histogram({
+    name: 'hogvm_filter_shadow_duration_ms',
+    help: 'Hog filter evaluation duration for shadow-sampled events, by VM',
     labelNames: ['vm'],
     buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100],
-})
-
-export const filterShadowBatchDuration = new Histogram({
-    name: 'hogvm_filter_shadow_batch_duration_ms',
-    help: 'Wall time of one rust executeBatch napi call for filters, marshalling included',
-    buckets: [0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500],
-})
-
-export const filterShadowFlushSize = new Histogram({
-    name: 'hogvm_filter_shadow_flush_invocations',
-    help: 'Captured filter invocations per shadow flush (scope=flush) and per bytecode group within it (scope=bytecode) — group size is what the rayon fan-out sees',
-    labelNames: ['scope'],
-    buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
 })
 
 export const filterShadowComparison = new Counter({
@@ -57,43 +31,7 @@ export const filterShadowComparison = new Counter({
     labelNames: ['outcome'],
 })
 
-export type FilterShadowOutcome =
-    | 'match'
-    | 'result_mismatch'
-    | 'status_mismatch'
-    | 'rust_error'
-    | 'skipped_unsupported'
-    | 'skipped_nondeterministic'
-    | 'dropped'
-
-export interface FilterShadowNodeResult {
-    /** Whether the Node filter matched (bytecode returned boolean true). */
-    match: boolean
-    /** Set when the Node VM threw while evaluating the filter. */
-    error?: string
-    durationMs: number
-}
-
-export interface FilterShadowCapturedInvocation {
-    functionId: string
-    teamId: number
-    /** Same array reference across events for a given function+filter, so it groups the batch. */
-    bytecode: HogBytecode
-    /** Snapshot of the filter globals taken before the Node VM ran. */
-    globalsJson: string
-    node: FilterShadowNodeResult
-}
-
-/**
- * The subset of {@link RustVmFilterShadow} that the shared filtering utility depends on. Kept as a
- * narrow interface so `filterFunctionInstrumented` doesn't import the whole service (and so tests
- * can pass a stub). Only the CDP events pipeline wires a real one in; every other caller leaves it
- * undefined, so nothing is captured.
- */
-export interface FilterShadowCapturer {
-    shouldCapture(): boolean
-    capture(item: FilterShadowCapturedInvocation): void
-}
+export type FilterShadowOutcome = 'match' | 'mismatch' | 'error'
 
 interface RustExecResult {
     result?: unknown
@@ -102,7 +40,6 @@ interface RustExecResult {
 }
 
 interface HogvmNodeModule {
-    init(options: { mmdbPath?: string; knownBotUaList?: string[]; knownBotIpList?: string[] }): void
     executeBatch(
         program: unknown[],
         events: unknown[],
@@ -110,212 +47,78 @@ interface HogvmNodeModule {
     ): Promise<RustExecResult[]>
 }
 
-/** The Rust VM returns the raw program result; a filter matches only when it returns boolean true,
- * mirroring the Node filtering logic. */
+/** A filter matches only when the program returns boolean true, mirroring the Node filtering logic. */
 function rustFilterMatch(result: unknown): boolean {
-    return typeof result === 'boolean' && result
+    return result === true
 }
 
-export function classifyFilterShadowOutcome(
-    node: FilterShadowNodeResult,
-    rust: RustExecResult | undefined
-): FilterShadowOutcome {
-    if (!rust) {
-        return 'rust_error'
+export function classifyFilterShadowOutcome(nodeMatch: boolean, rust: RustExecResult | undefined): FilterShadowOutcome {
+    if (!rust || rust.error) {
+        return 'error'
     }
-    if (rust.error) {
-        // Host functions the rust binding doesn't implement — not comparable, not a divergence.
-        // 'Unknown Global <name>' is the rust VM's exact error for calling a function it doesn't
-        // know; anchored to the prefix so other errors mentioning the words can't be swallowed.
-        if (rust.error.includes('unsupported_ext_fn:') || rust.error.startsWith('Unknown Global ')) {
-            return 'skipped_unsupported'
-        }
-        // Both VMs failed the program: they agree.
-        return node.error ? 'match' : 'status_mismatch'
-    }
-    if (node.error) {
-        return 'status_mismatch'
-    }
-    return rustFilterMatch(rust.result) === node.match ? 'match' : 'result_mismatch'
+    return rustFilterMatch(rust.result) === nodeMatch ? 'match' : 'mismatch'
 }
 
-export class RustVmFilterShadow {
-    private buffer: FilterShadowCapturedInvocation[] = []
+/**
+ * The hook the shared filtering utility depends on. Kept as a narrow interface so
+ * `filterFunctionInstrumented` doesn't import the whole service (and so tests can pass a stub).
+ * Only the CDP events pipeline wires a real one in; every other caller leaves it undefined, so
+ * nothing is compared.
+ */
+export interface FilterShadowCapturer {
+    compare(bytecode: HogBytecode, globals: object, nodeMatch: boolean, nodeDurationMs: number): Promise<void>
+}
+
+export class RustVmFilterShadow implements FilterShadowCapturer {
     private module_: HogvmNodeModule | null | undefined = undefined
-    private flushInFlight = false
-    private nondeterministicByFunction = new Map<string, boolean>()
 
-    constructor(
-        private options: {
-            sampleRate: number
-            mmdbPath: string
-        }
-    ) {}
-
-    /** True for the sampled fraction of invocations, and only when the native addon is loadable. */
-    public shouldCapture(): boolean {
-        if (this.options.sampleRate <= 0 || !this.getModule()) {
-            return false
-        }
-        return Math.random() < this.options.sampleRate
-    }
-
-    public capture(item: FilterShadowCapturedInvocation): void {
-        if (this.isNondeterministic(item.functionId, item.bytecode)) {
-            filterShadowComparison.inc({ outcome: 'skipped_nondeterministic' })
-            return
-        }
-        if (this.buffer.length >= MAX_BUFFER_SIZE) {
-            filterShadowComparison.inc({ outcome: 'dropped' })
-            return
-        }
-        this.buffer.push(item)
-    }
-
-    // Every string literal in hog bytecode is preceded by the STRING op (32); only CALL_GLOBAL (2)
-    // is directly followed by the function name, so this pair scan cannot false-positive on string
-    // literals that merely contain a function name.
-    private isNondeterministic(functionId: string, bytecode: HogBytecode): boolean {
-        let cached = this.nondeterministicByFunction.get(functionId)
-        if (cached === undefined) {
-            cached = bytecode.some(
-                (token, index) =>
-                    token === CALL_GLOBAL_OP &&
-                    typeof bytecode[index + 1] === 'string' &&
-                    NONDETERMINISTIC_FNS.has(bytecode[index + 1] as string)
-            )
-            if (this.nondeterministicByFunction.size >= MAX_BUFFER_SIZE) {
-                this.nondeterministicByFunction.clear()
-            }
-            this.nondeterministicByFunction.set(functionId, cached)
-        }
-        return cached
-    }
+    constructor(private options: { sampleRate: number }) {}
 
     /**
-     * Execute everything captured since the last flush on the Rust VM and compare. Runs off the hot
-     * path (fired from the events pipeline without being awaited); never throws.
+     * For the sampled fraction of filter runs, execute the same bytecode + globals on the Rust VM
+     * (off the JS event loop) and compare against the Node result. Fire-and-forget: callers don't
+     * await it, and it never throws — failures become the `error` outcome.
      */
-    public async flush(): Promise<void> {
-        const items = this.buffer
-        this.buffer = []
-        const module_ = this.getModule()
-        if (!module_ || items.length === 0) {
+    public async compare(
+        bytecode: HogBytecode,
+        globals: object,
+        nodeMatch: boolean,
+        nodeDurationMs: number
+    ): Promise<void> {
+        if (this.options.sampleRate <= 0 || Math.random() >= this.options.sampleRate) {
             return
         }
-
-        // A previous flush's native batch may still be running on its worker threads. Never stack
-        // batches: while one is in flight, drop this round.
-        if (this.flushInFlight) {
-            filterShadowComparison.inc({ outcome: 'dropped' }, items.length)
-            return
-        }
-        this.flushInFlight = true
-
-        filterShadowFlushSize.observe({ scope: 'flush' }, items.length)
-
-        try {
-            await this.executeAndCompare(items)
-        } catch (error) {
-            logger.warn('🦀', 'Rust HogVM filter shadow flush failed', { error: String(error) })
-        } finally {
-            this.flushInFlight = false
-        }
-    }
-
-    private async executeAndCompare(items: FilterShadowCapturedInvocation[]): Promise<void> {
         const module_ = this.getModule()
         if (!module_) {
             return
         }
 
-        // Group by bytecode reference: the hog function manager caches functions, so every event
-        // that ran the same filter shares the exact same bytecode array. Each group runs as one
-        // rust batch that fans its events out over rayon (`parallel: true`).
-        const byBytecode = new Map<HogBytecode, FilterShadowCapturedInvocation[]>()
-        for (const item of items) {
-            const group = byBytecode.get(item.bytecode)
-            if (group) {
-                group.push(item)
-            } else {
-                byBytecode.set(item.bytecode, [item])
-            }
-        }
-
-        // Run the groups concurrently, not one after another: each `executeBatch` is a napi
-        // AsyncTask off the JS event loop, so distinct filters execute in parallel with each other
-        // while every group also fans its own events out over rayon internally. This is where the
-        // full parallelism the shadow is measuring actually happens.
-        await Promise.all(
-            Array.from(byBytecode.entries()).map(([bytecode, group]) => this.executeGroup(module_, bytecode, group))
-        )
-    }
-
-    private async executeGroup(
-        module_: HogvmNodeModule,
-        bytecode: HogBytecode,
-        group: FilterShadowCapturedInvocation[]
-    ): Promise<void> {
-        filterShadowFlushSize.observe({ scope: 'bytecode' }, group.length)
-        let rustResults: RustExecResult[] = []
-        const stopTimer = filterShadowBatchDuration.startTimer()
+        filterShadowDuration.observe({ vm: 'node' }, nodeDurationMs)
         try {
-            rustResults = await module_.executeBatch(
-                bytecode,
-                group.map((item) => parseJSON(item.globalsJson)),
-                { parallel: true, maxSteps: RUST_MAX_STEPS }
-            )
-        } catch (error) {
-            logger.warn('🦀', 'Rust HogVM filter shadow batch failed', {
-                functionId: group[0].functionId,
-                error: String(error),
-            })
-        } finally {
-            stopTimer()
-        }
-
-        let mismatchLogged = false
-        group.forEach((item, index) => {
-            const rust: RustExecResult | undefined = rustResults[index]
-            filterShadowExecutionDuration.observe({ vm: 'node' }, item.node.durationMs)
-            if (rust) {
-                filterShadowExecutionDuration.observe({ vm: 'rust' }, rust.durationUs / 1000)
+            const [rust] = await module_.executeBatch(bytecode, [globals], { maxSteps: RUST_MAX_STEPS })
+            if (rust && !rust.error) {
+                filterShadowDuration.observe({ vm: 'rust' }, rust.durationUs / 1000)
             }
-            const outcome = classifyFilterShadowOutcome(item.node, rust)
+            const outcome = classifyFilterShadowOutcome(nodeMatch, rust)
             filterShadowComparison.inc({ outcome })
-            // One example per bytecode group per flush is enough to identify a diverging filter
-            // without flooding the logs; replay its bytecode offline for the actual diff.
-            if ((outcome === 'result_mismatch' || outcome === 'status_mismatch') && !mismatchLogged) {
-                mismatchLogged = true
+            if (outcome === 'mismatch') {
                 logger.warn('🦀', 'Rust HogVM filter shadow divergence', {
-                    outcome,
-                    functionId: item.functionId,
-                    teamId: item.teamId,
-                    nodeMatch: item.node.match,
-                    nodeError: item.node.error,
+                    nodeMatch,
                     rustResult: rust?.result,
-                    rustError: rust?.error,
                 })
             }
-        })
+        } catch (error) {
+            filterShadowComparison.inc({ outcome: 'error' })
+            logger.warn('🦀', 'Rust HogVM filter shadow failed', { error: String(error) })
+        }
     }
 
     private getModule(): HogvmNodeModule | null {
         if (this.module_ !== undefined) {
             return this.module_
         }
-        if (this.options.sampleRate <= 0) {
-            this.module_ = null
-            return null
-        }
         try {
-            const module_: HogvmNodeModule = require('@posthog/hogvm-node')
-            module_.init({
-                mmdbPath: this.options.mmdbPath,
-                knownBotUaList: KNOWN_BOT_UA_LIST,
-                knownBotIpList: KNOWN_BOT_IP_LIST,
-            })
-            this.module_ = module_
+            this.module_ = require('@posthog/hogvm-node') as HogvmNodeModule
             logger.info('🦀', 'Rust HogVM filter shadow mode enabled', { sampleRate: this.options.sampleRate })
         } catch (error) {
             this.module_ = null

--- a/nodejs/src/cdp/services/rust-vm-filter-shadow.ts
+++ b/nodejs/src/cdp/services/rust-vm-filter-shadow.ts
@@ -1,0 +1,316 @@
+import { Counter, Histogram } from 'prom-client'
+
+import { HogBytecode } from '~/cdp/types'
+import { parseJSON } from '~/common/utils/json-parse'
+import { logger } from '~/common/utils/logger'
+
+import { KNOWN_BOT_IP_LIST, KNOWN_BOT_UA_LIST } from '../hog-transformations/bots/bots'
+
+/**
+ * Shadow-executes sampled filter (bytecode) evaluations on the Rust HogVM (via the
+ * `@posthog/hogvm-node` napi addon) to compare latency and correctness against the Node VM used by
+ * the CDP events consumer to find matching hog functions. The Node result stays authoritative:
+ * captures buffer in memory and execute per batch off the hot path, results are discarded after
+ * comparison, and any failure only surfaces as a metric or log.
+ *
+ * The real win from the Rust VM is that a batch of events sharing the same filter bytecode can be
+ * fanned out over a rayon thread pool, so the flush groups by bytecode and executes each group as a
+ * single parallel batch.
+ *
+ * The native addon is optional — if it isn't built for this environment the shadow disables itself.
+ */
+
+// The Rust VM budgets steps, not wall-clock time; generous so it never trips before the Node VM's
+// timeout would.
+const RUST_MAX_STEPS = 1_000_000
+// STL functions whose output legitimately differs between two executions — filters using relative
+// dates (now/today) are common, so programs calling them can never be compared and are skipped at
+// capture time.
+const NONDETERMINISTIC_FNS = new Set(['randomFloat', 'generateUUIDv4', 'now', 'today'])
+const CALL_GLOBAL_OP = 2
+// Safety cap so a stalled flush can't grow the buffer unboundedly.
+const MAX_BUFFER_SIZE = 10_000
+
+export const filterShadowExecutionDuration = new Histogram({
+    name: 'hogvm_filter_shadow_execution_duration_ms',
+    help: 'Per-invocation hog filter execution duration for shadow-sampled events, by VM',
+    labelNames: ['vm'],
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100],
+})
+
+export const filterShadowBatchDuration = new Histogram({
+    name: 'hogvm_filter_shadow_batch_duration_ms',
+    help: 'Wall time of one rust executeBatch napi call for filters, marshalling included',
+    buckets: [0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500],
+})
+
+export const filterShadowFlushSize = new Histogram({
+    name: 'hogvm_filter_shadow_flush_invocations',
+    help: 'Captured filter invocations per shadow flush (scope=flush) and per bytecode group within it (scope=bytecode) — group size is what the rayon fan-out sees',
+    labelNames: ['scope'],
+    buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+})
+
+export const filterShadowComparison = new Counter({
+    name: 'hogvm_filter_shadow_comparison_total',
+    help: 'Outcomes of node-vs-rust hogvm filter shadow comparisons',
+    labelNames: ['outcome'],
+})
+
+export type FilterShadowOutcome =
+    | 'match'
+    | 'result_mismatch'
+    | 'status_mismatch'
+    | 'rust_error'
+    | 'skipped_unsupported'
+    | 'skipped_nondeterministic'
+    | 'dropped'
+
+export interface FilterShadowNodeResult {
+    /** Whether the Node filter matched (bytecode returned boolean true). */
+    match: boolean
+    /** Set when the Node VM threw while evaluating the filter. */
+    error?: string
+    durationMs: number
+}
+
+export interface FilterShadowCapturedInvocation {
+    functionId: string
+    teamId: number
+    /** Same array reference across events for a given function+filter, so it groups the batch. */
+    bytecode: HogBytecode
+    /** Snapshot of the filter globals taken before the Node VM ran. */
+    globalsJson: string
+    node: FilterShadowNodeResult
+}
+
+/**
+ * The subset of {@link RustVmFilterShadow} that the shared filtering utility depends on. Kept as a
+ * narrow interface so `filterFunctionInstrumented` doesn't import the whole service (and so tests
+ * can pass a stub). Only the CDP events pipeline wires a real one in; every other caller leaves it
+ * undefined, so nothing is captured.
+ */
+export interface FilterShadowCapturer {
+    shouldCapture(): boolean
+    capture(item: FilterShadowCapturedInvocation): void
+}
+
+interface RustExecResult {
+    result?: unknown
+    error?: string
+    durationUs: number
+}
+
+interface HogvmNodeModule {
+    init(options: { mmdbPath?: string; knownBotUaList?: string[]; knownBotIpList?: string[] }): void
+    executeBatch(
+        program: unknown[],
+        events: unknown[],
+        options?: { parallel?: boolean; maxSteps?: number }
+    ): Promise<RustExecResult[]>
+}
+
+/** The Rust VM returns the raw program result; a filter matches only when it returns boolean true,
+ * mirroring the Node filtering logic. */
+function rustFilterMatch(result: unknown): boolean {
+    return typeof result === 'boolean' && result
+}
+
+export function classifyFilterShadowOutcome(
+    node: FilterShadowNodeResult,
+    rust: RustExecResult | undefined
+): FilterShadowOutcome {
+    if (!rust) {
+        return 'rust_error'
+    }
+    if (rust.error) {
+        // Host functions the rust binding doesn't implement — not comparable, not a divergence.
+        // 'Unknown Global <name>' is the rust VM's exact error for calling a function it doesn't
+        // know; anchored to the prefix so other errors mentioning the words can't be swallowed.
+        if (rust.error.includes('unsupported_ext_fn:') || rust.error.startsWith('Unknown Global ')) {
+            return 'skipped_unsupported'
+        }
+        // Both VMs failed the program: they agree.
+        return node.error ? 'match' : 'status_mismatch'
+    }
+    if (node.error) {
+        return 'status_mismatch'
+    }
+    return rustFilterMatch(rust.result) === node.match ? 'match' : 'result_mismatch'
+}
+
+export class RustVmFilterShadow {
+    private buffer: FilterShadowCapturedInvocation[] = []
+    private module_: HogvmNodeModule | null | undefined = undefined
+    private flushInFlight = false
+    private nondeterministicByFunction = new Map<string, boolean>()
+
+    constructor(
+        private options: {
+            sampleRate: number
+            mmdbPath: string
+        }
+    ) {}
+
+    /** True for the sampled fraction of invocations, and only when the native addon is loadable. */
+    public shouldCapture(): boolean {
+        if (this.options.sampleRate <= 0 || !this.getModule()) {
+            return false
+        }
+        return Math.random() < this.options.sampleRate
+    }
+
+    public capture(item: FilterShadowCapturedInvocation): void {
+        if (this.isNondeterministic(item.functionId, item.bytecode)) {
+            filterShadowComparison.inc({ outcome: 'skipped_nondeterministic' })
+            return
+        }
+        if (this.buffer.length >= MAX_BUFFER_SIZE) {
+            filterShadowComparison.inc({ outcome: 'dropped' })
+            return
+        }
+        this.buffer.push(item)
+    }
+
+    // Every string literal in hog bytecode is preceded by the STRING op (32); only CALL_GLOBAL (2)
+    // is directly followed by the function name, so this pair scan cannot false-positive on string
+    // literals that merely contain a function name.
+    private isNondeterministic(functionId: string, bytecode: HogBytecode): boolean {
+        let cached = this.nondeterministicByFunction.get(functionId)
+        if (cached === undefined) {
+            cached = bytecode.some(
+                (token, index) =>
+                    token === CALL_GLOBAL_OP &&
+                    typeof bytecode[index + 1] === 'string' &&
+                    NONDETERMINISTIC_FNS.has(bytecode[index + 1] as string)
+            )
+            if (this.nondeterministicByFunction.size >= MAX_BUFFER_SIZE) {
+                this.nondeterministicByFunction.clear()
+            }
+            this.nondeterministicByFunction.set(functionId, cached)
+        }
+        return cached
+    }
+
+    /**
+     * Execute everything captured since the last flush on the Rust VM and compare. Runs off the hot
+     * path (fired from the events pipeline without being awaited); never throws.
+     */
+    public async flush(): Promise<void> {
+        const items = this.buffer
+        this.buffer = []
+        const module_ = this.getModule()
+        if (!module_ || items.length === 0) {
+            return
+        }
+
+        // A previous flush's native batch may still be running on its worker threads. Never stack
+        // batches: while one is in flight, drop this round.
+        if (this.flushInFlight) {
+            filterShadowComparison.inc({ outcome: 'dropped' }, items.length)
+            return
+        }
+        this.flushInFlight = true
+
+        filterShadowFlushSize.observe({ scope: 'flush' }, items.length)
+
+        try {
+            await this.executeAndCompare(items)
+        } catch (error) {
+            logger.warn('🦀', 'Rust HogVM filter shadow flush failed', { error: String(error) })
+        } finally {
+            this.flushInFlight = false
+        }
+    }
+
+    private async executeAndCompare(items: FilterShadowCapturedInvocation[]): Promise<void> {
+        const module_ = this.getModule()
+        if (!module_) {
+            return
+        }
+
+        // Group by bytecode reference: the hog function manager caches functions, so every event
+        // that ran the same filter shares the exact same bytecode array. Grouping lets each group
+        // run as one parallel rust batch, which is where the rayon win shows up.
+        const byBytecode = new Map<HogBytecode, FilterShadowCapturedInvocation[]>()
+        for (const item of items) {
+            const group = byBytecode.get(item.bytecode)
+            if (group) {
+                group.push(item)
+            } else {
+                byBytecode.set(item.bytecode, [item])
+            }
+        }
+
+        for (const [bytecode, group] of byBytecode.entries()) {
+            filterShadowFlushSize.observe({ scope: 'bytecode' }, group.length)
+            let rustResults: RustExecResult[] = []
+            const stopTimer = filterShadowBatchDuration.startTimer()
+            try {
+                rustResults = await module_.executeBatch(
+                    bytecode,
+                    group.map((item) => parseJSON(item.globalsJson)),
+                    { parallel: true, maxSteps: RUST_MAX_STEPS }
+                )
+            } catch (error) {
+                logger.warn('🦀', 'Rust HogVM filter shadow batch failed', {
+                    functionId: group[0].functionId,
+                    error: String(error),
+                })
+            } finally {
+                stopTimer()
+            }
+
+            let mismatchLogged = false
+            group.forEach((item, index) => {
+                const rust: RustExecResult | undefined = rustResults[index]
+                filterShadowExecutionDuration.observe({ vm: 'node' }, item.node.durationMs)
+                if (rust) {
+                    filterShadowExecutionDuration.observe({ vm: 'rust' }, rust.durationUs / 1000)
+                }
+                const outcome = classifyFilterShadowOutcome(item.node, rust)
+                filterShadowComparison.inc({ outcome })
+                // One example per bytecode group per flush is enough to identify a diverging filter
+                // without flooding the logs; replay its bytecode offline for the actual diff.
+                if ((outcome === 'result_mismatch' || outcome === 'status_mismatch') && !mismatchLogged) {
+                    mismatchLogged = true
+                    logger.warn('🦀', 'Rust HogVM filter shadow divergence', {
+                        outcome,
+                        functionId: item.functionId,
+                        teamId: item.teamId,
+                        nodeMatch: item.node.match,
+                        nodeError: item.node.error,
+                        rustResult: rust?.result,
+                        rustError: rust?.error,
+                    })
+                }
+            })
+        }
+    }
+
+    private getModule(): HogvmNodeModule | null {
+        if (this.module_ !== undefined) {
+            return this.module_
+        }
+        if (this.options.sampleRate <= 0) {
+            this.module_ = null
+            return null
+        }
+        try {
+            const module_: HogvmNodeModule = require('@posthog/hogvm-node')
+            module_.init({
+                mmdbPath: this.options.mmdbPath,
+                knownBotUaList: KNOWN_BOT_UA_LIST,
+                knownBotIpList: KNOWN_BOT_IP_LIST,
+            })
+            this.module_ = module_
+            logger.info('🦀', 'Rust HogVM filter shadow mode enabled', { sampleRate: this.options.sampleRate })
+        } catch (error) {
+            this.module_ = null
+            logger.warn('🦀', 'Rust HogVM native module unavailable, filter shadow mode disabled', {
+                error: String(error),
+            })
+        }
+        return this.module_
+    }
+}

--- a/nodejs/src/cdp/utils/hog-function-filtering.test.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.test.ts
@@ -1,4 +1,7 @@
+import { parseJSON } from '~/common/utils/json-parse'
+
 import { ClickHouseTimestamp, ProjectId, RawClickHouseEvent } from '../../types'
+import type { FilterShadowCapturedInvocation, FilterShadowCapturer } from '../services/rust-vm-filter-shadow'
 import { HogFunctionFilterGlobals, HogFunctionInvocationGlobals, HogFunctionType } from '../types'
 import {
     convertClickhouseRawEventToFilterGlobals,
@@ -356,6 +359,86 @@ describe('hog-function-filtering', () => {
 
             // Should execute bytecode because properties filters are present
             expect(result.match).toBe(true)
+        })
+    })
+
+    describe('Rust HogVM shadow capture', () => {
+        const makeShadow = (): { shadow: FilterShadowCapturer; captured: FilterShadowCapturedInvocation[] } => {
+            const captured: FilterShadowCapturedInvocation[] = []
+            return {
+                captured,
+                shadow: {
+                    shouldCapture: jest.fn().mockReturnValue(true),
+                    capture: (item) => captured.push(item),
+                },
+            }
+        }
+
+        const fn = {
+            id: 'shadow-fn',
+            team_id: 7,
+            name: 'Shadow Function',
+        } as unknown as HogFunctionType
+
+        const filterGlobals = {
+            event: '$pageview',
+            distinct_id: 'user_1',
+            timestamp: '2025-01-01T00:00:00.000Z',
+        } as HogFunctionFilterGlobals
+
+        it('captures the executed filter with the node match result, bytecode and globals snapshot', async () => {
+            const { shadow, captured } = makeShadow()
+            const filters = {
+                events: [{ id: '$pageview', name: '$pageview', type: 'events', order: 0 }],
+                properties: [{ key: '$browser', type: 'event', value: 'is_set', operator: 'is_set' }],
+                bytecode: ['_H', 1, 30], // FALSE — the shadow must record the real boolean, not assume true
+            } as HogFunctionType['filters']
+
+            const result = await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
+
+            expect(result.match).toBe(false)
+            expect(captured).toHaveLength(1)
+            expect(captured[0].functionId).toBe('shadow-fn')
+            expect(captured[0].teamId).toBe(7)
+            expect(captured[0].bytecode).toBe(filters!.bytecode)
+            expect(captured[0].node.match).toBe(false)
+            expect(parseJSON(captured[0].globalsJson).event).toBe('$pageview')
+        })
+
+        it('does not capture when the pre-filter short-circuits before running bytecode', async () => {
+            const { shadow, captured } = makeShadow()
+            const filters = {
+                events: [{ id: 'other_event', name: 'other_event', type: 'events', order: 0 }],
+                bytecode: ['_H', 1, 29],
+            } as HogFunctionType['filters']
+
+            const result = await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
+
+            expect(result.match).toBe(false)
+            expect(captured).toHaveLength(0)
+        })
+
+        it('does not capture when there are no filters and bytecode execution is skipped', async () => {
+            const { shadow, captured } = makeShadow()
+            const filters = { bytecode: ['_H', 1, 29] } as HogFunctionType['filters']
+
+            const result = await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
+
+            expect(result.match).toBe(true)
+            expect(captured).toHaveLength(0)
+        })
+
+        it('does not capture when sampling declines the invocation', async () => {
+            const { shadow, captured } = makeShadow()
+            ;(shadow.shouldCapture as jest.Mock).mockReturnValue(false)
+            const filters = {
+                properties: [{ key: '$browser', type: 'event', value: 'is_set', operator: 'is_set' }],
+                bytecode: ['_H', 1, 29],
+            } as HogFunctionType['filters']
+
+            await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
+
+            expect(captured).toHaveLength(0)
         })
     })
 })

--- a/nodejs/src/cdp/utils/hog-function-filtering.test.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.test.ts
@@ -1,7 +1,5 @@
-import { parseJSON } from '~/common/utils/json-parse'
-
 import { ClickHouseTimestamp, ProjectId, RawClickHouseEvent } from '../../types'
-import type { FilterShadowCapturedInvocation, FilterShadowCapturer } from '../services/rust-vm-filter-shadow'
+import type { FilterShadowCapturer } from '../services/rust-vm-filter-shadow'
 import { HogFunctionFilterGlobals, HogFunctionInvocationGlobals, HogFunctionType } from '../types'
 import {
     convertClickhouseRawEventToFilterGlobals,
@@ -362,16 +360,10 @@ describe('hog-function-filtering', () => {
         })
     })
 
-    describe('Rust HogVM shadow capture', () => {
-        const makeShadow = (): { shadow: FilterShadowCapturer; captured: FilterShadowCapturedInvocation[] } => {
-            const captured: FilterShadowCapturedInvocation[] = []
-            return {
-                captured,
-                shadow: {
-                    shouldCapture: jest.fn().mockReturnValue(true),
-                    capture: (item) => captured.push(item),
-                },
-            }
+    describe('Rust HogVM shadow', () => {
+        const makeShadow = (): { shadow: FilterShadowCapturer; compare: jest.Mock } => {
+            const compare = jest.fn()
+            return { shadow: { compare }, compare }
         }
 
         const fn = {
@@ -386,27 +378,27 @@ describe('hog-function-filtering', () => {
             timestamp: '2025-01-01T00:00:00.000Z',
         } as HogFunctionFilterGlobals
 
-        it('captures the executed filter with the node match result, bytecode and globals snapshot', async () => {
-            const { shadow, captured } = makeShadow()
+        it('compares the executed filter with the real node match, bytecode and globals', async () => {
+            const { shadow, compare } = makeShadow()
             const filters = {
                 events: [{ id: '$pageview', name: '$pageview', type: 'events', order: 0 }],
                 properties: [{ key: '$browser', type: 'event', value: 'is_set', operator: 'is_set' }],
-                bytecode: ['_H', 1, 30], // FALSE — the shadow must record the real boolean, not assume true
+                bytecode: ['_H', 1, 30], // FALSE — the shadow must be handed the real boolean, not assume true
             } as HogFunctionType['filters']
 
             const result = await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
 
             expect(result.match).toBe(false)
-            expect(captured).toHaveLength(1)
-            expect(captured[0].functionId).toBe('shadow-fn')
-            expect(captured[0].teamId).toBe(7)
-            expect(captured[0].bytecode).toBe(filters!.bytecode)
-            expect(captured[0].node.match).toBe(false)
-            expect(parseJSON(captured[0].globalsJson).event).toBe('$pageview')
+            expect(compare).toHaveBeenCalledTimes(1)
+            const [bytecode, globals, nodeMatch, nodeDurationMs] = compare.mock.calls[0]
+            expect(bytecode).toBe(filters!.bytecode)
+            expect(globals).toBe(filterGlobals)
+            expect(nodeMatch).toBe(false)
+            expect(typeof nodeDurationMs).toBe('number')
         })
 
-        it('does not capture when the pre-filter short-circuits before running bytecode', async () => {
-            const { shadow, captured } = makeShadow()
+        it('does not compare when the pre-filter short-circuits before running bytecode', async () => {
+            const { shadow, compare } = makeShadow()
             const filters = {
                 events: [{ id: 'other_event', name: 'other_event', type: 'events', order: 0 }],
                 bytecode: ['_H', 1, 29],
@@ -415,30 +407,17 @@ describe('hog-function-filtering', () => {
             const result = await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
 
             expect(result.match).toBe(false)
-            expect(captured).toHaveLength(0)
+            expect(compare).not.toHaveBeenCalled()
         })
 
-        it('does not capture when there are no filters and bytecode execution is skipped', async () => {
-            const { shadow, captured } = makeShadow()
+        it('does not compare when there are no filters and bytecode execution is skipped', async () => {
+            const { shadow, compare } = makeShadow()
             const filters = { bytecode: ['_H', 1, 29] } as HogFunctionType['filters']
 
             const result = await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
 
             expect(result.match).toBe(true)
-            expect(captured).toHaveLength(0)
-        })
-
-        it('does not capture when sampling declines the invocation', async () => {
-            const { shadow, captured } = makeShadow()
-            ;(shadow.shouldCapture as jest.Mock).mockReturnValue(false)
-            const filters = {
-                properties: [{ key: '$browser', type: 'event', value: 'is_set', operator: 'is_set' }],
-                bytecode: ['_H', 1, 29],
-            } as HogFunctionType['filters']
-
-            await filterFunctionInstrumented({ fn, filters, filterGlobals, shadow })
-
-            expect(captured).toHaveLength(0)
+            expect(compare).not.toHaveBeenCalled()
         })
     })
 })

--- a/nodejs/src/cdp/utils/hog-function-filtering.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.ts
@@ -349,8 +349,8 @@ export async function filterFunctionInstrumented(options: {
     filterGlobals: HogFunctionFilterGlobals
     /** Optional filters to use instead of those on the function */
     filters: HogFunctionType['filters']
-    /** Optional Rust HogVM shadow. When provided and sampling, the filter bytecode + globals are
-     * captured for out-of-band comparison. Never affects the returned result. */
+    /** Optional Rust HogVM shadow. When provided, sampled bytecode executions are re-run on the
+     * Rust VM off the hot path to compare timing and result. Never affects the returned result. */
     shadow?: FilterShadowCapturer
 }): Promise<HogFilterResult> {
     const { fn, filters, filterGlobals, shadow } = options
@@ -368,11 +368,9 @@ export async function filterFunctionInstrumented(options: {
 
     let preFilterMatch = null
 
-    // Rust HogVM shadow bookkeeping (outer scope so the post-execution capture below can read the
-    // final match/error regardless of whether the Node VM threw).
-    let shadowCapture = false
-    let shadowGlobalsJson: string | null = null
-    let shadowDurationMs: number | null = null
+    // Node filter duration, captured only when bytecode actually ran, so the Rust HogVM shadow at
+    // the bottom fires for exactly the executions it can compare.
+    let nodeFilterDurationMs: number | null = null
 
     try {
         // If there are no filters (only bytecode exists then on the filter object)
@@ -405,20 +403,11 @@ export async function filterFunctionInstrumented(options: {
             throw new Error('Filters were not compiled correctly and so could not be executed')
         }
 
-        // Decide once, before running, whether to shadow this execution. Snapshot the globals now:
-        // although the Node VM doesn't mutate them, this keeps the compared input pinned to what
-        // Node actually saw. Only the bytecode-executing path is sampled, so the pre-filtered and
-        // no-filter short-circuits above are never counted.
-        if (shadow?.shouldCapture()) {
-            shadowCapture = true
-            shadowGlobalsJson = JSON.stringify(filterGlobals)
-        }
-
         const execHogOutcome = await execHog(filters.bytecode, { globals: filterGlobals })
 
         if (execHogOutcome) {
             hogFunctionFilterDuration.observe({ type }, execHogOutcome.durationMs)
-            shadowDurationMs = execHogOutcome.durationMs
+            nodeFilterDurationMs = execHogOutcome.durationMs
         }
 
         if (execHogOutcome.durationMs > HOG_FILTERING_TIMEOUT_MS) {
@@ -483,20 +472,11 @@ export async function filterFunctionInstrumented(options: {
         result.error = error.message
     }
 
-    // Off the primary path: buffer this filter's bytecode, globals snapshot and Node outcome for
-    // out-of-band comparison against the Rust HogVM. Only fires for sampled bytecode executions.
-    if (shadowCapture && shadowGlobalsJson !== null && shadowDurationMs !== null && filters?.bytecode) {
-        shadow?.capture({
-            functionId: fn.id,
-            teamId: fn.team_id,
-            bytecode: filters.bytecode,
-            globalsJson: shadowGlobalsJson,
-            node: {
-                match: result.match,
-                error: result.error !== undefined ? String(result.error) : undefined,
-                durationMs: shadowDurationMs,
-            },
-        })
+    // Off the primary path: re-run the same bytecode + globals on the Rust HogVM and compare. Only
+    // fires for sampled bytecode executions (the pre-filtered and no-filter short-circuits above
+    // return early and are never compared). Fire-and-forget — it can't affect `result`.
+    if (shadow && filters?.bytecode && nodeFilterDurationMs !== null) {
+        void shadow.compare(filters.bytecode, filterGlobals, result.match, nodeFilterDurationMs)
     }
 
     return result

--- a/nodejs/src/cdp/utils/hog-function-filtering.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.ts
@@ -10,6 +10,7 @@ import { createTrackedRE2 } from '~/common/utils/tracked-re2'
 import { UUIDT, clickHouseTimestampToISO } from '~/common/utils/utils'
 
 import { RawClickHouseEvent } from '../../types'
+import type { FilterShadowCapturer } from '../services/rust-vm-filter-shadow'
 import {
     HogFunctionFilterGlobals,
     HogFunctionInvocationGlobals,
@@ -348,8 +349,11 @@ export async function filterFunctionInstrumented(options: {
     filterGlobals: HogFunctionFilterGlobals
     /** Optional filters to use instead of those on the function */
     filters: HogFunctionType['filters']
+    /** Optional Rust HogVM shadow. When provided and sampling, the filter bytecode + globals are
+     * captured for out-of-band comparison. Never affects the returned result. */
+    shadow?: FilterShadowCapturer
 }): Promise<HogFilterResult> {
-    const { fn, filters, filterGlobals } = options
+    const { fn, filters, filterGlobals, shadow } = options
     const type = 'type' in fn ? fn.type : 'hogflow'
     const fnKind = 'type' in fn ? 'HogFunction' : 'HogFlow'
     const logs: LogEntry[] = []
@@ -363,6 +367,12 @@ export async function filterFunctionInstrumented(options: {
     }
 
     let preFilterMatch = null
+
+    // Rust HogVM shadow bookkeeping (outer scope so the post-execution capture below can read the
+    // final match/error regardless of whether the Node VM threw).
+    let shadowCapture = false
+    let shadowGlobalsJson: string | null = null
+    let shadowDurationMs: number | null = null
 
     try {
         // If there are no filters (only bytecode exists then on the filter object)
@@ -395,10 +405,20 @@ export async function filterFunctionInstrumented(options: {
             throw new Error('Filters were not compiled correctly and so could not be executed')
         }
 
+        // Decide once, before running, whether to shadow this execution. Snapshot the globals now:
+        // although the Node VM doesn't mutate them, this keeps the compared input pinned to what
+        // Node actually saw. Only the bytecode-executing path is sampled, so the pre-filtered and
+        // no-filter short-circuits above are never counted.
+        if (shadow?.shouldCapture()) {
+            shadowCapture = true
+            shadowGlobalsJson = JSON.stringify(filterGlobals)
+        }
+
         const execHogOutcome = await execHog(filters.bytecode, { globals: filterGlobals })
 
         if (execHogOutcome) {
             hogFunctionFilterDuration.observe({ type }, execHogOutcome.durationMs)
+            shadowDurationMs = execHogOutcome.durationMs
         }
 
         if (execHogOutcome.durationMs > HOG_FILTERING_TIMEOUT_MS) {
@@ -462,5 +482,22 @@ export async function filterFunctionInstrumented(options: {
         })
         result.error = error.message
     }
+
+    // Off the primary path: buffer this filter's bytecode, globals snapshot and Node outcome for
+    // out-of-band comparison against the Rust HogVM. Only fires for sampled bytecode executions.
+    if (shadowCapture && shadowGlobalsJson !== null && shadowDurationMs !== null && filters?.bytecode) {
+        shadow?.capture({
+            functionId: fn.id,
+            teamId: fn.team_id,
+            bytecode: filters.bytecode,
+            globalsJson: shadowGlobalsJson,
+            node: {
+                match: result.match,
+                error: result.error !== undefined ? String(result.error) : undefined,
+                durationMs: shadowDurationMs,
+            },
+        })
+    }
+
     return result
 }

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -191,6 +191,10 @@ export type CommonConfig = BaseServerConfig & {
     // latency/correctness comparison; the Node VM result stays authoritative
     CDP_HOG_RUST_VM_SHADOW_SAMPLE_RATE: number
 
+    // Fraction (0-1) of CDP events-consumer filter evaluations shadow-executed on the Rust HogVM
+    // for latency/correctness comparison; the Node VM filtering result stays authoritative
+    CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE: number
+
     // Event loop yield helper (yieldEventLoopIfNeeded)
     EVENT_LOOP_YIELD_THRESHOLD_MS: number
 }
@@ -362,6 +366,7 @@ export function getDefaultCommonConfig(): CommonConfig {
         // Shared between ingestion and CDP
         CDP_HOG_WATCHER_SAMPLE_RATE: 0,
         CDP_HOG_RUST_VM_SHADOW_SAMPLE_RATE: 0,
+        CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE: 0,
 
         // Event loop yield helper
         EVENT_LOOP_YIELD_THRESHOLD_MS: 200,


### PR DESCRIPTION
## Problem

The CDP events consumer uses the Node HogVM to evaluate hog-function filters and find which functions to queue for an event. We want production evidence on how the Rust HogVM (`@posthog/hogvm-node`) compares on that path — both latency and whether it agrees with Node — before considering it for real work. Filters are pure Hog (no host functions), so this can stay small and observation-only.

## Changes

- Adds `RustVmFilterShadow` (`nodejs/src/cdp/services/rust-vm-filter-shadow.ts`): for a sampled filter execution it re-runs the same bytecode + globals on the Rust HogVM off the JS event loop, records how long each VM took, and compares the boolean match. Fire-and-forget — the Node result stays authoritative and nothing here can affect it or the hot path.
- Wired into the shared `filterFunctionInstrumented` utility and enabled only by the `HogFunctionInvocationPipeline` (the events consumer's filtering path). Every other caller leaves the shadow undefined, so nothing extra runs.
- Gated by `CDP_HOG_RUST_VM_SHADOW_FILTER_SAMPLE_RATE` (default 0). The native addon is optional; if it isn't built the shadow disables itself.
- Metrics: `hogvm_filter_shadow_duration_ms{vm=node|rust}` and `hogvm_filter_shadow_comparison_total{outcome=match|mismatch|error}`.

## How did you test this code?

- `rust-vm-filter-shadow.test.ts` (native module mocked): outcome classification (match / mismatch / non-boolean-as-no-match / rust error / missing result), that `compare` runs the same bytecode + globals and records the outcome, that a rejected native call is swallowed as `error` rather than thrown, and that a 0 sample rate never loads the addon or calls it.
- Added cases to `hog-function-filtering.test.ts`: the shadow is handed the real Node boolean, bytecode and globals for a bytecode-executing filter, and is not invoked on the pre-filter / no-filter short-circuits.
- `hogli` / `ci:preflight` weren't available in this environment; ran eslint, prettier, tsc (changed files clean) and the affected jest suites directly.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code. An earlier revision buffered captures and ran them as rayon-parallel batches with bytecode grouping, plus geoip/bot-list init; since filters are pure Hog and the goal is just timing + correctness observation, that was simplified to a single inline per-invocation `compare()`. The `/writing-tests` skill was used to gate the test changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
