### PR TITLE
feat(tasks): label run token metrics with terminal status

### DIFF
--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -139,6 +139,7 @@ def record_run_token_usage(
     origin_product: str | None,
     run_environment: str | None,
     rtk_enabled: bool | None,
+    status: str | None,
 ) -> None:
     """Record a terminal run's token expenditure (from ``TaskRun.state.token_usage``).
 
@@ -149,6 +150,7 @@ def record_run_token_usage(
             "origin_product": origin_product or "unknown",
             "run_environment": run_environment or "unknown",
             "rtk_enabled": _bool_label(rtk_enabled),
+            "status": status or "unknown",
         }
         for kind, key in _RUN_TOKEN_KINDS.items():
             value = usage.get(key)

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -94,6 +94,7 @@ class TestUpdateTaskRunStatusActivity:
         assert props["run_environment"] == test_task_run.environment
         mock_record.assert_called_once()
         assert mock_record.call_args.kwargs["rtk_enabled"] is True
+        assert mock_record.call_args.kwargs["status"] == status
 
     @pytest.mark.django_db(transaction=True)
     @patch("products.tasks.backend.models.posthoganalytics.capture")

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -87,6 +87,7 @@ def _capture_terminal_analytics(task_run: TaskRun, input: UpdateTaskRunStatusInp
                 origin_product=task_run.task.origin_product,
                 run_environment=task_run.environment,
                 rtk_enabled=task_run.effective_rtk(),
+                status=input.status,
             )
     except Exception:
         activity.logger.warning(f"Failed to capture terminal analytics for run {task_run.id}", exc_info=True)


### PR DESCRIPTION
## Problem

The run-level token metrics (`tasks_run_tokens_total`, `tasks_run_total_tokens`) carry `origin_product`, `run_environment` and `rtk_enabled` labels but not the terminal status.
Grafana can't split completed vs failed spend, so tokens burned by runs that deliver nothing are invisible - exactly the "cost of breakage" signal we want to watch during rollouts like the rtk ramp.