### PR TITLE
fix(conversations): make inbound email identity verification work

### DIFF
--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -202,7 +202,9 @@ CONSTANCE_CONFIG = {
     ),
     "CONVERSATIONS_EMAIL_INBOUND_DOMAIN": (
         get_from_env("CONVERSATIONS_EMAIL_INBOUND_DOMAIN", default=""),
-        "Mailgun receiving domain for inbound email routing, e.g. mg.posthog.com.",
+        "Mailgun receiving domain for inbound email routing, e.g. mg.posthog.com. "
+        "Its inbound spam filter must be set to 'Mark spam with MIME headers' (tag mode) in Mailgun, "
+        "otherwise X-Mailgun-Spf is never added and inbound sender authentication always fails.",
         str,
     ),
     "CONVERSATIONS_EMAIL_WEBHOOK_SIGNING_KEY": (

--- a/products/conversations/backend/api/email_events.py
+++ b/products/conversations/backend/api/email_events.py
@@ -1,6 +1,7 @@
 """Inbound email webhook endpoint for Mailgun routes."""
 
 import re
+import json
 from email.utils import getaddresses, parseaddr
 from typing import Any, cast
 
@@ -21,6 +22,7 @@ from products.conversations.backend.mailgun import validate_webhook_signature
 from products.conversations.backend.models import Channel, EmailChannel, EmailMessageMapping, Status
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import save_file_to_uploaded_media
+from products.conversations.backend.services.email_authentication import forwarder_attests_sender, registrable_domain
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
 
 logger = structlog.get_logger(__name__)
@@ -231,29 +233,102 @@ def _recover_dmarc_rewritten_sender(
     return sender_email, sender_name
 
 
-def _sender_authenticated(request: HttpRequest, sender_email: str) -> bool:
-    """Verify the From header domain is authenticated before trusting it for identity.
+def _get_message_headers(request: HttpRequest) -> list[tuple[str, str]]:
+    """Parse the `message-headers` field: a JSON list of [name, value] pairs, topmost first."""
+    raw_headers = request.POST.get("message-headers", "")
+    if not raw_headers:
+        return []
+    try:
+        headers = json.loads(raw_headers)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(headers, list):
+        return []
+    return [(str(entry[0]), str(entry[1])) for entry in headers if isinstance(entry, (list, tuple)) and len(entry) == 2]
 
-    We require SPF pass + envelope-to-From domain alignment:
-      - SPF pass means the sending IP is authorized by the envelope sender's
-        domain DNS (X-Mailgun-Spf). An attacker can't pass SPF for posthog.com
-        without controlling posthog.com's DNS records.
-      - Domain alignment means the envelope sender (MAIL FROM) domain matches
-        the From header domain, preventing an attacker from passing SPF on
-        evil.com while forging From: teammate@posthog.com.
+
+def _get_mime_header(request: HttpRequest, name: str) -> str:
+    """Read a MIME header from the Mailgun webhook payload.
+
+    Mailgun posts each header of a fully parsed message as its own form field,
+    but the complete set is also available in the `message-headers` field.
+    Prefer the flat field and fall back to the JSON blob so the lookup
+    survives payload-shape drift.
+    """
+    flat = request.POST.get(name, "")
+    if flat:
+        return flat
+    wanted = name.lower()
+    for header_name, header_value in _get_message_headers(request):
+        if header_name.lower() == wanted:
+            return header_value
+    return ""
+
+
+def _sender_authenticated(request: HttpRequest, sender_email: str, config: EmailChannel) -> bool:
+    """Verify the From header identity is authenticated before trusting it.
+
+    Everything is gated on SPF pass (X-Mailgun-Spf): the sending IP must be
+    authorized by the envelope sender's domain DNS, so an attacker can't inject
+    mail straight at Mailgun's MX while claiming someone else's envelope.
+    Mailgun only inserts X-Mailgun-Spf when the receiving domain's inbound spam
+    filter is in "Mark spam with MIME headers" (tag) mode — with the header
+    absent this check fails closed.
+
+    Two ways a sender can then authenticate:
+
+    1. Direct alignment: the envelope (MAIL FROM) domain aligns with the From
+       header domain, DMARC-relaxed (registrable domains compared, so envelope
+       bounce.acme.com aligns with From acme.com). Covers direct senders and —
+       because mailbox forwarding rewrites the envelope to the forwarding
+       tenant's own domain — teammates emailing their own support address.
+
+    2. Forwarder attestation: forwarding hides the original sender's SPF, but
+       the tenant's mail system verified the sender at its own boundary and
+       recorded the verdict in an Authentication-Results header. When the
+       envelope aligns with the channel's own *verified* domain (proving the
+       tenant's mail system did the forwarding — domain_verified keeps
+       shared-provider mailboxes like support@gmail.com out of this trust
+       path), we accept a trusted forwarder's topmost AR header reporting
+       dmarc=pass for the From domain. See services/email_authentication.py
+       for the injection-resistance reasoning.
 
     DKIM alone is insufficient — Mailgun's X-Mailgun-Dkim-Check-Result only
     confirms a valid signature exists without reporting which domain signed it.
-    An attacker signing with evil.com's key but forging From: teammate@posthog.com
-    would still get DKIM Pass.
     """
-    spf_passed = request.POST.get("X-Mailgun-Spf", "").lower() == "pass"
-    if not spf_passed:
-        return False
+    spf_result = _get_mime_header(request, "X-Mailgun-Spf").strip()
+    spf_passed = spf_result.lower() == "pass"
     envelope_sender = request.POST.get("sender", "")
     envelope_domain = envelope_sender.rsplit("@", 1)[-1].lower() if "@" in envelope_sender else ""
     from_domain = sender_email.rsplit("@", 1)[-1].lower() if "@" in sender_email else ""
-    return bool(envelope_domain and from_domain and envelope_domain == from_domain)
+    envelope_root = registrable_domain(envelope_domain) if envelope_domain else None
+    from_root = registrable_domain(from_domain) if from_domain else None
+
+    directly_aligned = envelope_root is not None and envelope_root == from_root
+
+    forwarder_attested = False
+    observed_authserv_id = ""
+    envelope_is_own_channel = (
+        config.domain_verified
+        and envelope_root is not None
+        and envelope_root == registrable_domain(config.domain or "")
+    )
+    if spf_passed and not directly_aligned and envelope_is_own_channel and from_domain:
+        forwarder_attested, observed_authserv_id = forwarder_attests_sender(_get_message_headers(request), from_domain)
+
+    authenticated = spf_passed and (directly_aligned or forwarder_attested)
+    logger.info(
+        "email_inbound_auth_signals",
+        team_id=config.team_id,
+        spf_result=spf_result or "absent",
+        envelope_domain=envelope_domain,
+        from_domain=from_domain,
+        directly_aligned=directly_aligned,
+        forwarder_attested=forwarder_attested,
+        authserv_id=observed_authserv_id or None,
+        authenticated=authenticated,
+    )
+    return authenticated
 
 
 def _resolve_team_member(email: str, team: Team) -> User | None:
@@ -264,6 +339,7 @@ def _resolve_team_member(email: str, team: Team) -> User | None:
         OrganizationMembership.objects.filter(
             organization_id=team.organization_id,
             user__email__iexact=email,
+            user__is_active=True,
         )
         .select_related("user")
         .first()
@@ -352,9 +428,9 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
     content = (request.POST.get("stripped-text", "") or request.POST.get("body-plain", ""))[:MAX_EMAIL_BODY_LENGTH]
     subject = request.POST.get("subject", "")[:500]
 
-    # 7b. Detect team member sender — only trust From when DKIM passes
-    # AND the envelope-sender domain aligns with the From domain.
-    sender_authenticated = _sender_authenticated(request, sender_email)
+    # 7b. Detect team member sender — only trust From when the sender
+    # authenticates (SPF + alignment, or a trusted forwarder attestation).
+    sender_authenticated = _sender_authenticated(request, sender_email, config)
     posthog_user = _resolve_team_member(sender_email, team) if sender_authenticated else None
     is_team_member = posthog_user is not None
 

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from io import BytesIO
 
@@ -1396,6 +1397,43 @@ class TestEmailInboundTeamMemberDetection(BaseTest):
             ("spf_pass_aligned_domain", {"sender": "alice@external.com", "X-Mailgun-Spf": "Pass"}, True),
             ("no_spf", {}, False),
             ("spf_pass_misaligned_domain", {"sender": "alice@evil.com", "X-Mailgun-Spf": "Pass"}, False),
+            # SPF result only present in the message-headers JSON blob, not as a flat field
+            (
+                "spf_pass_via_message_headers",
+                {
+                    "sender": "alice@external.com",
+                    "message-headers": json.dumps([["Subject", "Question"], ["X-Mailgun-Spf", "Pass"]]),
+                },
+                True,
+            ),
+            # Relaxed (DMARC-style) alignment: subdomain envelope aligns with the From org domain
+            ("spf_pass_subdomain_envelope", {"sender": "bounce@mail.external.com", "X-Mailgun-Spf": "Pass"}, True),
+            # Forwarded external customer: envelope rewritten to the channel's own domain,
+            # trusted forwarder AR attests dmarc=pass for the From domain
+            (
+                "forwarded_customer_trusted_ar",
+                {
+                    "sender": "support+caf_=team@posthog.com",
+                    "X-Mailgun-Spf": "Pass",
+                    "message-headers": json.dumps(
+                        [["Authentication-Results", "mx.google.com; dmarc=pass header.from=external.com"]]
+                    ),
+                },
+                True,
+            ),
+            # Same AR but the envelope isn't the channel's own domain: an attacker sending
+            # directly with their own SPF-passing envelope and a forged AR must not verify
+            (
+                "forwarded_ar_wrong_envelope",
+                {
+                    "sender": "attacker@otherco.com",
+                    "X-Mailgun-Spf": "Pass",
+                    "message-headers": json.dumps(
+                        [["Authentication-Results", "mx.google.com; dmarc=pass header.from=external.com"]]
+                    ),
+                },
+                False,
+            ),
         ]
     )
     @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
@@ -1440,6 +1478,48 @@ class TestEmailInboundTeamMemberDetection(BaseTest):
         forged = Comment.objects.filter(team=self.team, scope="conversations_ticket").order_by("created_at")[1]
         assert forged.item_context["author_type"] == "customer"
         assert forged.created_by is None
+
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_forwarder_attestation_requires_verified_channel_domain(self, _mock_sig: MagicMock):
+        # Without domain_verified, a shared-provider mailbox (e.g. support@gmail.com)
+        # must not unlock the forwarder-attestation trust path.
+        self.config.domain_verified = False
+        self.config.save()
+        self._post(
+            {
+                "recipient": "team-ab01cd23ef45@mg.posthog.com",
+                "from": "Alice <alice@external.com>",
+                "sender": "support+caf_=team@posthog.com",
+                "X-Mailgun-Spf": "Pass",
+                "message-headers": json.dumps(
+                    [["Authentication-Results", "mx.google.com; dmarc=pass header.from=external.com"]]
+                ),
+                "Message-Id": "<unverified-domain@external.com>",
+                "subject": "Question",
+                "stripped-text": "Hello",
+            }
+        )
+        ticket = Ticket.objects.get(team=self.team)
+        assert ticket.identity_verified is False
+
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_deactivated_team_member_not_attributed_as_support(self, _mock_sig: MagicMock):
+        self.user.is_active = False
+        self.user.save()
+        self._post(
+            {
+                "recipient": "team-ab01cd23ef45@mg.posthog.com",
+                "sender": self.user.email,
+                "from": f"Former Employee <{self.user.email}>",
+                "Message-Id": "<deactivated@team.com>",
+                "subject": "Question",
+                "stripped-text": "Hello",
+                "X-Mailgun-Spf": "Pass",
+            }
+        )
+        comment = Comment.objects.get(team=self.team, scope="conversations_ticket")
+        assert comment.item_context["author_type"] == "customer"
+        assert comment.created_by is None
 
     @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
     def test_spf_pass_but_mismatched_envelope_treated_as_customer(self, _mock_sig: MagicMock):

--- a/products/conversations/backend/services/email_authentication.py
+++ b/products/conversations/backend/services/email_authentication.py
@@ -1,0 +1,119 @@
+"""Parse forwarder Authentication-Results headers for inbound email sender verification.
+
+All customer mail reaches Mailgun via the tenant's own mailbox auto-forwarding,
+which rewrites the SMTP envelope (SRS / Gmail `+caf_`). SPF therefore only ever
+authenticates the forwarding hop, never the original sender. But the forwarder's
+mail system already validated the original sender (SPF/DKIM/DMARC) at its own
+boundary and recorded the outcome in an Authentication-Results header (RFC 8601)
+that survives forwarding. When the forwarding hop itself is authenticated, that
+header is a trustworthy attestation of the original sender's identity.
+
+Injection resistance: receivers prepend headers, so the forwarder's own
+Authentication-Results sits above any header the original sender injected — we
+only read the topmost one. Major providers additionally strip inbound AR headers
+claiming their own authserv-id (RFC 8601 §5), and we only trust authserv-ids on
+an explicit allowlist.
+"""
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import tldextract
+
+# Authserv-ids whose Authentication-Results we trust. These providers enforce
+# RFC 8601 §5 header hygiene (stripping spoofed inbound AR headers that claim
+# their id). Observed authserv-ids are logged via email_inbound_auth_signals —
+# extend this list from that data, never from a single unverified sample.
+TRUSTED_AUTHSERV_IDS = frozenset(
+    {
+        "mx.google.com",
+        "mx.microsoft.com",
+    }
+)
+
+_COMMENT_RE = re.compile(r"\([^)]*\)")
+_METHOD_RESULT_RE = re.compile(r"^\s*([\w-]+)\s*=\s*(\w+)")
+_PROPERTY_RE = re.compile(r"([\w.]+)\s*=\s*([^\s;]+)")
+
+
+def registrable_domain(domain: str) -> str | None:
+    """Return the eTLD+1 (registrable domain), e.g. `bounce.acme.co.uk` -> `acme.co.uk`."""
+    extracted = tldextract.extract(domain)
+    if not extracted.domain or not extracted.suffix:
+        return None
+    return f"{extracted.domain}.{extracted.suffix}".lower()
+
+
+@dataclass(frozen=True)
+class ForwarderAuthResults:
+    """The forwarder's verdict on the original sender, from its topmost AR header."""
+
+    authserv_id: str
+    dmarc_result: str
+    dmarc_header_from: str
+
+
+def parse_forwarder_auth_results(headers: Sequence[tuple[str, str]]) -> ForwarderAuthResults | None:
+    """Extract the topmost Authentication-Results header from a MIME header list.
+
+    `headers` must be in message order (topmost first), as delivered by
+    Mailgun's `message-headers` field. Only the first AR header is considered —
+    anything below it could have been injected by the original sender.
+    """
+    for name, value in headers:
+        if name.lower() == "authentication-results":
+            return _parse_ar_value(value)
+    return None
+
+
+def _parse_ar_value(value: str) -> ForwarderAuthResults | None:
+    value = _COMMENT_RE.sub("", value)
+    segments = [segment.strip() for segment in value.split(";") if segment.strip()]
+    if not segments:
+        return None
+
+    # First segment is the authserv-id (optionally followed by a version),
+    # unless the producer omitted it entirely (then it looks like `method=result`).
+    authserv_id = ""
+    if "=" not in segments[0].split()[0]:
+        authserv_id = segments[0].split()[0].lower()
+        segments = segments[1:]
+
+    dmarc_result = ""
+    dmarc_header_from = ""
+    for segment in segments:
+        method_match = _METHOD_RESULT_RE.match(segment)
+        if not method_match or method_match.group(1).lower() != "dmarc":
+            continue
+        dmarc_result = method_match.group(2).lower()
+        properties = dict(_PROPERTY_RE.findall(segment))
+        dmarc_header_from = properties.get("header.from", "").lower()
+        break
+
+    if not dmarc_result:
+        return None
+    return ForwarderAuthResults(
+        authserv_id=authserv_id,
+        dmarc_result=dmarc_result,
+        dmarc_header_from=dmarc_header_from,
+    )
+
+
+def forwarder_attests_sender(headers: Sequence[tuple[str, str]], from_domain: str) -> tuple[bool, str]:
+    """Whether a trusted forwarder's AR header attests DMARC pass for the From domain.
+
+    Returns (attested, observed_authserv_id) — the id is surfaced for logging so
+    the allowlist can be extended from real traffic.
+    """
+    results = parse_forwarder_auth_results(headers)
+    if results is None:
+        return False, ""
+    from_root = registrable_domain(from_domain)
+    attested = (
+        results.authserv_id in TRUSTED_AUTHSERV_IDS
+        and results.dmarc_result == "pass"
+        and from_root is not None
+        and registrable_domain(results.dmarc_header_from) == from_root
+    )
+    return attested, results.authserv_id

--- a/products/conversations/backend/services/test_email_authentication.py
+++ b/products/conversations/backend/services/test_email_authentication.py
@@ -1,0 +1,65 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from products.conversations.backend.services.email_authentication import (
+    forwarder_attests_sender,
+    parse_forwarder_auth_results,
+)
+
+GMAIL_AR = (
+    "mx.google.com; dkim=pass header.i=@external.com header.s=sel header.b=abc123; "
+    "spf=pass (google.com: domain of alice@external.com designates 1.2.3.4 as permitted sender) "
+    "smtp.mailfrom=alice@external.com; "
+    "dmarc=pass (p=NONE sp=NONE dis=NONE) header.from=external.com"
+)
+MICROSOFT_AR = (
+    "mx.microsoft.com 1; spf=pass smtp.mailfrom=external.com; "
+    "dkim=pass header.d=external.com; dmarc=pass action=none header.from=external.com"
+)
+
+
+class TestEmailAuthentication(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # (name, ar_value, from_domain, expected_attested)
+            ("gmail_format", GMAIL_AR, "external.com", True),
+            ("microsoft_format_with_version", MICROSOFT_AR, "external.com", True),
+            ("untrusted_authserv_id", "forwarder.example; dmarc=pass header.from=external.com", "external.com", False),
+            (
+                "missing_authserv_id",
+                "spf=pass smtp.mailfrom=alice@external.com; dmarc=pass header.from=external.com",
+                "external.com",
+                False,
+            ),
+            ("dmarc_fail", "mx.google.com; dmarc=fail header.from=external.com", "external.com", False),
+            ("header_from_misaligned", "mx.google.com; dmarc=pass header.from=evil.com", "external.com", False),
+            ("no_dmarc_method", "mx.google.com; spf=pass smtp.mailfrom=alice@external.com", "external.com", False),
+            (
+                "subdomain_header_from_relaxed_alignment",
+                "mx.google.com; dmarc=pass header.from=mail.external.com",
+                "external.com",
+                True,
+            ),
+        ]
+    )
+    def test_forwarder_attestation(self, _name: str, ar_value: str, from_domain: str, expected: bool):
+        headers = [("Subject", "Hello"), ("Authentication-Results", ar_value)]
+        attested, _ = forwarder_attests_sender(headers, from_domain)
+        assert attested is expected
+
+    def test_only_topmost_ar_header_is_trusted(self):
+        # The forwarder's verdict (fail) sits above an AR header the original
+        # sender injected (pass) — the injected one must be ignored.
+        headers = [
+            ("Authentication-Results", "mx.google.com; dmarc=fail header.from=external.com"),
+            ("Authentication-Results", "mx.google.com; dmarc=pass header.from=external.com"),
+        ]
+        attested, _ = forwarder_attests_sender(headers, "external.com")
+        assert attested is False
+
+    def test_no_ar_header(self):
+        assert parse_forwarder_auth_results([("Subject", "Hello")]) is None
+        attested, authserv_id = forwarder_attests_sender([("Subject", "Hello")], "external.com")
+        assert attested is False
+        assert authserv_id == ""


### PR DESCRIPTION
## Problem

Email-channel support tickets never get `identity_verified=True`, and teammate replies sent by email are attributed as customers. Both behaviors gate on `_sender_authenticated` in the Mailgun inbound webhook, which could effectively never return true, for two stacked reasons:

1. It reads `X-Mailgun-Spf`, a header Mailgun only inserts when the receiving domain's inbound spam filter is set to "Mark spam with MIME headers" (tag mode). That's off by default, so the field is likely absent from every webhook payload and the check fails closed for everyone.
2. It required the envelope sender domain to exactly equal the From domain. All customer mail reaches Mailgun via mailbox auto-forwarding (that's the documented channel setup), and forwarders rewrite the SMTP envelope to the forwarding tenant's domain. So the domains can never match for an external sender, and verification was structurally impossible for the very identities the flag exists to verify.

`identity_verified` matters because downstream features must not trust a spoofable email identity.

## Changes

```mermaid
flowchart TD
    A[Inbound webhook payload] --> B[SPF pass?<br/>X-Mailgun-Spf, flat field or message-headers JSON]
    B -->|no| F[Not authenticated]
    B -->|yes| C{Envelope aligns with From?<br/>registrable domains, DMARC relaxed}
    C -->|yes| E[Authenticated]
    C -->|no| D{Envelope is the channel's own verified domain<br/>+ trusted forwarder AR says dmarc=pass for From?}
    D -->|yes| E
    D -->|no| F
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class B,C,D phBlue;
    class A,E phYellow;
    class F phRed;
```

- Read `X-Mailgun-Spf` from the flat POST field, falling back to the `message-headers` JSON blob, so the lookup survives payload-shape drift.
- Relax envelope/From alignment from exact string equality to registrable-domain comparison (DMARC relaxed mode, via `tldextract`), so a subdomain envelope like `bounce.acme.com` aligns with From `acme.com`.
- Add a forwarder-attestation path (new `services/email_authentication.py`) so forwarded external senders can verify. When SPF passes and the envelope aligns with the channel's own **verified** domain, we know the tenant's mail system did the forwarding, and that system already validated the original sender at its boundary. We then trust its topmost `Authentication-Results` header, but only from an allowlisted authserv-id (Google, Microsoft) and only when it reports `dmarc=pass` with `header.from` aligned to the parsed From address. Topmost-only plus the allowlist plus the hop gate defeats injected AR headers, and requiring `domain_verified` keeps shared-provider mailboxes (e.g. a gmail.com support address) out of the trust path.
- Log an `email_inbound_auth_signals` line per inbound message (SPF result or absence, domains, which path matched) so the decision is observable in production.
- Exclude deactivated users from team-member attribution.
- Document the tag-mode requirement on the `CONVERSATIONS_EMAIL_INBOUND_DOMAIN` setting description.

> [!WARNING]
> Ops follow-up needed for this to take effect: the Mailgun receiving domain's inbound spam filter must be set to "Mark spam with MIME headers" (tag mode) in each region's Mailgun account. Until then `X-Mailgun-Spf` is absent and verification keeps failing closed (which is the safe direction). The new log line will confirm the header's arrival once flipped.

## How did you test this code?

Automated tests only (no manual/prod testing done by the agent):

- `products/conversations/backend/services/test_email_authentication.py` (new): parameterized matrix over the AR parser and trust decision. Catches regressions in real-world header format handling (Gmail and Microsoft formats), the authserv-id allowlist, the dmarc verdict and From-alignment requirements, and the topmost-header-only rule that provides injection resistance. Pure `SimpleTestCase`, no DB.
- `test_email_endpoints.py`: new parameterized rows covering the `message-headers` fallback (header absent as a flat field), relaxed subdomain-envelope alignment, a forwarded customer verifying via trusted AR end-to-end, and a forged-AR attempt from a non-channel envelope staying unverified. Plus standalone tests that the AR path requires `domain_verified` and that deactivated users are not attributed as support. Each row is a distinct branch of the trust decision no existing test exercised; the existing rows (no SPF, cross-domain envelope) still pass unchanged.

Ran both files locally: 105 passed (one unrelated local ClickHouse readonly-replica infra error on first run, passed in isolation).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Setting description updated in `posthog/settings/dynamic_settings.py`; no user-facing docs cover the email channel yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`. Investigation traced why `identity_verified` never flipped for email tickets: first hypothesis was only the missing Mailgun header, but stepping back showed the SPF check authenticates the forwarding hop rather than the original sender, so exact-alignment verification was structurally impossible for forwarded external customers and could even false-positive on spoofed same-domain senders. We considered (a) hardening the existing check only, (b) decoupling `identity_verified` from email entirely, and (c) cryptographic DKIM verification of the raw MIME. Chose forwarder AR attestation as the best value: it makes customers genuinely verifiable with no new plumbing, keeps fail-closed semantics, and leaves room to add DKIM verification later. The reviewer should scrutinize the trust chain in `email_authentication.py`'s module docstring.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
