### PR TITLE
feat(mcp_store): share/unshare escalation, admin delete, is_owner, sandbox dedupe

### DIFF
--- a/ee/hogai/tools/call_mcp_server/installations.py
+++ b/ee/hogai/tools/call_mcp_server/installations.py
@@ -1,21 +1,51 @@
 from __future__ import annotations
 
+from django.db.models import Q
+
 from posthog.models import Team, User
 
 from products.mcp_store.backend.models import MCPServerInstallation, MCPServerInstallationTool
 from products.mcp_store.backend.oauth import refresh_installation_token
 
 
+def _is_shared_row_ready(row: dict) -> bool:
+    """A shared row is only usable when the owner's credential is live.
+
+    Personal rows always surface (the user can be prompted to reauth their
+    own connection), but a teammate can't fix someone else's shared
+    credential, so unready shared rows are hidden from the agent instead of
+    failing at call time."""
+    if row["auth_type"] != "oauth":
+        return True
+    sensitive = row.get("sensitive_configuration") or {}
+    return bool(sensitive.get("access_token")) and not sensitive.get("needs_reauth")
+
+
 def _get_installations(team: Team, user: User) -> list[dict]:
-    return list(
-        MCPServerInstallation.objects.filter(team=team, user=user, is_enabled=True).values(  # type: ignore[arg-type]
+    """Return the MCP installations available to this user's agent: their
+    personal installations plus team-shared ones. When the user has a
+    personal installation for the same URL as a shared one, the personal
+    row wins — the agent acts as the user rather than through a teammate's
+    shared credential."""
+    rows = [
+        dict(row)
+        for row in MCPServerInstallation.objects.filter(team=team, is_enabled=True)
+        .filter(Q(scope="shared") | Q(user=user))
+        .values(
             "id",
             "display_name",
             "url",
             "auth_type",
             "sensitive_configuration",
+            "scope",
         )
-    )
+    ]
+    personal_urls = {row["url"] for row in rows if row["scope"] != "shared"}
+    return [
+        row
+        for row in rows
+        if row["scope"] != "shared" or (row["url"] not in personal_urls and _is_shared_row_ready(row))
+    ]
 
 
 def _get_cached_tools(installation_id: str) -> list[dict]:

--- a/ee/hogai/tools/call_mcp_server/installations.py
+++ b/ee/hogai/tools/call_mcp_server/installations.py
@@ -8,13 +8,7 @@ from products.mcp_store.backend.models import MCPServerInstallation, MCPServerIn
 from products.mcp_store.backend.oauth import refresh_installation_token
 
 
-def _is_shared_row_ready(row: dict) -> bool:
-    """A shared row is only usable when the owner's credential is live.
-
-    Personal rows always surface (the user can be prompted to reauth their
-    own connection), but a teammate can't fix someone else's shared
-    credential, so unready shared rows are hidden from the agent instead of
-    failing at call time."""
+def _is_row_ready(row: dict) -> bool:
     if row["auth_type"] != "oauth":
         return True
     sensitive = row.get("sensitive_configuration") or {}
@@ -23,10 +17,15 @@ def _is_shared_row_ready(row: dict) -> bool:
 
 def _get_installations(team: Team, user: User) -> list[dict]:
     """Return the MCP installations available to this user's agent: their
-    personal installations plus team-shared ones. When the user has a
-    personal installation for the same URL as a shared one, the personal
-    row wins — the agent acts as the user rather than through a teammate's
-    shared credential."""
+    personal installations plus team-shared ones.
+
+    Per-URL resolution matches the sandbox facade and PostHog Code: a ready
+    personal installation wins over a shared one (the agent acts as the user
+    rather than through a teammate's shared credential), but a dead personal
+    row doesn't shadow a working shared one. Unready shared rows are hidden
+    entirely — a teammate can't fix someone else's credential, while an
+    unready personal row still surfaces so Max can walk the user through
+    reauth."""
     rows = [
         dict(row)
         for row in MCPServerInstallation.objects.filter(team=team, is_enabled=True)
@@ -40,12 +39,16 @@ def _get_installations(team: Team, user: User) -> list[dict]:
             "scope",
         )
     ]
-    personal_urls = {row["url"] for row in rows if row["scope"] != "shared"}
-    return [
-        row
-        for row in rows
-        if row["scope"] != "shared" or (row["url"] not in personal_urls and _is_shared_row_ready(row))
-    ]
+    ready_shared_by_url = {row["url"]: row for row in rows if row["scope"] == "shared" and _is_row_ready(row)}
+    results: list[dict] = []
+    for row in rows:
+        if row["scope"] == "shared":
+            continue
+        if _is_row_ready(row) or row["url"] not in ready_shared_by_url:
+            results.append(row)
+            ready_shared_by_url.pop(row["url"], None)
+    results.extend(ready_shared_by_url.values())
+    return results
 
 
 def _get_cached_tools(installation_id: str) -> list[dict]:

--- a/ee/hogai/tools/call_mcp_server/test/test_tool.py
+++ b/ee/hogai/tools/call_mcp_server/test/test_tool.py
@@ -121,6 +121,33 @@ class TestCreateToolClass(TestCallMCPServerTool):
         )
         self.assertEqual(tool._installations, [])
 
+    async def test_sees_teammates_shared_installation(self):
+        from posthog.models import User
+
+        owner = await sync_to_async(User.objects.create_and_join)(self.organization, "owner@example.com", "password")
+        await sync_to_async(MCPServerInstallation.objects.create)(
+            team=self.team,
+            user=owner,
+            display_name="Shared Linear",
+            url="https://mcp.linear.app/mcp",
+            scope="shared",
+            auth_type="oauth",
+            sensitive_configuration={"access_token": "owner-token"},
+        )
+
+        tool = await CallMCPServerTool.create_tool_class(
+            team=self.team, user=self.user, state=self.state, context_manager=self.context_manager
+        )
+
+        self.assertEqual(len(tool._installations), 1)
+        self.assertIn("https://mcp.linear.app/mcp", tool._allowed_server_urls)
+        self.assertIn("Shared Linear", tool.description)
+        # Calls ride the owner's shared credential.
+        self.assertEqual(
+            tool._server_headers["https://mcp.linear.app/mcp"]["Authorization"],
+            "Bearer owner-token",
+        )
+
 
 class TestAuthHeaders(TestCallMCPServerTool):
     async def test_oauth_token_sent_as_bearer_header(self):
@@ -289,6 +316,24 @@ class TestCallTool(TestCallMCPServerTool):
 
 
 class TestGetInstallations(TestCallMCPServerTool):
+    def _create_teammate(self, email="teammate@example.com"):
+        from posthog.models import User
+
+        return User.objects.create_and_join(self.organization, email, "password")
+
+    def _install_shared_server(self, owner, url="https://mcp.linear.app/mcp", sensitive_configuration=None):
+        return MCPServerInstallation.objects.create(
+            team=self.team,
+            user=owner,
+            display_name="Shared Linear",
+            url=url,
+            scope="shared",
+            auth_type="oauth",
+            sensitive_configuration=(
+                sensitive_configuration if sensitive_configuration is not None else {"access_token": "owner-token"}
+            ),
+        )
+
     def test_returns_installed_servers(self):
         self._install_server(name="Linear", url="https://mcp.linear.app")
         result = _get_installations(self.team, self.user)
@@ -298,6 +343,53 @@ class TestGetInstallations(TestCallMCPServerTool):
 
     def test_returns_empty_when_none_installed(self):
         result = _get_installations(self.team, self.user)
+        self.assertEqual(result, [])
+
+    def test_includes_teammates_shared_installation(self):
+        owner = self._create_teammate()
+        self._install_shared_server(owner)
+
+        result = _get_installations(self.team, self.user)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["scope"], "shared")
+        self.assertEqual(result[0]["url"], "https://mcp.linear.app/mcp")
+
+    def test_personal_wins_over_shared_for_same_url(self):
+        owner = self._create_teammate()
+        self._install_shared_server(owner, url="https://mcp.linear.app/mcp")
+        self._install_server(name="My Linear", url="https://mcp.linear.app/mcp")
+
+        result = _get_installations(self.team, self.user)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["scope"], "personal")
+        self.assertEqual(result[0]["display_name"], "My Linear")
+
+    def test_hides_shared_installation_without_live_credential(self):
+        owner = self._create_teammate()
+        self._install_shared_server(owner, url="https://mcp.pending.com/mcp", sensitive_configuration={})
+        self._install_shared_server(
+            owner,
+            url="https://mcp.reauth.com/mcp",
+            sensitive_configuration={"access_token": "tok", "needs_reauth": True},
+        )
+
+        result = _get_installations(self.team, self.user)
+
+        self.assertEqual(result, [])
+
+    def test_excludes_teammates_personal_installations(self):
+        owner = self._create_teammate()
+        MCPServerInstallation.objects.create(
+            team=self.team,
+            user=owner,
+            display_name="Their Server",
+            url="https://mcp.other.com",
+        )
+
+        result = _get_installations(self.team, self.user)
+
         self.assertEqual(result, [])
 
 

--- a/ee/hogai/tools/call_mcp_server/test/test_tool.py
+++ b/ee/hogai/tools/call_mcp_server/test/test_tool.py
@@ -379,6 +379,34 @@ class TestGetInstallations(TestCallMCPServerTool):
 
         self.assertEqual(result, [])
 
+    def test_dead_personal_does_not_shadow_ready_shared(self):
+        owner = self._create_teammate()
+        self._install_shared_server(owner, url="https://mcp.linear.app/mcp")
+        self._install_server(
+            name="My Linear",
+            url="https://mcp.linear.app/mcp",
+            auth_type="oauth",
+            sensitive_configuration={"access_token": "tok", "needs_reauth": True},
+        )
+
+        result = _get_installations(self.team, self.user)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["scope"], "shared")
+
+    def test_keeps_unready_personal_without_shared_alternative(self):
+        self._install_server(
+            name="My Linear",
+            url="https://mcp.linear.app/mcp",
+            auth_type="oauth",
+            sensitive_configuration={"needs_reauth": True},
+        )
+
+        result = _get_installations(self.team, self.user)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["display_name"], "My Linear")
+
     def test_excludes_teammates_personal_installations(self):
         owner = self._create_teammate()
         MCPServerInstallation.objects.create(

--- a/ee/hogai/tools/call_mcp_server/tool.py
+++ b/ee/hogai/tools/call_mcp_server/tool.py
@@ -277,6 +277,18 @@ class CallMCPServerTool(MaxTool):
             )
         # needs_approval is handled earlier via `is_dangerous_operation` + LangGraph
         # interrupt; by the time we reach _call_tool we've already been approved.
+        inst = self._get_installation(server_url)
+        # Basic audit trail for who exercises which installation (especially
+        # shared credentials), mirroring the proxy path. Metadata only —
+        # never arguments or results.
+        logger.info(
+            "mcp_store max tool call",
+            team_id=self._team.id,
+            installation_id=str(inst["id"]),
+            scope=inst.get("scope", "personal"),
+            user_id=self._user.id,
+            tool_name=tool_name,
+        )
         return await client.call_tool(tool_name, arguments or {})
 
     def _validate_server_url(self, server_url: str) -> None:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4107,6 +4107,12 @@ const api = {
         async delete(id: string): Promise<void> {
             await new ApiRequest().mcpServerInstallation(id).delete()
         },
+        async share(id: string): Promise<Record<string, any>> {
+            return await new ApiRequest().mcpServerInstallation(id).withAction('share').create({ data: {} })
+        },
+        async unshare(id: string): Promise<Record<string, any>> {
+            return await new ApiRequest().mcpServerInstallation(id).withAction('unshare').create({ data: {} })
+        },
         async installCustom(data: {
             name: string
             url: string

--- a/products/mcp_store/backend/facade/api.py
+++ b/products/mcp_store/backend/facade/api.py
@@ -80,7 +80,10 @@ def get_installations_for_sandbox(
 
     Always includes shared (team-wide) installations. Optionally includes
     the user's personal installations when ``include_personal`` is True
-    and a ``user_id`` is provided.
+    and a ``user_id`` is provided. When the user has a ready personal
+    installation for the same URL as a shared one, only the personal one is
+    returned — the user acts as themselves rather than through the shared
+    credential.
     """
     try:
         scope_filter = Q(scope="shared")
@@ -96,11 +99,16 @@ def get_installations_for_sandbox(
         logger.warning("Error fetching MCP installations for sandbox", error=str(e), team_id=team_id)
         return []
 
-    results: list[ActiveInstallationInfo] = []
-    for installation in installations:
-        if not _is_oauth_ready(installation):
-            continue
-        results.append(_to_info(installation, team_id))
+    ready = [installation for installation in installations if _is_oauth_ready(installation)]
+    if include_personal and user_id is not None:
+        personal_urls = {installation.url for installation in ready if installation.scope == "personal"}
+        ready = [
+            installation
+            for installation in ready
+            if installation.scope == "personal" or installation.url not in personal_urls
+        ]
+
+    results = [_to_info(installation, team_id) for installation in ready]
 
     logger.debug(
         "Found MCP installations for sandbox",

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -26,7 +26,7 @@ from posthog.api.mixins import validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.cloud_utils import is_dev_mode
 from posthog.event_usage import report_user_action
-from posthog.models import OrganizationMembership, User
+from posthog.models import User
 from posthog.rate_limit import (
     MCPOAuthBurstThrottle,
     MCPOAuthRedirectBurstThrottle,
@@ -461,8 +461,17 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
             raise PermissionDenied("Only the credential owner can modify a shared server.")
 
     def _is_project_admin(self) -> bool:
-        level = self.user_permissions.current_team.effective_membership_level
-        return level is not None and level >= OrganizationMembership.Level.ADMIN
+        """True for organization admins/owners, or users explicitly granted
+        admin on this project via access controls.
+
+        Deliberately NOT `effective_membership_level`: on a project with no
+        access controls configured, that defaults to admin for every org
+        member (open-project semantics), which would let any member share,
+        unshare, or delete team-wide MCP credentials. `explicit=True` skips
+        that default, so regular members fail closed."""
+        if self.user_access_control.is_organization_admin:
+            return True
+        return bool(self.user_access_control.check_access_level_for_object(self.team, "admin", explicit=True))
 
     def _require_admin_for_shared_scope(self, scope: str) -> None:
         """Creating a team-wide shared MCP server is admin-only.

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -591,7 +591,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         serializer = self.get_serializer(installation)
         return Response(serializer.data)
 
-    @extend_schema(responses={200: OpenApiResponse(response=MCPServerInstallationSerializer)})
+    @extend_schema(request=None, responses={200: OpenApiResponse(response=MCPServerInstallationSerializer)})
     @action(detail=True, methods=["post"], url_path="share")
     def share(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Escalate a personal installation to a team-wide shared one.
@@ -630,7 +630,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         )
         return Response(self.get_serializer(installation).data)
 
-    @extend_schema(responses={200: OpenApiResponse(response=MCPServerInstallationSerializer)})
+    @extend_schema(request=None, responses={200: OpenApiResponse(response=MCPServerInstallationSerializer)})
     @action(detail=True, methods=["post"], url_path="unshare")
     def unshare(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """De-escalate a shared installation back to personal.

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -199,6 +199,9 @@ class MCPServerInstallationSerializer(serializers.ModelSerializer):
     tool_count = serializers.SerializerMethodField(
         help_text="Number of live (non-removed) tools exposed by this installation."
     )
+    is_owner = serializers.SerializerMethodField(
+        help_text="True when the requesting user owns this installation. Lets clients gate owner-only controls instead of surfacing 403s."
+    )
 
     class Meta:
         model = MCPServerInstallation
@@ -213,6 +216,7 @@ class MCPServerInstallationSerializer(serializers.ModelSerializer):
             "auth_type",
             "is_enabled",
             "scope",
+            "is_owner",
             "needs_reauth",
             "pending_oauth",
             "proxy_url",
@@ -220,7 +224,7 @@ class MCPServerInstallationSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
-        read_only_fields = ["id", "template_id", "created_at", "updated_at", "tool_count", "scope"]
+        read_only_fields = ["id", "template_id", "created_at", "updated_at", "tool_count", "scope", "is_owner"]
 
     def get_tool_count(self, obj: MCPServerInstallation) -> int:
         # Prefer the annotation to avoid N+1 on list; fall back to a direct
@@ -256,6 +260,12 @@ class MCPServerInstallationSerializer(serializers.ModelSerializer):
                 f"/api/environments/{obj.team_id}/mcp_server_installations/{obj.id}/proxy/"
             )
         return ""
+
+    def get_is_owner(self, obj: MCPServerInstallation) -> bool:
+        request = self.context.get("request")
+        if not request or not getattr(request, "user", None):
+            return False
+        return request.user.id == obj.user_id
 
 
 class InstallCustomSerializer(serializers.Serializer):
@@ -375,6 +385,8 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         "install_template",
         "update_tool_approval",
         "refresh_tools",
+        "share",
+        "unshare",
     ]
     queryset = MCPServerInstallation.objects.all()
     serializer_class = MCPServerInstallationSerializer
@@ -391,6 +403,9 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         "install_template",
         "update_tool_approval",
         "refresh_tools",
+        # share/unshare enforce their own owner/admin checks in the action bodies.
+        "share",
+        "unshare",
     }
 
     # Mutations restricted to the credential owner (installer) on shared rows.
@@ -425,6 +440,13 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
             and obj.scope == "shared"
             and obj.user_id != request.user.id
         ):
+            # destroy differs from the other owner-only actions: a project admin may
+            # delete another member's shared installation, so shared credentials
+            # don't become orphaned and unremovable when the owner leaves the team.
+            # partial_update / refresh_tools / update_tool_approval reconfigure how
+            # the owner's credential is used, so they stay strictly owner-only.
+            if self.action == "destroy" and self._is_project_admin():
+                return
             raise PermissionDenied("Only the credential owner can modify a shared server.")
 
     def _assert_shared_mutation_allowed(self, installation: MCPServerInstallation) -> None:
@@ -438,6 +460,10 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         if installation.scope == "shared" and installation.user_id != self.request.user.id:
             raise PermissionDenied("Only the credential owner can modify a shared server.")
 
+    def _is_project_admin(self) -> bool:
+        level = self.user_permissions.current_team.effective_membership_level
+        return level is not None and level >= OrganizationMembership.Level.ADMIN
+
     def _require_admin_for_shared_scope(self, scope: str) -> None:
         """Creating a team-wide shared MCP server is admin-only.
 
@@ -449,8 +475,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         """
         if scope != "shared":
             return
-        level = self.user_permissions.current_team.effective_membership_level
-        if level is None or level < OrganizationMembership.Level.ADMIN:
+        if not self._is_project_admin():
             raise PermissionDenied("Only project admins can create shared MCP servers.")
 
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -557,6 +582,85 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         serializer = self.get_serializer(installation)
         return Response(serializer.data)
 
+    @extend_schema(responses={200: OpenApiResponse(response=MCPServerInstallationSerializer)})
+    @action(detail=True, methods=["post"], url_path="share")
+    def share(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Escalate a personal installation to a team-wide shared one.
+
+        Owner-only AND admin-only: sharing exposes the owner's credential to
+        every project member and all autonomous agents, so it carries the same
+        gate as creating a shared install outright.
+        """
+        installation = self.get_object()
+        if installation.scope != "personal":
+            return Response(
+                {"detail": "Only personal installations can be shared."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if installation.user_id != request.user.id:
+            raise PermissionDenied("Only the installation owner can share it with the project.")
+        if not self._is_project_admin():
+            raise PermissionDenied("Only project admins can share MCP servers with the project.")
+        if MCPServerInstallation.objects.filter(team_id=self.team_id, url=installation.url, scope="shared").exists():
+            return Response(
+                {"detail": "A shared connection for this server already exists in this project."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        installation.scope = "shared"
+        installation.save(update_fields=["scope", "updated_at"])
+        report_user_action(
+            request.user,
+            "mcp_store server shared",
+            properties={
+                "server_name": _installation_name(installation),
+                "server_url": installation.url,
+                "auth_type": installation.auth_type,
+            },
+            team=self.team,
+        )
+        return Response(self.get_serializer(installation).data)
+
+    @extend_schema(responses={200: OpenApiResponse(response=MCPServerInstallationSerializer)})
+    @action(detail=True, methods=["post"], url_path="unshare")
+    def unshare(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """De-escalate a shared installation back to personal.
+
+        Allowed for the credential owner OR a project admin (the reclaim path
+        for shared credentials). The row always stays owned by the ORIGINAL
+        owner — an admin unsharing someone else's install must not capture
+        their credential.
+        """
+        installation = self.get_object()
+        if installation.scope != "shared":
+            return Response(
+                {"detail": "Only shared installations can be unshared."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if installation.user_id != request.user.id and not self._is_project_admin():
+            raise PermissionDenied("Only the credential owner or a project admin can unshare a shared server.")
+        if MCPServerInstallation.objects.filter(
+            team_id=self.team_id, user_id=installation.user_id, url=installation.url, scope="personal"
+        ).exists():
+            return Response(
+                {"detail": "The owner already has a personal installation for this server."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        installation.scope = "personal"
+        installation.save(update_fields=["scope", "updated_at"])
+        report_user_action(
+            request.user,
+            "mcp_store server unshared",
+            properties={
+                "server_name": _installation_name(installation),
+                "server_url": installation.url,
+                "auth_type": installation.auth_type,
+            },
+            team=self.team,
+        )
+        return Response(self.get_serializer(installation).data)
+
     @action(
         detail=True,
         methods=["post"],
@@ -567,6 +671,17 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
     )
     def proxy(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse | StreamingHttpResponse:
         installation = self.get_object()
+
+        # Basic audit trail for who exercises which installation (especially
+        # shared credentials). Metadata only — never request/response bodies
+        # or headers.
+        logger.info(
+            "mcp_store proxy request",
+            team_id=self.team_id,
+            installation_id=str(installation.id),
+            scope=installation.scope,
+            user_id=request.user.id,
+        )
 
         ok, error_response = validate_installation_auth(installation)
         if not ok and error_response is not None:

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -1611,6 +1611,176 @@ class TestMCPInstallationScopeAccess(ClickhouseTestMixin, APIBaseTest, QueryMatc
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    def test_non_owner_admin_can_delete_shared(self) -> None:
+        # Admins may delete another member's shared installation so shared
+        # credentials don't become orphaned when the owner leaves the team.
+        from posthog.models import User
+
+        self._make_admin()
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        shared = self._create_installation(user=other, scope="shared")
+
+        response = self.client.delete(self._api_url(f"{shared.id}/"))
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not MCPServerInstallation.objects.filter(id=shared.id).exists()
+
+    def test_non_owner_admin_still_cannot_patch_shared(self) -> None:
+        # The destroy override is delete-only: reconfiguring how the owner's
+        # credential is used stays strictly owner-only, even for admins.
+        from posthog.models import User
+
+        self._make_admin()
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        shared = self._create_installation(user=other, scope="shared")
+
+        response = self.client.patch(
+            self._api_url(f"{shared.id}/"),
+            data={"display_name": "Hijacked"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_admin_cannot_delete_another_members_personal(self) -> None:
+        # Personal rows behave as before: they aren't even visible to other
+        # members, admin or not.
+        from posthog.models import User
+
+        self._make_admin()
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        personal = self._create_installation(user=other, scope="personal")
+
+        response = self.client.delete(self._api_url(f"{personal.id}/"))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert MCPServerInstallation.objects.filter(id=personal.id).exists()
+
+    def test_share_by_owner_admin_flips_scope(self) -> None:
+        self._make_admin()
+        personal = self._create_installation(scope="personal")
+
+        response = self.client.post(self._api_url(f"{personal.id}/share/"))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["scope"] == "shared"
+        personal.refresh_from_db()
+        assert personal.scope == "shared"
+
+    def test_share_by_owner_non_admin_forbidden(self) -> None:
+        # self.user is a MEMBER by default; sharing carries the same admin
+        # gate as creating a shared install outright.
+        personal = self._create_installation(scope="personal")
+
+        response = self.client.post(self._api_url(f"{personal.id}/share/"))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        personal.refresh_from_db()
+        assert personal.scope == "personal"
+
+    def test_share_by_non_owner_admin_rejected(self) -> None:
+        # Another member's personal installation isn't even addressable: the
+        # queryset only exposes shared rows and your own, so a non-owner admin
+        # gets 404 before the in-action owner check (kept as defense in depth)
+        # could 403.
+        from posthog.models import User
+
+        self._make_admin()
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        personal = self._create_installation(user=other, scope="personal")
+
+        response = self.client.post(self._api_url(f"{personal.id}/share/"))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        personal.refresh_from_db()
+        assert personal.scope == "personal"
+
+    def test_share_conflicts_with_existing_shared_url(self) -> None:
+        from posthog.models import User
+
+        self._make_admin()
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        url = "https://mcp.share-conflict.example.com/mcp"
+        self._create_installation(user=other, scope="shared", url=url)
+        personal = self._create_installation(scope="personal", url=url)
+
+        response = self.client.post(self._api_url(f"{personal.id}/share/"))
+        assert response.status_code == status.HTTP_409_CONFLICT
+        personal.refresh_from_db()
+        assert personal.scope == "personal"
+
+    def test_share_already_shared_returns_400(self) -> None:
+        self._make_admin()
+        shared = self._create_installation(scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/share/"))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        shared.refresh_from_db()
+        assert shared.scope == "shared"
+
+    def test_unshare_by_owner(self) -> None:
+        shared = self._create_installation(scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["scope"] == "personal"
+        shared.refresh_from_db()
+        assert shared.scope == "personal"
+        assert shared.user_id == self.user.id
+
+    def test_unshare_by_non_owner_admin_keeps_original_owner(self) -> None:
+        from posthog.models import User
+
+        self._make_admin()
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        shared = self._create_installation(user=other, scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+        assert response.status_code == status.HTTP_200_OK
+        shared.refresh_from_db()
+        assert shared.scope == "personal"
+        # The row must stay owned by the ORIGINAL owner — an admin unsharing
+        # someone else's install must not capture their credential.
+        assert shared.user_id == other.id
+
+    def test_unshare_by_non_owner_member_forbidden(self) -> None:
+        from posthog.models import User
+
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        shared = self._create_installation(user=other, scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        shared.refresh_from_db()
+        assert shared.scope == "shared"
+
+    def test_unshare_conflicts_with_owner_personal_duplicate(self) -> None:
+        url = "https://mcp.unshare-conflict.example.com/mcp"
+        self._create_installation(scope="personal", url=url)
+        shared = self._create_installation(scope="shared", url=url)
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+        assert response.status_code == status.HTTP_409_CONFLICT
+        shared.refresh_from_db()
+        assert shared.scope == "shared"
+
+    def test_unshare_personal_returns_400(self) -> None:
+        personal = self._create_installation(scope="personal")
+
+        response = self.client.post(self._api_url(f"{personal.id}/unshare/"))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        personal.refresh_from_db()
+        assert personal.scope == "personal"
+
+    def test_is_owner_flag_in_list(self) -> None:
+        from posthog.models import User
+
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        own_personal = self._create_installation(scope="personal")
+        own_shared = self._create_installation(scope="shared")
+        other_shared = self._create_installation(user=other, scope="shared")
+
+        response = self.client.get(self._api_url())
+        assert response.status_code == status.HTTP_200_OK
+        by_id = {r["id"]: r for r in response.json()["results"]}
+        assert by_id[str(own_personal.id)]["is_owner"] is True
+        assert by_id[str(own_shared.id)]["is_owner"] is True
+        assert by_id[str(other_shared.id)]["is_owner"] is False
+
     def test_any_member_can_proxy_shared(self) -> None:
         from unittest.mock import (
             MagicMock,

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -2008,3 +2008,117 @@ class TestMCPInstallationScopeAccess(ClickhouseTestMixin, APIBaseTest, QueryMatc
         )
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()["scope"] == "personal"
+
+
+class TestMCPScopeAdminGateWithAccessControlFeature(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
+    """Regression tests for the admin gate on shared-credential management.
+
+    With the ACCESS_CONTROL feature available and a project that has no
+    access-control rows configured, `effective_membership_level` reports
+    every org member as project admin (open-project default). The share /
+    unshare / shared-delete gate must not inherit that default: only org
+    admins and explicitly-granted project admins pass.
+    """
+
+    def setUp(self):
+        super().setUp()
+        from posthog.constants import AvailableFeature
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+    def _api_url(self, suffix: str = "") -> str:
+        base = f"/api/environments/{self.team.id}/mcp_server_installations/"
+        return f"{base}{suffix}" if suffix else base
+
+    def _create_installation(self, user=None, scope="personal") -> MCPServerInstallation:
+        import uuid as _uuid
+
+        return MCPServerInstallation.objects.create(
+            team=self.team,
+            user=user or self.user,
+            display_name=f"Server-{_uuid.uuid4().hex[:6]}",
+            url=f"https://mcp.test-{_uuid.uuid4().hex[:8]}.example.com/mcp",
+            auth_type="api_key",
+            is_enabled=True,
+            scope=scope,
+        )
+
+    def _other_user(self):
+        from posthog.models import User
+
+        return User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+
+    def _make_org_admin(self) -> None:
+        from posthog.models import OrganizationMembership
+
+        membership = self.user.organization_memberships.get(organization=self.organization)
+        membership.level = OrganizationMembership.Level.ADMIN
+        membership.save()
+
+    def test_member_cannot_unshare_anothers_shared_on_open_project(self) -> None:
+        shared = self._create_installation(user=self._other_user(), scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        shared.refresh_from_db()
+        assert shared.scope == "shared"
+
+    def test_member_cannot_delete_anothers_shared_on_open_project(self) -> None:
+        shared = self._create_installation(user=self._other_user(), scope="shared")
+
+        response = self.client.delete(self._api_url(f"{shared.id}/"))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert MCPServerInstallation.objects.filter(id=shared.id).exists()
+
+    def test_member_cannot_share_own_personal_on_open_project(self) -> None:
+        personal = self._create_installation(scope="personal")
+
+        response = self.client.post(self._api_url(f"{personal.id}/share/"))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        personal.refresh_from_db()
+        assert personal.scope == "personal"
+
+    def test_org_admin_can_unshare_on_open_project(self) -> None:
+        self._make_org_admin()
+        shared = self._create_installation(user=self._other_user(), scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+
+        assert response.status_code == status.HTTP_200_OK
+        shared.refresh_from_db()
+        assert shared.scope == "personal"
+
+    def test_explicit_project_admin_can_unshare(self) -> None:
+        from ee.models.rbac.access_control import AccessControl
+
+        membership = self.user.organization_memberships.get(organization=self.organization)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            access_level="admin",
+            organization_member=membership,
+        )
+        shared = self._create_installation(user=self._other_user(), scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+
+        assert response.status_code == status.HTTP_200_OK
+        shared.refresh_from_db()
+        assert shared.scope == "personal"
+
+    def test_owner_can_still_unshare_own_shared_as_member(self) -> None:
+        # The credential owner reclaims their own connection regardless of role.
+        shared = self._create_installation(scope="shared")
+
+        response = self.client.post(self._api_url(f"{shared.id}/unshare/"))
+
+        assert response.status_code == status.HTTP_200_OK
+        shared.refresh_from_db()
+        assert shared.scope == "personal"

--- a/products/mcp_store/backend/test/test_facade.py
+++ b/products/mcp_store/backend/test/test_facade.py
@@ -211,6 +211,38 @@ class TestGetInstallationsForSandbox(BaseTest):
 
         assert len(results) == 0
 
+    def test_personal_wins_over_shared_for_same_url(self) -> None:
+        # The user acts as themselves rather than through the shared credential.
+        other_user = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        url = "https://mcp.same.example.com/mcp"
+        self._create_installation(scope="shared", user=other_user, url=url, display_name="Shared")
+        personal = self._create_installation(scope="personal", url=url, display_name="Personal")
+
+        results = get_installations_for_sandbox(self.team.id, user_id=self.user.id, include_personal=True)
+
+        assert [r.id for r in results] == [str(personal.id)]
+        assert results[0].scope == "personal"
+
+    def test_shared_returned_for_same_url_without_include_personal(self) -> None:
+        other_user = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        url = "https://mcp.same.example.com/mcp"
+        shared = self._create_installation(scope="shared", user=other_user, url=url)
+        self._create_installation(scope="personal", url=url)
+
+        results = get_installations_for_sandbox(self.team.id, user_id=self.user.id, include_personal=False)
+
+        assert [r.id for r in results] == [str(shared.id)]
+        assert results[0].scope == "shared"
+
+    def test_different_urls_not_deduped(self) -> None:
+        other_user = User.objects.create_and_join(self.organization, "other@posthog.com", "password")
+        self._create_installation(scope="shared", user=other_user, url="https://shared.example.com/mcp")
+        self._create_installation(scope="personal", url="https://personal.example.com/mcp")
+
+        results = get_installations_for_sandbox(self.team.id, user_id=self.user.id, include_personal=True)
+
+        assert {r.scope for r in results} == {"shared", "personal"}
+
     @parameterized.expand(
         [
             ("shared_include_personal", "shared", True, True),

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -45,6 +45,8 @@ export interface MCPServerInstallationApi {
     auth_type?: MCPAuthTypeEnumApi
     is_enabled?: boolean
     readonly scope: MCPServerInstallationScopeEnumApi
+    /** True when the requesting user owns this installation. Lets clients gate owner-only controls instead of surfacing 403s. */
+    readonly is_owner: boolean
     readonly needs_reauth: boolean
     readonly pending_oauth: boolean
     readonly proxy_url: string

--- a/products/mcp_store/frontend/generated/api.ts
+++ b/products/mcp_store/frontend/generated/api.ts
@@ -183,14 +183,11 @@ export const getMcpServerInstallationsShareCreateUrl = (projectId: string, id: s
 export const mcpServerInstallationsShareCreate = async (
     projectId: string,
     id: string,
-    mCPServerInstallationApi?: NonReadonly<MCPServerInstallationApi>,
     options?: RequestInit
 ): Promise<MCPServerInstallationApi> => {
     return apiMutator<MCPServerInstallationApi>(getMcpServerInstallationsShareCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(mCPServerInstallationApi),
     })
 }
 
@@ -270,14 +267,11 @@ export const getMcpServerInstallationsUnshareCreateUrl = (projectId: string, id:
 export const mcpServerInstallationsUnshareCreate = async (
     projectId: string,
     id: string,
-    mCPServerInstallationApi?: NonReadonly<MCPServerInstallationApi>,
     options?: RequestInit
 ): Promise<MCPServerInstallationApi> => {
     return apiMutator<MCPServerInstallationApi>(getMcpServerInstallationsUnshareCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(mCPServerInstallationApi),
     })
 }
 

--- a/products/mcp_store/frontend/generated/api.ts
+++ b/products/mcp_store/frontend/generated/api.ts
@@ -169,6 +169,31 @@ export const mcpServerInstallationsProxyCreate = async (
     })
 }
 
+export const getMcpServerInstallationsShareCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/mcp_server_installations/${id}/share/`
+}
+
+/**
+ * Escalate a personal installation to a team-wide shared one.
+ *
+ * Owner-only AND admin-only: sharing exposes the owner's credential to
+ * every project member and all autonomous agents, so it carries the same
+ * gate as creating a shared install outright.
+ */
+export const mcpServerInstallationsShareCreate = async (
+    projectId: string,
+    id: string,
+    mCPServerInstallationApi?: NonReadonly<MCPServerInstallationApi>,
+    options?: RequestInit
+): Promise<MCPServerInstallationApi> => {
+    return apiMutator<MCPServerInstallationApi>(getMcpServerInstallationsShareCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(mCPServerInstallationApi),
+    })
+}
+
 export const getMcpServerInstallationsToolsRetrieveUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/mcp_server_installations/${id}/tools/`
 }
@@ -228,6 +253,32 @@ export const mcpServerInstallationsToolsRefreshCreate = async (
             body: JSON.stringify(mCPServerInstallationApi),
         }
     )
+}
+
+export const getMcpServerInstallationsUnshareCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/mcp_server_installations/${id}/unshare/`
+}
+
+/**
+ * De-escalate a shared installation back to personal.
+ *
+ * Allowed for the credential owner OR a project admin (the reclaim path
+ * for shared credentials). The row always stays owned by the ORIGINAL
+ * owner — an admin unsharing someone else's install must not capture
+ * their credential.
+ */
+export const mcpServerInstallationsUnshareCreate = async (
+    projectId: string,
+    id: string,
+    mCPServerInstallationApi?: NonReadonly<MCPServerInstallationApi>,
+    options?: RequestInit
+): Promise<MCPServerInstallationApi> => {
+    return apiMutator<MCPServerInstallationApi>(getMcpServerInstallationsUnshareCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(mCPServerInstallationApi),
+    })
 }
 
 export const getMcpServerInstallationsAuthorizeRetrieveUrl = (

--- a/products/mcp_store/frontend/generated/api.zod.ts
+++ b/products/mcp_store/frontend/generated/api.zod.ts
@@ -51,25 +51,6 @@ export const McpServerInstallationsProxyCreateBody = /* @__PURE__ */ zod.object(
     is_enabled: zod.boolean().optional(),
 })
 
-/**
- * Escalate a personal installation to a team-wide shared one.
- *
- * Owner-only AND admin-only: sharing exposes the owner's credential to
- * every project member and all autonomous agents, so it carries the same
- * gate as creating a shared install outright.
- */
-export const mcpServerInstallationsShareCreateBodyDisplayNameMax = 200
-
-export const mcpServerInstallationsShareCreateBodyUrlMax = 2048
-
-export const McpServerInstallationsShareCreateBody = /* @__PURE__ */ zod.object({
-    display_name: zod.string().max(mcpServerInstallationsShareCreateBodyDisplayNameMax).optional(),
-    url: zod.url().max(mcpServerInstallationsShareCreateBodyUrlMax).optional(),
-    description: zod.string().optional(),
-    auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
-    is_enabled: zod.boolean().optional(),
-})
-
 export const McpServerInstallationsToolsPartialUpdateBody = /* @__PURE__ */ zod.object({
     approval_state: zod
         .enum(['approved', 'needs_approval', 'do_not_use'])
@@ -84,26 +65,6 @@ export const mcpServerInstallationsToolsRefreshCreateBodyUrlMax = 2048
 export const McpServerInstallationsToolsRefreshCreateBody = /* @__PURE__ */ zod.object({
     display_name: zod.string().max(mcpServerInstallationsToolsRefreshCreateBodyDisplayNameMax).optional(),
     url: zod.url().max(mcpServerInstallationsToolsRefreshCreateBodyUrlMax).optional(),
-    description: zod.string().optional(),
-    auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
-    is_enabled: zod.boolean().optional(),
-})
-
-/**
- * De-escalate a shared installation back to personal.
- *
- * Allowed for the credential owner OR a project admin (the reclaim path
- * for shared credentials). The row always stays owned by the ORIGINAL
- * owner — an admin unsharing someone else's install must not capture
- * their credential.
- */
-export const mcpServerInstallationsUnshareCreateBodyDisplayNameMax = 200
-
-export const mcpServerInstallationsUnshareCreateBodyUrlMax = 2048
-
-export const McpServerInstallationsUnshareCreateBody = /* @__PURE__ */ zod.object({
-    display_name: zod.string().max(mcpServerInstallationsUnshareCreateBodyDisplayNameMax).optional(),
-    url: zod.url().max(mcpServerInstallationsUnshareCreateBodyUrlMax).optional(),
     description: zod.string().optional(),
     auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
     is_enabled: zod.boolean().optional(),

--- a/products/mcp_store/frontend/generated/api.zod.ts
+++ b/products/mcp_store/frontend/generated/api.zod.ts
@@ -51,6 +51,25 @@ export const McpServerInstallationsProxyCreateBody = /* @__PURE__ */ zod.object(
     is_enabled: zod.boolean().optional(),
 })
 
+/**
+ * Escalate a personal installation to a team-wide shared one.
+ *
+ * Owner-only AND admin-only: sharing exposes the owner's credential to
+ * every project member and all autonomous agents, so it carries the same
+ * gate as creating a shared install outright.
+ */
+export const mcpServerInstallationsShareCreateBodyDisplayNameMax = 200
+
+export const mcpServerInstallationsShareCreateBodyUrlMax = 2048
+
+export const McpServerInstallationsShareCreateBody = /* @__PURE__ */ zod.object({
+    display_name: zod.string().max(mcpServerInstallationsShareCreateBodyDisplayNameMax).optional(),
+    url: zod.url().max(mcpServerInstallationsShareCreateBodyUrlMax).optional(),
+    description: zod.string().optional(),
+    auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
+    is_enabled: zod.boolean().optional(),
+})
+
 export const McpServerInstallationsToolsPartialUpdateBody = /* @__PURE__ */ zod.object({
     approval_state: zod
         .enum(['approved', 'needs_approval', 'do_not_use'])
@@ -65,6 +84,26 @@ export const mcpServerInstallationsToolsRefreshCreateBodyUrlMax = 2048
 export const McpServerInstallationsToolsRefreshCreateBody = /* @__PURE__ */ zod.object({
     display_name: zod.string().max(mcpServerInstallationsToolsRefreshCreateBodyDisplayNameMax).optional(),
     url: zod.url().max(mcpServerInstallationsToolsRefreshCreateBodyUrlMax).optional(),
+    description: zod.string().optional(),
+    auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
+    is_enabled: zod.boolean().optional(),
+})
+
+/**
+ * De-escalate a shared installation back to personal.
+ *
+ * Allowed for the credential owner OR a project admin (the reclaim path
+ * for shared credentials). The row always stays owned by the ORIGINAL
+ * owner — an admin unsharing someone else's install must not capture
+ * their credential.
+ */
+export const mcpServerInstallationsUnshareCreateBodyDisplayNameMax = 200
+
+export const mcpServerInstallationsUnshareCreateBodyUrlMax = 2048
+
+export const McpServerInstallationsUnshareCreateBody = /* @__PURE__ */ zod.object({
+    display_name: zod.string().max(mcpServerInstallationsUnshareCreateBodyDisplayNameMax).optional(),
+    url: zod.url().max(mcpServerInstallationsUnshareCreateBodyUrlMax).optional(),
     description: zod.string().optional(),
     auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
     is_enabled: zod.boolean().optional(),

--- a/products/mcp_store/frontend/mcpStoreLogic.ts
+++ b/products/mcp_store/frontend/mcpStoreLogic.ts
@@ -54,6 +54,8 @@ export const mcpStoreLogic = kea<mcpStoreLogicType>([
         openAddCustomServerModalWithDefaults: (defaults: Partial<CustomServerFormValues>) => ({ defaults }),
         closeAddCustomServerModal: true,
         toggleServerEnabled: ({ id, enabled }: { id: string; enabled: boolean }) => ({ id, enabled }),
+        shareInstallation: ({ id }: { id: string }) => ({ id }),
+        unshareInstallation: ({ id }: { id: string }) => ({ id }),
         setInstallations: (installations: MCPServerInstallationApi[]) => ({ installations }),
         installTemplate: ({ templateId }: { templateId: string }) => ({ templateId }),
         loadInstallationTools: ({ installationId }: { installationId: string }) => ({ installationId }),
@@ -375,6 +377,24 @@ export const mcpStoreLogic = kea<mcpStoreLogicType>([
                         i.id === id ? { ...i, is_enabled: !enabled } : i
                     )
                 )
+            }
+        },
+        shareInstallation: async ({ id }) => {
+            try {
+                await api.mcpServerInstallations.share(id)
+                lemonToast.success('Server shared with the project')
+                actions.loadInstallations()
+            } catch (e: any) {
+                lemonToast.error(e.detail || 'Failed to share server')
+            }
+        },
+        unshareInstallation: async ({ id }) => {
+            try {
+                await api.mcpServerInstallations.unshare(id)
+                lemonToast.success('Server is now personal')
+                actions.loadInstallations()
+            } catch (e: any) {
+                lemonToast.error(e.detail || 'Failed to unshare server')
             }
         },
         installTemplate: async ({ templateId }) => {

--- a/products/mcp_store/frontend/mcpStoreLogic.ts
+++ b/products/mcp_store/frontend/mcpStoreLogic.ts
@@ -54,8 +54,6 @@ export const mcpStoreLogic = kea<mcpStoreLogicType>([
         openAddCustomServerModalWithDefaults: (defaults: Partial<CustomServerFormValues>) => ({ defaults }),
         closeAddCustomServerModal: true,
         toggleServerEnabled: ({ id, enabled }: { id: string; enabled: boolean }) => ({ id, enabled }),
-        shareInstallation: ({ id }: { id: string }) => ({ id }),
-        unshareInstallation: ({ id }: { id: string }) => ({ id }),
         setInstallations: (installations: MCPServerInstallationApi[]) => ({ installations }),
         installTemplate: ({ templateId }: { templateId: string }) => ({ templateId }),
         loadInstallationTools: ({ installationId }: { installationId: string }) => ({ installationId }),
@@ -263,6 +261,31 @@ export const mcpStoreLogic = kea<mcpStoreLogicType>([
                     lemonToast.success('Server uninstalled')
                     return values.installations.filter((i: MCPServerInstallationApi) => i.id !== installationId)
                 },
+                // Both refetch rather than patching the row in place: unsharing another
+                // member's row (admin reclaim) makes it their personal install, which
+                // must drop out of the requester's list entirely.
+                shareInstallation: async ({ id }: { id: string }) => {
+                    try {
+                        await api.mcpServerInstallations.share(id)
+                        lemonToast.success('Server shared with the project')
+                    } catch (e: any) {
+                        lemonToast.error(e.detail || 'Failed to share server')
+                        throw e
+                    }
+                    const response = await api.mcpServerInstallations.list()
+                    return response.results as MCPServerInstallationApi[]
+                },
+                unshareInstallation: async ({ id }: { id: string }) => {
+                    try {
+                        await api.mcpServerInstallations.unshare(id)
+                        lemonToast.success('Server is now personal')
+                    } catch (e: any) {
+                        lemonToast.error(e.detail || 'Failed to unshare server')
+                        throw e
+                    }
+                    const response = await api.mcpServerInstallations.list()
+                    return response.results as MCPServerInstallationApi[]
+                },
             },
         ],
         installationTools: [
@@ -377,24 +400,6 @@ export const mcpStoreLogic = kea<mcpStoreLogicType>([
                         i.id === id ? { ...i, is_enabled: !enabled } : i
                     )
                 )
-            }
-        },
-        shareInstallation: async ({ id }) => {
-            try {
-                await api.mcpServerInstallations.share(id)
-                lemonToast.success('Server shared with the project')
-                actions.loadInstallations()
-            } catch (e: any) {
-                lemonToast.error(e.detail || 'Failed to share server')
-            }
-        },
-        unshareInstallation: async ({ id }) => {
-            try {
-                await api.mcpServerInstallations.unshare(id)
-                lemonToast.success('Server is now personal')
-                actions.loadInstallations()
-            } catch (e: any) {
-                lemonToast.error(e.detail || 'Failed to unshare server')
             }
         },
         installTemplate: async ({ templateId }) => {

--- a/products/mcp_store/frontend/scene/AddCustomServerForm.tsx
+++ b/products/mcp_store/frontend/scene/AddCustomServerForm.tsx
@@ -4,7 +4,7 @@ import { Form } from 'kea-forms'
 import { LemonButton, LemonCollapse, LemonInput, LemonModal, LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
-import { TeamMembershipLevel } from 'lib/constants'
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import type { McpInstallationScope } from '../mcpStoreLogic'
@@ -28,9 +28,12 @@ export function AddCustomServerForm(): JSX.Element {
     // Shared servers expose the installer's credential to every project member and all
     // autonomous agents, so creating one is admin-only (enforced again on the backend).
     // Members see shared servers in the list but can only add personal ones.
+    // Organization scope, not Project: on a project with no access controls
+    // configured every member reports as effective project admin, which must
+    // not open up shared-credential creation.
     const sharedRestrictionReason = useRestrictedArea({
-        scope: RestrictionScope.Project,
-        minimumAccessLevel: TeamMembershipLevel.Admin,
+        scope: RestrictionScope.Organization,
+        minimumAccessLevel: OrganizationMembershipLevel.Admin,
     })
     const canAddShared = !sharedRestrictionReason
 

--- a/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
+++ b/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
@@ -215,6 +215,7 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
         shareInstallation,
         unshareInstallation,
     } = useActions(mcpStoreLogic)
+    const { installationsLoading } = useValues(mcpStoreLogic)
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Member,
@@ -322,6 +323,7 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
                             type="secondary"
                             size="small"
                             icon={<IconShare />}
+                            loading={installationsLoading}
                             onClick={() =>
                                 LemonDialog.open({
                                     title: `Share "${installation.name}" with the project?`,
@@ -352,6 +354,7 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
                         <LemonButton
                             type="secondary"
                             size="small"
+                            loading={installationsLoading}
                             onClick={() => unshareInstallation({ id: installation.id })}
                             tooltip="Convert back to a personal server, visible only to its owner."
                         >
@@ -364,6 +367,7 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
                             status="danger"
                             size="small"
                             icon={<IconTrash />}
+                            loading={installationsLoading}
                             onClick={() => uninstallServer(installation.id)}
                             disabledReason={removeDisabledReason}
                         >

--- a/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
+++ b/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
@@ -324,10 +324,10 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
                                     title: `Share "${installation.name}" with the project?`,
                                     description: (
                                         <div className="max-w-120">
-                                            Everyone in this project — <strong>including autonomous agents</strong> —
-                                            will use this server through your connection, and actions taken with it will
-                                            be attributed to your account on the connected service. Consider connecting
-                                            a service account instead of your personal one before sharing.
+                                            Everyone in this project, including the PostHog agent, can use{' '}
+                                            <strong>{installation.name}</strong> via your connection. Their actions will
+                                            be attributed to your account. For better security, connect a service
+                                            account. You can unshare anytime.
                                         </div>
                                     ),
                                     secondaryButton: {

--- a/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
+++ b/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
@@ -1,8 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useMemo, useState } from 'react'
 
-import { IconCheck, IconChevronLeft, IconRefresh, IconShieldLock, IconTrash, IconX } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonSnack, LemonSwitch, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { IconCheck, IconChevronLeft, IconRefresh, IconShare, IconShieldLock, IconTrash, IconX } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonDivider, LemonSnack, LemonSwitch, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TeamMembershipLevel } from 'lib/constants'
@@ -206,12 +206,37 @@ interface Props {
 
 export function ServerDetailPanel({ installation, template }: Props): JSX.Element {
     const { currentTeamId } = useValues(teamLogic)
-    const { selectServer, setSceneView, toggleServerEnabled, uninstallServer, installTemplate } =
-        useActions(mcpStoreLogic)
+    const {
+        selectServer,
+        setSceneView,
+        toggleServerEnabled,
+        uninstallServer,
+        installTemplate,
+        shareInstallation,
+        unshareInstallation,
+    } = useActions(mcpStoreLogic)
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Member,
     })
+    // Sharing carries the same admin gate as creating a shared install outright
+    // (see AddCustomServerForm); admins can also unshare or remove another
+    // member's shared server.
+    const adminRestrictionReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+    const isAdmin = !adminRestrictionReason
+    const isOwner = installation?.is_owner === true
+    // The backend rejects owner-only mutations of shared rows (rename, toggle,
+    // tool policy) for non-owners — gate them client-side instead of surfacing 403s.
+    const ownerOnlyReason =
+        installation?.scope === 'shared' && !isOwner ? 'Only the owner can modify a shared server connection' : null
+    const mutationDisabledReason = restrictedReason ?? ownerOnlyReason
+    const removeDisabledReason =
+        installation?.scope === 'shared' && !isOwner && !isAdmin
+            ? 'Only the owner or a project admin can remove a shared server'
+            : restrictedReason
 
     if (!installation && !template) {
         return (
@@ -285,9 +310,50 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
                             <LemonSwitch
                                 checked={installation.is_enabled !== false}
                                 onChange={(checked) => toggleServerEnabled({ id: installation.id, enabled: checked })}
-                                disabledReason={restrictedReason ?? undefined}
+                                disabledReason={mutationDisabledReason ?? undefined}
                             />
                         </Tooltip>
+                    )}
+                    {installation?.scope === 'personal' && isOwner && isAdmin && (
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            icon={<IconShare />}
+                            onClick={() =>
+                                LemonDialog.open({
+                                    title: `Share "${installation.name}" with the project?`,
+                                    description: (
+                                        <div className="max-w-120">
+                                            Everyone in this project — <strong>including autonomous agents</strong> —
+                                            will use this server through your connection, and actions taken with it will
+                                            be attributed to your account on the connected service. Consider connecting
+                                            a service account instead of your personal one before sharing.
+                                        </div>
+                                    ),
+                                    secondaryButton: {
+                                        type: 'secondary',
+                                        children: 'Cancel',
+                                    },
+                                    primaryButton: {
+                                        type: 'primary',
+                                        children: 'Share with project',
+                                        onClick: () => shareInstallation({ id: installation.id }),
+                                    },
+                                })
+                            }
+                        >
+                            Share with project
+                        </LemonButton>
+                    )}
+                    {installation?.scope === 'shared' && (isOwner || isAdmin) && (
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            onClick={() => unshareInstallation({ id: installation.id })}
+                            tooltip="Convert back to a personal server, visible only to its owner."
+                        >
+                            Unshare
+                        </LemonButton>
                     )}
                     {installation && (
                         <LemonButton
@@ -296,7 +362,7 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
                             size="small"
                             icon={<IconTrash />}
                             onClick={() => uninstallServer(installation.id)}
-                            disabledReason={restrictedReason}
+                            disabledReason={removeDisabledReason}
                         >
                             Remove
                         </LemonButton>

--- a/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
+++ b/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
@@ -5,7 +5,7 @@ import { IconCheck, IconChevronLeft, IconRefresh, IconShare, IconShieldLock, Ico
 import { LemonButton, LemonDialog, LemonDivider, LemonSnack, LemonSwitch, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
-import { TeamMembershipLevel } from 'lib/constants'
+import { OrganizationMembershipLevel, TeamMembershipLevel } from 'lib/constants'
 import { Link } from 'lib/lemon-ui/Link'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -221,10 +221,13 @@ export function ServerDetailPanel({ installation, template }: Props): JSX.Elemen
     })
     // Sharing carries the same admin gate as creating a shared install outright
     // (see AddCustomServerForm); admins can also unshare or remove another
-    // member's shared server.
+    // member's shared server. Organization scope, not Project: on a project
+    // with no access controls configured every member reports as effective
+    // project admin, which must not open up shared-credential management.
+    // The backend applies the same gate (plus explicitly-granted project admins).
     const adminRestrictionReason = useRestrictedArea({
-        scope: RestrictionScope.Project,
-        minimumAccessLevel: TeamMembershipLevel.Admin,
+        scope: RestrictionScope.Organization,
+        minimumAccessLevel: OrganizationMembershipLevel.Admin,
     })
     const isAdmin = !adminRestrictionReason
     const isOwner = installation?.is_owner === true

--- a/products/mcp_store/mcp/tools.yaml
+++ b/products/mcp_store/mcp/tools.yaml
@@ -75,6 +75,12 @@ tools:
     mcp-connections-update:
         operation: mcp_server_installations_update
         enabled: false
+    mcp-server-installations-share-create:
+        operation: mcp_server_installations_share_create
+        enabled: false
+    mcp-server-installations-unshare-create:
+        operation: mcp_server_installations_unshare_create
+        enabled: false
     mcp-servers-list:
         operation: mcp_servers_list
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30875,6 +30875,8 @@ export namespace Schemas {
       auth_type?: MCPAuthTypeEnum;
       is_enabled?: boolean;
       readonly scope: MCPServerInstallationScopeEnum;
+      /** True when the requesting user owns this installation. Lets clients gate owner-only controls instead of surfacing 403s. */
+      readonly is_owner: boolean;
       readonly needs_reauth: boolean;
       readonly pending_oauth: boolean;
       readonly proxy_url: string;


### PR DESCRIPTION
## Problem

Stacked on #69658 (base: `feat/shared-mcp`). Phase 1 of the review feedback there: connecting should stay one-click personal with sharing as a deliberate, admin-gated escalation; shared credentials need basic auditing and an ownership story; and agents should prefer a user's own connection over a teammate's shared one.

## Changes

**Backend**
- `POST /{id}/share/` — escalate a personal installation to shared without re-auth. Owner **and** project admin only; 400 if not personal; 409 if a shared row for the URL already exists. Emits `mcp_store server shared`.
- `POST /{id}/unshare/` — revert to personal (reclaim path). Owner **or** project admin; row always stays owned by the original owner so an admin can't capture someone's credential; 409 if the owner already holds a personal duplicate. Emits `mcp_store server unshared`.
- **Admin delete override**: `destroy` of a shared row is now owner-or-admin (prevents orphaned, unremovable shared credentials when the owner leaves). `partial_update`/`refresh_tools`/`update_tool_approval` remain strictly owner-only.
- **`is_owner`** on the installation serializer so clients gate owner-only controls instead of surfacing 403s.
- **Personal-over-shared dedupe** in `get_installations_for_sandbox`: with `include_personal`, a ready personal install for the same URL wins over the shared one — the user acts as themselves. Dedupe runs among OAuth-ready rows so a broken personal connection doesn't shadow a working shared one.
- **Basic proxy audit line**: structlog metadata (team, installation, scope, user) on every proxied MCP request; no bodies or headers. Full audit logging is phase 2.
- No new migrations (scope column ships in #69658; share/unshare only flip its value).

**Frontend**
- `Share with project` in the server detail panel (owner + admin via `RestrictedArea`), behind a `LemonDialog` warning that project members **and autonomous agents** will act as the sharer on the connected service, suggesting a service account.
- `Unshare` for owner or admin; owner-only controls (rename, enable toggle, tool policy) get disabled reasons for non-owners; Remove reflects owner-or-admin.
- Generated API types regenerated with the real tooling (spectacular + openapi:types).

**Fixes from local two-user testing**
- **Max couldn't see shared servers**: `call_mcp_server` built its server list from installations filtered by `user`, so a team-shared server was invisible to everyone but the credential owner — a teammate's Max reported "No MCP servers installed". Now includes shared rows with the same per-URL semantics as the sandbox facade (ready personal wins over shared; a dead personal row doesn't shadow a working shared one; unready shared rows are hidden since a teammate can't fix someone else's OAuth). Also adds the phase-1 metadata-only audit line on Max tool calls.
- **Any member could unshare/delete shared servers**: the admin gate used `effective_membership_level`, which defaults to project admin for *every* org member on a project with no access controls configured (open-project RBAC semantics). Now the gate means org admins/owners, or users explicitly granted project admin via access controls; the frontend admin gates (detail panel + custom-server Visibility option) switched to Organization scope to match. Regression tests run with the `ACCESS_CONTROL` feature enabled — the configuration the original permission tests never hit.

## How did you test this code?

- `products/mcp_store/backend/test/test_api.py` — 113 passed locally (16 new: share/unshare permission matrix, 409 conflicts, admin destroy of shared rows, `is_owner`; +6 admin-gate regression tests with the access-control feature enabled).
- `products/mcp_store/backend/test/test_facade.py` — 30 passed locally (3 new dedupe tests).
- `ee/hogai/tools/call_mcp_server/test/test_tool.py` — 57 passed locally (7 new shared-visibility tests).
- `makemigrations mcp_store --check` — clean.
- ruff/mypy/oxlint/oxfmt clean; kea typegen regenerated; tsgo shows zero errors in touched files.
- Live two-user verification on local dev (admin + regular member): member sees and can use the shared server through Max and the proxy; member gets 403 on unshare/delete; admin unshare/share round-trips.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Implemented from Chris's phase-1 plan on #69658.
