### PR TITLE
fix(ingestion): guard BatchingPipeline against empty feeds

### DIFF
--- a/.agents/skills/ingestion-pipeline-doctor-nodejs/SKILL.md
+++ b/.agents/skills/ingestion-pipeline-doctor-nodejs/SKILL.md
@@ -60,6 +60,8 @@ See `nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts` for 
 
 **Composition**: `messageAware` wraps the pipeline. `handleResults` inside `messageAware`. `handleSideEffects` after. `concurrentlyPerGroup` for per-entity work. `gather` before batch steps.
 
+**Batching lifecycle hooks** (`BatchingPipeline` beforeBatch/afterBatch): enrich-only. Hooks may enrich elements and batch context but must return exactly the elements they received — a count change is a broken invariant and `feed()` throws. Filtering belongs in sub-pipeline steps that return `drop()`. An empty `feed()` is a no-op (no hooks, no capacity). Details: `nodejs/src/ingestion/framework/docs/14-batching.test.ts`.
+
 **Testing**: Step tests call factory directly. Use `consumeAll()`/`collectBatches()` helpers. Fake timers for async. Type guards for result assertions. No `any`.
 
 ## Running all doctors

--- a/nodejs/src/ingestion/framework/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/batching-pipeline.test.ts
@@ -379,20 +379,19 @@ describe('BatchingPipeline', () => {
 
         // beforeBatch must preserve the element count; a shrunken batch (worst
         // case zero elements) could never complete and would leak its slot.
-        it('rejects a beforeBatch that changes the element count without leaking a capacity slot', async () => {
+        // A count change is a broken framework invariant, so feed() throws.
+        it('throws when beforeBatch changes the element count, without registering state', async () => {
             beforeBatchStep.mockImplementationOnce(({ elements, batchContext }: any) =>
                 Promise.resolve(ok({ elements: elements.slice(1), batchContext }))
             )
             const collector = createCollector({ concurrentBatches: 1 })
 
-            expect(await collector.feed(makeBatch([1, 2]))).toEqual({
-                ok: false,
-                kind: 'before_batch_failed',
-                reason: expect.stringContaining('changed element count (2 -> 1)'),
-            })
+            await expect(collector.feed(makeBatch([1, 2]))).rejects.toThrow('changed element count (2 -> 1)')
             expect(await collector.next()).toBeNull()
 
-            // Nothing was registered: a subsequent normal batch is accepted and processed.
+            // Nothing was registered before the throw: a subsequent normal batch
+            // is accepted and processed (real drivers crash on the throw; this
+            // documents that the throw itself does not corrupt state).
             expect(await collector.feed(makeBatch([9]))).toEqual({ ok: true })
             const { allResults } = await drainAll(collector)
             expect(allResults).toHaveLength(1)

--- a/nodejs/src/ingestion/framework/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/batching-pipeline.test.ts
@@ -358,30 +358,41 @@ describe('BatchingPipeline', () => {
         })
     })
 
-    describe('empty batches', () => {
-        // An empty batch — fed empty, or mapped to empty by beforeBatch — used to
-        // register an un-completable batch: next() then threw the "null with N
-        // in-flight batches" corruption guard, and the phantom batch permanently
-        // occupied a concurrentBatches slot so every later feed() was rejected.
-        it.each([
-            ['fed empty', () => {}, [] as number[]],
-            [
-                'mapped to empty by beforeBatch',
-                () =>
-                    beforeBatchStep.mockImplementationOnce(({ batchContext }: any) =>
-                        Promise.resolve(ok({ elements: [], batchContext }))
-                    ),
-                [1, 2],
-            ],
-        ])('%s does not wedge next() or leak a capacity slot', async (_name, setup, offsets) => {
-            setup()
+    describe('empty and count-changing batches', () => {
+        // An empty feed used to register an un-completable batch: next() then
+        // threw the "null with N in-flight batches" corruption guard, and the
+        // phantom batch permanently occupied a concurrentBatches slot so every
+        // later feed() was rejected.
+        it('empty feed is a no-op that skips hooks and does not leak a capacity slot', async () => {
             const collector = createCollector({ concurrentBatches: 1 })
 
-            expect(await collector.feed(makeBatch(offsets))).toEqual({ ok: true })
+            expect(await collector.feed([])).toEqual({ ok: true })
+            expect(beforeBatchStep).not.toHaveBeenCalled()
             expect(await collector.next()).toBeNull()
-            expect(afterBatchStep).not.toHaveBeenCalled()
 
             // The slot was not leaked: a subsequent normal batch is accepted and processed.
+            expect(await collector.feed(makeBatch([9]))).toEqual({ ok: true })
+            const { allResults } = await drainAll(collector)
+            expect(allResults).toHaveLength(1)
+            expect(afterBatchStep).toHaveBeenCalledTimes(1)
+        })
+
+        // beforeBatch must preserve the element count; a shrunken batch (worst
+        // case zero elements) could never complete and would leak its slot.
+        it('rejects a beforeBatch that changes the element count without leaking a capacity slot', async () => {
+            beforeBatchStep.mockImplementationOnce(({ elements, batchContext }: any) =>
+                Promise.resolve(ok({ elements: elements.slice(1), batchContext }))
+            )
+            const collector = createCollector({ concurrentBatches: 1 })
+
+            expect(await collector.feed(makeBatch([1, 2]))).toEqual({
+                ok: false,
+                kind: 'before_batch_failed',
+                reason: expect.stringContaining('changed element count (2 -> 1)'),
+            })
+            expect(await collector.next()).toBeNull()
+
+            // Nothing was registered: a subsequent normal batch is accepted and processed.
             expect(await collector.feed(makeBatch([9]))).toEqual({ ok: true })
             const { allResults } = await drainAll(collector)
             expect(allResults).toHaveLength(1)

--- a/nodejs/src/ingestion/framework/batching-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/batching-pipeline.test.ts
@@ -358,6 +358,37 @@ describe('BatchingPipeline', () => {
         })
     })
 
+    describe('empty batches', () => {
+        // An empty batch — fed empty, or mapped to empty by beforeBatch — used to
+        // register an un-completable batch: next() then threw the "null with N
+        // in-flight batches" corruption guard, and the phantom batch permanently
+        // occupied a concurrentBatches slot so every later feed() was rejected.
+        it.each([
+            ['fed empty', () => {}, [] as number[]],
+            [
+                'mapped to empty by beforeBatch',
+                () =>
+                    beforeBatchStep.mockImplementationOnce(({ batchContext }: any) =>
+                        Promise.resolve(ok({ elements: [], batchContext }))
+                    ),
+                [1, 2],
+            ],
+        ])('%s does not wedge next() or leak a capacity slot', async (_name, setup, offsets) => {
+            setup()
+            const collector = createCollector({ concurrentBatches: 1 })
+
+            expect(await collector.feed(makeBatch(offsets))).toEqual({ ok: true })
+            expect(await collector.next()).toBeNull()
+            expect(afterBatchStep).not.toHaveBeenCalled()
+
+            // The slot was not leaked: a subsequent normal batch is accepted and processed.
+            expect(await collector.feed(makeBatch([9]))).toEqual({ ok: true })
+            const { allResults } = await drainAll(collector)
+            expect(allResults).toHaveLength(1)
+            expect(afterBatchStep).toHaveBeenCalledTimes(1)
+        })
+    })
+
     describe('concurrentBatches', () => {
         it('feed() rejects with reason when at limit (default concurrentBatches: 1)', async () => {
             const collector = createCollector({ concurrentBatches: 1 })

--- a/nodejs/src/ingestion/framework/batching-pipeline.ts
+++ b/nodejs/src/ingestion/framework/batching-pipeline.ts
@@ -18,6 +18,12 @@ export interface BeforeBatchInput<TInput, CInput, CBatch = Record<never, object>
     batchContext: { batchId: number } & CBatch
 }
 
+/**
+ * What a beforeBatch pipeline produces. Hooks may enrich elements (values or
+ * contexts) and the batch context, but must return exactly as many elements as
+ * they received — batch completion tracking counts messages, so a changed
+ * element count is a contract violation and the feed is rejected.
+ */
 export interface BeforeBatchOutput<TInput, CInput, CBatch> {
     elements: OkResultWithContext<TInput, CInput>[]
     batchContext: CBatch & { batchId: number }
@@ -79,8 +85,11 @@ interface TrackedBatch<TOutput, CBatch, COutput, R extends string = never> {
  * the collector matches them to their batch and fires hooks.
  *
  * Lifecycle:
- * - feed() runs beforeBatch which returns mapped elements and side effects.
- *   Elements are tagged with messageId, then fed to the sub-pipeline.
+ * - feed() with zero elements is a no-op that returns ok — no batch is
+ *   registered and no hooks run (a zero-message batch could never complete).
+ * - feed() runs beforeBatch which returns enriched elements (same count as
+ *   fed — count changes are rejected) and side effects. Elements are tagged
+ *   with messageId, then fed to the sub-pipeline.
  * - next() collects results. When all messages in a batch complete, calls
  *   afterBatch with the batchContext and ordered results, then returns a
  *   BatchResult with concatenated side effects.
@@ -163,6 +172,16 @@ export class BatchingPipeline<
     }
 
     private async feedSerialized(elements: OkResultWithContext<TInput, CInput>[]): Promise<FeedResult> {
+        // An empty feed has no messages that could ever complete a batch:
+        // completion is only detected in pump()'s result loop, so registering a
+        // zero-message batch would occupy a concurrentBatches slot forever and
+        // trip the "null with N in-flight batches" corruption guard on the next
+        // pull. Skip it entirely — no batchId consumed, no hooks run, nothing
+        // registered — so there are no side effects to surface either.
+        if (elements.length === 0) {
+            return { ok: true }
+        }
+
         if (this.batches.size >= this.options.concurrentBatches) {
             return {
                 ok: false,
@@ -187,20 +206,16 @@ export class BatchingPipeline<
         const { elements: mappedElements, batchContext } = beforeResult.result.value
         const beforeSideEffects = beforeResult.context.sideEffects
 
-        // A batch with zero elements — fed empty, or mapped to empty by beforeBatch —
-        // has no messages that could ever complete it. Registering it would occupy a
-        // concurrentBatches slot forever, and once the sub-pipeline drains it would
-        // trip the "null with N in-flight batches" corruption guard in pump(). So never
-        // register it: no batches.set, no capacity consumption, no subPipeline.feed, and
-        // no feedEpoch bump (nothing is buffered for a racing pull to pick up).
-        // beforeBatch may still have produced side effects; surface them as an
-        // empty-elements result so next() drains them instead of dropping them silently.
-        // With no side effects there is nothing to emit and next() stays null.
-        if (mappedElements.length === 0) {
-            if (beforeSideEffects.length > 0) {
-                this.completedResults.push({ elements: [], sideEffects: beforeSideEffects })
+        // beforeBatch may enrich elements and batch context but must not change
+        // the element count: a shrunken batch (worst case zero elements) could
+        // never complete and would leak its concurrentBatches slot forever. A
+        // count change is a contract violation, so reject the feed loudly.
+        if (mappedElements.length !== elements.length) {
+            return {
+                ok: false,
+                kind: 'before_batch_failed',
+                reason: `beforeBatch changed element count (${elements.length} -> ${mappedElements.length}) for batch ${batchId}`,
             }
-            return { ok: true }
         }
 
         const messageIds: number[] = []

--- a/nodejs/src/ingestion/framework/batching-pipeline.ts
+++ b/nodejs/src/ingestion/framework/batching-pipeline.ts
@@ -187,6 +187,22 @@ export class BatchingPipeline<
         const { elements: mappedElements, batchContext } = beforeResult.result.value
         const beforeSideEffects = beforeResult.context.sideEffects
 
+        // A batch with zero elements — fed empty, or mapped to empty by beforeBatch —
+        // has no messages that could ever complete it. Registering it would occupy a
+        // concurrentBatches slot forever, and once the sub-pipeline drains it would
+        // trip the "null with N in-flight batches" corruption guard in pump(). So never
+        // register it: no batches.set, no capacity consumption, no subPipeline.feed, and
+        // no feedEpoch bump (nothing is buffered for a racing pull to pick up).
+        // beforeBatch may still have produced side effects; surface them as an
+        // empty-elements result so next() drains them instead of dropping them silently.
+        // With no side effects there is nothing to emit and next() stays null.
+        if (mappedElements.length === 0) {
+            if (beforeSideEffects.length > 0) {
+                this.completedResults.push({ elements: [], sideEffects: beforeSideEffects })
+            }
+            return { ok: true }
+        }
+
         const messageIds: number[] = []
         const inflight = new Set<number>()
 

--- a/nodejs/src/ingestion/framework/batching-pipeline.ts
+++ b/nodejs/src/ingestion/framework/batching-pipeline.ts
@@ -22,7 +22,7 @@ export interface BeforeBatchInput<TInput, CInput, CBatch = Record<never, object>
  * What a beforeBatch pipeline produces. Hooks may enrich elements (values or
  * contexts) and the batch context, but must return exactly as many elements as
  * they received — batch completion tracking counts messages, so a changed
- * element count is a contract violation and the feed is rejected.
+ * element count is a broken framework invariant and feed() throws.
  */
 export interface BeforeBatchOutput<TInput, CInput, CBatch> {
     elements: OkResultWithContext<TInput, CInput>[]
@@ -88,8 +88,8 @@ interface TrackedBatch<TOutput, CBatch, COutput, R extends string = never> {
  * - feed() with zero elements is a no-op that returns ok — no batch is
  *   registered and no hooks run (a zero-message batch could never complete).
  * - feed() runs beforeBatch which returns enriched elements (same count as
- *   fed — count changes are rejected) and side effects. Elements are tagged
- *   with messageId, then fed to the sub-pipeline.
+ *   fed — count changes throw) and side effects. Elements are tagged with
+ *   messageId, then fed to the sub-pipeline.
  * - next() collects results. When all messages in a batch complete, calls
  *   afterBatch with the batchContext and ordered results, then returns a
  *   BatchResult with concatenated side effects.
@@ -208,14 +208,15 @@ export class BatchingPipeline<
 
         // beforeBatch may enrich elements and batch context but must not change
         // the element count: a shrunken batch (worst case zero elements) could
-        // never complete and would leak its concurrentBatches slot forever. A
-        // count change is a contract violation, so reject the feed loudly.
+        // never complete and would leak its concurrentBatches slot forever.
+        // That's a broken framework invariant, not an outcome a driver may
+        // handle, so throw instead of returning a FeedResult — mirroring
+        // BaseBatchPipeline's count-mismatch throw for batch steps. Nothing has
+        // been registered yet, so the throw leaves no phantom batch behind.
         if (mappedElements.length !== elements.length) {
-            return {
-                ok: false,
-                kind: 'before_batch_failed',
-                reason: `beforeBatch changed element count (${elements.length} -> ${mappedElements.length}) for batch ${batchId}`,
-            }
+            throw new Error(
+                `batching_pipeline beforeBatch changed element count (${elements.length} -> ${mappedElements.length}) for batch ${batchId}`
+            )
         }
 
         const messageIds: number[] = []

--- a/nodejs/src/ingestion/framework/docs/14-batching.test.ts
+++ b/nodejs/src/ingestion/framework/docs/14-batching.test.ts
@@ -15,6 +15,9 @@
  * - **`beforeBatch`** runs once per batch before its items enter the
  *   sub-pipeline. It receives the batch's elements and a `batchContext`, and
  *   can enrich both (e.g. attach a shared store) for the whole batch.
+ *   Enrich only: it must return exactly the elements it received (same
+ *   count). Filtering belongs in sub-pipeline steps that return `drop()`
+ *   results - a count-changing hook throws (see below).
  * - **`callback`** builds the per-item sub-pipeline (the same builder DSL as
  *   the other chapters).
  * - **`afterBatch`** runs once per batch after all its items exit, receiving
@@ -41,6 +44,21 @@
  * once. When the pipeline is at capacity, `feed()` returns
  * `{ ok: false, kind: 'at_capacity' }` instead of accepting the batch -
  * the caller must drain a batch (via `next()`) to free a slot before retrying.
+ *
+ * ## The lifecycle hooks contract
+ *
+ * Batch completion is tracked by counting messages, so a batch's element
+ * count is load-bearing:
+ *
+ * - **An empty `feed()` is a no-op.** It returns `{ ok: true }` without
+ *   running hooks, consuming a batchId, or occupying a capacity slot - a
+ *   zero-message batch could never complete.
+ * - **`beforeBatch` must preserve the element count.** A hook that returns
+ *   fewer (or more) elements than it received breaks completion tracking:
+ *   the batch could never complete and would leak its capacity slot. That is
+ *   a logic error in the hook, so `feed()` throws rather than returning a
+ *   `FeedResult`. To discard items, use sub-pipeline steps that return
+ *   `drop()` results (chapter 7) - dropped items still count as completed.
  */
 import { newBatchingPipeline } from '~/ingestion/framework/builders'
 import { createOkContext } from '~/ingestion/framework/helpers'
@@ -163,5 +181,62 @@ describe('Batching Pipelines', () => {
 
         // Now a new batch is accepted again
         expect(await pipeline.feed([{ id: 3 }].map((e) => createOkContext(e, {})))).toEqual({ ok: true })
+    })
+
+    /**
+     * An empty feed() is a no-op: it is accepted, but no batch exists - hooks
+     * do not run, no batchId or capacity slot is consumed, and next() has
+     * nothing to return.
+     */
+    it('an empty feed() is a no-op that runs no hooks and consumes no capacity', async () => {
+        let beforeBatchRan = false
+
+        const pipeline = newBatchingPipeline<Event, Event, NoCtx>(
+            (builder) =>
+                builder.pipe(function recordingBefore(input) {
+                    beforeBatchRan = true
+                    return Promise.resolve(ok({ elements: input.elements, batchContext: input.batchContext }))
+                }),
+            (builder) => builder,
+            (builder) =>
+                builder.pipe(function passThroughAfter(input) {
+                    return Promise.resolve(ok(input))
+                }),
+            { concurrentBatches: 1 }
+        )
+
+        expect(await pipeline.feed([])).toEqual({ ok: true })
+        expect(beforeBatchRan).toBe(false)
+        expect(await pipeline.next()).toBeNull()
+
+        // No capacity was consumed: a real batch still fits in the single slot
+        expect(await pipeline.feed([{ id: 1 }].map((e) => createOkContext(e, {})))).toEqual({ ok: true })
+        expect(await pipeline.next()).not.toBeNull()
+    })
+
+    /**
+     * beforeBatch is enrich-only: it must return exactly the elements it
+     * received. Returning a different count is a logic error - feed() throws.
+     * To discard items, use sub-pipeline steps that return drop() results
+     * instead; dropped items still count toward batch completion.
+     */
+    it('a beforeBatch that changes the element count throws', async () => {
+        const pipeline = newBatchingPipeline<Event, Event, NoCtx>(
+            (builder) =>
+                builder.pipe(function filteringBefore(input) {
+                    // Wrong: hooks must not filter elements
+                    return Promise.resolve(ok({ elements: input.elements.slice(1), batchContext: input.batchContext }))
+                }),
+            (builder) => builder,
+            (builder) =>
+                builder.pipe(function passThroughAfter(input) {
+                    return Promise.resolve(ok(input))
+                }),
+            { concurrentBatches: 1 }
+        )
+
+        await expect(pipeline.feed([{ id: 1 }, { id: 2 }].map((e) => createOkContext(e, {})))).rejects.toThrow(
+            'changed element count (2 -> 1)'
+        )
     })
 })


### PR DESCRIPTION
## Problem

`BatchingPipeline` wedges permanently on an empty feed.

`feedSerialized` with zero elements still assigned a `batchId` and registered a batch whose `inflight` set was empty.
Batch completion is only checked inside the result loop of `pump()`, which runs when a message result arrives.
A zero-message batch produces no results, so it can never complete.

Two things then break:

- The next `next()` trips the corruption guard and throws `sub-pipeline returned null with N in-flight batches and 0 in-flight messages`.
- The phantom batch permanently occupies a `concurrentBatches` capacity slot, so every later `feed()` is rejected `at_capacity`.

Reachability: the ingestion API server 400s empty request bodies, but the Kafka consumer path (`runIngestionPipeline`) has no such guard.
It is currently protected only by the consumer wrapper skipping empty polls when `callEachBatchWhenEmpty` is false (the default).
Any future consumer that sets `callEachBatchWhenEmpty: true` over a `BatchingPipeline` would wedge on the first idle poll.

A related hazard: a `beforeBatch` hook that changes the element count would corrupt completion tracking the same way (worst case, mapping to zero elements produces the identical wedge).
The `beforeBatch` contract is that hooks only enrich elements and batch context — all existing hooks pass elements through untouched — so a count change is a logic error in the hook, not something to absorb.

## Changes

Two guards in `feedSerialized`:

- **Empty feeds are a no-op.** At the top of `feedSerialized`, before any hooks run: zero elements returns `{ ok: true }` immediately. No `batchId` is consumed, `beforeBatch` never runs, nothing is registered, no capacity is used — and since no hooks ran, there are no side effects to surface.
- **`beforeBatch` must preserve the element count.** After the before pipeline runs, a changed count throws `batching_pipeline beforeBatch changed element count (N -> M) for batch B`. A broken framework invariant must be unmissable, so it throws rather than returning through the `FeedResult` channel — that channel is for outcomes a driver may legitimately handle (`at_capacity` backpressure, a hook returning non-ok for a batch, which keeps its existing `before_batch_failed` return). This mirrors `BaseBatchPipeline`'s count-mismatch throw for batch steps. The check runs before any registration (`batches.set`, `feedEpoch` bump, `subPipeline.feed`), so the throw leaves no phantom state behind.

The count-preservation contract is documented on `BeforeBatchOutput` and in the class lifecycle doc.
The hooks contract is also now covered in the framework doc-tests (`docs/14-batching.test.ts`, "The lifecycle hooks contract" section with two executable examples) and noted in the `ingestion-pipeline-doctor-nodejs` skill's convention reference.

## How did you test this code?

Extended `nodejs/src/ingestion/framework/batching-pipeline.test.ts` with two cases:

- Empty feed returns `{ ok: true }`, `beforeBatch` is not called, `next()` returns null instead of throwing, and a subsequent normal batch is still accepted and processed under `concurrentBatches: 1` — proving the capacity slot is not leaked. Regression caught: an empty feed used to poison the pipeline (corruption error on `next()`) and leak its capacity slot forever.
- A `beforeBatch` hook that changes the element count makes `feed()` reject with a thrown `changed element count (2 -> 1)` error, and nothing is registered before the throw: a subsequent normal batch on the same instance still processes (real drivers crash on the throw; this documents that the throw itself does not corrupt state). Regression caught: a count-changing hook used to silently corrupt completion tracking instead of failing loudly.

No existing test exercised either path.

Ran locally in `nodejs/`: `pnpm test -- src/ingestion/framework/batching-pipeline.test.ts` (22 passed) and `pnpm test -- src/ingestion/framework/docs/14-batching.test.ts` (5 passed), plus eslint and prettier on all changed files. The full `pnpm build` typecheck fails only on unrelated unbuilt native/workspace packages (`@posthog/hogvm`, `@posthog/cyclotron`, `@posthog/replay-anonymizer`) in this fresh worktree; no errors reference the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code). I invoked the `/writing-tests` skill before adding tests to gate their value and keep them at the cheapest unit level.

The first iteration absorbed a `beforeBatch` that mapped to zero elements gracefully (skipping registration after the hook ran, surfacing hook side effects via an empty result). Review feedback established that `beforeBatch` must not change the element count — all real hooks only enrich batch context — so the empty-feed guard moved before the hooks entirely (making the side-effect surfacing unnecessary). A second round of feedback classified a count change as a logic error rather than a request-level failure: it now throws (crashing the process, like `BaseBatchPipeline`'s count-mismatch throw) instead of returning `before_batch_failed`, which stays reserved for a hook's own non-ok decision. A third round asked to make the contract discoverable, which added the doc-test section and the skill convention note.
