### PR TITLE
fix(notebooks): replace near-root :has() anchors with body marker class

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -652,18 +652,22 @@
     margin: 0 auto;
 }
 
-body:has(.Notebook--markdown-v2),
-.Navigation3000:has(.Notebook--markdown-v2),
-.main-content-container:has(.Notebook--markdown-v2) > main {
+// `.has-markdown-v2-notebook` is toggled on <body> by Notebook.tsx and stands in for
+// `body:has(.Notebook--markdown-v2)`. Do not reintroduce near-root `:has()` anchors here:
+// they make Blink flag the whole document as :has-invalidation-suspect, after which any
+// class change anywhere costs a full-page style recalc (200ms+ per keystroke on large threads).
+body.has-markdown-v2-notebook,
+body.has-markdown-v2-notebook .Navigation3000,
+body.has-markdown-v2-notebook .main-content-container > main {
     --notebook-markdown-v2-page-background: var(--color-bg-primary);
     --scene-layout-background: var(--notebook-markdown-v2-page-background);
 
     background: var(--notebook-markdown-v2-page-background);
 }
 
-[theme='dark']:has(.Notebook--markdown-v2),
-[theme='dark'] .Navigation3000:has(.Notebook--markdown-v2),
-[theme='dark'] .main-content-container:has(.Notebook--markdown-v2) > main {
+body[theme='dark'].has-markdown-v2-notebook,
+body[theme='dark'].has-markdown-v2-notebook .Navigation3000,
+body[theme='dark'].has-markdown-v2-notebook .main-content-container > main {
     --notebook-markdown-v2-page-background: var(--color-bg-surface-primary);
 }
 

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -2,7 +2,7 @@ import './Notebook.scss'
 
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 
 import { commandLogic } from 'lib/components/Command/commandLogic'
 import { NotFound } from 'lib/components/NotFound'
@@ -32,6 +32,10 @@ import { NotebookLoadingState } from './NotebookLoadingState'
 import { NotebookMergeConflictDetails } from './NotebookMergeConflictDetails'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
 import { openUpgradeToMarkdownNotebookDialog } from './notebookUpgradeDialog'
+
+// Counts mounted markdown-v2 notebooks so the <body> marker class survives overlapping mounts
+// (e.g. one in the scene and one in the side panel)
+let markdownNotebookMountCount = 0
 
 export type NotebookProps = NotebookLogicProps & {
     initialAutofocus?: EditorFocusPosition
@@ -116,6 +120,22 @@ export function Notebook({
     }, [size]) // oxlint-disable-line exhaustive-deps
 
     const isMarkdownNotebook = isMarkdownNotebookContent(content)
+
+    // Marker class replacing `body:has(.Notebook--markdown-v2)` in Notebook.scss: a near-root
+    // `:has()` anchor makes every DOM class change cost a whole-document style recalc in Blink
+    useLayoutEffect(() => {
+        if (!isMarkdownNotebook) {
+            return
+        }
+        if (++markdownNotebookMountCount === 1) {
+            document.body.classList.add('has-markdown-v2-notebook')
+        }
+        return () => {
+            if (--markdownNotebookMountCount === 0) {
+                document.body.classList.remove('has-markdown-v2-notebook')
+            }
+        }
+    }, [isMarkdownNotebook])
     const isContentWidthExpanded = isMarkdownNotebook ? isMarkdownExpanded : isExpanded
     const canUpgradeToMarkdownNotebooks = !!featureFlags[FEATURE_FLAGS.MARKDOWN_NOTEBOOKS]
     const upgradeToMarkdownNotebook = (): void => {


### PR DESCRIPTION
## Problem

Typing in the PostHog AI composer on large threads (~20k DOM elements) lags at 200-350ms per keystroke, and #69399 (cutting per-keystroke React/layout work) didn't fix it.

Root cause, confirmed on a live production thread by CSS bisection and a Local Override A/B test: the markdown notebook background rules anchor `:has(.Notebook--markdown-v2)` on `body`, `.Navigation3000`, and `.main-content-container` (introduced in #61781). Evaluating these near-root `:has()` selectors makes Blink stamp its sticky affected-by-`:has` flags across essentially the whole document. Once armed, **any** class attribute change anywhere on the page triggers a full-document style recalc, even for a class no stylesheet references. On the affected thread a single `classList.add('__probe')` on the composer's submit button measured 215ms, and every keystroke pays that (button state flips, transition classes) as a synchronous recalc inside the input event.

With only these two rule blocks stripped from the bundle at page load (DevTools Local Override, same page, same thread), the identical class mutation costs 0-1ms and typing is smooth.

## Changes

- `Notebook.tsx` toggles a `has-markdown-v2-notebook` marker class on `<body>` (in a layout effect, mount-counted so overlapping notebook instances don't stomp each other) whenever a markdown-v2 notebook is rendered.
- `Notebook.scss` anchors the page background rules on that marker class instead of `:has()`. Selector targets and cascade order are unchanged (`body`, `.Navigation3000`, `.main-content-container > main`, plus the `[theme='dark']` variants, which live on `body`).

Visual behavior is identical, the invalidation cost is not.

> [!NOTE]
> Please don't reintroduce `:has()` anchored at or near the document root. Component-scoped `:has()` (small anchor subtree) is fine. One more near-root anchor exists in `CodeEditorImpl.scss` (`body:has(.monaco-editor .find-widget.visible)`), which arms the same pathology on any page that loads Monaco CSS. Follow-up PR coming for that one, since replacing it needs a JS hook into the find widget state.

## How did you test this code?

- Verified the mechanism empirically on the affected production thread: probe-measured forced style flush after each mutation type (class change 215ms, everything else ~0ms), runtime stylesheet bisection, and a Local Override with exactly these two rule blocks removed at page load, which brought the probe to 0-1ms and made typing smooth.
- Verified light/dark selector specificity relationships match the originals (each dark variant still beats its light counterpart).
- oxlint on changed files; CI covers typecheck/tests. I have not manually re-tested notebook visuals across all mount surfaces (scene, side panel, canvas) - screenshots/CI storybook diffs should cover the background styling.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during a live debugging session of the Max AI typing lag. The investigation went through several refuted hypotheses (React DevTools extension overhead, per-second timer re-renders, textarea autosize DOM churn) before converging via in-page probes: a MutationObserver census, a forced-flush timing probe per mutation type, an automated runtime CSS bisect, and finally a Local Override A/B on the production bundle that isolated these two rule blocks as the sole trigger. The body-class approach was chosen over restructuring the selectors because no `:has()`-free selector can express "ancestor of a future descendant" and the component already knows when it renders markdown-v2.
