### PR TITLE
chore(web-analytics): drop unused web_stats_paths_preaggregated_pathkey table

### DIFF
--- a/posthog/clickhouse/hcl/golden/local-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/local-aux.hcl
@@ -369,32 +369,32 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -428,32 +428,32 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -2739,50 +2739,6 @@ database "posthog" {
     }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated"
-      replica_name   = "{replica}"
-      version_column = "computed_at"
-    }
-  }
-
-  table "sharded_web_stats_paths_preaggregated_pathkey" {
-    order_by     = ["team_id", "time_window_start", "breakdown_value", "job_id"]
-    partition_by = "toYYYYMMDD(expires_at)"
-    ttl          = "toDateTime(expires_at)"
-    settings = {
-      index_granularity   = "8192"
-      ttl_only_drop_parts = "1"
-    }
-    column "team_id" {
-      type = "Int64"
-    }
-    column "job_id" {
-      type = "UUID"
-    }
-    column "time_window_start" {
-      type = "DateTime64(6, 'UTC')"
-    }
-    column "breakdown_value" {
-      type = "String"
-    }
-    column "uniq_users_state" {
-      type = "AggregateFunction(uniq, UUID)"
-    }
-    column "sum_pageviews_state" {
-      type = "AggregateFunction(sum, Int64)"
-    }
-    column "avg_bounce_state" {
-      type = "AggregateFunction(avg, Nullable(Float64))"
-    }
-    column "computed_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now()"
-    }
-    column "expires_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now() + toIntervalDay(7)"
-    }
-    engine "replicated_replacing_merge_tree" {
-      zoo_path       = "/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated_pathkey"
       replica_name   = "{replica}"
       version_column = "computed_at"
     }

--- a/posthog/clickhouse/hcl/golden/local-data.hcl
+++ b/posthog/clickhouse/hcl/golden/local-data.hcl
@@ -1764,32 +1764,32 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -7676,44 +7676,6 @@ database "posthog" {
       remote_database = "posthog"
       remote_table    = "sharded_web_stats_paths_preaggregated"
       sharding_key    = "sipHash64(job_id)"
-    }
-  }
-
-  table "web_stats_paths_preaggregated_pathkey" {
-    column "team_id" {
-      type = "Int64"
-    }
-    column "job_id" {
-      type = "UUID"
-    }
-    column "time_window_start" {
-      type = "DateTime64(6, 'UTC')"
-    }
-    column "breakdown_value" {
-      type = "String"
-    }
-    column "uniq_users_state" {
-      type = "AggregateFunction(uniq, UUID)"
-    }
-    column "sum_pageviews_state" {
-      type = "AggregateFunction(sum, Int64)"
-    }
-    column "avg_bounce_state" {
-      type = "AggregateFunction(avg, Nullable(Float64))"
-    }
-    column "computed_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now()"
-    }
-    column "expires_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now() + toIntervalDay(7)"
-    }
-    engine "distributed" {
-      cluster_name    = "aux"
-      remote_database = "posthog"
-      remote_table    = "sharded_web_stats_paths_preaggregated_pathkey"
-      sharding_key    = "sipHash64(breakdown_value)"
     }
   }
 

--- a/posthog/clickhouse/hcl/golden/prod-eu-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu-aux.hcl
@@ -370,32 +370,32 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -429,32 +429,32 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -2698,50 +2698,6 @@ database "posthog" {
     }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated"
-      replica_name   = "{replica}"
-      version_column = "computed_at"
-    }
-  }
-
-  table "sharded_web_stats_paths_preaggregated_pathkey" {
-    order_by     = ["team_id", "time_window_start", "breakdown_value", "job_id"]
-    partition_by = "toYYYYMMDD(expires_at)"
-    ttl          = "toDateTime(expires_at)"
-    settings = {
-      index_granularity   = "8192"
-      ttl_only_drop_parts = "1"
-    }
-    column "team_id" {
-      type = "Int64"
-    }
-    column "job_id" {
-      type = "UUID"
-    }
-    column "time_window_start" {
-      type = "DateTime64(6, 'UTC')"
-    }
-    column "breakdown_value" {
-      type = "String"
-    }
-    column "uniq_users_state" {
-      type = "AggregateFunction(uniq, UUID)"
-    }
-    column "sum_pageviews_state" {
-      type = "AggregateFunction(sum, Int64)"
-    }
-    column "avg_bounce_state" {
-      type = "AggregateFunction(avg, Nullable(Float64))"
-    }
-    column "computed_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now()"
-    }
-    column "expires_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now() + toIntervalDay(7)"
-    }
-    engine "replicated_replacing_merge_tree" {
-      zoo_path       = "/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated_pathkey"
       replica_name   = "{replica}"
       version_column = "computed_at"
     }

--- a/posthog/clickhouse/hcl/golden/prod-us-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us-aux.hcl
@@ -404,32 +404,32 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -463,32 +463,32 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -2772,50 +2772,6 @@ database "posthog" {
     }
     engine "replicated_replacing_merge_tree" {
       zoo_path       = "/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated"
-      replica_name   = "{replica}"
-      version_column = "computed_at"
-    }
-  }
-
-  table "sharded_web_stats_paths_preaggregated_pathkey" {
-    order_by     = ["team_id", "time_window_start", "breakdown_value", "job_id"]
-    partition_by = "toYYYYMMDD(expires_at)"
-    ttl          = "toDateTime(expires_at)"
-    settings = {
-      index_granularity   = "8192"
-      ttl_only_drop_parts = "1"
-    }
-    column "team_id" {
-      type = "Int64"
-    }
-    column "job_id" {
-      type = "UUID"
-    }
-    column "time_window_start" {
-      type = "DateTime64(6, 'UTC')"
-    }
-    column "breakdown_value" {
-      type = "String"
-    }
-    column "uniq_users_state" {
-      type = "AggregateFunction(uniq, UUID)"
-    }
-    column "sum_pageviews_state" {
-      type = "AggregateFunction(sum, Int64)"
-    }
-    column "avg_bounce_state" {
-      type = "AggregateFunction(avg, Nullable(Float64))"
-    }
-    column "computed_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now()"
-    }
-    column "expires_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now() + toIntervalDay(7)"
-    }
-    engine "replicated_replacing_merge_tree" {
-      zoo_path       = "/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated_pathkey"
       replica_name   = "{replica}"
       version_column = "computed_at"
     }

--- a/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
@@ -1752,49 +1752,6 @@ database "posthog" {
       version_column = "computed_at"
     }
   }
-  table "sharded_web_stats_paths_preaggregated_pathkey" {
-    order_by     = ["team_id", "time_window_start", "breakdown_value", "job_id"]
-    partition_by = "toYYYYMMDD(expires_at)"
-    ttl          = "toDateTime(expires_at)"
-    settings = {
-      index_granularity   = "8192"
-      ttl_only_drop_parts = "1"
-    }
-    column "team_id" {
-      type = "Int64"
-    }
-    column "job_id" {
-      type = "UUID"
-    }
-    column "time_window_start" {
-      type = "DateTime64(6, 'UTC')"
-    }
-    column "breakdown_value" {
-      type = "String"
-    }
-    column "uniq_users_state" {
-      type = "AggregateFunction(uniq, UUID)"
-    }
-    column "sum_pageviews_state" {
-      type = "AggregateFunction(sum, Int64)"
-    }
-    column "avg_bounce_state" {
-      type = "AggregateFunction(avg, Nullable(Float64))"
-    }
-    column "computed_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now()"
-    }
-    column "expires_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now() + toIntervalDay(7)"
-    }
-    engine "replicated_replacing_merge_tree" {
-      zoo_path       = "/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated_pathkey"
-      replica_name   = "{replica}"
-      version_column = "computed_at"
-    }
-  }
   table "sharded_web_stats_preaggregated" {
     order_by     = ["team_id", "job_id", "breakdown_by", "time_window_start", "breakdown_value"]
     partition_by = "toYYYYMMDD(expires_at)"

--- a/posthog/clickhouse/hcl/roles/data/local/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/data/local/tables.hcl
@@ -7233,43 +7233,6 @@ database "posthog" {
       sharding_key    = "sipHash64(job_id)"
     }
   }
-  table "web_stats_paths_preaggregated_pathkey" {
-    column "team_id" {
-      type = "Int64"
-    }
-    column "job_id" {
-      type = "UUID"
-    }
-    column "time_window_start" {
-      type = "DateTime64(6, 'UTC')"
-    }
-    column "breakdown_value" {
-      type = "String"
-    }
-    column "uniq_users_state" {
-      type = "AggregateFunction(uniq, UUID)"
-    }
-    column "sum_pageviews_state" {
-      type = "AggregateFunction(sum, Int64)"
-    }
-    column "avg_bounce_state" {
-      type = "AggregateFunction(avg, Nullable(Float64))"
-    }
-    column "computed_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now()"
-    }
-    column "expires_at" {
-      type    = "DateTime64(6, 'UTC')"
-      default = "now() + toIntervalDay(7)"
-    }
-    engine "distributed" {
-      cluster_name    = "aux"
-      remote_database = "posthog"
-      remote_table    = "sharded_web_stats_paths_preaggregated_pathkey"
-      sharding_key    = "sipHash64(breakdown_value)"
-    }
-  }
   table "web_stats_preaggregated" {
     column "team_id" {
       type = "Int64"

--- a/posthog/clickhouse/hcl/sql/local-aux.sql
+++ b/posthog/clickhouse/hcl/sql/local-aux.sql
@@ -577,17 +577,6 @@ CREATE TABLE posthog.sharded_web_stats_paths_preaggregated (
   computed_at DateTime64(6, 'UTC') DEFAULT now(),
   expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated', '{replica}', computed_at) ORDER BY (team_id, job_id, breakdown_value, time_window_start) PARTITION BY toYYYYMMDD(expires_at) TTL toDateTime(expires_at) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
-CREATE TABLE posthog.sharded_web_stats_paths_preaggregated_pathkey (
-  team_id Int64,
-  job_id UUID,
-  time_window_start DateTime64(6, 'UTC'),
-  breakdown_value String,
-  uniq_users_state AggregateFunction(uniq, UUID),
-  sum_pageviews_state AggregateFunction(sum, Int64),
-  avg_bounce_state AggregateFunction(avg, Nullable(Float64)),
-  computed_at DateTime64(6, 'UTC') DEFAULT now(),
-  expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated_pathkey', '{replica}', computed_at) ORDER BY (team_id, time_window_start, breakdown_value, job_id) PARTITION BY toYYYYMMDD(expires_at) TTL toDateTime(expires_at) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.sharded_web_stats_preaggregated (
   team_id Int64,
   job_id UUID,

--- a/posthog/clickhouse/hcl/sql/local-data.sql
+++ b/posthog/clickhouse/hcl/sql/local-data.sql
@@ -1772,17 +1772,6 @@ CREATE TABLE posthog.web_stats_paths_preaggregated (
   computed_at DateTime64(6, 'UTC') DEFAULT now(),
   expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
 ) ENGINE = Distributed('aux', 'posthog', 'sharded_web_stats_paths_preaggregated', sipHash64(job_id));
-CREATE TABLE posthog.web_stats_paths_preaggregated_pathkey (
-  team_id Int64,
-  job_id UUID,
-  time_window_start DateTime64(6, 'UTC'),
-  breakdown_value String,
-  uniq_users_state AggregateFunction(uniq, UUID),
-  sum_pageviews_state AggregateFunction(sum, Int64),
-  avg_bounce_state AggregateFunction(avg, Nullable(Float64)),
-  computed_at DateTime64(6, 'UTC') DEFAULT now(),
-  expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
-) ENGINE = Distributed('aux', 'posthog', 'sharded_web_stats_paths_preaggregated_pathkey', sipHash64(breakdown_value));
 CREATE TABLE posthog.web_stats_preaggregated (
   team_id Int64,
   job_id UUID,

--- a/posthog/clickhouse/hcl/sql/prod-eu-aux.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu-aux.sql
@@ -564,17 +564,6 @@ CREATE TABLE posthog.sharded_web_stats_paths_preaggregated (
   computed_at DateTime64(6, 'UTC') DEFAULT now(),
   expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated', '{replica}', computed_at) ORDER BY (team_id, job_id, breakdown_value, time_window_start) PARTITION BY toYYYYMMDD(expires_at) TTL toDateTime(expires_at) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
-CREATE TABLE posthog.sharded_web_stats_paths_preaggregated_pathkey (
-  team_id Int64,
-  job_id UUID,
-  time_window_start DateTime64(6, 'UTC'),
-  breakdown_value String,
-  uniq_users_state AggregateFunction(uniq, UUID),
-  sum_pageviews_state AggregateFunction(sum, Int64),
-  avg_bounce_state AggregateFunction(avg, Nullable(Float64)),
-  computed_at DateTime64(6, 'UTC') DEFAULT now(),
-  expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated_pathkey', '{replica}', computed_at) ORDER BY (team_id, time_window_start, breakdown_value, job_id) PARTITION BY toYYYYMMDD(expires_at) TTL toDateTime(expires_at) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.sharded_web_stats_preaggregated (
   team_id Int64,
   job_id UUID,

--- a/posthog/clickhouse/hcl/sql/prod-us-aux.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us-aux.sql
@@ -574,17 +574,6 @@ CREATE TABLE posthog.sharded_web_stats_paths_preaggregated (
   computed_at DateTime64(6, 'UTC') DEFAULT now(),
   expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated', '{replica}', computed_at) ORDER BY (team_id, job_id, breakdown_value, time_window_start) PARTITION BY toYYYYMMDD(expires_at) TTL toDateTime(expires_at) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
-CREATE TABLE posthog.sharded_web_stats_paths_preaggregated_pathkey (
-  team_id Int64,
-  job_id UUID,
-  time_window_start DateTime64(6, 'UTC'),
-  breakdown_value String,
-  uniq_users_state AggregateFunction(uniq, UUID),
-  sum_pageviews_state AggregateFunction(sum, Int64),
-  avg_bounce_state AggregateFunction(avg, Nullable(Float64)),
-  computed_at DateTime64(6, 'UTC') DEFAULT now(),
-  expires_at DateTime64(6, 'UTC') DEFAULT now() + toIntervalDay(7)
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.web_stats_paths_preaggregated_pathkey', '{replica}', computed_at) ORDER BY (team_id, time_window_start, breakdown_value, job_id) PARTITION BY toYYYYMMDD(expires_at) TTL toDateTime(expires_at) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.sharded_web_stats_preaggregated (
   team_id Int64,
   job_id UUID,

--- a/posthog/clickhouse/migrations/0288_drop_web_stats_paths_preaggregated_pathkey.py
+++ b/posthog/clickhouse/migrations/0288_drop_web_stats_paths_preaggregated_pathkey.py
@@ -1,0 +1,22 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.preaggregation.web_stats_paths_preaggregated_sql import (
+    DROP_SHARDED_WEB_STATS_PATHS_PREAGGREGATED_PATHKEY_TABLE_SQL,
+    DROP_WEB_STATS_PATHS_PREAGGREGATED_PATHKEY_TABLE_SQL,
+)
+
+operations = [
+    # The pathkey colocation experiment (migration 0278) never grew a read path and its
+    # dual-write was removed; drop the distributed entrypoint first so nothing can route
+    # writes mid-migration, then the sharded data table. Mirrors 0278's topology:
+    # distributed on DATA nodes, sharded on AUX.
+    run_sql_with_exceptions(
+        DROP_WEB_STATS_PATHS_PREAGGREGATED_PATHKEY_TABLE_SQL(),
+        node_roles=[NodeRole.DATA],
+    ),
+    run_sql_with_exceptions(
+        DROP_SHARDED_WEB_STATS_PATHS_PREAGGREGATED_PATHKEY_TABLE_SQL(),
+        node_roles=[NodeRole.AUX],
+        sharded=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0287_events_recent_inserted_at_not_nullable
+0288_drop_web_stats_paths_preaggregated_pathkey


### PR DESCRIPTION
## Problem

`web_stats_paths_preaggregated_pathkey` (created in ClickHouse migration 0278) was the storage side of a read-layout A/B experiment for the PATHS tile that never got its read path. Its only writer — the per-read dual-write — is removed in #69783, leaving a sharded table on the aux cluster that nothing reads or writes, still holding TTL-managed data and merge load.

## Changes

Migration-only PR: `0288_drop_web_stats_paths_preaggregated_pathkey` drops the distributed entrypoint first (DATA nodes), then the sharded data table (AUX, `SYNC`), mirroring 0278's topology. Uses the pre-existing `DROP ... IF EXISTS` SQL helpers; the table definition functions stay in `web_stats_paths_preaggregated_sql.py` because migration 0278 imports them when fresh environments replay history. The table was never listed in `schema.py`, so there is no local-parity entry to remove.

**Merge order: after #69783.** Until the dual-write removal is deployed everywhere, old pods may still attempt mirror inserts; those are swallowed by design (the mirror never raises), but sequencing avoids the noise entirely.

## How did you test this code?

Migration follows the drop pattern used by prior table removals (`IF EXISTS`, `SYNC` on the sharded drop, no `ON CLUSTER`); helpers it invokes are pre-existing and exercised by the schema test suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — internal experiment teardown.

## 🤖 Agent context

**Autonomy:** Human-approved deletion

Companion to #69783 (writer removal); the DRI asked for the full teardown of the pathkey experiment.
