### PR TITLE
fix(notebooks): stop query node update loop causing React #185

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -70,7 +70,7 @@ const Component = ({
     attributes,
     updateAttributes,
 }: NotebookNodeProps<NotebookNodeQueryAttributes>): JSX.Element | null => {
-    const { query, nodeId } = attributes
+    const { query, nodeId, isDefaultFilterApplied } = attributes
     const nodeLogic = useRequiredNotebookNode()
     const { expanded, nodeId: resolvedNodeId, notebookLogic } = useValues(nodeLogic)
     const {
@@ -137,7 +137,7 @@ const Component = ({
     }, [query, insightName])
 
     const modifiedQuery = useMemo(() => {
-        let modifiedQuery = { ...query, full: false }
+        const modifiedQuery = { ...query, full: false }
 
         if (isDataTableNode(modifiedQuery) || isSavedInsightNode(modifiedQuery)) {
             modifiedQuery.showOpenEditorButton = false
@@ -155,14 +155,25 @@ const Component = ({
             modifiedQuery.embedded = true
         }
 
-        if (isDataTableNode(modifiedQuery) && isEventsQuery(modifiedQuery.source)) {
-            modifiedQuery.source.fixedProperties = canvasFiltersOverride
-            updateAttributes({ isDefaultFilterApplied: true })
+        // Seed the canvas filter override once. Copy `source` rather than mutating in place —
+        // the spread above shares the original `source` reference with `query`.
+        if (isDataTableNode(modifiedQuery) && isEventsQuery(modifiedQuery.source) && !isDefaultFilterApplied) {
+            modifiedQuery.source = { ...modifiedQuery.source, fixedProperties: canvasFiltersOverride }
         }
 
         return modifiedQuery
         // oxlint-disable-next-line react-hooks/exhaustive-deps
-    }, [query])
+    }, [query, canvasFiltersOverride, isDefaultFilterApplied])
+
+    // Latch the "default filter applied" flag outside of render. Doing this write inside the memo
+    // above committed a document update mid-render, producing a new `query` reference that re-ran
+    // the memo and looped until React aborted with error #185 (max update depth exceeded).
+    useEffect(() => {
+        if (isDataTableNode(query) && isEventsQuery(query.source) && !isDefaultFilterApplied) {
+            updateAttributes({ isDefaultFilterApplied: true })
+        }
+        // oxlint-disable-next-line react-hooks/exhaustive-deps
+    }, [query, isDefaultFilterApplied])
 
     if (!isOutputPaneOpen) {
         return null


### PR DESCRIPTION
## Problem

A notebook that contains an events `DataTable` query node could crash with [React error #185](https://react.dev/errors/185) ("Maximum update depth exceeded"). When it fires, React tears down the subtree, so the notebook panel white-screens. It surfaced via error tracking on the AI observability clusters page, whose panel embeds such a query node.

Root cause: the render-path `modifiedQuery` `useMemo` in `NotebookNodeQuery.tsx` performed a side effect during render. For an events `DataTable` node it called `updateAttributes({ isDefaultFilterApplied: true })`, which commits a notebook document update (`updateNode` → `updateProps` → `commitDocument`). That commit produces a new `query` object reference, which re-runs the memo (dep `[query]`), which calls `updateAttributes` again. The loop never latches because the flag was never read as a guard, so React aborts it with #185. The sibling `Settings` component in the same file already does the same override gated on `!isDefaultFilterApplied`, confirming the intended "apply once" semantics.

## Changes

- Move the `updateAttributes({ isDefaultFilterApplied: true })` write out of the memo and into a `useEffect` guarded by `!isDefaultFilterApplied`, so it runs once instead of during every render.
- Gate the `fixedProperties` override on `!isDefaultFilterApplied` to match the `Settings` path's "apply once" intent.
- Copy `source` (`{ ...modifiedQuery.source, fixedProperties }`) instead of mutating it in place — the outer spread shares the `source` reference with the original `query`.

## How did you test this code?

I (Claude, via the PostHog Slack app) traced the resolved stack from the error tracking issue through the code path but did not run the app or add an automated test. Formatter/typecheck tooling was unavailable in the sandbox (no `node_modules`). Reviewer verification suggested: open a notebook with an events data-table query node (e.g. the AI observability clusters notebook panel) and confirm it renders without the #185 crash, and that the canvas filter override still seeds once.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack error-tracking alert. I (Claude) used the PostHog error tracking MCP tools to pull the issue baseline and a sample `$exception` event, read the resolved stack, then read the three files in the stack (`NotebookNodeQuery.tsx`, `NotebookComponentShell.tsx`) to locate the state-update-during-render. Invoked the `/investigating-error-issue` skill during triage.

Considered a minimal fix (only relocating the `updateAttributes` call while keeping the override unconditional), but aligned the render path with the `Settings` component's `!isDefaultFilterApplied` gating since the attribute's own comment documents "apply it only once". No API types touched, so no `hogli build:openapi` needed.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1783618270048679?thread_ts=1783618270.048679&cid=C0A006STKHR)*
