### PR TITLE
feat(tasks): alert when a wizard run ends without a bound PR

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1616,6 +1616,7 @@ def update_task_run(
     )
     from products.tasks.backend.metrics import (  # noqa: PLC0415 — keep prometheus deps off the api import path
         observe_agent_turn_failed,
+        observe_wizard_run_unbound,
     )
 
     run = _get_visible_run(run_id, task_id, team_id)
@@ -1686,6 +1687,7 @@ def update_task_run(
     if new_status in _TERMINAL_TASK_RUN_STATUSES and old_status != new_status:
         if new_status == TaskRun.Status.FAILED:
             observe_agent_turn_failed(run)
+        observe_wizard_run_unbound(run)
         signal_workflow_completion(run.id, new_status, validated_data.get("error_message"))
         if new_status == TaskRun.Status.CANCELLED:
             from products.tasks.backend.push_dispatcher import (  # noqa: PLC0415 — keep push deps off the api import path

--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -279,13 +279,19 @@ def observe_agent_turn_failed(task_run: "TaskRun") -> None:
     ).inc()
 
 
+_WIZARD_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+
+
 def observe_wizard_run_unbound(task_run: "TaskRun") -> None:
     """Record a wizard run ending without its PR ever binding.
 
-    Call on terminal status transitions. Every binding failure mode is silent
-    (agent used a different branch, webhook undelivered, write swallowed), so
-    this counter is the only signal that the wizard PR pipeline regressed.
+    Safe to call on any status write; only terminal wizard runs without an
+    output.pr_url count. Every binding failure mode is silent (agent used a
+    different branch, webhook undelivered, write swallowed), so this counter
+    is the only signal that the wizard PR pipeline regressed.
     """
+    if task_run.status not in _WIZARD_TERMINAL_STATUSES:
+        return
     state = task_run.state if isinstance(task_run.state, dict) else {}
     if not state.get("wizard_head_branch"):
         return

--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING, Literal
 
+import structlog
 from prometheus_client import Counter, Histogram
+
+logger = structlog.get_logger(__name__)
 
 if TYPE_CHECKING:
     from products.tasks.backend.models import TaskRun
@@ -143,6 +146,12 @@ TASK_RUN_FOLLOWUP_DELIVERY_FAILED_TOTAL = Counter(
     labelnames=["origin_product", "retryable"],
 )
 
+TASK_RUN_WIZARD_UNBOUND_TOTAL = Counter(
+    "posthog_tasks_wizard_run_unbound_total",
+    "Wizard cloud runs that reached a terminal status without an output.pr_url binding",
+    labelnames=["status"],
+)
+
 PUSH_DISPATCHER_FAILURES_TOTAL = Counter(
     "posthog_tasks_push_dispatcher_failures_total",
     "Push-notification dispatch attempts that failed and were swallowed by the best-effort dispatcher",
@@ -268,6 +277,28 @@ def observe_agent_turn_failed(task_run: "TaskRun") -> None:
         run_source=labels["run_source"],
         runtime_adapter=labels["runtime_adapter"],
     ).inc()
+
+
+def observe_wizard_run_unbound(task_run: "TaskRun") -> None:
+    """Record a wizard run ending without its PR ever binding.
+
+    Call on terminal status transitions. Every binding failure mode is silent
+    (agent used a different branch, webhook undelivered, write swallowed), so
+    this counter is the only signal that the wizard PR pipeline regressed.
+    """
+    state = task_run.state if isinstance(task_run.state, dict) else {}
+    if not state.get("wizard_head_branch"):
+        return
+    output = task_run.output if isinstance(task_run.output, dict) else {}
+    if output.get("pr_url"):
+        return
+    TASK_RUN_WIZARD_UNBOUND_TOTAL.labels(status=task_run.status).inc()
+    logger.warning(
+        "wizard_run_terminal_without_pr",
+        run_id=str(task_run.id),
+        status=task_run.status,
+        wizard_head_branch=state.get("wizard_head_branch"),
+    )
 
 
 def observe_followup_delivery_failed(task_run: "TaskRun", *, retryable: bool) -> None:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -63,3 +63,30 @@ class TestUpdateTaskRunStatusActivity:
             status=TaskRun.Status.IN_PROGRESS,
         )
         async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.parametrize(
+        "extra_state,output,expected_delta",
+        [
+            ({"wizard_head_branch": "posthog/instrumentation-ab12cd"}, None, 1.0),
+            ({"wizard_head_branch": "posthog/instrumentation-ab12cd"}, {"pr_url": "https://x/pull/1"}, 0.0),
+            ({}, None, 0.0),
+        ],
+    )
+    def test_terminal_status_counts_unbound_wizard_runs(
+        self, activity_environment, test_task_run, extra_state, output, expected_delta
+    ):
+        from prometheus_client import REGISTRY
+
+        test_task_run.state = {**(test_task_run.state or {}), **extra_state}
+        if output:
+            test_task_run.output = output
+        test_task_run.save(update_fields=["state", "output"])
+        labels = {"status": "completed"}
+        before = REGISTRY.get_sample_value("posthog_tasks_wizard_run_unbound_total", labels) or 0.0
+
+        input_data = UpdateTaskRunStatusInput(run_id=str(test_task_run.id), status=TaskRun.Status.COMPLETED)
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+        after = REGISTRY.get_sample_value("posthog_tasks_wizard_run_unbound_total", labels) or 0.0
+        assert after == before + expected_delta

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -7,6 +7,7 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
+from products.tasks.backend.metrics import observe_wizard_run_unbound
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.observability import log_with_activity_context
 
@@ -44,6 +45,9 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
 
     task_run.save(update_fields=["status", "error_message", "completed_at", "updated_at"])
     task_run.publish_stream_state_event()
+
+    if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED]:
+        observe_wizard_run_unbound(task_run)
 
     log_with_activity_context(
         "Task run status updated",

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -45,9 +45,7 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
 
     task_run.save(update_fields=["status", "error_message", "completed_at", "updated_at"])
     task_run.publish_stream_state_event()
-
-    if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED]:
-        observe_wizard_run_unbound(task_run)
+    observe_wizard_run_unbound(task_run)
 
     log_with_activity_context(
         "Task run status updated",

--- a/products/tasks/backend/tests/test_task_run_metrics.py
+++ b/products/tasks/backend/tests/test_task_run_metrics.py
@@ -260,3 +260,37 @@ class TestTaskRunMetrics(TestCase):
             )
 
         assert _sample_value("posthog_tasks_agent_turn_failed_total", labels) == before + expected_delta
+
+    @parameterized.expand(
+        [
+            ("unbound_wizard_run", {"wizard_head_branch": "posthog/instrumentation-ab12cd"}, {}, 1.0),
+            (
+                "bound_wizard_run",
+                {"wizard_head_branch": "posthog/instrumentation-ab12cd"},
+                {"pr_url": "https://x/pull/1"},
+                0.0,
+            ),
+            ("non_wizard_run", {}, {}, 0.0),
+        ]
+    )
+    def test_terminal_transition_counts_unbound_wizard_runs(
+        self, _name: str, extra_state: dict, output: dict, expected_delta: float
+    ) -> None:
+        from products.tasks.backend.facade import api as facade
+
+        run = self.task.create_run(environment=TaskRun.Environment.CLOUD, extra_state=extra_state)
+        if output:
+            run.output = output
+            run.save(update_fields=["output"])
+        labels = {"status": "completed"}
+        before = _sample_value("posthog_tasks_wizard_run_unbound_total", labels)
+
+        with patch.object(facade, "signal_workflow_completion"):
+            facade.update_task_run(
+                run.id,
+                self.task.id,
+                self.team.id,
+                validated_data={"status": "completed"},
+            )
+
+        assert _sample_value("posthog_tasks_wizard_run_unbound_total", labels) == before + expected_delta


### PR DESCRIPTION
## Problem

The wizard PR binding shipped in #69591 depends on two silent contracts: the sandbox agent obeying the server-generated head branch, and GitHub delivering the `pull_request` webhook. Every failure mode is invisible today — a run just ends with no `output.pr_url` and nothing fires, the same alerting gap that let a recent PR-attribution regression go undetected for days.

## Changes

- New counter `posthog_tasks_wizard_run_unbound_total{status}`: incremented when a run carrying `state.wizard_head_branch` reaches a terminal status with no `output.pr_url`, plus a `wizard_run_terminal_without_pr` structured warning log with the run id and branch.
- Wired into both terminal-transition writers: the facade `update_task_run` PATCH path and the workflow's `update_task_run_status` activity.

Alerting on any nonzero rate of this counter gives a direct signal that the wizard PR pipeline regressed (agent disobedience, webhook loss, or write failure), without waiting for a `pr_created` decline.

## How did you test this code?

- Added a parameterized case set to `test_task_run_metrics.py` driving the facade PATCH to `completed`: unbound wizard run increments, bound wizard run and non-wizard run do not — catches a regression where the condition inverts, the state key is renamed, or the call is dropped from the terminal block. No existing test observed this transition.
- Ran `backend/tests/test_task_run_metrics.py` locally (14 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal metric.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code (Fable 5) as the telemetry follow-up from the GROW-136 QA review (finding: the binding mechanism has no failure signal), prioritized after an internal thread about a silent PR-attribution regression with no alerts.
- Skills invoked: /writing-tests.
- Chose a counter at the terminal transition over a periodic reconciliation job: it needs no new scheduling, covers all failure modes uniformly, and the Grafana alert is a one-panel addition to the existing wizard dashboard.
