### PR TITLE
fix(slack): default agent runs to full auto permission mode

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -98,8 +98,9 @@ def _resolve_slack_permission_policy(
 
     # Modes are stored per integration (project): the workspace can route to multiple
     # projects, and a "full_auto" grant made in one must not apply to runs in another.
-    # A user row wins over the workspace-wide (slack_user_id IS NULL) row.
-    mode: str = SlackPermissionMode.ASK_BEFORE_WRITE
+    # A user row wins over the workspace-wide (slack_user_id IS NULL) row. Runs default
+    # to full auto; externally shared channels still force human approval regardless.
+    mode: str = SlackPermissionMode.FULL_AUTO
     settings = list(
         SlackSettings.objects.filter(slack_workspace_id=slack_workspace_id)
         .filter(models.Q(slack_user_id=slack_user_id) | models.Q(slack_user_id__isnull=True))

--- a/products/slack_app/backend/services/agent_permissions.py
+++ b/products/slack_app/backend/services/agent_permissions.py
@@ -228,15 +228,13 @@ def post_slack_permission_request_for_task_run(
         )
 
         text = f"<@{target_slack_user_id}> the agent needs permission to continue: *{tool_label}*"
-        current_permission_mode = _current_permission_mode(task_run, SlackPermissionMode.ASK_BEFORE_WRITE)
+        current_permission_mode = _current_permission_mode(task_run, SlackPermissionMode.FULL_AUTO)
         permission_mode_options = [
             _build_permission_mode_option(value, label) for value, label in SlackPermissionMode.choices
         ]
         initial_mode_option = next(
             (option for option in permission_mode_options if option["value"] == current_permission_mode),
-            _build_permission_mode_option(
-                SlackPermissionMode.ASK_BEFORE_WRITE, SlackPermissionMode.ASK_BEFORE_WRITE.label
-            ),
+            _build_permission_mode_option(SlackPermissionMode.FULL_AUTO, SlackPermissionMode.FULL_AUTO.label),
         )
         card_body = _build_card_body(tool_label, tool_detail)
 

--- a/products/slack_app/backend/tests/test_agent_permissions.py
+++ b/products/slack_app/backend/tests/test_agent_permissions.py
@@ -3,15 +3,17 @@ from unittest.mock import MagicMock, patch
 from django.core.cache import cache
 from django.test import TestCase
 
+from parameterized import parameterized
 from slack_sdk.errors import SlackApiError
 
 from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.temporal.ai.slack_app.activities.task_creation import _resolve_slack_permission_policy
 
 from products.slack_app.backend.api import _decode_picker_context
-from products.slack_app.backend.models import SlackPermissionMode, SlackThreadTaskMapping
+from products.slack_app.backend.models import SlackPermissionMode, SlackSettings, SlackThreadTaskMapping
 from products.slack_app.backend.services.agent_permissions import (
     SLACK_PERMISSION_ACTION_APPROVE,
     SLACK_PERMISSION_ACTION_DENY,
@@ -104,7 +106,7 @@ class TestSlackAgentPermissionPrompt(TestCase):
         assert blocks[1]["type"] == "actions"
         config_select = blocks[1]["elements"][0]
         assert config_select["action_id"] == SLACK_PERMISSION_ACTION_SELECT
-        assert config_select["initial_option"]["value"] == SlackPermissionMode.ASK_BEFORE_WRITE
+        assert config_select["initial_option"]["value"] == SlackPermissionMode.FULL_AUTO
         assert [option["value"] for option in config_select["options"]] == [
             SlackPermissionMode.READ_ONLY,
             SlackPermissionMode.ASK_BEFORE_WRITE,
@@ -130,14 +132,14 @@ class TestSlackAgentPermissionPrompt(TestCase):
 
     @patch("products.slack_app.backend.services.agent_permissions.SlackIntegration")
     def test_select_reflects_run_permission_mode(self, mock_slack_cls: MagicMock) -> None:
-        self.task_run.state = {"slack_permission_mode": SlackPermissionMode.FULL_AUTO}
+        self.task_run.state = {"slack_permission_mode": SlackPermissionMode.READ_ONLY}
         self.task_run.save(update_fields=["state"])
 
         post_slack_permission_request_for_task_run(self.task_run, self._permission_request())
 
         blocks = mock_slack_cls.return_value.client.chat_postMessage.call_args.kwargs["blocks"]
         config_select = blocks[1]["elements"][0]
-        assert config_select["initial_option"]["value"] == SlackPermissionMode.FULL_AUTO
+        assert config_select["initial_option"]["value"] == SlackPermissionMode.READ_ONLY
 
     @patch("products.slack_app.backend.services.agent_permissions.SlackIntegration")
     def test_dedupes_repeated_permission_request(self, mock_slack_cls: MagicMock) -> None:
@@ -181,3 +183,63 @@ class TestSlackAgentPermissionPrompt(TestCase):
         card = blocks[0]
         assert card["type"] == "card"
         assert len(card["body"]["text"]) <= 200
+
+
+class TestResolveSlackPermissionPolicy(TestCase):
+    WORKSPACE_ID = "T12345"
+    SLACK_USER_ID = "U1"
+    INTEGRATION_ID = 123
+
+    def _create_settings(self, rows: list[tuple[str | None, str]]) -> None:
+        for slack_user_id, mode in rows:
+            SlackSettings.objects.create(
+                slack_workspace_id=self.WORKSPACE_ID,
+                slack_user_id=slack_user_id,
+                permission_modes={str(self.INTEGRATION_ID): mode},
+            )
+
+    def _resolve(self, *, is_ext_shared_channel: bool = False):
+        return _resolve_slack_permission_policy(
+            integration_id=self.INTEGRATION_ID,
+            slack_workspace_id=self.WORKSPACE_ID,
+            slack_user_id=self.SLACK_USER_ID,
+            is_ext_shared_channel=is_ext_shared_channel,
+        )
+
+    @parameterized.expand(
+        [
+            ("no_settings_defaults_to_full_auto", [], SlackPermissionMode.FULL_AUTO, "default"),
+            (
+                "workspace_row_overrides_default",
+                [(None, SlackPermissionMode.ASK_BEFORE_WRITE)],
+                SlackPermissionMode.ASK_BEFORE_WRITE,
+                "default",
+            ),
+            (
+                "user_row_overrides_workspace_row",
+                [(None, SlackPermissionMode.ASK_BEFORE_WRITE), ("U1", SlackPermissionMode.READ_ONLY)],
+                SlackPermissionMode.READ_ONLY,
+                "plan",
+            ),
+        ]
+    )
+    def test_mode_resolution(
+        self,
+        _name: str,
+        rows: list[tuple[str | None, str]],
+        expected_mode: str,
+        expected_initial_permission_mode: str,
+    ) -> None:
+        self._create_settings(rows)
+
+        policy = self._resolve()
+
+        assert policy.mode == expected_mode
+        assert policy.initial_permission_mode == expected_initial_permission_mode
+        assert policy.customer_facing_approval_required is False
+
+    def test_ext_shared_channel_requires_customer_facing_approval(self) -> None:
+        policy = self._resolve(is_ext_shared_channel=True)
+
+        assert policy.mode == SlackPermissionMode.FULL_AUTO
+        assert policy.customer_facing_approval_required is True


### PR DESCRIPTION
## Problem

Since #66101 introduced permission modes for Slack-started agent runs, runs whose user never picked a mode default to `ask_before_write`. In practice that mode auto-allows only positively-identified read-only tool calls, so nearly every real command an agent runs (installs, builds, non-allowlisted shell, non-read-only MCP tools) raises a Slack approval card. Users are getting prompted on every step of every task.

We want full auto by default: no approval prompts unless the user explicitly opts into a stricter mode.

## Changes

- `_resolve_slack_permission_policy` now defaults to `full_auto` when neither a user-level nor workspace-level `SlackSettings` row carries a mode for the integration. A saved mode still wins, user row over workspace row, as before.
- The approval card's mode-select fallback (used only when a legacy run has no mode on its state) now shows `Full auto` instead of `Ask before write`, matching the new default.

> [!NOTE]
> The safety backstops are unchanged in this PR: externally shared (customer-facing) channels still force human approval for non-read-only actions regardless of mode, and users can still switch any run to `ask_before_write` or `read_only` from the approval card or settings. #69799 (stacked on this PR) removes the externally shared channel override.

## How did you test this code?

Ran locally:

- `products/slack_app/backend/tests/test_agent_permissions.py` (9 passed)
- `products/tasks/backend/logic/services/tests/test_permission_broker.py`, `posthog/temporal/tests/ai/slack_app/activities/test_task_creation.py`, `products/slack_app/backend/tests/test_posthog_code_interactivity.py` (104 passed)

Test changes:

- Updated the two approval-card assertions to the new default, and repointed `test_select_reflects_run_permission_mode` at `read_only` so it still distinguishes state-driven mode from the fallback.
- Added `TestResolveSlackPermissionPolicy`: pins the `full_auto` default (catches the default silently flipping back, which is exactly this bug), that saved workspace/user modes still override it (user row winning over workspace row), and that externally shared channels keep `customer_facing_approval_required` - nothing previously tested policy resolution at task creation, and that last guard matters more now that the default is permissive.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) at my direction after we noticed post-merge that every Slack agent command prompted for approval. The agent traced the prompts to the `ask_before_write` fallback in `_resolve_slack_permission_policy`, invoked /writing-tests before touching tests, and considered but rejected changing the sandbox `initial_permission_mode` to bypass permissions for full auto, since the broker-answered flow is what lets externally shared channels keep a human in the loop (and lets mid-run mode downgrades from the card take effect immediately).
