### PR TITLE
fix(hogql): stop sessions NOT-of-OR filter pruning every row

### DIFF
--- a/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
@@ -3,6 +3,8 @@ from typing import Any, Optional, Union
 import pytest
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+from parameterized import parameterized
+
 from posthog.schema import SessionTableVersion
 
 from posthog.hogql import ast
@@ -315,6 +317,69 @@ SELECT
         select = ast.SelectQuery(select=[], where=where)
         actual = f(self.inliner.get_inner_where(select))
         expected = f("raw_sessions.min_timestamp >= ('2024-03-12' - toIntervalDay(3))")
+        assert expected == actual
+
+    @parameterized.expand(
+        [
+            # `NOT (a OR b)` as an ast.Not node
+            ("not_node", lambda inner: ast.Not(expr=inner)),
+            # the same thing as a `not(...)` call, which the parser can also emit
+            ("not_call", lambda inner: ast.Call(name="not", args=[inner])),
+        ]
+    )
+    def test_negated_or_chain_fails_safe(self, _name, wrap):
+        # `NOT (host ILIKE 'a' OR host ILIKE 'b')` must not lift `NOT True` = False into the inner
+        # aggregation (which would drop every session). The extractor can't reduce it, so no inner filter.
+        negated_or = wrap(
+            ast.Or(
+                exprs=[
+                    ast.CompareOperation(
+                        left=ast.Field(chain=["host"]),
+                        op=ast.CompareOperationOp.ILike,
+                        right=ast.Constant(value="localhost:3000"),
+                    ),
+                    ast.CompareOperation(
+                        left=ast.Field(chain=["host"]),
+                        op=ast.CompareOperationOp.ILike,
+                        right=ast.Constant(value="localhost:3001"),
+                    ),
+                ]
+            )
+        )
+        select = ast.SelectQuery(select=[], where=negated_or)
+        assert self.inliner.get_inner_where(select) is None
+
+    def test_negated_or_chain_does_not_poison_timestamp_bound(self):
+        # A liftable timestamp bound alongside a negated OR-chain must still be extracted cleanly — the
+        # NOT branch fails safe to True and is dropped from the AND, rather than adding `NOT True` = False.
+        where = ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    left=ast.Field(chain=["$start_timestamp"]),
+                    op=ast.CompareOperationOp.Gt,
+                    right=ast.Constant(value="2021-01-01"),
+                ),
+                ast.Not(
+                    expr=ast.Or(
+                        exprs=[
+                            ast.CompareOperation(
+                                left=ast.Field(chain=["host"]),
+                                op=ast.CompareOperationOp.ILike,
+                                right=ast.Constant(value="localhost:3000"),
+                            ),
+                            ast.CompareOperation(
+                                left=ast.Field(chain=["host"]),
+                                op=ast.CompareOperationOp.ILike,
+                                right=ast.Constant(value="localhost:3001"),
+                            ),
+                        ]
+                    )
+                ),
+            ]
+        )
+        select = ast.SelectQuery(select=[], where=where)
+        actual = f(self.inliner.get_inner_where(select))
+        expected = f("raw_sessions.min_timestamp >= ('2021-01-01' - toIntervalDay(3))")
         assert expected == actual
 
     def test_handles_select_set_query_in_comparison(self):

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -153,13 +153,9 @@ class WhereClauseExtractor(CloningVisitor):
     def visit_not(self, node: ast.Not) -> ast.Expr:
         if self.is_join:
             return ast.Constant(value=True)
-        # This extractor over-approximates in positive polarity: a predicate it can't lift becomes the
-        # constant True, True conjuncts are dropped from ANDs, and an OR containing an unliftable disjunct
-        # collapses to True. Negating such an over-approximation flips it into an under-approximation that
-        # would prune valid rows from the inner aggregation (e.g. `NOT (a OR b OR c)` collapsing to `NOT True`
-        # = False, dropping every session). Buffered timestamp bounds are over-approximations too, so disable
-        # that rewrite while inspecting the operand. Only negate an operand that lifts to an exact predicate;
-        # otherwise fail safe to True and let the outer WHERE do the filtering.
+        # Unliftable predicates fail safe to True; negating that (`NOT (a OR b)` -> `NOT True` = False)
+        # would prune every row. Buffered timestamp bounds are over-approximations too, so ignore them
+        # here. Only negate an operand that lifts exactly; otherwise fail safe to True.
         previous_capture = self.capture_timestamp_comparisons
         self.capture_timestamp_comparisons = False
         try:
@@ -180,8 +176,7 @@ class WhereClauseExtractor(CloningVisitor):
         elif node.name == "not":
             if self.is_join:
                 return ast.Constant(value=True)
-            # Route the `not(...)` call form through visit_not so it gets the same over-approximation
-            # guard as the `ast.Not` node form; otherwise it would fall through and rebuild `not(True)`.
+            # Route the `not(...)` call form through visit_not for the same guard as the `ast.Not` form.
             if len(node.args) == 1:
                 return self.visit_not(ast.Not(expr=node.args[0]))
 
@@ -734,10 +729,8 @@ class HasTombstoneVisitor(TraversingVisitor):
 
 
 class _BooleanConstantFinder(TraversingVisitor):
-    """Detects a boolean True/False constant anywhere in an expression. Such a constant is the sentinel
-    this extractor substitutes for a predicate it can't lift (or produces when simplifying an AND/OR), so
-    its presence means the surrounding expression is a positive-polarity over-approximation that must not
-    be negated."""
+    """Finds a boolean True/False constant anywhere in an expression - the sentinel this extractor
+    substitutes for a predicate it can't lift, marking an over-approximation that must not be negated."""
 
     def __init__(self) -> None:
         super().__init__()

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -729,8 +729,9 @@ class HasTombstoneVisitor(TraversingVisitor):
 
 
 class _BooleanConstantFinder(TraversingVisitor):
-    """Finds a boolean True/False constant anywhere in an expression - the sentinel this extractor
-    substitutes for a predicate it can't lift, marking an over-approximation that must not be negated."""
+    """Finds a boolean True/False constant anywhere in an expression - usually the sentinel this extractor
+    substitutes for a predicate it can't lift, marking an over-approximation that must not be negated. A
+    literal `true`/`false` in the query matches too; that's fine, since it only skips the NOT pushdown."""
 
     def __init__(self) -> None:
         super().__init__()

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -153,9 +153,23 @@ class WhereClauseExtractor(CloningVisitor):
     def visit_not(self, node: ast.Not) -> ast.Expr:
         if self.is_join:
             return ast.Constant(value=True)
-        response = self.visit(node.expr)
+        # This extractor over-approximates in positive polarity: a predicate it can't lift becomes the
+        # constant True, True conjuncts are dropped from ANDs, and an OR containing an unliftable disjunct
+        # collapses to True. Negating such an over-approximation flips it into an under-approximation that
+        # would prune valid rows from the inner aggregation (e.g. `NOT (a OR b OR c)` collapsing to `NOT True`
+        # = False, dropping every session). Buffered timestamp bounds are over-approximations too, so disable
+        # that rewrite while inspecting the operand. Only negate an operand that lifts to an exact predicate;
+        # otherwise fail safe to True and let the outer WHERE do the filtering.
+        previous_capture = self.capture_timestamp_comparisons
+        self.capture_timestamp_comparisons = False
+        try:
+            response = self.visit(node.expr)
+        finally:
+            self.capture_timestamp_comparisons = previous_capture
         if has_tombstone(response, self.tombstone_string):
             return ast.Constant(value=self.tombstone_string)
+        if contains_boolean_constant(response):
+            return ast.Constant(value=True)
         return ast.Not(expr=response)
 
     def visit_call(self, node: ast.Call) -> ast.Expr:
@@ -166,6 +180,10 @@ class WhereClauseExtractor(CloningVisitor):
         elif node.name == "not":
             if self.is_join:
                 return ast.Constant(value=True)
+            # Route the `not(...)` call form through visit_not so it gets the same over-approximation
+            # guard as the `ast.Not` node form; otherwise it would fall through and rebuild `not(True)`.
+            if len(node.args) == 1:
+                return self.visit_not(ast.Not(expr=node.args[0]))
 
         elif node.name in HOGQL_COMPARISON_MAPPING:
             op = HOGQL_COMPARISON_MAPPING[node.name]
@@ -713,6 +731,27 @@ class HasTombstoneVisitor(TraversingVisitor):
     def visit_constant(self, node: ast.Constant):
         if node.value == self.tombstone_string:
             self.has_tombstone = True
+
+
+class _BooleanConstantFinder(TraversingVisitor):
+    """Detects a boolean True/False constant anywhere in an expression. Such a constant is the sentinel
+    this extractor substitutes for a predicate it can't lift (or produces when simplifying an AND/OR), so
+    its presence means the surrounding expression is a positive-polarity over-approximation that must not
+    be negated."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.found = False
+
+    def visit_constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, bool):
+            self.found = True
+
+
+def contains_boolean_constant(expr: ast.Expr) -> bool:
+    finder = _BooleanConstantFinder()
+    finder.visit(expr)
+    return finder.found
 
 
 def rewrite_timestamp_field(expr: ast.Expr, timestamp_field: ast.Expr, context: HogQLContext) -> ast.Expr:


### PR DESCRIPTION
## Problem

A `sessions` query with a negated OR-chain in the `WHERE` clause silently returns zero rows, even when hundreds of thousands match. No error is raised, so it reads as "no data" and produces silently wrong analytics.

Reproduced live against production (project 2), all on the same table, column, and 1-day window:

| Query | Result |
| --- | --- |
| `WHERE lower($entry_current_url) NOT LIKE '%localhost%'` | 549,390 rows |
| `WHERE NOT (…LIKE '%localhost%' OR …'%staging%' OR …'%test%')` | **0 rows** |
| `countIf(NOT (…same OR-chain…))` in the SELECT | ~500k (correct) |
| De Morgan expansion `AND NOT LIKE … AND NOT LIKE …` | 494,525 rows (correct) |

The data plainly exists. Only the `NOT (A OR B …)` form breaks, and only on `sessions`.

## Changes

`sessions` is an aggregated view. To prune work, HogQL lifts reductive filters from the outer `WHERE` down into the inner `raw_sessions` aggregation via `WhereClauseExtractor`. That extractor over-approximates: any predicate it can't reason about becomes the constant `True` ("fetch everything, filter later") so it never drops valid rows.

`visit_not` broke that contract. When its operand collapsed to the fail-safe `True`, it wrapped it as `NOT True` = `False` and pushed that into the inner aggregation, pruning every row. Negating an over-approximation flips it into an under-approximation. The `not(...)` call form had the same flaw via `visit_call`.

The fix:

- `visit_not` now disables the buffered-timestamp rewrite while inspecting its operand, and fails safe to `True` unless the operand lifts to an exact predicate (no boolean-constant sentinel introduced by the extractor's fail-safe logic).
- The `not(...)` call form routes through `visit_not` instead of falling through and rebuilding `not(true)`.
- Added a `contains_boolean_constant` helper to detect the over-approximation sentinel.

> [!NOTE]
> Trade-off: this skips the NOT-pushdown optimization whenever the operand isn't exactly liftable. That is correctness over a micro-optimization. The outer `WHERE` still filters, so results are right and only the inner pre-filter is skipped. This matches the existing behavior for the join path, which already forgoes all negations.

## How did you test this code?

Automated tests I (Claude) actually ran:

- Added 3 unit cases to `test_session_where_clause_extractor.py`: `NOT (a OR b)` as both an `ast.Not` node and a `not(...)` call fails safe to no inner filter, and a `NOT`-of-OR-chain combined with a timestamp filter still extracts the timestamp bound cleanly instead of poisoning it with `not(true)`. No existing test exercised a `NOT` node (`test_not_like` uses the `AND(NotILike, NotILike)` De Morgan form), so this is the gap that shipped the bug.
- Confirmed the poison test fails without the source fix and passes with it, so it is a real regression guard.
- Ran the full V1/V2/V3/person extractor suites (160 tests) and the sessions v2/v3 schema tests: all green, snapshots unchanged.

I also reproduced the bug and confirmed the root cause live via the read-only SQL path (the table above), including a distinguishing test that applies the same predicate one level outside the `sessions` boundary and gets the correct ~494k rows.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8) did the investigation and the fix, directed by me. It started from a HogQL/SQL papercut triage, reproduced the bug live against production via the read-only PostHog MCP `execute-sql` tool, traced it to `WhereClauseExtractor.visit_not`, and confirmed the root cause with a subquery-boundary test before writing any code.

Skills invoked: `/diagnosing-bugs` (structured the three-part diagnosis) and `/writing-tests` (gated the regression tests down to the cheapest pure-function level).

Decisions: the reporter guessed this was a query timeout returning an empty result. That was wrong. The 2-day window and the `countIf` both showed the data exists, which pointed at a correctness bug in the pushdown, not a resource cutoff. On the fix, a narrower "bail only when the operand is a constant" guard would fix the reported `NOT (OR)` case but miss `NOT (timestamp-bound AND unliftable)`, so I went with the broader over-approximation guard plus disabling timestamp capture under `NOT`.
