### PR TITLE
fix(tracing): remove broken span message search from filter bar

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1093,19 +1093,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                                       ...endpointFilters,
                                   }).url
                                 : undefined,
-                        localItemsSearch: (items: any[], q: string): any[] => {
-                            if (!q) {
-                                return items
-                            }
-                            return [
-                                {
-                                    key: 'message',
-                                    name: 'Search span message for "' + q + '"',
-                                    value: q,
-                                    propertyFilterType: 'span',
-                                },
-                            ].concat(items.filter((item) => item.name?.toLowerCase().includes(q.toLowerCase())))
-                        },
                         getName: (option: { key: string; name: string }) => option.name,
                         getValue: (option: { key: string; name: string }) => option.key,
                         getPopoverHeader: () => 'Span attributes',

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -599,19 +599,6 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
                           ...endpointFilters,
                       }).url
                     : undefined,
-            localItemsSearch: (items: any[], q: string): any[] => {
-                if (!q) {
-                    return items
-                }
-                return [
-                    {
-                        key: 'message',
-                        name: 'Search span message for "' + q + '"',
-                        value: q,
-                        propertyFilterType: 'span',
-                    },
-                ].concat(items.filter((item) => item.name?.toLowerCase().includes(q.toLowerCase())))
-            },
             getName: (option: { key: string; name: string }) => option.name,
             getValue: (option: { key: string; name: string }) => option.key,
             getPopoverHeader: () => 'Span attributes',


### PR DESCRIPTION
## Problem

The tracing filter bar reused the logs "search message" pattern. In the **Spans** taxonomic group, typing a query injected a synthetic top-of-list option `Search span message for "X"` hardcoded to `key: 'message'` / `propertyFilterType: 'span'`. Spans have no `message` attribute (only `name`, `kind`, `duration`, `trace_id`, `span_id`, `status_code`), so selecting it built an invalid `message` span filter — which produced a flood of backend errors.

This was inherited when tracing got its logs-style frontend; the logs version is valid because logs genuinely have a `message` field.

## Changes

Remove the `localItemsSearch` synthetic option from the Spans group. The TaxonomicFilter has parallel legacy and rebuild data layers, so the removal lands in both to keep the experiment arms consistent:

- `frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx` (legacy)
- `frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx` (rebuild)

With `localItemsSearch` gone, the Spans list falls back to the default Fuse fuzzy-search over the real static options, so those still filter by typed text — only the broken synthetic item disappears. No change to `TracingFilterBar.tsx` (its `onChange` handles synthetic items generically) and no backend change. The **Logs** group is untouched.

## How did you test this code?

I'm an agent (PostHog Code), directed by a human. Automated checks I actually ran:

- `hogli test frontend/src/lib/components/TaxonomicFilter/` — 495 tests pass.
- Confirmed via grep that only these two files referenced `Search span message`, and no test referenced it.

I did **not** run the manual dev-app check. Suggested manual verification: on `/tracing`, type in the filter search box and confirm no `Search span message for "X"` row appears, real span attributes still filter by typed text, and no `message` span filter / error flood is produced; sanity-check the logs filter bar still shows `Search log message for "X"`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @frankh to remove the broken tracing "search message" filter option. Invoked the `/modifying-taxonomic-filter` skill, which surfaced that the Spans group is defined in two parallel data layers (legacy `taxonomicFilterLogic.tsx` and rebuild `buildTaxonomicGroups.tsx`) — both had to be edited so the legacy/rebuild experiment arms don't diverge. Chose to fully remove `localItemsSearch` (rather than patch the synthetic item) so the list cleanly falls back to the existing fuzzy-search path over the real span options.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
