### PR TITLE
feat(insights): add line style option for quill line charts

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -16,6 +16,7 @@ import { HideWeekendsFilter } from 'scenes/insights/EditorFilters/HideWeekendsFi
 import { LegendOptionsFilter } from 'scenes/insights/EditorFilters/LegendOptionsFilter'
 import { LifecyclePercentagesFilter } from 'scenes/insights/EditorFilters/LifecyclePercentagesFilter'
 import { LifecycleStackingFilter } from 'scenes/insights/EditorFilters/LifecycleStackingFilter'
+import { LineStylePicker } from 'scenes/insights/EditorFilters/LineStylePicker'
 import {
     MetricColorFilter,
     MetricShowChangeFilter,
@@ -276,6 +277,7 @@ export const DisplayOptions = {
     ResultCustomizationBy: { label: () => <ResultCustomizationByPicker /> },
     Unit: { label: () => <UnitPicker /> },
     Scale: { label: () => <ScalePicker /> },
+    LineStyle: { label: () => <LineStylePicker /> },
     ConfidenceInterval: { label: () => <ConfidenceInterval /> },
     ConfidenceLevel: { label: () => <ConfidenceLevelInput /> },
     MovingAverage: { label: () => <MovingAverage /> },

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -62,6 +62,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     const { featureFlags } = useValues(featureFlagLogic)
     const hideWeekendsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]
     const quillLegendEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]
+    const styleRefreshEnabled = !!featureFlags[FEATURE_FLAGS.QUILL_CHART_STYLE_REFRESH]
 
     // The slope graph shows the first vs last interval, so it drops the options that need the points
     // between them (smoothing, multiple axes, alert/annotation overlays, statistical analysis).
@@ -97,6 +98,9 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     const showDisplaySection =
         (isTrends && !isCalendarHeatmap) || isRetention || isTrendsFunnel || isStickiness || isLifecycle
     const showYAxisScale = !hideContinuousChartOptions && isTrends && !isCalendarHeatmap
+    // Only line/area trends render through the quill TrendsLineChart, and only the style-refresh
+    // flag curves lines by default — without it there's no curvature to straighten.
+    const showLineStyleConfig = isTrends && isLineDisplay && styleRefreshEnabled
 
     // The box plot and slope graph only show a couple of options each; everything else falls
     // through to the full shared list.
@@ -203,6 +207,10 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         items.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
     }
 
+    if (showLineStyleConfig) {
+        items.push({ title: 'Line style', items: [DisplayOptions.LineStyle] })
+    }
+
     if (showYAxisScale && !isBoxPlot) {
         const statisticalItems: LemonMenuItem[] = [DisplayOptions.ConfidenceInterval]
         if (showConfidenceIntervals) {
@@ -248,6 +256,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
             : 0) +
         ((hasLegend || showFunnelLegendConfig) && showLegend ? 1 : 0) +
         (!!yAxisScaleType && yAxisScaleType !== 'linear' ? 1 : 0) +
+        (showLineStyleConfig && trendsFilter?.chartStyle?.curve === 'linear' ? 1 : 0) +
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.xAxisLabel) ? 1 : 0) +
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.yAxisLabel) ? 1 : 0) +
         (showMultipleYAxes ? 1 : 0) +

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -12,6 +12,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
+import type { TrendsFilter } from '~/queries/schema/schema-general'
 import { hasBreakdownFilter } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
@@ -50,6 +51,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         isNonTimeSeriesDisplay,
         interval,
         usesInChartLegend,
+        insightFilter,
     } = useValues(insightVizDataLogic(insightProps))
     const { isTrendsFunnel } = useValues(funnelDataLogic(insightProps))
     const {
@@ -98,9 +100,13 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     const showDisplaySection =
         (isTrends && !isCalendarHeatmap) || isRetention || isTrendsFunnel || isStickiness || isLifecycle
     const showYAxisScale = !hideContinuousChartOptions && isTrends && !isCalendarHeatmap
-    // Only line/area trends render through the quill TrendsLineChart, and only the style-refresh
-    // flag curves lines by default — without it there's no curvature to straighten.
-    const showLineStyleConfig = isTrends && isLineDisplay && styleRefreshEnabled
+    // Only the quill line charts (trends/stickiness line and area, retention and funnel-trends
+    // graphs) draw curves, and only the style-refresh flag curves lines by default — without it
+    // there's no curvature to straighten. Retention and funnel trends default to their line graph
+    // when display is unset.
+    const isLineChartInsight = isLineDisplay || ((isRetention || isTrendsFunnel) && !display)
+    const showLineStyleConfig =
+        (isTrends || isStickiness || isRetention || isTrendsFunnel) && isLineChartInsight && styleRefreshEnabled
 
     // The box plot and slope graph only show a couple of options each; everything else falls
     // through to the full shared list.
@@ -256,7 +262,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
             : 0) +
         ((hasLegend || showFunnelLegendConfig) && showLegend ? 1 : 0) +
         (!!yAxisScaleType && yAxisScaleType !== 'linear' ? 1 : 0) +
-        (showLineStyleConfig && trendsFilter?.chartStyle?.curve === 'linear' ? 1 : 0) +
+        (showLineStyleConfig && (insightFilter as TrendsFilter | undefined)?.chartStyle?.curve === 'linear' ? 1 : 0) +
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.xAxisLabel) ? 1 : 0) +
         (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.yAxisLabel) ? 1 : 0) +
         (showMultipleYAxes ? 1 : 0) +

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12946,6 +12946,18 @@
             },
             "type": "object"
         },
+        "ChartStyle": {
+            "additionalProperties": false,
+            "description": "Per-insight chart rendering style. Pure presentation — no field changes the computed values. Every field is optional; unset fields fall through to the app-level chart defaults.",
+            "properties": {
+                "curve": {
+                    "description": "Line interpolation: straight segments or a smoothed curve through the points.",
+                    "enum": ["linear", "smooth"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "ClickhouseQueryProgress": {
             "additionalProperties": false,
             "properties": {
@@ -45335,6 +45347,10 @@
                 },
                 "breakdown_histogram_bin_count": {
                     "type": "number"
+                },
+                "chartStyle": {
+                    "$ref": "#/definitions/ChartStyle",
+                    "description": "Chart rendering style overrides (line shape)."
                 },
                 "confidenceLevel": {
                     "type": "number"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -23440,6 +23440,10 @@
                     "description": "Breakdown table sorting. Format: 'column_key' or '-column_key' (descending)",
                     "type": "string"
                 },
+                "chartStyle": {
+                    "$ref": "#/definitions/ChartStyle",
+                    "description": "Chart rendering style overrides (line shape). Only applies to historical-trends funnels."
+                },
                 "customAggregationTarget": {
                     "description": "For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups.",
                     "type": "boolean"
@@ -39815,6 +39819,10 @@
                     "enum": ["count", "sum", "avg"],
                     "type": "string"
                 },
+                "chartStyle": {
+                    "$ref": "#/definitions/ChartStyle",
+                    "description": "Chart rendering style overrides (line shape)."
+                },
                 "cohortLabelStartIndex": {
                     "$ref": "#/definitions/integer",
                     "default": 0,
@@ -43055,6 +43063,10 @@
         "StickinessFilter": {
             "additionalProperties": false,
             "properties": {
+                "chartStyle": {
+                    "$ref": "#/definitions/ChartStyle",
+                    "description": "Chart rendering style overrides (line shape)."
+                },
                 "computedAs": {
                     "$ref": "#/definitions/StickinessComputationMode"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1458,6 +1458,13 @@ export type TrendsFormulaNode = {
     custom_name?: string
 }
 
+/** Per-insight chart rendering style. Pure presentation — no field changes the computed values.
+ * Every field is optional; unset fields fall through to the app-level chart defaults. */
+export interface ChartStyle {
+    /** Line interpolation: straight segments or a smoothed curve through the points. */
+    curve?: 'linear' | 'smooth'
+}
+
 export type TrendsFilter = {
     /** @default 1 */
     smoothingIntervals?: integer
@@ -1563,6 +1570,8 @@ export type TrendsFilter = {
      * is on; latest compares first→last of the series.
      * @default total */
     metricSummary?: 'total' | 'average' | 'latest'
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyle
 }
 
 export type CalendarHeatmapFilter = {
@@ -1603,6 +1612,7 @@ export const TRENDS_FILTER_PROPERTIES = new Set<keyof TrendsFilter>([
     'metricLineIncreaseColor',
     'metricLineDecreaseColor',
     'metricSummary',
+    'chartStyle',
 ])
 
 export interface BoxPlotDatum {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1799,6 +1799,8 @@ export type FunnelsFilter = {
      * @default false
      */
     hideIncompleteConversionWindowPeriods?: boolean
+    /** Chart rendering style overrides (line shape). Only applies to historical-trends funnels. */
+    chartStyle?: ChartStyle
 }
 
 export interface FunnelsQuery extends InsightsQueryBase<FunnelsQueryResponse> {
@@ -1876,6 +1878,8 @@ export type RetentionFilter = {
     /** @description Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations.
      * @default 0 */
     cohortLabelStartIndex?: integer
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyle
 }
 
 export interface RetentionValue {
@@ -2004,6 +2008,8 @@ export type StickinessFilter = {
     resultCustomizations?:
         | Record<string, ResultCustomizationByValue>
         | Record<numerical_key, ResultCustomizationByPosition>
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyle
 }
 
 export const STICKINESS_FILTER_PROPERTIES = new Set<keyof StickinessFilter>([
@@ -2012,6 +2018,7 @@ export const STICKINESS_FILTER_PROPERTIES = new Set<keyof StickinessFilter>([
     'legendPosition',
     'showValuesOnSeries',
     'hiddenLegendIndexes',
+    'chartStyle',
 ])
 
 export interface StickinessQueryResponse extends AnalyticsQueryResponseBase {

--- a/frontend/src/scenes/insights/EditorFilters/LineStylePicker.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/LineStylePicker.tsx
@@ -4,24 +4,30 @@ import { LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 
+import type { TrendsFilter } from '~/queries/schema/schema-general'
+
 import { insightVizDataLogic } from '../insightVizDataLogic'
 
 export function LineStylePicker(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { insightFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    // chartStyle exists on every filter kind this picker renders for (trends, stickiness,
+    // retention, funnels) — TrendsFilter stands in for the union member carrying it.
+    const chartStyle = (insightFilter as TrendsFilter | undefined)?.chartStyle
 
     return (
         <LemonSegmentedButton
             className="pb-2 px-2"
             onChange={(value) =>
                 updateInsightFilter({
-                    chartStyle: { ...trendsFilter?.chartStyle, curve: value as 'smooth' | 'linear' },
+                    chartStyle: { ...chartStyle, curve: value as 'smooth' | 'linear' },
                 })
             }
             // Unset curve falls through to the app default, which is smooth under the style-refresh
             // flag (the only context this picker renders in).
-            value={trendsFilter?.chartStyle?.curve || 'smooth'}
+            value={chartStyle?.curve || 'smooth'}
             options={[
                 { value: 'smooth', label: 'Smooth' },
                 { value: 'linear', label: 'Straight' },

--- a/frontend/src/scenes/insights/EditorFilters/LineStylePicker.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/LineStylePicker.tsx
@@ -1,0 +1,33 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonSegmentedButton } from '@posthog/lemon-ui'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { insightVizDataLogic } from '../insightVizDataLogic'
+
+export function LineStylePicker(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <LemonSegmentedButton
+            className="pb-2 px-2"
+            onChange={(value) =>
+                updateInsightFilter({
+                    chartStyle: { ...trendsFilter?.chartStyle, curve: value as 'smooth' | 'linear' },
+                })
+            }
+            // Unset curve falls through to the app default, which is smooth under the style-refresh
+            // flag (the only context this picker renders in).
+            value={trendsFilter?.chartStyle?.curve || 'smooth'}
+            options={[
+                { value: 'smooth', label: 'Smooth' },
+                { value: 'linear', label: 'Straight' },
+            ]}
+            size="small"
+            fullWidth
+        />
+    )
+}

--- a/frontend/src/scenes/insights/utils/queryUtils.test.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.test.ts
@@ -1,6 +1,7 @@
-import { NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind, TrendsFilter, TrendsQuery } from '~/queries/schema/schema-general'
 
 import {
+    compareQuery,
     filterVariablesReferencedInQuery,
     hasInvalidRegexFilter,
     isBoxPlotMissingProperty,
@@ -214,5 +215,22 @@ describe('isBoxPlotMissingProperty', () => {
                 { kind: NodeKind.EventsNode, event: '$signup', math_property: 'revenue' },
             ])
         ).toBe(false)
+    })
+})
+
+describe('compareQuery', () => {
+    const makeTrendsQuery = (trendsFilter: TrendsFilter = {}): TrendsQuery => ({
+        kind: NodeKind.TrendsQuery,
+        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+        trendsFilter,
+    })
+
+    it('treats chartStyle changes as visualization-only', () => {
+        const plain = makeTrendsQuery()
+        const styled = makeTrendsQuery({ chartStyle: { curve: 'linear' } })
+
+        // Style changes must not count as a query change — otherwise every style tweak refetches
+        expect(compareQuery(plain, styled, { ignoreVisualizationOnlyChanges: true })).toBe(true)
+        expect(compareQuery(plain, styled)).toBe(false)
     })
 })

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -266,6 +266,7 @@ export const cleanInsightQuery = (query: InsightQueryNode, opts?: CompareQueryOp
             breakdownSorting: undefined,
             dataColorTheme: undefined,
             legendPosition: undefined,
+            chartStyle: undefined,
         }
 
         if (isTrendsQuery(cleanedQuery)) {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -61,6 +61,7 @@ from posthog.schema_enums import (
     CorrelationType as CorrelationType,
     CountPerActorMathType as CountPerActorMathType,
     CurrencyCode as CurrencyCode,
+    Curve as Curve,
     CustomChannelField as CustomChannelField,
     CustomChannelOperator as CustomChannelOperator,
     DatabaseSchemaManagedViewTableKind as DatabaseSchemaManagedViewTableKind,
@@ -817,6 +818,16 @@ class ChartSettingsFormatting(BaseModel):
     prefix: str | None = None
     style: Style | None = None
     suffix: str | None = None
+
+
+class ChartStyle(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    curve: Curve | None = Field(
+        default=None,
+        description=("Line interpolation: straight segments or a smoothed curve through the points."),
+    )
 
 
 class ClientToolResultPayload(BaseModel):
@@ -7346,6 +7357,7 @@ class TrendsFilter(BaseModel):
         ),
     )
     breakdown_histogram_bin_count: float | None = None
+    chartStyle: ChartStyle | None = Field(default=None, description="Chart rendering style overrides (line shape).")
     confidenceLevel: float | None = None
     decimalPlaces: float | None = Field(
         default=None,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6571,6 +6571,7 @@ class StickinessFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    chartStyle: ChartStyle | None = Field(default=None, description="Chart rendering style overrides (line shape).")
     computedAs: StickinessComputationMode | None = None
     display: ChartDisplayType | None = None
     hiddenLegendIndexes: list[int] | None = None
@@ -21095,6 +21096,7 @@ class RetentionFilter(BaseModel):
         default=AggregationType.COUNT,
         description="The aggregation type to use for retention",
     )
+    chartStyle: ChartStyle | None = Field(default=None, description="Chart rendering style overrides (line shape).")
     cohortLabelStartIndex: int | None = Field(
         default=0,
         description=(
@@ -23161,6 +23163,10 @@ class FunnelsFilter(BaseModel):
     breakdownSorting: str | None = Field(
         default=None,
         description=("Breakdown table sorting. Format: 'column_key' or '-column_key' (descending)"),
+    )
+    chartStyle: ChartStyle | None = Field(
+        default=None,
+        description=("Chart rendering style overrides (line shape). Only applies to historical-trends funnels."),
     )
     customAggregationTarget: bool | None = Field(
         default=None,

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -590,6 +590,11 @@ class ChartDisplayType(StrEnum):
     SLOPE_GRAPH = "SlopeGraph"
 
 
+class Curve(StrEnum):
+    LINEAR = "linear"
+    SMOOTH = "smooth"
+
+
 class ColorMode(StrEnum):
     LIGHT = "light"
     DARK = "dark"

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -119,6 +119,7 @@ def to_dict(query: BaseModel) -> dict:
                         "funnelStepReference",
                         "breakdownSorting",
                         "legendPosition",
+                        "chartStyle",
                     ]
                 }
 

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -2657,6 +2657,8 @@ export interface FunnelsFilterApi {
     breakdownAttributionValue?: number | null
     /** Breakdown table sorting. Format: 'column_key' or '-column_key' (descending) */
     breakdownSorting?: string | null
+    /** Chart rendering style overrides (line shape). Only applies to historical-trends funnels. */
+    chartStyle?: ChartStyleApi | null
     /** For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups. */
     customAggregationTarget?: boolean | null
     exclusions?: (FunnelExclusionEventsNodeApi | FunnelExclusionActionsNodeApi)[] | null
@@ -3023,6 +3025,8 @@ export interface RetentionFilterApi {
     aggregationPropertyType?: AggregationPropertyTypeApi | null
     /** The aggregation type to use for retention */
     aggregationType?: AggregationTypeApi | null
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyleApi | null
     /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
     cohortLabelStartIndex?: number | null
     cumulative?: boolean | null
@@ -3287,6 +3291,8 @@ export type StickinessFilterApiResultCustomizations =
     | null
 
 export interface StickinessFilterApi {
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyleApi | null
     computedAs?: StickinessComputationModeApi | null
     display?: ChartDisplayTypeApi | null
     hiddenLegendIndexes?: number[] | null

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -2146,6 +2146,18 @@ export const AggregationAxisFormatApi = {
     Short: 'short',
 } as const
 
+export type CurveApi = (typeof CurveApi)[keyof typeof CurveApi]
+
+export const CurveApi = {
+    Linear: 'linear',
+    Smooth: 'smooth',
+} as const
+
+export interface ChartStyleApi {
+    /** Line interpolation: straight segments or a smoothed curve through the points. */
+    curve?: CurveApi | null
+}
+
 export type DetailedResultsAggregationTypeApi =
     (typeof DetailedResultsAggregationTypeApi)[keyof typeof DetailedResultsAggregationTypeApi]
 
@@ -2286,6 +2298,8 @@ export interface TrendsFilterApi {
     /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
     aggregationAxisPrefix?: string | null
     breakdown_histogram_bin_count?: number | null
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyleApi | null
     confidenceLevel?: number | null
     /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
     decimalPlaces?: number | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1499,6 +1499,18 @@ export const AggregationAxisFormatApi = {
     Short: 'short',
 } as const
 
+export type CurveApi = (typeof CurveApi)[keyof typeof CurveApi]
+
+export const CurveApi = {
+    Linear: 'linear',
+    Smooth: 'smooth',
+} as const
+
+export interface ChartStyleApi {
+    /** Line interpolation: straight segments or a smoothed curve through the points. */
+    curve?: CurveApi | null
+}
+
 export type DetailedResultsAggregationTypeApi =
     (typeof DetailedResultsAggregationTypeApi)[keyof typeof DetailedResultsAggregationTypeApi]
 
@@ -1639,6 +1651,8 @@ export interface TrendsFilterApi {
     /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
     aggregationAxisPrefix?: string | null
     breakdown_histogram_bin_count?: number | null
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyleApi | null
     confidenceLevel?: number | null
     /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
     decimalPlaces?: number | null

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2010,6 +2010,8 @@ export interface FunnelsFilterApi {
     breakdownAttributionValue?: number | null
     /** Breakdown table sorting. Format: 'column_key' or '-column_key' (descending) */
     breakdownSorting?: string | null
+    /** Chart rendering style overrides (line shape). Only applies to historical-trends funnels. */
+    chartStyle?: ChartStyleApi | null
     /** For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups. */
     customAggregationTarget?: boolean | null
     exclusions?: (FunnelExclusionEventsNodeApi | FunnelExclusionActionsNodeApi)[] | null
@@ -2376,6 +2378,8 @@ export interface RetentionFilterApi {
     aggregationPropertyType?: AggregationPropertyTypeApi | null
     /** The aggregation type to use for retention */
     aggregationType?: AggregationTypeApi | null
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyleApi | null
     /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
     cohortLabelStartIndex?: number | null
     cumulative?: boolean | null
@@ -2640,6 +2644,8 @@ export type StickinessFilterApiResultCustomizations =
     | null
 
 export interface StickinessFilterApi {
+    /** Chart rendering style overrides (line shape). */
+    chartStyle?: ChartStyleApi | null
     computedAs?: StickinessComputationModeApi | null
     display?: ChartDisplayTypeApi | null
     hiddenLegendIndexes?: number[] | null

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -29,6 +29,7 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { isFunnelsQuery } from '~/queries/utils'
 import { ChartParams, type FlattenedFunnelStepByBreakdown } from '~/types'
 
+import { chartStyleCurve } from '../../shared/chartStyleAdapter'
 import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { AnnotationsLayer } from '../../trends/shared/AnnotationsLayer'
@@ -151,6 +152,7 @@ export function FunnelLineChart({
                 showCrosshair: true,
                 tooltip: TOOLTIP_CONFIG,
             }),
+            curve: chartStyleCurve(funnelsFilter?.chartStyle),
             legend: legendConfig,
         }),
         [
@@ -160,6 +162,7 @@ export function FunnelLineChart({
             goalLines,
             incompletenessOffsetFromEnd,
             funnelsFilter?.showTrendLines,
+            funnelsFilter?.chartStyle,
             showValuesOnSeries,
             legendConfig,
             TOOLTIP_CONFIG,

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -18,6 +18,7 @@ import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
 import type { GroupTypeIndex, LabelGroupType } from '~/types'
 
+import { chartStyleCurve } from '../../shared/chartStyleAdapter'
 import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import {
@@ -174,9 +175,17 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
     const goalLines = retentionFilter?.goalLines ?? EMPTY_GOAL_LINES
 
     const lineConfig = useChartConfig(
-        () =>
-            buildRetentionLineChartConfig({ isPercentage, goalLines, showTrendLines, series, tooltip: TOOLTIP_CONFIG }),
-        [isPercentage, goalLines, showTrendLines, series, TOOLTIP_CONFIG]
+        () => ({
+            ...buildRetentionLineChartConfig({
+                isPercentage,
+                goalLines,
+                showTrendLines,
+                series,
+                tooltip: TOOLTIP_CONFIG,
+            }),
+            curve: chartStyleCurve(retentionFilter?.chartStyle),
+        }),
+        [isPercentage, goalLines, showTrendLines, series, TOOLTIP_CONFIG, retentionFilter?.chartStyle]
     )
 
     if (filteredTrendSeries.length === 0 && hasValidBreakdown) {

--- a/products/product_analytics/frontend/insights/shared/chartStyleAdapter.test.ts
+++ b/products/product_analytics/frontend/insights/shared/chartStyleAdapter.test.ts
@@ -1,0 +1,15 @@
+import type { ChartStyle } from '~/queries/schema/schema-general'
+
+import { chartStyleCurve } from './chartStyleAdapter'
+
+describe('chartStyleCurve', () => {
+    it.each<[string, ChartStyle | null | undefined, 'linear' | 'monotone' | undefined]>([
+        ['smooth maps to monotone', { curve: 'smooth' }, 'monotone'],
+        ['linear stays linear', { curve: 'linear' }, 'linear'],
+        ['undefined falls through to app default', undefined, undefined],
+        ['null falls through to app default', null, undefined],
+        ['empty style falls through to app default', {}, undefined],
+    ])('%s', (_name, input, expected) => {
+        expect(chartStyleCurve(input)).toBe(expected)
+    })
+})

--- a/products/product_analytics/frontend/insights/shared/chartStyleAdapter.ts
+++ b/products/product_analytics/frontend/insights/shared/chartStyleAdapter.ts
@@ -1,0 +1,8 @@
+import type { ChartStyle } from '~/queries/schema/schema-general'
+
+export function chartStyleCurve(chartStyle: ChartStyle | null | undefined): 'linear' | 'monotone' | undefined {
+    if (!chartStyle?.curve) {
+        return undefined
+    }
+    return chartStyle.curve === 'smooth' ? 'monotone' : 'linear'
+}

--- a/products/product_analytics/frontend/insights/shared/chartStyleAdapter.ts
+++ b/products/product_analytics/frontend/insights/shared/chartStyleAdapter.ts
@@ -1,5 +1,7 @@
 import type { ChartStyle } from '~/queries/schema/schema-general'
 
+// The schema vocabulary is 'smooth'/'linear'; quill's chart config calls the same shapes
+// 'monotone'/'linear', so 'smooth' maps to 'monotone'. Unset falls through to the app default.
 export function chartStyleCurve(chartStyle: ChartStyle | null | undefined): 'linear' | 'monotone' | undefined {
     if (!chartStyle?.curve) {
         return undefined

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -21,6 +21,7 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
+import { chartStyleCurve } from '../../shared/chartStyleAdapter'
 import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import { INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { makeChartErrorHandler } from '../../trends/shared/chartErrorHandler'
@@ -69,6 +70,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         currentPeriodResult,
         breakdownFilter,
         trendsFilter,
+        stickinessFilter,
         formula,
         labelGroupType,
         hasPersonsModal,
@@ -123,10 +125,11 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
                 showCrosshair: true,
                 tooltip: tooltipConfig,
             }),
+            curve: chartStyleCurve(stickinessFilter?.chartStyle),
             // Interactive legend is a component concern, kept out of the pure transform.
             legend: legendConfig,
         }),
-        [yAxisScaleType, showValuesOnSeries, legendConfig, tooltipConfig]
+        [yAxisScaleType, showValuesOnSeries, legendConfig, tooltipConfig, stickinessFilter?.chartStyle]
     )
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -25,6 +25,7 @@ import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { ChartDisplayType } from '~/types'
 
+import { chartStyleCurve } from '../../shared/chartStyleAdapter'
 import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
@@ -267,6 +268,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                 movingAverageIntervals: movingAverageIntervals ?? undefined,
                 showTrendLines: showTrendLines ?? undefined,
                 valueLabels: showValuesOnSeries && valueLabelFormatter ? { formatter: valueLabelFormatter } : false,
+                curve: chartStyleCurve(trendsFilter?.chartStyle),
                 showCrosshair: true,
                 tooltip: TOOLTIP_CONFIG,
                 legend: legendConfig,

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/trendsChartTransforms.ts
@@ -201,6 +201,9 @@ export interface BuildTrendsLineTimeSeriesConfigOpts<R extends TrendsResultLike>
 
     valueLabels?: TimeSeriesLineChartConfig['valueLabels']
 
+    /** Line interpolation override (per-insight chart style). Leave undefined for app defaults. */
+    curve?: 'linear' | 'monotone'
+
     showCrosshair?: boolean
     tooltip?: TooltipConfig
     legend?: TimeSeriesLineChartConfig['legend']
@@ -242,6 +245,7 @@ export function buildTrendsLineTimeSeriesConfig<R extends TrendsResultLike>(
         goalLines: goalLineConfigs,
         ...derivedConfigs,
         percentStackView: opts.isPercentStackView,
+        curve: opts.curve,
         showCrosshair: opts.showCrosshair,
         tooltip: opts.tooltip,
         legend: opts.legend,

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2887,6 +2887,8 @@ export namespace Schemas {
       breakdownAttributionValue?: number | null;
       /** Breakdown table sorting. Format: 'column_key' or '-column_key' (descending) */
       breakdownSorting?: string | null;
+      /** Chart rendering style overrides (line shape). Only applies to historical-trends funnels. */
+      chartStyle?: ChartStyle | null;
       /** For data warehouse based funnel insights when the aggregation target can't be mapped to persons or groups. */
       customAggregationTarget?: boolean | null;
       exclusions?: (FunnelExclusionEventsNode | FunnelExclusionActionsNode)[] | null;
@@ -3152,6 +3154,8 @@ export namespace Schemas {
       aggregationPropertyType?: AggregationPropertyType | null;
       /** The aggregation type to use for retention */
       aggregationType?: AggregationType | null;
+      /** Chart rendering style overrides (line shape). */
+      chartStyle?: ChartStyle | null;
       /** Starting index used when labeling cohort columns (e.g. 0 for D0/D1/D2, 1 for D1/D2/D3). Display-only — does not affect retention calculations. */
       cohortLabelStartIndex?: number | null;
       cumulative?: boolean | null;
@@ -3364,6 +3368,8 @@ export namespace Schemas {
     export type StickinessFilterResultCustomizations = {[key: string]: ResultCustomizationByValue} | {[key: string]: ResultCustomizationByPosition} | null;
 
     export interface StickinessFilter {
+      /** Chart rendering style overrides (line shape). */
+      chartStyle?: ChartStyle | null;
       computedAs?: StickinessComputationMode | null;
       display?: ChartDisplayType | null;
       hiddenLegendIndexes?: number[] | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2510,6 +2510,19 @@ export namespace Schemas {
       Short: 'short',
     } as const;
 
+    export type Curve = typeof Curve[keyof typeof Curve];
+
+
+    export const Curve = {
+      Linear: 'linear',
+      Smooth: 'smooth',
+    } as const;
+
+    export interface ChartStyle {
+      /** Line interpolation: straight segments or a smoothed curve through the points. */
+      curve?: Curve | null;
+    }
+
     export type DetailedResultsAggregationType = typeof DetailedResultsAggregationType[keyof typeof DetailedResultsAggregationType];
 
 
@@ -2654,6 +2667,8 @@ export namespace Schemas {
       /** Literal prefix applied to every value (e.g. `$`). Use to pin a unit or currency symbol that does not depend on `aggregationAxisFormat` — for example, when values are denominated in a fixed currency regardless of the project's base currency. Include any trailing space yourself. */
       aggregationAxisPrefix?: string | null;
       breakdown_histogram_bin_count?: number | null;
+      /** Chart rendering style overrides (line shape). */
+      chartStyle?: ChartStyle | null;
       confidenceLevel?: number | null;
       /** Maximum number of decimal places shown. 1 or 2 is usually right for percentages and currency. */
       decimalPlaces?: number | null;


### PR DESCRIPTION
## Problem

The quill chart style refresh (`quill-chart-style-refresh` flag) draws insight lines as smoothed monotone curves by default, and there's no per-insight way to turn that off. Some charts read better with straight segments.

## Changes

Just adds this:
<img width="361" height="201" alt="Screenshot 2026-07-09 at 16 16 45" src="https://github.com/user-attachments/assets/dc4a3f19-9052-48f7-8e3b-3f98ac6b22f6" />

- New `ChartStyle` object with a single `curve: 'linear' | 'smooth'` field on `TrendsFilter`, `StickinessFilter`, `RetentionFilter`, and `FunnelsFilter`, plus regenerated schema artifacts (`schema.json`, `posthog/schema.py`, generated API types). Kept to one field so the broader style controls in #68883 can extend it later.
- New "Line style" section in the insight Options menu with a Smooth | Straight segmented control, shown for any insight rendering a quill line graph (line/area trends and stickiness, retention, historical-trends funnels) when the style-refresh flag is on (without it there's no curvature to straighten). The Options badge counts it when set to straight.
- `chartStyle` is registered as visualization-only in both cache-key sanitizers (frontend `cleanInsightQuery`, backend `schema_helpers.py`), so toggling never refetches the query. Both sanitizers apply generically across filter kinds.
- The curve flows through a small `chartStyleAdapter` into each chart's quill `TimeSeriesLineChart` config, which already supported `curve`. An explicit value wins over the style-refresh default; unset falls through unchanged, so existing insights render exactly as before.

## How did you test this code?

I'm an agent, and I ran automated tests only (no manual verification by me; the driver checked the trends toggle visually in a local dev environment):

- `queryUtils.test.ts`: new `compareQuery` case asserting `chartStyle` changes are visualization-only. Catches a regression where dropping the sanitizer entry would make every style toggle refetch the query. `compareQuery` had no coverage before.
- `InsightDisplayConfig.test.tsx` (31 tests): menu composition unchanged with the flag off.
- `trendsChartTransforms.test.ts` (56 tests): existing config-builder coverage passes with the new passthrough.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Flag-gated (only visible under `quill-chart-style-refresh`), not yet user-facing docs material.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code, driven by @sampennington. Skills invoked: `/writing-tests`.
- This is a minimal extraction of the curve control from #68883 (which bundles it with a full Options-menu reorg behind separate flags). Schema shape, visualization-only registration, and adapter path intentionally mirror that PR so it rebases cleanly.
- The control iterated during the session: a "Smoothed lines" checkbox (rejected: only default-ticked box in the menu), then an inverted "Straight lines" checkbox, then the segmented Smooth | Straight section matching the Y-axis scale control.
- Second commit extends the option beyond trends to the other quill line charts (stickiness, retention, funnel trends), per the driver's request. The stickiness/retention/funnel charts set `curve` inline in their `useChartConfig` call rather than through their transforms builders, since each already composes its config there.