### PR TITLE
feat(tasks): surface PR merged state in the installation progress card

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7306,6 +7306,10 @@ snapshots:
         hash: v1.k794b7964.36cf7228ba594332bed453ada313646e689878696d65f2e732ef4f20b9942b27.f5PtRTQsoB2LQF0JI-0_pmtiH7Lkd8HH3BnE6uSLoGU
     scenes-other-onboarding-shared-installation-progress--completed-local-handoff--light:
         hash: v1.k794b7964.0f40b7a983cb6f76ca10f79e72e7dfba4f974171a9e0ae670d6beae5ca6a5804.8x3ZMHjKx92IRRDfpRdipq0OEhUp0EmRlhjz9ZwrCsc
+    scenes-other-onboarding-shared-installation-progress--completed-merged--dark:
+        hash: v1.k794b7964.48c882f0b7d703503d0be6d629acdf785f7b7e2073b8ec0dfb99d8fb0baefee9.Ag4zdI8qORUkoAxyrbVQO0wja3mRQVhbKwMAyt6mr9k
+    scenes-other-onboarding-shared-installation-progress--completed-merged--light:
+        hash: v1.k794b7964.00d7ba883b7a9f23dec598f0e3beb5e708173d9637d37411969d52d8955151bb.a4WgCV7mt614PYHhNdoS9IM2OYiUGfYbVltyfeJrKiE
     scenes-other-onboarding-shared-installation-progress--connecting--dark:
         hash: v1.k794b7964.c979fc93fe8ea9d6a8d7ecfc667cba31879bfcafce56b1f09ae143d43e77efce.cHHBvXk9MnAaTdks6cwqJLv_--qKj8AwUXIv6FZRV3U
     scenes-other-onboarding-shared-installation-progress--connecting--light:
@@ -7338,6 +7342,10 @@ snapshots:
         hash: v1.k794b7964.73dd3b1ca302d1d915814fb1c93516188ee3a6c010a9deedc21aba892b0c4eaa.TED9G6l7yoWOiiXzoG27nGeTlcy4E02tWrI0-iEqOBM
     scenes-other-onboarding-shared-installation-progress--playground--light:
         hash: v1.k794b7964.136fe9ea63b8e3301642e87d677f6e9d46f1796683a666a3ab18ee23fbbf5539.4sb2JpWGGJR3UBjBelT0C_Y2JvuppqCQCzwvFT5RptI
+    scenes-other-onboarding-shared-installation-progress--pull-request-merged--dark:
+        hash: v1.k794b7964.ed63a038b7850e6fca64b61fddc7d786b95612b0cb313d1a8fec7e1e300cf7a7.KpidhTaObETHkR2JsrXbAl9Cgh7vqmF12CGN2DZYejI
+    scenes-other-onboarding-shared-installation-progress--pull-request-merged--light:
+        hash: v1.k794b7964.46a6ac2335f607534242f15615f19b9f75cb81c2d48099cfa9772f57df091d76.3Na2Ka58ITzwK3nfOXc8iuwudjObb8rH6LUoDAahiw0
     scenes-other-onboarding-shared-installation-progress--pull-request-ready--dark:
         hash: v1.k794b7964.c0dd7977c4b4e125098401eb4643e2896f600b116c04bf0ff56f09de25579835.x7qV5sJxPaxI27L4YuzDnvP5qLdsHcFQtGRM1cQE23c
     scenes-other-onboarding-shared-installation-progress--pull-request-ready--light:

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.stories.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.stories.tsx
@@ -45,7 +45,7 @@ function steps(
 }
 
 function progress(overrides: Partial<InstallationProgress>): InstallationProgress {
-    return { phase: 'running', steps: [], error: null, prUrl: null, isCurrent: true, ...overrides }
+    return { phase: 'running', steps: [], error: null, prUrl: null, prMerged: false, isCurrent: true, ...overrides }
 }
 
 export const Connecting: Story = {
@@ -124,6 +124,39 @@ export const PullRequestReady: Story = {
                 { id: 'setup:agent', label: 'Started agent', status: 'completed', detail: null },
                 { id: 'deliver:pr', label: 'Opened pull request', status: 'completed', detail: null },
                 { id: 'deliver:ci', label: 'Keeping CI green', status: 'in_progress', detail: null },
+            ],
+        }),
+    },
+}
+
+export const PullRequestMerged: Story = {
+    args: {
+        progress: progress({
+            phase: 'running',
+            prUrl: 'https://github.com/acme-co/web/pull/42',
+            prMerged: true,
+            steps: [
+                { id: 'setup:sandbox', label: 'Set up sandbox', status: 'completed', detail: null },
+                { id: 'setup:clone', label: 'Cloned repository', status: 'completed', detail: null },
+                { id: 'setup:wizard', label: 'Ran PostHog setup wizard', status: 'completed', detail: null },
+                { id: 'setup:agent', label: 'Started agent', status: 'completed', detail: null },
+                { id: 'deliver:pr', label: 'Pull request merged', status: 'completed', detail: null },
+            ],
+        }),
+    },
+}
+
+export const CompletedMerged: Story = {
+    args: {
+        progress: progress({
+            phase: 'completed',
+            prUrl: 'https://github.com/acme-co/web/pull/42',
+            prMerged: true,
+            steps: [
+                { id: 'setup:sandbox', label: 'Set up sandbox', status: 'completed', detail: null },
+                { id: 'setup:clone', label: 'Cloned repository', status: 'completed', detail: null },
+                { id: 'setup:wizard', label: 'Ran PostHog setup wizard', status: 'completed', detail: null },
+                { id: 'deliver:pr', label: 'Pull request merged', status: 'completed', detail: null },
             ],
         }),
     },

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import * as wizardHogPng from '@posthog/brand/hoggies/png/wizard-hog'
 import {
@@ -14,7 +14,9 @@ import {
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { pngHoggie } from 'lib/brand/hoggies'
+import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
 import { cn } from 'lib/utils/css-classes'
+import { inStorybookTestRunner } from 'lib/utils/dom'
 import { urls } from 'scenes/urls'
 
 import { onboardingEventUsageLogic } from '../../onboardingEventUsageLogic'
@@ -32,8 +34,15 @@ import { DetectedDashboard, wizardDashboardLogic } from './wizardDashboardLogic'
 const HedgehogWizardHog = pngHoggie(wizardHogPng)
 
 // Timeline dot for a single step.
-function StepIcon({ status }: { status: InstallationStepStatus }): JSX.Element {
+function StepIcon({ status, prState }: { status: InstallationStepStatus; prState?: 'open' | 'merged' }): JSX.Element {
     if (status === 'completed') {
+        // GitHub's PR color language: green while open, purple once merged.
+        if (prState === 'merged') {
+            return <IconPullRequest className="text-purple text-base" />
+        }
+        if (prState === 'open') {
+            return <IconPullRequest className="text-success text-base" />
+        }
         return <IconCheckCircle className="text-success text-base" />
     }
     if (status === 'failed') {
@@ -90,6 +99,20 @@ export function InstallationProgressContent({
     // than an indefinite "setting up". Terminal phases keep their own headline.
     const prReady = !!prUrl && phase !== 'completed' && phase !== 'error'
 
+    // Celebrate a merge the user performs while watching, exactly once per mount. Gated on the
+    // false -> true transition so mounting an already-merged run (reloads, storybook snapshots)
+    // stays quiet; the test-runner guard keeps hogfetti out of visual regression captures.
+    const { trigger: triggerHogfetti, HogfettiComponent } = useHogfetti()
+    const prevMergedRef = useRef(prMerged)
+    const mergeCelebratedRef = useRef(false)
+    useEffect(() => {
+        if (prMerged && !prevMergedRef.current && !mergeCelebratedRef.current && !inStorybookTestRunner()) {
+            mergeCelebratedRef.current = true
+            triggerHogfetti()
+        }
+        prevMergedRef.current = prMerged
+    }, [prMerged, triggerHogfetti])
+
     const headline =
         phase === 'completed'
             ? 'PostHog is wired up'
@@ -131,6 +154,7 @@ export function InstallationProgressContent({
             className="rounded-lg border border-border bg-bg-light p-4 flex flex-col gap-3"
             data-attr="installation-progress"
         >
+            <HogfettiComponent />
             <div className="flex items-start justify-between gap-2">
                 <div className="flex items-start gap-2.5 min-w-0">
                     {waitingForSteps && <Spinner className="text-xl shrink-0 mt-0.5 text-accent" textColored />}
@@ -164,7 +188,12 @@ export function InstallationProgressContent({
                         // One flat rail for pipeline and wizard-reported steps alike.
                         <li key={step.id} className="flex gap-3">
                             <div className="flex flex-col items-center pt-0.5">
-                                <StepIcon status={step.status} />
+                                <StepIcon
+                                    status={step.status}
+                                    prState={
+                                        step.id.endsWith(':pr') && prUrl ? (prMerged ? 'merged' : 'open') : undefined
+                                    }
+                                />
                                 {i < steps.length - 1 && <div className="w-px flex-1 bg-border my-1 min-h-[0.75rem]" />}
                             </div>
                             <div className="flex-1 min-w-0 pb-3">

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
@@ -33,18 +33,6 @@ import { DetectedDashboard, wizardDashboardLogic } from './wizardDashboardLogic'
 
 const HedgehogWizardHog = pngHoggie(wizardHogPng)
 
-// GitHub's merged-PR treatment: a purple filled badge with white text.
-function MergedBadge(): JSX.Element {
-    return (
-        <span
-            className="rounded-full px-1.5 py-0.5 text-[0.6875rem] font-semibold leading-none text-white shrink-0"
-            style={{ backgroundColor: 'var(--purple)' }}
-        >
-            Merged
-        </span>
-    )
-}
-
 // Timeline dot for a single step.
 function StepIcon({ status, prState }: { status: InstallationStepStatus; prState?: 'open' | 'merged' }): JSX.Element {
     if (status === 'completed') {
@@ -217,8 +205,11 @@ export function InstallationProgressContent({
                                         step.status === 'in_progress' && 'font-medium'
                                     )}
                                 >
-                                    <span className="truncate">{step.label}</span>
-                                    {step.id.endsWith(':pr') && prMerged && <MergedBadge />}
+                                    <span className="truncate">
+                                        {step.id.endsWith(':pr') && prMerged
+                                            ? 'PR merged, congratulations!'
+                                            : step.label}
+                                    </span>
                                 </div>
                                 {step.detail && <div className="text-xs text-muted truncate">{step.detail}</div>}
                             </div>
@@ -294,7 +285,7 @@ export function InstallationProgressContent({
                 </div>
             )}
 
-            {prUrl && (
+            {prUrl && !prMerged && (
                 // ph-no-capture: the label carries the customer's repo name and the href their PR
                 // url — neither may reach autocapture in the shared app analytics project.
                 <LemonButton
@@ -306,8 +297,34 @@ export function InstallationProgressContent({
                     className="ph-no-capture"
                 >
                     <span className="truncate">{prNameLabel(prUrl)}</span>
-                    {prMerged && <MergedBadge />}
                 </LemonButton>
+            )}
+
+            {prUrl && prMerged && (
+                <div className="flex items-center gap-3 rounded-lg border p-3" style={{ borderColor: 'var(--purple)' }}>
+                    <span
+                        className="flex items-center justify-center rounded w-8 h-8 shrink-0 text-white"
+                        style={{ backgroundColor: 'var(--purple)' }}
+                    >
+                        <IconPullRequest className="text-lg" />
+                    </span>
+                    <div className="flex-1 min-w-0">
+                        <div className="text-sm font-semibold">Pull request successfully merged</div>
+                        <div className="text-xs text-muted">
+                            You're all set. Deploy the changes and your events start flowing.
+                        </div>
+                    </div>
+                    {/* ph-no-capture: the href is the customer's PR url. */}
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        to={prUrl}
+                        targetBlank
+                        className="ph-no-capture shrink-0"
+                    >
+                        View PR
+                    </LemonButton>
+                </div>
             )}
 
             {phase === 'completed' && dashboard && (

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
@@ -103,14 +103,22 @@ export function InstallationProgressContent({
     // false -> true transition so mounting an already-merged run (reloads, storybook snapshots)
     // stays quiet; the test-runner guard keeps hogfetti out of visual regression captures.
     const { trigger: triggerHogfetti, HogfettiComponent } = useHogfetti()
-    const prevMergedRef = useRef(prMerged)
+    // Only a live false -> true transition celebrates. Start null so the first hydrated state (SSE
+    // replay / poll snapshot arrives async after mount) arms the detector instead of reading as a
+    // transition — otherwise every reload of a merged run re-fires. One-shot per mount on top.
+    const prevMergedRef = useRef<boolean | null>(null)
     const mergeCelebratedRef = useRef(false)
     useEffect(() => {
-        if (prMerged && !prevMergedRef.current && !mergeCelebratedRef.current && !inStorybookTestRunner()) {
-            mergeCelebratedRef.current = true
-            triggerHogfetti()
-        }
+        const prev = prevMergedRef.current
         prevMergedRef.current = prMerged
+        if (prev === null || prev || !prMerged || mergeCelebratedRef.current) {
+            return
+        }
+        if (inStorybookTestRunner() || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            return
+        }
+        mergeCelebratedRef.current = true
+        triggerHogfetti()
     }, [prMerged, triggerHogfetti])
 
     const headline =
@@ -211,7 +219,9 @@ export function InstallationProgressContent({
                                             : step.label}
                                     </span>
                                 </div>
-                                {step.detail && <div className="text-xs text-muted truncate">{step.detail}</div>}
+                                {step.detail && (
+                                    <div className="text-xs text-muted truncate ph-no-capture">{step.detail}</div>
+                                )}
                             </div>
                         </li>
                     ))}
@@ -285,7 +295,7 @@ export function InstallationProgressContent({
                 </div>
             )}
 
-            {prUrl && !prMerged && (
+            {prUrl && !prMerged && phase !== 'error' && (
                 // ph-no-capture: the label carries the customer's repo name and the href their PR
                 // url — neither may reach autocapture in the shared app analytics project.
                 <LemonButton
@@ -300,12 +310,9 @@ export function InstallationProgressContent({
                 </LemonButton>
             )}
 
-            {prUrl && prMerged && (
-                <div className="flex items-center gap-3 rounded-lg border p-3" style={{ borderColor: 'var(--purple)' }}>
-                    <span
-                        className="flex items-center justify-center rounded w-8 h-8 shrink-0 text-white"
-                        style={{ backgroundColor: 'var(--purple)' }}
-                    >
+            {prUrl && prMerged && phase !== 'error' && (
+                <div className="flex items-center gap-3 rounded-lg border border-[var(--color-purple-500)] p-3">
+                    <span className="flex items-center justify-center rounded w-8 h-8 shrink-0 bg-[var(--color-purple-500)] text-white">
                         <IconPullRequest className="text-lg" />
                     </span>
                     <div className="flex-1 min-w-0">

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
@@ -33,6 +33,18 @@ import { DetectedDashboard, wizardDashboardLogic } from './wizardDashboardLogic'
 
 const HedgehogWizardHog = pngHoggie(wizardHogPng)
 
+// GitHub's merged-PR treatment: a purple filled badge with white text.
+function MergedBadge(): JSX.Element {
+    return (
+        <span
+            className="rounded-full px-1.5 py-0.5 text-[0.6875rem] font-semibold leading-none text-white shrink-0"
+            style={{ backgroundColor: 'var(--purple)' }}
+        >
+            Merged
+        </span>
+    )
+}
+
 // Timeline dot for a single step.
 function StepIcon({ status, prState }: { status: InstallationStepStatus; prState?: 'open' | 'merged' }): JSX.Element {
     if (status === 'completed') {
@@ -199,13 +211,14 @@ export function InstallationProgressContent({
                             <div className="flex-1 min-w-0 pb-3">
                                 <div
                                     className={cn(
-                                        'text-sm truncate',
+                                        'text-sm truncate flex items-center gap-1.5',
                                         step.status === 'pending' && 'text-muted',
                                         step.status === 'failed' && 'text-danger font-medium',
                                         step.status === 'in_progress' && 'font-medium'
                                     )}
                                 >
-                                    {step.label}
+                                    <span className="truncate">{step.label}</span>
+                                    {step.id.endsWith(':pr') && prMerged && <MergedBadge />}
                                 </div>
                                 {step.detail && <div className="text-xs text-muted truncate">{step.detail}</div>}
                             </div>
@@ -292,7 +305,8 @@ export function InstallationProgressContent({
                     center
                     className="ph-no-capture"
                 >
-                    <span className="truncate">{prNameLabel(prUrl) + (prMerged ? ' (merged)' : '')}</span>
+                    <span className="truncate">{prNameLabel(prUrl)}</span>
+                    {prMerged && <MergedBadge />}
                 </LemonButton>
             )}
 

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.tsx
@@ -84,7 +84,7 @@ export function InstallationProgressContent({
      * command). Omitted where no local fallback exists (e.g. the floating FAB), which shows only docs. */
     onRetryLocally?: () => void
 }): JSX.Element {
-    const { phase, steps, error, prUrl } = progress
+    const { phase, steps, error, prUrl, prMerged } = progress
 
     // The PR is opened mid-run: while the run keeps going (keeping CI green), surface it as ready rather
     // than an indefinite "setting up". Terminal phases keep their own headline.
@@ -96,19 +96,25 @@ export function InstallationProgressContent({
             : phase === 'error'
               ? (error?.title ?? "Setup didn't finish")
               : prReady
-                ? 'Pull request ready'
+                ? prMerged
+                    ? 'Pull request merged'
+                    : 'Pull request ready'
                 : 'Setting up PostHog'
     const subtitle =
         phase === 'completed'
             ? prUrl
-                ? 'Review and merge the pull request, then deploy. Data starts flowing the moment it ships.'
+                ? prMerged
+                    ? 'Your pull request is merged. Deploy the changes and data starts flowing.'
+                    : 'Review and merge the pull request, then deploy. Data starts flowing the moment it ships.'
                 : mode === 'local'
                   ? 'The wizard finished its work on your machine.'
                   : "You're all set."
             : phase === 'error'
               ? "We couldn't finish the setup."
               : prReady
-                ? "Review it whenever you like; we'll keep CI green in the meantime."
+                ? prMerged
+                    ? 'Deploy the changes and data starts flowing. The run will wrap up on its own.'
+                    : "Review it whenever you like; we'll keep CI green in the meantime."
                 : phase === 'connecting'
                   ? ((mode && CONNECTING_SUBTITLE[mode]) ?? 'Getting things ready…')
                   : phase === 'idle'
@@ -257,7 +263,7 @@ export function InstallationProgressContent({
                     center
                     className="ph-no-capture"
                 >
-                    <span className="truncate">{prNameLabel(prUrl)}</span>
+                    <span className="truncate">{prNameLabel(prUrl) + (prMerged ? ' (merged)' : '')}</span>
                 </LemonButton>
             )}
 

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/WizardSyncCard.stories.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/WizardSyncCard.stories.tsx
@@ -50,7 +50,7 @@ function cloudSteps(
 }
 
 function progress(overrides: Partial<InstallationProgress>): InstallationProgress {
-    return { phase: 'running', steps: [], error: null, prUrl: null, isCurrent: true, ...overrides }
+    return { phase: 'running', steps: [], error: null, prUrl: null, prMerged: false, isCurrent: true, ...overrides }
 }
 
 export const Connecting: Story = {

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/WizardSyncCard.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/WizardSyncCard.tsx
@@ -36,6 +36,9 @@ export function StatusGlyph({ progress }: { progress: InstallationProgress }): J
     if (progress.phase === 'error') {
         return <IconWarning className="text-danger text-xl shrink-0" />
     }
+    if (progress.prMerged) {
+        return <IconPullRequest className="text-purple text-xl shrink-0" />
+    }
     return <Spinner className="text-xl shrink-0 text-accent" textColored />
 }
 

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/WizardSyncFab.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/WizardSyncFab.tsx
@@ -220,10 +220,10 @@ function WizardSyncSurface({
                             openDialog()
                         }}
                         // Mid-run, the X only minimizes — hiding a live run for good would orphan
-                        // it. Once terminal there is nothing to orphan, so the X is the real
-                        // dismissal (the run never leaves on its own; the user decides when).
-                        onDismiss={isTerminal && handleClear ? handleClear : handleMinimize}
-                        dismissTooltip={isTerminal && handleClear ? 'Dismiss' : 'Minimize'}
+                        // it. Once the run is terminal or the PR exists, the user's part is done,
+                        // so the X becomes the real dismissal (the run never leaves on its own).
+                        onDismiss={(isTerminal || prOpened) && handleClear ? handleClear : handleMinimize}
+                        dismissTooltip={(isTerminal || prOpened) && handleClear ? 'Dismiss' : 'Minimize'}
                     />
                 )}
             </div>

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/helpers.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/helpers.ts
@@ -46,14 +46,11 @@ export function currentTaskLabel(progress: InstallationProgress): string | null 
     if (progress.phase === 'error') {
         return progress.error?.detail ?? 'Something stopped the run'
     }
-    if (progress.phase === 'completed') {
-        if (progress.prMerged) {
-            return 'PR merged, congratulations!'
-        }
-        return progress.prUrl ? 'Pull request is ready to review' : 'Everything is wired up'
-    }
     if (progress.prMerged) {
         return 'PR merged, congratulations!'
+    }
+    if (progress.phase === 'completed') {
+        return progress.prUrl ? 'Pull request is ready to review' : 'Everything is wired up'
     }
     const step = activeStep(progress.steps)
     if (step) {

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/helpers.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/helpers.ts
@@ -21,6 +21,9 @@ export function syncHeadline(progress: InstallationProgress): string {
     if (progress.phase === 'error') {
         return progress.error?.title ?? 'Setup hit a snag'
     }
+    if (progress.prMerged) {
+        return 'Pull request merged'
+    }
     if (progress.prUrl) {
         return 'Pull request ready'
     }
@@ -41,7 +44,13 @@ export function activeStep(steps: InstallationStep[]): InstallationStep | null {
 // otherwise the step label. This is what gives the wizard's own work top billing in the card.
 export function currentTaskLabel(progress: InstallationProgress): string | null {
     if (progress.phase === 'completed') {
+        if (progress.prMerged) {
+            return 'PR merged, congratulations!'
+        }
         return progress.prUrl ? 'Pull request is ready to review' : 'Everything is wired up'
+    }
+    if (progress.prMerged) {
+        return 'PR merged, congratulations!'
     }
     if (progress.phase === 'error') {
         return progress.error?.detail ?? 'Something stopped the run'

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/helpers.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/helpers.ts
@@ -43,6 +43,9 @@ export function activeStep(steps: InstallationStep[]): InstallationStep | null {
 // The prominent line: the active step's live detail (the wizard's current sub-task) when present,
 // otherwise the step label. This is what gives the wizard's own work top billing in the card.
 export function currentTaskLabel(progress: InstallationProgress): string | null {
+    if (progress.phase === 'error') {
+        return progress.error?.detail ?? 'Something stopped the run'
+    }
     if (progress.phase === 'completed') {
         if (progress.prMerged) {
             return 'PR merged, congratulations!'
@@ -51,9 +54,6 @@ export function currentTaskLabel(progress: InstallationProgress): string | null 
     }
     if (progress.prMerged) {
         return 'PR merged, congratulations!'
-    }
-    if (progress.phase === 'error') {
-        return progress.error?.detail ?? 'Something stopped the run'
     }
     const step = activeStep(progress.steps)
     if (step) {

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.test.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.test.ts
@@ -334,6 +334,7 @@ describe('installationProgressLogic merge', () => {
                 ],
                 error: null,
                 prUrl: null,
+                prMerged: false,
                 isCurrent: true,
             })
         })

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.ts
@@ -226,6 +226,12 @@ export function cloudProgress(
     const prUrl = taskRunPrUrl(taskRunState, progressSteps)
     const prMerged = taskRunPrMerged(taskRunState)
 
+    // A merged PR ends the story: the CI-babysitting row would otherwise keep spinning forever
+    // (the workflow's follow-up loop skips closed PRs, so nothing will ever complete it).
+    if (prMerged) {
+        steps = steps.filter((s) => !s.id.endsWith(':ci'))
+    }
+
     // The pipeline goes quiet between agent start and the PR opening: everything reads completed
     // while the agent is still writing code, committing, and drafting the PR — which looks stalled.
     // Flip the still-pending PR slot to in-progress with an honest detail line for that window; the

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.ts
@@ -9,7 +9,13 @@ import { wizardSessionStreamLogic } from 'products/wizard/frontend/wizardSession
 import { activeCloudRunLogic } from './activeCloudRunLogic'
 import { finishedLocalRunLogic, FinishedLocalRunHandle } from './finishedLocalRunLogic'
 import type { installationProgressLogicType } from './installationProgressLogicType'
-import { taskRunPrUrl, taskRunStreamLogic, TaskRunProgressStep, TaskRunStreamState } from './taskRunStreamLogic'
+import {
+    taskRunPrMerged,
+    taskRunPrUrl,
+    taskRunStreamLogic,
+    TaskRunProgressStep,
+    TaskRunStreamState,
+} from './taskRunStreamLogic'
 import { isSessionActive, wizardActiveSessionDetectorLogic } from './wizardActiveSessionDetectorLogic'
 import { wizardDashboardLogic } from './wizardDashboardLogic'
 
@@ -81,6 +87,8 @@ export interface InstallationProgress {
     steps: InstallationStep[]
     error: { title: string; detail: string | null } | null
     prUrl: string | null
+    /** The bound PR was merged (webhook-recorded on the run's output). */
+    prMerged: boolean
     isCurrent: boolean
 }
 
@@ -216,6 +224,7 @@ export function cloudProgress(
     }
 
     const prUrl = taskRunPrUrl(taskRunState, progressSteps)
+    const prMerged = taskRunPrMerged(taskRunState)
 
     // The pipeline goes quiet between agent start and the PR opening: everything reads completed
     // while the agent is still writing code, committing, and drafting the PR — which looks stalled.
@@ -248,6 +257,7 @@ export function cloudProgress(
         steps,
         error,
         prUrl,
+        prMerged,
         isCurrent: phase !== 'idle',
     }
 }
@@ -268,6 +278,7 @@ export function localProgress(
             steps: [],
             error: null,
             prUrl: null,
+            prMerged: false,
             isCurrent: false,
         }
     }
@@ -298,7 +309,7 @@ export function localProgress(
               }
             : null
 
-    return { phase, steps, error, prUrl: null, isCurrent: sessionIsCurrent && !dismissed }
+    return { phase, steps, error, prUrl: null, prMerged: false, isCurrent: sessionIsCurrent && !dismissed }
 }
 
 // A finished local run rendered from its persisted snapshot, after the live session stream has
@@ -312,6 +323,7 @@ export function progressFromFinishedLocalRun(handle: FinishedLocalRunHandle): In
                 ? { title: 'Wizard hit an error', detail: handle.error?.message ?? null }
                 : null,
         prUrl: null,
+        prMerged: false,
         isCurrent: true,
     }
 }

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
@@ -219,6 +219,11 @@ export const taskRunStreamLogic = kea<taskRunStreamLogicType>([
                         return state
                     }
                     const output = { ...state.output }
+                    // A state event that replaces the PR (resumed run, new branch) carries its own
+                    // url; don't drag the prior PR's merge onto it. Pin only while the url matches.
+                    if (output.pr_url && prev.output.pr_url && output.pr_url !== prev.output.pr_url) {
+                        return { ...state, output }
+                    }
                     if (prev.output.pr_url && !output.pr_url) {
                         output.pr_url = prev.output.pr_url
                     }

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
@@ -22,7 +22,7 @@ export function taskRunDetailToStreamState(dto: TaskRunDetailDTOApi): TaskRunStr
     return {
         status: dto.status,
         stage: dto.stage ?? null,
-        output: (dto.output as { pr_url?: string | null } | null) ?? null,
+        output: (dto.output as { pr_url?: string | null; pr_merged?: boolean | null } | null) ?? null,
         branch: dto.branch ?? null,
         error_message: dto.error_message ?? null,
         updated_at: dto.updated_at ?? '',
@@ -37,7 +37,7 @@ export function taskRunDetailToStreamState(dto: TaskRunDetailDTOApi): TaskRunStr
 export interface TaskRunStreamState {
     status: string // queued | in_progress | completed | failed | cancelled
     stage: string | null
-    output: { pr_url?: string | null } | null
+    output: { pr_url?: string | null; pr_merged?: boolean | null } | null
     branch: string | null
     error_message: string | null
     updated_at: string
@@ -129,6 +129,10 @@ export function taskRunPrUrl(state: TaskRunStreamState | null, steps: TaskRunPro
         (outputUrl && outputUrl.startsWith('http') ? outputUrl : null) ??
         (prStepUrl && prStepUrl.startsWith('http') ? prStepUrl : null)
     )
+}
+
+export function taskRunPrMerged(state: TaskRunStreamState | null): boolean {
+    return state?.output?.pr_merged === true
 }
 
 export interface CloudRunCompletionReport {

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
@@ -212,7 +212,21 @@ export const taskRunStreamLogic = kea<taskRunStreamLogicType>([
         taskRunState: [
             null as TaskRunStreamState | null,
             {
-                taskRunStateUpdated: (_, { state }) => state,
+                // Reconnects (tab-visibility resume) replay historical state events; PR facts only
+                // move forward, so a replayed pre-merge state must not regress them mid-replay.
+                taskRunStateUpdated: (prev, { state }) => {
+                    if (!prev?.output) {
+                        return state
+                    }
+                    const output = { ...state.output }
+                    if (prev.output.pr_url && !output.pr_url) {
+                        output.pr_url = prev.output.pr_url
+                    }
+                    if (prev.output.pr_merged && !output.pr_merged) {
+                        output.pr_merged = prev.output.pr_merged
+                    }
+                    return { ...state, output }
+                },
             },
         ],
         // Last-write-wins per (group, step), kept in arrival order so the UI renders a stable timeline.

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1745,7 +1745,14 @@ def set_task_run_output(
     if run is None:
         return None
     task = run.task
-    run.output = output
+    # Preserve PR facts a webhook may have written concurrently: this assignment is wholesale,
+    # so a bare `= output` would drop output.pr_url / output.pr_merged recorded out of band.
+    existing = run.output if isinstance(run.output, dict) else {}
+    merged = {**output}
+    for key in ("pr_url", "pr_merged"):
+        if not merged.get(key) and existing.get(key):
+            merged[key] = existing[key]
+    run.output = merged
     run.save(update_fields=["output", "updated_at"])
     if task.json_schema:
         signal_workflow_completion(run.id, TaskRun.Status.COMPLETED, None)

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -107,6 +107,29 @@ class TestGitHubPRWebhook(TestCase):
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_merged_publishes_stream_events(self, mock_capture, mock_get_secret):
+        # A live installation-progress view only learns about the merge through the stream;
+        # recording output.pr_merged without publishing leaves the UI stuck on "opened".
+        mock_get_secret.return_value = self.webhook_secret
+        payload = {
+            "action": "closed",
+            "pull_request": {
+                "html_url": "https://github.com/posthog/posthog/pull/123",
+                "merged": True,
+            },
+        }
+
+        with patch.object(TaskRun, "publish_stream_event") as mock_publish:
+            response = self._make_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+        published = [c.args[0] for c in mock_publish.call_args_list if c.args]
+        progress = [e for e in published if e.get("notification", {}).get("method") == "_posthog/progress"]
+        self.assertEqual(len(progress), 1)
+        self.assertEqual(progress[0]["notification"]["params"]["label"], "Pull request merged")
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
     def test_pr_merged_from_fork_does_not_record_pr_merged(self, mock_capture, mock_get_secret):
         mock_get_secret.return_value = self.webhook_secret
         run = TaskRun.objects.create(

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -207,7 +207,17 @@ def _record_run_pr_merged(task_run: TaskRun) -> None:
     the wizard's setup PR) read it off the run's ``output``, which is the only PR state the task
     APIs expose.
     """
-    _record_run_output_field(task_run, "pr_merged", True, "github_pr_webhook_record_pr_merged_failed")
+    if not _record_run_output_field(task_run, "pr_merged", True, "github_pr_webhook_record_pr_merged_failed"):
+        return
+    # Publish-only (no append_log), same rationale and failure tolerance as _record_run_pr_url.
+    try:
+        pr_url = task_run.output.get("pr_url") if isinstance(task_run.output, dict) else None
+        task_run.publish_stream_event(
+            task_run.build_progress_event("pr", "completed", "Pull request merged", "setup", detail=pr_url)
+        )
+        task_run.publish_stream_state_event()
+    except Exception:
+        logger.warning("github_pr_webhook_pr_merged_events_failed", run_id=str(task_run.id), exc_info=True)
 
 
 def _record_run_output_field(task_run: TaskRun, key: str, value: str | bool, failure_log_event: str) -> bool:


### PR DESCRIPTION
## Problem

When a user merges the wizard's PR while the onboarding installation progress card is open, nothing changes: the card keeps saying "Pull request ready / review and merge it". The GitHub webhook already records `output.pr_merged` on the run, but the write publishes no stream event, so a live client never learns about it (the same gap #69591 closed for `pr_url`), and the frontend had no rendering for the merged state anyway.

Closes GROW-139.

## Changes

- `webhooks._record_run_pr_merged` now publishes on a successful write, mirroring `_record_run_pr_url`: a `pr` progress event with the label "Pull request merged" (coalesces into the existing PR step) plus the stream state event carrying the updated `output`. Publish-only, no S3 `append_log`, same failure tolerance.
- `taskRunStreamLogic` output typing gains `pr_merged`, with a `taskRunPrMerged` helper; `installationProgressLogic` threads a `prMerged` flag through every progress shape.
- `InstallationProgressView` renders the merged state: headline flips to "Pull request merged", subtitles switch to deploy-focused copy, and the PR link button gets a "(merged)" suffix.

<img width="594" height="322" alt="Screenshot 2026-07-09 at 15 11 21" src="https://github.com/user-attachments/assets/0652afd8-645e-49f2-adb5-7a080f6cc9d8" />

## How did you test this code?

- Backend: added `test_pr_merged_publishes_stream_events` — full merged-webhook payload asserting exactly one `_posthog/progress` publish with the merged label; catches a regression where the publish is dropped and live UIs silently stop updating (the exact bug this PR fixes). Ran `test_webhooks.py` merged tests (6 passed).
- Frontend: wizard-sync jest suites all pass (140 tests), including the snapshot-parity test updated for the new `prMerged` field.
- Not tested by the agent: an end-to-end prod merge while a live card is open.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — in-product state rendering.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code (Fable 5), continuing the GROW-136/139 wizard cloud-run work; motivated by a live prod test where the user merged the PR and the card kept spinning.
- Skills invoked: /writing-tests, /comments.
- Chose stream-publish from the existing webhook write over frontend polling: the transport, coalescing, and idempotent write gating already exist from #69591, so the merged state rides the same path with no new moving parts.
