### PR TITLE
fix(slack): drop forced approval in externally shared channels

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -98,8 +98,9 @@ def _resolve_slack_permission_policy(
 
     # Modes are stored per integration (project): the workspace can route to multiple
     # projects, and a "full_auto" grant made in one must not apply to runs in another.
-    # A user row wins over the workspace-wide (slack_user_id IS NULL) row.
-    mode: str = SlackPermissionMode.ASK_BEFORE_WRITE
+    # A user row wins over the workspace-wide (slack_user_id IS NULL) row. Runs default
+    # to full auto; externally shared channels still force human approval regardless.
+    mode: str = SlackPermissionMode.FULL_AUTO
     settings = list(
         SlackSettings.objects.filter(slack_workspace_id=slack_workspace_id)
         .filter(models.Q(slack_user_id=slack_user_id) | models.Q(slack_user_id__isnull=True))

--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -63,14 +63,12 @@ class SlackPermissionPolicy:
     mode: str
     initial_permission_mode: _InitialPermissionMode
     is_ext_shared_channel: bool
-    customer_facing_approval_required: bool
 
 
 def _slack_permission_state_updates(policy: SlackPermissionPolicy) -> dict[str, Any]:
     return {
         "slack_permission_mode": policy.mode,
         "slack_is_ext_shared_channel": policy.is_ext_shared_channel,
-        "slack_customer_facing_approval_required": policy.customer_facing_approval_required,
     }
 
 
@@ -99,7 +97,7 @@ def _resolve_slack_permission_policy(
     # Modes are stored per integration (project): the workspace can route to multiple
     # projects, and a "full_auto" grant made in one must not apply to runs in another.
     # A user row wins over the workspace-wide (slack_user_id IS NULL) row. Runs default
-    # to full auto; externally shared channels still force human approval regardless.
+    # to full auto.
     mode: str = SlackPermissionMode.FULL_AUTO
     settings = list(
         SlackSettings.objects.filter(slack_workspace_id=slack_workspace_id)
@@ -119,13 +117,10 @@ def _resolve_slack_permission_policy(
     else:
         initial_permission_mode = "default"
 
-    customer_facing_approval_required = is_ext_shared_channel
-
     return SlackPermissionPolicy(
         mode=mode,
         initial_permission_mode=initial_permission_mode,
         is_ext_shared_channel=is_ext_shared_channel,
-        customer_facing_approval_required=customer_facing_approval_required,
     )
 
 

--- a/products/slack_app/backend/services/agent_permissions.py
+++ b/products/slack_app/backend/services/agent_permissions.py
@@ -228,15 +228,13 @@ def post_slack_permission_request_for_task_run(
         )
 
         text = f"<@{target_slack_user_id}> the agent needs permission to continue: *{tool_label}*"
-        current_permission_mode = _current_permission_mode(task_run, SlackPermissionMode.ASK_BEFORE_WRITE)
+        current_permission_mode = _current_permission_mode(task_run, SlackPermissionMode.FULL_AUTO)
         permission_mode_options = [
             _build_permission_mode_option(value, label) for value, label in SlackPermissionMode.choices
         ]
         initial_mode_option = next(
             (option for option in permission_mode_options if option["value"] == current_permission_mode),
-            _build_permission_mode_option(
-                SlackPermissionMode.ASK_BEFORE_WRITE, SlackPermissionMode.ASK_BEFORE_WRITE.label
-            ),
+            _build_permission_mode_option(SlackPermissionMode.FULL_AUTO, SlackPermissionMode.FULL_AUTO.label),
         )
         card_body = _build_card_body(tool_label, tool_detail)
 

--- a/products/slack_app/backend/tests/test_agent_permissions.py
+++ b/products/slack_app/backend/tests/test_agent_permissions.py
@@ -3,15 +3,17 @@ from unittest.mock import MagicMock, patch
 from django.core.cache import cache
 from django.test import TestCase
 
+from parameterized import parameterized
 from slack_sdk.errors import SlackApiError
 
 from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.temporal.ai.slack_app.activities.task_creation import _resolve_slack_permission_policy
 
 from products.slack_app.backend.api import _decode_picker_context
-from products.slack_app.backend.models import SlackPermissionMode, SlackThreadTaskMapping
+from products.slack_app.backend.models import SlackPermissionMode, SlackSettings, SlackThreadTaskMapping
 from products.slack_app.backend.services.agent_permissions import (
     SLACK_PERMISSION_ACTION_APPROVE,
     SLACK_PERMISSION_ACTION_DENY,
@@ -104,7 +106,7 @@ class TestSlackAgentPermissionPrompt(TestCase):
         assert blocks[1]["type"] == "actions"
         config_select = blocks[1]["elements"][0]
         assert config_select["action_id"] == SLACK_PERMISSION_ACTION_SELECT
-        assert config_select["initial_option"]["value"] == SlackPermissionMode.ASK_BEFORE_WRITE
+        assert config_select["initial_option"]["value"] == SlackPermissionMode.FULL_AUTO
         assert [option["value"] for option in config_select["options"]] == [
             SlackPermissionMode.READ_ONLY,
             SlackPermissionMode.ASK_BEFORE_WRITE,
@@ -130,14 +132,14 @@ class TestSlackAgentPermissionPrompt(TestCase):
 
     @patch("products.slack_app.backend.services.agent_permissions.SlackIntegration")
     def test_select_reflects_run_permission_mode(self, mock_slack_cls: MagicMock) -> None:
-        self.task_run.state = {"slack_permission_mode": SlackPermissionMode.FULL_AUTO}
+        self.task_run.state = {"slack_permission_mode": SlackPermissionMode.READ_ONLY}
         self.task_run.save(update_fields=["state"])
 
         post_slack_permission_request_for_task_run(self.task_run, self._permission_request())
 
         blocks = mock_slack_cls.return_value.client.chat_postMessage.call_args.kwargs["blocks"]
         config_select = blocks[1]["elements"][0]
-        assert config_select["initial_option"]["value"] == SlackPermissionMode.FULL_AUTO
+        assert config_select["initial_option"]["value"] == SlackPermissionMode.READ_ONLY
 
     @patch("products.slack_app.backend.services.agent_permissions.SlackIntegration")
     def test_dedupes_repeated_permission_request(self, mock_slack_cls: MagicMock) -> None:
@@ -181,3 +183,63 @@ class TestSlackAgentPermissionPrompt(TestCase):
         card = blocks[0]
         assert card["type"] == "card"
         assert len(card["body"]["text"]) <= 200
+
+
+class TestResolveSlackPermissionPolicy(TestCase):
+    WORKSPACE_ID = "T12345"
+    SLACK_USER_ID = "U1"
+    INTEGRATION_ID = 123
+
+    def _create_settings(self, rows: list[tuple[str | None, str]]) -> None:
+        for slack_user_id, mode in rows:
+            SlackSettings.objects.create(
+                slack_workspace_id=self.WORKSPACE_ID,
+                slack_user_id=slack_user_id,
+                permission_modes={str(self.INTEGRATION_ID): mode},
+            )
+
+    def _resolve(self, *, is_ext_shared_channel: bool = False):
+        return _resolve_slack_permission_policy(
+            integration_id=self.INTEGRATION_ID,
+            slack_workspace_id=self.WORKSPACE_ID,
+            slack_user_id=self.SLACK_USER_ID,
+            is_ext_shared_channel=is_ext_shared_channel,
+        )
+
+    @parameterized.expand(
+        [
+            ("no_settings_defaults_to_full_auto", [], SlackPermissionMode.FULL_AUTO, "default"),
+            (
+                "workspace_row_overrides_default",
+                [(None, SlackPermissionMode.ASK_BEFORE_WRITE)],
+                SlackPermissionMode.ASK_BEFORE_WRITE,
+                "default",
+            ),
+            (
+                "user_row_overrides_workspace_row",
+                [(None, SlackPermissionMode.ASK_BEFORE_WRITE), ("U1", SlackPermissionMode.READ_ONLY)],
+                SlackPermissionMode.READ_ONLY,
+                "plan",
+            ),
+        ]
+    )
+    def test_mode_resolution(
+        self,
+        _name: str,
+        rows: list[tuple[str | None, str]],
+        expected_mode: str,
+        expected_initial_permission_mode: str,
+    ) -> None:
+        self._create_settings(rows)
+
+        policy = self._resolve()
+
+        assert policy.mode == expected_mode
+        assert policy.initial_permission_mode == expected_initial_permission_mode
+        assert policy.customer_facing_approval_required is False
+
+    def test_ext_shared_channel_requires_customer_facing_approval(self) -> None:
+        policy = self._resolve(is_ext_shared_channel=True)
+
+        assert policy.mode == SlackPermissionMode.FULL_AUTO
+        assert policy.customer_facing_approval_required is True

--- a/products/slack_app/backend/tests/test_agent_permissions.py
+++ b/products/slack_app/backend/tests/test_agent_permissions.py
@@ -198,12 +198,12 @@ class TestResolveSlackPermissionPolicy(TestCase):
                 permission_modes={str(self.INTEGRATION_ID): mode},
             )
 
-    def _resolve(self, *, is_ext_shared_channel: bool = False):
+    def _resolve(self):
         return _resolve_slack_permission_policy(
             integration_id=self.INTEGRATION_ID,
             slack_workspace_id=self.WORKSPACE_ID,
             slack_user_id=self.SLACK_USER_ID,
-            is_ext_shared_channel=is_ext_shared_channel,
+            is_ext_shared_channel=False,
         )
 
     @parameterized.expand(
@@ -236,10 +236,3 @@ class TestResolveSlackPermissionPolicy(TestCase):
 
         assert policy.mode == expected_mode
         assert policy.initial_permission_mode == expected_initial_permission_mode
-        assert policy.customer_facing_approval_required is False
-
-    def test_ext_shared_channel_requires_customer_facing_approval(self) -> None:
-        policy = self._resolve(is_ext_shared_channel=True)
-
-        assert policy.mode == SlackPermissionMode.FULL_AUTO
-        assert policy.customer_facing_approval_required is True

--- a/products/tasks/backend/logic/services/permission_broker.py
+++ b/products/tasks/backend/logic/services/permission_broker.py
@@ -5,10 +5,10 @@ The sandbox agent session starts with an ``initial_permission_mode`` and raises 
 runs whose origin surface recorded a broker permission mode on the run state
 (``slack_permission_mode``, written at Slack task creation and updated from the Slack
 approval card), the relay activity answers safe requests here — read-only tool calls
-always, and everything except customer-facing runs in ``full_auto`` — so only
-decisions that genuinely need a human are surfaced to the origin (e.g. as a Slack
-approval card). Human responses are delivered on the durable workflow signal path
-instead (see ``send_permission_response_to_sandbox``).
+always, and everything in ``full_auto`` — so only decisions that genuinely need a
+human are surfaced to the origin (e.g. as a Slack approval card). Human responses
+are delivered on the durable workflow signal path instead (see
+``send_permission_response_to_sandbox``).
 
 Auto-responses deliberately skip the workflow: they fire on every allowed tool call,
 so routing them through Temporal would bloat history and add latency for no
@@ -38,7 +38,6 @@ logger = structlog.get_logger(__name__)
 
 POSTHOG_PERMISSION_REQUEST_METHOD = "_posthog/permission_request"
 PERMISSION_MODE_STATE_KEY = "slack_permission_mode"
-CUSTOMER_FACING_APPROVAL_STATE_KEY = "slack_customer_facing_approval_required"
 # Values written by the origin surface (products/slack_app SlackPermissionMode).
 FULL_AUTO_PERMISSION_MODE = "full_auto"
 # Must comfortably outlive the run so a replayed relay event can't double-answer.
@@ -362,12 +361,7 @@ def _broker_permission_mode(task_run: "TaskRun") -> str | None:
 
 
 def _run_uses_full_auto(task_run: "TaskRun") -> bool:
-    state = _run_state(task_run)
-    # Customer-facing (externally shared) channels always keep a human in the loop
-    # for non-read-only actions, no matter the user's permission mode.
-    if state.get(CUSTOMER_FACING_APPROVAL_STATE_KEY):
-        return False
-    return state.get(PERMISSION_MODE_STATE_KEY) == FULL_AUTO_PERMISSION_MODE
+    return _run_state(task_run).get(PERMISSION_MODE_STATE_KEY) == FULL_AUTO_PERMISSION_MODE
 
 
 def _should_auto_allow(task_run: "TaskRun", permission_request: dict[str, Any]) -> bool:

--- a/products/tasks/backend/logic/services/tests/test_permission_broker.py
+++ b/products/tasks/backend/logic/services/tests/test_permission_broker.py
@@ -209,14 +209,6 @@ class TestTryAutoRespondPermissionRequest(APIBaseTest):
         assert handled is True
         mock_send.assert_called_once()
 
-    def test_full_auto_customer_facing_still_escalates(self) -> None:
-        self._set_state(slack_permission_mode="full_auto", slack_customer_facing_approval_required=True)
-
-        handled, mock_send = self._auto_respond(self._permission_request(command="rm -rf report.xlsx"))
-
-        assert handled is False
-        mock_send.assert_not_called()
-
     def test_run_without_permission_mode_is_never_auto_answered(self) -> None:
         self._set_state()
 


### PR DESCRIPTION
## Problem

Slack-started agent runs in externally shared channels force a human approval card for every non-read-only action, even when the user explicitly set their permission mode to `full_auto` (#66101). Getting prompted despite having picked full auto subverts the mode the user chose.

## Changes

- Removed the customer-facing override: `slack_customer_facing_approval_required` is no longer written to run state at task creation nor read by the permission broker. The run's permission mode is now the only thing deciding whether a human is prompted.
- `slack_is_ext_shared_channel` is still recorded on run state, and the separate ext-shared channel onboarding approval (whether the bot engages in the channel at all, `_channel_is_approved`) is untouched.
- 
Stacked on #69795 (full auto by default).

## How did you test this code?

Ran locally (all passing, 160 tests total): `test_agent_permissions.py`, `test_permission_broker.py`, `test_task_creation.py`, `test_posthog_code_interactivity.py`, `test_followup_forwarding.py`.

Removed `test_full_auto_customer_facing_still_escalates` along with the override it covered; no new tests, since this deletes a behavior rather than adding one.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) at my direction as a follow-up to #69795. The agent flagged the prompt-injection tradeoff of unattended full-auto runs in externally shared channels; I accepted it in favor of respecting the user's chosen mode. Originally one PR with the default change, split out on my request.
