### PR TITLE
perf(ingestion): batch-prefetch groups for $groupidentify events

### DIFF
--- a/nodejs/src/common/groups/repositories/group-repository.interface.ts
+++ b/nodejs/src/common/groups/repositories/group-repository.interface.ts
@@ -64,6 +64,17 @@ export interface GroupRepository {
         }[]
     >
 
+    /**
+     * Batch-fetch full group rows for the given (team, type index, key) tuples in a single query.
+     * Unlike `fetchGroupsByKeys` (a partial, personhog-routed projection used by CDP/error-tracking),
+     * this returns the complete `Group` — including `created_at` and `version` — so the ingestion
+     * group cache can be warmed with entries equivalent to a per-key `fetchGroup`.
+     */
+    fetchGroups(
+        entries: { teamId: TeamId; groupTypeIndex: GroupTypeIndex; groupKey: string }[],
+        callerTag?: string
+    ): Promise<Group[]>
+
     insertGroup(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,

--- a/nodejs/src/common/groups/repositories/postgres-group-repository.integration.test.ts
+++ b/nodejs/src/common/groups/repositories/postgres-group-repository.integration.test.ts
@@ -381,6 +381,48 @@ describe('PostgresGroupRepository Integration', () => {
             ])
             expect(result).toHaveLength(1)
         })
+
+        it('matches on the full tuple and never crosses teams', async () => {
+            const otherTeamId = 77 as TeamId
+            await insertTestTeam(teamId)
+            await insertTestTeam(otherTeamId)
+            // Same key and type index on both teams, distinguishable by properties.
+            await insertTestGroup({
+                team_id: teamId,
+                group_type_index: 0,
+                group_key: 'shared-key',
+                group_properties: JSON.stringify({ owner: 'team-1' }),
+            })
+            await insertTestGroup({
+                team_id: otherTeamId,
+                group_type_index: 0,
+                group_key: 'shared-key',
+                group_properties: JSON.stringify({ owner: 'team-2' }),
+            })
+            // A key that exists only for the other team.
+            await insertTestGroup({ team_id: otherTeamId, group_type_index: 0, group_key: 'only-team-2' })
+
+            const result = await repository.fetchGroups([
+                { teamId, groupTypeIndex: 0 as GroupTypeIndex, groupKey: 'shared-key' },
+                { teamId: otherTeamId, groupTypeIndex: 0 as GroupTypeIndex, groupKey: 'shared-key' },
+                // Key + index exist for the other team only — must not cross-match.
+                { teamId, groupTypeIndex: 0 as GroupTypeIndex, groupKey: 'only-team-2' },
+            ])
+
+            expect(result).toHaveLength(2)
+            const byTeam = new Map(result.map((group) => [group.team_id, group]))
+            expect(byTeam.get(teamId)).toMatchObject({
+                team_id: teamId,
+                group_key: 'shared-key',
+                group_properties: { owner: 'team-1' },
+            })
+            expect(byTeam.get(otherTeamId)).toMatchObject({
+                team_id: otherTeamId,
+                group_key: 'shared-key',
+                group_properties: { owner: 'team-2' },
+            })
+            expect(result.some((group) => group.team_id === teamId && group.group_key === 'only-team-2')).toBe(false)
+        })
     })
 
     describe('insertGroup', () => {

--- a/nodejs/src/common/groups/repositories/postgres-group-repository.integration.test.ts
+++ b/nodejs/src/common/groups/repositories/postgres-group-repository.integration.test.ts
@@ -337,6 +337,52 @@ describe('PostgresGroupRepository Integration', () => {
         })
     })
 
+    describe('fetchGroups', () => {
+        it('returns full group rows for matching tuples and omits non-matching ones', async () => {
+            await insertTestTeam(teamId)
+            await insertTestGroup({ group_type_index: 0, group_key: 'group-a', version: 3 })
+            await insertTestGroup({ group_type_index: 1, group_key: 'group-b' })
+
+            const result = await repository.fetchGroups([
+                { teamId, groupTypeIndex: 0 as GroupTypeIndex, groupKey: 'group-a' },
+                { teamId, groupTypeIndex: 1 as GroupTypeIndex, groupKey: 'group-b' },
+                // Right key but wrong type index — must not match.
+                { teamId, groupTypeIndex: 2 as GroupTypeIndex, groupKey: 'group-a' },
+                // Absent key — must not match.
+                { teamId, groupTypeIndex: 0 as GroupTypeIndex, groupKey: 'missing' },
+            ])
+
+            expect(result).toHaveLength(2)
+            const byKey = new Map(result.map((group) => [group.group_key, group]))
+            expect(byKey.get('group-a')).toMatchObject({
+                team_id: teamId,
+                group_type_index: 0,
+                group_key: 'group-a',
+                group_properties: groupProperties,
+                created_at: createdAt,
+                version: 3,
+            })
+            expect(byKey.get('group-b')).toMatchObject({
+                team_id: teamId,
+                group_type_index: 1,
+                group_key: 'group-b',
+            })
+        })
+
+        it('deduplicates repeated tuples and returns [] for empty input', async () => {
+            await insertTestTeam(teamId)
+            await insertTestGroup({ group_type_index: 0, group_key: 'group-a' })
+
+            expect(await repository.fetchGroups([])).toEqual([])
+
+            const result = await repository.fetchGroups([
+                { teamId, groupTypeIndex: 0 as GroupTypeIndex, groupKey: 'group-a' },
+                { teamId, groupTypeIndex: 0 as GroupTypeIndex, groupKey: 'group-a' },
+            ])
+            expect(result).toHaveLength(1)
+        })
+    })
+
     describe('insertGroup', () => {
         it('should insert a group successfully', async () => {
             await insertTestTeam(teamId)

--- a/nodejs/src/common/groups/repositories/postgres-group-repository.ts
+++ b/nodejs/src/common/groups/repositories/postgres-group-repository.ts
@@ -61,6 +61,48 @@ export class PostgresGroupRepository
         }
     }
 
+    async fetchGroups(
+        entries: { teamId: TeamId; groupTypeIndex: GroupTypeIndex; groupKey: string }[],
+        callerTag?: string
+    ): Promise<Group[]> {
+        if (entries.length === 0) {
+            return []
+        }
+
+        // Deduplicate inputs so a repeated tuple can't produce duplicate rows.
+        const seen = new Set<string>()
+        const teamIds: TeamId[] = []
+        const groupTypeIndexes: GroupTypeIndex[] = []
+        const groupKeys: string[] = []
+        for (const { teamId, groupTypeIndex, groupKey } of entries) {
+            const key = `${teamId}:${groupTypeIndex}:${groupKey}`
+            if (seen.has(key)) {
+                continue
+            }
+            seen.add(key)
+            teamIds.push(teamId)
+            groupTypeIndexes.push(groupTypeIndex)
+            groupKeys.push(groupKey)
+        }
+
+        // UNNEST with constant query shape keeps the plan cacheable regardless of batch size.
+        // Read from the primary (PERSONS_WRITE) so the warmed cache reflects in-flight writes,
+        // matching the freshness the per-key fetchGroup path uses for updates.
+        const { rows } = await this.postgres.query<RawGroup>(
+            PostgresUse.PERSONS_WRITE,
+            `SELECT g.*
+             FROM posthog_group g
+             JOIN unnest($1::int[], $2::int[], $3::text[]) AS t(team_id, group_type_index, group_key)
+               ON g.team_id = t.team_id
+              AND g.group_type_index = t.group_type_index
+              AND g.group_key = t.group_key`,
+            [teamIds, groupTypeIndexes, groupKeys],
+            queryTag('fetchGroups', callerTag)
+        )
+
+        return rows.map((row) => this.toGroup(row))
+    }
+
     async fetchGroupsByKeys(
         teamIds: TeamId[],
         groupTypeIndexes: GroupTypeIndex[],

--- a/nodejs/src/common/personhog/personhog-group-repository.test.ts
+++ b/nodejs/src/common/personhog/personhog-group-repository.test.ts
@@ -95,6 +95,7 @@ function createMockPostgres(): jest.Mocked<GroupRepository> {
     return {
         fetchGroup: jest.fn(),
         fetchGroupsByKeys: jest.fn(),
+        fetchGroups: jest.fn(),
         fetchGroupTypesByTeamIds: jest.fn(),
         fetchGroupTypesByProjectIds: jest.fn(),
         insertGroup: jest.fn(),

--- a/nodejs/src/common/personhog/personhog-group-repository.ts
+++ b/nodejs/src/common/personhog/personhog-group-repository.ts
@@ -52,6 +52,15 @@ export class PersonHogGroupRepository implements GroupRepository {
         }
     }
 
+    fetchGroups(
+        entries: { teamId: TeamId; groupTypeIndex: GroupTypeIndex; groupKey: string }[],
+        callerTag?: string
+    ): Promise<Group[]> {
+        // Full group rows (with created_at/version) aren't exposed over the gRPC proto,
+        // so this always reads from Postgres.
+        return timedPostgres(this.clientLabel, 'fetchGroups', () => this.postgres.fetchGroups(entries, callerTag))
+    }
+
     async fetchGroupsByKeys(
         teamIds: TeamId[],
         groupTypeIndexes: GroupTypeIndex[],

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
@@ -159,6 +159,50 @@ describe('BatchWritingGroupStore', () => {
         expect(cacheMetrics.cacheMisses).toBe(0)
     })
 
+    it('keeps groups with the same key but different type indexes as independent cache entries', async () => {
+        // The DB unique key is (team_id, group_key, group_type_index) — a cache keyed without the
+        // type index would serve type-1's upsert from type-0's entry and flush one group's
+        // properties and version onto the other.
+        jest.spyOn(groupRepository, 'fetchGroup').mockImplementation((_teamId, groupTypeIndex) =>
+            Promise.resolve({
+                ...group,
+                group_type_index: groupTypeIndex,
+                group_properties: { existing: `type-${groupTypeIndex}` },
+                version: groupTypeIndex === 0 ? 3 : 7,
+            })
+        )
+
+        await groupStore.upsertGroup(teamId, projectId, 0, 'test', { a: '1' }, DateTime.now())
+        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now())
+
+        // Each tuple pays its own fetch — the second must not be served by the first's entry.
+        expect(groupRepository.fetchGroup).toHaveBeenCalledTimes(2)
+
+        await groupStore.flush()
+
+        expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(2)
+        expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledWith(
+            teamId,
+            0,
+            'test',
+            3,
+            { existing: 'type-0', a: '1' },
+            group.created_at,
+            {},
+            {}
+        )
+        expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledWith(
+            teamId,
+            1,
+            'test',
+            7,
+            { existing: 'type-1', b: '2' },
+            group.created_at,
+            {},
+            {}
+        )
+    })
+
     it('should immediately write to db if new group', async () => {
         jest.spyOn(groupRepository, 'fetchGroup').mockResolvedValue(undefined)
         await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
@@ -317,7 +361,7 @@ describe('BatchWritingGroupStore', () => {
             details: {
                 groupTypeIndex: 1,
                 groupKey: 'test',
-                distinctId: `${teamId}:test`,
+                distinctId: `${teamId}:1:test`,
             },
             pipelineStep: 'group-store',
         })
@@ -370,7 +414,7 @@ describe('BatchWritingGroupStore', () => {
         expect(groupRepository.inTransaction).toHaveBeenCalledTimes(1) // Once for initial insert, once for retry (new group)
         expect((groupRepository as any).lastTransactionMock.insertGroup).toHaveBeenCalledTimes(1)
 
-        expect(cacheDeleteSpy).toHaveBeenCalledWith(teamId, 'test')
+        expect(cacheDeleteSpy).toHaveBeenCalledWith(teamId, 1, 'test')
 
         // Final call should succeed
         expect(groupRepository.updateGroupOptimistically).toHaveBeenLastCalledWith(
@@ -471,7 +515,7 @@ describe('BatchWritingGroupStore', () => {
 
             // Re-dirty the entry during the async DB write after the linearization point.
             jest.spyOn(groupRepository, 'updateGroupOptimistically').mockImplementationOnce(() => {
-                const entry = groupStore.getGroupCache().get(teamId, 'test')
+                const entry = groupStore.getGroupCache().get(teamId, 1, 'test')
                 if (entry) {
                     entry.needsWrite = true
                 }
@@ -481,7 +525,7 @@ describe('BatchWritingGroupStore', () => {
             await groupStore.flush()
 
             expect(groupStore.getGroupCache().getSize()).toBe(1)
-            expect(groupStore.getGroupCache().get(teamId, 'test')?.needsWrite).toBe(true)
+            expect(groupStore.getGroupCache().get(teamId, 1, 'test')?.needsWrite).toBe(true)
         })
 
         it('defers eviction of dirty entries until after flush', async () => {
@@ -576,6 +620,79 @@ describe('BatchWritingGroupStore', () => {
             expect(groupRepository.fetchGroup).not.toHaveBeenCalled()
             // Confirmed miss routes to the create transaction rather than a per-key fetch.
             expect(groupRepository.inTransaction).toHaveBeenCalledTimes(1)
+        })
+
+        it('fetches and caches the same key under different type indexes separately', async () => {
+            const groupIdx0: Group = {
+                ...group,
+                group_type_index: 0,
+                group_properties: { existing: 'type-0' },
+                version: 3,
+            }
+            const groupIdx1: Group = {
+                ...group,
+                group_type_index: 1,
+                group_properties: { existing: 'type-1' },
+                version: 7,
+            }
+            jest.spyOn(groupRepository, 'fetchGroups').mockResolvedValue([groupIdx0, groupIdx1])
+
+            await groupStore.prefetchGroups([
+                { teamId, groupTypeIndex: 0, groupKey: 'test', batchId: 0 },
+                { teamId, groupTypeIndex: 1, groupKey: 'test', batchId: 0 },
+            ])
+
+            // Same key, two type indexes: both tuples are fetched, not collapsed into one.
+            expect(groupRepository.fetchGroups).toHaveBeenCalledWith(
+                [
+                    { teamId, groupTypeIndex: 0, groupKey: 'test' },
+                    { teamId, groupTypeIndex: 1, groupKey: 'test' },
+                ],
+                'ingestion/group-prefetch'
+            )
+
+            await groupStore.upsertGroup(teamId, projectId, 0, 'test', { a: '1' }, DateTime.now(), 0)
+            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now(), 0)
+            expect(groupRepository.fetchGroup).not.toHaveBeenCalled()
+
+            await groupStore.flush()
+
+            // Each upsert merged into its own group's entry, not the other's.
+            expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledWith(
+                teamId,
+                0,
+                'test',
+                3,
+                { existing: 'type-0', a: '1' },
+                group.created_at,
+                {},
+                {}
+            )
+            expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledWith(
+                teamId,
+                1,
+                'test',
+                7,
+                { existing: 'type-1', b: '2' },
+                group.created_at,
+                {},
+                {}
+            )
+        })
+
+        it('collapses duplicate tuples within one call into a single fetch entry', async () => {
+            jest.spyOn(groupRepository, 'fetchGroups').mockResolvedValue([])
+
+            await groupStore.prefetchGroups([
+                { teamId, groupTypeIndex: 1, groupKey: 'dup', batchId: 0 },
+                { teamId, groupTypeIndex: 1, groupKey: 'dup', batchId: 0 },
+            ])
+
+            expect(groupRepository.fetchGroups).toHaveBeenCalledTimes(1)
+            expect(groupRepository.fetchGroups).toHaveBeenCalledWith(
+                [{ teamId, groupTypeIndex: 1, groupKey: 'dup' }],
+                'ingestion/group-prefetch'
+            )
         })
 
         it('dedupes an in-flight prefetch so concurrent calls issue one query', async () => {

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
@@ -53,6 +53,7 @@ describe('BatchWritingGroupStore', () => {
             fetchGroup: jest.fn().mockImplementation(() => {
                 return Promise.resolve(group)
             }),
+            fetchGroups: jest.fn().mockResolvedValue([]),
             insertGroup: jest.fn().mockImplementation(() => {
                 return Promise.resolve(1)
             }),
@@ -539,6 +540,71 @@ describe('BatchWritingGroupStore', () => {
 
             await groupStore.flush()
             await expect(groupStore.shutdown()).resolves.not.toThrow()
+        })
+    })
+
+    describe('prefetchGroups', () => {
+        it('warms the cache from fetched groups so a later upsertGroup merges without a per-key fetchGroup', async () => {
+            jest.spyOn(groupRepository, 'fetchGroups').mockResolvedValue([group])
+
+            await groupStore.prefetchGroups([{ teamId, groupTypeIndex: 1, groupKey: 'test', batchId: 0 }])
+            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { extra: 'v' }, DateTime.now(), 0)
+
+            expect(groupRepository.fetchGroups).toHaveBeenCalledTimes(1)
+            expect(groupRepository.fetchGroup).not.toHaveBeenCalled()
+
+            await groupStore.flush()
+            expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledWith(
+                teamId,
+                1,
+                'test',
+                1,
+                { test: 'test', extra: 'v' },
+                group.created_at,
+                {},
+                {}
+            )
+        })
+
+        it('caches a negative entry for a miss so a later upsertGroup creates without a per-key fetchGroup', async () => {
+            jest.spyOn(groupRepository, 'fetchGroups').mockResolvedValue([])
+
+            await groupStore.prefetchGroups([{ teamId, groupTypeIndex: 2, groupKey: 'new-key', batchId: 0 }])
+            await groupStore.upsertGroup(teamId, projectId, 2, 'new-key', { a: '1' }, DateTime.now(), 0)
+
+            expect(groupRepository.fetchGroups).toHaveBeenCalledTimes(1)
+            expect(groupRepository.fetchGroup).not.toHaveBeenCalled()
+            // Confirmed miss routes to the create transaction rather than a per-key fetch.
+            expect(groupRepository.inTransaction).toHaveBeenCalledTimes(1)
+        })
+
+        it('dedupes an in-flight prefetch so concurrent calls issue one query', async () => {
+            let resolveFetch: (groups: Group[]) => void = () => {}
+            jest.spyOn(groupRepository, 'fetchGroups').mockImplementation(
+                () => new Promise<Group[]>((resolve) => (resolveFetch = resolve))
+            )
+
+            const first = groupStore.prefetchGroups([{ teamId, groupTypeIndex: 1, groupKey: 'test', batchId: 0 }])
+            const second = groupStore.prefetchGroups([{ teamId, groupTypeIndex: 1, groupKey: 'test', batchId: 0 }])
+            resolveFetch([group])
+            await Promise.all([first, second])
+
+            expect(groupRepository.fetchGroups).toHaveBeenCalledTimes(1)
+        })
+
+        it('rejects a consumer waiting on an in-flight prefetch when the batch fetch fails', async () => {
+            let rejectFetch: (error: Error) => void = () => {}
+            jest.spyOn(groupRepository, 'fetchGroups').mockImplementation(
+                () => new Promise<Group[]>((_, reject) => (rejectFetch = reject))
+            )
+
+            const prefetch = groupStore.prefetchGroups([{ teamId, groupTypeIndex: 1, groupKey: 'test', batchId: 0 }])
+            const consumer = groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now(), 0)
+            rejectFetch(new Error('groups db unavailable'))
+
+            await expect(consumer).rejects.toThrow('groups db unavailable')
+            // A non-retriable failure also rethrows out of the fire-and-forget warmer.
+            await expect(prefetch).rejects.toThrow('groups db unavailable')
         })
     })
 })

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
@@ -34,6 +34,8 @@ class GroupCache {
     private batchGroupKeys: Map<number, Set<string>>
     private groupKeyRefCount: Map<string, number>
     private deferredEvictions: Set<string>
+    private pendingPrefetchesByBatchId: Map<number, number>
+    private releasedBatchIdsWithPendingPrefetch: Set<number>
 
     constructor() {
         this.cache = new Map()
@@ -41,6 +43,8 @@ class GroupCache {
         this.batchGroupKeys = new Map()
         this.groupKeyRefCount = new Map()
         this.deferredEvictions = new Set()
+        this.pendingPrefetchesByBatchId = new Map()
+        this.releasedBatchIdsWithPendingPrefetch = new Set()
         this.metrics = {
             cacheHits: 0,
             cacheMisses: 0,
@@ -149,6 +153,11 @@ class GroupCache {
 
     releaseBatchId(batchId: number): void {
         const keys = this.batchGroupKeys.get(batchId)
+        // If a prefetch for this batch is still in flight, remember the release so the
+        // prefetch's late cache writes are dropped rather than resurrecting an evicted key.
+        if (this.pendingPrefetchesByBatchId.has(batchId)) {
+            this.releasedBatchIdsWithPendingPrefetch.add(batchId)
+        }
         if (!keys) {
             return
         }
@@ -164,6 +173,28 @@ class GroupCache {
         }
 
         this.batchGroupKeys.delete(batchId)
+    }
+
+    trackPendingPrefetch(batchIds: Set<number>): void {
+        for (const batchId of batchIds) {
+            this.pendingPrefetchesByBatchId.set(batchId, (this.pendingPrefetchesByBatchId.get(batchId) ?? 0) + 1)
+        }
+    }
+
+    finishPendingPrefetch(batchIds: Set<number>): void {
+        for (const batchId of batchIds) {
+            const pendingCount = (this.pendingPrefetchesByBatchId.get(batchId) ?? 1) - 1
+            if (pendingCount <= 0) {
+                this.pendingPrefetchesByBatchId.delete(batchId)
+                this.releasedBatchIdsWithPendingPrefetch.delete(batchId)
+            } else {
+                this.pendingPrefetchesByBatchId.set(batchId, pendingCount)
+            }
+        }
+    }
+
+    isBatchReleasedWithPendingPrefetch(batchId: number): boolean {
+        return this.releasedBatchIdsWithPendingPrefetch.has(batchId)
     }
 
     processDeferredEvictions(): void {
@@ -447,6 +478,106 @@ export class BatchWritingGroupStore implements GroupStore {
                 effectiveBatchId
             )
         }
+    }
+
+    /**
+     * Best-effort cache warmer for the given group keys. Callers fire this without awaiting it,
+     * so its own rejection would become an unhandled rejection that exits the worker — so it swallows
+     * transient persons-Postgres unavailability (isRetriable errors) here. The failure is not masked:
+     * each per-key promise (awaited by the get-or-fetch path in `getGroup`) still rejects, so a
+     * consumer propagates the error and the per-distinct-id pipeline retries it. Any other error
+     * (e.g. a broken query) is rethrown so it crashes loudly rather than being silently masked.
+     */
+    async prefetchGroups(
+        entries: { teamId: TeamId; groupTypeIndex: GroupTypeIndex; groupKey: string; batchId: number }[]
+    ): Promise<void> {
+        if (entries.length === 0) {
+            return
+        }
+
+        // Skip keys already cached (hit or negative) or with an in-flight fetch.
+        const uncachedEntries: {
+            teamId: TeamId
+            groupTypeIndex: GroupTypeIndex
+            groupKey: string
+            batchId: number
+            cacheKey: string
+        }[] = []
+        for (const { teamId, groupTypeIndex, groupKey, batchId } of entries) {
+            const cache = this.groupCache.obtainForBatchId(batchId)
+            if (cache.has(teamId, groupKey)) {
+                continue
+            }
+            if (cache.getFetchPromise(teamId, groupKey)) {
+                continue
+            }
+            uncachedEntries.push({ teamId, groupTypeIndex, groupKey, batchId, cacheKey: `${teamId}:${groupKey}` })
+        }
+
+        if (uncachedEntries.length === 0) {
+            return
+        }
+
+        const prefetchBatchIds = new Set(uncachedEntries.map(({ batchId }) => batchId))
+        this.groupCache.trackPendingPrefetch(prefetchBatchIds)
+        this.incrementDatabaseOperation('prefetchGroups')
+
+        const batchFetchPromise = this.groupRepository
+            .fetchGroups(
+                uncachedEntries.map(({ teamId, groupTypeIndex, groupKey }) => ({ teamId, groupTypeIndex, groupKey })),
+                'ingestion/group-prefetch'
+            )
+            .then((groups) => {
+                const groupsByKey = new Map<string, GroupUpdate>()
+                for (const group of groups) {
+                    groupsByKey.set(`${group.team_id}:${group.group_key}`, fromGroup(group))
+                }
+
+                // Cache all results: found groups and negative (null) entries for misses.
+                for (const { teamId, groupKey, batchId, cacheKey } of uncachedEntries) {
+                    if (this.groupCache.isBatchReleasedWithPendingPrefetch(batchId)) {
+                        continue
+                    }
+                    const cache = this.groupCache.obtainForBatchId(batchId)
+                    const groupUpdate = groupsByKey.get(cacheKey)
+                    cache.set(teamId, groupKey, groupUpdate ? { ...groupUpdate } : null)
+                }
+
+                return groupsByKey
+            })
+            .finally(() => {
+                for (const { teamId, groupKey } of uncachedEntries) {
+                    this.groupCache.deleteFetchPromise(teamId, groupKey)
+                }
+                this.groupCache.finishPendingPrefetch(prefetchBatchIds)
+            })
+
+        // Register per-key promises so the get-or-fetch path in getGroup waits on the in-flight
+        // batch. On failure these reject, so a consumer propagates the error (and a transient
+        // isRetriable error is retried in the per-distinct-id pipeline) rather than seeing a
+        // misleading "group absent" null. The throwaway catch only marks the promise handled so an
+        // unconsumed key (its event may be dropped before the fetch) can't become an unhandled
+        // rejection — it does not change what awaiting consumers observe.
+        for (const { teamId, groupKey, cacheKey } of uncachedEntries) {
+            const keyPromise = batchFetchPromise.then((groupsByKey) => groupsByKey.get(cacheKey) ?? null)
+            keyPromise.catch(() => {})
+            this.groupCache.setFetchPromise(teamId, groupKey, keyPromise)
+        }
+
+        // Recover from a retriable failure (e.g. transient persons-Postgres unavailability) so this
+        // best-effort, fire-and-forget warmer can't crash the worker. The failure is not masked:
+        // consumers still observe the rejection on their per-key promise and retry it. We recover
+        // only on an explicit `isRetriable === true`: an unflagged error (e.g. a broken query)
+        // rethrows and crashes loudly rather than being silently masked.
+        await batchFetchPromise.catch((error) => {
+            if (error?.isRetriable === true) {
+                logger.warn('⚠️', 'prefetchGroups failed on a retriable persons-Postgres error', {
+                    error: String(error),
+                })
+                return
+            }
+            throw error
+        })
     }
 
     private async addToBatch(

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
@@ -55,19 +55,24 @@ class GroupCache {
         return new BatchBoundGroupCache(this, batchId)
     }
 
-    get(teamId: TeamId, groupKey: string): GroupUpdate | null | undefined {
-        return this.cache.get(this.getCacheKey(teamId, groupKey))
+    get(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): GroupUpdate | null | undefined {
+        return this.cache.get(this.getCacheKey(teamId, groupTypeIndex, groupKey))
     }
 
-    hasForBatch(batchId: number, teamId: TeamId, groupKey: string): boolean {
-        this.trackBatchEntry(batchId, teamId, groupKey)
-        const key = this.getCacheKey(teamId, groupKey)
+    hasForBatch(batchId: number, teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): boolean {
+        this.trackBatchEntry(batchId, teamId, groupTypeIndex, groupKey)
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         return this.cache.has(key)
     }
 
-    getForBatch(batchId: number, teamId: TeamId, groupKey: string): GroupUpdate | null | undefined {
-        this.trackBatchEntry(batchId, teamId, groupKey)
-        const key = this.getCacheKey(teamId, groupKey)
+    getForBatch(
+        batchId: number,
+        teamId: TeamId,
+        groupTypeIndex: GroupTypeIndex,
+        groupKey: string
+    ): GroupUpdate | null | undefined {
+        this.trackBatchEntry(batchId, teamId, groupTypeIndex, groupKey)
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         const result = this.cache.get(key)
         if (result !== undefined) {
             this.metrics.cacheHits++
@@ -77,29 +82,44 @@ class GroupCache {
         return result
     }
 
-    setForBatch(batchId: number, teamId: TeamId, groupKey: string, group: GroupUpdate | null): void {
-        this.trackBatchEntry(batchId, teamId, groupKey)
-        const key = this.getCacheKey(teamId, groupKey)
+    setForBatch(
+        batchId: number,
+        teamId: TeamId,
+        groupTypeIndex: GroupTypeIndex,
+        groupKey: string,
+        group: GroupUpdate | null
+    ): void {
+        this.trackBatchEntry(batchId, teamId, groupTypeIndex, groupKey)
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         this.cache.set(key, group)
     }
 
-    delete(teamId: TeamId, groupKey: string): void {
-        const key = this.getCacheKey(teamId, groupKey)
+    delete(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): void {
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         this.cache.delete(key)
     }
 
-    getFetchPromise(teamId: TeamId, groupKey: string): Promise<GroupUpdate | null> | undefined {
-        const key = this.getCacheKey(teamId, groupKey)
+    getFetchPromise(
+        teamId: TeamId,
+        groupTypeIndex: GroupTypeIndex,
+        groupKey: string
+    ): Promise<GroupUpdate | null> | undefined {
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         return this.fetchPromises.get(key)
     }
 
-    setFetchPromise(teamId: TeamId, groupKey: string, promise: Promise<GroupUpdate | null>): void {
-        const key = this.getCacheKey(teamId, groupKey)
+    setFetchPromise(
+        teamId: TeamId,
+        groupTypeIndex: GroupTypeIndex,
+        groupKey: string,
+        promise: Promise<GroupUpdate | null>
+    ): void {
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         this.fetchPromises.set(key, promise)
     }
 
-    deleteFetchPromise(teamId: TeamId, groupKey: string): void {
-        const key = this.getCacheKey(teamId, groupKey)
+    deleteFetchPromise(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): void {
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         this.fetchPromises.delete(key)
     }
 
@@ -207,12 +227,15 @@ class GroupCache {
         }
     }
 
-    private getCacheKey(teamId: TeamId, groupKey: string): string {
-        return `${teamId}:${groupKey}`
+    // The DB unique key is (team_id, group_key, group_type_index) — the cache key must carry
+    // all three, or two groups sharing a key across type indexes would alias one entry and a
+    // flush could write one group's properties onto the other.
+    private getCacheKey(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): string {
+        return `${teamId}:${groupTypeIndex}:${groupKey}`
     }
 
-    private trackBatchEntry(batchId: number, teamId: TeamId, groupKey: string): void {
-        const key = this.getCacheKey(teamId, groupKey)
+    private trackBatchEntry(batchId: number, teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): void {
+        const key = this.getCacheKey(teamId, groupTypeIndex, groupKey)
         let keys = this.batchGroupKeys.get(batchId)
         if (!keys) {
             keys = new Set()
@@ -241,28 +264,37 @@ class BatchBoundGroupCache {
         private readonly batchId: number
     ) {}
 
-    has(teamId: TeamId, groupKey: string): boolean {
-        return this.cache.hasForBatch(this.batchId, teamId, groupKey)
+    has(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): boolean {
+        return this.cache.hasForBatch(this.batchId, teamId, groupTypeIndex, groupKey)
     }
 
-    get(teamId: TeamId, groupKey: string): GroupUpdate | null | undefined {
-        return this.cache.getForBatch(this.batchId, teamId, groupKey)
+    get(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): GroupUpdate | null | undefined {
+        return this.cache.getForBatch(this.batchId, teamId, groupTypeIndex, groupKey)
     }
 
-    set(teamId: TeamId, groupKey: string, group: GroupUpdate | null): void {
-        this.cache.setForBatch(this.batchId, teamId, groupKey, group)
+    set(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string, group: GroupUpdate | null): void {
+        this.cache.setForBatch(this.batchId, teamId, groupTypeIndex, groupKey, group)
     }
 
-    getFetchPromise(teamId: TeamId, groupKey: string): Promise<GroupUpdate | null> | undefined {
-        return this.cache.getFetchPromise(teamId, groupKey)
+    getFetchPromise(
+        teamId: TeamId,
+        groupTypeIndex: GroupTypeIndex,
+        groupKey: string
+    ): Promise<GroupUpdate | null> | undefined {
+        return this.cache.getFetchPromise(teamId, groupTypeIndex, groupKey)
     }
 
-    setFetchPromise(teamId: TeamId, groupKey: string, promise: Promise<GroupUpdate | null>): void {
-        this.cache.setFetchPromise(teamId, groupKey, promise)
+    setFetchPromise(
+        teamId: TeamId,
+        groupTypeIndex: GroupTypeIndex,
+        groupKey: string,
+        promise: Promise<GroupUpdate | null>
+    ): void {
+        this.cache.setFetchPromise(teamId, groupTypeIndex, groupKey, promise)
     }
 
-    deleteFetchPromise(teamId: TeamId, groupKey: string): void {
-        this.cache.deleteFetchPromise(teamId, groupKey)
+    deleteFetchPromise(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): void {
+        this.cache.deleteFetchPromise(teamId, groupTypeIndex, groupKey)
     }
 }
 
@@ -428,7 +460,7 @@ export class BatchWritingGroupStore implements GroupStore {
         })
 
         // Remove from cache to prevent retry
-        this.groupCache.delete(update.team_id, update.group_key)
+        this.groupCache.delete(update.team_id, update.group_type_index, update.group_key)
 
         try {
             await this.executeGroupUpsert(
@@ -495,7 +527,10 @@ export class BatchWritingGroupStore implements GroupStore {
             return
         }
 
-        // Skip keys already cached (hit or negative) or with an in-flight fetch.
+        // Skip tuples already cached (hit or negative), with an in-flight fetch, or repeated
+        // within this call. Dedup is by the full (team, type index, key) tuple — the same key
+        // under two type indexes is two distinct groups and both must be fetched.
+        const seen = new Set<string>()
         const uncachedEntries: {
             teamId: TeamId
             groupTypeIndex: GroupTypeIndex
@@ -504,14 +539,19 @@ export class BatchWritingGroupStore implements GroupStore {
             cacheKey: string
         }[] = []
         for (const { teamId, groupTypeIndex, groupKey, batchId } of entries) {
+            const cacheKey = `${teamId}:${groupTypeIndex}:${groupKey}`
+            if (seen.has(cacheKey)) {
+                continue
+            }
+            seen.add(cacheKey)
             const cache = this.groupCache.obtainForBatchId(batchId)
-            if (cache.has(teamId, groupKey)) {
+            if (cache.has(teamId, groupTypeIndex, groupKey)) {
                 continue
             }
-            if (cache.getFetchPromise(teamId, groupKey)) {
+            if (cache.getFetchPromise(teamId, groupTypeIndex, groupKey)) {
                 continue
             }
-            uncachedEntries.push({ teamId, groupTypeIndex, groupKey, batchId, cacheKey: `${teamId}:${groupKey}` })
+            uncachedEntries.push({ teamId, groupTypeIndex, groupKey, batchId, cacheKey })
         }
 
         if (uncachedEntries.length === 0) {
@@ -530,24 +570,24 @@ export class BatchWritingGroupStore implements GroupStore {
             .then((groups) => {
                 const groupsByKey = new Map<string, GroupUpdate>()
                 for (const group of groups) {
-                    groupsByKey.set(`${group.team_id}:${group.group_key}`, fromGroup(group))
+                    groupsByKey.set(`${group.team_id}:${group.group_type_index}:${group.group_key}`, fromGroup(group))
                 }
 
                 // Cache all results: found groups and negative (null) entries for misses.
-                for (const { teamId, groupKey, batchId, cacheKey } of uncachedEntries) {
+                for (const { teamId, groupTypeIndex, groupKey, batchId, cacheKey } of uncachedEntries) {
                     if (this.groupCache.isBatchReleasedWithPendingPrefetch(batchId)) {
                         continue
                     }
                     const cache = this.groupCache.obtainForBatchId(batchId)
                     const groupUpdate = groupsByKey.get(cacheKey)
-                    cache.set(teamId, groupKey, groupUpdate ? { ...groupUpdate } : null)
+                    cache.set(teamId, groupTypeIndex, groupKey, groupUpdate ? { ...groupUpdate } : null)
                 }
 
                 return groupsByKey
             })
             .finally(() => {
-                for (const { teamId, groupKey } of uncachedEntries) {
-                    this.groupCache.deleteFetchPromise(teamId, groupKey)
+                for (const { teamId, groupTypeIndex, groupKey } of uncachedEntries) {
+                    this.groupCache.deleteFetchPromise(teamId, groupTypeIndex, groupKey)
                 }
                 this.groupCache.finishPendingPrefetch(prefetchBatchIds)
             })
@@ -558,10 +598,10 @@ export class BatchWritingGroupStore implements GroupStore {
         // misleading "group absent" null. The throwaway catch only marks the promise handled so an
         // unconsumed key (its event may be dropped before the fetch) can't become an unhandled
         // rejection — it does not change what awaiting consumers observe.
-        for (const { teamId, groupKey, cacheKey } of uncachedEntries) {
+        for (const { teamId, groupTypeIndex, groupKey, cacheKey } of uncachedEntries) {
             const keyPromise = batchFetchPromise.then((groupsByKey) => groupsByKey.get(cacheKey) ?? null)
             keyPromise.catch(() => {})
-            this.groupCache.setFetchPromise(teamId, groupKey, keyPromise)
+            this.groupCache.setFetchPromise(teamId, groupTypeIndex, groupKey, keyPromise)
         }
 
         // Recover from a retriable failure (e.g. transient persons-Postgres unavailability) so this
@@ -607,7 +647,7 @@ export class BatchWritingGroupStore implements GroupStore {
 
         const propertiesUpdate = calculateUpdate(group.group_properties || {}, properties)
         if (propertiesUpdate.updated) {
-            groupCache.set(teamId, groupKey, {
+            groupCache.set(teamId, groupTypeIndex, groupKey, {
                 team_id: teamId,
                 group_type_index: groupTypeIndex,
                 group_key: groupKey,
@@ -724,7 +764,7 @@ export class BatchWritingGroupStore implements GroupStore {
                     expectedVersion,
                     tx
                 )
-                groupCache?.set(teamId, groupKey, {
+                groupCache?.set(teamId, groupTypeIndex, groupKey, {
                     team_id: teamId,
                     group_type_index: groupTypeIndex,
                     group_key: groupKey,
@@ -843,14 +883,14 @@ export class BatchWritingGroupStore implements GroupStore {
         groupCache: BatchBoundGroupCache | undefined,
         tx?: GroupRepositoryTransaction
     ): Promise<GroupUpdate | null> {
-        if (groupCache?.has(teamId, groupKey) && !forUpdate) {
-            const cachedGroup = groupCache.get(teamId, groupKey)
+        if (groupCache?.has(teamId, groupTypeIndex, groupKey) && !forUpdate) {
+            const cachedGroup = groupCache.get(teamId, groupTypeIndex, groupKey)
             if (cachedGroup !== undefined) {
                 return cachedGroup
             }
         }
 
-        let fetchPromise = groupCache?.getFetchPromise(teamId, groupKey)
+        let fetchPromise = groupCache?.getFetchPromise(teamId, groupTypeIndex, groupKey)
         if (!fetchPromise) {
             groupFetchPromisesCacheOperationsCounter.inc({ operation: 'miss' })
             fetchPromise = (async () => {
@@ -860,20 +900,20 @@ export class BatchWritingGroupStore implements GroupStore {
                     const existingGroup = await repository.fetchGroup(teamId, groupTypeIndex, groupKey, { forUpdate })
                     if (existingGroup) {
                         const groupUpdate = fromGroup(existingGroup)
-                        groupCache?.set(teamId, groupKey, {
+                        groupCache?.set(teamId, groupTypeIndex, groupKey, {
                             ...groupUpdate,
                             needsWrite: false,
                         })
                         return groupUpdate
                     } else {
-                        groupCache?.set(teamId, groupKey, null)
+                        groupCache?.set(teamId, groupTypeIndex, groupKey, null)
                         return null
                     }
                 } finally {
-                    groupCache?.deleteFetchPromise(teamId, groupKey)
+                    groupCache?.deleteFetchPromise(teamId, groupTypeIndex, groupKey)
                 }
             })()
-            groupCache?.setFetchPromise(teamId, groupKey, fetchPromise)
+            groupCache?.setFetchPromise(teamId, groupTypeIndex, groupKey, fetchPromise)
         } else {
             groupFetchPromisesCacheOperationsCounter.inc({ operation: 'hit' })
         }
@@ -903,7 +943,7 @@ export class BatchWritingGroupStore implements GroupStore {
         }
         if (error instanceof RaceConditionError) {
             // Remove from cache to prevent retry, the group was already created by another thread
-            this.groupCache.delete(teamId, groupKey)
+            this.groupCache.delete(teamId, groupTypeIndex, groupKey)
             return this.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, properties, timestamp, batchId)
         }
         throw error

--- a/nodejs/src/ingestion/common/groups/group-store-for-batch.ts
+++ b/nodejs/src/ingestion/common/groups/group-store-for-batch.ts
@@ -16,6 +16,9 @@ export type GroupStoreForBatch = Omit<GroupStore, 'upsertGroup' | 'releaseBatch'
         properties: Properties,
         timestamp: DateTime
     ): Promise<void>
+    prefetchGroups(
+        entries: { teamId: TeamId; groupTypeIndex: GroupTypeIndex; groupKey: string; batchId: number }[]
+    ): Promise<void>
     readonly batchId: number
 }
 
@@ -34,6 +37,12 @@ export class BatchBoundGroupStore implements GroupStoreForBatch {
         timestamp: DateTime
     ): Promise<void> {
         return this.store.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, properties, timestamp, this.batchId)
+    }
+
+    prefetchGroups(
+        entries: { teamId: TeamId; groupTypeIndex: GroupTypeIndex; groupKey: string; batchId: number }[]
+    ): Promise<void> {
+        return this.store.prefetchGroups(entries)
     }
 
     getCacheMetrics(): CacheMetrics {

--- a/nodejs/src/ingestion/common/steps/event-processing/groups.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/groups.ts
@@ -1,8 +1,29 @@
 import { DateTime } from 'luxon'
 
 import { GroupTypeManager } from '~/common/groups/group-type-manager'
+import { sanitizeString } from '~/common/utils/db/utils'
 import { Properties } from '~/plugin-scaffold'
 import { GroupTypeToColumnIndex, ProjectId, TeamId } from '~/types'
+
+/**
+ * Extract the group identity from a $groupidentify event's properties. Owns the
+ * presence checks (falsy $group_type / $group_key are skipped) and the exact key
+ * normalization the group store is keyed by, so every reader and writer of the
+ * group cache — the upsert path and the prefetch path — lands on a byte-identical
+ * key. Group-type-index resolution intentionally stays out: the upsert path may
+ * insert a new mapping while the prefetch path is read-only.
+ */
+export function extractGroupIdentify(
+    properties: Properties | undefined
+): { groupType: string; groupKey: string } | null {
+    if (!properties || !properties['$group_type'] || !properties['$group_key']) {
+        return null
+    }
+    return {
+        groupType: properties['$group_type'],
+        groupKey: sanitizeString(properties['$group_key'].toString()),
+    }
+}
 
 export function enrichPropertiesWithGroupTypes(
     properties: Properties,

--- a/nodejs/src/ingestion/common/steps/event-processing/process-groups-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/process-groups-step.ts
@@ -1,7 +1,6 @@
 import { DateTime } from 'luxon'
 
 import { GroupTypeManager } from '~/common/groups/group-type-manager'
-import { sanitizeString } from '~/common/utils/db/utils'
 import { logger } from '~/common/utils/logger'
 import { captureException } from '~/common/utils/posthog'
 import { TeamManager } from '~/common/utils/team-manager'
@@ -12,7 +11,7 @@ import { Properties } from '~/plugin-scaffold'
 import { PreIngestionEvent, ProjectId, Team, TeamId } from '~/types'
 
 import { EventPipelineRunnerOptions } from './event-pipeline-options'
-import { addGroupProperties } from './groups'
+import { addGroupProperties, extractGroupIdentify } from './groups'
 
 const EVENTS_WITHOUT_EVENT_DEFINITION = ['$$plugin_metrics']
 
@@ -108,19 +107,24 @@ async function upsertGroup(
     properties: Properties,
     timestamp: DateTime
 ): Promise<void> {
-    if (!properties['$group_type'] || !properties['$group_key']) {
+    const groupIdentify = extractGroupIdentify(properties)
+    if (!groupIdentify) {
         return
     }
 
-    const { $group_type: groupType, $group_key: groupKey, $group_set: groupPropertiesToSet } = properties
-    const groupTypeIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, groupType, timestamp)
+    const groupTypeIndex = await groupTypeManager.fetchGroupTypeIndex(
+        teamId,
+        projectId,
+        groupIdentify.groupType,
+        timestamp
+    )
     if (groupTypeIndex !== null) {
         await groupStore.upsertGroup(
             teamId,
             projectId,
             groupTypeIndex,
-            sanitizeString(groupKey.toString()),
-            groupPropertiesToSet || {},
+            groupIdentify.groupKey,
+            properties['$group_set'] || {},
             timestamp
         )
     }

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -129,6 +129,7 @@ export type IngestionConsumerConfig = {
     PERSON_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES: number
     PERSON_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS: number
     PERSONS_PREFETCH_ENABLED: boolean
+    GROUPS_PREFETCH_ENABLED: boolean
 
     // Person properties config
     PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE: number
@@ -243,6 +244,7 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         PERSON_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES: 5,
         PERSON_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS: 50,
         PERSONS_PREFETCH_ENABLED: false,
+        GROUPS_PREFETCH_ENABLED: false,
 
         // Person properties config
         PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE: 0,

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -272,6 +272,7 @@ export class IngestionConsumer {
             overflowMode: this.config.INGESTION_OVERFLOW_MODE,
             preservePartitionLocality: this.config.INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY,
             personsPrefetchEnabled: this.config.PERSONS_PREFETCH_ENABLED,
+            groupsPrefetchEnabled: this.config.GROUPS_PREFETCH_ENABLED,
             cdpHogWatcherSampleRate: this.config.CDP_HOG_WATCHER_SAMPLE_RATE,
             outputs,
             perDistinctIdOptions: {

--- a/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
@@ -73,6 +73,7 @@ export interface JoinedIngestionPipelineConfig {
     overflowMode: IngestionOverflowMode
     preservePartitionLocality: boolean
     personsPrefetchEnabled: boolean
+    groupsPrefetchEnabled: boolean
     cdpHogWatcherSampleRate: number
     outputs: IngestionOutputs<
         | EventOutput
@@ -153,6 +154,7 @@ export function createJoinedIngestionPipeline<
         overflowMode,
         preservePartitionLocality,
         personsPrefetchEnabled,
+        groupsPrefetchEnabled,
         cdpHogWatcherSampleRate,
         outputs,
         perDistinctIdOptions,
@@ -195,6 +197,8 @@ export function createJoinedIngestionPipeline<
         overflowLaneTTLRefreshService,
         featureFlagCalledDedupService,
         personsPrefetchEnabled,
+        groupsPrefetchEnabled,
+        groupTypeManager,
         flagCalledPersonlessDefaultTeams: perDistinctIdOptions.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS,
         hogTransformer,
         cdpHogWatcherSampleRate,

--- a/nodejs/src/ingestion/pipelines/analytics/post-team-preprocessing-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/post-team-preprocessing-subpipeline.ts
@@ -1,5 +1,6 @@
 import { Message } from 'node-rdkafka'
 
+import { GroupTypeManager } from '~/common/groups/group-type-manager'
 import { HogTransformer } from '~/common/hog-transformations/hog-transformer.interface'
 import { EventIngestionRestrictionManager } from '~/common/utils/event-ingestion-restrictions'
 import { EventSchemaEnforcementManager } from '~/common/utils/event-schema-enforcement-manager'
@@ -7,6 +8,7 @@ import { CookielessManager } from '~/ingestion/common/cookieless/cookieless-mana
 import { EventFilterManager } from '~/ingestion/common/event-filters'
 import { EventFiltersBatchAppMetrics } from '~/ingestion/common/event-filters/batch-app-metrics'
 import { FeatureFlagCalledDedupService } from '~/ingestion/common/feature-flag-called-dedup/feature-flag-called-dedup-service'
+import { GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
 import { OverflowRedirectService } from '~/ingestion/common/overflow-redirect/overflow-redirect-service'
 import { PersonsStoreForBatch } from '~/ingestion/common/persons/persons-store-for-batch'
 import { createApplyEventFiltersStep } from '~/ingestion/common/steps/event-filters-steps'
@@ -23,6 +25,7 @@ import {
 import { createDropOldEventsStep } from '~/ingestion/common/steps/event-processing/drop-old-events-step'
 import { createPrefetchHogFunctionsStep } from '~/ingestion/common/steps/event-processing/prefetch-hog-functions-step'
 import { BatchPipelineBuilder } from '~/ingestion/framework/builders/batch-pipeline-builders'
+import { prefetchGroupsStep } from '~/ingestion/pipelines/analytics/steps/prefetchGroupsStep'
 import { prefetchPersonsStep } from '~/ingestion/pipelines/analytics/steps/prefetchPersonsStep'
 import { processPersonlessDistinctIdsBatchStep } from '~/ingestion/pipelines/analytics/steps/processPersonlessDistinctIdsBatchStep'
 import { PluginEvent } from '~/plugin-scaffold'
@@ -35,6 +38,7 @@ export interface PostTeamPreprocessingSubpipelineInput {
     team: Team
     eventFiltersBatchAppMetrics: EventFiltersBatchAppMetrics
     personsStoreForBatch: PersonsStoreForBatch
+    groupStoreForBatch: GroupStoreForBatch
 }
 
 export interface PostTeamPreprocessingSubpipelineConfig {
@@ -48,6 +52,8 @@ export interface PostTeamPreprocessingSubpipelineConfig {
     overflowLaneTTLRefreshService?: OverflowRedirectService
     featureFlagCalledDedupService?: FeatureFlagCalledDedupService
     personsPrefetchEnabled: boolean
+    groupsPrefetchEnabled: boolean
+    groupTypeManager: GroupTypeManager
     flagCalledPersonlessDefaultTeams: string
     hogTransformer: HogTransformer
     cdpHogWatcherSampleRate: number
@@ -68,6 +74,8 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
         overflowLaneTTLRefreshService,
         featureFlagCalledDedupService,
         personsPrefetchEnabled,
+        groupsPrefetchEnabled,
+        groupTypeManager,
         flagCalledPersonlessDefaultTeams,
         hogTransformer,
         cdpHogWatcherSampleRate,
@@ -109,6 +117,12 @@ export function createPostTeamPreprocessingSubpipeline<TInput extends PostTeamPr
             // no-op — transient persons-Postgres failures are swallowed inside prefetchPersons so
             // they can't surface as an unhandled rejection and crash the worker.
             .pipeBatch(prefetchPersonsStep(personsPrefetchEnabled))
+            // Warm the group cache for $groupidentify events with one multi-key query per batch,
+            // so cold group keys don't each pay a sequential per-event SELECT in the per-distinct_id
+            // lane. Fire-and-forget like the person prefetch: retriable failures are swallowed inside
+            // prefetchGroups so they can't crash the worker, and the per-key promises still surface
+            // errors to the consumer that awaits them.
+            .pipeBatch(prefetchGroupsStep(groupsPrefetchEnabled, groupTypeManager))
             // Batch insert personless distinct IDs after prefetch (uses prefetch cache).
             // This step awaits its DB write, so retry transient persons-Postgres failures
             // (e.g. PgBouncer scale-down) instead of letting them crash the consumer loop.

--- a/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.test.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.test.ts
@@ -1,0 +1,98 @@
+import { GroupTypeManager } from '~/common/groups/group-type-manager'
+import { GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
+import { PipelineResultType } from '~/ingestion/framework/results'
+import { prefetchGroupsStep } from '~/ingestion/pipelines/analytics/steps/prefetchGroupsStep'
+import { PluginEvent } from '~/plugin-scaffold'
+import { ProjectId, Team } from '~/types'
+
+type TestInput = { event: PluginEvent; team: Team; groupStoreForBatch: GroupStoreForBatch }
+
+function createStore(batchId: number): GroupStoreForBatch {
+    return {
+        batchId,
+        prefetchGroups: jest.fn().mockResolvedValue(undefined),
+    } as unknown as GroupStoreForBatch
+}
+
+function createGroupTypeManager(mapping: Record<number, Record<string, number>>): GroupTypeManager {
+    return {
+        fetchGroupTypesForProjects: jest.fn().mockResolvedValue(mapping),
+    } as unknown as GroupTypeManager
+}
+
+function createInput(
+    eventName: string,
+    properties: Record<string, unknown>,
+    teamId: number,
+    projectId: number,
+    groupStoreForBatch: GroupStoreForBatch
+): TestInput {
+    return {
+        event: { event: eventName, properties } as unknown as PluginEvent,
+        team: { id: teamId, project_id: projectId as ProjectId } as unknown as Team,
+        groupStoreForBatch,
+    }
+}
+
+describe('prefetchGroupsStep', () => {
+    it('collects resolvable $groupidentify keys and skips other events, missing keys, and unknown types', async () => {
+        const store = createStore(1)
+        const groupTypeManager = createGroupTypeManager({ 10: { company: 0 } })
+        const step = prefetchGroupsStep<TestInput>(true, groupTypeManager)
+
+        const results = await step([
+            createInput('$groupidentify', { $group_type: 'company', $group_key: 'acme' }, 3, 10, store),
+            // non-$groupidentify event is ignored
+            createInput('$pageview', { $group_type: 'company', $group_key: 'other' }, 3, 10, store),
+            // missing $group_key is skipped
+            createInput('$groupidentify', { $group_type: 'company' }, 3, 10, store),
+            // unresolved group type (not in the cached mapping) is skipped
+            createInput('$groupidentify', { $group_type: 'unknown', $group_key: 'x' }, 3, 10, store),
+        ])
+
+        expect(results.map((result) => result.type)).toEqual([
+            PipelineResultType.OK,
+            PipelineResultType.OK,
+            PipelineResultType.OK,
+            PipelineResultType.OK,
+        ])
+        expect(store.prefetchGroups).toHaveBeenCalledWith([
+            { teamId: 3, groupTypeIndex: 0, groupKey: 'acme', batchId: 1 },
+        ])
+    })
+
+    it('groups entries by batch store', async () => {
+        const storeA = createStore(1)
+        const storeB = createStore(2)
+        const groupTypeManager = createGroupTypeManager({ 10: { company: 0 } })
+        const step = prefetchGroupsStep<TestInput>(true, groupTypeManager)
+
+        await step([
+            createInput('$groupidentify', { $group_type: 'company', $group_key: 'a' }, 3, 10, storeA),
+            createInput('$groupidentify', { $group_type: 'company', $group_key: 'b' }, 4, 10, storeB),
+            createInput('$groupidentify', { $group_type: 'company', $group_key: 'c' }, 5, 10, storeA),
+        ])
+
+        expect(storeA.prefetchGroups).toHaveBeenCalledWith([
+            { teamId: 3, groupTypeIndex: 0, groupKey: 'a', batchId: 1 },
+            { teamId: 5, groupTypeIndex: 0, groupKey: 'c', batchId: 1 },
+        ])
+        expect(storeB.prefetchGroups).toHaveBeenCalledWith([
+            { teamId: 4, groupTypeIndex: 0, groupKey: 'b', batchId: 2 },
+        ])
+    })
+
+    it('passes events through without prefetching when disabled', async () => {
+        const store = createStore(1)
+        const groupTypeManager = createGroupTypeManager({ 10: { company: 0 } })
+        const step = prefetchGroupsStep<TestInput>(false, groupTypeManager)
+
+        const results = await step([
+            createInput('$groupidentify', { $group_type: 'company', $group_key: 'acme' }, 3, 10, store),
+        ])
+
+        expect(results.map((result) => result.type)).toEqual([PipelineResultType.OK])
+        expect(store.prefetchGroups).not.toHaveBeenCalled()
+        expect(groupTypeManager.fetchGroupTypesForProjects).not.toHaveBeenCalled()
+    })
+})

--- a/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.test.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.test.ts
@@ -92,6 +92,30 @@ describe('prefetchGroupsStep', () => {
         ])
     })
 
+    // The group-type mappings are plain objects, so an attacker-chosen $group_type naming an
+    // Object.prototype member would resolve to an inherited function/object instead of undefined
+    // and flow a non-integer into the prefetch's int[] query — a non-retriable error rejecting a
+    // fire-and-forget promise, i.e. an unhandled rejection that downs the worker.
+    it.each(['__proto__', 'toString', 'constructor', 'valueOf', 'hasOwnProperty'])(
+        'skips $group_type %s that resolves to an inherited property, not a real index',
+        async (poisonType) => {
+            const store = createStore(1)
+            const groupTypeManager = createGroupTypeManager({ 10: { company: 0 } })
+            const step = prefetchGroupsStep<TestInput>(true, groupTypeManager)
+
+            const results = await step([
+                createInput('$groupidentify', { $group_type: poisonType, $group_key: 'poison' }, 3, 10, store),
+                createInput('$groupidentify', { $group_type: 'company', $group_key: 'acme' }, 3, 10, store),
+            ])
+
+            expect(results.map((result) => result.type)).toEqual([PipelineResultType.OK, PipelineResultType.OK])
+            // Only the legit entry reaches the store — the poison type never becomes an "index".
+            expect(store.prefetchGroups).toHaveBeenCalledWith([
+                { teamId: 3, groupTypeIndex: 0, groupKey: 'acme', batchId: 1 },
+            ])
+        }
+    )
+
     it('passes events through without prefetching when disabled', async () => {
         const store = createStore(1)
         const groupTypeManager = createGroupTypeManager({ 10: { company: 0 } })

--- a/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.test.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.test.ts
@@ -1,9 +1,16 @@
 import { GroupTypeManager } from '~/common/groups/group-type-manager'
-import { GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
+import { ClickhouseGroupRepository } from '~/common/groups/repositories/clickhouse-group-repository'
+import { GroupRepository } from '~/common/groups/repositories/group-repository.interface'
+import { GroupsOutput, IngestionWarningsOutput } from '~/common/outputs'
+import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
+import { TeamManager } from '~/common/utils/team-manager'
+import { BatchWritingGroupStore } from '~/ingestion/common/groups/batch-writing-group-store'
+import { BatchBoundGroupStore, GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
+import { createProcessGroupsStep } from '~/ingestion/common/steps/event-processing/process-groups-step'
 import { PipelineResultType } from '~/ingestion/framework/results'
 import { prefetchGroupsStep } from '~/ingestion/pipelines/analytics/steps/prefetchGroupsStep'
 import { PluginEvent } from '~/plugin-scaffold'
-import { ProjectId, Team } from '~/types'
+import { PreIngestionEvent, ProjectId, Team } from '~/types'
 
 type TestInput = { event: PluginEvent; team: Team; groupStoreForBatch: GroupStoreForBatch }
 
@@ -46,11 +53,14 @@ describe('prefetchGroupsStep', () => {
             createInput('$pageview', { $group_type: 'company', $group_key: 'other' }, 3, 10, store),
             // missing $group_key is skipped
             createInput('$groupidentify', { $group_type: 'company' }, 3, 10, store),
+            // falsy $group_key is skipped, matching the upsert path's check
+            createInput('$groupidentify', { $group_type: 'company', $group_key: '' }, 3, 10, store),
             // unresolved group type (not in the cached mapping) is skipped
             createInput('$groupidentify', { $group_type: 'unknown', $group_key: 'x' }, 3, 10, store),
         ])
 
         expect(results.map((result) => result.type)).toEqual([
+            PipelineResultType.OK,
             PipelineResultType.OK,
             PipelineResultType.OK,
             PipelineResultType.OK,
@@ -95,4 +105,84 @@ describe('prefetchGroupsStep', () => {
         expect(store.prefetchGroups).not.toHaveBeenCalled()
         expect(groupTypeManager.fetchGroupTypesForProjects).not.toHaveBeenCalled()
     })
+
+    // End-to-end key alignment: the prefetch must cache under the exact key the upsert path
+    // looks up, or the warmed entries are never read and the upsert pays its per-key fetch anyway.
+    it.each([
+        ['a key with a null byte', 'acme\u0000corp', 'acme\uFFFDcorp'],
+        ['a numeric key', 42, '42'],
+    ])(
+        'prefetched entries are read by a subsequent upsert for the same event with %s',
+        async (_desc, rawKey, normalizedKey) => {
+            let lastTx: { fetchGroup: jest.Mock; insertGroup: jest.Mock; updateGroup: jest.Mock } | null = null
+            const groupRepository = {
+                fetchGroups: jest.fn().mockResolvedValue([]),
+                fetchGroup: jest.fn().mockResolvedValue(undefined),
+                inTransaction: jest.fn().mockImplementation(async (_description, transaction) => {
+                    lastTx = {
+                        fetchGroup: jest.fn().mockResolvedValue(undefined),
+                        insertGroup: jest.fn().mockResolvedValue(1),
+                        updateGroup: jest.fn().mockResolvedValue(1),
+                    }
+                    return await transaction(lastTx)
+                }),
+            } as unknown as GroupRepository
+            const clickhouseGroupRepository = {
+                upsertGroup: jest.fn().mockResolvedValue(undefined),
+            } as unknown as ClickhouseGroupRepository
+            const outputs = {} as unknown as IngestionOutputs<GroupsOutput | IngestionWarningsOutput>
+            const groupStore = new BatchWritingGroupStore(outputs, groupRepository, clickhouseGroupRepository, {
+                metricEmissionIntervalMs: 0,
+            })
+            const boundStore = new BatchBoundGroupStore(groupStore, 0)
+
+            const properties = { $group_type: 'company', $group_key: rawKey, $group_set: { a: '1' } }
+            const groupTypeManager = {
+                fetchGroupTypesForProjects: jest.fn().mockResolvedValue({ 10: { company: 0 } }),
+                fetchGroupTypeIndex: jest.fn().mockResolvedValue(0),
+            } as unknown as GroupTypeManager
+
+            const step = prefetchGroupsStep<TestInput>(true, groupTypeManager)
+            await step([createInput('$groupidentify', properties, 3, 10, boundStore)])
+            // Let the fire-and-forget prefetch land in the cache (mocked repo resolves immediately).
+            await new Promise((resolve) => setImmediate(resolve))
+            expect(groupRepository.fetchGroups).toHaveBeenCalledTimes(1)
+
+            const processStep = createProcessGroupsStep(
+                { setTeamIngestedEvent: jest.fn() } as unknown as TeamManager,
+                groupTypeManager,
+                { SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: true }
+            )
+            await processStep({
+                preparedEvent: {
+                    eventUuid: 'test-uuid',
+                    event: '$groupidentify',
+                    teamId: 3,
+                    projectId: 10 as ProjectId,
+                    distinctId: 'd1',
+                    properties,
+                    timestamp: '2023-01-01T00:00:00.000Z',
+                } as unknown as PreIngestionEvent,
+                team: { id: 3, project_id: 10 as ProjectId } as unknown as Team,
+                processPerson: true,
+                groupStoreForBatch: boundStore,
+            })
+
+            // The upsert was served from the prefetched (negative) cache entry: no per-key fetch,
+            // straight to the create path under the same normalized key the prefetch used.
+            expect(groupRepository.fetchGroup).not.toHaveBeenCalled()
+            expect(lastTx!.fetchGroup).not.toHaveBeenCalled()
+            expect(lastTx!.insertGroup).toHaveBeenCalledWith(
+                3,
+                0,
+                normalizedKey,
+                { a: '1' },
+                expect.anything(),
+                expect.anything(),
+                expect.anything()
+            )
+
+            await groupStore.shutdown()
+        }
+    )
 })

--- a/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.ts
@@ -1,0 +1,77 @@
+import { GroupTypeManager } from '~/common/groups/group-type-manager'
+import { sanitizeString } from '~/common/utils/db/utils'
+import { GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
+import { PipelineResult, ok } from '~/ingestion/framework/results'
+import { PluginEvent } from '~/plugin-scaffold'
+import { GroupTypeIndex, ProjectId, Team } from '~/types'
+
+type PrefetchGroupsStepInput = { event: PluginEvent; team: Team; groupStoreForBatch: GroupStoreForBatch }
+
+type PrefetchGroupEntry = { teamId: number; groupTypeIndex: GroupTypeIndex; groupKey: string; batchId: number }
+
+/**
+ * Warms the group cache for `$groupidentify` events in the chunk with one multi-key query per
+ * batch store, so cold group keys don't each pay a sequential per-event SELECT inside the
+ * per-distinct_id lane. Group type indexes are resolved read-only from the cached group-type
+ * mappings — an unknown type means the group can't exist yet, so we skip it and let the normal
+ * create path register the type. Fire-and-forget: the per-key fetch promises registered inside
+ * `prefetchGroups` let the get-or-fetch path dedupe and surface errors.
+ */
+export function prefetchGroupsStep<T extends PrefetchGroupsStepInput>(
+    enabled: boolean,
+    groupTypeManager: GroupTypeManager
+) {
+    return async function prefetchGroupsStep(events: T[]): Promise<PipelineResult<T>[]> {
+        if (enabled && events.length > 0) {
+            const projectIds = new Set<ProjectId>()
+            for (const event of events) {
+                if (event.event.event === '$groupidentify') {
+                    projectIds.add(event.team.project_id)
+                }
+            }
+
+            if (projectIds.size > 0) {
+                const groupTypesByProject = await groupTypeManager.fetchGroupTypesForProjects(projectIds)
+
+                // Events in a chunk may come from different Kafka batches (due to the feed primitive).
+                // Group by batch store so each store only receives entries it owns. Fire without
+                // awaiting — the get-or-fetch path in getGroup will wait on the pending promises if
+                // it needs data that's still being fetched.
+                const entriesByStore = new Map<GroupStoreForBatch, PrefetchGroupEntry[]>()
+
+                for (const event of events) {
+                    if (event.event.event !== '$groupidentify') {
+                        continue
+                    }
+                    const properties = event.event.properties
+                    const groupType = properties?.['$group_type']
+                    const groupKey = properties?.['$group_key']
+                    if (!groupType || groupKey === undefined || groupKey === null) {
+                        continue
+                    }
+                    const groupTypeIndex = groupTypesByProject[event.team.project_id]?.[groupType]
+                    if (groupTypeIndex === undefined) {
+                        continue
+                    }
+
+                    let entries = entriesByStore.get(event.groupStoreForBatch)
+                    if (!entries) {
+                        entries = []
+                        entriesByStore.set(event.groupStoreForBatch, entries)
+                    }
+                    entries.push({
+                        teamId: event.team.id,
+                        groupTypeIndex,
+                        groupKey: sanitizeString(groupKey.toString()),
+                        batchId: event.groupStoreForBatch.batchId,
+                    })
+                }
+
+                for (const [store, entries] of entriesByStore) {
+                    void store.prefetchGroups(entries)
+                }
+            }
+        }
+        return events.map((event) => ok(event))
+    }
+}

--- a/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.ts
@@ -1,6 +1,6 @@
 import { GroupTypeManager } from '~/common/groups/group-type-manager'
-import { sanitizeString } from '~/common/utils/db/utils'
 import { GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
+import { extractGroupIdentify } from '~/ingestion/common/steps/event-processing/groups'
 import { PipelineResult, ok } from '~/ingestion/framework/results'
 import { PluginEvent } from '~/plugin-scaffold'
 import { GroupTypeIndex, ProjectId, Team } from '~/types'
@@ -43,13 +43,13 @@ export function prefetchGroupsStep<T extends PrefetchGroupsStepInput>(
                     if (event.event.event !== '$groupidentify') {
                         continue
                     }
-                    const properties = event.event.properties
-                    const groupType = properties?.['$group_type']
-                    const groupKey = properties?.['$group_key']
-                    if (!groupType || groupKey === undefined || groupKey === null) {
+                    // Shared with the upsert path so the prefetched cache key is byte-identical
+                    // to the key the upsert will look up.
+                    const groupIdentify = extractGroupIdentify(event.event.properties)
+                    if (!groupIdentify) {
                         continue
                     }
-                    const groupTypeIndex = groupTypesByProject[event.team.project_id]?.[groupType]
+                    const groupTypeIndex = groupTypesByProject[event.team.project_id]?.[groupIdentify.groupType]
                     if (groupTypeIndex === undefined) {
                         continue
                     }
@@ -62,7 +62,7 @@ export function prefetchGroupsStep<T extends PrefetchGroupsStepInput>(
                     entries.push({
                         teamId: event.team.id,
                         groupTypeIndex,
-                        groupKey: sanitizeString(groupKey.toString()),
+                        groupKey: groupIdentify.groupKey,
                         batchId: event.groupStoreForBatch.batchId,
                     })
                 }

--- a/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/steps/prefetchGroupsStep.ts
@@ -1,4 +1,4 @@
-import { GroupTypeManager } from '~/common/groups/group-type-manager'
+import { GroupTypeManager, MAX_GROUP_TYPES_PER_TEAM } from '~/common/groups/group-type-manager'
 import { GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
 import { extractGroupIdentify } from '~/ingestion/common/steps/event-processing/groups'
 import { PipelineResult, ok } from '~/ingestion/framework/results'
@@ -49,8 +49,23 @@ export function prefetchGroupsStep<T extends PrefetchGroupsStepInput>(
                     if (!groupIdentify) {
                         continue
                     }
-                    const groupTypeIndex = groupTypesByProject[event.team.project_id]?.[groupIdentify.groupType]
-                    if (groupTypeIndex === undefined) {
+                    // The group type name is attacker-controlled and the mappings are plain objects:
+                    // a name like "__proto__" or "toString" would resolve to an INHERITED property
+                    // (an object or function, not undefined) and flow into the int[] query param,
+                    // producing a non-retriable Postgres error from the fire-and-forget prefetch.
+                    // Guard with an own-property lookup AND a numeric-range check so neither alone
+                    // can be regressed away.
+                    const projectTypes = groupTypesByProject[event.team.project_id]
+                    const groupTypeIndex =
+                        projectTypes && Object.prototype.hasOwnProperty.call(projectTypes, groupIdentify.groupType)
+                            ? projectTypes[groupIdentify.groupType]
+                            : undefined
+                    if (
+                        typeof groupTypeIndex !== 'number' ||
+                        !Number.isInteger(groupTypeIndex) ||
+                        groupTypeIndex < 0 ||
+                        groupTypeIndex >= MAX_GROUP_TYPES_PER_TEAM
+                    ) {
                         continue
                     }
 
@@ -67,6 +82,11 @@ export function prefetchGroupsStep<T extends PrefetchGroupsStepInput>(
                     })
                 }
 
+                // Fire-and-forget is safe here: every entry is validated above (own-property type
+                // resolution, integer index in [0, MAX_GROUP_TYPES_PER_TEAM), sanitized key), so no
+                // event-derived input can produce a non-retriable rejection. prefetchGroups swallows
+                // retriable failures itself and rethrows only genuine code/schema bugs, which should
+                // crash loudly — the same contract as prefetchPersons above.
                 for (const [store, entries] of entriesByStore) {
                     void store.prefetchGroups(entries)
                 }

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -364,6 +364,7 @@ export class IngestionApiServer implements NodeServer {
             overflowMode: this.config.INGESTION_OVERFLOW_MODE,
             preservePartitionLocality: this.config.INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY,
             personsPrefetchEnabled: this.config.PERSONS_PREFETCH_ENABLED,
+            groupsPrefetchEnabled: this.config.GROUPS_PREFETCH_ENABLED,
             cdpHogWatcherSampleRate: this.config.CDP_HOG_WATCHER_SAMPLE_RATE,
             outputs: ingestionOutputs,
             perDistinctIdOptions: {


### PR DESCRIPTION
## Problem

`$groupidentify` events with cold group keys are expensive to ingest. The analytics pipeline groups events by `token:distinct_id` and processes each group's events strictly sequentially. For every `$groupidentify` whose group key is not already cached, the batch group store issues an inline per-event `fetchGroup` SELECT against Postgres inside that per-distinct_id lane. A burst of such events from a single distinct_id, most of them referencing keys the cache has never seen, turns into a long sequence of one-row SELECTs that pin the lane and starve every other partition sharing the worker.

The group store already batches property updates (write-behind cache flushed once per batch), but the initial reads get no batching at all. This is the same asymmetry personless distinct IDs had before they were moved to a batched prefetch.

## Changes

This warms the group cache once per chunk instead of once per event, mirroring the person prefetch that already runs in the same subpipeline.

- New `prefetchGroupsStep` in the post-team preprocessing subpipeline, next to `prefetchPersonsStep`. For `$groupidentify` events in the chunk it resolves the group type index read-only from the cached group-type mappings, collects the `(team, type index, key)` tuples per batch store, dedupes by the full tuple, and fires one batched prefetch.
- The step validates the resolved group type index before use: an own-property lookup on the type mapping plus an integer range check (`0 <= index < MAX_GROUP_TYPES_PER_TEAM`). Since `$group_type` is event-supplied and the mappings are plain objects, a type name matching an `Object.prototype` member would otherwise resolve to an inherited value and flow a non-integer into the query (see Security below).
- New shared helper `extractGroupIdentify` in `event-processing/groups.ts` that owns the `$group_type` / `$group_key` presence checks and the exact key normalization (`sanitizeString(groupKey.toString())`). Both the upsert path (`process-groups-step`) and the prefetch step call it, so the prefetched cache key is byte-identical to the key the upsert looks up. Group-type-index resolution intentionally stays out of the helper, since the upsert path may insert a new mapping while the prefetch is read-only.
- New `BatchWritingGroupStore.prefetchGroups`, exposed through `GroupStoreForBatch`. It runs one multi-key fetch that populates the cache with hits **and** negative (null) entries for misses, so a later `upsertGroup` for a prefetched key skips the per-key SELECT entirely (a miss goes straight to the create path). It registers per-key fetch promises in the shared cache so a concurrent `getGroup` dedupes against the in-flight prefetch, and it reference-counts prefetched keys against their batch id so cache eviction on `releaseBatchId` stays correct.
- New `GroupRepository.fetchGroups`, a single `UNNEST`-join query returning full `Group` rows (with `created_at` and `version`). This is distinct from the existing partial, personhog-routed `fetchGroupsByKeys` used by CDP and error tracking, which does not carry the fields the cache needs.
- Gated behind `GROUPS_PREFETCH_ENABLED`, default off, threaded through the joined pipeline config and wired from both the consumer and ingestion-api drivers.

> [!WARNING]
> This also fixes a pre-existing latent bug surfaced during review: `GroupCache` keyed entries by `teamId:groupKey` only, while the DB unique key is `(team_id, group_key, group_type_index)`. Two groups sharing a key across type indexes aliased one cache entry — an upsert for one type index could be served the other's cached row, diff against the wrong group's properties, and the flush would write one group's properties and version onto the other. The cache key now includes the type index (`teamId:groupTypeIndex:groupKey`), threaded through every cache access, the fetch-promise map, and the per-batch refcount bookkeeping. The prefetch made this materially likelier within a batch, so the fix ships in the same PR.

### Security

Review caught a remotely-triggerable crash in the initial version of the prefetch step, fixed here before the feature ships anywhere. The class: an unvalidated, event-supplied group-type name used as a lookup key on a plain object. A name matching an `Object.prototype` member (`__proto__`, `toString`, `constructor`, ...) resolves to an **inherited** value rather than `undefined`, so an undefined-check guard passes it through as a "group type index" into an `int[]` query parameter. The resulting non-retriable Postgres error rejects a fire-and-forget promise, becoming an unhandled rejection that terminates the worker. The fix is defense in depth: inherited members no longer resolve (own-property lookup), and the resolved value must be an integer in the valid index range before use, with a parameterized regression test verified to fail on the unguarded lookup.

Read-only and flag-gated. The prefetch resolves group type indexes without creating any (an unknown type means the group cannot exist yet, so it is skipped and left to the normal create path), and a retriable fetch failure is swallowed by the fire-and-forget warmer while the per-key promises still surface the error to any waiting consumer.

```mermaid
flowchart TD
    A[chunk of events] --> B{$groupidentify with cold key?}
    B -- each event --> C[inline fetchGroup SELECT in per-distinct_id lane]
    C --> D[upsertGroup]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class C phRed;
```

```mermaid
flowchart TD
    A[chunk of events] --> P[prefetchGroups: one multi-key query per batch store]
    P --> E[group cache warmed: hits + negative entries]
    E --> D[upsertGroup reads cache, no per-event SELECT]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class P phBlue;
```

## How did you test this code?

Automated tests I (Claude) actually ran, all green:

- `prefetchGroupsStep.test.ts` (new): entry collection and type resolution, filtering out non-`$groupidentify` events / missing or falsy keys / unresolved types, grouping by batch store, and the disabled-flag no-op. A parameterized case sends `$group_type` values naming `Object.prototype` members (`__proto__`, `toString`, `constructor`, `valueOf`, `hasOwnProperty`) and asserts they are skipped while a legit type in the same chunk still prefetches — verified to fail on the unguarded lookup, i.e. it catches the worker-crash class described under Security. Plus an end-to-end key-alignment test: for keys needing normalization (a null byte, a numeric key), a prefetch followed by the real `process-groups-step` upsert performs no per-key `fetchGroup` and creates under the same normalized key — this is what breaks if either path stops using the shared extraction helper.
- `batch-writing-group-store.test.ts` (extended): a hit warms the cache so a later `upsertGroup` merges without a per-key `fetchGroup`; a miss caches a negative entry so a later `upsertGroup` creates without a per-key `fetchGroup`; two concurrent prefetches issue one query (in-flight dedup); duplicate tuples within one prefetch call collapse to one entry; a non-retriable batch-fetch failure rejects a waiting consumer and rethrows out of the warmer. For the cache-key fix: two upserts for the same `(team, key)` with different type indexes stay independent entries (each pays its own fetch, and the flush writes each group's own version and properties — the regression that aliased entries would corrupt), and a prefetch of the same key under two type indexes fetches and caches both tuples separately.
- `postgres-group-repository.integration.test.ts` (extended, `fetchGroups` describe): full rows for matching tuples with non-matching tuples omitted; dedup of repeated tuples and `[]` for empty input; and a multi-team case proving the UNNEST join matches on the full `(team_id, group_type_index, group_key)` tuple — two teams sharing the same key and index each get their own row, and a tuple whose key exists only for another team returns nothing (no cross-tenant match).
- Existing `process-groups-step.test.ts` and `groups.test.ts` suites still pass after routing the upsert path through the shared helper.
- Updated the `PersonHogGroupRepository` mock to satisfy the new interface method; its suite still passes.

I did not run the pipeline end to end against a live stack. Typecheck and lint pass on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by Claude (Claude Code) from a written plan I provided, then amended per review feedback. This is PR2 of a staged effort to make `$groupidentify`-heavy traffic follow the same shape person processing already uses (prefetch per chunk, defer writes to the per-batch flush). It is independent of the other PRs and touches only the read path (plus the cache-key fix noted above).

Invoked the `/writing-tests` skill before writing tests to keep the suite focused on real regressions rather than coverage padding.

Key decisions:
- Added a new `fetchGroups` method rather than extending the existing `fetchGroupsByKeys`. The existing one returns a partial projection and is routed through the personhog gRPC proto, which does not carry `created_at`/`version`; changing its shape would ripple across CDP and error tracking. `PersonHogGroupRepository.fetchGroups` therefore delegates straight to Postgres.
- Resolved group type indexes with the cached read-only `fetchGroupTypesForProjects` instead of `fetchGroupTypeIndex`, because the latter inserts a new group-type mapping on a miss. A prefetch must stay side-effect free, so an unknown type is skipped and left to the normal create path.
- Copied the person store's prefetch promise-registration and batch-refcounting semantics faithfully so the two stores behave the same under concurrent batches.
- After review, extracted the `$group_type`/`$group_key` presence checks and key normalization into a shared `extractGroupIdentify` helper used by both the upsert and prefetch paths — the initial version duplicated the logic and had already diverged from the upsert path's falsy-skip and sanitize semantics.
- Review of the prefetch's result-map keying surfaced that the underlying `GroupCache` key itself omitted `group_type_index`; rather than only fixing the prefetch map, the cache key was corrected store-wide since the aliasing could corrupt group data on the existing per-event path too.
- The security fix keeps the fire-and-forget `void store.prefetchGroups(...)` call rather than adding a blanket catch: with the index validated and the key sanitized, no event-derived input can produce a non-retriable rejection, and the remaining non-retriable rejections are genuine code/schema bugs that should crash loudly — the same contract `prefetchPersons` already has. A blanket catch would silently mask those.
