### PR TITLE
fix(data-warehouse): surface the real error behind 'Failed to retrieve types for view'

### DIFF
--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -453,7 +453,9 @@ class DataWarehouseSavedQuerySerializer(
                     view.columns = columns
 
                 view.external_tables = view.s3_tables
-            except Exception:
+            except Exception as e:
+                capture_exception(e)
+                logger.exception("Failed to retrieve types for view %s", view.name)
                 raise serializers.ValidationError("Failed to retrieve types for view")
 
         with transaction.atomic():
@@ -594,7 +596,9 @@ class DataWarehouseSavedQuerySerializer(
                     view.external_tables = view.s3_tables
                 except RecursionError:
                     raise serializers.ValidationError("Model contains a cycle")
-                except Exception:
+                except Exception as e:
+                    capture_exception(e)
+                    logger.exception("Failed to retrieve types for view %s", view.name)
                     raise serializers.ValidationError("Failed to retrieve types for view")
 
                 view.status = DataWarehouseSavedQuery.Status.MODIFIED


### PR DESCRIPTION
## Problem

Creating or updating a data-warehouse saved view can fail with a generic `Failed to retrieve types for view` and nothing else - no underlying error, no Sentry event, no log line. The real cause is discarded, so the failure is undiagnosable.

This surfaced from a papercut: view create/update intermittently fails this way for views reading a Postgres-mirror external table, while `execute-sql` against the same tables works fine. I traced the create/update flow: it runs two things in the `try` - `view.get_columns()` (which executes the query, same path as `execute-sql`) and `view.external_tables = view.s3_tables` (a static `resolve_types` pass that runs unconditionally). Since execution works, the failure is almost certainly the static resolution pass. But I couldn't confirm the exact throw, because the handler throws the original exception away:

```python
except Exception:
    raise serializers.ValidationError("Failed to retrieve types for view")
```

## Changes

Capture and log the original exception before raising the generic message, in both the `create` and `update` handlers. This matches the `setup_model_paths` handler a few lines below, which already does `capture_exception(e); logger.exception(...)`.

```diff
-            except Exception:
+            except Exception as e:
+                capture_exception(e)
+                logger.exception("Failed to retrieve types for view %s", view.name)
                 raise serializers.ValidationError("Failed to retrieve types for view")
```

> [!NOTE]
> This does not fix the underlying Postgres-mirror resolution failure - it makes it diagnosable. The next occurrence will land in Sentry with the real stack trace, which is what's needed to fix the root cause properly. I deliberately did not blind-patch the `resolve_types` path I haven't reproduced.

User-facing behavior is unchanged: the same `ValidationError` with the same message is still returned. The only new behavior is the capture/log side effect.

## How did you test this code?

No new automated test. The observable behavior through the public interface (the `ValidationError` and its message) is unchanged, and the only new behavior is the capture/log side effect - asserting a mock was called would be a change-detector test with no real regression to catch, which the repo's `/writing-tests` gate says not to add. There are no existing tests asserting on this error path, so nothing regresses.

I confirmed the file lints clean and passes the `ty` typecheck via the pre-push hooks. I did not run the app end-to-end for this change - it's an error-logging edit with no runtime surface to drive beyond what the type check and lint already cover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8) did the investigation and the fix, directed by me, as one item from a HogQL/SQL papercut triage. It traced the create/update flow to isolate the failing static `resolve_types` pass from the working query-execution path, then found that the bare `except` was discarding the real error - which is why the papercut was undiagnosable in the first place.

Skills invoked: `/improving-drf-endpoints` (mandatory before touching a serializer; its checklist is about field typing and schema annotations, none of which this error-logging change affects) and `/writing-tests` (which is why there's no new test - the change has no observable-behavior delta to assert on).

Decision: fix the masking now rather than blind-patch the underlying Postgres-mirror resolution failure I could not reproduce. Making the error diagnosable is the safe, immediately useful step and is the prerequisite for fixing the root cause with a real stack trace.
