### PR TITLE
fix(monaco): replace body:has() find widget anchor with body marker class

### DIFF
--- a/frontend/src/lib/monaco/CodeEditorImpl.scss
+++ b/frontend/src/lib/monaco/CodeEditorImpl.scss
@@ -20,7 +20,10 @@
 // to overlap the button. Force a single-row layout so the tooltip stays
 // short and clear of the button. Scoped to when the find widget is open so
 // tooltips on other action bars are unaffected.
-body:has(.monaco-editor .find-widget.visible) .workbench-hover-container {
+// `.has-monaco-find-widget-open` is toggled on <body> by findWidgetBodyClass.ts and stands in
+// for `body:has(.monaco-editor .find-widget.visible)`. Do not reintroduce near-root `:has()`
+// anchors: they make any class change anywhere cost a full-document style recalc.
+body.has-monaco-find-widget-open .workbench-hover-container {
     pointer-events: none !important;
 
     &,

--- a/frontend/src/lib/monaco/CodeEditorImpl.tsx
+++ b/frontend/src/lib/monaco/CodeEditorImpl.tsx
@@ -13,6 +13,7 @@ import { Spinner } from 'lib/lemon-ui/Spinner'
 import { codeEditorLogic } from 'lib/monaco/codeEditorLogic'
 import { codeEditorLogicType } from 'lib/monaco/codeEditorLogicType'
 import { findNextFocusableElement, findPreviousFocusableElement } from 'lib/monaco/domUtils'
+import { trackFindWidgetVisibility } from 'lib/monaco/findWidgetBodyClass'
 import { initCodeownersLanguage } from 'lib/monaco/languages/codeowners'
 import { initHogLanguage } from 'lib/monaco/languages/hog'
 import { initHogJsonLanguage } from 'lib/monaco/languages/hogJson'
@@ -416,6 +417,7 @@ export function CodeEditor({
         setMonacoAndEditor([monaco, editor])
         initEditor(monaco, editor, editorProps, options ?? {}, builtCodeEditorLogic)
         remeasureFontsWhenReady(monaco)
+        monacoDisposables.current.push(trackFindWidgetVisibility(editor))
 
         // Override Monaco's suggestion widget styling to prevent truncation
         const styleId = 'monaco-suggestion-widget-fix'
@@ -525,6 +527,8 @@ export function CodeEditor({
             editorRef.current = modifiedEditor
             diffEditorRef.current = diff
             trackEditorModels(modifiedEditor, monaco)
+            monacoDisposables.current.push(trackFindWidgetVisibility(modifiedEditor))
+            monacoDisposables.current.push(trackFindWidgetVisibility(diff.getOriginalEditor()))
             const original = diff.getOriginalEditor().getModel()
             if (original) {
                 editorModelsRef.current.add(original)

--- a/frontend/src/lib/monaco/findWidgetBodyClass.ts
+++ b/frontend/src/lib/monaco/findWidgetBodyClass.ts
@@ -20,11 +20,11 @@ interface FindControllerLike extends importedEditor.IEditorContribution {
 
 export function trackFindWidgetVisibility(codeEditor: importedEditor.IStandaloneCodeEditor): IDisposable {
     const findController = codeEditor.getContribution<FindControllerLike>('editor.contrib.findController')
-    if (!findController || typeof findController.getState !== 'function') {
+    const state = typeof findController?.getState === 'function' ? findController.getState() : null
+    if (!state || typeof state.onFindReplaceStateChange !== 'function') {
         // Internal contribution shape changed: degrade to the tooltip flicker workaround not applying
         return { dispose: () => {} }
     }
-    const state = findController.getState()
     let revealed = false
     const setRevealed = (nextRevealed: boolean): void => {
         if (nextRevealed === revealed) {

--- a/frontend/src/lib/monaco/findWidgetBodyClass.ts
+++ b/frontend/src/lib/monaco/findWidgetBodyClass.ts
@@ -1,0 +1,50 @@
+import { IDisposable, editor as importedEditor } from 'monaco-editor'
+
+// Mirrors the find widget's visibility onto <body> so CodeEditorImpl.scss can style Monaco's
+// body-level hover tooltips without a `body:has()` anchor. Near-root `:has()` selectors make
+// Blink flag the whole document as :has-invalidation-suspect at load, after which any class
+// change anywhere costs a full-document style recalc (see the same pattern in Notebook.scss).
+const FIND_WIDGET_OPEN_BODY_CLASS = 'has-monaco-find-widget-open'
+
+// Counts editors with an open find widget, so the body class survives multiple editors
+let openFindWidgetCount = 0
+
+interface FindReplaceStateLike {
+    readonly isRevealed: boolean
+    onFindReplaceStateChange(listener: (event: { isRevealed: boolean }) => void): IDisposable
+}
+
+interface FindControllerLike extends importedEditor.IEditorContribution {
+    getState(): FindReplaceStateLike
+}
+
+export function trackFindWidgetVisibility(codeEditor: importedEditor.IStandaloneCodeEditor): IDisposable {
+    const findController = codeEditor.getContribution<FindControllerLike>('editor.contrib.findController')
+    if (!findController || typeof findController.getState !== 'function') {
+        // Internal contribution shape changed: degrade to the tooltip flicker workaround not applying
+        return { dispose: () => {} }
+    }
+    const state = findController.getState()
+    let revealed = false
+    const setRevealed = (nextRevealed: boolean): void => {
+        if (nextRevealed === revealed) {
+            return
+        }
+        revealed = nextRevealed
+        openFindWidgetCount += revealed ? 1 : -1
+        document.body.classList.toggle(FIND_WIDGET_OPEN_BODY_CLASS, openFindWidgetCount > 0)
+    }
+    setRevealed(state.isRevealed)
+    const listener = state.onFindReplaceStateChange((event) => {
+        // The event carries change flags per field, the current value lives on the state
+        if (event.isRevealed) {
+            setRevealed(state.isRevealed)
+        }
+    })
+    return {
+        dispose: () => {
+            listener.dispose()
+            setRevealed(false)
+        },
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up to #69733. A bundle-wide scan of the shipped `index-*.css` found exactly one remaining near-root `:has()` anchor: `body:has(.monaco-editor .find-widget.visible)` in `CodeEditorImpl.scss` (the find widget tooltip flicker workaround for microsoft/monaco-editor#5208).

Because it ships in the main bundle, it arms the same pathology as the notebook rules on **every** page, regardless of whether an editor or the find widget is ever shown: evaluating a near-root `:has()` at load makes Blink stamp sticky affected-by-`:has` flags across the document, after which any class attribute change anywhere costs a full-document style recalc (~215ms measured on a ~20k-element page in the #69733 investigation).

## Changes

- New `findWidgetBodyClass.ts`: hooks Monaco's find controller state (`editor.contrib.findController`) per editor and mirrors find widget visibility onto a `has-monaco-find-widget-open` class on `<body>`, mount-counted across editors. Degrades to a no-op (workaround simply not applying) if Monaco's internal contribution shape ever changes.
- `CodeEditorImpl.tsx` registers the tracker in both the regular editor and diff editor mount paths (both panes of a diff), disposed with the existing `monacoDisposables`.
- `CodeEditorImpl.scss` anchors the tooltip workaround on the body class instead of `body:has()`. Styling behavior is unchanged.

> [!NOTE]
> With this and #69733, the shipped bundle has zero near-root `:has()` anchors (114 remaining `:has()` uses are all component-scoped, which is fine). Please don't reintroduce `body:has()` / `:root:has()`-style selectors.

## How did you test this code?

- oxlint on the changed files; CI covers typecheck.
- I (the agent) did not manually exercise the find widget tooltip flicker scenario. The behavior change to verify manually: open a SQL/Hog editor, press Cmd+F, hover the find widget's action buttons, and confirm the tooltip still renders one-row and click-through (and that `has-monaco-find-widget-open` appears on `<body>` while the widget is open).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as the promised follow-up from the #69733 typing lag investigation, prompted by the question of whether more `body:has()` anchors existed. The inventory came from scanning the actual shipped production CSS bundle (127 `:has()` selectors, 114 component-scoped, only notebook + this one near-root). The JS hook into find controller state was chosen over a MutationObserver on `.find-widget` class changes to avoid adding another document-wide observer.