### PR TITLE
ci(devex): decouple quarantine gate verdict from trunk upload

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -16,10 +16,11 @@
 #   auto-commit (handle-snapshots), posthog-github-action telemetry,
 #   --store-durations write, test-selection verdict, Trunk flaky-test quarantine
 #   gate (canonical runs per-shard analytics-uploader steps that post to the
-#   external Trunk service and gate the job on the quarantine list; the shadow
-#   strips them — no Trunk posting from a non-blocking timing trial — and so also
-#   omits the test steps' continue-on-error and the fork/no-gate failure
-#   fallbacks that exist only to hand the pass/fail verdict to that gate)
+#   external Trunk service; the upload is best-effort and a local "Fail on test
+#   failure" step owns the pass/fail verdict. The shadow strips all of it — no
+#   Trunk posting from a non-blocking timing trial — and so also omits the test
+#   steps' continue-on-error and that verdict step, letting each shard's test
+#   exit code be the verdict directly)
 # - OpenAPI types: the check-openapi-types job is folded into check-migrations as a
 #   check-only step (drift still fails the run); only its auto-commit side effect is dropped
 # - actions/cache reads/writes route to Depot Cache, not GitHub Actions Cache,

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2660,33 +2660,37 @@ jobs:
                   name: junit-results-backend-${{ matrix.artifact_key }}
                   path: junit-*.xml
 
-            # Quarantine gate: uploads junit to Trunk and gates the job. Exit 0 when every
-            # failure is an already-quarantined flake, non-zero otherwise (falls back to the
-            # raw test outcome if Trunk is unreachable). Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no
-            # secret.
+            # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
+            # the verdict, so a Trunk outage can't red a passing shard. Internal PRs only (needs the
+            # secret); cli-version pinned, not 'latest' (skips the release redirect).
             - name: Quarantine gate (Core)
+              id: quarantine_gate_core
+              continue-on-error: true
               if: ${{ !cancelled() && matrix.segment == 'Core' && needs.changes.outputs.backend == 'true' && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: junit-core.xml
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
                   quarantine: true
                   previous-step-outcome: ${{ steps.run-core-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
             - name: Quarantine gate (Temporal)
+              id: quarantine_gate_temporal
+              continue-on-error: true
               if: ${{ !cancelled() && matrix.segment == 'Temporal' && needs.changes.outputs.backend == 'true' && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: junit-temporal.xml
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
                   quarantine: true
                   previous-step-outcome: ${{ steps.run-temporal-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
-            # No Trunk secret on fork PRs and Dependabot; fall back to the raw test outcome so
-            # a genuine failure still goes red exactly as before.
-            - name: Fail on test failure (no quarantine gate)
-              if: ${{ !cancelled() && needs.changes.outputs.backend == 'true' && (steps.run-core-tests.outcome == 'failure' || steps.run-temporal-tests.outcome == 'failure') && !(env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]') }}
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot. Passing shards never red here.
+            - name: Fail on test failure
+              if: ${{ !cancelled() && ((steps.run-core-tests.outcome == 'failure' && steps.quarantine_gate_core.outcome != 'success') || (steps.run-temporal-tests.outcome == 'failure' && steps.quarantine_gate_temporal.outcome != 'success')) }}
               shell: bash
               run: exit 1
 

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -727,24 +727,25 @@ jobs:
                   path: playwright/junit-results.xml
                   if-no-files-found: ignore
 
-            # Quarantine gate: uploads junit to Trunk and gates the job. Exit 0 when every
-            # failure is an already-quarantined flake, non-zero otherwise (falls back to the
-            # raw test outcome if Trunk is unreachable). Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no
-            # secret.
+            # Best-effort Trunk upload (continue-on-error); the "Fail on Playwright failure" step
+            # below is the verdict, so a Trunk outage can't red a passing job. Internal PRs only
+            # (needs the secret); cli-version pinned, not 'latest' (skips the release redirect).
             - name: Quarantine gate
+              id: quarantine_gate
+              continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: playwright/junit-results.xml
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
                   quarantine: true
                   previous-step-outcome: ${{ steps.playwright-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
-            # No Trunk secret on fork PRs and Dependabot; fall back to the raw playwright
-            # outcome so a genuine failure still goes red exactly as before.
-            - name: Fail on Playwright failure (no quarantine gate)
-              if: ${{ !cancelled() && steps.playwright-tests.outcome == 'failure' && !(env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]') }}
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot.
+            - name: Fail on Playwright failure
+              if: ${{ !cancelled() && steps.playwright-tests.outcome == 'failure' && steps.quarantine_gate.outcome != 'success' }}
               shell: bash
               run: exit 1
 

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -688,26 +688,27 @@ jobs:
                   if-no-files-found: ignore
                   retention-days: 1
 
-            # Quarantine gate: uploads junit to Trunk and gates the job. Exit 0 when every
-            # failure is an already-quarantined flake, non-zero otherwise (falls back to the
-            # raw test outcome if Trunk is unreachable). FOSS and EE run the same test files,
-            # so each segment uploads under its own variant to keep their histories distinct.
-            # Runs the token only on internal PRs, master, and the merge queue — never on fork
-            # PRs or Dependabot, which have no secret.
+            # Best-effort Trunk upload (continue-on-error); the "Fail on jest failure" step below is
+            # the verdict, so a Trunk outage can't red a passing shard. FOSS and EE share test files,
+            # so each segment uploads under its own variant. Internal PRs only (needs the secret);
+            # cli-version pinned, not 'latest' (skips the release redirect).
             - name: Quarantine gate
+              id: quarantine_gate
+              continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: junit-results/junit-${{ matrix.segment }}-${{ matrix.chunk }}.xml
                   org-slug: posthog-inc
                   variant: ${{ matrix.segment }}
+                  cli-version: '0.13.7'
                   quarantine: true
                   previous-step-outcome: ${{ steps.run-jest.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
-            # No Trunk secret on fork PRs and Dependabot; fall back to the raw jest outcome so
-            # a genuine failure still goes red exactly as before.
-            - name: Fail on jest failure (no quarantine gate)
-              if: ${{ !cancelled() && steps.run-jest.outcome == 'failure' && !(env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]') }}
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot. Passing shards never red here.
+            - name: Fail on jest failure
+              if: ${{ !cancelled() && steps.run-jest.outcome == 'failure' && steps.quarantine_gate.outcome != 'success' }}
               shell: bash
               run: exit 1
 
@@ -747,22 +748,23 @@ jobs:
                   if-no-files-found: ignore
                   retention-days: 1
 
-            # Quarantine gate: see the jest job for the full rationale. Runs the token only
-            # on internal PRs, master, and the merge queue — never on fork PRs or Dependabot.
+            # Best-effort Trunk upload (continue-on-error); the "Fail on jest failure" step below is
+            # the verdict. See the jest job for the full rationale. cli-version pinned, not 'latest'.
             - name: Quarantine gate
+              id: quarantine_gate
+              continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: junit-results/junit-replay-shared.xml
                   org-slug: posthog-inc
                   variant: replay-shared
+                  cli-version: '0.13.7'
                   quarantine: true
                   previous-step-outcome: ${{ steps.run-jest.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
-            # No Trunk secret on fork PRs and Dependabot; fall back to the raw jest outcome so
-            # a genuine failure still goes red exactly as before.
-            - name: Fail on jest failure (no quarantine gate)
-              if: ${{ !cancelled() && steps.run-jest.outcome == 'failure' && !(env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]') }}
+            - name: Fail on jest failure
+              if: ${{ !cancelled() && steps.run-jest.outcome == 'failure' && steps.quarantine_gate.outcome != 'success' }}
               shell: bash
               run: exit 1
 


### PR DESCRIPTION
## Problem

The "Quarantine gate" step doubled as the pass/fail verdict.
It uploads junit via `trunk-io/analytics-uploader`, which downloads its CLI from GitHub releases.
A transient 5xx on that download reded master across unrelated shards even though every test passed.

## Changes

- Upload is now best-effort (`continue-on-error`), like every non-gating Trunk upload already in CI.
- Verdict moved to a local step: red only when tests failed and the gate didn't clear them (`outcome != 'success'` also covers the skipped-gate fork/Dependabot path).
- Pin `cli-version` off `latest` so the CLI comes from a fixed asset URL instead of the release redirect.
- Applied to all 5 gating sites: backend Core+Temporal, frontend jest+replay-shared, e2e. Non-gating Trunk uploads already tolerate failure.

> [!NOTE]
> Behavior is unchanged except that a shard whose tests passed can no longer be reded by a Trunk outage.

## How did you test this code?

No new tests.
I validated all 3 workflows with actionlint and a YAML parse, and `hogli ci:preflight` workflow-lint passed.
I did not run the workflows end to end.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl directed this after investigating a master-red incident.
I (Claude) read the failing job logs and confirmed tests passed while the gate's CLI download returned a 5xx, then checked the Trunk docs and action (no built-in retry, only `cli-version`).
Rejected along the way: a duplicated retry step (the verdict guard already makes a gate infra failure harmless, so the retry only re-uploads on already-green shards) and extracting a shared composite action (it would be a shallow module, and job-level env like `RUNS_ON_INTERNAL_PR` is not visible in a composite's `if:`).
Ran /simplify, which trimmed the backend verdict's redundant `matrix.segment` guards.
