### PR TITLE
chore(batch-imports): full-worker lifecycle tests against postgres

### DIFF
--- a/rust/batch-import-worker/E2E_TEST_PLAN.md
+++ b/rust/batch-import-worker/E2E_TEST_PLAN.md
@@ -129,14 +129,15 @@ Scenario 13 pins the resume contract that makes scenario 8 work: `release_job_re
 
 Goal: cover the only layer Phases 1-2 skip: `JobModel`'s sqlx claim/lease/commit/pause path against the real `posthog_batchimport` table.
 
-- Local dev Postgres runs on port 15432 (hogli dev stack). Skip if unreachable, same pattern as Kafka.
-- Insert a `posthog_batchimport` row with a Mixpanel source config pointed at the mock server, then drive `JobModel::claim_next_job` + the real `Job` run path in-process (preferable to spawning the binary: no env juggling, direct assertions).
-- Scenarios (smoke-level only, the matrix lives in Phase 1):
-  - Claim → run to completion → status `completed`, state parts all done.
-  - Claim → `Reorder` restart failure → status `paused`, `display_status_message` contains the user-facing parse error with the date range suffix.
-  - Paused job resumed (status flipped back to `running` by the test, offset of the poisoned part reset to 0) → completes; ClickHouse-level dedup is out of scope, but assert re-emitted UUIDs equal first-run UUIDs.
-- One Kafka smoke test (reuse `person_processing_kafka_integration_test.rs` infra): happy-path Mixpanel range emitted via `KafkaEmitter`, consume the topic, exactly-once by UUID.
-- One config-wiring smoke test for staging: build the worker `Config` with `STAGING_BACKEND=temp_bucket` + `TEMP_BUCKET_*` set (see `src/config.rs`) and assert the constructed context/source actually gets a staging backend. Phases 1-2 inject `RemoteStaging` directly, so this is the only place the env-to-backend wiring is exercised.
+- Local dev Postgres runs on port 15432 (hogli dev stack). Skip if unreachable, same pattern as Kafka. Also skip if the DB already has claimable batch imports: `claim_next_job` claims *any* claimable row, and a test must never steal a developer's real local import.
+- Insert a `posthog_batchimport` row with a Mixpanel source config pointed at the mock server, then drive `JobModel::claim_next_job` + the real `Job::process` loop in-process (preferable to spawning the binary: no env juggling, direct assertions). Secrets caveat: `JobSecrets::encrypt` expects pre-base64-encoded fernet keys while the claim path's `decrypt` encodes the raw configured keys internally, so seed with `encrypt(&[b64(raw_key)])`.
+- Scenarios, implemented in `tests/job_lifecycle_postgres_test.rs`:
+  - Claim → run to completion → status `completed`, state parts all done, one download per day.
+  - Claim → `CorruptLine` parse failure → status `paused`, `display_status_message` contains the user-facing parse error with the date range suffix (the exact support-facing surface).
+  - Resume: mirror the resume endpoint (`BatchImportViewSet.resume`) exactly, clearing `lease_id`/`leased_until`/backoff along with the status flip. Pausing deliberately keeps the worker's lease, so a bare `status = 'running'` update leaves the row unclaimable for up to 30 minutes.
+  - `STAGING_BACKEND=temp_bucket` + `TEMP_BUCKET_*` via env → claimed job constructs the temp-bucket backend from the real envconfig path and completes through it (SeaweedFS-gated). This covers the env-to-backend wiring Phases 1-2 bypass; config *parse* errors are already unit-tested in `src/config.rs`.
+- Deferred: the Kafka emit smoke test (the `KafkaEmitter` already has its own integration test; wiring it into the lifecycle loop adds little) and offset-reset-to-0 re-import (UUID determinism is already pinned in Phase 1).
+- CI caveat: these tests require a Django-migrated Postgres with a team row, which the rust CI job does not currently provide, so they skip in CI and run against the local dev stack. Wiring a migrated database into rust CI is follow-up work.
 
 ---
 
@@ -147,12 +148,55 @@ Goal: cover the only layer Phases 1-2 skip: `JobModel`'s sqlx claim/lease/commit
 - Double-compressed part (gzip magic at offset 0 of decompressed stream) → the compression-mismatch user error.
 - A `Slow`/stall behavior in the mock to exercise request timeout handling (`extract_client_request_error`).
 
+## Phase 5: real-endpoint contract testing (Mixpanel/Amplitude)
+
+Goal: catch what no mock can anticipate - real API drift (auth quirks, response framing, compression changes, new fields, rate-limit behavior, export instability) - and give developers a one-command way to import real vendor data into local dev.
+
+Principles:
+
+- **Never in per-PR CI.** External dependencies, shared credentials, vendor rate limits, and multi-minute ingestion lag make these unfit to block merges. They run nightly and on demand.
+- **Deterministic ground truth via an immutable seeded dataset.** Both vendors' export APIs serve historical data indefinitely; seed once, assert forever. Do not seed-then-assert in the same run (ingestion-to-export lag is minutes to hours and flaky).
+- **Real response bytes in normal CI via record/replay.** Recording against the real APIs produces sanitized fixtures; replay tests parse them with the production parser on every PR, so "does our parser handle real Mixpanel/Amplitude output" is still continuously covered.
+
+Work items, in order:
+
+### 5a. Vendor test accounts and secrets
+
+- PostHog-owned Mixpanel project and Amplitude project (free tiers suffice), used exclusively for this. Export credentials (Mixpanel API secret; Amplitude API key + secret key) stored as GitHub Actions secrets (see the managing-github-actions-secrets skill) and in the team vault for local use. Env names: `MIXPANEL_CONTRACT_TEST_API_SECRET`, `AMPLITUDE_CONTRACT_TEST_API_KEY`, `AMPLITUDE_CONTRACT_TEST_SECRET_KEY`.
+
+### 5b. One-time seeding + checked-in manifest
+
+- `scripts/seed_vendor_contract_data` (per-vendor): pushes a fixed synthetic dataset into a fixed **past** date range (e.g. 2020-03-01 to 2020-03-03) via Mixpanel's `/import` and Amplitude's batch upload API. Deterministic `$insert_id`s / `insert_id`s and distinct_ids (reuse the Phase 1 generator so ground truth is computable).
+- The script also writes `tests/fixtures/vendor_manifest_{mixpanel,amplitude}.json`: the expected `(uuid, event, distinct_id)` set per day. Checked in; regenerated only if the dataset is ever re-seeded.
+
+### 5c. Contract tests (opt-in, `#[ignore]`)
+
+- `tests/vendor_contract_test.rs`: `#[ignore]`-d tests, skipped unless the credential env vars are set. Real `DateRangeExportSource` (real auth, real gzip framing) over the seeded range through the Phase 1 harness loop; assert exactly-once against the manifest.
+- A byte-stability probe: download the same day twice and report (not assert) whether the bytes matched - drift telemetry for the instability class behind the incident.
+- Run locally with `cargo test -p batch-import-worker --test vendor_contract_test -- --ignored`.
+
+### 5d. Nightly workflow
+
+- Scheduled GitHub Actions workflow (with `timeout-minutes`), non-blocking for PRs: runs the ignored contract tests with the secrets, posts failures to the owning team's alert channel. A red nightly means vendor drift or seeded-data loss - both worth a human look within a day, neither worth blocking merges.
+
+### 5e. Record/replay fixtures
+
+- A recording flag on the contract tests writes each day's raw export response body to `tests/fixtures/vendor_exports/` (already synthetic data, so nothing to sanitize beyond stripping any response headers).
+- Replay tests (normal, not ignored, no network) feed the fixture bytes through the production extractor + parser and assert against the manifest - real vendor output shapes covered on every PR.
+- Refresh fixtures by re-running the recorder manually when the nightly catches a format change.
+
+### 5f. Developer ergonomics: ad hoc real imports into local dev
+
+- Document (README section in this crate) the one-command path for importing real vendor data into a local PostHog: a small management command or script that inserts a `posthog_batchimport` row for the local team via `BatchImportConfigBuilder` (Mixpanel or Amplitude date-range source, the developer's own credentials from env), then runs the worker binary pointed at the dev stack. The Phase 3 test file is the reference for exactly what the row needs.
+- This is the "does a real customer export actually import" smoke a developer runs before shipping source changes - with their own throwaway vendor account or the shared contract-test account.
+
 ## Suggested PR sequencing
 
 1. PR 1: Phase 1 (mock service + harness + scenarios 1-7). This is the highest-value slice; scenario 4 alone would have caught the incident.
 2. PR 2: Phase 2 (stacks on PR 1's harness).
 3. PR 3: Phase 3.
 4. Phase 4 items as opportunistic follow-ups.
+5. Phase 5 in three PRs: seeding script + manifest (5a-5b, includes the one-time account setup), contract tests + nightly workflow (5c-5d), record/replay + dev docs (5e-5f).
 
 ## Verification checklist per PR
 

--- a/rust/batch-import-worker/tests/common/mock_export.rs
+++ b/rust/batch-import-worker/tests/common/mock_export.rs
@@ -57,6 +57,12 @@ pub enum Behavior {
         failures: u32,
         retry_after_secs: u64,
     },
+    /// Line `line` of the export is overwritten with same-length garbage that
+    /// is not valid JSON, on every attempt. Same-length so byte offsets before
+    /// and after the corrupt line are identical to the `Stable` body: a job
+    /// paused on the corruption can resume byte-aligned once the behavior is
+    /// flipped back to `Stable` (the "customer fixed their data" path).
+    CorruptLine { line: usize },
     /// The day has no data: 404.
     NotFound,
     /// The day has no data: 200 with a zero-byte body.
@@ -333,19 +339,43 @@ pub fn day_body(
     permutation: u64,
     late_events: usize,
 ) -> Vec<u8> {
+    day_body_inner(
+        provider,
+        seed,
+        day,
+        events_per_day,
+        permutation,
+        late_events,
+        None,
+    )
+}
+
+fn day_body_inner(
+    provider: Provider,
+    seed: u64,
+    day: &str,
+    events_per_day: usize,
+    permutation: u64,
+    late_events: usize,
+    corrupt_line: Option<usize>,
+) -> Vec<u8> {
     let mut events = generate_day(seed, day, events_per_day);
     events.extend(generate_late(seed, day, late_events));
     permute(&mut events, seed ^ day_hash(day), permutation);
 
+    let mut lines: Vec<String> = match provider {
+        Provider::Mixpanel => events.iter().map(mixpanel_line).collect(),
+        Provider::Amplitude => events.iter().map(amplitude_line).collect(),
+    };
+    if let Some(line) = corrupt_line {
+        // Same-length garbage keeps every other line's byte offset identical
+        // to the Stable body (see Behavior::CorruptLine).
+        lines[line] = "x".repeat(lines[line].len());
+    }
+
     match provider {
-        Provider::Mixpanel => {
-            let lines: Vec<String> = events.iter().map(mixpanel_line).collect();
-            gzip(lines.join("\n").as_bytes())
-        }
-        Provider::Amplitude => {
-            let lines: Vec<String> = events.iter().map(amplitude_line).collect();
-            amplitude_zip(&lines)
-        }
+        Provider::Mixpanel => gzip(lines.join("\n").as_bytes()),
+        Provider::Amplitude => amplitude_zip(&lines),
     }
 }
 
@@ -363,13 +393,14 @@ pub fn day_expected(
 }
 
 fn body_for(state: &ServerState, day: &str, permutation: u64, late_events: usize) -> Vec<u8> {
-    day_body(
+    day_body_inner(
         state.provider,
         state.seed,
         day,
         state.events_per_day,
         permutation,
         late_events,
+        None,
     )
 }
 
@@ -416,6 +447,15 @@ async fn handle_export(
             }
             body_for(&state, &day, 0, 0)
         }
+        Behavior::CorruptLine { line } => day_body_inner(
+            state.provider,
+            state.seed,
+            &day,
+            state.events_per_day,
+            0,
+            0,
+            Some(line),
+        ),
         Behavior::NotFound => return StatusCode::NOT_FOUND.into_response(),
         Behavior::EmptyBody => Vec::new(),
         Behavior::TruncatedGzip => {

--- a/rust/batch-import-worker/tests/job_lifecycle_postgres_test.rs
+++ b/rust/batch-import-worker/tests/job_lifecycle_postgres_test.rs
@@ -1,0 +1,387 @@
+//! Full-worker lifecycle tests against the real `posthog_batchimport` table:
+//! claim, run, pause-with-user-message, resume, complete - the only layer the
+//! in-process e2e suites skip. Uses the dev-stack Postgres (localhost:15432,
+//! `DATABASE_URL` overrides) and skips when it, the table, or a team row is
+//! unavailable.
+//!
+//! Tests are serialized: `JobModel::claim_next_job` claims *any* claimable job,
+//! so concurrent tests would steal each other's rows. For the same reason each
+//! test skips if the database already has claimable batch-import jobs (e.g. a
+//! developer's real local import) - claiming those would mutate their leases.
+
+use std::sync::{Arc, OnceLock};
+
+use base64::prelude::*;
+use batch_import_worker::config::Config;
+use batch_import_worker::context::AppContext;
+use batch_import_worker::job::config::JobSecrets;
+use batch_import_worker::job::model::{JobModel, JobStatus};
+use batch_import_worker::job::Job;
+use envconfig::Envconfig;
+use lifecycle::{ComponentOptions, Manager};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+mod common;
+use common::mock_export::{Behavior, MockExport, Provider};
+use common::{seaweedfs_reachable, seaweedfs_store};
+
+const DEV_DATABASE_URL: &str = "postgres://posthog:posthog@localhost:15432/posthog";
+const SEED: u64 = 0x11f3;
+
+static PG_TEST_MUTEX: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+/// Restores (or removes) env vars on drop, so a panicking test can't leak
+/// staging config into the next test in the same process.
+struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn set(vars: &[(&str, &str)]) -> Self {
+        let saved = vars
+            .iter()
+            .map(|(k, _)| (k.to_string(), std::env::var(k).ok()))
+            .collect();
+        for (k, v) in vars {
+            std::env::set_var(k, v);
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, old) in &self.saved {
+            match old {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}
+
+struct PgHarness {
+    context: Arc<AppContext>,
+    team_id: i32,
+    handle: lifecycle::Handle,
+    // Keeps the lifecycle manager's monitor alive for the handle's lifetime.
+    _monitor: lifecycle::MonitorGuard,
+    inserted: Vec<Uuid>,
+}
+
+impl PgHarness {
+    /// `None` means skip: Postgres/schema/team unavailable, or the DB already
+    /// has claimable jobs this test must not touch.
+    async fn try_new() -> Option<Self> {
+        if std::env::var("DATABASE_URL").is_err() {
+            std::env::set_var("DATABASE_URL", DEV_DATABASE_URL);
+        }
+        let config = Config::init_from_env().ok()?;
+        let Ok(context) = AppContext::new(&config).await else {
+            eprintln!("Postgres unreachable, skipping test");
+            return None;
+        };
+
+        let team_id: i32 =
+            match sqlx::query_scalar::<_, i32>("SELECT id FROM posthog_team ORDER BY id LIMIT 1")
+                .fetch_optional(&context.db)
+                .await
+            {
+                Ok(Some(id)) => id,
+                Ok(None) => {
+                    eprintln!("No team in database, skipping test");
+                    return None;
+                }
+                Err(e) => {
+                    eprintln!("Schema probe failed ({e}), skipping test");
+                    return None;
+                }
+            };
+
+        let claimable: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM posthog_batchimport \
+             WHERE status = 'running' AND (leased_until IS NULL OR leased_until <= now())",
+        )
+        .fetch_one(&context.db)
+        .await
+        .ok()?;
+        if claimable > 0 {
+            eprintln!("Database already has {claimable} claimable batch imports, skipping test");
+            return None;
+        }
+
+        let token = CancellationToken::new();
+        let mut manager = Manager::builder("batch-import-lifecycle-test")
+            .with_trap_signals(false)
+            .with_prestop_check(false)
+            .with_shutdown_token(token)
+            .build();
+        let handle = manager.register("job", ComponentOptions::new());
+        let monitor = manager.monitor_background();
+
+        Some(Self {
+            context: Arc::new(context),
+            team_id,
+            handle,
+            _monitor: monitor,
+            inserted: Vec::new(),
+        })
+    }
+
+    /// Insert a claimable Mixpanel date-range job pointed at `mock`.
+    async fn insert_job(&mut self, mock: &MockExport, start_day: &str, days: u32) -> Uuid {
+        let start = format!("{start_day}T00:00:00Z");
+        let end_date = chrono::NaiveDate::parse_from_str(start_day, "%Y-%m-%d").unwrap()
+            + chrono::Duration::days(days as i64);
+        let end = format!("{end_date}T00:00:00Z");
+
+        let import_config = serde_json::json!({
+            "source": {
+                "type": "date_range_export",
+                "base_url": mock.export_url(),
+                "extractor_type": "plain_gzip",
+                "start": start,
+                "end": end,
+                "start_qp": "from_date",
+                "end_qp": "to_date",
+                "auth": { "type": "mixpanel_auth", "secret_key_secret": "secret_key" },
+                "interval_duration": 86400,
+                "date_format": "%Y-%m-%d",
+            },
+            "data_format": {
+                "type": "json_lines",
+                "skip_blanks": true,
+                "content": {
+                    "type": "mixpanel",
+                    "skip_no_distinct_id": false,
+                    "timestamp_offset_seconds": null,
+                },
+            },
+            "sink": { "type": "noop" },
+        });
+
+        // `encrypt` expects already-b64-encoded fernet keys, while `decrypt`
+        // (the claim path) encodes the raw configured keys itself - so encode
+        // here to produce what the worker will successfully decrypt.
+        let keys: Vec<String> = self
+            .context
+            .encryption_keys
+            .iter()
+            .map(|k| BASE64_URL_SAFE.encode(k.as_bytes()))
+            .collect();
+        let secrets = JobSecrets {
+            secrets: [(
+                "secret_key".to_string(),
+                serde_json::Value::String("mock-secret".to_string()),
+            )]
+            .into_iter()
+            .collect(),
+        }
+        .encrypt(&keys)
+        .expect("encrypting job secrets");
+
+        let id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO posthog_batchimport \
+             (id, team_id, created_at, updated_at, status, import_config, secrets, backoff_attempt) \
+             VALUES ($1, $2, now(), now(), 'running', $3, $4, 0)",
+        )
+        .bind(id)
+        .bind(self.team_id)
+        .bind(&import_config)
+        .bind(&secrets)
+        .execute(&self.context.db)
+        .await
+        .expect("inserting batch import row");
+        self.inserted.push(id);
+        id
+    }
+
+    /// Claim the next job (must be `expected`, per the claimable-jobs guard)
+    /// and drive `Job::process` until the worker relinquishes it.
+    async fn claim_and_run(&self, expected: Uuid) {
+        let model = JobModel::claim_next_job(self.context.clone())
+            .await
+            .expect("claiming job")
+            .expect("a claimable job");
+        assert_eq!(model.id, expected, "claimed a different job than seeded");
+
+        let mut next = Some(
+            Job::new(model, self.context.clone(), self.handle.clone())
+                .await
+                .expect("job init"),
+        );
+        while let Some(job) = next {
+            next = job.process().await.expect("job process step");
+        }
+    }
+
+    async fn row(&self, id: Uuid) -> (String, Option<String>, Option<serde_json::Value>) {
+        sqlx::query_as::<_, (String, Option<String>, Option<serde_json::Value>)>(
+            "SELECT status, display_status_message, state FROM posthog_batchimport WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_one(&self.context.db)
+        .await
+        .expect("fetching job row")
+    }
+
+    async fn cleanup(&self) {
+        for id in &self.inserted {
+            let _unused = sqlx::query("DELETE FROM posthog_batchimport WHERE id = $1")
+                .bind(id)
+                .execute(&self.context.db)
+                .await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn claimed_job_runs_to_completion_and_persists_state() {
+    let _lock = PG_TEST_MUTEX
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let Some(mut h) = PgHarness::try_new().await else {
+        return;
+    };
+
+    let mock = MockExport::start(Provider::Mixpanel, SEED, 400).await;
+    let id = h.insert_job(&mock, "2022-01-24", 2).await;
+
+    h.claim_and_run(id).await;
+
+    let (status, display, state) = h.row(id).await;
+    assert_eq!(status, JobStatus::Completed.to_string());
+    assert_eq!(display, None);
+    let parts = state.expect("state persisted")["parts"]
+        .as_array()
+        .expect("parts array")
+        .clone();
+    assert_eq!(parts.len(), 2);
+    for part in &parts {
+        let offset = part["current_offset"].as_u64().unwrap();
+        let total = part["total_size"].as_u64().expect("total_size persisted");
+        assert!(
+            offset >= total,
+            "part not complete in persisted state: {part}"
+        );
+    }
+    for day in ["2022-01-24", "2022-01-25"] {
+        assert_eq!(mock.download_count(day), 1, "day {day}");
+    }
+
+    h.cleanup().await;
+}
+
+/// The support-facing surface of a bad-data pause, end to end: the row a
+/// customer-facing engineer reads must carry the user-facing parse message
+/// with the date-range suffix, and flipping the row back to running (what the
+/// resume endpoint does) must let the job finish once the data is fixed.
+#[tokio::test]
+async fn parse_failure_pauses_with_date_ranged_message_and_resume_completes() {
+    let _lock = PG_TEST_MUTEX
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let Some(mut h) = PgHarness::try_new().await else {
+        return;
+    };
+
+    let mock = MockExport::start(Provider::Mixpanel, SEED, 400).await;
+    // Corrupt a line deep enough into the day to prove mid-part offsets
+    // survive the pause/resume round trip through the DB.
+    mock.set_behavior("2022-01-24", Behavior::CorruptLine { line: 300 });
+    let id = h.insert_job(&mock, "2022-01-24", 1).await;
+
+    h.claim_and_run(id).await;
+
+    let (status, display, _) = h.row(id).await;
+    assert_eq!(status, JobStatus::Paused.to_string());
+    let display = display.expect("paused jobs carry a user-facing message");
+    assert!(
+        display.contains("Invalid JSON syntax"),
+        "expected the parse message, got: {display}"
+    );
+    assert!(
+        display.contains("Date range: 2022-01-24"),
+        "expected the date-range suffix, got: {display}"
+    );
+
+    // The customer fixes their data; support resumes the job. Mirror the
+    // resume endpoint exactly (BatchImportViewSet.resume): pausing keeps the
+    // worker's lease, so the resume must clear it or no worker can re-claim
+    // the row for up to 30 minutes.
+    mock.set_behavior("2022-01-24", Behavior::Stable);
+    sqlx::query(
+        "UPDATE posthog_batchimport \
+         SET status = 'running', status_message = 'Resumed by user', \
+             lease_id = NULL, leased_until = NULL, \
+             backoff_attempt = 0, backoff_until = NULL \
+         WHERE id = $1",
+    )
+    .bind(id)
+    .execute(&h.context.db)
+    .await
+    .unwrap();
+
+    h.claim_and_run(id).await;
+
+    let (status, _, _) = h.row(id).await;
+    assert_eq!(status, JobStatus::Completed.to_string());
+    assert_eq!(
+        mock.download_count("2022-01-24"),
+        2,
+        "pause + resume is exactly one re-download"
+    );
+
+    h.cleanup().await;
+}
+
+/// The env-to-backend wiring Phases 1-2 bypass: with `STAGING_BACKEND=
+/// temp_bucket` configured through the real `Config`, a claimed job must
+/// construct the temp-bucket backend from env and complete through it.
+#[tokio::test]
+async fn temp_bucket_staging_wired_from_env_config() {
+    let _lock = PG_TEST_MUTEX
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+
+    let store = seaweedfs_store();
+    if !seaweedfs_reachable(&store).await {
+        eprintln!("SeaweedFS unreachable, skipping test");
+        return;
+    }
+
+    let _env = EnvGuard::set(&[
+        ("STAGING_BACKEND", "temp_bucket"),
+        ("TEMP_BUCKET_NAME", common::SEAWEEDFS_BUCKET),
+        ("TEMP_BUCKET_ENDPOINT", common::SEAWEEDFS_ENDPOINT),
+        ("TEMP_BUCKET_REGION", "us-east-1"),
+        ("TEMP_BUCKET_ACCESS_KEY_ID", "any"),
+        ("TEMP_BUCKET_SECRET_ACCESS_KEY", "any"),
+        ("TEMP_BUCKET_FORCE_PATH_STYLE", "true"),
+    ]);
+    // Context is built AFTER the env guard so the staging config flows through
+    // the real envconfig path.
+    let Some(mut h) = PgHarness::try_new().await else {
+        return;
+    };
+
+    let mock = MockExport::start(Provider::Mixpanel, SEED, 400).await;
+    let id = h.insert_job(&mock, "2022-01-24", 1).await;
+
+    h.claim_and_run(id).await;
+
+    let (status, display, _) = h.row(id).await;
+    assert_eq!(
+        status,
+        JobStatus::Completed.to_string(),
+        "job through env-configured temp-bucket staging failed: {display:?}"
+    );
+    assert_eq!(mock.download_count("2022-01-24"), 1);
+
+    h.cleanup().await;
+}


### PR DESCRIPTION
## Problem

Phases 1-2 of the e2e plan (#69815, #69820) drive the DB-free fetch loop directly, so the one layer still untested is the worker's actual lifecycle against the `posthog_batchimport` table: claiming with lease semantics, the pause that writes the user-facing error a support engineer reads in the admin, the resume contract, and the env-to-backend staging wiring that production depends on.

Stacked on #69820.

## Changes

Phase 3 of `E2E_TEST_PLAN.md`: `tests/job_lifecycle_postgres_test.rs`, three tests against the dev-stack Postgres (skip when it, the schema, or a team row is unavailable - and also when the DB already has claimable batch imports, so a test can never steal a developer's real local job and mutate its lease):

- **Claim to completion**: seed a row, `JobModel::claim_next_job`, drive the real `Job::process` loop, assert the persisted row (completed, all parts done in `state`, one download per day).
- **Parse failure pauses with the support-facing message, resume completes**: a new `CorruptLine` mock behavior overwrites one line with same-length garbage, so the job pauses with `display_status_message` carrying the parse error plus the `Date range:` suffix (the exact row a support engineer reads), and a later resume stays byte-aligned once the behavior is flipped back. The resume mirrors `BatchImportViewSet.resume` exactly - which the test itself proved necessary: pausing keeps the worker's lease, so a bare `status = 'running'` update leaves the row unclaimable for up to 30 minutes.
- **`STAGING_BACKEND=temp_bucket` wired from env**: a claimed job builds the temp-bucket backend through the real envconfig path and completes through SeaweedFS staging. Phases 1-2 inject `RemoteStaging` directly; this is the only end-to-end coverage of the config-to-backend chain production uses.

Also documented in the plan: the `JobSecrets::encrypt`/`decrypt` key-encoding asymmetry (encrypt wants pre-base64-encoded fernet keys, decrypt encodes raw keys itself), and a new **Phase 5: real-endpoint contract testing** section - opt-in nightly tests against real Mixpanel/Amplitude accounts with a one-time-seeded immutable dataset, record/replay fixtures for per-PR coverage of real response shapes, and a documented path for developers to import real vendor data into local dev.

> [!NOTE]
> These tests skip in CI: the rust CI job has no Django-migrated Postgres with a team row. They run against the local dev stack. Wiring a migrated database into rust CI is called out as follow-up in the plan.

## How did you test this code?

Automated only, no manual testing:

- New suite: 3 tests pass against the dev-stack Postgres and SeaweedFS, leaving no rows behind (`cargo test -p batch-import-worker --test job_lifecycle_postgres_test`).
- Full crate suite passes (371 unit tests plus all integration targets); fmt and clippy clean.
- The resume test failed until it mirrored the resume endpoint's lease clearing - evidence it pins the real contract, found by inspecting the leased row it left behind.

Regressions caught that nothing caught before: nothing previously exercised `claim_next_job`'s lease SQL, `Job::process`'s pause/complete persistence, the date-range-suffixed `display_status_message` a support engineer relies on, the pause-keeps-lease/resume-clears-lease contract, or the `STAGING_BACKEND` env wiring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, test-only change; the plan doc is updated in the same PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), continuing the session behind #69815 and #69820. Skills invoked: /writing-tests.
- Decisions: dropped the planned Kafka emit smoke test (the `KafkaEmitter` already has a dedicated integration test; wiring it into this loop added no discriminating power) and replaced the planned synthetic config-wiring check with a real job run through env-configured staging, which exercises strictly more.
- Debugging note: the resume test initially updated only `status` and the re-claim found nothing; the leftover row showed a live 30-minute lease, which led to the pause-keeps-lease finding now documented in the plan.