### PR TITLE
feat(experiments): show wasted cost of failed precompute builds

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/PrecomputeOverview.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/PrecomputeOverview.tsx
@@ -31,6 +31,8 @@ const EXCEPTION_CODE_LABELS: Record<string, string> = {
     '159': 'timeout',
     '241': 'out of memory',
     '202': 'cluster busy',
+    '164': 'readonly (AI context)',
+    '47': 'unknown identifier',
 }
 
 const formatMs = (ms: number | null): string => {
@@ -311,6 +313,23 @@ export function PrecomputeOverview(): JSX.Element {
                                     : undefined
                             }
                             tooltip="Total bytes scanned and time spent by precompute-build INSERTs. This is the investment; the read-path savings are the return."
+                        />
+                        <StatCard
+                            title="Wasted on failed builds"
+                            value={builds ? humanizeBytes(builds.failed_read_bytes ?? 0) : '–'}
+                            subtitle={
+                                builds
+                                    ? `${humanFriendlyDuration((builds.failed_duration_ms ?? 0) / 1000)} ClickHouse time on builds that failed`
+                                    : undefined
+                            }
+                            tooltip="Bytes scanned and time spent by precompute-build INSERTs that errored. Pure waste: the read then falls back to a full events scan on top. Should stay near zero."
+                            type={
+                                builds &&
+                                builds.total_read_bytes > 0 &&
+                                (builds.failed_read_bytes ?? 0) / builds.total_read_bytes > 0.05
+                                    ? 'danger'
+                                    : undefined
+                            }
                         />
                         <StatCard
                             title="Metric-events precompute"

--- a/frontend/src/scenes/instance/QueryPerformance/PrecomputeOverview.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/PrecomputeOverview.tsx
@@ -31,7 +31,7 @@ const EXCEPTION_CODE_LABELS: Record<string, string> = {
     '159': 'timeout',
     '241': 'out of memory',
     '202': 'cluster busy',
-    '164': 'readonly (AI context)',
+    '164': 'readonly',
     '47': 'unknown identifier',
 }
 

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -55,6 +55,8 @@ const EXCEPTION_CODE_OPTIONS = [
     { value: '159', label: '159 (timeout)' },
     { value: '241', label: '241 (memory)' },
     { value: '202', label: '202 (cluster busy)' },
+    { value: '164', label: '164 (readonly)' },
+    { value: '47', label: '47 (unknown identifier)' },
 ]
 
 // Group total = the read plus its precompute-build sub-queries (the user paid for all of them),
@@ -92,6 +94,8 @@ const EXCEPTION_CODE_LABELS: Record<number, string> = {
     159: 'timeout',
     241: 'out of memory',
     202: 'cluster busy',
+    164: 'readonly',
+    47: 'unknown identifier',
 }
 
 const codeLabel = (code: number): string => EXCEPTION_CODE_LABELS[code] ?? `error ${code}`

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -37,8 +37,9 @@ export interface PrecomputeBuildStats {
     failed: number
     total_duration_ms: number
     total_read_bytes: number
-    failed_duration_ms: number
-    failed_read_bytes: number
+    // Optional: responses served by a backend from before these fields existed omit them.
+    failed_duration_ms?: number
+    failed_read_bytes?: number
     by_table: Record<string, { succeeded: number; failed: number }>
     failures_by_code: Record<string, number>
 }

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -37,6 +37,8 @@ export interface PrecomputeBuildStats {
     failed: number
     total_duration_ms: number
     total_read_bytes: number
+    failed_duration_ms: number
+    failed_read_bytes: number
     by_table: Record<string, { succeeded: number; failed: number }>
     failures_by_code: Record<string, number>
 }

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -849,6 +849,10 @@ class DebugCHQueries(viewsets.ViewSet):
             "failed": 0,
             "total_duration_ms": 0,
             "total_read_bytes": 0,
+            # Spend on builds that failed: pure waste (the read then falls back to a full
+            # events scan on top). The number that should stay near zero.
+            "failed_duration_ms": 0,
+            "failed_read_bytes": 0,
             "by_table": {},
             "failures_by_code": {},
         }
@@ -864,6 +868,8 @@ class DebugCHQueries(viewsets.ViewSet):
             else:
                 builds["failed"] += count
                 table_entry["failed"] += count
+                builds["failed_duration_ms"] += total_duration_ms
+                builds["failed_read_bytes"] += total_read_bytes
                 code_key = str(exception_code)
                 builds["failures_by_code"][code_key] = builds["failures_by_code"].get(code_key, 0) + count
 


### PR DESCRIPTION
## Problem

The precompute overview shows total build cost, but not how much of it was spent on builds that failed. That wasted spend is the number that matters most for spotting problems (at its worst it was ~0.9 PiB/day), and today you can only get it from ad-hoc query_log analysis. Two failure codes we now see regularly (164 readonly, 47 unknown identifier) also render as unexplained numbers in the UI.

## Changes

- New "Wasted on failed builds" card on the precompute overview: bytes and ClickHouse time spent on builds that errored. Red when waste exceeds 5% of total build cost. Backend already grouped builds by exception code, so this just splits the sums.
- Added 164 (readonly) and 47 (unknown identifier) to the exit-code labels on both tabs and to the slowest-queries filter dropdown.

## How did you test this code?

Endpoint tests pass (5, auth-level; SQL is mocked there). Frontend typecheck reports no errors in the touched files. No new tests: the change is a stat card plus two label entries on an internal staff dashboard, and the accumulation logic has no test harness that exercises response shape today.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal staff tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Second in the precompute-observability series (#69643 is the first; this one is independent and targets master directly). The 5% danger threshold mirrors the existing build-success-rate card's threshold. Invoked /improving-drf-endpoints and /writing-tests (gate outcome: no new test, reasons in the testing section).
