### PR TITLE
feat(ingestion): add tophog timer for group processing

### DIFF
--- a/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
@@ -136,9 +136,16 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
             { retry: { tries: 5, sleepMs: 100, name: 'process_persons' } }
         )
         .pipe(createPrepareEventStep())
-        .pipe(createProcessGroupsStep(teamManager, groupTypeManager, options), {
-            retry: { tries: 5, sleepMs: 100, name: 'process_groups' },
-        })
+        .pipe(
+            topHog(createProcessGroupsStep(teamManager, groupTypeManager, options), [
+                timer('process_groups_time', (input) => ({
+                    team_id: String(input.team.id),
+                    distinct_id: input.preparedEvent.distinctId,
+                    partition: String(input.message.partition),
+                })),
+            ]),
+            { retry: { tries: 5, sleepMs: 100, name: 'process_groups' } }
+        )
         .pipe(createCreateEventStep(EVENTS_OUTPUT))
         .pipe(
             topHog(


### PR DESCRIPTION
## Problem

Person processing in the analytics per-event pipeline already emits a per-actor tophog timer (`process_persons_time`), keyed by `(team_id, distinct_id, partition)`. Group processing has no equivalent signal. When a single distinct_id sends a burst of `$groupidentify` events, the group-processing step can pin a pipeline lane, but there is no direct metric that attributes the time to a `(team_id, distinct_id, partition)` heavy hitter. Today that cost can only be inferred indirectly, which makes triage slower than it should be.

## Changes

Wrap `processGroupsStep` in the analytics event subpipeline with a tophog `timer` named `process_groups_time`, keyed by `(team_id, distinct_id, partition)`. This mirrors how `process_persons_time` is wired one step earlier, so group-processing hot keys surface in tophog the same way person-processing hot keys already do.

The key shape is intentionally identical to the persons timer, with no extra dimensions, to keep the metric cheap. The distinct_id is read from `preparedEvent.distinctId` because the prepare step drops `normalizedEvent` from the pipeline context before groups are processed (the persons timer, which runs before prepare, reads `normalizedEvent.distinct_id`). `team_id` and `partition` come from the same fields as the persons timer.

```diff
-        .pipe(createProcessGroupsStep(teamManager, groupTypeManager, options), {
-            retry: { tries: 5, sleepMs: 100, name: 'process_groups' },
-        })
+        .pipe(
+            topHog(createProcessGroupsStep(teamManager, groupTypeManager, options), [
+                timer('process_groups_time', (input) => ({
+                    team_id: String(input.team.id),
+                    distinct_id: input.preparedEvent.distinctId,
+                    partition: String(input.message.partition),
+                })),
+            ]),
+            { retry: { tries: 5, sleepMs: 100, name: 'process_groups' } }
+        )
```

## How did you test this code?

- `pnpm build` (TypeScript compile): no errors in the changed file or the analytics pipeline. The wiring typechecks against the pipeline context available at that step.
- `prettier --check` and `eslint` on the changed file: clean.
- `jest src/ingestion/framework/extensions/tophog.test.ts`: 27/27 pass. This suite already covers that `timer(name, keyFn)` records `keyFn(input)` with a numeric duration through the tophog wrapper.
- `hogli ci:preflight`: no failures.

No new test added. The `process_persons_time` wiring it mirrors has no dedicated per-metric test, the tophog wrapper's timer behavior is already covered by `tophog.test.ts`, and the field accesses in the key function are compile-time guaranteed. There is no existing harness that stands up `createEventSubpipeline`, so a wiring-level assertion would require a full-subpipeline integration test disproportionate to a one-line, typechecked change. Per the testing gate, adding one would be redundant coverage.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected. This is an internal ingestion metric.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paweł directed this work; I (Claude) implemented it. This is the metric portion of a larger group-processing improvement plan. Scope was deliberately limited to the tophog timer in the analytics per-event pipeline. Alerting changes discussed in the plan live in dashboards and alert configs and are out of scope here.

Skills invoked: `/writing-tests`, which drove the decision not to add a test (the mirrored persons timer has no per-metric test, and the tophog timer key-shape recording is already covered).

Decisions along the way: the persons timer reads `normalizedEvent.distinct_id`, but `normalizedEvent` is removed from the pipeline context by the prepare step that runs before groups, so the groups timer reads the equivalent `preparedEvent.distinctId` instead. `team_id` and `partition` are sourced identically to the persons timer. I considered mirroring the same timer in the AI subpipeline (which also has `process_persons_time`) but kept scope to the analytics pipeline as directed.
