### PR TITLE
fix(husky): quote branch comparison to handle detached HEAD

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,7 +4,7 @@
 protected_branch='master'
 current_branch=$(git branch --show-current)
 
-if [ $protected_branch = $current_branch ]
+if [ "$protected_branch" = "$current_branch" ]
 then
     echo "Pushing to $protected_branch is a sin! Instead, create a pull request and repent."
     exit 1 # push will not execute


### PR DESCRIPTION
## Problem

The pre-push hook compares branch names unquoted:

```sh
if [ $protected_branch = $current_branch ]
```

On a detached HEAD, `git branch --show-current` returns an empty string, so the test expands to `[ master = ]` and `sh` aborts with `[: master: unary operator expected` on every push from a detached-HEAD worktree.
Surfaced via `hogli devex:feedback` (reported twice).

## Changes

Quote both operands so an empty `current_branch` is compared as a string, not dropped:

```diff
-if [ $protected_branch = $current_branch ]
+if [ "$protected_branch" = "$current_branch" ]
```

## How did you test this code?

- Pushed this branch: the hook ran clean and `ci:preflight` passed.
- Shell repro of the empty-branch case (what a detached HEAD produces):
  - before (unquoted): `sh: [: master: unary operator expected`
  - after (quoted): no error, prints `neq`
  - `master` vs `master` still returns `eq`, so pushing to master is still blocked (behavior preserved).
- No automated test added: a shell-hook test for a one-token quoting fix would be low value and there is no existing harness for `.husky/*`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl surfaced this while triaging `hogli devex:feedback` entries for low-hanging fixes.
I (Claude) confirmed the root cause at `.husky/pre-push:7`, applied the quoting fix, and verified before/after behavior plus the preserved master-block in a scratch shell.
No repo skills were needed beyond the CI-failure triage that found it.
