### PR TITLE
perf(experiments): spill precompute build GROUP BY to disk instead of OOMing

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -125,6 +125,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             table=LazyComputationTable.EXPERIMENT_EXPOSURES_PREAGGREGATED,
             placeholders=placeholders,
             sentinel_placeholders={"experiment_date_to"},
+            spill_to_disk=True,
         )
 
     def _get_exposure_query(self) -> ast.SelectQuery:

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -290,6 +290,9 @@ class ExperimentQueryRunner(QueryRunner):
             table=LazyComputationTable.EXPERIMENT_EXPOSURES_PREAGGREGATED,
             placeholders=placeholders,
             sentinel_placeholders={"experiment_date_to"},
+            # High-volume teams' builds OOM even at capped window widths; spilling the
+            # GROUP BY to disk degrades gracefully instead of failing the build.
+            spill_to_disk=True,
         )
 
     def _ensure_metric_events_precomputed(self, builder: ExperimentQueryBuilder) -> LazyComputationResult:
@@ -321,6 +324,7 @@ class ExperimentQueryRunner(QueryRunner):
             table=LazyComputationTable.EXPERIMENT_METRIC_EVENTS_PREAGGREGATED,
             placeholders=placeholders,
             sentinel_placeholders={"experiment_date_to"},
+            spill_to_disk=True,
         )
 
     @cached_property

--- a/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
+++ b/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
@@ -18,8 +18,9 @@ from posthog.schema import (
     IntervalType,
 )
 
-from posthog.hogql.constants import get_default_hogql_global_settings
+from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, get_default_hogql_global_settings
 
+from posthog.clickhouse.client import sync_execute
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
@@ -203,6 +204,41 @@ class TestExperimentExposurePreaggregation(ExperimentQueryRunnerBaseTest):
         assert max(widths) <= PRECOMPUTE_MAX_WINDOW_DAYS
         assert min(job.time_range_start for job in jobs) == datetime(2024, 1, 1, tzinfo=UTC)
         assert max(job.time_range_end for job in jobs) >= datetime(2024, 1, 31, tzinfo=UTC)
+
+    def test_precompute_inserts_spill_group_by_to_disk(self):
+        feature_flag = self.create_feature_flag(key="spill-test")
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 3),
+        )
+
+        metric = ExperimentMeanMetric(
+            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
+        )
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        _create_person(distinct_ids=["spill_user"], team_id=self.team.pk)
+        self._create_exposure_event("spill_user", feature_flag, "control", datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC))
+
+        self._enable_precomputation()
+        with patch(
+            "products.analytics_platform.backend.lazy_computation.lazy_computation_executor.sync_execute",
+            side_effect=sync_execute,
+        ) as spy_execute:
+            self._run_experiment(experiment, metric)
+
+        insert_settings = [
+            call.kwargs["settings"]
+            for call in spy_execute.call_args_list
+            if str(call.args[0]).lstrip().startswith("INSERT")
+        ]
+        assert insert_settings
+        assert all(
+            settings["max_bytes_before_external_group_by"] == MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY
+            for settings in insert_settings
+        )
 
     def test_lazy_computed_results_match_direct_scan_multiple_jobs(self):
         feature_flag = self.create_feature_flag(key="multi-job-test")

--- a/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
+++ b/products/experiments/backend/hogql_queries/test/test_experiment_exposure_preaggregation.py
@@ -1,15 +1,18 @@
+from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
 from posthog.test.base import _create_event, _create_person
 from unittest.mock import MagicMock, patch
 
+from django.forms.models import model_to_dict
 from django.test import override_settings
 
 from parameterized import parameterized
 
 from posthog.schema import (
     EventsNode,
+    ExperimentExposureQuery,
     ExperimentFunnelMetric,
     ExperimentMeanMetric,
     ExperimentMetricMathType,
@@ -30,6 +33,7 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
 )
 from products.analytics_platform.backend.models import PreaggregationJob
 from products.experiments.backend.hogql_queries.base_query_utils import experiment_window
+from products.experiments.backend.hogql_queries.experiment_exposures_query_runner import ExperimentExposuresQueryRunner
 from products.experiments.backend.hogql_queries.experiment_query_builder import (
     ExperimentQueryBuilder,
     get_exposure_config_params_for_builder,
@@ -205,40 +209,79 @@ class TestExperimentExposurePreaggregation(ExperimentQueryRunnerBaseTest):
         assert min(job.time_range_start for job in jobs) == datetime(2024, 1, 1, tzinfo=UTC)
         assert max(job.time_range_end for job in jobs) >= datetime(2024, 1, 31, tzinfo=UTC)
 
+    def _spy_insert_settings_by_table(self, run: Callable[[], Any]) -> dict[str, list[dict]]:
+        """Run `run` with the executor's sync_execute spied, returning INSERT settings keyed by target table."""
+        with patch(
+            "products.analytics_platform.backend.lazy_computation.lazy_computation_executor.sync_execute",
+            side_effect=sync_execute,
+        ) as spy_execute:
+            run()
+        by_table: dict[str, list[dict]] = {}
+        for call in spy_execute.call_args_list:
+            sql = str(call.args[0]).lstrip()
+            if not sql.startswith("INSERT"):
+                continue
+            table = sql.removeprefix("INSERT INTO ").split(" ")[0]
+            by_table.setdefault(table, []).append(call.kwargs["settings"])
+        return by_table
+
     def test_precompute_inserts_spill_group_by_to_disk(self):
+        # Covers all three ensure_precomputed call sites: the metric runner's exposures and
+        # metric_events builds (funnel metric), and the exposures timeline runner's build
+        # (separate experiment, so it can't reuse the first runner's cached jobs).
         feature_flag = self.create_feature_flag(key="spill-test")
         experiment = self.create_experiment(
             feature_flag=feature_flag,
             start_date=datetime(2024, 1, 1),
             end_date=datetime(2024, 1, 3),
         )
-
-        metric = ExperimentMeanMetric(
-            source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
-        )
+        metric = ExperimentFunnelMetric(series=[EventsNode(event="purchase")])
         experiment.metrics = [metric.model_dump(mode="json")]
         experiment.save()
 
-        _create_person(distinct_ids=["spill_user"], team_id=self.team.pk)
-        self._create_exposure_event("spill_user", feature_flag, "control", datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC))
+        timeline_flag = self.create_feature_flag(key="spill-timeline-test")
+        timeline_experiment = self.create_experiment(
+            feature_flag=timeline_flag,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 3),
+        )
+
+        for flag, user in ((feature_flag, "spill_user"), (timeline_flag, "spill_timeline_user")):
+            _create_person(distinct_ids=[user], team_id=self.team.pk)
+            self._create_exposure_event(user, flag, "control", datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC))
 
         self._enable_precomputation()
-        with patch(
-            "products.analytics_platform.backend.lazy_computation.lazy_computation_executor.sync_execute",
-            side_effect=sync_execute,
-        ) as spy_execute:
-            self._run_experiment(experiment, metric)
 
-        insert_settings = [
-            call.kwargs["settings"]
-            for call in spy_execute.call_args_list
-            if str(call.args[0]).lstrip().startswith("INSERT")
-        ]
-        assert insert_settings
-        assert all(
-            settings["max_bytes_before_external_group_by"] == MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY
-            for settings in insert_settings
-        )
+        metric_run_settings = self._spy_insert_settings_by_table(lambda: self._run_experiment(experiment, metric))
+
+        def run_timeline() -> None:
+            query = ExperimentExposureQuery(
+                kind="ExperimentExposureQuery",
+                experiment_id=timeline_experiment.id,
+                experiment_name=timeline_experiment.name,
+                feature_flag=model_to_dict(timeline_flag),
+                holdout=None,
+                start_date=timeline_experiment.start_date.isoformat(),
+                end_date=timeline_experiment.end_date.isoformat(),
+                exposure_criteria=timeline_experiment.exposure_criteria,
+            )
+            ExperimentExposuresQueryRunner(team=self.team, query=query).calculate()
+
+        timeline_run_settings = self._spy_insert_settings_by_table(run_timeline)
+
+        # One insert batch per call site: exposures + metric_events from the metric runner,
+        # exposures from the timeline runner.
+        assert set(metric_run_settings) == {
+            "experiment_exposures_preaggregated",
+            "experiment_metric_events_preaggregated",
+        }
+        assert set(timeline_run_settings) == {"experiment_exposures_preaggregated"}
+        for settings_by_table in (metric_run_settings, timeline_run_settings):
+            for settings_list in settings_by_table.values():
+                assert all(
+                    settings["max_bytes_before_external_group_by"] == MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY
+                    for settings in settings_list
+                )
 
     def test_lazy_computed_results_match_direct_scan_multiple_jobs(self):
         feature_flag = self.create_feature_flag(key="multi-job-test")


### PR DESCRIPTION
## Problem

Some experiment precompute builds fail with `MEMORY_LIMIT_EXCEEDED` (error 241) even at capped 7-day windows: on very high-volume teams the build's GROUP BY hash table outgrows the per-query memory limit, so the build dies and the read falls back to a full events scan.

## Changes

Pass `spill_to_disk=True` at all three experiment `ensure_precomputed` call sites (exposures, funnel metric events, exposures timeline). The framework then sets `max_bytes_before_external_group_by` on the build INSERT, so an oversized GROUP BY spills to disk and finishes slower instead of failing. It's a spill threshold, not a memory reservation: builds that fit in memory are unaffected. Web analytics precompute already runs with this on.

## How did you test this code?

New test asserting the spill threshold reaches the INSERT settings (spies on the executor's `sync_execute`); catches the kwarg being silently dropped in a refactor, which no existing test would notice. Ran the exposure preaggregation file (12 passed) and the exposures runner suite (34 passed, query snapshots unchanged since this is a settings-only change).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed. The lazy computation doc doesn't cover insert settings.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Third reliability fix in the experiment precompute series (#68931 no-retry on byte-cap errors, #68987 7-day job width cap). After those two, a query-log check showed the remaining build failures were memory-bound (241) at already-capped windows, which is exactly the failure mode this framework option was added for in #64093. Invoked /writing-tests for the new test.
