### PR TITLE
chore(cli): refresh CLI README help output and add install docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,17 @@
 
 For full documentation, see [posthog.com/docs/cli](https://posthog.com/docs/cli).
 
+## What it does
+
+`posthog-cli` is a single binary for talking to PostHog from your terminal and CI. It covers two main jobs:
+
+- **Uploading debug symbols for error tracking.** Most of the commands upload the artifacts PostHog needs to turn minified or stripped stack traces back into readable source. `sourcemap` handles JavaScript bundles, `hermes` handles React Native (Hermes) sourcemaps, `proguard` handles Android mapping files, `dsym` handles Apple dSYM bundles, and `symbol-sets` uploads, downloads, and manages native (ELF/dSYM) symbol sets.
+- **Agent-first API access.** `api` exposes PostHog's MCP tool catalog through a shell-friendly interface, so coding agents (and the humans driving them) can discover, inspect, and call PostHog API tools without loading every schema into context. See [Agent-first API tools](#agent-first-api-tools) below.
+
+The rest of the commands are supporting utilities: `login` authenticates and stores a personal API token locally, and `exp` groups experimental commands that aren't quite ready for prime time yet — running HogQL/SQL queries (`exp query`), managing endpoints as YAML (`exp endpoints`), syncing event schemas into a typed SDK (`exp schema`), and working with tasks (`exp task`).
+
+The global `--dry-run` flag turns the upload commands into a no-op for CI gates that bundle to catch regressions but must not (or cannot) upload — see [Skipping uploads (dry run)](#skipping-uploads-dry-run).
+
 ## Installation
 
 Install the PostHog CLI with our wizard by running this command:

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,17 +1,6 @@
 # The Posthog CLI
 
-For full documentation, see [posthog.com/docs/cli](https://posthog.com/docs/cli).
-
-## What it does
-
-`posthog-cli` is a single binary for talking to PostHog from your terminal and CI. It covers two main jobs:
-
-- **Uploading debug symbols for error tracking.** Most of the commands upload the artifacts PostHog needs to turn minified or stripped stack traces back into readable source. `sourcemap` handles JavaScript bundles, `hermes` handles React Native (Hermes) sourcemaps, `proguard` handles Android mapping files, `dsym` handles Apple dSYM bundles, and `symbol-sets` uploads, downloads, and manages native (ELF/dSYM) symbol sets.
-- **Agent-first API access.** `api` exposes PostHog's MCP tool catalog through a shell-friendly interface, so coding agents (and the humans driving them) can discover, inspect, and call PostHog API tools without loading every schema into context. See [Agent-first API tools](#agent-first-api-tools) below.
-
-The rest of the commands are supporting utilities: `login` authenticates and stores a personal API token locally, and `exp` groups experimental commands that aren't quite ready for prime time yet — running HogQL/SQL queries (`exp query`), managing endpoints as YAML (`exp endpoints`), syncing event schemas into a typed SDK (`exp schema`), and working with tasks (`exp task`).
-
-The global `--dry-run` flag turns the upload commands into a no-op for CI gates that bundle to catch regressions but must not (or cannot) upload — see [Skipping uploads (dry run)](#skipping-uploads-dry-run).
+The command line interface for PostHog. Exposes PostHog's MCP tool catalog through a shell-friendly interface, handles debug symbol uploads for error tracking, and more. For full documentation, see [our CLI docs](https://posthog.com/docs/cli).
 
 ## Installation
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,25 @@
 # The Posthog CLI
 
+For full documentation, see [posthog.com/docs/cli](https://posthog.com/docs/cli).
+
+## Installation
+
+Install the PostHog CLI with our wizard by running this command:
+
+```bash
+npx -y @posthog/wizard@latest cli add
+```
+
+If you'd rather not use our wizard, you can install the CLI by running:
+
+```bash
+npm install -g @posthog/cli@latest
+```
+
+Note: if you are installing the CLI for use with a coding agent, you should follow our [setup for agents](https://posthog.com/docs/cli#setup-for-agents) instructions.
+
+## Usage
+
 ```bash
 > posthog-cli --help
 The command line interface for PostHog 🦔
@@ -7,17 +27,25 @@ The command line interface for PostHog 🦔
 Usage: posthog-cli [OPTIONS] <COMMAND>
 
 Commands:
-  login      Interactively authenticate with PostHog, storing a personal API token locally. You can also use the environment variables `POSTHOG_CLI_API_KEY`, `POSTHOG_CLI_PROJECT_ID` and `POSTHOG_CLI_HOST`
-  query      Run a SQL query against any data you have in posthog. This is mostly for fun, and subject to change
-  sourcemap  Upload a directory of bundled chunks to PostHog
-  exp        Contains a set of experimental commands
-  help       Print this message or the help of the given subcommand(s)
+  login        Interactively authenticate with PostHog, storing a personal API token locally. You can also use the environment variables `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID`
+  exp          Experimental commands, not quite ready for prime time
+  sourcemap    Upload a directory of bundled chunks to PostHog
+  dsym         Upload Apple dSYM debug symbol files to PostHog
+  hermes       Upload hermes sourcemaps to PostHog
+  proguard     Upload proguard mapping files to PostHog
+  symbol-sets  Upload, download, and manage symbol sets
+  api          Agent-first PostHog API tools
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
-      --host <HOST>  The PostHog host to connect to [default: https://us.posthog.com]
-      --dry-run      Skip artifact processing and upload without contacting PostHog or requiring credentials
-  -h, --help         Print help
-  -V, --version      Print version
+      --host <HOST>              The PostHog host to connect to
+      --no-fail                  Disable non-zero exit codes on errors. Use with caution
+      --skip-ssl-verification    Skip SSL certificate verification when talking to the PostHog API. Use only with self-signed certificates
+      --rate-limit <RATE_LIMIT>  Set the number of requests per minute for the Posthog API Client [env: POSTHOG_CLIENT_RATE_LIMIT=]
+      --dotenv-file <PATH>       Load PostHog credentials from this dotenv-style file when not present in the process environment. Prefer this over the `--env-file` alias: the npm package runs the binary through a `node` wrapper, and Node's own built-in `--env-file` flag intercepts that spelling
+      --dry-run[=<DRY_RUN>]      Skip artifact processing and upload (sourcemap, dSYM, hermes, proguard) without contacting PostHog or requiring credentials. Intended for CI gates that bundle to catch regressions but must not (or cannot) upload. Not for release builds. Pass it before the subcommand (`posthog-cli --dry-run hermes upload ...`) or set `POSTHOG_CLI_DRY_RUN`. This is distinct from the `exp endpoints` `--dry-run`, which previews endpoint changes [env: POSTHOG_CLI_DRY_RUN=] [default: false] [possible values: true, false]
+  -h, --help                     Print help
+  -V, --version                  Print version
 ```
 
 ## Env-based Authentication


### PR DESCRIPTION
## Problem

The [`cli/README.md`](https://github.com/PostHog/posthog/blob/master/cli/README.md) `posthog-cli --help` snippet at the top was stale. It listed `query` and a small set of commands but was missing the newer subcommands (notably `api`) and the current top-level options. It also had no installation instructions or a link to the hosted docs.

## Changes

- Updated the top-level `--help` output to match current CLI output: adds `dsym`, `hermes`, `proguard`, `symbol-sets`, and `api` commands, and refreshes the options list (`--no-fail`, `--skip-ssl-verification`, `--rate-limit`, `--dotenv-file`, and the updated `--dry-run`).
- Added an **Installation** section (wizard via `npx @posthog/wizard@latest cli add` and manual `npm install -g @posthog/cli@latest`), plus a note pointing agent installs at the setup-for-agents docs.
- Added a link to [posthog.com/docs/cli](https://posthog.com/docs/cli) near the top.

## How did you test this code?

Docs-only change. No automated tests run; verified the rendered markdown structure by review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Docs-only README refresh.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

@ivanagas asked me (Claude) to sync the CLI README's help snippet with the current `posthog-cli --help` output, add installation instructions, and link the hosted CLI docs. The help text and install commands were supplied directly, so this was a straightforward docs edit with no code changes.
