### PR TITLE
fix(web-analytics): warm the cleaned paths variant dashboards actually read

### DIFF
--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -265,14 +265,16 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
         # through to the raw stats query and the paths preagg table stays cold.
         if breakdown in (WebStatsBreakdown.PAGE, WebStatsBreakdown.INITIAL_PAGE):
             query["includeBounceRate"] = True
-        # EXIT_PAGE is served by the simple precompute, which bakes the cleaned-or-raw
-        # path into the stored breakdown value and the job hash (unlike PAGE/INITIAL_PAGE,
-        # whose paths precompute stores raw paths and cleans at read time). The End-paths
-        # tile sends `doPathCleaning=isPathCleaningEnabled` (true for teams with cleaning
-        # rules), so without this the warmer fills the raw variant while the dashboard
-        # reads the cleaned one and misses. True is a no-op for teams without cleaning
-        # rules (`apply_path_cleaning` returns the bare expression → identical hash).
-        if breakdown == WebStatsBreakdown.EXIT_PAGE:
+        # Every path breakdown bakes the cleaned-or-raw path into the stored breakdown
+        # value at INSERT time (#65660 for PAGE/INITIAL_PAGE via the paths precompute,
+        # and the simple precompute for EXIT_PAGE), so cleaned and raw are distinct job
+        # hashes. The dashboard tiles send `doPathCleaning=isPathCleaningEnabled` (true
+        # for teams with cleaning rules); without matching it here the warmer fills the
+        # raw variant while those teams' dashboards read the cleaned one and stay
+        # permanently cold, rebuilding synchronously on every real load. True is a
+        # no-op for teams without cleaning rules (`apply_path_cleaning` returns the
+        # bare expression, so the hash is identical).
+        if breakdown in (WebStatsBreakdown.PAGE, WebStatsBreakdown.INITIAL_PAGE, WebStatsBreakdown.EXIT_PAGE):
             query["doPathCleaning"] = True
         queries.append(query)
 

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -300,9 +300,14 @@ class TestWarmBaselineForTeam(APIBaseTest):
                 assert q["includeBounceRate"] is True
             else:
                 assert "includeBounceRate" not in q
-            # EXIT_PAGE (simple precompute) bakes path cleaning into the stored value,
-            # so the warmer must match the dashboard's cleaned End-paths request.
-            if q["breakdownBy"] == WebStatsBreakdown.EXIT_PAGE.value:
+            # Every path breakdown bakes cleaned-or-raw into the job hash, and the
+            # dashboard sends doPathCleaning=true for teams with cleaning rules —
+            # the warmer must warm the variant those dashboards actually read.
+            if q["breakdownBy"] in (
+                WebStatsBreakdown.PAGE.value,
+                WebStatsBreakdown.INITIAL_PAGE.value,
+                WebStatsBreakdown.EXIT_PAGE.value,
+            ):
                 assert q["doPathCleaning"] is True
             else:
                 assert "doPathCleaning" not in q

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -301,8 +301,8 @@ class TestWarmBaselineForTeam(APIBaseTest):
             else:
                 assert "includeBounceRate" not in q
             # Every path breakdown bakes cleaned-or-raw into the job hash, and the
-            # dashboard sends doPathCleaning=true for teams with cleaning rules —
-            # the warmer must warm the variant those dashboards actually read.
+            # dashboard sends doPathCleaning=true for teams with cleaning rules,
+            # so the warmer must warm the variant those dashboards actually read.
             if q["breakdownBy"] in (
                 WebStatsBreakdown.PAGE.value,
                 WebStatsBreakdown.INITIAL_PAGE.value,


### PR DESCRIPTION
## Problem

The hourly eager warmer sends the PAGE and INITIAL_PAGE baseline queries without `doPathCleaning`, but path cleaning is baked into the paths precompute INSERT (#65660), making cleaned and raw distinct job hashes. Dashboards send `doPathCleaning=isPathCleaningEnabled`, which is true for any team with cleaning rules — so for those teams the warmer keeps the raw variant warm while every real dashboard load reads the cleaned variant, finds it cold, and synchronously rebuilds it. Observed directly on a large enrolled team: a dashboard paths-tile load triggered ~40 user-facing rebuild inserts (3-26s each) while the warmer-maintained raw variant sat unused; query_log over 26h shows all warmer inserts uncleaned and all user-triggered inserts cleaned, i.e. zero overlap between what was warmed and what was read.

## Changes

Send `doPathCleaning=True` for PAGE and INITIAL_PAGE in the warmer's baseline matrix, matching the existing EXIT_PAGE behavior and the dashboard's request shape. For teams without cleaning rules this is a no-op: `apply_path_cleaning` returns the bare expression, so the insert AST and job hash are identical to the raw variant (the EXIT_PAGE path has relied on this since it was added). Stale comment about PAGE/INITIAL_PAGE cleaning at read time corrected (that predates #65660).

## How did you test this code?

Extended the existing warmer-matrix quirks test to assert all three path breakdowns carry `doPathCleaning=True` and non-path breakdowns still don't (20 passed). The no-op-without-rules property is already exercised by the paths precompute suite's distinct-cache-entry tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — internal warming behavior, documented inline.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused from a live report: dashboard fast everywhere except the paths tile. The warmed-variant/read-variant mismatch also means warm-read monitoring based on warmer traffic overstates real-user warmth for cleaning-enabled teams.
