### PR TITLE
fix(experiments): add recalc queue-wait metric and adjust concurrency

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -63,6 +63,8 @@ from products.experiments.backend.temporal.recalculation_metrics import (
     EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_METRICS,
     EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_BUCKETS,
     EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_METRICS,
+    EXPERIMENT_METRICS_RECALCULATION_SCHEDULE_TO_START_HISTOGRAM_BUCKETS,
+    EXPERIMENT_METRICS_RECALCULATION_SCHEDULE_TO_START_HISTOGRAM_METRICS,
     ExperimentsRecalculationMetricsInterceptor,
 )
 from products.logs.backend.facade.temporal import (
@@ -319,6 +321,12 @@ async def create_worker(
             zip(
                 EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_METRICS,
                 itertools.repeat(EXPERIMENT_METRICS_RECALCULATION_ATTEMPT_HISTOGRAM_BUCKETS),
+            )
+        )
+        | dict(
+            zip(
+                EXPERIMENT_METRICS_RECALCULATION_SCHEDULE_TO_START_HISTOGRAM_METRICS,
+                itertools.repeat(EXPERIMENT_METRICS_RECALCULATION_SCHEDULE_TO_START_HISTOGRAM_BUCKETS),
             )
         )
         | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]}

--- a/products/experiments/backend/temporal/recalculation_metrics.py
+++ b/products/experiments/backend/temporal/recalculation_metrics.py
@@ -50,7 +50,7 @@ EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_BUCKETS = [
 
 # Schedule-to-start latency is the queue-pressure signal: how long an activity sat in the task queue before
 # a worker picked it up. Buckets reach 30m (vs 5m for execution latency) because queue wait under backlog is
-# unbounded by the activity timeout — it's exactly the regime this histogram exists to observe.
+# unbounded by the activity timeout; that is exactly the regime this histogram exists to observe.
 EXPERIMENT_METRICS_RECALCULATION_SCHEDULE_TO_START_HISTOGRAM_METRICS = (
     "experiment_metrics_recalculation_activity_schedule_to_start_latency",
 )

--- a/products/experiments/backend/temporal/recalculation_metrics.py
+++ b/products/experiments/backend/temporal/recalculation_metrics.py
@@ -48,6 +48,25 @@ EXPERIMENT_METRICS_RECALCULATION_LATENCY_HISTOGRAM_BUCKETS = [
     300_000.0,  # 5m
 ]
 
+# Schedule-to-start latency is the queue-pressure signal: how long an activity sat in the task queue before
+# a worker picked it up. Buckets reach 30m (vs 5m for execution latency) because queue wait under backlog is
+# unbounded by the activity timeout — it's exactly the regime this histogram exists to observe.
+EXPERIMENT_METRICS_RECALCULATION_SCHEDULE_TO_START_HISTOGRAM_METRICS = (
+    "experiment_metrics_recalculation_activity_schedule_to_start_latency",
+)
+EXPERIMENT_METRICS_RECALCULATION_SCHEDULE_TO_START_HISTOGRAM_BUCKETS = [
+    100.0,  # 100ms
+    500.0,  # 500ms
+    1_000.0,  # 1s
+    5_000.0,  # 5s
+    10_000.0,  # 10s
+    30_000.0,  # 30s
+    60_000.0,  # 1m
+    300_000.0,  # 5m
+    600_000.0,  # 10m
+    1_800_000.0,  # 30m
+]
+
 # Bucket boundaries for `_activity_success_attempts` (counts the attempt number at which success was reached).
 # With `RetryPolicy(maximum_attempts=2)` today, only buckets [1, 2] are populated, but the wider range survives
 # a future policy change without needing a new histogram.
@@ -85,6 +104,13 @@ class _ActivityInboundInterceptor(ActivityInboundInterceptor):
         meter = activity.metric_meter().with_additional_attributes(
             {"activity_type": activity_type, "workflow_type": _RECALCULATION_WORKFLOW_TYPE}
         )
+        # Queue-pressure signal (see bucket comment above). Pattern mirrors mcp_analytics' intent_clustering.
+        if info.scheduled_time and info.started_time:
+            meter.create_histogram_timedelta(
+                name="experiment_metrics_recalculation_activity_schedule_to_start_latency",
+                description="Time between activity scheduling and start (task queue wait).",
+                unit="ms",
+            ).record(info.started_time - info.scheduled_time)
         # Fires on every attempt (first run + each retry). Comparing this to `_activity_successes` reveals
         # retry rate; without it a transient ClickHouse blip is indistinguishable from a healthy first-try
         # success. Pattern mirrors batch_exports' `batch_exports_activity_attempts`.

--- a/products/experiments/backend/temporal/recalculation_workflow.py
+++ b/products/experiments/backend/temporal/recalculation_workflow.py
@@ -24,10 +24,11 @@ with temporalio.workflow.unsafe.imports_passed_through():
     )
     from products.experiments.backend.temporal.recalculation_metrics import increment_workflow_finished
 
-# Per-run metric fan-out: how many metric activities one run keeps in flight, sized so a typical experiment
-# recalculates in a single concurrent wave. Cross-run ClickHouse load is bounded separately by the dedicated
-# recalc worker's activity-slot cap (MAX_CONCURRENT_ACTIVITIES), not by this constant.
-MAX_CONCURRENT_METRICS = 14
+# Per-run metric fan-out: how many metric activities one run keeps in flight. Sized so two concurrent runs
+# from the same org fit exactly inside the per-org ClickHouse app-query limit (DEFAULT_APP_ORG_CONCURRENT_QUERIES
+# = 20 in posthog/clickhouse/client/limit.py); a third same-org run bounces off that limiter. Cross-run worker
+# load is bounded separately by the dedicated recalc worker's activity-slot cap (MAX_CONCURRENT_ACTIVITIES).
+MAX_CONCURRENT_METRICS = 10
 
 
 @temporalio.workflow.defn(name="experiment-metrics-recalculation-workflow")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

PostHog/charts#13049 moves the experiments recalculation Temporal worker from a static 2-pod pool to KEDA autoscaling driven by task queue backlog. Two gaps on the app side:

- The worker emits no schedule-to-start latency metric, so there's no worker-side signal for how long calc activities actually wait in the queue, which is the number that tells us whether the autoscaler is keeping up.
- The per-run metric fan-out (`MAX_CONCURRENT_METRICS = 14`) is misaligned with the per-org ClickHouse app-query concurrency limit (20) that governs recalc queries. Two concurrent runs from the same org demand 28 slots against a quota of 20, so the second run bounces off the limiter with `ConcurrencyLimitExceeded` instead of running at full width.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

App-side counterpart to the autoscaling PR: adds the queue-pressure signal and aligns per-run concurrency with the org query quota.

### Schedule-to-start latency histogram

New `experiment_metrics_recalculation_activity_schedule_to_start_latency` histogram recording scheduled-to-started time per activity, emitted from the existing metrics interceptor (mirrors the `mcp_analytics` intent clustering pattern). Buckets reach 30m, wider than the 5m execution-latency buckets, because queue wait under backlog is not bounded by the activity timeout.

- `products/experiments/backend/temporal/recalculation_metrics.py`
- `posthog/temporal/common/worker.py`

### Per-run fan-out aligned to the org query limit

`MAX_CONCURRENT_METRICS` goes from 14 to 10 so two concurrent same-org runs fit exactly inside `DEFAULT_APP_ORG_CONCURRENT_QUERIES` (20). Pairs with the charts PR setting `MAX_CONCURRENT_ACTIVITIES: 20` per pod, making one pod's slots equal one org's quota.

- `products/experiments/backend/temporal/recalculation_workflow.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/91ac7749-9a2d-4d52-bb2b-bc32dfb3b306)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Fable 5
Manually refactored: **yes**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Verified which ClickHouse limiter actually governs recalc queries: they bypass the per-team API, dashboard, and materialized-endpoints limiters and are subject only to `app_per_org` (20), so the fan-out was sized against that number.
- The histogram gets its own bucket set instead of reusing the execution-latency buckets, since the interesting failure mode (queue wait growing past minutes under backlog) sits entirely above the 5m cap of the existing buckets.