### PR TITLE
docs: clarify pr:upload-image visibility warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Do not invent a different format.
 Always fill the `## 🤖 Agent context` section when creating PRs.
 NEVER share sensitive information in a PR description. Users may share sensitive data in an agent session, but those should never surface to a PR description, or comments.
 
-**Screenshots:** Upload frontend/visual changes with `hogli pr:upload-image <file>` (PostHog employees only; public + permanent `PostHog/pr-assets`) and embed the printed markdown. The first run only warns and uploads nothing; re-run with `--yes` to confirm, and only if the image has no customer data, secrets, or internal info.
+**Screenshots:** Upload frontend/visual changes with `hogli pr:upload-image <file>` and embed the printed markdown. The first run only warns and uploads nothing; re-run with `--yes` to confirm. Only PostHog employees can upload, but the public can permanently view these assets, so only upload the image if you're certain it doesn't contain customer data (including customer names), secrets, or sensitive internal info.
 
 ### Rules
 


### PR DESCRIPTION
## Problem

- Follow-up to review feedback on [add pr:upload-image command](https://github.com/PostHog/posthog/pull/69335): the screenshot-upload note in `AGENTS.md` was too terse about the public, permanent visibility of uploaded assets.

## Changes

- Reword the `**Screenshots:**` guidance to spell out that uploads are public and permanent, and to only upload when certain the image has no customer data (including customer names), secrets, or sensitive internal info.
- Docs-only; `CLAUDE.md` symlinks to `AGENTS.md`, so both surfaces get the update.

## How did you test this code?

- No tests; markdown-only change. Passed the pre-push `AGENTS/CLAUDE.md` symlink check and markdown formatter via lint-staged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Applied [Piccirello's suggestion](https://github.com/PostHog/posthog/pull/69335#discussion_r3552753016) verbatim from the PR review.
- Tools: Claude Code.
