### PR TITLE
fix(replay-vision): stop requiring a slack channel to save a summary

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -307,6 +307,12 @@ function DeliverySection(): JSX.Element {
                     )}
                 </LemonField>
             )}
+            {!actionForm.channel && (
+                <span className="text-xs text-muted">
+                    No channel selected — this summary will appear on the scanner page and in its run history, without a
+                    Slack notification.
+                </span>
+            )}
         </div>
     )
 }
@@ -393,7 +399,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
                             </LemonField>
 
                             <div>
-                                <h4 className="mb-1">Deliver to Slack</h4>
+                                <h4 className="mb-1">Deliver to Slack (optional)</h4>
                                 <DeliverySection />
                             </div>
 

--- a/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
@@ -134,12 +134,11 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
     forms(({ values }) => ({
         actionForm: {
             defaults: NEW_ACTION_FORM(),
-            errors: ({ name, cadence, integration_id, channel, min_score, max_score }: VisionActionForm) => ({
+            errors: ({ name, cadence, min_score, max_score }: VisionActionForm) => ({
                 name: !name?.trim() ? 'Give this summary a name' : undefined,
                 // kea-forms can't carry a string error on the weekdays array, so hang it on `hour` to
                 // mark the form invalid and block Enter-to-submit; the visible copy is the inline text.
                 cadence: cadence.weekdays.length === 0 ? { hour: 'Pick at least one day' } : undefined,
-                channel: integration_id && !channel ? 'Pick a channel' : undefined,
                 min_score:
                     min_score != null && max_score != null && min_score > max_score
                         ? "Min score can't exceed max score"


### PR DESCRIPTION
## Problem

Saving a summary (including the built-in daily digest) demanded a Slack channel whenever the team has a Slack integration: `IntegrationChoice` auto-selects the team's first integration on mount, and the editor's "Pick a channel" validation then blocked Save. Delivery was designed to be optional — deliveryless runs are fully supported and surface on the scanner page's digest hero and in run history.

## Changes

- Removed the "Pick a channel" blocking validation: a selected integration without a channel now simply means no Slack delivery (`buildActionBody` already omits `delivery_config` in that case).
- The section is labeled "Deliver to Slack (optional)", and when no channel is picked an inline note states the summary will appear on the scanner page and in run history without a Slack notification.

## How did you test this code?

- Existing editor/actions logic suites (10 tests) pass; no new tests — the change removes a validation and the no-delivery body shape is already covered by `buildActionBody` tests.
- Reproduced the blocked-save locally with a connected Slack workspace before the fix.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — behind the `replay-vision-actions` internal flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), directed by Kim after hitting the blocked save while testing digests locally. Root cause traced to `IntegrationChoice`'s auto-select-first-integration behavior colliding with our channel-required validation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
