### PR TITLE
feat(cymbal): set posthog-rs wire-order cutoff at 0.19.0

### DIFF
--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -61,10 +61,13 @@ struct LibRule {
 
 /// The normalization table, keyed on `$lib`.
 ///
-/// All cutoffs are `None` today: no SDK has shipped the canonical-order flip
-/// yet. When an SDK ships it, change its `canonical_since` to the release
-/// version and leave everything else alone — legacy payloads keep normalizing,
-/// new payloads pass through.
+/// A `None` cutoff means the SDK has not shipped the canonical-order flip yet.
+/// When an SDK ships it, change its `canonical_since` to the release version
+/// and leave everything else alone — legacy payloads keep normalizing, new
+/// payloads pass through. The cutoff must be merged and deployed BEFORE the
+/// SDK release it names exists, and that release must be the flip: an
+/// unrelated release claiming the version would ship crash-first payloads the
+/// gate no longer fixes.
 ///
 /// Built lazily because `semver::Version` is not `const`-constructible; cached
 /// for the process lifetime since this is consulted for every ingested event.
@@ -92,7 +95,11 @@ fn lib_rules() -> &'static [LibRule] {
             .map(|lib| LibRule {
                 lib,
                 fix: WireOrderFix::FRAMES,
-                canonical_since: None,
+                canonical_since: match lib {
+                    // posthog-rs ships the flip in 0.19.0 (PostHog/posthog-rs#176).
+                    "posthog-rs" => Some(Version::new(0, 19, 0)),
+                    _ => None,
+                },
             })
             .collect();
 
@@ -306,6 +313,38 @@ mod test {
         // Natively-canonical SDKs have no legacy order.
         assert!(legacy_wire_order(Some("posthog-node"), &canonical).is_none());
         assert!(legacy_wire_order(None, &canonical).is_none());
+    }
+
+    #[test]
+    fn rs_cutoff_gates_normalization_by_version() {
+        // Below the 0.19.0 cutoff (and for unparseable versions): still
+        // crash-first on the wire, so frames reverse and a legacy snapshot is
+        // returned.
+        for version in [Some("0.18.0"), Some("0.3.7"), Some("garbage"), None] {
+            let mut list: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-rs"), version);
+            assert!(legacy.is_some(), "{version:?} should normalize");
+            assert_eq!(frame_names(&list[0]), vec!["boom", "main"]);
+        }
+
+        // At/above the cutoff: canonical on the wire, untouched.
+        for version in ["0.19.0", "0.19.1", "0.20.0", "1.0.0"] {
+            let mut list: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-rs"), Some(version));
+            assert!(legacy.is_none(), "{version} should pass through");
+            assert_eq!(frame_names(&list[0]), vec!["main", "boom"]);
+        }
+
+        // Post-flip events still reconstruct the legacy order for the legacy
+        // fingerprint versions — the cutoff stops reordering, not legacy
+        // hashing.
+        let canonical: ExceptionList =
+            vec![exception_with_frames("Boom", &["main", "boom"])].into();
+        let legacy = legacy_wire_order(Some("posthog-rs"), &canonical)
+            .expect("reconstruction must ignore the cutoff");
+        assert_eq!(frame_names(&legacy[0]), vec!["boom", "main"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

First SDK flip of the wire-order standardization (PostHog/sdk-specs#11): posthog-rs ships canonical bottom-up frames in **0.19.0** (PostHog/posthog-rs#176). Cymbal's normalization gate (#68189, deployed) must stop reordering rs payloads at that version — otherwise it would double-flip already-canonical events.

posthog-rs goes first deliberately: smallest blast radius of the crash-first SDKs (~7.4k exception events/day across 6 teams, one of which is our own project, so we dogfood the flip), and it exercises the one known reconstruction caveat (inline-expanded native frames) on the smallest possible population.

## Changes

- `posthog-rs` gets `canonical_since: Some(0.19.0)` in the normalization table. Payloads at/above 0.19.0 pass through untouched; everything below (or with an unparseable version) keeps normalizing exactly as today.
- Table doc comment now spells out the ordering contract: a cutoff must merge and deploy **before** the SDK release it names exists, and that release must be the flip.
- No other lib changes. Legacy fingerprint matching is unaffected — reconstruction deliberately ignores the cutoff, so pre-flip-keyed rs issues keep matching after 0.19.0 (covered by the new test).

## Merge sequencing — do not merge out of order

1. Merge this, wait for cymbal autodeploy to complete.
2. Then (and only then) merge PostHog/posthog-rs#176 and let it release as 0.19.0.
3. **No other posthog-rs minor may release between those two steps** — an unrelated 0.19.0 would ship crash-first payloads this gate no longer fixes. Patch releases of 0.18.x are fine (they stay below the cutoff).

Rollout watch: the wire-order launch dashboard (`et-wire-order-launch`) — rs legacy matches should continue via reconstruction post-flip, issue creation stays on baseline; a handful of one-time splits on symbolicated (inline-expanded) rs issues spanning the flip are expected and auto-merge cleans them up.

## How did you test this code?

Automated only:

- New unit test pinning the cutoff semantics for `posthog-rs`: 0.18.0 / 0.3.7 / unparseable / missing versions still normalize; 0.19.0, 0.19.1, 0.20.0, 1.0.0 pass through; and `legacy_wire_order` still reconstructs the pre-flip order post-cutoff (the continuity path for existing issues).
- Full `cargo test -p cymbal` green; clippy `-D warnings` and fmt clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Rollout process is documented in the sdk-specs change; no product docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this under my direction as step 1 of the per-SDK flip rollout. The 0.19.0 target was derived from posthog-rs main (0.18.0) plus #176's minor changeset; the sequencing rules in this description are the operational contract agreed for all subsequent flips.
