### PR TITLE
fix(persons): produce Kafka messages after merge transactions commit

### DIFF
--- a/nodejs/src/ingestion/common/persons/person-create-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-create-service.test.ts
@@ -93,7 +93,7 @@ describe('PersonCreateService', () => {
 
             mockPersonStore.createPerson.mockResolvedValue(mockResult)
 
-            const [person, created] = await personCreateService.createPerson(
+            const [person, created, messages] = await personCreateService.createPerson(
                 createdAt,
                 properties,
                 propertiesOnce,
@@ -106,11 +106,10 @@ describe('PersonCreateService', () => {
 
             expect(person).toEqual(mockPerson)
             expect(created).toBe(true)
-            expect(mockOutputs.produce).toHaveBeenCalledWith('persons', {
-                value: Buffer.from('test'),
-                key: null,
-                teamId,
-            })
+            // The messages are handed back for the caller to produce after any enclosing
+            // transaction commits; createPerson must not produce them itself.
+            expect(messages).toEqual(mockResult.messages)
+            expect(mockOutputs.produce).not.toHaveBeenCalled()
         })
 
         it('should handle PersonPropertiesSizeViolationError and log ingestion warning', async () => {
@@ -174,7 +173,7 @@ describe('PersonCreateService', () => {
             mockPersonStore.createPerson.mockResolvedValue(conflictResult)
             mockPersonStore.fetchForUpdate.mockResolvedValue(existingPerson)
 
-            const [person, created] = await personCreateService.createPerson(
+            const [person, created, messages] = await personCreateService.createPerson(
                 createdAt,
                 properties,
                 propertiesOnce,
@@ -187,6 +186,8 @@ describe('PersonCreateService', () => {
 
             expect(person).toEqual(existingPerson)
             expect(created).toBe(false)
+            // A concurrent creation produced the messages already, so this path returns none.
+            expect(messages).toEqual([])
             expect(mockPersonStore.fetchForUpdate).toHaveBeenCalledWith(teamId, 'test-distinct-id')
         })
 

--- a/nodejs/src/ingestion/common/persons/person-create-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-create-service.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 
+import { PersonMessage } from '~/common/persons/person-message'
 import { PersonPropertiesSizeViolationError } from '~/common/persons/repositories/person-repository'
 import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
 import { uuidFromDistinctId } from '~/ingestion/common/persons/person-uuid'
@@ -13,7 +14,13 @@ export class PersonCreateService {
     constructor(private context: PersonContext) {}
 
     /**
-     * @returns [Person, boolean that indicates if person was created or not, true if person was created by this call, false if found existing person from concurrent creation]
+     * Creates the person and returns the Kafka messages the caller is responsible for producing.
+     * Producing is left to the caller so that, when this runs inside a Postgres transaction, the
+     * produce can happen after the transaction commits rather than holding a persons-pool connection
+     * open for the duration of the Kafka ack.
+     *
+     * @returns [Person, boolean that indicates if person was created by this call (false if an
+     *   existing person was found from concurrent creation), Kafka messages the caller must produce]
      */
     async createPerson(
         createdAt: DateTime,
@@ -26,7 +33,7 @@ export class PersonCreateService {
         primaryDistinctId: { distinctId: string; version?: number },
         extraDistinctIds?: { distinctId: string; version?: number }[],
         tx?: PersonsStoreTransactionForBatch
-    ): Promise<[InternalPerson, boolean]> {
+    ): Promise<[InternalPerson, boolean, PersonMessage[]]> {
         const uuid = uuidFromDistinctId(teamId, primaryDistinctId.distinctId)
 
         const props = { ...propertiesOnce, ...properties, ...{ $creator_event_uuid: creatorEventUuid } }
@@ -56,8 +63,7 @@ export class PersonCreateService {
             )
 
             if (result.success) {
-                await this.context.produceMessages(result.messages)
-                return [result.person, result.created]
+                return [result.person, result.created, result.messages]
             }
 
             // Handle creation conflict - another process created the person concurrently
@@ -70,7 +76,7 @@ export class PersonCreateService {
                         distinctIdInfo.distinctId
                     )
                     if (existingPerson) {
-                        return [existingPerson, false]
+                        return [existingPerson, false, []]
                     }
                 }
 

--- a/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.test.ts
@@ -1,0 +1,134 @@
+import { DateTime } from 'luxon'
+
+import { UUIDT } from '~/common/utils/utils'
+import { InternalPerson } from '~/types'
+
+import { PersonContext } from './person-context'
+import { PersonMergeService } from './person-merge-service'
+import { createDefaultSyncMergeMode } from './person-merge-types'
+
+jest.mock('~/ingestion/common/ingestion-warnings', () => ({
+    emitIngestionWarning: jest.fn().mockResolvedValue(undefined),
+}))
+
+describe('PersonMergeService', () => {
+    const teamId = 123
+    const timestamp = DateTime.now()
+
+    // Records the interleaving of transaction boundaries and Kafka produce calls so we can assert
+    // that produce only happens after the transaction commits (never awaited inside it).
+    let events: string[]
+    let mockPersonStore: any
+    let mockOutputs: any
+
+    function buildPerson(distinctId: string): InternalPerson {
+        return {
+            id: distinctId,
+            uuid: new UUIDT().toString(),
+            team_id: teamId,
+            properties: {},
+            created_at: timestamp,
+            version: 0,
+            is_identified: false,
+            is_user_id: null,
+            properties_last_updated_at: {},
+            properties_last_operation: {},
+            last_seen_at: null,
+        } as InternalPerson
+    }
+
+    function buildService(): PersonMergeService {
+        const context = new PersonContext(
+            { uuid: new UUIDT().toString(), event: '$identify', distinct_id: 'target', properties: {} } as any,
+            { id: teamId } as any,
+            'target',
+            timestamp,
+            true,
+            mockOutputs,
+            mockPersonStore,
+            0,
+            createDefaultSyncMergeMode(),
+            false,
+            false
+        )
+        return new PersonMergeService(context)
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        events = []
+
+        mockOutputs = {
+            produce: jest.fn().mockImplementation(() => {
+                events.push('produce')
+                return Promise.resolve()
+            }),
+        }
+
+        mockPersonStore = {
+            fetchForUpdate: jest.fn(),
+            removeDistinctIdFromCache: jest.fn(),
+            inTransaction: jest.fn().mockImplementation(async (_name: string, fn: (tx: any) => Promise<unknown>) => {
+                events.push('tx:start')
+                const tx = {
+                    addPersonlessDistinctIdForMerge: jest.fn().mockResolvedValue(true),
+                    addDistinctId: jest
+                        .fn()
+                        .mockResolvedValue([{ output: 'persons', value: Buffer.from('distinct-id-msg') }]),
+                    createPerson: jest.fn().mockImplementation((...args: any[]) => {
+                        const uuid = args[7]
+                        return Promise.resolve({
+                            success: true,
+                            created: true,
+                            person: { ...buildPerson('created'), uuid },
+                            messages: [{ output: 'persons', value: Buffer.from('created-person-msg') }],
+                        })
+                    }),
+                }
+                const result = await fn(tx)
+                events.push('tx:end')
+                return result
+            }),
+        }
+    })
+
+    describe('produce-after-commit', () => {
+        it('produces distinct-id messages only after the OneExists transaction commits', async () => {
+            // Only the "merge into" person exists, the other distinct id is new.
+            mockPersonStore.fetchForUpdate.mockImplementation((_teamId: number, distinctId: string) =>
+                Promise.resolve(distinctId === 'target' ? buildPerson('target') : null)
+            )
+
+            const result = await buildService().merge('other', 'target', teamId, timestamp)
+
+            expect(result.success).toBe(true)
+            expect(events).toEqual(['tx:start', 'tx:end', 'produce'])
+        })
+
+        it('produces created-person messages only after the NeitherExist transaction commits', async () => {
+            // Neither distinct id points at an existing person, so a person is created in-transaction.
+            mockPersonStore.fetchForUpdate.mockResolvedValue(null)
+
+            const result = await buildService().merge('other', 'target', teamId, timestamp)
+
+            expect(result.success).toBe(true)
+            expect(events).toEqual(['tx:start', 'tx:end', 'produce'])
+        })
+
+        it('surfaces the produce failure through the returned kafkaAck without failing the merge', async () => {
+            mockPersonStore.fetchForUpdate.mockImplementation((_teamId: number, distinctId: string) =>
+                Promise.resolve(distinctId === 'target' ? buildPerson('target') : null)
+            )
+            mockOutputs.produce.mockRejectedValue(new Error('kafka is down'))
+
+            const result = await buildService().merge('other', 'target', teamId, timestamp)
+
+            // The transaction committed, so the merge succeeds; the produce outcome is threaded into
+            // the ack so it is still awaited before the offset is committed downstream.
+            expect(result.success).toBe(true)
+            if (result.success) {
+                await expect(result.kafkaAck).rejects.toThrow('kafka is down')
+            }
+        })
+    })
+})

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -254,18 +254,23 @@ export class PersonMergeService {
                 }
             })()
 
-            return await this.context.personStore.inTransaction('mergeDistinctIds-OneExists', async (tx) => {
-                // See comment above about `distinctIdVersion`
-                const insertedDistinctId = await tx.addPersonlessDistinctIdForMerge(
-                    this.context.team.id,
-                    distinctIdToAdd
-                )
-                const distinctIdVersion = insertedDistinctId ? 0 : 1
+            const kafkaMessages = await this.context.personStore.inTransaction(
+                'mergeDistinctIds-OneExists',
+                async (tx) => {
+                    // See comment above about `distinctIdVersion`
+                    const insertedDistinctId = await tx.addPersonlessDistinctIdForMerge(
+                        this.context.team.id,
+                        distinctIdToAdd
+                    )
+                    const distinctIdVersion = insertedDistinctId ? 0 : 1
 
-                const kafkaMessages = await tx.addDistinctId(existingPerson, distinctIdToAdd, distinctIdVersion)
-                await this.context.produceMessages(kafkaMessages)
-                return mergeSuccess(existingPerson, Promise.resolve(), true)
-            })
+                    return await tx.addDistinctId(existingPerson, distinctIdToAdd, distinctIdVersion)
+                }
+            )
+            // Produce-after-commit: accumulate messages inside the txn and produce only after it
+            // commits, so a slow Kafka producer never holds the persons-pool connection open.
+            const kafkaAck = this.context.produceMessages(kafkaMessages)
+            return mergeSuccess(existingPerson, kafkaAck, true)
         } else if (otherPerson && mergeIntoPerson) {
             // Both Distinct IDs point at an existing Person
 
@@ -288,58 +293,71 @@ export class PersonMergeService {
             let distinctId1 = mergeIntoDistinctId
             let distinctId2 = otherPersonDistinctId
 
-            return await this.context.personStore.inTransaction('mergeDistinctIds-NeitherExist', async (tx) => {
-                // See comment above about `distinctIdVersion`
-                const insertedDistinctId1 = await tx.addPersonlessDistinctIdForMerge(this.context.team.id, distinctId1)
+            const [person, kafkaMessages, needsPersonUpdate] = await this.context.personStore.inTransaction(
+                'mergeDistinctIds-NeitherExist',
+                async (tx) => {
+                    // See comment above about `distinctIdVersion`
+                    const insertedDistinctId1 = await tx.addPersonlessDistinctIdForMerge(
+                        this.context.team.id,
+                        distinctId1
+                    )
 
-                // See comment above about `distinctIdVersion`
-                const insertedDistinctId2 = await tx.addPersonlessDistinctIdForMerge(this.context.team.id, distinctId2)
+                    // See comment above about `distinctIdVersion`
+                    const insertedDistinctId2 = await tx.addPersonlessDistinctIdForMerge(
+                        this.context.team.id,
+                        distinctId2
+                    )
 
-                // `createPerson` uses the first Distinct ID provided to generate the Person
-                // UUID. That means the first Distinct ID definitely doesn't need an override,
-                // and can always use version 0. Below, we exhaust all of the options to decide
-                // whether we can optimize away an override by doing a swap, or whether we
-                // need to actually write an override. (But mostly we're being verbose for
-                // documentation purposes)
-                let distinctId2Version = 0
-                if (insertedDistinctId1 && insertedDistinctId2) {
-                    // We were the first to insert both (neither was used for Personless), so we
-                    // can use either as the primary Person UUID and create no overrides.
-                } else if (insertedDistinctId1 && !insertedDistinctId2) {
-                    // We created 1, but 2 was already used for Personless. Let's swap so
-                    // that 2 can be the primary Person UUID and no override is needed.
-                    ;[distinctId1, distinctId2] = [distinctId2, distinctId1]
-                } else if (!insertedDistinctId1 && insertedDistinctId2) {
-                    // We created 2, but 1 was already used for Personless, so we want to
-                    // use 1 as the primary Person UUID so that no override is needed.
-                } else if (!insertedDistinctId1 && !insertedDistinctId2) {
-                    // Both were used in Personless mode, so there is no more-correct choice of
-                    // primary Person UUID to make here, and we need to drop an override by
-                    // using version = 1 for Distinct ID 2.
-                    distinctId2Version = 1
+                    // `createPerson` uses the first Distinct ID provided to generate the Person
+                    // UUID. That means the first Distinct ID definitely doesn't need an override,
+                    // and can always use version 0. Below, we exhaust all of the options to decide
+                    // whether we can optimize away an override by doing a swap, or whether we
+                    // need to actually write an override. (But mostly we're being verbose for
+                    // documentation purposes)
+                    let distinctId2Version = 0
+                    if (insertedDistinctId1 && insertedDistinctId2) {
+                        // We were the first to insert both (neither was used for Personless), so we
+                        // can use either as the primary Person UUID and create no overrides.
+                    } else if (insertedDistinctId1 && !insertedDistinctId2) {
+                        // We created 1, but 2 was already used for Personless. Let's swap so
+                        // that 2 can be the primary Person UUID and no override is needed.
+                        ;[distinctId1, distinctId2] = [distinctId2, distinctId1]
+                    } else if (!insertedDistinctId1 && insertedDistinctId2) {
+                        // We created 2, but 1 was already used for Personless, so we want to
+                        // use 1 as the primary Person UUID so that no override is needed.
+                    } else if (!insertedDistinctId1 && !insertedDistinctId2) {
+                        // Both were used in Personless mode, so there is no more-correct choice of
+                        // primary Person UUID to make here, and we need to drop an override by
+                        // using version = 1 for Distinct ID 2.
+                        distinctId2Version = 1
+                    }
+
+                    // The first Distinct ID is used to create the new Person's UUID, and so it
+                    // never needs an override.
+                    const distinctId1Version = 0
+
+                    const [createdPerson, wasCreated, createMessages] = await this.personCreateService.createPerson(
+                        timestamp,
+                        this.context.eventProperties['$set'] || {},
+                        this.context.eventProperties['$set_once'] || {},
+                        teamId,
+                        null,
+                        true,
+                        this.context.event.uuid,
+                        { distinctId: distinctId1, version: distinctId1Version },
+                        [{ distinctId: distinctId2, version: distinctId2Version }],
+                        tx
+                    )
+                    // If person was not created (creation conflict) and is not identified,
+                    // we need to update it later
+                    const needsUpdate = !wasCreated && !createdPerson.is_identified
+                    return [createdPerson, createMessages, needsUpdate] as const
                 }
-
-                // The first Distinct ID is used to create the new Person's UUID, and so it
-                // never needs an override.
-                const distinctId1Version = 0
-
-                const [person, wasCreated] = await this.personCreateService.createPerson(
-                    timestamp,
-                    this.context.eventProperties['$set'] || {},
-                    this.context.eventProperties['$set_once'] || {},
-                    teamId,
-                    null,
-                    true,
-                    this.context.event.uuid,
-                    { distinctId: distinctId1, version: distinctId1Version },
-                    [{ distinctId: distinctId2, version: distinctId2Version }],
-                    tx
-                )
-                // If person was not created (creation conflict) and is not identified,
-                // we need to update it later
-                const needsPersonUpdate = !wasCreated && !person.is_identified
-                return mergeSuccess(person, Promise.resolve(), needsPersonUpdate)
-            })
+            )
+            // Produce-after-commit: accumulate messages inside the txn and produce only after it
+            // commits, so a slow Kafka producer never holds the persons-pool connection open.
+            const kafkaAck = this.context.produceMessages(kafkaMessages)
+            return mergeSuccess(person, kafkaAck, needsPersonUpdate)
         }
     }
 

--- a/nodejs/src/ingestion/common/persons/person-property-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-property-service.ts
@@ -32,20 +32,20 @@ export class PersonPropertyService {
     }
 
     async updateProperties(): Promise<[InternalPerson, Promise<void>]> {
-        const [person, propertiesHandled] = await this.createOrGetPerson()
+        const [person, propertiesHandled, kafkaAck] = await this.createOrGetPerson()
         if (propertiesHandled) {
-            return [person, Promise.resolve()]
+            return [person, kafkaAck]
         }
         return await this.updatePersonProperties(person)
     }
 
     /**
-     * @returns [Person, boolean that indicates if properties were already handled or not]
+     * @returns [Person, boolean that indicates if properties were already handled or not, Kafka ack]
      */
-    private async createOrGetPerson(): Promise<[InternalPerson, boolean]> {
+    private async createOrGetPerson(): Promise<[InternalPerson, boolean, Promise<void>]> {
         const person = await this.context.personStore.fetchForUpdate(this.context.team.id, this.context.distinctId)
         if (person) {
-            return [person, false]
+            return [person, false, Promise.resolve()]
         }
 
         let properties = {}
@@ -55,7 +55,7 @@ export class PersonPropertyService {
             propertiesOnce = this.context.eventProperties['$set_once']
         }
 
-        return await this.personCreateService.createPerson(
+        const [createdPerson, wasCreated, kafkaMessages] = await this.personCreateService.createPerson(
             this.context.timestamp,
             properties || {},
             propertiesOnce || {},
@@ -66,6 +66,10 @@ export class PersonPropertyService {
             this.context.event.uuid,
             { distinctId: this.context.distinctId }
         )
+        // Not inside a transaction here, so producing immediately is safe; thread the ack so it is
+        // still awaited before the offset is committed.
+        const kafkaAck = this.context.produceMessages(kafkaMessages)
+        return [createdPerson, wasCreated, kafkaAck]
     }
 
     async updatePersonProperties(person: InternalPerson): Promise<[InternalPerson, Promise<void>]> {


### PR DESCRIPTION
## Problem

In the analytics ingestion pipeline, the person-merge path awaited Kafka produces
_inside_ open Postgres transactions.
When the Kafka producer is slow or stalled, that produce holds a persons-Postgres pool
connection open for the full produce-ack duration.
With unbounded merge concurrency, a Kafka slowdown converts directly into
persons-pool exhaustion: connections pile up waiting on Kafka while still checked out
of the pool.

Two sites did this:

- `mergeDistinctIds` OneExists transaction awaited `produceMessages` inside `inTransaction`.
- `PersonCreateService.createPerson` awaited `produceMessages` internally, and it is
  called inside the `mergeDistinctIds` NeitherExist transaction.

The main merge transaction (`executeTransaction`) already does the right thing:
it collects the Kafka messages inside the transaction and produces them _after_ commit,
returning the produce promise as the `kafkaAck`.
This change brings the other two sites in line with that pattern.

## Changes

> [!NOTE]
> This decouples Kafka produce latency from persons-pool capacity.
> The produce still happens, and its ack is still awaited before the offset commits.
> Only the timing moves: after the transaction commits, not while it is open.

- `mergeDistinctIds` OneExists and NeitherExist now accumulate their Kafka messages
  inside the transaction, and produce them only after it commits, threading the ack
  into the existing `mergeSuccess(person, kafkaAck, ...)` contract.
- `PersonCreateService.createPerson` no longer produces its own messages.
  It returns them (`[person, wasCreated, messages]`) so the caller decides when to produce.
  The in-transaction caller defers until after commit; the non-transaction caller
  (`PersonPropertyService`) produces immediately and threads the ack through, so nothing
  is silently dropped.

Crash semantics match the existing produce-after-commit site: a crash between commit and
ack loses the produce, and downstream replay is idempotent.

```mermaid
flowchart TD
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    A[begin txn] --> B[write rows]
    B --> C[await Kafka produce]
    C --> D[commit txn]
    class C phRed;
```

```mermaid
flowchart TD
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    A[begin txn] --> B[write rows, collect messages]
    B --> C[commit txn]
    C --> D[produce after commit, thread ack]
    class D phBlue;
```

## How did you test this code?

Automated only (I, Claude, did not run this against a live pipeline):

- New `person-merge-service.test.ts` uses a fake store whose `inTransaction` and
  `produce` record their interleaving.
  It asserts produce happens only after the transaction commits for both the OneExists
  and NeitherExist paths, and that a produce failure still surfaces through the returned
  `kafkaAck` without failing the merge.
  Regression caught: reintroducing an awaited produce inside either merge transaction, or
  dropping the ack so produce outcomes stop being awaited before offset commit.
- Updated `person-create-service.test.ts` to assert `createPerson` returns its messages
  and does not produce them itself.
  Regression caught: reverting `createPerson` to produce internally (which is what put the
  produce inside the NeitherExist transaction).
- Ran the full `nodejs/src/ingestion/common/persons/` Jest suite: 222 passed.
- Lint (eslint) and prettier clean; `hogli ci:preflight` clean.

Invoked the `/writing-tests` skill before writing tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) implemented this. The direction: fix the merge path so Kafka produces no
longer run inside open Postgres transactions, mirroring the produce-after-commit pattern
`executeTransaction` already uses.

Key decision: rather than have `createPerson` produce after the transaction (it does not
know whether it is inside one), I made it return its messages and let each caller own the
produce timing. That keeps the fix minimal at the in-transaction site while preserving the
non-transaction caller's behavior (it produces immediately and threads the ack). I audited
both `createPerson` callers (`PersonPropertyService` non-tx, `PersonMergeService` tx) and
confirmed the ack still flows into the pipeline result so it is awaited before the offset
commits.

Skills invoked: `/writing-tests`.
