### PR TITLE
fix(logs): stop the worker's cohort save clobbering concurrent control-plane writes

### DIFF
--- a/products/logs/backend/alert_state_machine.py
+++ b/products/logs/backend/alert_state_machine.py
@@ -94,6 +94,23 @@ def evaluate_alert_check(
     (CloudWatch-style) for firing, immediate resolution on the first OK
     check, and cooldown suppression.
     """
+    # Honor an active snooze regardless of persisted state (except BROKEN, which
+    # is terminal). The worker loads alerts at batch start and bulk-saves minutes
+    # later, so its stale non-SNOOZED state can clobber a concurrent user snooze;
+    # snooze_until survives (it's not in the worker's field list) and unsnooze
+    # nulls it, so a future value always means "user snoozed". Returning SNOOZED
+    # silences the alert and repairs the clobbered row next cycle. The shared
+    # machine deliberately ignores a stray snooze_until on a non-SNOOZED alert, so
+    # this repair lives here — alongside the logs worker that causes the clobber.
+    if snapshot.state != AlertState.BROKEN and snapshot.snooze_until is not None and snapshot.snooze_until > now:
+        return AlertCheckOutcome(
+            new_state=AlertState.SNOOZED,
+            notification=NotificationAction.NONE,
+            consecutive_failures=snapshot.consecutive_failures,
+            update_last_notified_at=False,
+            error_message=None,
+        )
+
     return shared_evaluate_alert_check(
         SharedAlertSnapshot(
             state=snapshot.state,

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -1175,7 +1175,7 @@ def _save_cohort_outcomes(
 
 def _save_staged_per_alert(
     staged: list[tuple[_DispatchedAlert, list[str], LogsAlertEvent | None]],
-    loaded_updated_at: dict[uuid.UUID, datetime],
+    loaded_updated_at: dict[uuid.UUID, datetime | None],
 ) -> tuple[list[_DispatchedAlert], list[_DispatchedAlert], list[_DispatchedAlert]]:
     """Fallback path used when `bulk_update` raises `IntegrityError`.
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -2,6 +2,7 @@
 
 import gc
 import time
+import uuid
 import asyncio
 import contextlib
 import dataclasses
@@ -74,6 +75,7 @@ from products.logs.backend.temporal.metrics import (
     increment_checkpoint_unavailable,
     increment_checks_total,
     increment_cohort_query_fallback,
+    increment_cohort_save_conflicts,
     increment_cohort_save_fallback,
     increment_notification_failures,
     increment_state_transition,
@@ -677,7 +679,9 @@ async def evaluate_cohort_batch_activity(input: EvaluateCohortBatchInput) -> Eva
                     dispatched = await asyncio.to_thread(_resolve_notification_deliveries, dispatched)
 
                 try:
-                    saved, failed = (await save_cohort_async(dispatched, now)) if dispatched else ([], [])
+                    saved, failed, conflicted = (
+                        (await save_cohort_async(dispatched, now)) if dispatched else ([], [], [])
+                    )
                 except Exception as e:
                     logger.exception("Cohort bulk save failed (non-recoverable)", team_id=cohort.team_id)
                     capture_exception(e, {"team_id": cohort.team_id, "phase": "bulk_save"})
@@ -708,6 +712,10 @@ async def evaluate_cohort_batch_activity(input: EvaluateCohortBatchInput) -> Eva
                     slo_handles[str(dispatched_alert.evaluation.alert.id)].fail(failure_phase="save")
                     local_stats["checked"] += 1
                     local_stats["errored"] += 1
+                # Conflicted: a control-plane write won; the evaluation was
+                # discarded, not errored. Counted as checked, and the SLO handle
+                # is left to report success since the check itself completed cleanly.
+                local_stats["checked"] += len(conflicted)
 
                 local_notified.extend(_build_notified_from_saved(saved))
                 return local_stats, local_notified
@@ -1063,11 +1071,17 @@ _COHORT_UPDATE_FIELDS: list[str] = [
 
 def _save_cohort_outcomes(
     dispatched: list[_DispatchedAlert], now: datetime
-) -> tuple[list[_DispatchedAlert], list[_DispatchedAlert]]:
+) -> tuple[list[_DispatchedAlert], list[_DispatchedAlert], list[_DispatchedAlert]]:
     """Phase 3: persist the cohort's outcomes via one bulk_create + one bulk_update.
 
-    Returns `(saved, failed)` — saved alerts advanced to their committed state,
-    failed alerts didn't (caller treats them as errored).
+    Returns `(saved, failed, conflicted)` — saved alerts advanced to their
+    committed state, failed alerts didn't (caller treats them as errored), and
+    conflicted alerts were modified by a control-plane write (snooze, reset,
+    threshold change) between batch load and this save. The user's write wins:
+    the worker's stale outcome is discarded and the next cycle re-evaluates
+    against the fresh row. Conflicts are detected by comparing `updated_at`
+    under `SELECT ... FOR UPDATE` (every control-plane save bumps it via
+    `auto_now`), so a write can't slip between the check and the bulk write.
 
     On `IntegrityError` (constraint shaped — a row hit a DB constraint we didn't
     anticipate), fall back to per-alert UPDATEs so the rest still advance.
@@ -1076,9 +1090,13 @@ def _save_cohort_outcomes(
     fallback against the same broken cluster wouldn't help.
     """
     if not dispatched:
-        return [], []
+        return [], [], []
 
     save_start = time.perf_counter()
+
+    # Capture the load-time row version before staging mutates the instances
+    # (staging overwrites `updated_at` with `now` for the bulk write).
+    loaded_updated_at = {d.evaluation.alert.id: d.evaluation.alert.updated_at for d in dispatched}
 
     # Stage every alert exactly once: mutates the in-memory alert (apply_outcome,
     # advance_next_check_at, etc.) and produces the (update_fields, event) tuple
@@ -1090,23 +1108,39 @@ def _save_cohort_outcomes(
         update_fields, event = _stage_alert_for_save(d, now)
         staged.append((d, update_fields, event))
 
-    events = [event for _, _, event in staged if event is not None]
-    alerts = [d.evaluation.alert for d, _, _ in staged]
-
     event_insert_ms: int | None = None
     update_ms: int | None = None
-    saved: list[_DispatchedAlert] = list(dispatched)
     failed: list[_DispatchedAlert] = []
     try:
         with transaction.atomic():
+            current_updated_at = dict(
+                LogsAlertConfiguration.objects.select_for_update()
+                .filter(id__in=loaded_updated_at)
+                .values_list("id", "updated_at")
+            )
+            fresh_staged = []
+            conflicted = []
+            for t in staged:
+                alert_id = t[0].evaluation.alert.id
+                # A missing row (deleted since load) is also a conflict.
+                if current_updated_at.get(alert_id) == loaded_updated_at[alert_id]:
+                    fresh_staged.append(t)
+                else:
+                    conflicted.append(t[0])
+
+            saved = [d for d, _, _ in fresh_staged]
+            events = [event for _, _, event in fresh_staged if event is not None]
+            alerts = [d.evaluation.alert for d, _, _ in fresh_staged]
+
             if events:
                 event_insert_start = time.perf_counter()
                 LogsAlertEvent.objects.bulk_create(events)
                 event_insert_ms = int((time.perf_counter() - event_insert_start) * 1000)
 
-            update_start = time.perf_counter()
-            LogsAlertConfiguration.objects.bulk_update(alerts, fields=_COHORT_UPDATE_FIELDS)
-            update_ms = int((time.perf_counter() - update_start) * 1000)
+            if alerts:
+                update_start = time.perf_counter()
+                LogsAlertConfiguration.objects.bulk_update(alerts, fields=_COHORT_UPDATE_FIELDS)
+                update_ms = int((time.perf_counter() - update_start) * 1000)
     except IntegrityError as e:
         # Recover the rest of the cohort via per-alert UPDATEs using the
         # already-staged data.
@@ -1117,7 +1151,14 @@ def _save_cohort_outcomes(
         )
         capture_exception(e, {"cohort_size": len(dispatched), "fallback": "per_alert"})
         increment_cohort_save_fallback("integrity_error")
-        saved, failed = _save_staged_per_alert(staged)
+        saved, failed, conflicted = _save_staged_per_alert(staged, loaded_updated_at)
+
+    if conflicted:
+        logger.info(
+            "Cohort save skipped alerts changed by a concurrent control-plane write",
+            conflicted_count=len(conflicted),
+            alert_ids=[str(d.evaluation.alert.id) for d in conflicted],
+        )
 
     save_ms = int((time.perf_counter() - save_start) * 1000)
     with _safe_record_block("cohort save metrics"):
@@ -1126,38 +1167,53 @@ def _save_cohort_outcomes(
             record_cohort_event_insert_duration(event_insert_ms)
         if update_ms is not None:
             record_cohort_update_duration(update_ms)
+        if conflicted:
+            increment_cohort_save_conflicts(len(conflicted))
 
-    return saved, failed
+    return saved, failed, conflicted
 
 
 def _save_staged_per_alert(
     staged: list[tuple[_DispatchedAlert, list[str], LogsAlertEvent | None]],
-) -> tuple[list[_DispatchedAlert], list[_DispatchedAlert]]:
+    loaded_updated_at: dict[uuid.UUID, datetime],
+) -> tuple[list[_DispatchedAlert], list[_DispatchedAlert], list[_DispatchedAlert]]:
     """Fallback path used when `bulk_update` raises `IntegrityError`.
 
-    Returns `(saved, failed)`. Each alert saves independently so a single bad
-    row doesn't strand the cohort. Takes pre-staged tuples (alert already
-    mutated, event already instantiated) so we don't re-run
+    Returns `(saved, failed, conflicted)`. Each alert saves independently so a
+    single bad row doesn't strand the cohort. Takes pre-staged tuples (alert
+    already mutated, event already instantiated) so we don't re-run
     `_stage_alert_for_save` and accidentally advance `next_check_at` twice.
+
+    The conditional UPDATE re-applies the version guard here because the bulk
+    transaction rolled back and released its locks — a control-plane write can
+    land before this retry. `.update()` writes the staged values verbatim
+    (including `updated_at`, already set to the cycle's `now`).
     """
     saved: list[_DispatchedAlert] = []
     failed: list[_DispatchedAlert] = []
+    conflicted: list[_DispatchedAlert] = []
     for d, update_fields, event in staged:
+        alert = d.evaluation.alert
         try:
             with transaction.atomic():
+                updated = LogsAlertConfiguration.objects.filter(
+                    id=alert.id, updated_at=loaded_updated_at[alert.id]
+                ).update(**{f: getattr(alert, f) for f in update_fields})
+                if not updated:
+                    conflicted.append(d)
+                    continue
                 if event is not None:
                     event.save()
-                d.evaluation.alert.save(update_fields=update_fields)
             saved.append(d)
         except Exception as e:
             logger.exception(
                 "Per-alert fallback save failed",
-                alert_id=str(d.evaluation.alert.id),
-                team_id=d.evaluation.alert.team_id,
+                alert_id=str(alert.id),
+                team_id=alert.team_id,
             )
-            capture_exception(e, {"alert_id": str(d.evaluation.alert.id), "phase": "per_alert_fallback"})
+            capture_exception(e, {"alert_id": str(alert.id), "phase": "per_alert_fallback"})
             failed.append(d)
-    return saved, failed
+    return saved, failed, conflicted
 
 
 def _finalize_alert(dispatched: _DispatchedAlert, elapsed_ms: int, stats: dict[str, int]) -> None:

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -227,6 +227,19 @@ def increment_cohort_save_fallback(reason: CohortSaveFallbackReason) -> None:
     counter.add(1)
 
 
+def increment_cohort_save_conflicts(count: int) -> None:
+    """Counts alerts whose cohort save was skipped because a control-plane write
+    (snooze, reset, threshold change) landed between batch load and save. The
+    user's write wins; the alert re-evaluates next cycle. A steady rate here is
+    normal user activity — a spike means cycles are running long."""
+    meter = get_metric_meter()
+    counter = meter.create_counter(
+        "logs_alerting_cohort_save_conflict_total",
+        "Cohort save skipped alerts changed concurrently by a control-plane write",
+    )
+    counter.add(count)
+
+
 def increment_cohort_query_fallback(reason: CohortQueryFallbackReason) -> None:
     """Counts batched CH query failures that triggered the per-alert query fallback path.
 

--- a/products/logs/backend/test/test_alert_state_machine.py
+++ b/products/logs/backend/test/test_alert_state_machine.py
@@ -410,6 +410,29 @@ class TestSnooze(TestCase):
         outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
         assert outcome.new_state == NOT_FIRING
 
+    # The worker's bulk save can overwrite a concurrent user snooze with a stale
+    # non-SNOOZED state (snooze_until survives — it's not in the worker's field
+    # list). An active snooze_until must silence the alert regardless of state,
+    # and the outcome restores SNOOZED so the row self-repairs.
+    @parameterized.expand(
+        [
+            ("clobbered_firing_breaching", FIRING, _check(breached=True)),
+            ("clobbered_not_firing_breaching", NOT_FIRING, _check(breached=True)),
+            ("clobbered_firing_resolving", FIRING, _check(breached=False)),
+            ("clobbered_firing_error", FIRING, _check(error="timeout")),
+        ]
+    )
+    def test_active_snooze_honored_regardless_of_state(self, _name: str, state: AlertState, check: CheckResult) -> None:
+        snapshot = _snapshot(state=state, snooze_until=NOW + timedelta(hours=1))
+        outcome = evaluate_alert_check(snapshot, check, NOW)
+        assert outcome.new_state == SNOOZED
+        assert outcome.notification == NotificationAction.NONE
+
+    def test_broken_wins_over_active_snooze(self) -> None:
+        snapshot = _snapshot(state=BROKEN, snooze_until=NOW + timedelta(hours=1), consecutive_failures=5)
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.new_state == BROKEN
+
 
 class TestEdgeCases(TestCase):
     def test_non_breaching_check_resolves_immediately(self) -> None:

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1868,7 +1868,7 @@ class TestSimulateEvaluatorLifecycleParity(ClickhouseTestMixin, APIBaseTest):
                 for a in cohort.alerts:
                     evaluation = _evaluate_single_alert(a, now, prefetched=query_result.for_alert(a))
                     dispatched = _dispatch_for_alert(evaluation, now)
-                    saved, _failed = _save_cohort_outcomes([dispatched], now)
+                    saved, _failed, _conflicted = _save_cohort_outcomes([dispatched], now)
                     for d in saved:
                         _finalize_alert(d, 0, stats)
 

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -59,7 +59,7 @@ def _evaluate_and_save_one(
     evaluation = _evaluate_single_alert(alert, now, checkpoint=checkpoint)
     dispatched = _dispatch_for_alert(evaluation, now)
     elapsed_ms = int((time.perf_counter() - eval_start) * 1000)
-    saved, _failed = _save_cohort_outcomes([dispatched], now)
+    saved, _failed, _conflicted = _save_cohort_outcomes([dispatched], now)
     if saved:
         _finalize_alert(saved[0], elapsed_ms, stats)
     else:
@@ -219,12 +219,12 @@ class TestSaveCohortOutcomesFallback(APIBaseTest):
         defaults.update(kwargs)
         return LogsAlertConfiguration.objects.create(**defaults)
 
-    def _make_dispatched(self, alert: LogsAlertConfiguration):
+    def _make_dispatched(self, alert: LogsAlertConfiguration, new_state: AlertState = AlertState.NOT_FIRING):
         from products.logs.backend.alert_state_machine import AlertCheckOutcome, CheckResult
         from products.logs.backend.temporal.activities import _AlertEvaluation, _DispatchedAlert
 
         outcome = AlertCheckOutcome(
-            new_state=AlertState.NOT_FIRING,
+            new_state=new_state,
             notification=NotificationAction.NONE,
             consecutive_failures=0,
             update_last_notified_at=False,
@@ -239,6 +239,76 @@ class TestSaveCohortOutcomesFallback(APIBaseTest):
             state_before=alert.state,
         )
         return _DispatchedAlert(evaluation=evaluation, notification_failed=False)
+
+    def test_concurrent_control_plane_write_wins_over_cohort_save(self):
+        # Simulates the lost-update race: the worker loaded the alert, then the
+        # user snoozed it, then the worker's cohort save lands. The user's write
+        # must survive and the worker's stale outcome must be discarded.
+        stale = self._make_alert()
+        dispatched = self._make_dispatched(stale, new_state=AlertState.FIRING)
+
+        concurrent = LogsAlertConfiguration.objects.get(id=stale.id)
+        concurrent.state = LogsAlertConfiguration.State.SNOOZED
+        concurrent.snooze_until = datetime(2025, 1, 2, 0, 0, tzinfo=UTC)
+        concurrent.save()
+
+        saved, failed, conflicted = _save_cohort_outcomes([dispatched], datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC))
+
+        stale.refresh_from_db()
+        assert stale.state == LogsAlertConfiguration.State.SNOOZED
+        assert stale.snooze_until is not None
+        assert saved == []
+        assert failed == []
+        assert conflicted == [dispatched]
+        assert LogsAlertEvent.objects.filter(alert_id=stale.id).count() == 0
+
+    def test_conflict_isolated_within_cohort(self):
+        untouched = self._make_alert(name="untouched")
+        clobber_target = self._make_alert(name="snoozed-mid-cycle")
+        dispatched = [self._make_dispatched(untouched), self._make_dispatched(clobber_target)]
+
+        concurrent = LogsAlertConfiguration.objects.get(id=clobber_target.id)
+        concurrent.state = LogsAlertConfiguration.State.SNOOZED
+        concurrent.snooze_until = datetime(2025, 1, 2, 0, 0, tzinfo=UTC)
+        concurrent.save()
+
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        saved, _failed, conflicted = _save_cohort_outcomes(dispatched, now)
+
+        untouched.refresh_from_db()
+        assert untouched.last_checked_at == now
+        assert saved == [dispatched[0]]
+        assert conflicted == [dispatched[1]]
+
+    @patch("products.logs.backend.temporal.activities.LogsAlertConfiguration.objects.bulk_update")
+    def test_per_alert_fallback_also_respects_conflicts(self, mock_bulk_update):
+        # A control-plane write landing after the bulk transaction aborts but
+        # before the per-alert fallback saves must still win. A write inside the
+        # atomic block would roll back with the test's savepoint (unlike prod's
+        # separate connections), so hook the metric call that runs between
+        # rollback and fallback to place the write in the real race window.
+        from django.db.utils import IntegrityError
+
+        stale = self._make_alert()
+        dispatched = self._make_dispatched(stale, new_state=AlertState.FIRING)
+        mock_bulk_update.side_effect = IntegrityError("constraint violation")
+
+        def _write_concurrently(*args, **kwargs):
+            concurrent = LogsAlertConfiguration.objects.get(id=stale.id)
+            concurrent.state = LogsAlertConfiguration.State.SNOOZED
+            concurrent.snooze_until = datetime(2025, 1, 2, 0, 0, tzinfo=UTC)
+            concurrent.save()
+
+        with patch(
+            "products.logs.backend.temporal.activities.increment_cohort_save_fallback",
+            side_effect=_write_concurrently,
+        ):
+            saved, failed, conflicted = _save_cohort_outcomes([dispatched], datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC))
+
+        stale.refresh_from_db()
+        assert stale.state == LogsAlertConfiguration.State.SNOOZED
+        assert saved == []
+        assert conflicted == [dispatched]
 
     @patch("products.logs.backend.temporal.activities.LogsAlertConfiguration.objects.bulk_update")
     def test_integrity_error_falls_back_to_per_alert(self, mock_bulk_update):


### PR DESCRIPTION
## Problem

The alerting worker loads alerts at batch start and bulk-saves the whole cohort minutes later with no lock or version guard.
Any control-plane write landing in between is silently overwritten:

- **Snooze voided.** Users snooze an alert precisely while it's firing - exactly when the worker rewrites the row every cycle. The worker's stale `FIRING` clobbers `state=SNOOZED`; `snooze_until` survives (not in the worker's field list) but was only read when `state == SNOOZED`, so notifications kept coming for an alert the user explicitly silenced.
- **Threshold change's immediate-recheck intent lost.** `clear_next_check()` is overwritten by the worker's advanced `next_check_at`.
- **Reset of a broken alert clobbered** if an evaluation was in flight.

## Changes

Two complementary layers:

**1. Honor an active snooze regardless of persisted state** (`alert_state_machine.py`).
A future `snooze_until` silences the check before any evaluation, whatever the state column says (only the terminal BROKEN guard precedes it).
Sound because `snooze_until` is trustworthy alone: setting a snooze requires a future datetime and unsnooze nulls the column.
The outcome returns `SNOOZED`, so a clobbered row self-repairs on the next cycle.
This layer means a voided snooze is silenced by the very next check even in windows the second layer can't cover.

**2. Version-guard the cohort bulk save** (`activities.py`).
Inside the save transaction, re-read each row's `updated_at` under `SELECT ... FOR UPDATE` and compare against its load-time value (every control-plane save bumps it via `auto_now`).
Rows that changed are skipped entirely: the user's write wins, no audit event row is written, and the alert re-evaluates against the fresh row next cycle.
The lock means no write can slip between the check and the bulk write.
The existing IntegrityError per-alert fallback re-applies the same guard via conditional `UPDATE ... WHERE updated_at = <loaded>` (rowcount 0 = conflict), since the bulk transaction's locks were released on rollback.
Conflicted alerts count as checked (not errored) and emit a new `logs_alerting_cohort_save_conflict_total` counter; a steady low rate is normal user activity.

Cost on the happy path: one extra primary-key `SELECT ... FOR UPDATE` per cohort save (≤50 rows), and control-plane saves can block on the row lock for the duration of one bulk write (milliseconds).

## How did you test this code?

TDD - both layers' tests were written first and watched fail against the old behavior.

- `test_active_snooze_honored_regardless_of_state` (parameterized: clobbered FIRING/NOT_FIRING x breaching/resolving/error checks) + `test_broken_wins_over_active_snooze` - pin layer 1; no existing test covered an active `snooze_until` with a non-SNOOZED state.
- `test_concurrent_control_plane_write_wins_over_cohort_save`, `test_conflict_isolated_within_cohort`, `test_per_alert_fallback_also_respects_conflicts` - pin layer 2, including that a conflict doesn't strand the rest of the cohort and that the fallback path re-checks after the bulk transaction rolls back. The fallback test injects the concurrent write via the metric hook between rollback and retry, because a write inside the atomic block would roll back with the test's savepoint (unlike production's separate connections).
- Full local runs: `test_alert_state_machine.py` (90), `test_logs_alerting_activities.py` (89), `test_alerts_api.py` (167, incl. the simulate/evaluator lifecycle parity suite), workflow + metrics suites - all green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe snooze or save internals; behavior now matches what the UI already promises.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude), TDD workflow. Skills invoked: `/writing-tests`.
- Chose `SELECT ... FOR UPDATE` + `updated_at` compare over per-alert conditional UPDATEs for the main path (keeps the single bulk statement; one extra indexed SELECT) and over rebasing the worker's outcome onto the fresh row (the evaluation used a stale snapshot - discarding it is the only correct option).
- On conflict the alert's dispatched notification may already be out; that's the same at-least-once trade-off the delivery barrier makes, and conflicts are rare (single-digit per cycle globally).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
