### PR TITLE
chore(stamphog): fix flaky gate-denied wait test

### DIFF
--- a/tools/pr-approval-agent/test_review_pr.py
+++ b/tools/pr-approval-agent/test_review_pr.py
@@ -1,6 +1,7 @@
 """Tests for the review_pr.py output format."""
 
 import sys
+from pathlib import Path
 
 import pytest
 from unittest.mock import MagicMock
@@ -357,10 +358,15 @@ def test_title_flags_respect_exempt_paths(
     assert pipeline.classification["title_scrutiny_flags"] == expected_flags
 
 
-def test_gate_denied_pr_skips_the_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_gate_denied_pr_skips_the_wait(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # A deny-listed PR can't be approved over an in-flight review, so waiting
     # 5 minutes before the inevitable REFUSE is pure runner cost.
     monkeypatch.setattr(review_pr, "_POSTHOG_AVAILABLE", False)
+    # Stub the diff production: the review path would otherwise shell out to a real
+    # `git diff` here, whose internal waiting trips the sleep trap below.
+    diff_path = tmp_path / "diff.patch"
+    diff_path.write_text("")
+    monkeypatch.setattr(review_pr, "write_pr_diff", lambda *a, **k: diff_path)
     monkeypatch.setattr(review_pr.time, "sleep", lambda _s: pytest.fail("gate-denied PR must not wait"))
 
     class _RefusingReviewer:


### PR DESCRIPTION
## Problem

`test_gate_denied_pr_skips_the_wait` fails intermittently on unrelated PRs:

```
tools/pr-approval-agent/github.py:450: in write_pr_diff
    result = subprocess.run(
...
subprocess.py:2079: in _wait
    time.sleep(delay)
E   Failed: gate-denied PR must not wait
```

Two test bugs interact:
- the sleep trap patches `review_pr.time.sleep`, but `review_pr.time` **is** the stdlib `time` module — the trap applies to every module in the process, including `subprocess`
- `write_pr_diff` is unmocked, so the gate-denied pipeline still shells out to a real `git diff` with fake SHAs (reachable since #68604 added author familiarity, which needs the diff)

Whether `communicate()`'s poll loop hits the trapped `time.sleep` before that doomed `git diff` exits is pure timing — so the test passes on fast runners and fails on slow ones. Example failure on an unrelated PR: #68311.

## Changes

- Stub `write_pr_diff` in the test to return a tmp file — the unit test no longer spawns a subprocess (it never should have), and the sleep trap is then reachable only by the pipeline's own bot-reaction wait, which is the thing the test actually forbids.

## How did you test this code?

Tests — `pytest tools/pr-approval-agent/test_review_pr.py`, all 23 pass. The stubbed test still fails if the gate-denied path reintroduces the 5-minute wait (the trap is untouched).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed while investigating why this test failed the Python code quality check on #68311 (which doesn't touch stamphog). Also reported via `hogli devex:feedback`.
