### PR TITLE
fix(experiments): remove unused values from the recalculation query progress

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -2,11 +2,12 @@ import { useActions, useValues } from 'kea'
 
 import { IconBell, IconCheck, IconInfo } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+import { useAnimatedNumber } from '@posthog/quill-charts'
 
-import { TZLabel } from 'lib/components/TZLabel'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
+import { ExperimentLastRefreshText } from 'scenes/experiments/ExperimentView/ExperimentReloadAction'
 
 import { experimentMetricsLogic } from '~/scenes/experiments/experimentMetricsLogic'
 import { experimentResultsNotificationLogic } from '~/scenes/experiments/experimentResultsNotificationLogic'
@@ -69,8 +70,8 @@ export function RecalculationStatus({ experiment }: { experiment: Experiment }):
                         <>
                             <LemonDivider vertical className="h-3.5" />
                             <span className="flex items-center gap-1 whitespace-nowrap text-muted text-xs [&_span]:align-baseline">
-                                <span>Refreshed</span>
-                                <TZLabel time={currentRecalculation.completed_at} timestampStyle="relative" />
+                                <span>Results calculated </span>
+                                <ExperimentLastRefreshText lastRefresh={currentRecalculation.completed_at} />
                             </span>
                         </>
                     )}
@@ -179,10 +180,14 @@ function CountsSegment({
 
 function ClimbingRows({ rowsRead, estimatedRows }: { rowsRead: number; estimatedRows?: number }): JSX.Element {
     const showCeiling = estimatedRows !== undefined && estimatedRows >= rowsRead
+
+    const animatedRowsRead = useAnimatedNumber(rowsRead, 350)
+    const animatedEstimatedTotal = useAnimatedNumber(estimatedRows ?? 0, 350)
+
     return (
         <span className="text-muted text-xs whitespace-nowrap">
-            · {humanFriendlyNumber(rowsRead, 0)}
-            {showCeiling && ` / ${humanFriendlyNumber(estimatedRows, 0)}`} rows
+            · {humanFriendlyNumber(animatedRowsRead, 0)}
+            {showCeiling && ` / ${humanFriendlyNumber(animatedEstimatedTotal, 0)}`} rows read
         </span>
     )
 }

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -1229,18 +1229,6 @@ class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
         required=False,
         help_text="Per-metric results computed by this run, scoped by the run's recalc fingerprint",
     )
-    # Live ClickHouse progress, present only on the GET poll path while the run is in_progress (in-flight
-    # queries from system.processes plus queries finished during the run from system.query_log, matched by
-    # query_id prefix; see get_live_query_progress). build_job_payload omits these keys entirely for terminal
-    # or just-created runs, so they are genuinely optional in the response — NOT read_only=True, which
-    # drf-spectacular would force into the schema's `required` list (making the generated TypeScript
-    # `number | null` instead of the honest `number | null | undefined`). The serializer is output-only
-    # (never .is_valid()), so omitting read_only costs no input-validation safety.
-    running_metrics = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-        help_text="Count of metric queries currently running in ClickHouse (bounded by worker-pool concurrency)",
-    )
     rows_read = serializers.IntegerField(
         required=False,
         allow_null=True,
@@ -1256,19 +1244,6 @@ class ExperimentMetricsRecalculationSerializer(serializers.Serializer):
             "ClickHouse's total_rows_approx across running queries plus the final read_rows of finished ones. "
             "A soft ceiling revised mid-scan, so it can exceed or trail rows_read; treat rows_read as the "
             "reliable signal"
-        ),
-    )
-    bytes_read = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-        help_text="Bytes read by the run's metric queries so far, both finished and currently running",
-    )
-    active_cpu_time = serializers.IntegerField(
-        required=False,
-        allow_null=True,
-        help_text=(
-            "Active CPU time (microseconds) consumed by the run's metric queries so far, both finished and "
-            "currently running"
         ),
     )
 

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -95,9 +95,8 @@ def get_live_query_progress(recalc: ExperimentMetricsRecalculation) -> dict | No
     alone reads zero for most of the run; the query_log branch keeps finished queries counted, making
     rows_read cumulative and roughly monotonic across the run (modulo query_log flush lag).
 
-    `running_metrics` counts only the currently in-flight queries (bounded by the workflow's worker-pool
-    concurrency). `estimated_rows_total` is ClickHouse's own total_rows_approx for in-flight queries (revised
-    upward mid-scan) plus the final read_rows of finished ones, so it can trail rows_read; treat rows_read as
+    `estimated_rows_total` is ClickHouse's own total_rows_approx for in-flight queries (revised upward
+    mid-scan) plus the final read_rows of finished ones, so it can trail rows_read; treat rows_read as
     the primary signal. Temporal retries of a metric produce one query_log row per attempt and each attempt's
     rows are summed; that overcount is accepted for a decorative counter.
     """
@@ -122,27 +121,18 @@ def get_live_query_progress(recalc: ExperimentMetricsRecalculation) -> dict | No
                 """
                 SELECT
                     sum(rows_read) AS rows_read,
-                    sum(estimated_rows_total) AS estimated_rows_total,
-                    sum(bytes_read) AS bytes_read,
-                    sum(active_cpu_time) AS active_cpu_time,
-                    countIf(is_running = 1) AS running_metrics
+                    sum(estimated_rows_total) AS estimated_rows_total
                 FROM
                 (
                     SELECT
                         read_rows AS rows_read,
-                        total_rows_approx AS estimated_rows_total,
-                        read_bytes AS bytes_read,
-                        ProfileEvents['OSCPUVirtualTimeMicroseconds'] AS active_cpu_time,
-                        1 AS is_running
+                        total_rows_approx AS estimated_rows_total
                     FROM clusterAllReplicas(%(cluster)s, system.processes)
                     WHERE query_id LIKE %(prefix)s
                     UNION ALL
                     SELECT
                         read_rows AS rows_read,
-                        read_rows AS estimated_rows_total,
-                        read_bytes AS bytes_read,
-                        ProfileEvents['OSCPUVirtualTimeMicroseconds'] AS active_cpu_time,
-                        0 AS is_running
+                        read_rows AS estimated_rows_total
                     FROM clusterAllReplicas(%(cluster)s, system.query_log)
                     WHERE query_id LIKE %(prefix)s
                         AND type = 'QueryFinish'
@@ -161,16 +151,13 @@ def get_live_query_progress(recalc: ExperimentMetricsRecalculation) -> dict | No
         capture_exception()
         return None
 
-    rows_read, estimated_rows_total, bytes_read, active_cpu_time, running_metrics = rows[0]
+    rows_read, estimated_rows_total = rows[0]
     # All-zeros is a real, non-terminal state (queries not started yet, or finished but not flushed to
     # query_log), distinct from "run finished". Return the zeros so the poll can tell "in-flight, nothing
     # visible yet" from terminal null.
     return {
         "rows_read": int(rows_read or 0),
         "estimated_rows_total": int(estimated_rows_total or 0),
-        "bytes_read": int(bytes_read or 0),
-        "active_cpu_time": int(active_cpu_time or 0),
-        "running_metrics": int(running_metrics or 0),
     }
 
 

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -453,15 +453,12 @@ class TestLiveQueryProgress(BaseTest):
         with team_scope(self.team.id, canonical=True):
             with patch(
                 "products.experiments.backend.recalculation.sync_execute",
-                return_value=[(1_284_512, 9_800_000, 41_000_000, 250_000, 3)],
+                return_value=[(1_284_512, 9_800_000)],
             ):
                 progress = get_live_query_progress(recalc)
         assert progress == {
             "rows_read": 1_284_512,
             "estimated_rows_total": 9_800_000,
-            "bytes_read": 41_000_000,
-            "active_cpu_time": 250_000,
-            "running_metrics": 3,
         }
 
     def test_maps_all_zero_row_to_zeros_while_in_progress(self):
@@ -471,15 +468,12 @@ class TestLiveQueryProgress(BaseTest):
         with team_scope(self.team.id, canonical=True):
             with patch(
                 "products.experiments.backend.recalculation.sync_execute",
-                return_value=[(0, 0, 0, 0, 0)],
+                return_value=[(0, 0)],
             ):
                 progress = get_live_query_progress(recalc)
         assert progress == {
             "rows_read": 0,
             "estimated_rows_total": 0,
-            "bytes_read": 0,
-            "active_cpu_time": 0,
-            "running_metrics": 0,
         }
 
     def test_returns_none_when_clickhouse_read_raises(self):
@@ -520,4 +514,3 @@ class TestLiveQueryProgressFinishedQueries(BaseTest, ClickhouseTestMixin):
         assert progress is not None
         assert progress["rows_read"] == 1000
         assert progress["estimated_rows_total"] == 1000
-        assert progress["running_metrics"] == 0

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1860,11 +1860,6 @@ export interface ExperimentMetricsRecalculationApi {
     /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */
     readonly results: readonly MetricRecalculationResultApi[]
     /**
-     * Count of metric queries currently running in ClickHouse (bounded by worker-pool concurrency)
-     * @nullable
-     */
-    running_metrics?: number | null
-    /**
      * Rows read by the run's metric queries so far, both finished and currently running. Cumulative and roughly monotonic across the run; the primary live progress signal
      * @nullable
      */
@@ -1874,16 +1869,6 @@ export interface ExperimentMetricsRecalculationApi {
      * @nullable
      */
     estimated_rows_total?: number | null
-    /**
-     * Bytes read by the run's metric queries so far, both finished and currently running
-     * @nullable
-     */
-    bytes_read?: number | null
-    /**
-     * Active CPU time (microseconds) consumed by the run's metric queries so far, both finished and currently running
-     * @nullable
-     */
-    active_cpu_time?: number | null
 }
 
 export interface ShipVariantApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -23221,11 +23221,6 @@ export namespace Schemas {
       /** Per-metric results computed by this run, scoped by the run's recalc fingerprint */
       readonly results: readonly MetricRecalculationResult[];
       /**
-         * Count of metric queries currently running in ClickHouse (bounded by worker-pool concurrency)
-         * @nullable
-         */
-      running_metrics?: number | null;
-      /**
          * Rows read by the run's metric queries so far, both finished and currently running. Cumulative and roughly monotonic across the run; the primary live progress signal
          * @nullable
          */
@@ -23235,16 +23230,6 @@ export namespace Schemas {
          * @nullable
          */
       estimated_rows_total?: number | null;
-      /**
-         * Bytes read by the run's metric queries so far, both finished and currently running
-         * @nullable
-         */
-      bytes_read?: number | null;
-      /**
-         * Active CPU time (microseconds) consumed by the run's metric queries so far, both finished and currently running
-         * @nullable
-         */
-      active_cpu_time?: number | null;
     }
 
     export type ExperimentResultsWidgetCatalogEntryOpenApiWidgetType = typeof ExperimentResultsWidgetCatalogEntryOpenApiWidgetType[keyof typeof ExperimentResultsWidgetCatalogEntryOpenApiWidgetType];


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The recalculation poll endpoint returned live ClickHouse progress fields the status bar never renders: `running_metrics`, `bytes_read`, and `active_cpu_time`. They widened the `system.processes` + `system.query_log` progress query, the serializer, and the generated TypeScript for no consumer. The status bar itself also had rough edges: row counts jumped on every poll and the completed timestamp didn't match how the reload action renders it.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR trims the live progress payload to what the UI actually consumes and polishes the recalculation status bar.

### Trim the live progress payload

`get_live_query_progress` now selects only `rows_read` and `estimated_rows_total`; `running_metrics`, `bytes_read`, and `active_cpu_time` are gone from the ClickHouse query, the serializer, and the generated types.

- `products/experiments/backend/recalculation.py`
- `products/experiments/backend/presentation/serializers.py`
- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `services/mcp/src/api/generated.ts` (generated)

### Status bar polish

Row counters animate between polls with `useAnimatedNumber` (350ms) so they count up instead of jumping, the label now reads "rows read", and the completed state reuses `ExperimentLastRefreshText` ("Results calculated ...") so the timestamp renders exactly like the experiment reload action.

- `frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/3665ffb1-41e2-4954-98db-d9c321114c1d)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Fable 5
Manually refactored: **yes** (code written entirely by hand)

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- The agent's only contribution is this PR description; all code changes are hand-written.

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->