### PR TITLE
feat(support): add Traces area and consolidate observability ownership under team apm

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -126,10 +126,10 @@ posthog/hogql/** @PostHog/team-data-tools
 posthog/hogql_queries/hogql_query_runner.py @PostHog/team-data-tools
 rust/hogql/ @PostHog/team-data-tools
 
-# Tracing/Metrics — owned by @PostHog/team-apm (logs itself comes from products/logs/product.yaml)
-products/tracing/** @PostHog/team-apm
-products/metrics/** @PostHog/team-apm
-posthog/temporal/logs_alerting/ @PostHog/team-apm
+# Tracing/Metrics — owned by @PostHog/apm (logs itself comes from products/logs/product.yaml)
+products/tracing/** @PostHog/apm
+products/metrics/** @PostHog/apm
+posthog/temporal/logs_alerting/ @PostHog/apm
 
 # Error Tracking - owned by @PostHog/team-error-tracking
 products/error_tracking/backend/** @PostHog/team-error-tracking

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -126,10 +126,10 @@ posthog/hogql/** @PostHog/team-data-tools
 posthog/hogql_queries/hogql_query_runner.py @PostHog/team-data-tools
 rust/hogql/ @PostHog/team-data-tools
 
-# Tracing/Metrics — owned by @PostHog/logs (logs itself comes from products/logs/product.yaml)
-products/tracing/** @PostHog/logs
-products/metrics/** @PostHog/logs
-posthog/temporal/logs_alerting/ @PostHog/logs
+# Tracing/Metrics — owned by @PostHog/apm (logs itself comes from products/logs/product.yaml)
+products/tracing/** @PostHog/apm
+products/metrics/** @PostHog/apm
+posthog/temporal/logs_alerting/ @PostHog/apm
 
 # Error Tracking - owned by @PostHog/team-error-tracking
 products/error_tracking/backend/** @PostHog/team-error-tracking

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -126,10 +126,10 @@ posthog/hogql/** @PostHog/team-data-tools
 posthog/hogql_queries/hogql_query_runner.py @PostHog/team-data-tools
 rust/hogql/ @PostHog/team-data-tools
 
-# Tracing/Metrics — owned by @PostHog/apm (logs itself comes from products/logs/product.yaml)
-products/tracing/** @PostHog/apm
-products/metrics/** @PostHog/apm
-posthog/temporal/logs_alerting/ @PostHog/apm
+# Tracing/Metrics — owned by @PostHog/team-apm (logs itself comes from products/logs/product.yaml)
+products/tracing/** @PostHog/team-apm
+products/metrics/** @PostHog/team-apm
+posthog/temporal/logs_alerting/ @PostHog/team-apm
 
 # Error Tracking - owned by @PostHog/team-error-tracking
 products/error_tracking/backend/** @PostHog/team-error-tracking

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -306,6 +306,11 @@ const TARGET_AREA_TO_NAME_PRODUCTS = [
         label: 'Toolbar',
     },
     {
+        value: 'apm',
+        'data-attr': `support-form-target-area-apm`,
+        label: 'Traces',
+    },
+    {
         value: 'web_analytics',
         'data-attr': `support-form-target-area-web_analytics`,
         label: 'Web analytics',
@@ -388,6 +393,8 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     workflows: 'workflows',
     billing: 'billing',
     logs: 'logs',
+    tracing: 'apm',
+    traces: 'apm',
 }
 
 export const SUPPORT_TICKET_TEMPLATES = {

--- a/products/logs/product.yaml
+++ b/products/logs/product.yaml
@@ -1,3 +1,3 @@
 name: Logs
 owners:
-    - apm
+    - team-apm

--- a/products/logs/product.yaml
+++ b/products/logs/product.yaml
@@ -1,3 +1,3 @@
 name: Logs
 owners:
-    - team-apm
+    - apm

--- a/products/logs/product.yaml
+++ b/products/logs/product.yaml
@@ -1,3 +1,3 @@
 name: Logs
 owners:
-    - logs
+    - apm

--- a/products/metrics/product.yaml
+++ b/products/metrics/product.yaml
@@ -1,3 +1,3 @@
 name: Metrics
 owners:
-    - apm
+    - team-apm

--- a/products/metrics/product.yaml
+++ b/products/metrics/product.yaml
@@ -1,3 +1,3 @@
 name: Metrics
 owners:
-    - team-apm
+    - apm

--- a/products/metrics/product.yaml
+++ b/products/metrics/product.yaml
@@ -1,3 +1,3 @@
 name: Metrics
 owners:
-    - team-devex
+    - apm

--- a/products/tracing/product.yaml
+++ b/products/tracing/product.yaml
@@ -1,3 +1,3 @@
 name: Tracing
 owners:
-    - team-self-driving
+    - apm

--- a/products/tracing/product.yaml
+++ b/products/tracing/product.yaml
@@ -1,3 +1,3 @@
 name: Tracing
 owners:
-    - team-apm
+    - apm

--- a/products/tracing/product.yaml
+++ b/products/tracing/product.yaml
@@ -1,3 +1,3 @@
 name: Tracing
 owners:
-    - apm
+    - team-apm


### PR DESCRIPTION
## Problem

Two related observability/support changes:

1. Support tickets about the Tracing (APM) product had no dedicated target area on the support form, so they couldn't be routed to Team APM.
2. Logs, Tracing, and Metrics ownership was split and partly stale — `products/tracing/product.yaml` pointed at `team-self-driving` and `products/metrics/product.yaml` at `team-devex`, even though `CODEOWNERS-soft` already routed tracing/metrics to the logs team.

## Changes

- Support form: add a "Traces" target area (value `apm`) and map the `/tracing` URL path to it.
- Feature ownership: point Logs, Tracing, and Metrics `product.yaml` owners at `team-apm`, and repoint the `CODEOWNERS-soft` tracing/metrics/logs_alerting entries from `@PostHog/logs` to `@PostHog/apm`, consolidating all three observability products under one team.

**Depends on:** the GitHub `logs` team being renamed so its slug is `apm`. Until that rename lands, the `@PostHog/apm` handle will not resolve for reviewer auto-assignment.

Zendesk keys its group-assignment trigger on the `target_area` value (`apm`) to route support tickets to Team APM — that trigger is configured Zendesk-side, not in this repo.

## How did you test this code?

Not manually tested by the agent. Changes are config-only (support-form option list, `product.yaml` owners, `CODEOWNERS-soft`). Frontend format/typecheck could not be run in this environment (no `node_modules` in the clone).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app. Started as a support-routing request (add "Traces" area → Team APM), then extended to consolidate Logs/Tracing/Metrics ownership under the APM team. Confirmed via `establishing-code-ownership` conventions that `product.yaml` is the source of truth and found the tracing/metrics `product.yaml` owners were stale versus the existing `CODEOWNERS-soft` intent. Used the `apm` slug on the assumption the `logs` GitHub team is renamed to `apm`; flagged the rename as a prerequisite.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SHNXN4E7/p1783603600179789?thread_ts=1783603600.179789&cid=C09SHNXN4E7)*


