### PR TITLE
feat(lemon-ui): prototype skin bridges between lemon-ui and quill

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { IconPlus, IconTrash } from '@posthog/icons'
+import { Button as QuillButton } from '@posthog/quill'
+
+import { LemonButton } from './LemonButton'
+
+/**
+ * Prototype of the "token bridge" migration strategy: `quill-skin.scss` restyles
+ * LemonButton to quill's visual language purely via the CSS custom properties it
+ * already consumes. The middle column renders the exact same LemonButton code as
+ * the left column — only the `data-quill data-quill-skin` wrapper differs. The
+ * right column is the real quill Button for comparison.
+ */
+const meta: Meta = {
+    title: 'Lemon UI/Lemon Button Quill Skin',
+}
+export default meta
+
+function LemonExamples(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-2 items-start">
+            <LemonButton type="primary">Primary</LemonButton>
+            <LemonButton type="secondary">Secondary</LemonButton>
+            <LemonButton type="tertiary">Tertiary</LemonButton>
+            <LemonButton type="primary" icon={<IconPlus />}>
+                With icon
+            </LemonButton>
+            <LemonButton type="secondary" status="danger" icon={<IconTrash />}>
+                Danger
+            </LemonButton>
+            <LemonButton type="tertiary" status="danger">
+                Danger tertiary
+            </LemonButton>
+            <LemonButton type="primary" disabledReason="Disabled for demo purposes">
+                Disabled
+            </LemonButton>
+            <LemonButton type="primary" loading>
+                Loading
+            </LemonButton>
+            <div className="flex gap-2 items-center">
+                <LemonButton type="secondary" size="xsmall">
+                    xsmall
+                </LemonButton>
+                <LemonButton type="secondary" size="small">
+                    small
+                </LemonButton>
+                <LemonButton type="secondary">medium</LemonButton>
+                <LemonButton type="secondary" size="large">
+                    large
+                </LemonButton>
+            </div>
+        </div>
+    )
+}
+
+function QuillExamples(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-2 items-start">
+            <QuillButton variant="primary">Primary</QuillButton>
+            <QuillButton variant="outline">Secondary</QuillButton>
+            <QuillButton variant="default">Tertiary</QuillButton>
+            <QuillButton variant="primary">
+                <IconPlus />
+                With icon
+            </QuillButton>
+            <QuillButton variant="destructive">
+                <IconTrash />
+                Danger
+            </QuillButton>
+            <QuillButton variant="destructive">Danger tertiary</QuillButton>
+            <QuillButton variant="primary" disabled>
+                Disabled
+            </QuillButton>
+            <QuillButton variant="primary" loading>
+                Loading
+            </QuillButton>
+            <div className="flex gap-2 items-center">
+                <QuillButton variant="outline" size="xs">
+                    xsmall
+                </QuillButton>
+                <QuillButton variant="outline" size="sm">
+                    small
+                </QuillButton>
+                <QuillButton variant="outline">medium</QuillButton>
+                <QuillButton variant="outline" size="lg">
+                    large
+                </QuillButton>
+            </div>
+        </div>
+    )
+}
+
+export const SideBySide: StoryObj = {
+    render: () => (
+        <div className="grid grid-cols-3 gap-4">
+            <div className="border rounded p-4">
+                <h4 className="mb-4">LemonButton today</h4>
+                <LemonExamples />
+            </div>
+            <div className="border rounded p-4" data-quill data-quill-skin>
+                <h4 className="mb-4">LemonButton + quill skin (same code)</h4>
+                <LemonExamples />
+            </div>
+            <div className="border rounded p-4" data-quill>
+                <h4 className="mb-4">Quill Button (target)</h4>
+                <QuillExamples />
+            </div>
+        </div>
+    ),
+}

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
@@ -6,11 +6,15 @@ import { Button as QuillButton } from '@posthog/quill'
 import { LemonButton } from './LemonButton'
 
 /**
- * Prototype of the "token bridge" migration strategy: `quill-skin.scss` restyles
- * LemonButton to quill's visual language purely via the CSS custom properties it
- * already consumes. The middle column renders the exact same LemonButton code as
- * the left column — only the `data-quill data-quill-skin` wrapper differs. The
- * right column is the real quill Button for comparison.
+ * Prototypes of the two possible "skin bridge" migration directions:
+ *
+ * - `SideBySide` (quill-skin.scss): LemonButton restyled to quill's visual
+ *   language — ship the new look first, migrate code later.
+ * - `ReverseSideBySide` (lemon-skin.scss): quill Button restyled to Lemon's
+ *   current look — migrate code invisibly first, flip the look at the end.
+ *
+ * In both stories the middle column renders the exact same code as its
+ * reference column — only the skin wrapper attribute differs.
  */
 const meta: Meta = {
     title: 'Lemon UI/Lemon Button Quill Skin',
@@ -112,6 +116,25 @@ export const SideBySide: StoryObj = {
             <div className="border rounded p-4" data-quill>
                 <h4 className="mb-4">Quill Button (target)</h4>
                 <QuillExamples />
+            </div>
+        </div>
+    ),
+}
+
+export const ReverseSideBySide: StoryObj = {
+    render: () => (
+        <div className="grid grid-cols-3 gap-4">
+            <div className="border rounded p-4" data-quill>
+                <h4 className="mb-4">Quill Button today</h4>
+                <QuillExamples />
+            </div>
+            <div className="border rounded p-4" data-quill data-lemon-skin>
+                <h4 className="mb-4">Quill Button + lemon skin (same code)</h4>
+                <QuillExamples />
+            </div>
+            <div className="border rounded p-4">
+                <h4 className="mb-4">LemonButton (target)</h4>
+                <LemonExamples />
             </div>
         </div>
     ),

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
@@ -14,6 +14,13 @@ import { LemonButton } from './LemonButton'
  */
 const meta: Meta = {
     title: 'Lemon UI/Lemon Button Quill Skin',
+    parameters: {
+        testOptions: {
+            // The story intentionally shows always-loading buttons, whose spinners
+            // would otherwise time out the snapshot runner's loader wait
+            waitForLoadersToDisappear: false,
+        },
+    },
 }
 export default meta
 

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButtonQuillSkin.stories.tsx
@@ -1,7 +1,48 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { IconPlus, IconTrash } from '@posthog/icons'
-import { Button as QuillButton } from '@posthog/quill'
+import {
+    LemonCheckbox,
+    LemonDivider,
+    LemonInput,
+    LemonLabel,
+    LemonSelect,
+    LemonSkeleton,
+    LemonSnack,
+    LemonSwitch,
+    LemonTabs,
+    LemonTag,
+    LemonTextArea,
+} from '@posthog/lemon-ui'
+import {
+    Badge,
+    Button as QuillButton,
+    Checkbox,
+    Chip,
+    Input,
+    Kbd,
+    Label,
+    Progress,
+    RadioGroup,
+    RadioGroupItem,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Separator,
+    Skeleton,
+    Switch,
+    Tabs,
+    TabsList,
+    TabsTrigger,
+    Textarea,
+} from '@posthog/quill'
+
+import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
+import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 
 import { LemonButton } from './LemonButton'
 
@@ -135,6 +176,201 @@ export const ReverseSideBySide: StoryObj = {
             <div className="border rounded p-4">
                 <h4 className="mb-4">LemonButton (target)</h4>
                 <LemonExamples />
+            </div>
+        </div>
+    ),
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1">
+            <h5>{title}</h5>
+            {children}
+        </div>
+    )
+}
+
+function QuillKitchenSink({ idPrefix }: { idPrefix: string }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-4">
+            <Section title="Input">
+                <Input placeholder="Type here..." />
+            </Section>
+            <Section title="Textarea">
+                <Textarea placeholder="Longer text here..." />
+            </Section>
+            <Section title="Checkbox">
+                <div className="flex items-center gap-2">
+                    <Checkbox id={`${idPrefix}-check`} defaultChecked />
+                    <Label htmlFor={`${idPrefix}-check`}>Accept terms</Label>
+                </div>
+            </Section>
+            <Section title="Switch">
+                <div className="flex items-center gap-2">
+                    <Switch id={`${idPrefix}-switch`} defaultChecked />
+                    <Label htmlFor={`${idPrefix}-switch`}>Notifications</Label>
+                </div>
+            </Section>
+            <Section title="Radio">
+                <RadioGroup defaultValue="a" className="flex flex-col gap-2">
+                    <div className="flex items-center gap-2">
+                        <RadioGroupItem value="a" id={`${idPrefix}-radio-a`} />
+                        <Label htmlFor={`${idPrefix}-radio-a`}>Option A</Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <RadioGroupItem value="b" id={`${idPrefix}-radio-b`} />
+                        <Label htmlFor={`${idPrefix}-radio-b`}>Option B</Label>
+                    </div>
+                </RadioGroup>
+            </Section>
+            <Section title="Select (closed)">
+                <Select>
+                    <SelectTrigger>
+                        <SelectValue placeholder="Choose a fruit..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="apple">Apple</SelectItem>
+                        <SelectItem value="banana">Banana</SelectItem>
+                    </SelectContent>
+                </Select>
+            </Section>
+            <Section title="Badge / tag">
+                <div className="flex gap-2">
+                    <Badge>default</Badge>
+                    <Badge variant="success">success</Badge>
+                    <Badge variant="warning">warning</Badge>
+                    <Badge variant="destructive">danger</Badge>
+                </div>
+            </Section>
+            <Section title="Chip / snack">
+                <div className="flex gap-2">
+                    <Chip>browser: Chrome</Chip>
+                    <Chip>os: macOS</Chip>
+                </div>
+            </Section>
+            <Section title="Kbd">
+                <div className="flex gap-1">
+                    <Kbd>Cmd</Kbd>
+                    <Kbd>K</Kbd>
+                </div>
+            </Section>
+            <Section title="Progress">
+                <Progress value={40} />
+            </Section>
+            <Section title="Skeleton">
+                <Skeleton className="h-4 w-32" />
+            </Section>
+            <Section title="Divider">
+                <Separator />
+            </Section>
+            <Section title="Tabs">
+                <Tabs defaultValue="first">
+                    <TabsList variant="line">
+                        <TabsTrigger value="first">First tab</TabsTrigger>
+                        <TabsTrigger value="second">Second tab</TabsTrigger>
+                    </TabsList>
+                </Tabs>
+            </Section>
+            <Section title="Label">
+                <Label>Field label</Label>
+            </Section>
+        </div>
+    )
+}
+
+function LemonKitchenSink(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-4">
+            <Section title="Input">
+                <LemonInput placeholder="Type here..." />
+            </Section>
+            <Section title="Textarea">
+                <LemonTextArea placeholder="Longer text here..." />
+            </Section>
+            <Section title="Checkbox">
+                <LemonCheckbox checked label="Accept terms" onChange={() => {}} />
+            </Section>
+            <Section title="Switch">
+                <LemonSwitch checked label="Notifications" onChange={() => {}} />
+            </Section>
+            <Section title="Radio">
+                <LemonRadio
+                    value="a"
+                    onChange={() => {}}
+                    options={[
+                        { value: 'a', label: 'Option A' },
+                        { value: 'b', label: 'Option B' },
+                    ]}
+                />
+            </Section>
+            <Section title="Select (closed)">
+                <LemonSelect<string>
+                    value={null}
+                    onChange={() => {}}
+                    placeholder="Choose a fruit..."
+                    options={[
+                        { value: 'apple', label: 'Apple' },
+                        { value: 'banana', label: 'Banana' },
+                    ]}
+                />
+            </Section>
+            <Section title="Badge / tag">
+                <div className="flex gap-2">
+                    <LemonTag>default</LemonTag>
+                    <LemonTag type="success">success</LemonTag>
+                    <LemonTag type="warning">warning</LemonTag>
+                    <LemonTag type="danger">danger</LemonTag>
+                </div>
+            </Section>
+            <Section title="Chip / snack">
+                <div className="flex gap-2">
+                    <LemonSnack>browser: Chrome</LemonSnack>
+                    <LemonSnack>os: macOS</LemonSnack>
+                </div>
+            </Section>
+            <Section title="Kbd">
+                <KeyboardShortcut command k />
+            </Section>
+            <Section title="Progress">
+                <LemonProgress percent={40} />
+            </Section>
+            <Section title="Skeleton">
+                <LemonSkeleton className="h-4 w-32" />
+            </Section>
+            <Section title="Divider">
+                <LemonDivider />
+            </Section>
+            <Section title="Tabs">
+                <LemonTabs
+                    activeKey="first"
+                    onChange={() => {}}
+                    tabs={[
+                        { key: 'first', label: 'First tab' },
+                        { key: 'second', label: 'Second tab' },
+                    ]}
+                />
+            </Section>
+            <Section title="Label">
+                <LemonLabel>Field label</LemonLabel>
+            </Section>
+        </div>
+    )
+}
+
+export const ReverseKitchenSink: StoryObj = {
+    render: () => (
+        <div className="grid grid-cols-3 gap-4">
+            <div className="border rounded p-4" data-quill>
+                <h4 className="mb-4">Quill today</h4>
+                <QuillKitchenSink idPrefix="native" />
+            </div>
+            <div className="border rounded p-4" data-quill data-lemon-skin>
+                <h4 className="mb-4">Quill + lemon skin (same code)</h4>
+                <QuillKitchenSink idPrefix="skinned" />
+            </div>
+            <div className="border rounded p-4">
+                <h4 className="mb-4">LemonUI (target)</h4>
+                <LemonKitchenSink />
             </div>
         </div>
     ),

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -14,3 +14,4 @@
 @import '../../node_modules/@posthog/quill/dist/primitives.css';
 @import 'quill-bridge';
 @import 'quill-skin';
+@import 'lemon-skin';

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -13,3 +13,4 @@
 @import '../../node_modules/@posthog/quill/dist/base.scoped.css';
 @import '../../node_modules/@posthog/quill/dist/primitives.css';
 @import 'quill-bridge';
+@import 'quill-skin';

--- a/frontend/src/styles/lemon-skin.scss
+++ b/frontend/src/styles/lemon-skin.scss
@@ -1,11 +1,12 @@
 /*
- * PROTOTYPE — Lemon skin for quill (Button only, for now).
+ * PROTOTYPE — Lemon skin for quill.
  *
- * The mirror of quill-skin.scss: restyles quill's Button to LemonUI's current
- * visual language, so quill components can be adopted inside Lemon scenes with
- * zero visible change. Under this strategy the code migrates Lemon → quill
- * invisibly (migration PRs are snapshot-identical), and the new design ships
- * in one final flip: removing this skin reveals quill's native look app-wide.
+ * The mirror of quill-skin.scss: restyles quill primitives to LemonUI's
+ * current visual language, so quill components can be adopted inside Lemon
+ * scenes with zero visible change. Under this strategy the code migrates
+ * Lemon → quill invisibly (migration PRs are snapshot-identical), and the new
+ * design ships in one final flip: removing this skin reveals quill's native
+ * look app-wide.
  *
  * Opt in with a wrapper attribute (alongside `data-quill`, which quill
  * components need for their tokens anyway):
@@ -13,38 +14,72 @@
  *     <div data-quill data-lemon-skin>…</div>
  *
  * Quill's own rules live in `@layer components`, so these unlayered overrides
- * win the cascade without specificity hacks — the reverse skin doesn't need
- * the doubled selectors and !important that quill-skin.scss does.
+ * win the cascade without specificity hacks.
  *
- * Mapping (quill Button variant → Lemon type):
- *   primary     → primary    (white face, brown border, amber 3D frame below)
- *   outline     → secondary  (off-white face, grey border, grey frame)
- *   default     → tertiary   (ghost: transparent, grey fill on hover)
- *   destructive → secondary + status="danger" (orange text/border, orange frame)
+ * Covered: Button, Input, Textarea, Checkbox, Switch, RadioGroup, Select,
+ * Badge (→ LemonTag), Chip (→ LemonSnack), Separator, Skeleton, Label, Kbd,
+ * Tooltip, Popover/DropdownMenu/ContextMenu surfaces, Tabs (line variant),
+ * Dialog (→ LemonModal), Progress.
  *
- * Lemon's 3D chrome (a bordered frame extending below the button face) is
- * approximated on quill's single-element markup with two hard box-shadows:
- * the frame band, plus a 1px spread ring for the border around it.
+ * PORTAL CAVEAT: overlay content (tooltip, menus, select popup, dialog)
+ * renders in portals at <body>, outside any scoped wrapper. Those rules only
+ * take effect when the attributes sit on <body>/<html> — which is exactly the
+ * eventual app-wide flip deployment. In scoped demos, overlays keep quill's
+ * native look.
  *
- * Known gaps, acceptable for a prototype:
- *   - link / link-muted variants and icon-* sizes keep quill's styling
- *   - no hover-raise / press-sink travel (Lemon moves ±0.5px; static here)
- *   - focus rings keep quill's style
+ * Known gaps, acceptable for a prototype: link/link-muted button variants,
+ * icon-* button sizes, Accordion/Collapsible, Card, Avatar, Table, Toast,
+ * Drawer, Slider, Toggle, NumberField, and quill's `sm` control sizes keep
+ * quill styling; no hover-raise/press-sink travel on buttons.
  */
 
+/*
+ * Lemon token aliases. quill-bridge.scss rebinds several Lemon var names
+ * (`--color-border-primary`, `--color-accent`, `--color-bg-surface-primary`,
+ * `--color-text-secondary`, `--color-bg-primary`, …) to QUILL tokens inside
+ * `[data-quill]`, so referencing those names here would resolve to quill
+ * values. These aliases restore the Lemon values (mirroring base.scss) under
+ * skin-local names. `--radius`/`--radius-lg` are likewise shadowed by quill's
+ * scoped tokens, hence the literals.
+ */
+[data-lemon-skin] {
+    --lemon-skin-accent: hsl(
+        var(--color-brand-primary-hue),
+        var(--color-brand-primary-saturation),
+        var(--color-brand-primary-lightness)
+    );
+    --lemon-skin-accent-hover: hsl(
+        var(--color-brand-primary-hue),
+        var(--color-brand-primary-saturation),
+        calc(var(--color-brand-primary-lightness) + 10%)
+    );
+    --lemon-skin-border: var(--color-posthog-3000-200);
+    --lemon-skin-border-hover: var(--color-posthog-3000-400);
+    --lemon-skin-surface: var(--color-white);
+    --lemon-skin-bg-page: var(--color-posthog-3000-50);
+    --lemon-skin-radius: 0.375rem;
+    --lemon-skin-radius-lg: 0.625rem;
+}
+
+[theme='dark'] [data-lemon-skin] {
+    --lemon-skin-border: var(--color-neutral-cool-800);
+    --lemon-skin-border-hover: var(--color-neutral-cool-600);
+    --lemon-skin-surface: var(--color-neutral-cool-850);
+    --lemon-skin-bg-page: var(--color-neutral-cool-950);
+}
+
+/* ═══ Button → LemonButton ═════════════════════════════════════════════ */
+
 [data-lemon-skin] .quill-button {
-    /* Lemon's scale: 6px corners, 14px text, 37px medium height.
-       0.375rem is Lemon's --radius literal — quill's scoped tokens shadow
-       `--radius` (0.58rem) inside [data-quill], so the var can't be used here */
     font-family: var(--font-button);
     font-size: 0.875rem;
     font-weight: 500;
     line-height: 1.5rem;
     color: var(--text-3000);
-    border-radius: 0.375rem;
+    border-radius: var(--lemon-skin-radius);
 }
 
-/* ── primary → Lemon primary ──────────────────────────────────────────── */
+/* primary → Lemon primary (white face, brown border, amber 3D frame below) */
 
 [data-lemon-skin] .quill-button--variant-primary {
     color: var(--text-3000-light);
@@ -66,7 +101,7 @@
     translate: 0 0.1875rem;
 }
 
-/* ── outline → Lemon secondary ────────────────────────────────────────── */
+/* outline → Lemon secondary */
 
 [data-lemon-skin] .quill-button--variant-outline {
     background-color: var(--secondary-3000-button-bg);
@@ -87,7 +122,7 @@
     translate: 0 0.1875rem;
 }
 
-/* ── default (ghost) → Lemon tertiary ─────────────────────────────────── */
+/* default (ghost) → Lemon tertiary */
 
 [data-lemon-skin] .quill-button--variant-default {
     background-color: transparent;
@@ -104,7 +139,7 @@
     background-color: var(--color-bg-fill-button-tertiary-active);
 }
 
-/* ── destructive → Lemon secondary + status="danger" ──────────────────── */
+/* destructive → Lemon secondary + status="danger" */
 
 [data-lemon-skin] .quill-button--variant-destructive {
     color: var(--danger-3000-button-border-hover);
@@ -125,7 +160,7 @@
     translate: 0 0.1875rem;
 }
 
-/* ── Sizes → Lemon's xsmall / small / medium / large scale ────────────── */
+/* Sizes → Lemon's xsmall / small / medium / large scale */
 
 [data-lemon-skin] .quill-button--size-default {
     gap: 0.5rem;
@@ -144,7 +179,7 @@
     height: 1.625rem;
     padding-inline: 0.375rem;
     font-size: 0.75rem;
-    border-radius: 0.375rem;
+    border-radius: var(--lemon-skin-radius);
 }
 
 [data-lemon-skin] .quill-button--size-xs svg:not([class*='size-']) {
@@ -174,4 +209,380 @@
 [data-lemon-skin] .quill-button--size-lg svg:not([class*='size-']) {
     width: 1.75rem;
     height: 1.75rem;
+}
+
+/* ═══ Input → LemonInput ═══════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-input {
+    height: calc(2.125rem + 3px);
+    padding: 0.25rem 0.5rem;
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    color: var(--text-3000);
+    background-color: var(--color-bg-fill-input);
+    border: 1px solid var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-input:hover:not(:disabled),
+[data-lemon-skin] .quill-input:focus-visible {
+    /* Lemon inputs signal focus with a border-color change, not a ring */
+    border-color: var(--lemon-skin-border-hover);
+    box-shadow: none;
+}
+
+/* ═══ Textarea → LemonTextArea ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-textarea {
+    min-height: 2.5rem;
+    padding: 0.5rem;
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    line-height: 1.4;
+    color: var(--text-3000);
+    background-color: var(--color-bg-fill-input);
+    border: 1px solid var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-textarea:hover:not(:disabled),
+[data-lemon-skin] .quill-textarea:focus-visible {
+    border-color: var(--lemon-skin-border-hover);
+    box-shadow: none;
+}
+
+/* ═══ Checkbox → LemonCheckbox ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-checkbox,
+[data-lemon-skin] .quill-checkbox-indicator {
+    /* Lemon has a single 1rem box size */
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--lemon-skin-surface);
+    border: 1.5px solid var(--lemon-skin-border);
+    border-radius: 0.25rem;
+}
+
+[data-lemon-skin] .quill-checkbox:hover:not(:disabled) {
+    border-color: var(--lemon-skin-accent-hover);
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-checkbox:focus-visible {
+    border-color: var(--lemon-skin-accent-hover);
+    box-shadow: none;
+    outline: -webkit-focus-ring-color auto 1px;
+}
+
+[data-lemon-skin] .quill-checkbox[data-checked],
+[data-lemon-skin] .quill-checkbox-indicator--checked {
+    color: var(--lemon-skin-surface);
+    background-color: var(--lemon-skin-accent);
+    border-color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-checkbox[data-checked]:hover:not(:disabled) {
+    background-color: var(--lemon-skin-accent-hover);
+    border-color: var(--lemon-skin-accent-hover);
+}
+
+/* ═══ Switch → LemonSwitch ═════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-switch {
+    border: none;
+    outline: 1px solid var(--lemon-skin-border);
+}
+
+/* Lemon medium: 13px handle in a 28×15 pill track */
+
+[data-lemon-skin] .quill-switch[data-size='default'] {
+    width: 28px;
+    height: 15px;
+}
+
+[data-lemon-skin] .quill-switch[data-size='default'] .quill-switch__thumb {
+    width: 13px;
+    height: 13px;
+}
+
+[data-lemon-skin] .quill-switch[data-unchecked] {
+    background-color: var(--color-bg-fill-switch);
+}
+
+[data-lemon-skin] .quill-switch[data-checked] {
+    background-color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-switch__thumb {
+    /* Lemon hardcodes a white handle in the off state */
+    background-color: #fff;
+}
+
+[data-lemon-skin] .quill-switch[data-checked] .quill-switch__thumb {
+    background-color: var(--lemon-skin-surface);
+    transform: translateX(100%);
+}
+
+/* ═══ RadioGroup — Lemon uses native radios; accent-tint is the analog ═ */
+
+[data-lemon-skin] .quill-radio {
+    background-color: var(--lemon-skin-surface);
+    border-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-radio:focus-visible {
+    border-color: var(--lemon-skin-accent-hover);
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-radio[data-checked] {
+    color: var(--lemon-skin-surface);
+    background-color: var(--lemon-skin-accent);
+    border-color: var(--lemon-skin-accent);
+}
+
+/* ═══ Badge → LemonTag ═════════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-badge {
+    height: auto;
+    padding: 0.125rem 0.25rem;
+    font-family: var(--font-sans);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    line-height: 1rem;
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-badge--variant-default {
+    color: var(--text-3000);
+    background-color: transparent;
+    border-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-badge--variant-info {
+    /* Lemon has no blue tag; its "primary" (accent outline) is the analog */
+    color: var(--lemon-skin-accent);
+    background-color: transparent;
+    border-color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-badge--variant-success {
+    color: var(--success);
+    background-color: transparent;
+    border-color: var(--success);
+}
+
+[data-lemon-skin] .quill-badge--variant-warning {
+    color: var(--warning);
+    background-color: transparent;
+    border-color: var(--warning);
+}
+
+[data-lemon-skin] .quill-badge--variant-destructive {
+    color: var(--danger);
+    background-color: transparent;
+    border-color: var(--danger);
+}
+
+/* ═══ Chip → LemonSnack ════════════════════════════════════════════════ */
+
+/*
+ * Chip composes Button (variant=outline), so this must out-order the button
+ * outline rules above to strip the secondary-button chrome.
+ */
+[data-lemon-skin] .quill-chip {
+    padding-block: 0.25rem;
+    padding-inline: 0.375rem;
+    font-size: 0.8125rem;
+    color: var(--text-3000);
+    background-color: var(--color-accent-highlight-secondary);
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-chip:not(:disabled, [aria-disabled='true']):hover {
+    background-color: var(--color-accent-highlight-secondary);
+    border-color: transparent;
+}
+
+/* ═══ Separator → LemonDivider ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-separator {
+    background-color: var(--lemon-skin-border);
+}
+
+/* ═══ Skeleton → LemonSkeleton (shimmer, not pulse) ════════════════════ */
+
+[data-lemon-skin] .quill-skeleton {
+    background: linear-gradient(
+        90deg,
+        var(--color-skeleton-light) 25%,
+        var(--color-skeleton-dark) 45%,
+        var(--color-skeleton-light) 65%
+    );
+    background-size: 400% 100%;
+    border-radius: var(--lemon-skin-radius);
+
+    /* Reuses the global keyframes from LemonSkeleton.scss */
+    animation: LemonSkeleton__shimmer 2s ease infinite;
+}
+
+/* ═══ Label → LemonLabel ═══════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-label {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.5rem;
+}
+
+/* ═══ Kbd → KeyboardShortcut keycap ════════════════════════════════════ */
+
+[data-lemon-skin] .quill-kbd {
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0.125rem 0.25rem;
+    font-family: var(--font-title);
+    font-size: 0.75rem;
+    color: var(--text-3000);
+    background: var(--lemon-skin-surface);
+    border: 1px solid var(--secondary-3000-button-border-hover);
+
+    /* The thicker bottom edge gives Lemon's keycap bevel */
+    border-bottom-width: 2px;
+    border-radius: 0.25rem;
+}
+
+/* ═══ Tooltip → Lemon Tooltip (see PORTAL CAVEAT above) ════════════════ */
+
+[data-lemon-skin] .quill-tooltip__content {
+    font-family: var(--font-sans);
+    color: var(--color-text-primary-inverse);
+    background-color: var(--color-bg-surface-tooltip);
+    border-radius: var(--lemon-skin-radius);
+    box-shadow: var(--modal-shadow-elevation);
+}
+
+[data-lemon-skin] .quill-tooltip__arrow {
+    background-color: var(--color-bg-surface-tooltip);
+    fill: var(--color-bg-surface-tooltip);
+}
+
+/* ═══ Popover / menu / select surfaces → Lemon Popover box ═════════════ */
+
+[data-lemon-skin] .quill-popover__content,
+[data-lemon-skin] .quill-menu__content,
+[data-lemon-skin] .quill-menu__sub-content,
+[data-lemon-skin] .quill-select__content {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    background-color: var(--color-bg-surface-popover);
+    border: 1px solid var(--secondary-3000-button-border);
+    border-radius: var(--lemon-skin-radius-lg);
+    box-shadow: var(--shadow-elevation-3000);
+}
+
+[data-lemon-skin] .quill-menu__separator,
+[data-lemon-skin] .quill-select__separator {
+    background-color: var(--lemon-skin-border);
+}
+
+/* Select/menu rows sized like the small LemonButtons LemonMenu renders */
+
+[data-lemon-skin] .quill-select__item {
+    min-height: 2.0625rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-select__item:focus {
+    background-color: var(--color-bg-fill-button-tertiary-hover);
+}
+
+[data-lemon-skin] .quill-select__item:not(:hover)[aria-selected='true'] {
+    background-color: var(--color-bg-fill-button-tertiary-active);
+}
+
+/* ═══ Tabs (line variant) → LemonTabs ══════════════════════════════════ */
+
+[data-lemon-skin] .quill-tabs__trigger {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-tertiary);
+}
+
+[data-lemon-skin] .quill-tabs__trigger:hover {
+    color: var(--text-3000);
+    background-color: transparent;
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-line {
+    gap: 1rem;
+    height: auto;
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-line .quill-tabs__trigger {
+    flex: 0 0 auto;
+    padding-block: 0.5rem;
+    padding-inline: 0;
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-line .quill-tabs__trigger[data-active] {
+    /*
+     * Quill paints the active tab `var(--background) !important`; a layered
+     * !important can't be out-cascaded from here, but rebinding the var it
+     * resolves can.
+     */
+    --background: transparent;
+
+    color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-tabs__indicator--variant-line {
+    background-color: var(--lemon-skin-accent);
+}
+
+/* ═══ Progress → LemonProgress ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-progress__track {
+    height: 0.375rem;
+    background-color: var(--lemon-skin-bg-page);
+    border-radius: 9999px;
+}
+
+[data-lemon-skin] .quill-progress__indicator {
+    border-radius: 9999px;
+}
+
+[data-lemon-skin] .quill-progress__indicator--variant-default {
+    background-color: var(--brand-blue);
+}
+
+/* ═══ Dialog → LemonModal (see PORTAL CAVEAT above) ════════════════════ */
+
+[data-lemon-skin] .quill-dialog__content {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    background-color: var(--lemon-skin-surface);
+    border: 1px solid var(--border-bold);
+    border-radius: var(--lemon-skin-radius);
+    box-shadow: var(--modal-shadow-elevation);
+}
+
+[data-lemon-skin] .quill-dialog__title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    line-height: 1.5rem;
+}
+
+[data-lemon-skin] .quill-dialog__header:has(~ [data-slot='dialog-body']) {
+    border-bottom-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-dialog__footer {
+    background-color: transparent;
+    border-top-color: var(--lemon-skin-border);
 }

--- a/frontend/src/styles/lemon-skin.scss
+++ b/frontend/src/styles/lemon-skin.scss
@@ -1,0 +1,177 @@
+/*
+ * PROTOTYPE — Lemon skin for quill (Button only, for now).
+ *
+ * The mirror of quill-skin.scss: restyles quill's Button to LemonUI's current
+ * visual language, so quill components can be adopted inside Lemon scenes with
+ * zero visible change. Under this strategy the code migrates Lemon → quill
+ * invisibly (migration PRs are snapshot-identical), and the new design ships
+ * in one final flip: removing this skin reveals quill's native look app-wide.
+ *
+ * Opt in with a wrapper attribute (alongside `data-quill`, which quill
+ * components need for their tokens anyway):
+ *
+ *     <div data-quill data-lemon-skin>…</div>
+ *
+ * Quill's own rules live in `@layer components`, so these unlayered overrides
+ * win the cascade without specificity hacks — the reverse skin doesn't need
+ * the doubled selectors and !important that quill-skin.scss does.
+ *
+ * Mapping (quill Button variant → Lemon type):
+ *   primary     → primary    (white face, brown border, amber 3D frame below)
+ *   outline     → secondary  (off-white face, grey border, grey frame)
+ *   default     → tertiary   (ghost: transparent, grey fill on hover)
+ *   destructive → secondary + status="danger" (orange text/border, orange frame)
+ *
+ * Lemon's 3D chrome (a bordered frame extending below the button face) is
+ * approximated on quill's single-element markup with two hard box-shadows:
+ * the frame band, plus a 1px spread ring for the border around it.
+ *
+ * Known gaps, acceptable for a prototype:
+ *   - link / link-muted variants and icon-* sizes keep quill's styling
+ *   - no hover-raise / press-sink travel (Lemon moves ±0.5px; static here)
+ *   - focus rings keep quill's style
+ */
+
+[data-lemon-skin] .quill-button {
+    /* Lemon's scale: 6px corners, 14px text, 37px medium height.
+       0.375rem is Lemon's --radius literal — quill's scoped tokens shadow
+       `--radius` (0.58rem) inside [data-quill], so the var can't be used here */
+    font-family: var(--font-button);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.5rem;
+    color: var(--text-3000);
+    border-radius: 0.375rem;
+}
+
+/* ── primary → Lemon primary ──────────────────────────────────────────── */
+
+[data-lemon-skin] .quill-button--variant-primary {
+    color: var(--text-3000-light);
+    background-color: var(--primary-3000-button-bg);
+    border: 1px solid var(--primary-3000-button-border);
+    box-shadow:
+        0 0.1875rem 0 0 var(--primary-3000-frame-bg),
+        0 0.1875rem 0 1px var(--primary-3000-button-border);
+    translate: none;
+}
+
+[data-lemon-skin] .quill-button--variant-primary:not(:disabled, [aria-disabled='true']):hover {
+    background-color: var(--primary-3000-button-bg);
+    border-color: var(--primary-3000-button-border-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-primary:not(:disabled, [aria-disabled='true']):active {
+    box-shadow: none;
+    translate: 0 0.1875rem;
+}
+
+/* ── outline → Lemon secondary ────────────────────────────────────────── */
+
+[data-lemon-skin] .quill-button--variant-outline {
+    background-color: var(--secondary-3000-button-bg);
+    border: 1px solid var(--secondary-3000-button-border);
+    box-shadow:
+        0 0.1875rem 0 0 var(--secondary-3000-frame-bg),
+        0 0.1875rem 0 1px var(--secondary-3000-button-border);
+}
+
+[data-lemon-skin] .quill-button--variant-outline:not(:disabled, [aria-disabled='true']):hover {
+    color: var(--text-3000);
+    background-color: var(--secondary-3000-button-bg);
+    border-color: var(--secondary-3000-button-border-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-outline:not(:disabled, [aria-disabled='true']):active {
+    box-shadow: none;
+    translate: 0 0.1875rem;
+}
+
+/* ── default (ghost) → Lemon tertiary ─────────────────────────────────── */
+
+[data-lemon-skin] .quill-button--variant-default {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-button--variant-default:not(:disabled, [aria-disabled='true']):hover {
+    color: var(--text-3000);
+    background-color: var(--color-bg-fill-button-tertiary-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-default:not(:disabled, [aria-disabled='true']):active {
+    background-color: var(--color-bg-fill-button-tertiary-active);
+}
+
+/* ── destructive → Lemon secondary + status="danger" ──────────────────── */
+
+[data-lemon-skin] .quill-button--variant-destructive {
+    color: var(--danger-3000-button-border-hover);
+    background-color: var(--secondary-3000-button-bg);
+    border: 1px solid var(--danger-3000-button-border);
+    box-shadow:
+        0 0.1875rem 0 0 var(--danger-3000-frame-bg),
+        0 0.1875rem 0 1px var(--danger-3000-button-border);
+}
+
+[data-lemon-skin] .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):hover {
+    background-color: var(--secondary-3000-button-bg);
+    border-color: var(--danger-3000-button-border-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):active {
+    box-shadow: none;
+    translate: 0 0.1875rem;
+}
+
+/* ── Sizes → Lemon's xsmall / small / medium / large scale ────────────── */
+
+[data-lemon-skin] .quill-button--size-default {
+    gap: 0.5rem;
+    height: 2.3125rem;
+    padding-inline: 0.75rem;
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-button--size-default svg:not([class*='size-']) {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+[data-lemon-skin] .quill-button--size-xs {
+    gap: 0.25rem;
+    height: 1.625rem;
+    padding-inline: 0.375rem;
+    font-size: 0.75rem;
+    border-radius: 0.375rem;
+}
+
+[data-lemon-skin] .quill-button--size-xs svg:not([class*='size-']) {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+[data-lemon-skin] .quill-button--size-sm {
+    gap: 0.5rem;
+    height: 2.0625rem;
+    padding-inline: 0.5rem;
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-button--size-sm svg:not([class*='size-']) {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+[data-lemon-skin] .quill-button--size-lg {
+    gap: 0.75rem;
+    height: 3.0625rem;
+    padding-inline: 0.75rem;
+    font-size: 1rem;
+}
+
+[data-lemon-skin] .quill-button--size-lg svg:not([class*='size-']) {
+    width: 1.75rem;
+    height: 1.75rem;
+}

--- a/frontend/src/styles/quill-skin.scss
+++ b/frontend/src/styles/quill-skin.scss
@@ -1,0 +1,163 @@
+/*
+ * PROTOTYPE — quill skin for LemonUI (LemonButton only, for now).
+ *
+ * Restyles LemonButton to quill's visual language without touching a single
+ * call site. LemonButton is styled almost entirely through CSS custom
+ * properties (`--lemon-button-*`), so the skin is mostly variable
+ * reassignment: point those vars at quill's semantic tokens (`--primary`,
+ * `--foreground`, `--fill-hover`, …) and the existing markup renders with
+ * quill's look.
+ *
+ * Opt in by putting BOTH attributes on a subtree root:
+ *
+ *     <div data-quill data-quill-skin>…</div>
+ *
+ * `data-quill` brings quill's scoped tokens into scope (tokens.scoped.css
+ * gates all quill vars behind it); `data-quill-skin` opts into this reskin.
+ * Keeping the two separate means existing quill islands (`data-quill` only)
+ * are unaffected. Flipping the whole app would mean setting both attributes
+ * at the root — the "ship the theme before the code migration" strategy this
+ * prototype exists to evaluate.
+ *
+ * See LemonButtonQuillSkin.stories.tsx for a side-by-side of
+ * Lemon today / Lemon + skin (same code) / native quill Button.
+ *
+ * Mapping (Lemon type → quill Button variant):
+ *   primary         → primary      (brand bg, 2px lift + hard shadow — quill
+ *                                    primary uses the same lift mechanic as
+ *                                    Lemon's chrome, expressed via
+ *                                    `--lemon-button-chrome-depth`)
+ *   secondary       → outline      (flat, hairline border, translucent muted bg)
+ *   tertiary        → default      (ghost: transparent, foreground-mix fill on hover)
+ *   status="danger" → destructive  (dark-red text on translucent pink)
+ *
+ * Known gaps, acceptable for a prototype:
+ *   - status="alt" keeps its Lemon styling
+ *   - sideAction buttons inherit the base skin but aren't specifically tuned
+ *   - LemonButton's font stays --font-sans; quill's line-height differs slightly
+ */
+
+/*
+ * Specificity note: Lemon's own variant rules reach (0,3,0) — e.g.
+ * `.LemonButton.LemonButton--secondary:not(…)` — and the import order between
+ * this file and component SCSS chunks isn't guaranteed. The
+ * `[data-quill][data-quill-skin]` prefix (0,2,0) plus the doubled classes on
+ * variant rules keeps everything here safely above Lemon's own declarations.
+ */
+
+/* stylelint-disable no-descending-specificity */
+
+[data-quill][data-quill-skin] .LemonButton {
+    /* Quill's scale: 4px corners, 12px text, 28px default height */
+    --lemon-button-radius: var(--radius-sm);
+    --lemon-button-font-size: 0.75rem;
+    --lemon-button-height: 1.75rem;
+    --lemon-button-icon-size: 0.875rem;
+    --lemon-button-gap: 0.5rem;
+    --lemon-button-padding-horizontal: 0.5rem;
+    --lemon-button-color: var(--foreground);
+    --lemon-button-icon-opacity: 1;
+    --opacity-disabled: 0.5;
+
+    /* Quill buttons are flat by default — no 3D chrome, no hover/press travel */
+    --lemon-button-chrome-depth: 0px;
+    --lemon-button-hover-depth: 0px;
+    --lemon-button-press-depth: 0px;
+
+    /* Tertiary ("ghost") fills read these app vars — point them at quill's */
+    --color-bg-fill-button-tertiary-hover: var(--fill-hover);
+    --color-bg-fill-button-tertiary-active: var(--fill-expanded);
+
+    font-family: var(--font-sans);
+}
+
+/* ── Sizes → quill's xs / sm / default / lg scale ─────────────────────── */
+
+[data-quill][data-quill-skin] .LemonButton.LemonButton--xxsmall,
+[data-quill][data-quill-skin] .LemonButton.LemonButton--xsmall {
+    --lemon-button-height: 1.25rem;
+    --lemon-button-font-size: 0.625rem;
+    --lemon-button-icon-size: 0.625rem;
+    --lemon-button-gap: 0.25rem;
+    --lemon-button-radius: var(--radius-sm);
+    --lemon-button-padding-horizontal: 0.5rem;
+}
+
+[data-quill][data-quill-skin] .LemonButton.LemonButton--small {
+    --lemon-button-height: 1.5rem;
+    --lemon-button-font-size: 0.75rem;
+    --lemon-button-icon-size: 0.75rem;
+    --lemon-button-gap: 0.25rem;
+    --lemon-button-padding-horizontal: 0.5rem;
+}
+
+[data-quill][data-quill-skin] .LemonButton.LemonButton--large {
+    --lemon-button-height: 2rem;
+    --lemon-button-font-size: 0.75rem;
+    --lemon-button-icon-size: 1rem;
+    --lemon-button-gap: 0.5rem;
+    --lemon-button-padding-horizontal: 0.625rem;
+}
+
+/* ── primary → quill primary ──────────────────────────────────────────── */
+
+[data-quill][data-quill-skin] .LemonButton.LemonButton--primary:not(.LemonButton--status-danger) {
+    --lemon-button-bg-color: var(--primary);
+    --lemon-button-bg-color-active: var(--primary);
+    --lemon-button-color: var(--primary-foreground);
+    --button-border-color: transparent;
+    --lemon-button-border-color-hover: transparent;
+
+    /* Quill primary's lift: 2px hard shadow in the brand color at 50% */
+    --lemon-button-frame-bg-color: color-mix(in oklab, var(--primary) 50%, transparent);
+    --lemon-button-chrome-depth: 0.125rem;
+    --lemon-button-hover-depth: 0px;
+    --lemon-button-press-depth: 0.125rem; /* pressing sits the button flat, like quill's :active */
+}
+
+[data-quill][data-quill-skin]
+    .LemonButton.LemonButton--primary:not(.LemonButton--status-danger):hover:not([aria-disabled='true']) {
+    --lemon-button-bg-color: color-mix(in oklab, var(--primary) 98%, black 5%);
+}
+
+/* ── secondary → quill outline ────────────────────────────────────────── */
+
+[data-quill][data-quill-skin] .LemonButton.LemonButton--secondary.LemonButton--secondary {
+    --lemon-button-bg-color: color-mix(in oklab, var(--muted) 30%, transparent);
+    --lemon-button-bg-color-active: var(--fill-expanded);
+    --button-border-color: color-mix(in oklab, var(--foreground) 10%, transparent);
+    --lemon-button-border-color-hover: color-mix(in oklab, var(--foreground) 10%, transparent);
+    --lemon-button-frame-bg-color: transparent;
+    --lemon-button-chrome-depth: 0px;
+}
+
+[data-quill][data-quill-skin]
+    .LemonButton.LemonButton--secondary.LemonButton--secondary:hover:not([aria-disabled='true']) {
+    --lemon-button-bg-color: var(--fill-hover);
+}
+
+[theme='dark'] [data-quill][data-quill-skin] .LemonButton.LemonButton--secondary.LemonButton--secondary {
+    --button-border-color: color-mix(in oklab, var(--foreground) 15%, transparent);
+    --lemon-button-border-color-hover: color-mix(in oklab, var(--foreground) 15%, transparent);
+}
+
+/* ── status="danger" → quill destructive ──────────────────────────────── */
+
+[data-quill][data-quill-skin] .LemonButton.LemonButton--status-danger.LemonButton--status-danger {
+    /* !important matches Lemon's own danger color declaration, which we must out-rank */
+    --lemon-button-color: var(--destructive-foreground) !important;
+    --lemon-button-bg-color: color-mix(in oklab, var(--destructive) 50%, transparent);
+    --lemon-button-bg-color-active: var(--destructive);
+    --button-border-color: transparent;
+    --lemon-button-border-color-hover: transparent;
+    --lemon-button-frame-bg-color: transparent;
+    --lemon-button-chrome-depth: 0px;
+
+    /* Tertiary danger's hover fill reads this app var directly */
+    --danger-highlight: color-mix(in oklab, var(--destructive) 50%, transparent);
+}
+
+[data-quill][data-quill-skin]
+    .LemonButton.LemonButton--status-danger.LemonButton--status-danger:hover:not([aria-disabled='true']) {
+    --lemon-button-bg-color: var(--destructive);
+}


### PR DESCRIPTION
## Problem

We want to move the app to the quill design system, but LemonUI is ~72% of the frontend (3,169 files, ~12,300 `Lemon*` usages across 144 components). Migrating call sites will take quarters, and users shouldn't live with a half-and-half theme while that happens.

This PR prototypes both possible directions of a "skin bridge":

1. **Lemon-as-quill** (`quill-skin.scss`): restyle LemonButton to quill's visual language via the CSS custom properties it already consumes. Ships the new look first, code migrates later.
2. **Quill-as-lemon** (`lemon-skin.scss`): restyle quill primitives to Lemon's current look. Code migrates invisibly first (migration PRs are snapshot-identical), then removing the skin flips the whole app to quill's native look in one release.

Direction 2 has a structural advantage: quill's rules live in `@layer components`, so plain unlayered overrides win the cascade cleanly, and each future migration PR becomes verifiable by existing snapshot tests (zero visual change expected) instead of needing per-PR visual review.

The first real consumer (the taxonomic filter menu rebuild) is stacked on top: [#69476](https://github.com/PostHog/posthog/pull/69476).

## Changes

- `frontend/src/styles/quill-skin.scss` (new): LemonButton → quill look, gated behind `[data-quill][data-quill-skin]`.
- `frontend/src/styles/lemon-skin.scss` (new): quill → Lemon look, gated behind `[data-lemon-skin]`. Two layers:
  - A **core-token rebind**: quill's semantic tokens (`--foreground`, `--border`, `--card`, `--primary`, `--fill-*`, `--radius-*`, `--text-xs`, …) point at Lemon values inside the skin scope, which recolors quill primitive CSS *and* bespoke Tailwind in quill-based feature code wholesale. Extra selectors out-specificity `tokens.scoped.css`, which sets tokens directly on every `[data-quill]` element.
  - **Per-component rules** refining geometry/typography: Button, Input, InputGroup, Textarea, Checkbox, Switch, RadioGroup, Select, Badge (→ LemonTag), Chip (→ LemonSnack), Separator, Skeleton, Label, Kbd, Item, MenuLabel, Empty, Tooltip, Popover/DropdownMenu surfaces, Tabs, Dialog (→ LemonModal), Progress. Includes a `--lemon-skin-*` alias block restoring Lemon token values that `quill-bridge.scss` rebinds inside `[data-quill]` scopes.
- Three Storybook stories under `Lemon UI/Lemon Button Quill Skin` (`SideBySide`, `ReverseSideBySide`, `ReverseKitchenSink`), each rendering the same code with and without the skin next to the reference implementation.

> [!NOTE]
> The skin stylesheets are inert unless a subtree opts in via wrapper attributes — this PR changes no product surface by itself. Known gaps are documented in the stylesheet headers.

## How did you test this code?

The stories are the test surface: they render every mapped component three ways (quill native, quill + skin, Lemon reference) and snapshot in light and dark. No product behavior changes to test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: internal styling prototype, no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code). Sam directed the exploration: prototype both skin directions with real pixels, compare against reference components in side-by-side stories, and keep the skins inert-by-default behind opt-in attributes. The quill-as-lemon direction was chosen as the migration strategy; the lemon-as-quill stylesheet is kept as the comparison artifact.

This PR is the base of a two-PR stack; the taxonomic filter application and the iteration that followed (measured against the legacy picker with computed-style comparisons in a live app) lives in [#69476](https://github.com/PostHog/posthog/pull/69476).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
