### PR TITLE
perf(ingestion): produce group ClickHouse messages as side effects

### DIFF
--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.test.ts
@@ -111,13 +111,20 @@ describe('BatchWritingGroupStore', () => {
         groupStore = new BatchWritingGroupStore(mockOutputs, groupRepository, clickhouseGroupRepository)
     })
 
+    // upsertGroup/flush now return deferred ClickHouse produce promises. Tests
+    // that only assert DB behavior drop them explicitly (the produce mocks
+    // resolve on their own) so the returned array isn't a floating promise.
+    const upsertGroupDropProduces = (...args: Parameters<BatchWritingGroupStore['upsertGroup']>): Promise<void> =>
+        groupStore.upsertGroup(...args).then(() => undefined)
+    const flushGroupDropProduces = (): Promise<void> => groupStore.flush().then(() => undefined)
+
     afterEach(async () => {
         // Clear the metric-emission interval started in the constructor;
         // unref() prevents it from blocking process exit, but we still want
         // a clean slate between tests. Tests may leave dirty entries behind,
         // so flush first — shutdown() throws on dirty cache by design.
         try {
-            await groupStore?.flush()
+            await groupStore?.flush().then(() => undefined)
         } catch {
             // ignore — some tests intentionally fail flush
         }
@@ -130,11 +137,11 @@ describe('BatchWritingGroupStore', () => {
     })
 
     it('should accumulate writes in cache, write once to db', async () => {
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: 'test' }, DateTime.now())
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { c: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { b: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { c: 'test' }, DateTime.now())
 
-        await groupStore.flush()
+        const sideEffects = await groupStore.flush()
 
         expect(groupRepository.fetchGroup).toHaveBeenCalledTimes(1)
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(1)
@@ -152,31 +159,43 @@ describe('BatchWritingGroupStore', () => {
             {}
         )
 
+        // flush() returns the deferred ClickHouse produce as a side effect for
+        // the caller to await before offset commit — not a fire-and-forget.
+        expect(sideEffects).toHaveLength(1)
+        expect(clickhouseGroupRepository.upsertGroup).toHaveBeenCalledTimes(1)
+        await Promise.all(sideEffects)
+
         const cacheMetrics = groupStore.getCacheMetrics()
 
         expect(cacheMetrics.cacheHits).toBe(2)
         expect(cacheMetrics.cacheMisses).toBe(0)
     })
 
-    it('should immediately write to db if new group', async () => {
+    it('should immediately write to db if new group and return its produce as a side effect', async () => {
         jest.spyOn(groupRepository, 'fetchGroup').mockResolvedValue(undefined)
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+        const sideEffects = await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
 
         expect(groupRepository.fetchGroup).toHaveBeenCalledTimes(1)
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(0)
         expect(groupRepository.updateGroup).toHaveBeenCalledTimes(0)
         expect(groupRepository.inTransaction).toHaveBeenCalledTimes(1)
         expect((groupRepository as any).lastTransactionMock.insertGroup).toHaveBeenCalledTimes(1)
+
+        // The create path commits Postgres inline but hands the ClickHouse
+        // produce back un-awaited so the caller attaches it as a side effect.
+        expect(sideEffects).toHaveLength(1)
+        expect(clickhouseGroupRepository.upsertGroup).toHaveBeenCalledTimes(1)
+        await Promise.all(sideEffects)
     })
 
     it('should accumulate changes in cache after db write, even if new group', async () => {
         jest.spyOn(groupRepository, 'fetchGroup').mockResolvedValue(undefined)
         const createdAt = DateTime.now()
 
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, createdAt)
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: 'test' }, createdAt)
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, createdAt)
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { b: 'test' }, createdAt)
 
-        await groupStore.flush()
+        await flushGroupDropProduces()
 
         expect(groupRepository.fetchGroup).toHaveBeenCalledTimes(1)
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(1)
@@ -220,11 +239,11 @@ describe('BatchWritingGroupStore', () => {
             return Promise.resolve(updateCounter)
         })
 
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: 'test' }, DateTime.now())
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { c: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { b: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { c: 'test' }, DateTime.now())
 
-        await groupStore.flush()
+        await flushGroupDropProduces()
 
         // Should fetch 3 times, 1 for initial fetch, 2 for retries
         expect(groupRepository.fetchGroup).toHaveBeenCalledTimes(3)
@@ -249,13 +268,13 @@ describe('BatchWritingGroupStore', () => {
         jest.spyOn(groupRepository, 'updateGroupOptimistically').mockResolvedValue(undefined)
         jest.spyOn(groupRepository, 'updateGroup').mockResolvedValue(2)
         jest.spyOn(groupRepository, 'fetchGroup').mockResolvedValue(group)
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'updated' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'updated' }, DateTime.now())
 
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(0)
         expect(groupRepository.updateGroup).toHaveBeenCalledTimes(0)
         expect(clickhouseGroupRepository.upsertGroup).toHaveBeenCalledTimes(0)
 
-        await groupStore.flush()
+        await flushGroupDropProduces()
 
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(5)
         expect(groupRepository.inTransaction).toHaveBeenCalledTimes(1)
@@ -264,10 +283,10 @@ describe('BatchWritingGroupStore', () => {
     })
 
     it('should share cache between distinct ids', async () => {
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { b: 'test' }, DateTime.now())
 
-        await groupStore.flush()
+        await flushGroupDropProduces()
 
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(1)
         expect(groupRepository.inTransaction).toHaveBeenCalledTimes(0) // Uses optimistic update for existing groups
@@ -287,9 +306,9 @@ describe('BatchWritingGroupStore', () => {
         // Mock the groupRepository.fetchGroup to return a group with the same properties
         jest.spyOn(groupRepository, 'fetchGroup').mockResolvedValue(group)
 
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', group.group_properties, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', group.group_properties, DateTime.now())
 
-        await groupStore.flush()
+        await flushGroupDropProduces()
 
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(0)
         expect(groupRepository.updateGroup).toHaveBeenCalledTimes(0)
@@ -297,20 +316,22 @@ describe('BatchWritingGroupStore', () => {
         // No transaction calls expected since no properties changed
     })
 
-    it('should capture warning and stop retrying if message size too large', async () => {
-        // we need to mock the clickhouse repository upsertGroup method
+    it('downgrades a message-size-too-large produce to an ingestion warning via the side effect', async () => {
         clickhouseGroupRepository.upsertGroup = jest
             .fn()
             .mockRejectedValue(new MessageSizeTooLarge('test', new Error('test')))
 
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
 
-        await groupStore.flush()
+        const sideEffects = await groupStore.flush()
 
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(1)
         expect(groupRepository.updateGroup).toHaveBeenCalledTimes(0)
         expect(groupRepository.inTransaction).toHaveBeenCalledTimes(0)
-        // No transaction calls expected since optimistic update failed
+
+        // The oversized produce is downgraded inside the side effect: awaiting it
+        // resolves (the batch is not failed) and an ingestion warning is emitted.
+        await expect(Promise.all(sideEffects)).resolves.toHaveLength(1)
         expect(emitIngestionWarning).toHaveBeenCalledWith(mockOutputs, teamId, {
             type: 'group_upsert_message_size_too_large',
             details: {
@@ -320,6 +341,22 @@ describe('BatchWritingGroupStore', () => {
             },
             pipelineStep: 'group-store',
         })
+    })
+
+    it('surfaces a non-size produce rejection through the side effect so the batch fails', async () => {
+        const produceError = new Error('kafka produce failed')
+        clickhouseGroupRepository.upsertGroup = jest.fn().mockRejectedValue(produceError)
+
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+
+        const sideEffects = await groupStore.flush()
+
+        // Postgres committed, but the deferred produce failed for a non-size
+        // reason: awaiting the side effect rejects so the pipeline fails and
+        // redelivers the batch. No warning is emitted for this case.
+        expect(sideEffects).toHaveLength(1)
+        await expect(Promise.all(sideEffects)).rejects.toThrow('kafka produce failed')
+        expect(emitIngestionWarning).not.toHaveBeenCalled()
     })
 
     it('should retry on race condition error and clear cache', async () => {
@@ -360,9 +397,9 @@ describe('BatchWritingGroupStore', () => {
         const cacheDeleteSpy = jest.spyOn(groupCache, 'delete')
 
         // Add to cache to verify it gets cleared on race condition
-        await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+        await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
 
-        await groupStore.flush()
+        await flushGroupDropProduces()
 
         expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(1)
         expect(groupRepository.fetchGroup).toHaveBeenCalledTimes(2) // Once for initial fetch, once for retry
@@ -390,7 +427,7 @@ describe('BatchWritingGroupStore', () => {
             // any DB I/O. Any code path that introduces an await between the
             // dirty-filter pass and the clear would re-open the cross-batch
             // race documented in the design doc — this test guards against it.
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: 'test' }, DateTime.now())
 
             const groupCache = groupStore.getGroupCache()
             const dirtyBefore = Array.from(groupCache.entries()).filter(([_, u]) => u && u.needsWrite)
@@ -399,7 +436,7 @@ describe('BatchWritingGroupStore', () => {
             // Kick off flush WITHOUT awaiting it, then synchronously inspect
             // needsWrite. If flush yields before clearing the flag, this will
             // catch it — the assertion runs at the first microtask boundary.
-            const flushPromise = groupStore.flush()
+            const flushPromise = groupStore.flush().then(() => undefined)
 
             const stillDirty = Array.from(groupCache.entries()).filter(([_, u]) => u && u.needsWrite)
             expect(stillDirty).toHaveLength(0)
@@ -411,18 +448,18 @@ describe('BatchWritingGroupStore', () => {
             // After an entry is written and cleaned by a flush, a subsequent
             // upsert with new properties re-dirties it, and the next flush picks
             // up the delta.
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
-            await groupStore.flush()
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
+            await flushGroupDropProduces()
             ;(groupRepository.updateGroupOptimistically as jest.Mock).mockClear()
 
             // Re-dirty via a second update with new properties. The cache is
             // still referenced by batch 0 until releaseBatch() runs, so the
             // second update merges with the first batch's cached properties.
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now())
             const dirtyAfter = Array.from(groupStore.getGroupCache().entries()).filter(([_, u]) => u && u.needsWrite)
             expect(dirtyAfter.length).toBeGreaterThan(0)
 
-            await groupStore.flush()
+            await flushGroupDropProduces()
 
             // Second flush wrote the updated properties merged onto the still-referenced cache.
             expect(groupRepository.updateGroupOptimistically).toHaveBeenCalledTimes(1)
@@ -445,8 +482,8 @@ describe('BatchWritingGroupStore', () => {
         })
 
         it('reports dirty entries and referenced batches in flush stats', async () => {
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now(), 0)
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now(), 1)
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now(), 0)
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now(), 1)
 
             expect(groupStore.getFlushStats()).toEqual({
                 dirtyEntryCount: 1,
@@ -456,9 +493,9 @@ describe('BatchWritingGroupStore', () => {
         })
 
         it('removes clean entries from cache after flush and release', async () => {
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
 
-            await groupStore.flush()
+            await flushGroupDropProduces()
             expect(groupStore.getGroupCache().getSize()).toBe(1)
             groupStore.releaseBatch(0)
 
@@ -466,7 +503,7 @@ describe('BatchWritingGroupStore', () => {
         })
 
         it('keeps entries that were re-dirtied during the DB write', async () => {
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
 
             // Re-dirty the entry during the async DB write after the linearization point.
             jest.spyOn(groupRepository, 'updateGroupOptimistically').mockImplementationOnce(() => {
@@ -477,28 +514,28 @@ describe('BatchWritingGroupStore', () => {
                 return Promise.resolve(2)
             })
 
-            await groupStore.flush()
+            await flushGroupDropProduces()
 
             expect(groupStore.getGroupCache().getSize()).toBe(1)
             expect(groupStore.getGroupCache().get(teamId, 'test')?.needsWrite).toBe(true)
         })
 
         it('defers eviction of dirty entries until after flush', async () => {
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
 
             groupStore.releaseBatch(0)
             expect(groupStore.getGroupCache().getSize()).toBe(1)
 
-            await groupStore.flush()
+            await flushGroupDropProduces()
 
             expect(groupStore.getGroupCache().getSize()).toBe(0)
         })
 
         it('keeps overlapping batch entries until the last release', async () => {
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now(), 0)
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now(), 1)
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now(), 0)
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { b: '2' }, DateTime.now(), 1)
 
-            await groupStore.flush()
+            await flushGroupDropProduces()
 
             groupStore.releaseBatch(0)
             expect(groupStore.getGroupCache().getSize()).toBe(1)
@@ -519,13 +556,13 @@ describe('BatchWritingGroupStore', () => {
 
         it('throws when dirty entries exist — caller must flush first', async () => {
             // upsertGroup on an existing group with new properties marks the cache entry dirty
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
 
             expect(() => groupStore.shutdown()).toThrow(/dirty cache entries/)
         })
 
         it('emits accumulated metrics before throwing on dirty cache', async () => {
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
 
             const emitSpy = jest.spyOn(groupStore as any, 'emitAccumulatedMetrics')
 
@@ -535,9 +572,9 @@ describe('BatchWritingGroupStore', () => {
         })
 
         it('explicit flush before shutdown succeeds', async () => {
-            await groupStore.upsertGroup(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
+            await upsertGroupDropProduces(teamId, projectId, 1, 'test', { a: '1' }, DateTime.now())
 
-            await groupStore.flush()
+            await flushGroupDropProduces()
             await expect(groupStore.shutdown()).resolves.not.toThrow()
         })
     })

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.ts
@@ -11,7 +11,6 @@ import { logger } from '~/common/utils/logger'
 import { promiseRetry } from '~/common/utils/retries'
 import { RaceConditionError } from '~/common/utils/utils'
 import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
-import { FlushResult } from '~/ingestion/common/persons/persons-store'
 import { BatchWritingStoreFlushStats } from '~/ingestion/common/stores/batch-writing-store'
 import { Properties } from '~/plugin-scaffold'
 import { GroupTypeIndex, TeamId } from '~/types'
@@ -305,7 +304,17 @@ export class BatchWritingGroupStore implements GroupStore {
         return this.groupCache
     }
 
-    async flush(): Promise<FlushResult[]> {
+    /**
+     * Flush the batched group updates to Postgres and return the ClickHouse
+     * produce promises for the caller to attach as pipeline side effects.
+     *
+     * The Postgres writes are awaited here (so a failure fails the batch), but
+     * the ClickHouse produces are only *started* and handed back un-awaited —
+     * they are awaited before the consumer commits offsets via the side-effect
+     * machinery, keeping the at-least-once envelope while taking the produce
+     * off the critical flush path.
+     */
+    async flush(): Promise<Promise<unknown>[]> {
         // SYNCHRONOUS LINEARIZATION POINT for cross-batch correctness.
         // Walk every dirty entry, capture it for writing, and clear
         // `needsWrite` before any await below. Concurrent batches that
@@ -332,63 +341,78 @@ export class BatchWritingGroupStore implements GroupStore {
 
         const limit = pLimit(this.options.maxConcurrentUpdates)
 
-        try {
-            await Promise.all(
-                pendingUpdates.map(([distinctId, update]) => limit(() => this.processGroupUpdate(update, distinctId)))
+        // Wait for every Postgres write to settle before deciding the batch's
+        // fate. Each update's outcome is captured (never rejecting the outer
+        // Promise.all) so we can still collect the produce promises for the
+        // writes that succeeded when a sibling write fails, then detach them to
+        // avoid unhandled rejections while the batch is torn down.
+        const outcomes = await Promise.all(
+            pendingUpdates.map(([distinctId, update]) =>
+                limit(() =>
+                    this.processGroupUpdate(update, distinctId).then((r) => ({ ok: true as const, value: r }))
+                ).catch((error: unknown) => ({ ok: false as const, error }))
             )
-            this.groupCache.processDeferredEvictions()
-            return []
-        } catch (error) {
-            logger.error('Failed to flush group updates', {
-                error,
-                errorMessage: error instanceof Error ? error.message : String(error),
-                errorStack: error instanceof Error ? error.stack : undefined,
-            })
-            throw error
+        )
+
+        const producePromises: Promise<unknown>[] = []
+        let firstError: unknown
+        let hasError = false
+        for (const outcome of outcomes) {
+            if (outcome.ok) {
+                producePromises.push(...outcome.value)
+            } else if (!hasError) {
+                hasError = true
+                firstError = outcome.error
+            }
         }
+
+        if (hasError) {
+            // A Postgres write failed; the batch must fail and be redelivered.
+            // Swallow rejections on the ClickHouse produces already started for
+            // the successful writes so their settlement can't surface as an
+            // unhandled rejection during teardown.
+            producePromises.forEach((promise) => promise.catch(() => undefined))
+            logger.error('Failed to flush group updates', {
+                error: firstError,
+                errorMessage: firstError instanceof Error ? firstError.message : String(firstError),
+                errorStack: firstError instanceof Error ? firstError.stack : undefined,
+            })
+            throw firstError
+        }
+
+        this.groupCache.processDeferredEvictions()
+        return producePromises
     }
 
     getFlushStats(): BatchWritingStoreFlushStats {
         return this.groupCache.getFlushStats()
     }
 
-    private async processGroupUpdate(update: GroupUpdate, distinctId: string): Promise<void> {
+    private async processGroupUpdate(update: GroupUpdate, distinctId: string): Promise<Promise<unknown>[]> {
         try {
-            await promiseRetry(
-                () => this.executeOptimisticUpdate(update),
+            return await promiseRetry(
+                () => this.executeOptimisticUpdate(update, distinctId),
                 'updateGroupOptimistically',
                 this.options.maxOptimisticUpdateRetries,
-                this.options.optimisticUpdateRetryInterval,
-                undefined,
-                [MessageSizeTooLarge]
+                this.options.optimisticUpdateRetryInterval
             )
         } catch (error) {
-            await this.handleOptimisticUpdateFailure(error, update, distinctId)
+            return await this.handleOptimisticUpdateFailure(error, update, distinctId)
         }
     }
 
     private async handleOptimisticUpdateFailure(
-        error: unknown,
+        _error: unknown,
         update: GroupUpdate,
         distinctId: string
-    ): Promise<void> {
-        if (error instanceof MessageSizeTooLarge) {
-            await emitIngestionWarning(this.outputs, update.team_id, {
-                type: 'group_upsert_message_size_too_large',
-                details: {
-                    groupTypeIndex: update.group_type_index,
-                    groupKey: update.group_key,
-                    distinctId: distinctId,
-                },
-                pipelineStep: 'group-store',
-            })
-            return
-        }
-
-        await this.fallbackToDirectUpsert(update, distinctId)
+    ): Promise<Promise<unknown>[]> {
+        // MessageSizeTooLarge no longer reaches here: the ClickHouse produce is
+        // deferred, so it surfaces from the produce promise (downgraded to an
+        // ingestion warning) instead of throwing during the Postgres write.
+        return await this.fallbackToDirectUpsert(update, distinctId)
     }
 
-    private async fallbackToDirectUpsert(update: GroupUpdate, distinctId: string): Promise<void> {
+    private async fallbackToDirectUpsert(update: GroupUpdate, distinctId: string): Promise<Promise<unknown>[]> {
         logger.warn('⚠️', 'Falling back to direct upsert after max retries', {
             teamId: update.team_id,
             groupTypeIndex: update.group_type_index,
@@ -400,7 +424,7 @@ export class BatchWritingGroupStore implements GroupStore {
         this.groupCache.delete(update.team_id, update.group_key)
 
         try {
-            await this.executeGroupUpsert(
+            return await this.executeGroupUpsert(
                 update.team_id,
                 update.group_type_index,
                 update.group_key,
@@ -431,12 +455,12 @@ export class BatchWritingGroupStore implements GroupStore {
         properties: Properties,
         timestamp: DateTime,
         batchId?: number
-    ): Promise<void> {
+    ): Promise<Promise<unknown>[]> {
         const effectiveBatchId = batchId ?? 0
         try {
-            await this.addToBatch(teamId, groupTypeIndex, groupKey, properties, timestamp, effectiveBatchId)
+            return await this.addToBatch(teamId, groupTypeIndex, groupKey, properties, timestamp, effectiveBatchId)
         } catch (error) {
-            await this.handleUpsertError(
+            return await this.handleUpsertError(
                 error,
                 teamId,
                 projectId,
@@ -456,12 +480,12 @@ export class BatchWritingGroupStore implements GroupStore {
         properties: Properties,
         timestamp: DateTime,
         batchId: number
-    ): Promise<void> {
+    ): Promise<Promise<unknown>[]> {
         const groupCache = this.groupCache.obtainForBatchId(batchId)
         const group = await this.getGroup(teamId, groupTypeIndex, groupKey, false, groupCache)
 
         if (!group) {
-            await this.executeGroupUpsert(
+            return await this.executeGroupUpsert(
                 teamId,
                 groupTypeIndex,
                 groupKey,
@@ -471,7 +495,6 @@ export class BatchWritingGroupStore implements GroupStore {
                 'batch-create',
                 batchId
             )
-            return
         }
 
         const propertiesUpdate = calculateUpdate(group.group_properties || {}, properties)
@@ -486,6 +509,7 @@ export class BatchWritingGroupStore implements GroupStore {
                 needsWrite: true,
             })
         }
+        return []
     }
 
     private async executeGroupUpsert(
@@ -497,7 +521,7 @@ export class BatchWritingGroupStore implements GroupStore {
         forUpdate: boolean,
         source: string,
         batchId?: number
-    ): Promise<void> {
+    ): Promise<Promise<unknown>[]> {
         const operation = 'upsertGroup' + (source ? `-${source}` : '')
         this.incrementDatabaseOperation(operation)
 
@@ -517,36 +541,55 @@ export class BatchWritingGroupStore implements GroupStore {
         )
 
         if (propertiesUpdate.updated) {
-            await this.upsertToClickhouse(
-                teamId,
-                groupTypeIndex,
-                groupKey,
-                propertiesUpdate.properties,
-                createdAt,
-                actualVersion,
-                source
-            )
+            return [
+                this.produceToClickhouse(
+                    teamId,
+                    groupTypeIndex,
+                    groupKey,
+                    propertiesUpdate.properties,
+                    createdAt,
+                    actualVersion,
+                    source
+                ),
+            ]
         }
+        return []
     }
 
-    private async upsertToClickhouse(
+    /**
+     * Start the ClickHouse group produce and return the promise WITHOUT
+     * awaiting it. The caller attaches it as a pipeline side effect. Postgres
+     * has already committed by the time this runs, so a MessageSizeTooLarge is
+     * downgraded to a non-fatal ingestion warning inside the promise rather
+     * than failing the batch.
+     */
+    private produceToClickhouse(
         teamId: TeamId,
         groupTypeIndex: GroupTypeIndex,
         groupKey: string,
         properties: Properties,
         createdAt: DateTime,
         actualVersion: number,
-        source: string
-    ): Promise<void> {
+        source: string,
+        distinctId?: string
+    ): Promise<unknown> {
         this.incrementDatabaseOperation('upsertClickhouse' + (source ? `-${source}` : ''))
-        await this.clickhouseGroupRepository.upsertGroup(
-            teamId,
-            groupTypeIndex,
-            groupKey,
-            properties,
-            createdAt,
-            actualVersion
-        )
+        return this.clickhouseGroupRepository
+            .upsertGroup(teamId, groupTypeIndex, groupKey, properties, createdAt, actualVersion)
+            .catch((error: unknown) => {
+                if (error instanceof MessageSizeTooLarge) {
+                    return emitIngestionWarning(this.outputs, teamId, {
+                        type: 'group_upsert_message_size_too_large',
+                        details: {
+                            groupTypeIndex,
+                            groupKey,
+                            ...(distinctId !== undefined ? { distinctId } : {}),
+                        },
+                        pipelineStep: 'group-store',
+                    })
+                }
+                throw error
+            })
     }
 
     private async executeUpsertTransaction(
@@ -660,7 +703,7 @@ export class BatchWritingGroupStore implements GroupStore {
         return insertedVersion
     }
 
-    private async executeOptimisticUpdate(update: GroupUpdate): Promise<void> {
+    private async executeOptimisticUpdate(update: GroupUpdate, distinctId: string): Promise<Promise<unknown>[]> {
         this.incrementDatabaseOperation('updateGroupOptimistically')
         const actualVersion = await this.groupRepository.updateGroupOptimistically(
             update.team_id,
@@ -674,16 +717,18 @@ export class BatchWritingGroupStore implements GroupStore {
         )
 
         if (actualVersion !== undefined) {
-            await this.upsertToClickhouse(
-                update.team_id,
-                update.group_type_index,
-                update.group_key,
-                update.group_properties,
-                update.created_at,
-                actualVersion,
-                'optimistically'
-            )
-            return
+            return [
+                this.produceToClickhouse(
+                    update.team_id,
+                    update.group_type_index,
+                    update.group_key,
+                    update.group_properties,
+                    update.created_at,
+                    actualVersion,
+                    'optimistically',
+                    distinctId
+                ),
+            ]
         }
 
         groupOptimisticUpdateConflictsPerBatchCounter.inc()
@@ -758,18 +803,10 @@ export class BatchWritingGroupStore implements GroupStore {
         properties: Properties,
         timestamp: DateTime,
         batchId: number
-    ): Promise<void> {
-        if (error instanceof MessageSizeTooLarge) {
-            await emitIngestionWarning(this.outputs, teamId, {
-                type: 'group_upsert_message_size_too_large',
-                details: {
-                    groupTypeIndex,
-                    groupKey,
-                },
-                pipelineStep: 'group-store',
-            })
-            return
-        }
+    ): Promise<Promise<unknown>[]> {
+        // MessageSizeTooLarge no longer reaches here: the ClickHouse produce is
+        // deferred past the Postgres transaction, so it surfaces from the
+        // produce promise (downgraded to an ingestion warning) instead.
         if (error instanceof RaceConditionError) {
             // Remove from cache to prevent retry, the group was already created by another thread
             this.groupCache.delete(teamId, groupKey)

--- a/nodejs/src/ingestion/common/groups/group-store-for-batch.ts
+++ b/nodejs/src/ingestion/common/groups/group-store-for-batch.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon'
 
-import { FlushResult } from '~/ingestion/common/persons/persons-store'
 import { Properties } from '~/plugin-scaffold'
 import { GroupTypeIndex, ProjectId, TeamId } from '~/types'
 
@@ -15,7 +14,7 @@ export type GroupStoreForBatch = Omit<GroupStore, 'upsertGroup' | 'releaseBatch'
         groupKey: string,
         properties: Properties,
         timestamp: DateTime
-    ): Promise<void>
+    ): Promise<Promise<unknown>[]>
     readonly batchId: number
 }
 
@@ -32,7 +31,7 @@ export class BatchBoundGroupStore implements GroupStoreForBatch {
         groupKey: string,
         properties: Properties,
         timestamp: DateTime
-    ): Promise<void> {
+    ): Promise<Promise<unknown>[]> {
         return this.store.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, properties, timestamp, this.batchId)
     }
 
@@ -40,7 +39,7 @@ export class BatchBoundGroupStore implements GroupStoreForBatch {
         return this.store.getCacheMetrics()
     }
 
-    flush(): Promise<FlushResult[]> {
+    flush(): Promise<Promise<unknown>[]> {
         return this.store.flush()
     }
 

--- a/nodejs/src/ingestion/common/groups/group-store.interface.ts
+++ b/nodejs/src/ingestion/common/groups/group-store.interface.ts
@@ -9,7 +9,14 @@ export interface CacheMetrics {
     cacheMisses: number
 }
 
-export interface GroupStore extends BatchWritingStore {
+/**
+ * The group store defers its ClickHouse group produces so they run off the
+ * per-event hot path. Both `upsertGroup` (inline create) and `flush` (batched
+ * updates) return the produce promises for the caller to attach as pipeline
+ * side effects; those side effects are awaited before the consumer commits
+ * offsets, preserving the at-least-once envelope.
+ */
+export interface GroupStore extends BatchWritingStore<Promise<unknown>> {
     /**
      * Stop any background work (e.g., periodic metric emission) and flush
      * remaining accumulated metrics. Called on graceful shutdown. Does NOT
@@ -25,7 +32,7 @@ export interface GroupStore extends BatchWritingStore {
         properties: Properties,
         timestamp: DateTime,
         batchId: number
-    ): Promise<void>
+    ): Promise<Promise<unknown>[]>
 
     getCacheMetrics(): CacheMetrics
 }

--- a/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.test.ts
@@ -211,6 +211,23 @@ describe('flush-batch-stores-step', () => {
             }
         })
 
+        it('attaches the group store produce promises as side effects', async () => {
+            // The group store returns already-started ClickHouse produce promises;
+            // the step must attach them alongside the person produces so they are
+            // awaited before offset commit.
+            const groupProduce = Promise.resolve('group-produce')
+            mockGroupStore.flush.mockResolvedValue([groupProduce])
+            mockPersonsStore.flush.mockResolvedValue([])
+
+            const result = await step(makeInput())
+
+            expect(isOkResult(result)).toBe(true)
+            if (isOkResult(result)) {
+                expect(result.sideEffects).toContain(groupProduce)
+            }
+            expect(batchStoreFlushKafkaMessagesHistogram.observe).toHaveBeenCalledWith({ store: 'group' }, 1)
+        })
+
         it('reports flush lifecycle metrics', async () => {
             const personMessages: FlushResult[] = [
                 {

--- a/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.ts
@@ -62,9 +62,14 @@ export function createFlushBatchStoresStep<TOutput, COutput, CBatch, R extends s
             // started in their constructors, drained by shutdown()), so this
             // step no longer touches reset/reportBatch — caches persist across
             // batches by design under concurrentBatches > 1.
-            const [groupResults, personsStoreMessages] = await Promise.all([
-                flushStore('group', groupStore),
-                flushStore('person', personsStore),
+            //
+            // The person store returns Kafka message descriptors that we turn
+            // into produce promises here. The group store owns its ClickHouse
+            // group outputs, so it returns already-started produce promises
+            // that we attach directly as side effects.
+            const [groupProducePromises, personsStoreMessages] = await Promise.all([
+                flushStore('group', groupStore, (results) => results.length),
+                flushStore('person', personsStore, countFlushResultMessages),
             ])
 
             const personStoreKafkaMessageCount = countFlushResultMessages(personsStoreMessages)
@@ -73,11 +78,10 @@ export function createFlushBatchStoresStep<TOutput, COutput, CBatch, R extends s
                 batchSize: input.elements.length,
                 personStoreMessageCount: personsStoreMessages.length,
                 personStoreKafkaMessageCount,
-                groupStoreMessageCount: groupResults.length,
+                groupStoreMessageCount: groupProducePromises.length,
             })
 
-            // Create Kafka produce promises for all person/group store updates
-            const producePromises = createProducePromises(personsStoreMessages, outputs)
+            const producePromises = [...groupProducePromises, ...createProducePromises(personsStoreMessages, outputs)]
 
             return ok(input, producePromises)
         } catch (error) {
@@ -96,7 +100,11 @@ export function createFlushBatchStoresStep<TOutput, COutput, CBatch, R extends s
     }
 }
 
-async function flushStore(store: BatchStoreName, batchWritingStore: BatchWritingStore): Promise<FlushResult[]> {
+async function flushStore<T>(
+    store: BatchStoreName,
+    batchWritingStore: BatchWritingStore<T>,
+    countMessages: (results: T[]) => number
+): Promise<T[]> {
     const flushStats = batchWritingStore.getFlushStats()
     batchStoreFlushDirtyEntriesHistogram.observe({ store }, flushStats.dirtyEntryCount)
     batchStoreFlushReferencedBatchesHistogram.observe({ store }, flushStats.referencedBatchCount)
@@ -109,7 +117,7 @@ async function flushStore(store: BatchStoreName, batchWritingStore: BatchWriting
         batchStoreFlushLatencyHistogram.observe({ store, outcome: 'success' }, latencySeconds)
         batchStoreFlushOperationsCounter.inc({ store, outcome: 'success' })
         batchStoreFlushResultRecordsHistogram.observe({ store }, flushResults.length)
-        batchStoreFlushKafkaMessagesHistogram.observe({ store }, countFlushResultMessages(flushResults))
+        batchStoreFlushKafkaMessagesHistogram.observe({ store }, countMessages(flushResults))
         return flushResults
     } catch (error) {
         const latencySeconds = (performance.now() - flushStartTime) / 1000

--- a/nodejs/src/ingestion/common/steps/event-processing/process-groups-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/process-groups-step.test.ts
@@ -38,7 +38,7 @@ describe('createProcessGroupsStep', () => {
 
         mockTeamManager = { setTeamIngestedEvent: jest.fn().mockResolvedValue(undefined) }
         mockGroupTypeManager = { fetchGroupTypeIndex: jest.fn().mockResolvedValue(null) }
-        mockGroupStore = { upsertGroup: jest.fn().mockResolvedValue(undefined) }
+        mockGroupStore = { upsertGroup: jest.fn().mockResolvedValue([]) }
     })
 
     const createInput = (overrides: Partial<TestInput> = {}): TestInput => ({
@@ -107,8 +107,12 @@ describe('createProcessGroupsStep', () => {
         }
     })
 
-    it('calls upsertGroup for $groupidentify events', async () => {
+    it('calls upsertGroup for $groupidentify events and attaches its produces as side effects', async () => {
         mockGroupTypeManager.fetchGroupTypeIndex.mockResolvedValue(0)
+        // The store returns deferred ClickHouse produce promises; the step must
+        // forward them as side effects so they are awaited before offset commit.
+        const groupProduce = Promise.resolve('group-produce')
+        mockGroupStore.upsertGroup.mockResolvedValue([groupProduce])
 
         const step = createStep()
         const result = await step(
@@ -126,6 +130,9 @@ describe('createProcessGroupsStep', () => {
 
         expect(result.type).toBe(PipelineResultType.OK)
         expect(mockGroupStore.upsertGroup).toHaveBeenCalledWith(1, 1, 0, 'org::5', { foo: 'bar' }, expect.any(DateTime))
+        if (result.type === PipelineResultType.OK) {
+            expect(result.sideEffects).toContain(groupProduce)
+        }
     })
 
     it.each([

--- a/nodejs/src/ingestion/common/steps/event-processing/process-groups-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/process-groups-step.ts
@@ -46,6 +46,11 @@ export function createProcessGroupsStep<TInput extends ProcessGroupsStepInput>(
             }
         }
 
+        // ClickHouse group produces are deferred by the store and returned here
+        // so we can attach them as pipeline side effects instead of awaiting
+        // them mid-lane on the per-event hot path.
+        let sideEffects: Promise<unknown>[] = []
+
         if (processPerson) {
             preparedEvent.properties = await addGroupProperties(
                 team.id,
@@ -56,7 +61,7 @@ export function createProcessGroupsStep<TInput extends ProcessGroupsStepInput>(
             )
 
             if (preparedEvent.event === '$groupidentify') {
-                await upsertGroup(
+                sideEffects = await upsertGroup(
                     groupTypeManager,
                     groupStoreForBatch,
                     team.id,
@@ -67,7 +72,7 @@ export function createProcessGroupsStep<TInput extends ProcessGroupsStepInput>(
             }
         }
 
-        return ok(input)
+        return ok(input, sideEffects)
     }
 }
 
@@ -107,15 +112,15 @@ async function upsertGroup(
     projectId: ProjectId,
     properties: Properties,
     timestamp: DateTime
-): Promise<void> {
+): Promise<Promise<unknown>[]> {
     if (!properties['$group_type'] || !properties['$group_key']) {
-        return
+        return []
     }
 
     const { $group_type: groupType, $group_key: groupKey, $group_set: groupPropertiesToSet } = properties
     const groupTypeIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, projectId, groupType, timestamp)
     if (groupTypeIndex !== null) {
-        await groupStore.upsertGroup(
+        return await groupStore.upsertGroup(
             teamId,
             projectId,
             groupTypeIndex,
@@ -124,4 +129,5 @@ async function upsertGroup(
             timestamp
         )
     }
+    return []
 }

--- a/nodejs/src/ingestion/common/stores/batch-writing-store.ts
+++ b/nodejs/src/ingestion/common/stores/batch-writing-store.ts
@@ -6,7 +6,7 @@ export interface BatchWritingStoreFlushStats {
     cacheEntryCount: number
 }
 
-export interface BatchWritingStore {
+export interface BatchWritingStore<TFlushResult = FlushResult> {
     /*
      * Returns a point-in-time summary of entries that would be captured by
      * flush(), plus the batch IDs that currently reference those dirty entries.
@@ -14,10 +14,14 @@ export interface BatchWritingStore {
     getFlushStats(): BatchWritingStoreFlushStats
 
     /*
-     * Flushes all batch data that needs to be written
-     * Returns Kafka messages that need to be sent
+     * Flushes all batch data that needs to be written.
+     *
+     * The person store returns Kafka message descriptors (`FlushResult`) that
+     * the flush step turns into produce promises. The group store owns its own
+     * ClickHouse group outputs, so it returns already-built produce promises
+     * (`Promise<unknown>`) that the flush step attaches directly as side effects.
      */
-    flush(): Promise<FlushResult[]>
+    flush(): Promise<TFlushResult[]>
 
     /*
      * Releases cache entries associated with the given batch ID.


### PR DESCRIPTION
## Problem

On the analytics ingestion lane, events are grouped by `token:distinct_id` and each group is processed strictly sequentially. For every `$groupidentify` event, `processGroupsStep` calls into the group store, which — until now — **awaited a ClickHouse Kafka produce inline, per event**, on that sequential lane.

That inline awaited produce sits on the hot path. A burst of `$groupidentify` traffic from a single distinct_id serializes behind those per-event produces and starves the rest of the lane. The person store already solved the equivalent problem: its `flush()` returns Kafka message descriptors that the pipeline turns into produce side effects, awaited off the critical path but still before offset commit. The group store was the odd one out.

## Changes

Align the group store with the person store's message-returning contract so the ClickHouse produce becomes a pipeline side effect instead of an inline await.

- `BatchWritingGroupStore.flush()` now returns the ClickHouse produce promises instead of awaiting them. `flushBatchStoresStep` attaches them as side effects alongside the person produces (it already flushed both stores; it just ignored the empty group result before).
- The inline create path (`upsertGroup` -> `addToBatch` -> `executeGroupUpsert`) returns its produce promise up through `upsertGroup`, and `processGroupsStep` attaches it via `ok(input, sideEffects)` instead of awaiting mid-lane.
- `MessageSizeTooLarge` handling moved into the produce promise itself: it is downgraded to a non-fatal ingestion warning where the produce is created, mirroring `createProducePromises`.
- `GroupStore` / `GroupStoreForBatch` signatures change from `Promise<void>` to returning the produce promises; `BatchWritingStore` gained an optional flush-result type parameter so the group store can return produce promises while the person store keeps returning `FlushResult[]`.

> [!NOTE]
> The at-least-once envelope is unchanged. Postgres still commits before the produce promise is created, and every produce is awaited before the consumer commits offsets via the existing side-effect machinery. A flush failure still throws and fails the batch (redelivery). This only moves *when* the produce is awaited (as a side effect, off the per-event lane) not whether it is awaited.

One behavior refinement worth calling out: previously a `MessageSizeTooLarge` on the optimistic-update fallback path was fatal, while on the other paths it was a warning. Now it is uniformly downgraded to a non-fatal ingestion warning, since an oversized ClickHouse row should not fail a batch.

## How did you test this code?

Automated only (I, Claude, ran these; I did not manually exercise the running pipeline):

- `pnpm test -- src/ingestion/common/groups/ src/ingestion/common/steps/event-processing/` — 267 tests green, including the updated group store and step suites.
- `pnpm test -- src/ingestion/common/persons/batch-writing-person-store.test.ts` — 106 green (unaffected by the `BatchWritingStore` generic).
- Typecheck (`tsc -b`) is clean for all touched files. The only remaining errors in the tree are pre-existing, from unbuilt rust NAPI workspace bindings (`@posthog/cyclotron`, `@posthog/replay-anonymizer`) in unrelated `cdp/` and `sessionreplay/` files.
- eslint clean on all changed files.

Test changes and the regression each catches:

- Group store: assert `flush()` and the inline-create `upsertGroup` **return** the produce promise as a side effect (catches a silent revert to fire-and-forget, which would break at-least-once). The existing `MessageSizeTooLarge` case was rewritten to await the returned side effect and assert the warning is emitted and the batch is not failed (the old assertion passed only by microtask-timing coincidence once the produce became deferred). Added one case: a non-size produce rejection surfaces through the awaited side effect (batch fails, no warning).
- `processGroupsStep`: assert the store's returned produce promises are forwarded into `result.sideEffects` (catches the step dropping them, which would leave produces unawaited before commit).
- `flushBatchStoresStep`: assert group-store produce promises are attached as side effects and counted (this step never exercised a non-empty group flush before).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) at my direction. This is the first of a small stack aimed at making `$groupidentify`-heavy traffic follow the same shape as person processing (prefetch per chunk, defer writes to the per-batch flush, produce as side effects); this PR is just the "produce as a side effect" step and is safe to ship on its own with no flag.

Skills invoked: `/writing-tests` (to gate the test changes against the value bar before writing them).

Design note for reviewers: the group store returns already-built produce promises rather than person-shaped message descriptors. That is a deliberate deviation from a literal mirror of the person store. The group store owns its own ClickHouse group `IngestionOutputs`, whereas the flush step's output type is person-scoped and `processGroupsStep` has no outputs at all. Having the store build the produce keeps the `MessageSizeTooLarge` handling in one place and avoids threading `GroupsOutput` through the step and the AI subpipeline contract. The tradeoff is that `flush()`/`upsertGroup` return `Promise<unknown>[]`, so the store's unit tests wrap the discard sites in small helpers to keep them off the `no-floating-promises` radar.
