### PR TITLE
fix(insights): show "None" unit label for numeric aggregation format

### DIFF
--- a/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
+++ b/frontend/src/lib/components/UnitPicker/UnitPicker.tsx
@@ -69,7 +69,8 @@ export function UnitPicker(): JSX.Element {
 
     const displayValue = useMemo(() => {
         let displayValue: React.ReactNode = 'None'
-        if (effectiveAxisFormat) {
+        // 'numeric' is the explicit "None" option, so keep the "None" label rather than its empty short symbol.
+        if (effectiveAxisFormat && effectiveAxisFormat !== 'numeric') {
             displayValue = INSIGHT_UNIT_OPTIONS_SHORT[effectiveAxisFormat]
         }
         if (trendsFilter?.aggregationAxisPrefix?.length) {


### PR DESCRIPTION
## Problem

For a Trends "number" insight, opening **Display options → Unit** from a dashboard card showed a blank value instead of **None**. The normal insight view correctly showed "None". Small papercut reported in Slack.

## Changes
<img width="389" height="188" alt="Screenshot 2026-07-09 at 16 46 34" src="https://github.com/user-attachments/assets/75793439-c23f-4a99-b75d-a4c7e4b7cdeb" />

The `UnitPicker` button label defaults to "None" but only rendered it when the aggregation format was falsy. The explicit "None" option stores the value `'numeric'` (a truthy string) whose short symbol in `INSIGHT_UNIT_OPTIONS_SHORT` is an empty string, so the label came out blank. This surfaced on cards whose insight persists `aggregationAxisFormat: 'numeric'` explicitly rather than leaving it unset.

Now `'numeric'` is treated the same as an unset format, so the label reads "None" in every context.

## How did you test this code?

I (the agent) traced the label logic and applied the one-line guard; I did not run the app or add automated tests. The change is a display-only string fix in the `UnitPicker` label memo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Investigated with a read-only exploration agent to locate the Unit selector rendering (`frontend/src/lib/components/UnitPicker/UnitPicker.tsx`) and confirmed the root cause: the `displayValue` memo mapped the `'numeric'` "None" value to its empty short symbol. Fix guards the lookup with `effectiveAxisFormat !== 'numeric'`, matching the existing `!== 'numeric'` convention already used elsewhere (e.g. `insightDisplayOptions.tsx`).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1783603694257939?thread_ts=1783603694.257939&cid=C0368RPHLQH)*
