### PR TITLE
feat(alerts): support funnel and SQL insights in Max AI alert tool

### DIFF
--- a/products/alerts/backend/api/alert.py
+++ b/products/alerts/backend/api/alert.py
@@ -23,7 +23,6 @@ from posthog.schema import (
     FunnelsAlertConfig,
     HogQLAlertConfig,
     InsightThreshold,
-    NodeKind,
     TrendsAlertConfig,
 )
 
@@ -51,6 +50,7 @@ from products.alerts.backend.evaluation.contract import AlertExtractionError
 from products.alerts.backend.evaluation.detector import simulate_detector_on_insight
 from products.alerts.backend.evaluation.validation import (
     THRESHOLD_BOUNDS_REQUIRED_MESSAGE,
+    alertable_insight_kind_error,
     should_default_check_ongoing_interval,
     validate_alert_config,
 )
@@ -552,21 +552,7 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
         # a PATCH that omits `insight` (which skips this field-level validator), so an alert can't be
         # repointed at a flag-gated insight kind in an account where the flag is off. The model stays
         # flag-agnostic so existing alerts keep working when the flag is off.
-        kind = insight.alertable_query_kind
-        if kind is None:
-            raise ValidationError("Alerts are not supported for this insight.")
-        if kind == NodeKind.HOG_QL_QUERY and not self._hogql_alerts_enabled():
-            raise ValidationError("SQL insight alerts are not enabled for your account.")
-        if kind == NodeKind.FUNNELS_QUERY and not self._funnel_alerts_enabled():
-            raise ValidationError("Funnel insight alerts are not enabled for your account.")
-
-    def _hogql_alerts_enabled(self) -> bool:
-        return self._insight_alert_flag_enabled("hogql-insight-alerts")
-
-    def _funnel_alerts_enabled(self) -> bool:
-        return self._insight_alert_flag_enabled("funnel-insight-alerts")
-
-    def _insight_alert_flag_enabled(self, flag: str) -> bool:
+        #
         # Scope the flag to the alert's organization (via team scope), not the user's current
         # organization — otherwise a user in multiple orgs could flip their current org to a
         # flag-on org and create an alert in a team where the flag is disabled. get_organization is
@@ -574,13 +560,10 @@ class AlertSerializer(SearchMatchTypeSerializerMixin, serializers.ModelSerialize
         # invariant can't silently degrade to an unscoped check.
         user = self.context["request"].user
         org = self.context["get_organization"]()
-        return bool(
-            posthoganalytics.feature_enabled(
-                flag,
-                str(user.distinct_id),
-                groups={"organization": str(org.id)},
-            )
-        )
+        if error := alertable_insight_kind_error(
+            insight.alertable_query_kind, distinct_id=str(user.distinct_id), organization_id=str(org.id)
+        ):
+            raise ValidationError(error)
 
     def validate_subscribed_users(self, value):
         for user in value:

--- a/products/alerts/backend/api/test/test_alert.py
+++ b/products/alerts/backend/api/test/test_alert.py
@@ -183,13 +183,17 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         }
 
         # Flag off: the insight gate rejects funnel alerts.
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=False):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=False
+        ):
             response = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request)
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         assert "Funnel insight alerts are not enabled" in str(response.content)
 
         # Flag on: the same request is accepted.
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             response = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request)
         assert response.status_code == status.HTTP_201_CREATED, response.content
 
@@ -529,7 +533,9 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         }
         hogql_insight = self.client.post(f"/api/projects/{self.team.id}/insights", data=hogql_insight_data).json()
 
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             alert = self.client.post(
                 f"/api/projects/{self.team.id}/alerts",
                 {
@@ -573,7 +579,9 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         }
         funnel_insight = self.client.post(f"/api/projects/{self.team.id}/insights", data=funnel_insight_data).json()
 
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             alert = self.client.post(
                 f"/api/projects/{self.team.id}/alerts",
                 {
@@ -621,7 +629,9 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         # flag must be enforced in the object-level validate() — otherwise an existing SQL alert could
         # be reconfigured in an account where the flag is no longer enabled.
         hogql_insight = self._create_hogql_insight()
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             alert = self.client.post(
                 f"/api/projects/{self.team.id}/alerts",
                 {
@@ -637,12 +647,16 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             alert_id = alert.json()["id"]
 
         config_patch = {"config": {"type": "HogQLAlertConfig", "evaluation": "first_row"}}
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=False):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=False
+        ):
             blocked = self.client.patch(f"/api/projects/{self.team.id}/alerts/{alert_id}", config_patch)
         assert blocked.status_code == status.HTTP_400_BAD_REQUEST, blocked.content
         assert "SQL insight alerts are not enabled" in str(blocked.content)
 
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             allowed = self.client.patch(f"/api/projects/{self.team.id}/alerts/{alert_id}", config_patch)
         assert allowed.status_code == status.HTTP_200_OK, allowed.content
 
@@ -667,7 +681,9 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         ).json()["id"]
 
         # Switch the insight from trends to SQL — a different alertable kind.
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             self.client.patch(
                 f"/api/projects/{self.team.id}/insights/{trends_insight['id']}",
                 data={
@@ -694,7 +710,9 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
                 }
             },
         ).json()
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             alert = self.client.post(
                 f"/api/projects/{self.team.id}/alerts",
                 {
@@ -712,12 +730,16 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         config_patch = {
             "config": {"type": "FunnelsAlertConfig", "metric": "conversion_from_previous", "funnel_step": 1}
         }
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=False):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=False
+        ):
             blocked = self.client.patch(f"/api/projects/{self.team.id}/alerts/{alert_id}", config_patch)
         assert blocked.status_code == status.HTTP_400_BAD_REQUEST, blocked.content
         assert "Funnel insight alerts are not enabled" in str(blocked.content)
 
-        with mock.patch("products.alerts.backend.api.alert.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             allowed = self.client.patch(f"/api/projects/{self.team.id}/alerts/{alert_id}", config_patch)
         assert allowed.status_code == status.HTTP_200_OK, allowed.content
 

--- a/products/alerts/backend/evaluation/validation.py
+++ b/products/alerts/backend/evaluation/validation.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
+import posthoganalytics
 from pydantic import ValidationError as PydanticValidationError
 
 from posthog.schema import (
@@ -26,6 +27,35 @@ from products.alerts.backend.evaluation.dispatcher import DETECTOR_EXTRACTORS
 from products.alerts.backend.evaluation.funnel_strategies import strategy_for_viz
 
 THRESHOLD_BOUNDS_REQUIRED_MESSAGE = "At least one threshold bound (lower or upper) must be provided."
+
+
+def _insight_alert_flag_enabled(flag: str, *, distinct_id: str, organization_id: str) -> bool:
+    return bool(
+        posthoganalytics.feature_enabled(
+            flag,
+            distinct_id,
+            groups={"organization": organization_id},
+        )
+    )
+
+
+def alertable_insight_kind_error(kind: NodeKind | None, *, distinct_id: str, organization_id: str) -> str | None:
+    """Returns an error message if this insight kind can't be alerted on for this org, else None.
+
+    Shared by the alerts API serializer and the Max AI tool so the two surfaces can't drift on
+    which insight kinds are alertable, or on the account-level flags gating funnels and SQL.
+    """
+    if kind is None:
+        return "Alerts are not supported for this insight."
+    if kind == NodeKind.HOG_QL_QUERY and not _insight_alert_flag_enabled(
+        "hogql-insight-alerts", distinct_id=distinct_id, organization_id=organization_id
+    ):
+        return "SQL insight alerts are not enabled for your account."
+    if kind == NodeKind.FUNNELS_QUERY and not _insight_alert_flag_enabled(
+        "funnel-insight-alerts", distinct_id=distinct_id, organization_id=organization_id
+    ):
+        return "Funnel insight alerts are not enabled for your account."
+    return None
 
 
 @dataclass(frozen=True)

--- a/products/alerts/backend/max_tools.py
+++ b/products/alerts/backend/max_tools.py
@@ -221,6 +221,20 @@ class UpdateAlertAction(BaseModel):
     skip_weekend: bool | None = Field(default=None, description="Whether to skip weekend checks")
 
 
+# Action attribute name -> key in the persisted config dict. Single source of truth for what
+# each per-kind field is called in storage, used by both the update path's config patching and
+# _build_create_config (which additionally applies per-kind defaults and the type discriminator),
+# so a rename or new field means updating one place instead of two.
+ALERT_CONFIG_FIELD_TO_KEY: dict[str, str] = {
+    "series_index": "series_index",
+    "check_ongoing_interval": "check_ongoing_interval",
+    "funnel_step": "funnel_step",
+    "funnel_metric": "metric",
+    "hogql_column": "column",
+    "hogql_evaluation": "evaluation",
+    "hogql_label_column": "label_column",
+}
+
 UpsertAlertAction = Union[CreateAlertAction, UpdateAlertAction]
 
 
@@ -437,21 +451,11 @@ class UpsertAlertTool(MaxTool):
                 alert.calculation_interval = action.calculation_interval
                 update_fields.append("calculation_interval")
 
-            config_updates: dict[str, Any] = {}
-            if action.series_index is not None:
-                config_updates["series_index"] = action.series_index
-            if action.check_ongoing_interval is not None:
-                config_updates["check_ongoing_interval"] = action.check_ongoing_interval
-            if action.funnel_step is not None:
-                config_updates["funnel_step"] = action.funnel_step
-            if action.funnel_metric is not None:
-                config_updates["metric"] = action.funnel_metric
-            if action.hogql_column is not None:
-                config_updates["column"] = action.hogql_column
-            if action.hogql_evaluation is not None:
-                config_updates["evaluation"] = action.hogql_evaluation
-            if action.hogql_label_column is not None:
-                config_updates["label_column"] = action.hogql_label_column
+            config_updates: dict[str, Any] = {
+                config_key: getattr(action, field_name)
+                for field_name, config_key in ALERT_CONFIG_FIELD_TO_KEY.items()
+                if getattr(action, field_name) is not None
+            }
             if config_updates:
                 alert.config = {**(alert.config or {}), **config_updates}
                 update_fields.append("config")
@@ -571,12 +575,13 @@ class UpsertAlertTool(MaxTool):
         insight, was_auto_saved = await self._resolve_insight(insight_id)
         await self.check_object_access(insight, "viewer", resource="insight", action=action_description)
         kind = await sync_to_async(lambda: insight.alertable_query_kind)()
+        if kind is None:
+            raise ValueError("Alerts are not supported for this insight.")
         team = self._team
         user = self._user
         org = await sync_to_async(lambda: team.organization)()
         if error := alertable_insight_kind_error(kind, distinct_id=str(user.distinct_id), organization_id=str(org.id)):
             raise ValueError(error)
-        assert kind is not None
         return insight, was_auto_saved, kind
 
     @staticmethod
@@ -586,14 +591,15 @@ class UpsertAlertTool(MaxTool):
 
     @staticmethod
     def _build_create_config(kind: NodeKind, action: CreateAlertAction) -> dict[str, Any]:
+        field_to_key = ALERT_CONFIG_FIELD_TO_KEY
         config: dict[str, Any]
         if kind == NodeKind.TRENDS_QUERY:
-            config = {"type": "TrendsAlertConfig", "series_index": action.series_index}
+            config = {"type": "TrendsAlertConfig", field_to_key["series_index"]: action.series_index}
         elif kind == NodeKind.FUNNELS_QUERY:
             config = {
                 "type": "FunnelsAlertConfig",
-                "funnel_step": action.funnel_step,
-                "metric": action.funnel_metric or FunnelConversionMetric.CONVERSION_FROM_START,
+                field_to_key["funnel_step"]: action.funnel_step,
+                field_to_key["funnel_metric"]: action.funnel_metric or FunnelConversionMetric.CONVERSION_FROM_START,
             }
         else:
             if action.hogql_evaluation is None:
@@ -602,13 +608,13 @@ class UpsertAlertTool(MaxTool):
                 )
             config = {
                 "type": "HogQLAlertConfig",
-                "column": action.hogql_column,
-                "evaluation": action.hogql_evaluation,
-                "label_column": action.hogql_label_column,
+                field_to_key["hogql_column"]: action.hogql_column,
+                field_to_key["hogql_evaluation"]: action.hogql_evaluation,
+                field_to_key["hogql_label_column"]: action.hogql_label_column,
             }
 
         if action.check_ongoing_interval is not None and kind in (NodeKind.TRENDS_QUERY, NodeKind.FUNNELS_QUERY):
-            config["check_ongoing_interval"] = action.check_ongoing_interval
+            config[field_to_key["check_ongoing_interval"]] = action.check_ongoing_interval
 
         return config
 

--- a/products/alerts/backend/max_tools.py
+++ b/products/alerts/backend/max_tools.py
@@ -486,6 +486,8 @@ class UpsertAlertTool(MaxTool):
             insight = await sync_to_async(lambda: alert.insight)()
             if config_updates or conditions_or_threshold_changed:
                 query = await sync_to_async(self._get_upgraded_query)(insight)
+                if query is None:
+                    return "Insight has no valid query.", {"error": "unsupported_insight"}
                 threshold_config = alert.threshold.configuration if alert.threshold else None
                 try:
                     validate_alert_config(

--- a/products/alerts/backend/max_tools.py
+++ b/products/alerts/backend/max_tools.py
@@ -4,7 +4,6 @@ from typing import Any, Literal, Union, cast
 from django.core.exceptions import ValidationError
 from django.db import transaction
 
-import posthoganalytics
 from asgiref.sync import sync_to_async
 from pydantic import BaseModel, Field
 
@@ -27,7 +26,11 @@ from posthog.rbac.user_access_control import AccessControlLevel
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 from posthog.scopes import APIScopeObject
 
-from products.alerts.backend.evaluation.validation import THRESHOLD_BOUNDS_REQUIRED_MESSAGE, validate_alert_config
+from products.alerts.backend.evaluation.validation import (
+    THRESHOLD_BOUNDS_REQUIRED_MESSAGE,
+    alertable_insight_kind_error,
+    validate_alert_config,
+)
 from products.alerts.backend.models.alert import AlertConfiguration, AlertSubscription, Threshold
 from products.product_analytics.backend.models.insight import Insight
 
@@ -568,29 +571,13 @@ class UpsertAlertTool(MaxTool):
         insight, was_auto_saved = await self._resolve_insight(insight_id)
         await self.check_object_access(insight, "viewer", resource="insight", action=action_description)
         kind = await sync_to_async(lambda: insight.alertable_query_kind)()
-        if kind is None:
-            raise ValueError(
-                "Alerts are only supported for trends, funnel, or SQL insights. This insight type is not supported."
-            )
-        if kind == NodeKind.HOG_QL_QUERY and not await self._insight_alert_flag_enabled("hogql-insight-alerts"):
-            raise ValueError("SQL insight alerts are not enabled for your account.")
-        if kind == NodeKind.FUNNELS_QUERY and not await self._insight_alert_flag_enabled("funnel-insight-alerts"):
-            raise ValueError("Funnel insight alerts are not enabled for your account.")
-        return insight, was_auto_saved, kind
-
-    async def _insight_alert_flag_enabled(self, flag: str) -> bool:
         team = self._team
         user = self._user
         org = await sync_to_async(lambda: team.organization)()
-        return await sync_to_async(
-            lambda: bool(
-                posthoganalytics.feature_enabled(
-                    flag,
-                    str(user.distinct_id),
-                    groups={"organization": str(org.id)},
-                )
-            )
-        )()
+        if error := alertable_insight_kind_error(kind, distinct_id=str(user.distinct_id), organization_id=str(org.id)):
+            raise ValueError(error)
+        assert kind is not None
+        return insight, was_auto_saved, kind
 
     @staticmethod
     def _get_upgraded_query(insight: Insight) -> dict | None:

--- a/products/alerts/backend/max_tools.py
+++ b/products/alerts/backend/max_tools.py
@@ -4,12 +4,15 @@ from typing import Any, Literal, Union, cast
 from django.core.exceptions import ValidationError
 from django.db import transaction
 
+import posthoganalytics
 from asgiref.sync import sync_to_async
 from pydantic import BaseModel, Field
 
 from posthog.schema import (
     AlertCalculationInterval,
     AlertConditionType,
+    FunnelConversionMetric,
+    HogQLAlertEvaluation,
     InsightThresholdType,
     InsightVizNode,
     NodeKind,
@@ -21,9 +24,10 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.rbac.user_access_control import AccessControlLevel
+from posthog.schema_migrations.upgrade_manager import upgrade_query
 from posthog.scopes import APIScopeObject
 
-from products.alerts.backend.evaluation.validation import THRESHOLD_BOUNDS_REQUIRED_MESSAGE
+from products.alerts.backend.evaluation.validation import THRESHOLD_BOUNDS_REQUIRED_MESSAGE, validate_alert_config
 from products.alerts.backend.models.alert import AlertConfiguration, AlertSubscription, Threshold
 from products.product_analytics.backend.models.insight import Insight
 
@@ -57,7 +61,8 @@ UPSERT_ALERT_TOOL_DESCRIPTION = dedent("""
     - **update**: Edit an existing alert (requires alert_id, all other fields are optional)
 
     # Requirements
-    - Only works for TrendsQuery insights (not funnels, retention, etc.)
+    - Supports trends, funnel, and SQL insights (retention and other insight types are not supported)
+    - Funnel and SQL insight alerts require the account to have those alert kinds enabled
     - For create: insight_id is required
     - For update: the alert_id must be provided (find it via list_data with kind="alerts")
 
@@ -83,14 +88,30 @@ UPSERT_ALERT_TOOL_DESCRIPTION = dedent("""
     - **weekly**: Check once per week
     - **monthly**: Check once per month
 
-    # Series index
+    # Series index (trends insights only)
     - If the insight has multiple series (e.g., multiple event types), use series_index to specify which one to monitor
     - Default is 0 (first series) for create
+
+    # Funnel insight fields
+    - **funnel_step**: Zero-based step index to monitor. Leave unset to monitor the overall conversion (last step)
+    - **funnel_metric**: conversion_from_start (default) or conversion_from_previous
+    - Only steps funnels support absolute_value conditions; historical-trend funnels also support relative_increase/relative_decrease
+
+    # SQL insight fields
+    - **hogql_evaluation** (required for SQL insights): last_row, first_row, or any_row - how to read the result rows
+    - **hogql_column**: which result column to evaluate (defaults to the single numeric column)
+    - **hogql_label_column**: column used to label the evaluated row(s) in breach messages
+    - any_row alerts only support absolute_value conditions
+
+    # Check ongoing interval (trends and time-series funnels)
+    - **check_ongoing_interval**: when true, also evaluates the current (still in-progress) period, not just completed ones
 
     # Create examples
     - "Alert me when daily signups drop below 100": action=create, condition_type=absolute_value, lower_threshold=100
     - "Alert when pageviews increase by more than 50%": action=create, condition_type=relative_increase, upper_threshold=0.5, threshold_type=percentage
     - "Notify me if revenue drops more than 20% week over week": action=create, condition_type=relative_decrease, lower_threshold=0.2, threshold_type=percentage, calculation_interval=weekly
+    - "Alert me if signup conversion drops below 20%": action=create, condition_type=absolute_value, lower_threshold=0.2, funnel_step=2
+    - "Alert me if the total from this SQL query drops below 1000": action=create, condition_type=absolute_value, lower_threshold=1000, hogql_evaluation=last_row
 
     # Update examples
     - "Change my alert threshold to 200": action=update, alert_id=<id>, upper_threshold=200
@@ -132,7 +153,31 @@ class CreateAlertAction(BaseModel):
     )
     series_index: int = Field(
         default=0,
-        description="Which series to monitor (0-indexed). Use 0 for single-series insights.",
+        description="Trends insights only: which series to monitor (0-indexed). Use 0 for single-series insights.",
+    )
+    check_ongoing_interval: bool | None = Field(
+        default=None,
+        description="Trends and time-series funnel insights only: also evaluate the current (still in-progress) period.",
+    )
+    funnel_step: int | None = Field(
+        default=None,
+        description="Funnel insights only: zero-based step index to monitor. Unset monitors the overall conversion (last step).",
+    )
+    funnel_metric: FunnelConversionMetric | None = Field(
+        default=None,
+        description="Funnel insights only: conversion_from_start (default) or conversion_from_previous.",
+    )
+    hogql_column: str | None = Field(
+        default=None,
+        description="SQL insights only: name of the result column to evaluate. Defaults to the single numeric column.",
+    )
+    hogql_evaluation: HogQLAlertEvaluation | None = Field(
+        default=None,
+        description="SQL insights only, required: last_row, first_row, or any_row - how to read the result rows.",
+    )
+    hogql_label_column: str | None = Field(
+        default=None,
+        description="SQL insights only: column used to label the evaluated row(s) in breach messages.",
     )
     enabled: bool = Field(
         default=True,
@@ -156,7 +201,19 @@ class UpdateAlertAction(BaseModel):
     upper_threshold: float | None = Field(default=None, description="New upper threshold bound")
     lower_threshold: float | None = Field(default=None, description="New lower threshold bound")
     threshold_type: InsightThresholdType | None = Field(default=None, description="New threshold type")
-    series_index: int | None = Field(default=None, description="New series index to monitor")
+    series_index: int | None = Field(default=None, description="Trends insights only: new series index to monitor")
+    check_ongoing_interval: bool | None = Field(
+        default=None, description="Trends and time-series funnel insights only: new check_ongoing_interval value"
+    )
+    funnel_step: int | None = Field(default=None, description="Funnel insights only: new funnel step to monitor")
+    funnel_metric: FunnelConversionMetric | None = Field(
+        default=None, description="Funnel insights only: new conversion metric"
+    )
+    hogql_column: str | None = Field(default=None, description="SQL insights only: new result column to evaluate")
+    hogql_evaluation: HogQLAlertEvaluation | None = Field(
+        default=None, description="SQL insights only: new evaluation mode (last_row, first_row, or any_row)"
+    )
+    hogql_label_column: str | None = Field(default=None, description="SQL insights only: new label column")
     enabled: bool | None = Field(default=None, description="Enable or disable the alert")
     skip_weekend: bool | None = Field(default=None, description="Whether to skip weekend checks")
 
@@ -251,7 +308,7 @@ class UpsertAlertTool(MaxTool):
                 return real_time_msg, {"error": "plan_limit_reached"}
 
             try:
-                insight, was_auto_saved = await self._resolve_and_validate_insight(
+                insight, was_auto_saved, insight_kind = await self._resolve_and_validate_insight(
                     action.insight_id, action_description="create alert for"
                 )
             except Insight.DoesNotExist:
@@ -260,6 +317,11 @@ class UpsertAlertTool(MaxTool):
                 }
             except ValueError as e:
                 return str(e), {"error": "unsupported_insight"}
+
+            try:
+                config = self._build_create_config(insight_kind, action)
+            except ValueError as e:
+                return str(e), {"error": "validation_failed"}
 
             truncated_name = action.name[:255]
             unsaved_threshold = Threshold(
@@ -278,6 +340,21 @@ class UpsertAlertTool(MaxTool):
             except ValidationError as e:
                 return str(e), {"error": "validation_failed"}
 
+            query = await sync_to_async(self._get_upgraded_query)(insight)
+            if query is None:
+                return "Insight has no valid query.", {"error": "unsupported_insight"}
+
+            try:
+                validate_alert_config(
+                    query,
+                    {"type": action.condition_type},
+                    config,
+                    unsaved_threshold.configuration,
+                    action.calculation_interval,
+                )
+            except ValueError as e:
+                return str(e), {"error": "validation_failed"}
+
             alert = await self._persist_alert(
                 team=team,
                 user=user,
@@ -285,7 +362,7 @@ class UpsertAlertTool(MaxTool):
                 name=truncated_name,
                 threshold_to_persist=unsaved_threshold,
                 condition={"type": action.condition_type},
-                config={"type": "TrendsAlertConfig", "series_index": action.series_index},
+                config=config,
                 calculation_interval=action.calculation_interval,
                 enabled=action.enabled,
                 skip_weekend=action.skip_weekend,
@@ -357,8 +434,23 @@ class UpsertAlertTool(MaxTool):
                 alert.calculation_interval = action.calculation_interval
                 update_fields.append("calculation_interval")
 
+            config_updates: dict[str, Any] = {}
             if action.series_index is not None:
-                alert.config = {**(alert.config or {}), "series_index": action.series_index}
+                config_updates["series_index"] = action.series_index
+            if action.check_ongoing_interval is not None:
+                config_updates["check_ongoing_interval"] = action.check_ongoing_interval
+            if action.funnel_step is not None:
+                config_updates["funnel_step"] = action.funnel_step
+            if action.funnel_metric is not None:
+                config_updates["metric"] = action.funnel_metric
+            if action.hogql_column is not None:
+                config_updates["column"] = action.hogql_column
+            if action.hogql_evaluation is not None:
+                config_updates["evaluation"] = action.hogql_evaluation
+            if action.hogql_label_column is not None:
+                config_updates["label_column"] = action.hogql_label_column
+            if config_updates:
+                alert.config = {**(alert.config or {}), **config_updates}
                 update_fields.append("config")
 
             if action.enabled is not None:
@@ -384,11 +476,25 @@ class UpsertAlertTool(MaxTool):
             if not update_fields and not has_threshold_changes:
                 return "No changes provided. Specify at least one field to update.", {"error": "no_changes"}
 
+            insight = await sync_to_async(lambda: alert.insight)()
+            if config_updates or conditions_or_threshold_changed:
+                query = await sync_to_async(self._get_upgraded_query)(insight)
+                threshold_config = alert.threshold.configuration if alert.threshold else None
+                try:
+                    validate_alert_config(
+                        query,
+                        alert.condition,
+                        alert.config,
+                        threshold_config,
+                        alert.calculation_interval,
+                    )
+                except ValueError as e:
+                    return str(e), {"error": "validation_failed"}
+
             update_fields.extend(alert.mark_for_recheck(reset_state=conditions_or_threshold_changed))
             await sync_to_async(alert.save)(update_fields=update_fields)
             await sync_to_async(alert.report_updated)(self._user, {"source": EventSource.POSTHOG_AI})
 
-            insight = await sync_to_async(lambda: alert.insight)()
             alert_url = f"/insights/{insight.short_id}/alerts?alert_id={alert.id}"
             return (
                 f"Alert '{alert.name}' updated successfully. [View alert]({alert_url}).",
@@ -458,14 +564,66 @@ class UpsertAlertTool(MaxTool):
 
     async def _resolve_and_validate_insight(
         self, insight_id: str | int, *, action_description: str
-    ) -> tuple[Insight, bool]:
+    ) -> tuple[Insight, bool, NodeKind]:
         insight, was_auto_saved = await self._resolve_insight(insight_id)
         await self.check_object_access(insight, "viewer", resource="insight", action=action_description)
-        # Max's alert tooling only builds trends configs, so it accepts only trends — narrower
-        # than the model's alertable_query_kind (which also allows SQL).
-        if await sync_to_async(lambda: insight.alertable_query_kind)() != NodeKind.TRENDS_QUERY:
-            raise ValueError("Alerts are only supported for TrendsQuery insights. This insight type is not supported.")
-        return insight, was_auto_saved
+        kind = await sync_to_async(lambda: insight.alertable_query_kind)()
+        if kind is None:
+            raise ValueError(
+                "Alerts are only supported for trends, funnel, or SQL insights. This insight type is not supported."
+            )
+        if kind == NodeKind.HOG_QL_QUERY and not await self._insight_alert_flag_enabled("hogql-insight-alerts"):
+            raise ValueError("SQL insight alerts are not enabled for your account.")
+        if kind == NodeKind.FUNNELS_QUERY and not await self._insight_alert_flag_enabled("funnel-insight-alerts"):
+            raise ValueError("Funnel insight alerts are not enabled for your account.")
+        return insight, was_auto_saved, kind
+
+    async def _insight_alert_flag_enabled(self, flag: str) -> bool:
+        team = self._team
+        user = self._user
+        org = await sync_to_async(lambda: team.organization)()
+        return await sync_to_async(
+            lambda: bool(
+                posthoganalytics.feature_enabled(
+                    flag,
+                    str(user.distinct_id),
+                    groups={"organization": str(org.id)},
+                )
+            )
+        )()
+
+    @staticmethod
+    def _get_upgraded_query(insight: Insight) -> dict | None:
+        with upgrade_query(insight):
+            return insight.query
+
+    @staticmethod
+    def _build_create_config(kind: NodeKind, action: CreateAlertAction) -> dict[str, Any]:
+        config: dict[str, Any]
+        if kind == NodeKind.TRENDS_QUERY:
+            config = {"type": "TrendsAlertConfig", "series_index": action.series_index}
+        elif kind == NodeKind.FUNNELS_QUERY:
+            config = {
+                "type": "FunnelsAlertConfig",
+                "funnel_step": action.funnel_step,
+                "metric": action.funnel_metric or FunnelConversionMetric.CONVERSION_FROM_START,
+            }
+        else:
+            if action.hogql_evaluation is None:
+                raise ValueError(
+                    "hogql_evaluation is required for SQL insight alerts (last_row, first_row, or any_row)."
+                )
+            config = {
+                "type": "HogQLAlertConfig",
+                "column": action.hogql_column,
+                "evaluation": action.hogql_evaluation,
+                "label_column": action.hogql_label_column,
+            }
+
+        if action.check_ongoing_interval is not None and kind in (NodeKind.TRENDS_QUERY, NodeKind.FUNNELS_QUERY):
+            config["check_ongoing_interval"] = action.check_ongoing_interval
+
+        return config
 
     async def _resolve_insight(self, insight_id: str | int) -> tuple[Insight, bool]:
         """Resolve an insight by numeric ID, short_id, or conversation artifact.

--- a/products/alerts/backend/test_max_tools.py
+++ b/products/alerts/backend/test_max_tools.py
@@ -310,7 +310,9 @@ class TestUpsertAlertTool(BaseTest):
         insight = await self._create_insight(query_kind="FunnelsQuery")
         tool = self._setup_tool()
 
-        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=False):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=False
+        ):
             content, artifact = await tool._arun_impl(
                 action=CreateAlertAction(
                     name="Funnel alert",
@@ -329,7 +331,9 @@ class TestUpsertAlertTool(BaseTest):
         insight = await self._create_insight(query_kind="FunnelsQuery")
         tool = self._setup_tool()
 
-        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             content, artifact = await tool._arun_impl(
                 action=CreateAlertAction(
                     name="Funnel alert",
@@ -349,7 +353,9 @@ class TestUpsertAlertTool(BaseTest):
         insight = await self._create_insight(query_kind="HogQLQuery")
         tool = self._setup_tool()
 
-        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             content, artifact = await tool._arun_impl(
                 action=CreateAlertAction(
                     name="SQL alert",
@@ -375,7 +381,9 @@ class TestUpsertAlertTool(BaseTest):
         insight = await self._create_insight(query_kind="HogQLQuery")
         tool = self._setup_tool()
 
-        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=True):
+        with mock.patch(
+            "products.alerts.backend.evaluation.validation.posthoganalytics.feature_enabled", return_value=True
+        ):
             content, artifact = await tool._arun_impl(
                 action=CreateAlertAction(
                     name="SQL alert",

--- a/products/alerts/backend/test_max_tools.py
+++ b/products/alerts/backend/test_max_tools.py
@@ -43,14 +43,21 @@ class TestUpsertAlertTool(BaseTest):
     async def _create_insight(
         self, name: str = "Test Insight", team: Team | None = None, query_kind: str = "TrendsQuery"
     ) -> Insight:
+        if query_kind == "HogQLQuery":
+            query = {
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "HogQLQuery", "query": "select count() from events"},
+            }
+        else:
+            query = {
+                "kind": "InsightVizNode",
+                "source": {"kind": query_kind, "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            }
         return await sync_to_async(Insight.objects.create)(
             team=team or self.team,
             name=name,
             created_by=self.user,
-            query={
-                "kind": "InsightVizNode",
-                "source": {"kind": query_kind, "series": [{"kind": "EventsNode", "event": "$pageview"}]},
-            },
+            query=query,
         )
 
     async def _create_alert(
@@ -281,13 +288,13 @@ class TestUpsertAlertTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
-    async def test_rejects_non_trends_insight(self):
-        insight = await self._create_insight(query_kind="FunnelsQuery")
+    async def test_rejects_retention_insight(self):
+        insight = await self._create_insight(query_kind="RetentionQuery")
         tool = self._setup_tool()
 
         content, artifact = await tool._arun_impl(
             action=CreateAlertAction(
-                name="Funnel alert",
+                name="Retention alert",
                 condition_type=AlertConditionType.ABSOLUTE_VALUE,
                 insight_id=insight.id,
                 lower_threshold=100.0,
@@ -296,6 +303,90 @@ class TestUpsertAlertTool(BaseTest):
 
         assert "not supported" in content.lower()
         assert artifact["error"] == "unsupported_insight"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_rejects_funnel_insight_when_flag_disabled(self):
+        insight = await self._create_insight(query_kind="FunnelsQuery")
+        tool = self._setup_tool()
+
+        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=False):
+            content, artifact = await tool._arun_impl(
+                action=CreateAlertAction(
+                    name="Funnel alert",
+                    condition_type=AlertConditionType.ABSOLUTE_VALUE,
+                    insight_id=insight.id,
+                    lower_threshold=100.0,
+                )
+            )
+
+        assert "not enabled for your account" in content.lower()
+        assert artifact["error"] == "unsupported_insight"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_create_funnel_alert_when_flag_enabled(self):
+        insight = await self._create_insight(query_kind="FunnelsQuery")
+        tool = self._setup_tool()
+
+        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=True):
+            content, artifact = await tool._arun_impl(
+                action=CreateAlertAction(
+                    name="Funnel alert",
+                    condition_type=AlertConditionType.ABSOLUTE_VALUE,
+                    insight_id=insight.id,
+                    lower_threshold=0.2,
+                )
+            )
+
+        assert "created successfully" in content
+        alert = await sync_to_async(AlertConfiguration.objects.get)(id=artifact["alert_id"])
+        assert alert.config == {"type": "FunnelsAlertConfig", "funnel_step": None, "metric": "conversion_from_start"}
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_create_hogql_alert_when_flag_enabled(self):
+        insight = await self._create_insight(query_kind="HogQLQuery")
+        tool = self._setup_tool()
+
+        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=True):
+            content, artifact = await tool._arun_impl(
+                action=CreateAlertAction(
+                    name="SQL alert",
+                    condition_type=AlertConditionType.ABSOLUTE_VALUE,
+                    insight_id=insight.id,
+                    lower_threshold=100.0,
+                    hogql_evaluation="last_row",
+                )
+            )
+
+        assert "created successfully" in content
+        alert = await sync_to_async(AlertConfiguration.objects.get)(id=artifact["alert_id"])
+        assert alert.config == {
+            "type": "HogQLAlertConfig",
+            "column": None,
+            "evaluation": "last_row",
+            "label_column": None,
+        }
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_create_hogql_alert_requires_evaluation(self):
+        insight = await self._create_insight(query_kind="HogQLQuery")
+        tool = self._setup_tool()
+
+        with mock.patch("products.alerts.backend.max_tools.posthoganalytics.feature_enabled", return_value=True):
+            content, artifact = await tool._arun_impl(
+                action=CreateAlertAction(
+                    name="SQL alert",
+                    condition_type=AlertConditionType.ABSOLUTE_VALUE,
+                    insight_id=insight.id,
+                    lower_threshold=100.0,
+                )
+            )
+
+        assert "hogql_evaluation is required" in content
+        assert artifact["error"] == "validation_failed"
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Max AI's `upsert_alert` tool only worked with trends insights ("Only works for TrendsQuery insights"). The alerts REST API and MCP tools already support funnel and SQL (HogQL) insight alerts, gated behind account feature flags. Max AI was narrower than what the platform actually supports.

## Changes

- `upsert_alert` now accepts trends, funnel, and SQL insights, mirroring the `alertable_query_kind` gate already used by the alerts API (`hogql-insight-alerts` / `funnel-insight-alerts` feature flags).
- Added funnel-specific (`funnel_step`, `funnel_metric`) and SQL-specific (`hogql_column`, `hogql_evaluation`, `hogql_label_column`) fields to both create and update actions, plus `check_ongoing_interval` for trends/funnels.
- Config is now validated with the shared `validate_alert_config` helper before persisting, so misconfigured alerts (e.g. missing `hogql_evaluation`, out-of-range `funnel_step`) are rejected with a clear message instead of silently saving.

## How did you test this code?

Added test coverage in `products/alerts/backend/test_max_tools.py`:
- Retention insight still rejected as unsupported.
- Funnel insight rejected when the flag is off, created successfully when the flag is on.
- SQL insight created successfully when the flag is on, and rejected when `hogql_evaluation` is missing.

I wasn't able to run the test suite in this environment (no Django/Postgres available), so these haven't been executed against a live database - please run CI to confirm.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code cloud task).
- Investigated the discrepancy first, confirming the backend model, serializer, and MCP-generated tool already support `TrendsAlertConfig | HogQLAlertConfig | FunnelsAlertConfig`, while Max AI's tool hard-coded a trends-only check and always built a `TrendsAlertConfig`.
- Reused the existing `validate_alert_config` and per-kind flag-gating logic from `products/alerts/backend/api/alert.py` rather than re-deriving new validation rules, to avoid the two paths drifting.
---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*