### PR TITLE
perf(web-analytics): serve stale precompute jobs within grace instead of blocking

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -424,6 +424,9 @@ class QueryTags(BaseModel):
     # Generic across products (experiments, marketing, web analytics) since they share the executor.
     precompute_window_start: Optional[str] = None
     precompute_window_end: Optional[str] = None
+    # True on precompute READ queries served from expired-within-grace jobs (serve-stale path),
+    # so query_log can compare stale-served vs fresh reads without joining Prometheus.
+    precompute_stale: Optional[bool] = None
     entity_math: Optional[list[str]] = None
 
     # replays

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -884,7 +884,7 @@ class LazyComputationExecutor:
                 # fully cover the range, return them immediately — complete-but-stale beats
                 # blocking. Whoever refreshes (the warmer, or a request after the grace)
                 # replaces the data; `filter_overlapping_jobs` always prefers newer jobs.
-                if self.serve_stale_grace_seconds and (ttl_ranges or pending_jobs):
+                if self.serve_stale_grace_seconds is not None and (ttl_ranges or pending_jobs):
                     graced = find_existing_jobs(
                         team, query_hash, start, end, expired_grace_seconds=self.serve_stale_grace_seconds
                     )
@@ -892,10 +892,14 @@ class LazyComputationExecutor:
                         [j for j in graced if j.status == PreaggregationJob.Status.READY],
                         grace_seconds=self.serve_stale_grace_seconds,
                     )
-                    if not find_missing_contiguous_windows(graced_ready, start, end):
+                    # Coverage must be checked on the overlap-filtered set that will actually
+                    # be returned: the filter prefers newer jobs, so a newer narrow job can
+                    # evict an older broad one and reopen a gap the unfiltered set covered.
+                    covering = filter_overlapping_jobs(graced_ready)
+                    if not find_missing_contiguous_windows(covering, start, end):
                         result = LazyComputationResult(
                             ready=True,
-                            job_ids=[j.id for j in filter_overlapping_jobs(graced_ready)],
+                            job_ids=[j.id for j in covering],
                             stale=True,
                         )
                         _log_execution("stale_hit", result)

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -430,6 +430,10 @@ class LazyComputationResult:
     # True if any insert failed with ClickHouse MEMORY_LIMIT_EXCEEDED. Lets callers react
     # to an OOM (e.g. cap a high-cardinality team's future inserts) without parsing errors.
     memory_exceeded: bool = False
+    # True when the returned job_ids include recently-expired jobs served under the
+    # executor's serve-stale grace instead of recomputing inline. The data is complete
+    # but up to (TTL + grace) old; the caller decides whether to surface that.
+    stale: bool = False
 
 
 def compute_query_hash(query_info: QueryInfo) -> str:
@@ -483,6 +487,7 @@ def find_existing_jobs(
     query_hash: str,
     start: datetime,
     end: datetime,
+    expired_grace_seconds: float = 0,
 ) -> list[PreaggregationJob]:
     """
     Find all existing lazy computation jobs for the given team and query hash
@@ -490,9 +495,11 @@ def find_existing_jobs(
 
     Excludes expired jobs. ClickHouse data outlives the PG job by
     EXPIRY_BUFFER_SECONDS, so queries in flight when a job expires still
-    find data.
+    find data. `expired_grace_seconds` relaxes the expiry cutoff to also return
+    recently-expired jobs (for serve-stale reads); it must stay well under
+    EXPIRY_BUFFER_SECONDS or the PG row may outlive its ClickHouse data.
     """
-    min_expires_at = django_timezone.now()
+    min_expires_at = django_timezone.now() - timedelta(seconds=expired_grace_seconds)
 
     return list(
         PreaggregationJob.objects.filter(
@@ -758,6 +765,11 @@ class LazyComputationExecutor:
     - ttl_schedule: TtlSchedule controlling how long lazy-computed data persists per time range
     - stale_pending_threshold_seconds: How long before a PENDING job is considered stale
     - ch_start_grace_period_seconds: Grace period before declaring "not started" as stale
+    - serve_stale_grace_seconds: When set, a request that would otherwise compute inline
+      (or block on another executor's pending jobs) is served from READY jobs that expired
+      within the last N seconds — complete-but-stale data, returned immediately with
+      `stale=True`. Must stay well under EXPIRY_BUFFER_SECONDS (48h) so the underlying
+      ClickHouse rows are guaranteed to still exist.
     """
 
     def __init__(
@@ -769,7 +781,10 @@ class LazyComputationExecutor:
         ttl_schedule: TtlSchedule = DEFAULT_TTL_SCHEDULE,
         stale_pending_threshold_seconds: float = DEFAULT_STALE_PENDING_THRESHOLD_SECONDS,
         ch_start_grace_period_seconds: float = DEFAULT_CH_START_GRACE_PERIOD_SECONDS,
+        serve_stale_grace_seconds: float | None = None,
     ) -> None:
+        if serve_stale_grace_seconds is not None and serve_stale_grace_seconds >= EXPIRY_BUFFER_SECONDS:
+            raise ValueError("serve_stale_grace_seconds must be below EXPIRY_BUFFER_SECONDS")
         self.wait_timeout_seconds = wait_timeout_seconds
         self.poll_interval_seconds = poll_interval_seconds
         self.max_poll_interval_seconds = max_poll_interval_seconds
@@ -777,6 +792,7 @@ class LazyComputationExecutor:
         self.ttl_schedule = ttl_schedule
         self.stale_pending_threshold_seconds = stale_pending_threshold_seconds
         self.ch_start_grace_period_seconds = ch_start_grace_period_seconds
+        self.serve_stale_grace_seconds = serve_stale_grace_seconds
 
     def execute(
         self,
@@ -862,6 +878,28 @@ class LazyComputationExecutor:
 
                 if had_ready_at_start is None:
                     had_ready_at_start = any(j.status == PreaggregationJob.Status.READY for j in fresh_jobs)
+
+                # Step 2.5: Serve stale. If this request would otherwise compute inline or
+                # block on another executor's pending jobs, and READY jobs within the grace
+                # fully cover the range, return them immediately — complete-but-stale beats
+                # blocking. Whoever refreshes (the warmer, or a request after the grace)
+                # replaces the data; `filter_overlapping_jobs` always prefers newer jobs.
+                if self.serve_stale_grace_seconds and (ttl_ranges or pending_jobs):
+                    graced = find_existing_jobs(
+                        team, query_hash, start, end, expired_grace_seconds=self.serve_stale_grace_seconds
+                    )
+                    graced_ready = self._filter_by_freshness(
+                        [j for j in graced if j.status == PreaggregationJob.Status.READY],
+                        grace_seconds=self.serve_stale_grace_seconds,
+                    )
+                    if not find_missing_contiguous_windows(graced_ready, start, end):
+                        result = LazyComputationResult(
+                            ready=True,
+                            job_ids=[j.id for j in filter_overlapping_jobs(graced_ready)],
+                            stale=True,
+                        )
+                        _log_execution("stale_hit", result)
+                        return result
 
                 # Step 3: Insert missing ranges
                 did_work = False
@@ -1062,11 +1100,14 @@ class LazyComputationExecutor:
         job_age = (django_timezone.now() - job.created_at).total_seconds()
         return job_age > self.stale_pending_threshold_seconds
 
-    def _filter_by_freshness(self, jobs: list[PreaggregationJob]) -> list[PreaggregationJob]:
+    def _filter_by_freshness(
+        self, jobs: list[PreaggregationJob], grace_seconds: float = 0.0
+    ) -> list[PreaggregationJob]:
         """Filter jobs by freshness according to the TTL schedule.
 
         PENDING jobs always pass (they were recently created and we should wait).
-        READY jobs must satisfy: created_at + desired_ttl >= now().
+        READY jobs must satisfy: created_at + desired_ttl + grace_seconds >= now().
+        `grace_seconds` is only non-zero for the serve-stale path.
 
         This is per-query: a job created by executor A with a long TTL may be
         rejected by executor B using a stricter schedule for the same hash.
@@ -1078,7 +1119,7 @@ class LazyComputationExecutor:
                 result.append(job)
             else:
                 desired_ttl = self.ttl_schedule.get_ttl(job.time_range_start)
-                if job.created_at + timedelta(seconds=desired_ttl) >= now:
+                if job.created_at + timedelta(seconds=desired_ttl + grace_seconds) >= now:
                     result.append(job)
         return result
 
@@ -1099,6 +1140,7 @@ def ensure_precomputed(
     query_type: str | None = None,
     spill_to_disk: bool = False,
     wait_timeout_seconds: float | None = None,
+    serve_stale_grace_seconds: float | None = None,
 ) -> LazyComputationResult:
     """
     Ensure lazy-computed data exists for the given query and time range.
@@ -1144,6 +1186,12 @@ def ensure_precomputed(
                       persists as a READY job even when the overall call times out —
                       repeated calls converge. Use a small value for user-facing
                       requests that have a cheap fallback path.
+        serve_stale_grace_seconds: When set, requests that would otherwise compute
+                      inline or wait are served from READY jobs expired within the
+                      last N seconds (result comes back with `stale=True`). Only for
+                      user-facing callers with a refresh mechanism (e.g. an hourly
+                      warmer); background refreshers must leave this unset or they
+                      would serve stale to themselves and never recompute.
 
     Returns:
         ComputationResult with job_ids that can be used to query the data
@@ -1236,6 +1284,7 @@ def ensure_precomputed(
     executor = LazyComputationExecutor(
         ttl_schedule=ttl_schedule,
         wait_timeout_seconds=wait_timeout_seconds if wait_timeout_seconds is not None else DEFAULT_WAIT_TIMEOUT_SECONDS,
+        serve_stale_grace_seconds=serve_stale_grace_seconds,
     )
     return executor.execute(team, query_info, time_range_start, time_range_end, run_insert=_run_manual_insert)
 

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -1645,20 +1645,27 @@ class TestComputationExecutorExecute(BaseTest):
         assert insert_count[0] == 1
         assert stale_job.id not in result.job_ids
 
-    def test_stale_ready_job_served_within_grace(self):
+    @parameterized.expand(
+        [
+            # Expired 1h ago (created 2h ago, 1h TTL) — within the 6h grace: served as-is.
+            ("within_grace", 1, True),
+            # Expired 9h ago — beyond the 6h grace: the normal recompute path runs.
+            ("beyond_grace", 9, False),
+        ]
+    )
+    def test_stale_ready_job_serve_stale_by_grace(self, _name: str, expired_hours_ago: int, served: bool) -> None:
         query_info, query_hash = self._make_query_info()
 
-        # READY job that expired 1h ago (created 2h ago, 1h TTL) — within the 6h grace.
         stale_job = PreaggregationJob.objects.create(
             team=self.team,
             query_hash=query_hash,
             time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
             time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
             status=PreaggregationJob.Status.READY,
-            expires_at=django_timezone.now() - timedelta(hours=1),
+            expires_at=django_timezone.now() - timedelta(hours=expired_hours_ago),
         )
         PreaggregationJob.objects.filter(id=stale_job.id).update(
-            created_at=django_timezone.now() - timedelta(hours=2),
+            created_at=django_timezone.now() - timedelta(hours=expired_hours_ago + 1),
         )
 
         executor = LazyComputationExecutor(
@@ -1675,25 +1682,36 @@ class TestComputationExecutorExecute(BaseTest):
         )
 
         assert result.ready is True
-        assert result.stale is True
-        assert result.job_ids == [stale_job.id]
-        assert insert_count[0] == 0, "serve-stale must not compute inline"
+        if served:
+            assert result.stale is True
+            assert result.job_ids == [stale_job.id]
+            assert insert_count[0] == 0, "serve-stale must not compute inline"
+        else:
+            assert result.stale is False
+            assert stale_job.id not in result.job_ids
+            assert insert_count[0] == 1
 
-    def test_stale_job_beyond_grace_is_recomputed(self):
+    def test_serve_stale_rechecks_coverage_after_overlap_filtering(self):
         query_info, query_hash = self._make_query_info()
 
-        # Expired 9h ago — beyond the 6h grace, so the normal recompute path runs.
-        stale_job = PreaggregationJob.objects.create(
-            team=self.team,
-            query_hash=query_hash,
-            time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
-            time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
-            status=PreaggregationJob.Status.READY,
-            expires_at=django_timezone.now() - timedelta(hours=9),
-        )
-        PreaggregationJob.objects.filter(id=stale_job.id).update(
-            created_at=django_timezone.now() - timedelta(hours=10),
-        )
+        now = django_timezone.now()
+        # An older broad stale job fully covers the range, but a newer narrow stale job
+        # overlaps it. The overlap filter prefers the newer job and evicts the broad one,
+        # reopening gaps (Jan 1–2 and Jan 3–4) — serving that set would silently drop
+        # covered days, so the executor must fall through to recompute instead.
+        for time_range, created_ago_h in [
+            ((datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 4, tzinfo=UTC)), 3),
+            ((datetime(2024, 1, 2, tzinfo=UTC), datetime(2024, 1, 3, tzinfo=UTC)), 2),
+        ]:
+            job = PreaggregationJob.objects.create(
+                team=self.team,
+                query_hash=query_hash,
+                time_range_start=time_range[0],
+                time_range_end=time_range[1],
+                status=PreaggregationJob.Status.READY,
+                expires_at=now - timedelta(hours=1),
+            )
+            PreaggregationJob.objects.filter(id=job.id).update(created_at=now - timedelta(hours=created_ago_h))
 
         executor = LazyComputationExecutor(
             ttl_schedule=TtlSchedule.from_seconds(60 * 60), serve_stale_grace_seconds=6 * 60 * 60
@@ -1704,14 +1722,13 @@ class TestComputationExecutorExecute(BaseTest):
             team=self.team,
             query_info=query_info,
             start=datetime(2024, 1, 1, tzinfo=UTC),
-            end=datetime(2024, 1, 2, tzinfo=UTC),
+            end=datetime(2024, 1, 4, tzinfo=UTC),
             run_insert=lambda t, j: insert_count.__setitem__(0, insert_count[0] + 1),
         )
 
         assert result.ready is True
-        assert result.stale is False
-        assert stale_job.id not in result.job_ids
-        assert insert_count[0] == 1
+        assert result.stale is False, "gappy filtered coverage must not be served as a stale hit"
+        assert insert_count[0] > 0
 
     def test_serve_stale_grace_must_stay_under_expiry_buffer(self):
         # A grace at/above EXPIRY_BUFFER_SECONDS could return PG jobs whose ClickHouse

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -31,6 +31,7 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     DEFAULT_RETRIES,
     DEFAULT_TTL_SCHEDULE,
     DEFAULT_WAIT_TIMEOUT_SECONDS,
+    EXPIRY_BUFFER_SECONDS,
     NON_RETRYABLE_CLICKHOUSE_ERROR_CODES,
     PREAGGREGATION_INSERT_QUORUM,
     LazyComputationExecutor,
@@ -1643,6 +1644,80 @@ class TestComputationExecutorExecute(BaseTest):
         # A new job was created (stale one was filtered out)
         assert insert_count[0] == 1
         assert stale_job.id not in result.job_ids
+
+    def test_stale_ready_job_served_within_grace(self):
+        query_info, query_hash = self._make_query_info()
+
+        # READY job that expired 1h ago (created 2h ago, 1h TTL) — within the 6h grace.
+        stale_job = PreaggregationJob.objects.create(
+            team=self.team,
+            query_hash=query_hash,
+            time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+            time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
+            status=PreaggregationJob.Status.READY,
+            expires_at=django_timezone.now() - timedelta(hours=1),
+        )
+        PreaggregationJob.objects.filter(id=stale_job.id).update(
+            created_at=django_timezone.now() - timedelta(hours=2),
+        )
+
+        executor = LazyComputationExecutor(
+            ttl_schedule=TtlSchedule.from_seconds(60 * 60), serve_stale_grace_seconds=6 * 60 * 60
+        )
+        insert_count = [0]
+
+        result = executor.execute(
+            team=self.team,
+            query_info=query_info,
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 1, 2, tzinfo=UTC),
+            run_insert=lambda t, j: insert_count.__setitem__(0, insert_count[0] + 1),
+        )
+
+        assert result.ready is True
+        assert result.stale is True
+        assert result.job_ids == [stale_job.id]
+        assert insert_count[0] == 0, "serve-stale must not compute inline"
+
+    def test_stale_job_beyond_grace_is_recomputed(self):
+        query_info, query_hash = self._make_query_info()
+
+        # Expired 9h ago — beyond the 6h grace, so the normal recompute path runs.
+        stale_job = PreaggregationJob.objects.create(
+            team=self.team,
+            query_hash=query_hash,
+            time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+            time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
+            status=PreaggregationJob.Status.READY,
+            expires_at=django_timezone.now() - timedelta(hours=9),
+        )
+        PreaggregationJob.objects.filter(id=stale_job.id).update(
+            created_at=django_timezone.now() - timedelta(hours=10),
+        )
+
+        executor = LazyComputationExecutor(
+            ttl_schedule=TtlSchedule.from_seconds(60 * 60), serve_stale_grace_seconds=6 * 60 * 60
+        )
+        insert_count = [0]
+
+        result = executor.execute(
+            team=self.team,
+            query_info=query_info,
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 1, 2, tzinfo=UTC),
+            run_insert=lambda t, j: insert_count.__setitem__(0, insert_count[0] + 1),
+        )
+
+        assert result.ready is True
+        assert result.stale is False
+        assert stale_job.id not in result.job_ids
+        assert insert_count[0] == 1
+
+    def test_serve_stale_grace_must_stay_under_expiry_buffer(self):
+        # A grace at/above EXPIRY_BUFFER_SECONDS could return PG jobs whose ClickHouse
+        # rows were already TTL-deleted — silent empty reads. Constructor must refuse.
+        with self.assertRaises(ValueError):
+            LazyComputationExecutor(serve_stale_grace_seconds=EXPIRY_BUFFER_SECONDS)
 
     def test_fresh_ready_job_is_reused(self):
         query_info, query_hash = self._make_query_info()

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
@@ -858,10 +858,15 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 )
 
         budget = ensure_mock.call_args.kwargs["wait_timeout_seconds"]
+        grace = ensure_mock.call_args.kwargs["serve_stale_grace_seconds"]
         if trigger is None:
             assert budget == mod.PATHS_USER_ENSURE_WAIT_SECONDS
+            assert grace == mod.PATHS_USER_STALE_GRACE_SECONDS
         else:
+            # Warmers keep the full budget AND must never serve stale to themselves —
+            # they are the refresh mechanism the stale path relies on.
             assert budget is None, f"warmer trigger {trigger} must keep the framework default budget"
+            assert grace is None, f"warmer trigger {trigger} must not serve stale"
 
     @parameterized.expand([("no_compare", False), ("compare", True)])
     @freeze_time("2024-01-15T12:00:00Z")

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -95,6 +95,11 @@ WEB_STATS_PATHS_LAZY_EMPTY = Counter(
     "Lazy precompute reads that returned zero rows (potential silent ingestion drop or fresh team).",
 )
 
+WEB_STATS_PATHS_LAZY_STALE_SERVED = Counter(
+    "web_stats_paths_lazy_precompute_stale_served_total",
+    "Reads served from expired-within-grace jobs instead of recomputing inline (serve-stale path).",
+)
+
 WEB_STATS_PATHS_LAZY_ROWS = Histogram(
     "web_stats_paths_lazy_precompute_rows",
     "Distinct `breakdown_value` rows returned by the lazy precompute read (post-LIMIT cap).",
@@ -432,6 +437,15 @@ _BACKGROUND_WARMING_TRIGGERS = frozenset({"webAnalyticsEagerBaselineWarming", "w
 # (many stale windows after a hash rotation), which previously held requests for 30s+.
 PATHS_USER_ENSURE_WAIT_SECONDS = 10
 
+# Serve-stale grace for *user-facing* requests: windows that expired within this grace are
+# served from their existing (complete-but-stale) rows instantly instead of recomputing
+# inline. Refresh comes from the hourly eager warmer, which covers every enrolled team, so
+# observed staleness is normally bounded by the warmer cadence — the grace is the ceiling
+# for unwarmed query shapes and warmer outages. Must stay well under the framework's 48h
+# ClickHouse expiry buffer (rows must still exist). Background warmers never get the grace:
+# they are the refresh mechanism and would otherwise serve stale to themselves forever.
+PATHS_USER_STALE_GRACE_SECONDS = 6 * 60 * 60
+
 
 def ensure_web_stats_paths_precomputed(
     runner: "WebStatsTableQueryRunner",
@@ -471,6 +485,7 @@ def ensure_web_stats_paths_precomputed(
         query_type="web_stats_paths_lazy_insert",
         spill_to_disk=True,  # high-cardinality path breakdown GROUP BY; can build a large hash table
         wait_timeout_seconds=None if is_background else PATHS_USER_ENSURE_WAIT_SECONDS,
+        serve_stale_grace_seconds=None if is_background else PATHS_USER_STALE_GRACE_SECONDS,
     )
 
 
@@ -790,7 +805,10 @@ def execute_lazy_precomputed_read(
             team_id=team_id,
             job_count=len(result.job_ids),
             ensure_duration_ms=ensure_duration_ms,
+            stale=result.stale,
         )
+        if result.stale:
+            WEB_STATS_PATHS_LAZY_STALE_SERVED.inc()
 
         if not result.job_ids:
             return None

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -809,6 +809,9 @@ def execute_lazy_precomputed_read(
         )
         if result.stale:
             WEB_STATS_PATHS_LAZY_STALE_SERVED.inc()
+            # Tag the upcoming read query so query_log can split stale-served vs fresh
+            # reads (the Prometheus counter above can't be joined against query latency).
+            tag_queries(precompute_stale=True)
 
         if not result.job_ids:
             return None


### PR DESCRIPTION
## Problem

Stacked on #69556. Even with the ensure budget from #69556, a request whose windows are stale still pays either an inline recompute (2–8s on large teams) or the raw fallback (~17s worst on the largest team) — while the previous, complete data for those exact windows usually still exists: PostgreSQL jobs persist until `expires_at` and ClickHouse rows for another 48h beyond that. Blocking users on a recompute when complete-but-slightly-old data is sitting there is the main remaining "slow tile" moment.

## Changes

- **Framework:** `serve_stale_grace_seconds` on `LazyComputationExecutor` / `ensure_precomputed`. When a request would compute inline or block on another executor's pending jobs, and READY jobs that expired within the grace fully cover the range, they are returned immediately with `stale=True` (new field on `LazyComputationResult`, new `stale_hit` outcome in the execution log/metric). The constructor refuses a grace ≥ the 48h ClickHouse expiry buffer so returned jobs always still have their rows.
- **Paths:** 6h grace for user-facing requests. Warming triggers get no grace — they are the refresh mechanism; a warmer that serves stale to itself would freeze the cache. Refresh therefore comes from the hourly eager warmer (covers every enrolled team), so observed staleness is normally bounded by the warmer cadence, not the grace ceiling. New counter `web_stats_paths_lazy_precompute_stale_served_total`.

Combined with #69556, the user-facing distribution becomes: fresh ~300ms; stale-within-grace ~300ms (+async refresh by the warmer); truly cold → one budgeted attempt, then raw once, warm after.

## How did you test this code?

Three new framework tests (stale-within-grace serves without inserting and flags `stale`; beyond-grace recomputes normally; grace ≥ expiry buffer refused at construction) and the paths trigger test extended to assert warmers never receive the grace. Full framework suite 169 passed; paths suite 49 passed / 9 pre-existing skips.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — internal query-path behavior, documented inline.

## 🤖 Agent context

**Autonomy:** Human-directed (agent-built overnight)

R8 from the paths speed research: monitoring showed warm reads ~300ms but stale-window recomputes adding seconds. Serve-stale is bounded (6h grace, 48h buffer guard) and deliberately excludes background warmers. Note: rotation events still produce genuinely cold caches (a new hash has no stale jobs) — the semantic-hash rework tracks that separately.
