### PR TITLE
fix(phai): say "PostHog AI" instead of "Max" in MCP tool approval

### DIFF
--- a/ee/hogai/tools/call_mcp_server/tool.py
+++ b/ee/hogai/tools/call_mcp_server/tool.py
@@ -170,7 +170,7 @@ class CallMCPServerTool(MaxTool):
             args_block = f"\n\n```json\n{args_str}\n```"
         else:
             args_block = "\n\n*(no arguments)*"
-        return f"Max wants to call **{tool_name}** on **{display}**.{args_block}"
+        return f"PostHog AI wants to call **{tool_name}** on **{display}**.{args_block}"
 
     async def _arun_impl(self, server_url: str, tool_name: str, arguments: dict | None = None) -> tuple[str, None]:
         self._validate_server_url(server_url)


### PR DESCRIPTION
## Problem

When PostHog AI asks the user to approve an MCP tool call, the approval prompt still says "Max wants to call **list_issues** on **Linear**." The agent is no longer called Max, it's PostHog AI.

## Changes

One-line copy change in `format_dangerous_operation_preview` in `ee/hogai/tools/call_mcp_server/tool.py`: the approval preview now reads "PostHog AI wants to call ...".

## How did you test this code?

No behavior change, just a string. I grepped the repo to confirm no tests assert on the old copy and no other "Max wants ..." strings remain. Lint and ci:preflight passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code found the string via grep, made the one-line edit in a worktree, and opened this PR. No skills were invoked. No other occurrences of the old "Max" naming were found in approval copy.
