### PR TITLE
fix(persons): move oversized-properties remediation out of the repository update path

### DIFF
--- a/nodejs/src/common/personhog/personhog-person-repository.test.ts
+++ b/nodejs/src/common/personhog/personhog-person-repository.test.ts
@@ -77,6 +77,7 @@ function createMockPostgres(): jest.Mocked<PersonRepository> {
         fetchDistinctIdsForPersons: jest.fn(),
         createPerson: jest.fn(),
         updatePerson: jest.fn(),
+        remediateOversizedPersonProperties: jest.fn(),
         updatePersonAssertVersion: jest.fn(),
         updatePersonsBatch: jest.fn(),
         deletePerson: jest.fn(),

--- a/nodejs/src/common/personhog/personhog-person-repository.ts
+++ b/nodejs/src/common/personhog/personhog-person-repository.ts
@@ -189,6 +189,13 @@ export class PersonHogPersonRepository implements PersonRepository {
         return this.postgres.updatePerson(person, update, tag)
     }
 
+    remediateOversizedPersonProperties(
+        person: InternalPerson,
+        update: PersonUpdateFields
+    ): Promise<[InternalPerson, PersonMessage[], boolean]> {
+        return this.postgres.remediateOversizedPersonProperties(person, update)
+    }
+
     updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[number | undefined, PersonMessage[]]> {
         return this.postgres.updatePersonAssertVersion(personUpdate)
     }

--- a/nodejs/src/common/persons/repositories/person-repository.ts
+++ b/nodejs/src/common/persons/repositories/person-repository.ts
@@ -116,6 +116,17 @@ export interface PersonRepository {
         tag?: string
     ): Promise<[InternalPerson, PersonMessage[], boolean]>
 
+    /**
+     * Recover from a PersonPropertiesSizeViolationError thrown by updatePerson by trimming the
+     * existing oversized row and re-applying the update. Must not be called while holding a
+     * transaction — it acquires its own connections. Throws PersonPropertiesSizeViolationError
+     * when remediation is impossible (existing row within limits) or the trimmed retry fails.
+     */
+    remediateOversizedPersonProperties(
+        person: InternalPerson,
+        update: PersonUpdateFields
+    ): Promise<[InternalPerson, PersonMessage[], boolean]>
+
     updatePersonAssertVersion(personUpdate: PersonUpdate): Promise<[number | undefined, PersonMessage[]]>
 
     /**

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
@@ -2069,7 +2069,56 @@ describe('PostgresPersonRepository', () => {
         })
 
         describe('updatePerson with oversized properties', () => {
-            it('should trim existing oversized person properties and update successfully', async () => {
+            it.each([
+                ['inside a transaction', true],
+                ['outside a transaction', false],
+            ])('rejects the violation %s without attempting remediation', async (_, inTransaction) => {
+                const team = await getFirstTeam(hub.postgres)
+                const person = await createTestPerson(team.id, `test-oversized-${inTransaction}`, { name: 'John' })
+
+                // Remediation reads the current size via personPropertiesSize, which queries the pool
+                // (PostgresUse.PERSONS_READ). Inside a transaction that would acquire a second
+                // connection while the transaction still holds one — a deadlock hazard on a saturated
+                // pool — so updatePerson must throw immediately and never remediate on its own.
+                const personPropertiesSizeSpy = jest.spyOn(oversizedRepository, 'personPropertiesSize')
+
+                const originalQuery = postgres.query.bind(postgres)
+                const mockQuery = jest.spyOn(postgres, 'query').mockImplementation(async (use, query, values, tag) => {
+                    if (typeof query === 'string' && query.includes('UPDATE posthog_person SET')) {
+                        const error = new Error('Check constraint violation')
+                        ;(error as any).code = '23514'
+                        ;(error as any).constraint = 'check_properties_size'
+                        throw error
+                    }
+                    return originalQuery(use, query, values, tag)
+                })
+
+                const oversizedUpdate = { properties: { description: 'x'.repeat(200) } }
+                const updateFields = createPersonUpdateFields(person, oversizedUpdate)
+
+                await expect(
+                    inTransaction
+                        ? oversizedRepository.inTransaction('test-in-tx-oversized', (tx) =>
+                              tx.updatePerson(person, updateFields)
+                          )
+                        : oversizedRepository.updatePerson(person, updateFields)
+                ).rejects.toThrow(PersonPropertiesSizeViolationError)
+
+                expect(personPropertiesSizeSpy).not.toHaveBeenCalled()
+                if (inTransaction) {
+                    const acquiredPoolConnection = mockQuery.mock.calls.some(
+                        ([use]) => use === PostgresUse.PERSONS_READ
+                    )
+                    expect(acquiredPoolConnection).toBe(false)
+                }
+
+                mockQuery.mockRestore()
+                personPropertiesSizeSpy.mockRestore()
+            })
+        })
+
+        describe('remediateOversizedPersonProperties', () => {
+            it('trims the existing oversized record and applies the update', async () => {
                 const team = await getFirstTeam(hub.postgres)
 
                 const normalPerson = await createTestPerson(team.id, 'test-oversized-update', {
@@ -2089,37 +2138,27 @@ describe('PostgresPersonRepository', () => {
                     },
                 }
 
-                const [updatedPerson, messages] = await oversizedRepository.updatePerson(
+                const [updatedPerson, messages] = await oversizedRepository.remediateOversizedPersonProperties(
                     normalPerson,
                     createPersonUpdateFields(normalPerson, oversizedUpdate)
                 )
 
-                expect(updatedPerson).toBeDefined()
                 expect(updatedPerson.version).toBe(normalPerson.version + 1)
                 expect(messages).toHaveLength(1)
-                expect(Object.keys(updatedPerson.properties).length).toBeLessThanOrEqual(3)
+                // The trimmed existing properties are written; the trimmable 'description' is dropped
+                // and the update's own properties are discarded.
+                expect(updatedPerson.properties).toEqual({ name: 'John' })
 
                 mockPersonPropertiesSize.mockRestore()
             })
 
-            it('should reject update when current person is under limit but update would exceed it', async () => {
+            it('rejects when the existing record is within limits (the update itself violates)', async () => {
                 const team = await getFirstTeam(hub.postgres)
                 const normalPerson = await createTestPerson(team.id, 'test-normal-person', { name: 'John' })
 
                 const mockPersonPropertiesSize = jest
                     .spyOn(oversizedRepository, 'personPropertiesSize')
                     .mockResolvedValue(30)
-
-                const originalQuery = postgres.query.bind(postgres)
-                const mockQuery = jest.spyOn(postgres, 'query').mockImplementation(async (use, query, values, tag) => {
-                    if (typeof query === 'string' && query.includes('UPDATE posthog_person SET')) {
-                        const error = new Error('Check constraint violation')
-                        ;(error as any).code = '23514'
-                        ;(error as any).constraint = 'check_properties_size'
-                        throw error
-                    }
-                    return originalQuery(use, query, values, tag)
-                })
 
                 const oversizedUpdate = {
                     properties: {
@@ -2128,59 +2167,16 @@ describe('PostgresPersonRepository', () => {
                 }
 
                 await expect(
-                    oversizedRepository.updatePerson(
-                        normalPerson,
-                        createPersonUpdateFields(normalPerson, oversizedUpdate)
-                    )
-                ).rejects.toThrow(PersonPropertiesSizeViolationError)
-                await expect(
-                    oversizedRepository.updatePerson(
+                    oversizedRepository.remediateOversizedPersonProperties(
                         normalPerson,
                         createPersonUpdateFields(normalPerson, oversizedUpdate)
                     )
                 ).rejects.toThrow('Person properties update would exceed size limit')
 
                 mockPersonPropertiesSize.mockRestore()
-                mockQuery.mockRestore()
             })
 
-            it('rejects an in-transaction size violation without acquiring a pool connection', async () => {
-                const team = await getFirstTeam(hub.postgres)
-                const person = await createTestPerson(team.id, 'test-in-tx-oversized', { name: 'John' })
-
-                // Remediation reads the current size via personPropertiesSize, which queries the pool
-                // (PostgresUse.PERSONS_READ) and would acquire a second connection while the transaction
-                // still holds one — a deadlock hazard on a saturated pool. It must never run inside a tx.
-                const personPropertiesSizeSpy = jest.spyOn(oversizedRepository, 'personPropertiesSize')
-
-                const originalQuery = postgres.query.bind(postgres)
-                const mockQuery = jest.spyOn(postgres, 'query').mockImplementation(async (use, query, values, tag) => {
-                    if (typeof query === 'string' && query.includes('UPDATE posthog_person SET')) {
-                        const error = new Error('Check constraint violation')
-                        ;(error as any).code = '23514'
-                        ;(error as any).constraint = 'check_properties_size'
-                        throw error
-                    }
-                    return originalQuery(use, query, values, tag)
-                })
-
-                const oversizedUpdate = { properties: { description: 'x'.repeat(200) } }
-
-                await expect(
-                    oversizedRepository.inTransaction('test-in-tx-oversized', (tx) =>
-                        tx.updatePerson(person, createPersonUpdateFields(person, oversizedUpdate))
-                    )
-                ).rejects.toThrow(PersonPropertiesSizeViolationError)
-
-                expect(personPropertiesSizeSpy).not.toHaveBeenCalled()
-                const acquiredPoolConnection = mockQuery.mock.calls.some(([use]) => use === PostgresUse.PERSONS_READ)
-                expect(acquiredPoolConnection).toBe(false)
-
-                mockQuery.mockRestore()
-                personPropertiesSizeSpy.mockRestore()
-            })
-
-            it('should fail gracefully when trimming fails', async () => {
+            it('should fail gracefully when the trimmed retry still violates the constraint', async () => {
                 const team = await getFirstTeam(hub.postgres)
                 const normalPerson = await createTestPerson(team.id, 'test-trim-failure', {
                     name: 'John',
@@ -2192,18 +2188,12 @@ describe('PostgresPersonRepository', () => {
                     .mockResolvedValue(60)
 
                 const originalQuery = postgres.query.bind(postgres)
-                let updateCallCount = 0
                 const mockQuery = jest.spyOn(postgres, 'query').mockImplementation(async (use, query, values, tag) => {
                     if (typeof query === 'string' && query.includes('UPDATE posthog_person SET')) {
-                        updateCallCount++
-                        if (updateCallCount === 1) {
-                            const error = new Error('Check constraint violation')
-                            ;(error as any).code = '23514'
-                            ;(error as any).constraint = 'check_properties_size'
-                            throw error
-                        } else if (updateCallCount === 2) {
-                            throw new Error('Trimming update failed')
-                        }
+                        const error = new Error('Check constraint violation')
+                        ;(error as any).code = '23514'
+                        ;(error as any).constraint = 'check_properties_size'
+                        throw error
                     }
                     return originalQuery(use, query, values, tag)
                 })
@@ -2217,90 +2207,11 @@ describe('PostgresPersonRepository', () => {
                 }
 
                 await expect(
-                    oversizedRepository.updatePerson(
-                        normalPerson,
-                        createPersonUpdateFields(normalPerson, oversizedUpdate)
-                    )
-                ).rejects.toThrow(PersonPropertiesSizeViolationError)
-
-                updateCallCount = 0
-                await expect(
-                    oversizedRepository.updatePerson(
+                    oversizedRepository.remediateOversizedPersonProperties(
                         normalPerson,
                         createPersonUpdateFields(normalPerson, oversizedUpdate)
                     )
                 ).rejects.toThrow('Person properties update failed after trying to trim oversized properties')
-
-                mockPersonPropertiesSize.mockRestore()
-                mockQuery.mockRestore()
-            })
-
-            it('should fail when protected properties alone exceed size limit and cannot be trimmed', async () => {
-                const team = await getFirstTeam(hub.postgres)
-
-                const largeProtectedProperties = {
-                    name: 'John Doe with a very long name that takes up significant space',
-                    email: 'john.doe.with.an.extremely.long.email.address.that.should.be.protected@example.com',
-                    utm_source: 'x'.repeat(30),
-                    utm_medium: 'x'.repeat(30),
-                    utm_campaign: 'x'.repeat(30),
-                    utm_content: 'x'.repeat(30),
-                    utm_term: 'x'.repeat(30),
-                    $browser: 'Chrome with very long user agent string information',
-                    $browser_version: 'Version 120.0.0.0 with extended metadata',
-                    $os: 'Operating System with detailed version information',
-                    $device_type: 'Desktop computer with specific hardware details',
-                    $current_url:
-                        'https://example.com/very/long/path/with/many/segments/and/parameters?param1=value1&param2=value2',
-                    $referring_domain: 'referring-domain-with-long-name.example.com',
-                    $referrer: 'https://referring-site.com/with/very/long/path/that/contains/many/details',
-                    description: 'This is a trimmable property',
-                    customData: 'This can be removed',
-                }
-
-                const oversizedPerson = await createTestPerson(
-                    team.id,
-                    'test-protected-oversized',
-                    largeProtectedProperties
-                )
-
-                const mockPersonPropertiesSize = jest
-                    .spyOn(oversizedRepository, 'personPropertiesSize')
-                    .mockResolvedValue(60)
-
-                const originalQuery = postgres.query.bind(postgres)
-                let updateCallCount = 0
-                const mockQuery = jest.spyOn(postgres, 'query').mockImplementation(async (use, query, values, tag) => {
-                    if (typeof query === 'string' && query.includes('UPDATE posthog_person SET')) {
-                        updateCallCount++
-
-                        const error = new Error('Check constraint violation')
-                        ;(error as any).code = '23514'
-                        ;(error as any).constraint = 'check_properties_size'
-                        throw error
-                    }
-                    return originalQuery(use, query, values, tag)
-                })
-
-                const update = {
-                    properties: {
-                        $app_name: 'Application name with detailed information',
-                        $app_version: 'Version 1.2.3 with build metadata',
-                    },
-                }
-
-                await expect(
-                    oversizedRepository.updatePerson(oversizedPerson, createPersonUpdateFields(oversizedPerson, update))
-                ).rejects.toThrow(PersonPropertiesSizeViolationError)
-
-                expect(updateCallCount).toBe(2)
-
-                updateCallCount = 0
-                await expect(
-                    oversizedRepository.updatePerson(oversizedPerson, createPersonUpdateFields(oversizedPerson, update))
-                ).rejects.toThrow('Person properties update failed after trying to trim oversized properties')
-
-                expect(updateCallCount).toBe(2)
 
                 mockPersonPropertiesSize.mockRestore()
                 mockQuery.mockRestore()
@@ -2457,17 +2368,18 @@ describe('PostgresPersonRepository', () => {
                     },
                 }
 
-                try {
-                    await oversizedRepository.updatePerson(person, createPersonUpdateFields(person, oversizedUpdate))
-                    expect(mockInc).toHaveBeenCalledWith({ result: 'success' })
-                } catch {}
+                await oversizedRepository.remediateOversizedPersonProperties(
+                    person,
+                    createPersonUpdateFields(person, oversizedUpdate)
+                )
+                expect(mockInc).toHaveBeenCalledWith({ result: 'success' })
 
                 mockPersonPropertiesSize.mockRestore()
                 metrics.oversizedPersonPropertiesTrimmedCounter.inc = originalInc
             })
         })
 
-        describe('handleOversizedPersonProperties and related methods', () => {
+        describe('oversized properties helpers', () => {
             it('should test trimPropertiesToFitSize respects protected properties', () => {
                 const properties = {
                     email: 'user@example.com',

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
@@ -2144,6 +2144,42 @@ describe('PostgresPersonRepository', () => {
                 mockQuery.mockRestore()
             })
 
+            it('rejects an in-transaction size violation without acquiring a pool connection', async () => {
+                const team = await getFirstTeam(hub.postgres)
+                const person = await createTestPerson(team.id, 'test-in-tx-oversized', { name: 'John' })
+
+                // Remediation reads the current size via personPropertiesSize, which queries the pool
+                // (PostgresUse.PERSONS_READ) and would acquire a second connection while the transaction
+                // still holds one — a deadlock hazard on a saturated pool. It must never run inside a tx.
+                const personPropertiesSizeSpy = jest.spyOn(oversizedRepository, 'personPropertiesSize')
+
+                const originalQuery = postgres.query.bind(postgres)
+                const mockQuery = jest.spyOn(postgres, 'query').mockImplementation(async (use, query, values, tag) => {
+                    if (typeof query === 'string' && query.includes('UPDATE posthog_person SET')) {
+                        const error = new Error('Check constraint violation')
+                        ;(error as any).code = '23514'
+                        ;(error as any).constraint = 'check_properties_size'
+                        throw error
+                    }
+                    return originalQuery(use, query, values, tag)
+                })
+
+                const oversizedUpdate = { properties: { description: 'x'.repeat(200) } }
+
+                await expect(
+                    oversizedRepository.inTransaction('test-in-tx-oversized', (tx) =>
+                        tx.updatePerson(person, createPersonUpdateFields(person, oversizedUpdate))
+                    )
+                ).rejects.toThrow(PersonPropertiesSizeViolationError)
+
+                expect(personPropertiesSizeSpy).not.toHaveBeenCalled()
+                const acquiredPoolConnection = mockQuery.mock.calls.some(([use]) => use === PostgresUse.PERSONS_READ)
+                expect(acquiredPoolConnection).toBe(false)
+
+                mockQuery.mockRestore()
+                personPropertiesSizeSpy.mockRestore()
+            })
+
             it('should fail gracefully when trimming fails', async () => {
                 const team = await getFirstTeam(hub.postgres)
                 const normalPerson = await createTestPerson(team.id, 'test-trim-failure', {

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.ts
@@ -74,34 +74,27 @@ export class PostgresPersonRepository
         this.options = { ...DEFAULT_OPTIONS, ...options }
     }
 
-    // Only safe to call outside a transaction: it reads person size from the pool and retries the
-    // update, which cannot work on an aborted transaction connection (see updatePerson's catch).
-    private async handleOversizedPersonProperties(
+    /**
+     * Remediate a person row whose properties violate the size constraint: trim the existing
+     * properties down to the configured target and apply `update` with its `properties` replaced
+     * by the trimmed set (the update's own properties are discarded — data is lost either way).
+     *
+     * MUST NOT be called while holding a transaction. It runs its own queries (size check on
+     * PERSONS_READ, update on PERSONS_WRITE), so calling it with a transaction open acquires a
+     * second connection while the first is still held — a deadlock hazard on a shared pool with
+     * no acquire timeout. And a transaction that just hit the 23514 violation is aborted anyway:
+     * every statement on it fails with 25P02 until rollback.
+     *
+     * Throws PersonPropertiesSizeViolationError if the existing row is already within limits (the
+     * incoming update itself violates — nothing to trim) or if the trimmed retry still fails.
+     */
+    async remediateOversizedPersonProperties(
         person: InternalPerson,
         update: PersonUpdateFields
     ): Promise<[InternalPerson, PersonMessage[], boolean]> {
         const currentSize = await this.personPropertiesSize(person.id, person.team_id)
 
-        if (currentSize >= this.options.personPropertiesDbConstraintLimitBytes) {
-            try {
-                personPropertiesSizeViolationCounter.inc({
-                    violation_type: 'existing_record_violates_limit',
-                })
-                return await this.handleExistingOversizedRecord(person, update)
-            } catch {
-                logger.warn('Failed to handle previously oversized person record', {
-                    team_id: person.team_id,
-                    person_id: person.id,
-                    violation_type: 'existing_record_violates_limit',
-                })
-
-                throw new PersonPropertiesSizeViolationError(
-                    `Person properties update failed after trying to trim oversized properties`,
-                    person.team_id,
-                    person.id
-                )
-            }
-        } else {
+        if (currentSize < this.options.personPropertiesDbConstraintLimitBytes) {
             // current record is within limits, reject the write
             personPropertiesSizeViolationCounter.inc({
                 violation_type: 'attempt_to_violate_limit',
@@ -119,12 +112,11 @@ export class PostgresPersonRepository
                 person.id
             )
         }
-    }
 
-    private async handleExistingOversizedRecord(
-        person: InternalPerson,
-        update: PersonUpdateFields
-    ): Promise<[InternalPerson, PersonMessage[], boolean]> {
+        personPropertiesSizeViolationCounter.inc({
+            violation_type: 'existing_record_violates_limit',
+        })
+
         try {
             const trimmedProperties = this.trimPropertiesToFitSize(
                 // NOTE: we exclude the properties in the update and just try to trim the existing properties for simplicity
@@ -152,7 +144,12 @@ export class PostgresPersonRepository
                 person_id: person.id,
                 error,
             })
-            throw error
+
+            throw new PersonPropertiesSizeViolationError(
+                `Person properties update failed after trying to trim oversized properties`,
+                person.team_id,
+                person.id
+            )
         }
     }
 
@@ -1020,27 +1017,22 @@ export class PostgresPersonRepository
 
             return [updatedPerson, [kafkaMessage], versionDisparity > 0]
         } catch (error) {
-            if (this.isPropertiesSizeConstraintViolation(error) && tag !== 'oversized_properties_remediation') {
-                if (tx) {
-                    // We can't remediate inside a transaction. The 23514 violation has already aborted
-                    // the transaction, so every subsequent statement on this client fails with 25P02
-                    // until rollback (we use no savepoints). On top of that, the remediation path's
-                    // size check runs against the pool (PostgresUse.PERSONS_READ), which would acquire
-                    // a second connection while this one still holds the transaction. On a shared pool
-                    // with no acquire timeout, enough concurrent merges taking that path deadlock the
-                    // pool permanently. The merge callers already handle this error, so surface it.
-                    personPropertiesSizeViolationCounter.inc({
-                        violation_type: 'attempt_to_violate_limit_in_transaction',
-                    })
+            if (this.isPropertiesSizeConstraintViolation(error)) {
+                // No remediation here: this may be running on a transaction connection, which the
+                // 23514 violation has already aborted (every statement fails with 25P02 until
+                // rollback — we use no savepoints), and remediation reads from the pool, which
+                // would acquire a second connection while this one is still held — a deadlock
+                // hazard on a shared pool with no acquire timeout. Callers that can remediate do
+                // so via remediateOversizedPersonProperties, outside any transaction.
+                personPropertiesSizeViolationCounter.inc({
+                    violation_type: 'update_person_size_violation',
+                })
 
-                    throw new PersonPropertiesSizeViolationError(
-                        `Person properties update would exceed size limit`,
-                        person.team_id,
-                        person.id
-                    )
-                }
-
-                return await this.handleOversizedPersonProperties(person, update)
+                throw new PersonPropertiesSizeViolationError(
+                    `Person properties update would exceed size limit`,
+                    person.team_id,
+                    person.id
+                )
             }
 
             // Re-throw other errors

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.ts
@@ -74,10 +74,11 @@ export class PostgresPersonRepository
         this.options = { ...DEFAULT_OPTIONS, ...options }
     }
 
+    // Only safe to call outside a transaction: it reads person size from the pool and retries the
+    // update, which cannot work on an aborted transaction connection (see updatePerson's catch).
     private async handleOversizedPersonProperties(
         person: InternalPerson,
-        update: PersonUpdateFields,
-        tx?: TransactionClient
+        update: PersonUpdateFields
     ): Promise<[InternalPerson, PersonMessage[], boolean]> {
         const currentSize = await this.personPropertiesSize(person.id, person.team_id)
 
@@ -86,7 +87,7 @@ export class PostgresPersonRepository
                 personPropertiesSizeViolationCounter.inc({
                     violation_type: 'existing_record_violates_limit',
                 })
-                return await this.handleExistingOversizedRecord(person, update, tx)
+                return await this.handleExistingOversizedRecord(person, update)
             } catch {
                 logger.warn('Failed to handle previously oversized person record', {
                     team_id: person.team_id,
@@ -122,8 +123,7 @@ export class PostgresPersonRepository
 
     private async handleExistingOversizedRecord(
         person: InternalPerson,
-        update: PersonUpdateFields,
-        tx?: TransactionClient
+        update: PersonUpdateFields
     ): Promise<[InternalPerson, PersonMessage[], boolean]> {
         try {
             const trimmedProperties = this.trimPropertiesToFitSize(
@@ -141,8 +141,7 @@ export class PostgresPersonRepository
             const [updatedPerson, kafkaMessages, versionDisparity] = await this.updatePerson(
                 person,
                 trimmedUpdate,
-                'oversized_properties_remediation',
-                tx
+                'oversized_properties_remediation'
             )
             oversizedPersonPropertiesTrimmedCounter.inc({ result: 'success' })
             return [updatedPerson, kafkaMessages, versionDisparity]
@@ -1022,7 +1021,26 @@ export class PostgresPersonRepository
             return [updatedPerson, [kafkaMessage], versionDisparity > 0]
         } catch (error) {
             if (this.isPropertiesSizeConstraintViolation(error) && tag !== 'oversized_properties_remediation') {
-                return await this.handleOversizedPersonProperties(person, update, tx)
+                if (tx) {
+                    // We can't remediate inside a transaction. The 23514 violation has already aborted
+                    // the transaction, so every subsequent statement on this client fails with 25P02
+                    // until rollback (we use no savepoints). On top of that, the remediation path's
+                    // size check runs against the pool (PostgresUse.PERSONS_READ), which would acquire
+                    // a second connection while this one still holds the transaction. On a shared pool
+                    // with no acquire timeout, enough concurrent merges taking that path deadlock the
+                    // pool permanently. The merge callers already handle this error, so surface it.
+                    personPropertiesSizeViolationCounter.inc({
+                        violation_type: 'attempt_to_violate_limit_in_transaction',
+                    })
+
+                    throw new PersonPropertiesSizeViolationError(
+                        `Person properties update would exceed size limit`,
+                        person.team_id,
+                        person.id
+                    )
+                }
+
+                return await this.handleOversizedPersonProperties(person, update)
             }
 
             // Re-throw other errors

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -8,6 +8,7 @@ import {
     personPropertyKeyUpdateCounter,
 } from '~/common/persons/metrics'
 import { fromInternalPerson } from '~/common/persons/person-update-batch'
+import { PersonPropertiesSizeViolationError } from '~/common/persons/repositories/person-repository'
 import { DependencyUnavailableError, MessageSizeTooLarge } from '~/common/utils/db/error'
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
@@ -128,6 +129,7 @@ describe('BatchWritingPersonStore', () => {
             fetchDistinctIdsForPersons: jest.fn().mockResolvedValue({}),
             createPerson: jest.fn().mockResolvedValue([person, []]),
             updatePerson: jest.fn().mockResolvedValue([person, [], false]),
+            remediateOversizedPersonProperties: jest.fn().mockResolvedValue([person, [], false]),
             updatePersonAssertVersion: jest.fn().mockResolvedValue([person.version + 1, []]),
             updatePersonsBatch: jest.fn().mockImplementation((updates) => {
                 // Return a map with success for each update
@@ -809,6 +811,57 @@ describe('BatchWritingPersonStore', () => {
                 expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
                 expect(mockRepo.updatePersonsBatch).not.toHaveBeenCalled()
                 expect(mockRepo.updatePersonAssertVersion).not.toHaveBeenCalled()
+            })
+
+            it('should remediate oversized properties and succeed when the individual update hits the size limit', async () => {
+                const personStore = new BatchWritingPersonsStore(mockRepo, mockIngestionWarningsOutputs, {
+                    dbWriteMode: 'NO_ASSERT',
+                    useBatchUpdates: false,
+                })
+
+                mockRepo.updatePerson = jest
+                    .fn()
+                    .mockRejectedValue(new PersonPropertiesSizeViolationError('too big', teamId, person.id))
+
+                await personStore.updatePersonWithPropertiesDiffForUpdate(
+                    person,
+                    { new_value: 'new_value' },
+                    [],
+                    {},
+                    'test'
+                )
+                await personStore.flush()
+
+                expect(mockRepo.updatePerson).toHaveBeenCalledTimes(1)
+                expect(mockRepo.remediateOversizedPersonProperties).toHaveBeenCalledTimes(1)
+                expect(emitIngestionWarning).not.toHaveBeenCalled()
+            })
+
+            it('should emit an ingestion warning and continue the flush when remediation also fails', async () => {
+                const personStore = new BatchWritingPersonsStore(mockRepo, mockIngestionWarningsOutputs, {
+                    dbWriteMode: 'NO_ASSERT',
+                    useBatchUpdates: false,
+                })
+
+                const violation = new PersonPropertiesSizeViolationError('too big', teamId, person.id)
+                mockRepo.updatePerson = jest.fn().mockRejectedValue(violation)
+                mockRepo.remediateOversizedPersonProperties = jest.fn().mockRejectedValue(violation)
+
+                await personStore.updatePersonWithPropertiesDiffForUpdate(
+                    person,
+                    { new_value: 'new_value' },
+                    [],
+                    {},
+                    'test'
+                )
+                await expect(personStore.flush()).resolves.toEqual([])
+
+                expect(mockRepo.remediateOversizedPersonProperties).toHaveBeenCalledTimes(1)
+                expect(emitIngestionWarning).toHaveBeenCalledWith(
+                    expect.anything(),
+                    teamId,
+                    expect.objectContaining({ type: 'person_properties_size_violation' })
+                )
             })
 
             it('should retry individual updates on error when useBatchUpdates is false', async () => {

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -1887,7 +1887,19 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         this.incrementDatabaseOperation('updatePersonNoAssert', personUpdate.distinct_id)
         const start = performance.now()
 
-        const [_, messages] = await this.personRepository.updatePerson(person, updateFields, 'updatePersonNoAssert')
+        let messages: PersonMessage[]
+        try {
+            ;[, messages] = await this.personRepository.updatePerson(person, updateFields, 'updatePersonNoAssert')
+        } catch (error) {
+            if (!(error instanceof PersonPropertiesSizeViolationError)) {
+                throw error
+            }
+            // We're not inside a transaction here, so it's safe to remediate: trim the oversized
+            // row and retry the update once. If the row can't be remediated (it's the incoming
+            // update that violates, or the trimmed retry fails), this throws the violation again
+            // and handleIndividualUpdateError emits the ingestion warning.
+            ;[, messages] = await this.personRepository.remediateOversizedPersonProperties(person, updateFields)
+        }
         this.recordUpdateLatency('updatePersonNoAssert', (performance.now() - start) / 1000, personUpdate.distinct_id)
         observeLatencyByVersion(person, start, 'updatePersonNoAssert')
 

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -3,6 +3,7 @@ import { Counter } from 'prom-client'
 
 import { personMergeFailureCounter } from '~/common/persons/metrics'
 import { PersonMessage } from '~/common/persons/person-message'
+import { PersonPropertiesSizeViolationError } from '~/common/persons/repositories/person-repository'
 import { timeoutGuard } from '~/common/utils/db/utils'
 import { logger } from '~/common/utils/logger'
 import { captureException } from '~/common/utils/posthog'
@@ -438,6 +439,31 @@ export class PersonMergeService {
             return mergeSuccess(mergeInto, Promise.resolve(), true)
         }
 
+        if (result.error instanceof PersonPropertiesSizeViolationError) {
+            // The combined properties of the two persons exceed the size limit. We skip the merge
+            // (the transaction rolled back) and keep processing the event with the target person.
+            // No remediation is attempted here: the violating value is the merged blob itself, so
+            // trimming the target row wouldn't make a retry with the same properties succeed.
+            await emitIngestionWarning(this.context.outputs, this.context.team.id, {
+                type: 'person_properties_size_violation',
+                details: {
+                    sourcePersonDistinctId: otherPersonDistinctId,
+                    targetPersonDistinctId: mergeIntoDistinctId,
+                    distinctId: mergeIntoDistinctId,
+                    eventUuid: this.context.event.uuid,
+                    personId: mergeInto.uuid,
+                    otherPersonId: otherPerson.uuid,
+                    message: 'Merged person properties would exceed size limit, merge was skipped',
+                },
+                pipelineStep: 'person-merge',
+                alwaysSend: true,
+            })
+            logger.warn('🤔', 'refused to merge persons, merged properties would exceed size limit', {
+                team_id: this.context.team.id,
+            })
+            return mergeSuccess(mergeInto, Promise.resolve(), true)
+        }
+
         // For other errors (PersonMergeLimitExceededError, etc.), return the error result
         return result
     }
@@ -543,6 +569,11 @@ export class PersonMergeService {
             } else if (error instanceof TargetPersonNotFoundError) {
                 return mergeError(error)
             } else if (error instanceof PersonMergeLimitExceededError) {
+                return mergeError(error)
+            } else if (error instanceof PersonPropertiesSizeViolationError) {
+                // The merged properties blob violates the size constraint. The transaction has
+                // rolled back; retrying with the same properties would fail identically, so this
+                // is surfaced as a non-retryable merge failure and handled in mergePeople.
                 return mergeError(error)
             } else if (error.code === '23503') {
                 // Foreign key constraint violation when attempting to delete the source person.

--- a/nodejs/src/ingestion/common/persons/person-merge-types.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-types.ts
@@ -1,3 +1,4 @@
+import { PersonPropertiesSizeViolationError } from '~/common/persons/repositories/person-repository'
 import { InternalPerson } from '~/types'
 
 /**
@@ -90,7 +91,7 @@ export type PersonMergeResult =
       }
     | {
           success: false
-          error: PersonMergeError
+          error: PersonMergeError | PersonPropertiesSizeViolationError
       }
 
 /**
@@ -129,7 +130,7 @@ export function mergeSuccess(
 /**
  * Helper function to create a merge error result
  */
-export function mergeError(error: PersonMergeError): PersonMergeResult {
+export function mergeError(error: PersonMergeError | PersonPropertiesSizeViolationError): PersonMergeResult {
     return {
         success: false,
         error,

--- a/nodejs/tests/ingestion/person-state-batch.test.ts
+++ b/nodejs/tests/ingestion/person-state-batch.test.ts
@@ -16,6 +16,7 @@ import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '~/common/outputs/single-ingestion-output'
 import { PersonMessage } from '~/common/persons/person-message'
 import { fromInternalPerson } from '~/common/persons/person-update-batch'
+import { PersonPropertiesSizeViolationError } from '~/common/persons/repositories/person-repository'
 import { PostgresPersonRepository } from '~/common/persons/repositories/postgres-person-repository'
 import { fetchDistinctIdValues } from '~/common/persons/repositories/test-helpers'
 import { DependencyUnavailableError } from '~/common/utils/db/error'
@@ -2832,6 +2833,63 @@ describe('PersonState.processEvent()', () => {
             })
             expect(personRepository.updatePerson).not.toHaveBeenCalled()
             expect(kafkaProducer.produce).not.toHaveBeenCalled()
+        })
+
+        it(`merge is skipped with an ingestion warning when the merged person write violates the size limit`, async () => {
+            const first = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, firstUserUuid, {
+                distinctId: firstUserDistinctId,
+            })
+            const second = await createPerson(hub, timestamp, {}, {}, {}, teamId, null, false, secondUserUuid, {
+                distinctId: secondUserDistinctId,
+            })
+
+            const produceSpy = jest.spyOn(kafkaProducer, 'produce')
+
+            // Simulate the check_properties_size violation surfacing from the person write
+            // inside the merge transaction
+            const personsStore = new BatchWritingPersonsStore(personRepository, createPersonOutputs(kafkaProducer))
+            jest.spyOn(personsStore, 'updatePersonForMerge').mockRejectedValue(
+                new PersonPropertiesSizeViolationError(
+                    'Person properties update would exceed size limit',
+                    teamId,
+                    first.id
+                )
+            )
+
+            const mergeService: PersonMergeService = personMergeService(
+                {},
+                hub,
+                personRepository,
+                true,
+                timestamp,
+                mainTeam,
+                createDefaultSyncMergeMode(),
+                undefined,
+                personsStore
+            )
+
+            const result = await mergeService.mergePeople({
+                mergeInto: first,
+                mergeIntoDistinctId: firstUserDistinctId,
+                otherPerson: second,
+                otherPersonDistinctId: secondUserDistinctId,
+            })
+
+            // The merge is abandoned but the event keeps processing with the target person
+            expect(result.success).toBe(true)
+            if (!result.success) {
+                throw new Error('Merge should have been skipped gracefully')
+            }
+            expect(result.person).toMatchObject({ uuid: firstUserUuid })
+
+            // The transaction rolled back: both persons still exist
+            const persons = sortPersons(await fetchPostgresPersonsH())
+            expect(persons.length).toEqual(2)
+
+            const warningCalls = produceSpy.mock.calls.filter((call) => call[0].topic === KAFKA_INGESTION_WARNINGS)
+            expect(warningCalls).toHaveLength(1)
+            const payload = parseJSON(String(warningCalls[0][0].value))
+            expect(payload.type).toBe('person_properties_size_violation')
         })
 
         it(`postgres and clickhouse get updated`, async () => {


### PR DESCRIPTION
## Problem

When `updatePerson` hits the `check_properties_size` constraint (Postgres error `23514`), the repository used to remediate implicitly inside its own catch block: read the row's current size, trim the properties, and retry. That remediation policy living inside the repository update path is wrong in two concrete ways.

> [!WARNING]
> **Acquire-while-holding on a shared pool with no acquire timeout.** The remediation size check reads from the persons pool via `PostgresUse.PERSONS_READ`. When `updatePerson` runs on a transaction connection (person merges) and `PERSONS_READONLY_DATABASE_URL` is unset, that read resolves to the same bounded pool the transaction's connection came from, and the pool has no `connectionTimeoutMillis`. Enough concurrent transactions taking this path all hold a connection while waiting for another one, and the pool wedges permanently and silently.

And remediation could never have worked inside a transaction anyway. The `23514` violation aborts the transaction, so every subsequent statement on that connection fails with `25P02` until rollback (no savepoints are used). The in-transaction retry was dead on arrival.

## Changes

Remediation policy moves out of the repository's update path and up to the callers.

```mermaid
flowchart LR
    UP[updatePerson hits 23514] --> SZ[size check on the pool]
    SZ --> TRIM[trim + retry inside catch]
    TRIM --> OK[result or throw]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class SZ,TRIM phRed;
    class UP,OK phGray;
```

```mermaid
flowchart LR
    UP[updatePerson hits 23514] --> THROW[always throw PersonPropertiesSizeViolationError]
    THROW --> FLUSH[store flush path: remediate + retry once]
    THROW --> MERGE[merge service: skip merge + ingestion warning]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class FLUSH,MERGE phBlue;
    class UP phGray;
    class THROW phYellow;
```

**Repository** (`postgres-person-repository.ts`)
- `updatePerson` now always throws `PersonPropertiesSizeViolationError` on `23514` — transaction or not, no remediation, no size read, no branching. It records the violation counter with a new `update_person_size_violation` label and a comment explains why remediation can't happen there.
- The trim mechanics stay in the repository as one explicit method, `remediateOversizedPersonProperties(person, update)`: size check on `PERSONS_READ`, trim the existing properties to the configured target, apply via `updatePerson` with the `oversized_properties_remediation` tag. Its doc comment states it must not be called while holding a transaction (it acquires its own connections, and a post-`23514` transaction is aborted anyway). It preserves the existing `attempt_to_violate_limit` / `existing_record_violates_limit` metric labels and the trimmed-result counter.
- The old private `handleOversizedPersonProperties` / `handleExistingOversizedRecord` helpers are gone.

**Batch person store** (`batch-writing-person-store.ts`)
- The non-transactional flush write `updatePersonNoAssert` (used by the individual NO_ASSERT flush, the batch-flush fallback, and the max-retries fallback) catches the violation, calls `remediateOversizedPersonProperties`, which applies the trimmed update as the single retry. If remediation also fails, the violation propagates and the existing `handleIndividualUpdateError` path emits the `person_properties_size_violation` ingestion warning — the same net behavior as before, now explicit.

**Merge service** (`person-merge-service.ts`)
- A violation escaping the merge transaction (the transaction rolls back) is mapped to a merge failure result and handled in `mergePeople` like the existing race-condition case: emit a `person_properties_size_violation` ingestion warning and continue processing the event with the target person. No remediation is attempted in the merge path: the violating value is the merged properties blob itself, so trimming the target row and retrying with the same computed properties would fail identically. A meaningful retry would need to restart above `mergePeople` to recompute the merged properties, which is not worth the machinery for this edge.

> [!NOTE]
> In the current batch-writing store, the merged person's write is cached during the merge transaction and lands at flush time, where the store-level remediation applies. The merge-service mapping covers the repository's transactional `updatePerson` surface so any tx-writing caller degrades to a skipped merge instead of an unhandled error.

## How did you test this code?

Repository tests (`postgres-person-repository.test.ts`):
- Parameterized case: `updatePerson` rejects with `PersonPropertiesSizeViolationError` on a mocked `23514` both inside and outside a transaction, without ever calling `personPropertiesSize`; the in-transaction case additionally asserts no query targets `PostgresUse.PERSONS_READ` (no second-connection acquire). This catches the pool-deadlock regression; no existing test exercised the in-transaction path.
- The existing implicit-remediation tests were reworked to target `remediateOversizedPersonProperties` directly: trims and applies when the row is oversized, rejects when the row is within limits (the update itself violates), and wraps a still-failing trimmed retry. A near-duplicate DB-backed protected-properties case was collapsed into the pure `trimPropertiesToFitSize` test that already covers it.

Store tests (`batch-writing-person-store.test.ts`):
- Flush with a violating individual update remediates and succeeds without emitting a warning; catches the regression of losing the previously implicit remediation on the flush path.
- Flush where remediation also fails emits the `person_properties_size_violation` ingestion warning and continues (resolves, doesn't crash the batch).

Merge test (`person-state-batch.test.ts`):
- A violation surfacing from the person write inside the merge transaction results in a successful (skipped) merge with the target person, both persons still present in Postgres, and exactly one `person_properties_size_violation` warning produced.

I confirmed the tx-path test catches the bug: with the guard removed it fails because the remediation size read runs (one pool acquire), and passes with the fix.

Ran locally:

```
pnpm test -- src/common/persons/repositories/postgres-person-repository.test.ts   # 98 passed, 1 skipped
pnpm test -- src/ingestion/common/persons/batch-writing-person-store.test.ts      # 108 passed
pnpm test -- tests/ingestion/person-state-batch.test.ts                           # 84 passed; 5 pre-existing local-env failures (missing ClickHouse tables), unrelated to this diff
```

Lint is clean on all touched files, and `tsc --noEmit` shows no errors in the touched areas. I (Claude) could not run a fully green `pnpm build` in this fresh worktree because sibling workspace packages (`@posthog/hogvm`, `@posthog/cyclotron`, `@posthog/replay-anonymizer`) aren't compiled here; all remaining type errors are in unrelated `cdp/` and `sessionreplay/` files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) wrote this after Paweł flagged the potential pool self-deadlock in the in-transaction oversized-properties path, and reworked it per reviewer feedback to move remediation policy out of the repository catch entirely and up to the callers. Invoked the repo `/writing-tests` skill before writing tests.

Key decisions:
- "Thread `tx` into the size check" was rejected: the transaction is already aborted after `23514`, so it would just convert the deadlock into a guaranteed `25P02`.
- The first iteration short-circuited only the tx branch inside `updatePerson`'s catch; the final design removes remediation from `updatePerson` altogether and exposes it as an explicit repository method the flush path calls.
- For the merge path I implemented the acceptable minimum (propagate, no in-merge remediation) plus explicit surfacing: map the violation to a skipped merge with an ingestion warning, consistent with `person-create-service`. I did not wire remediate-then-retry-from-scratch into the merge retry machinery because a retry with the same computed merged properties deterministically re-violates; a real retry would need to recompute properties above `mergePeople`, which is disproportionate for this edge case.
