### PR TITLE
fix(error-tracking): stop flagging search typing as kea router url loops

### DIFF
--- a/frontend/src/lib/logic/scenes/urlChangeTracker.test.ts
+++ b/frontend/src/lib/logic/scenes/urlChangeTracker.test.ts
@@ -69,7 +69,7 @@ describe('getUrlChangeTracker', () => {
         const insightsTracker = getUrlChangeTracker('insightsLogic')
 
         for (let i = 0; i < 6; i++) {
-            webTracker.recordChange(`/web?v=${i}`, 'webAnalyticsLogic', 'setFilters')
+            webTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
         }
 
         expect(webTracker.isRapidlyChanging()).toBe(true)
@@ -136,12 +136,22 @@ describe('UrlChangeTracker', () => {
             { count: 4, expected: false },
             { count: 5, expected: true },
             { count: 10, expected: true },
-        ])('returns $expected when $count changes recorded', ({ count, expected }) => {
+        ])('flags a loop re-setting the same URL: $expected at $count changes', ({ count, expected }) => {
             for (let i = 0; i < count; i++) {
-                tracker.recordChange(`/web?v=${i}`, 'webAnalyticsLogic', 'setFilters')
+                tracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
             }
 
             expect(tracker.isRapidlyChanging()).toBe(expected)
+        })
+
+        it('does not flag a burst of distinct URLs, e.g. typing into a search box', () => {
+            // Each keystroke syncs a new search term to the query string, so every URL differs.
+            // This is legitimate navigation, not the infinite loop the tracker exists to catch.
+            for (let i = 0; i < 10; i++) {
+                tracker.recordChange(`/dashboard?search=${i}`, 'dashboardsLogic', 'setSearch')
+            }
+
+            expect(tracker.isRapidlyChanging()).toBe(false)
         })
     })
 
@@ -239,11 +249,11 @@ describe('UrlChangeTracker', () => {
                 maxChangesPerSecond: 2,
             })
 
-            customTracker.recordChange('/web?v=1', 'webAnalyticsLogic', 'setFilters')
-            customTracker.recordChange('/web?v=2', 'webAnalyticsLogic', 'setFilters')
+            customTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
+            customTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
             expect(customTracker.isRapidlyChanging()).toBe(false)
 
-            customTracker.recordChange('/web?v=3', 'webAnalyticsLogic', 'setFilters')
+            customTracker.recordChange('/web?foo=bar', 'webAnalyticsLogic', 'setFilters')
             expect(customTracker.isRapidlyChanging()).toBe(true)
         })
 

--- a/frontend/src/lib/logic/scenes/urlChangeTracker.ts
+++ b/frontend/src/lib/logic/scenes/urlChangeTracker.ts
@@ -84,7 +84,16 @@ class UrlChangeTracker {
     }
 
     isRapidlyChanging(): boolean {
-        return this.changes.length > this.config.maxChangesPerSecond
+        if (this.changes.length <= this.config.maxChangesPerSecond) {
+            return false
+        }
+        // A genuine infinite loop re-sets the same handful of URLs over and over, so the burst is
+        // dominated by duplicates. Legitimate rapid navigation - e.g. a user typing into a search
+        // box that syncs each keystroke to the query string - produces a stream of mostly-distinct
+        // URLs and must not be flagged as a loop. Only treat the burst as rapid when at most half of
+        // the recorded changes are distinct URLs.
+        const uniqueUrls = new Set(this.changes.map((c) => c.url)).size
+        return uniqueUrls * 2 <= this.changes.length
     }
 
     canWarn(): boolean {


### PR DESCRIPTION
## Problem

The `urlChangeTracker` (owned by team-web-analytics) exists to catch a real bug: an infinite URL sync loop where `[object Object]` gets serialized into the URL and freezes the tab. It flags a burst as a possible loop whenever a single logic path pushes more than 4 URL changes inside a 3 second window, then captures an `Error("Rapid URL changes detected in kea router")` for monitoring.

The problem is that normal navigation hits that same shape. Any search box that syncs each keystroke to the query string (the dashboards list is the loudest, but persons, insights, web analytics, cohorts and others use the same `trackedActionToUrl` pattern) fires several distinct `replace: true` URL updates in a second or two of typing. That trips the heuristic and captures a handled exception. Nothing breaks for the user, but it produces a large, steady stream of false-positive exceptions in error tracking, and the on-issue alert keeps firing a new issue per distinct stack. This was raised from an error-tracking alert in [this Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1783605536270529?thread_ts=1783605536.270529&cid=C0A006STKHR).

## Changes

Scope `isRapidlyChanging()` to duplicate-dominated bursts. A genuine loop re-sets the same handful of URLs over and over, so its recent changes are mostly duplicates. Legitimate rapid navigation produces a stream of mostly-distinct URLs. The burst is now only flagged when at most half of the recorded changes are distinct URLs, so search typing no longer counts as a loop while the `[object Object]` serialization loop (same URL repeated) is still caught.

> [!NOTE]
> The dashboards search input is already debounced at 300ms, so this fix lives in the tracker rather than in one scene. That removes the false positives across every scene that syncs input to the URL, not just dashboards.

## How did you test this code?

I (the PostHog Slack app / Claude) updated the Jest unit tests for the tracker. I could not run the suite locally because this environment has no installed frontend toolchain (`node_modules` absent, and a full monorepo install was out of scope), so I verified each case by hand and am relying on CI to run them.

- Existing loop-detection cases were rewritten to re-set the *same* URL, so they still assert the behavior that matters (a real loop is flagged past the threshold).
- Added a regression guard: a burst of 10 *distinct* URLs (a user typing into a search box) is not flagged. This is the exact false positive that produced the exceptions, and no existing test covered it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Radu asked me (the PostHog Slack app, running Claude) to investigate an error-tracking alert for "Rapid URL changes detected in kea router" and then to open this fix. I traced the top issue's stack to the dashboards filter search input, read `urlChangeTracker.ts` / `trackedActionToUrl.ts` / `dashboardsLogic.ts`, and found the dashboards search is already debounced, so the real fix belongs in the tracker's heuristic.

I considered bumping the dashboards debounce or raising the raw count threshold, and rejected both: the debounce is already there, and a higher count threshold still fires for fast typers and does nothing for the other scenes. Keying off duplicate URLs (loop signature) vs distinct URLs (navigation) targets the actual difference between the two populations and fixes every scene at once.

Skill invoked: the repo's `/writing-tests` gate before changing the tests.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1783605536270529?thread_ts=1783605536.270529&cid=C0A006STKHR)*
