### PR TITLE
fix(web-analytics): coerce non-string page URL in page reports filters

### DIFF
--- a/frontend/src/scenes/web-analytics/pageReportsLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.test.ts
@@ -48,6 +48,11 @@ describe('createPageReportsFilters', () => {
         expect(filters.map((filter) => filter.key).sort()).toEqual([...expectKeys].sort())
     })
 
+    // kea-router JSON-parses query params, so ?pageURL=123 arrives (and gets persisted) as a number
+    test.each([123, true, null])('non-string page URL %p does not crash the filter builder', (url) => {
+        expect(() => createPageReportsFilters(url as unknown as string, true, null)).not.toThrow()
+    })
+
     test.each([
         {
             name: 'cleaning off keeps the pathname an exact match',

--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -66,7 +66,7 @@ export interface PageURLSearchResult {
 export function createUrlPropertyFilter(url: string, stripQueryParams: boolean): WebAnalyticsPropertyFilters {
     // kea-router JSON-parses query params (?pageURL=123 arrives as a number) and pageUrl is
     // persisted, so a non-string value would otherwise crash `url.split` below on every recompute
-    const urlString: string = typeof url === 'string' ? url : String(url ?? '')
+    const urlString: string = String(url ?? '')
     const parsed = parseWebAnalyticsURL(urlString)
 
     if (parsed.isValid && parsed.host && parsed.pathname) {

--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -64,7 +64,10 @@ export interface PageURLSearchResult {
 }
 
 export function createUrlPropertyFilter(url: string, stripQueryParams: boolean): WebAnalyticsPropertyFilters {
-    const parsed = parseWebAnalyticsURL(url)
+    // kea-router JSON-parses query params (?pageURL=123 arrives as a number) and pageUrl is
+    // persisted, so a non-string value would otherwise crash `url.split` below on every recompute
+    const urlString: string = typeof url === 'string' ? url : String(url ?? '')
+    const parsed = parseWebAnalyticsURL(urlString)
 
     if (parsed.isValid && parsed.host && parsed.pathname) {
         return [
@@ -87,7 +90,7 @@ export function createUrlPropertyFilter(url: string, stripQueryParams: boolean):
     return [
         {
             key: '$current_url',
-            value: stripQueryParams ? `^${url.split('?')[0]}(\\?.*)?$` : url,
+            value: stripQueryParams ? `^${urlString.split('?')[0]}(\\?.*)?$` : urlString,
             operator: stripQueryParams ? PropertyOperator.Regex : PropertyOperator.Exact,
             type: PropertyFilterType.Event,
         },
@@ -164,7 +167,7 @@ export function buildPageUrlOptions(
     }
 
     const representativeByCleaned = new Map<string, string>()
-    if (pageUrl) {
+    if (typeof pageUrl === 'string' && pageUrl) {
         representativeByCleaned.set(cleanPageURLForDisplay(pageUrl, filters), pageUrl)
     }
     for (const { url } of pagesUrls) {
@@ -957,8 +960,10 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
 
     urlToAction: ({ actions, values }) => ({
         '/web/page-reports': (_, searchParams) => {
-            if (searchParams.pageURL && searchParams.pageURL !== values.pageUrl) {
-                actions.setPageUrl(searchParams.pageURL)
+            // kea-router JSON-parses query params, so ?pageURL=123 arrives as a number
+            const pageURL = searchParams.pageURL == null ? null : String(searchParams.pageURL)
+            if (pageURL && pageURL !== values.pageUrl) {
+                actions.setPageUrl(pageURL)
             }
         },
     }),


### PR DESCRIPTION
## Problem

The web analytics scene can crash entirely with `TypeError: e.split is not a function` (error tracking issue [019f458b-93cc](https://us.posthog.com/project/2/error_tracking/019f458b-93cc-79b3-a527-3700a0370b81), reported by two customers via support).

kea-router JSON-parses query param values, so `?pageURL=123` arrives in `pageReportsLogic` as a **number**. The `pageUrl` reducer is persisted, so the bad value sticks in localStorage. From then on, every recompute of the `queries` selector (any date range or filter change, including on the main `/web` page since the logic is connected there) hits `createUrlPropertyFilter`, which calls `url.split('?')` on the non-string and throws.

## Changes

- `createUrlPropertyFilter` coerces non-string input to a string before parsing. This also heals already-persisted bad values, which a boundary-only fix would leave crashing forever.
- `urlToAction` for `/web/page-reports` stringifies `searchParams.pageURL` before comparing and dispatching, so numeric params never enter state.
- `buildPageUrlOptions` guards its `pageUrl` use with a string check (same persisted value, different consumer, would crash in `cleanPathnameForDisplay` with path cleaning enabled).

## How did you test this code?

Added 3 parameterized cases to the existing `createPageReportsFilters` suite asserting non-string inputs (`123`, `true`, `null`) don't throw. They fail without the coercion and pin the exact prod regression. Full suite (21 tests) passes, and `typescript:check` is green. I did not manually reproduce in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session triaging web analytics support tickets. Root cause was confirmed against sourcemapped stacks in error tracking (selector -> `createPageReportsFilters` -> `createUrlPropertyFilter`) rather than reproduced locally. Skills invoked: /writing-tests. Chose runtime coercion at both the read path and the router boundary over a reducer-only fix because the value is persisted and a reducer fix alone would leave affected users crashing until they picked a new URL.