### PR TITLE
fix(data-warehouse): pin mark_primed streak-reset test to its run generation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill.py
@@ -333,10 +333,7 @@ class TestFailureStreak:
     def test_mark_primed_resets_streak(self):
         candidate = _sink_state(self._team(), _State.BACKFILLING)
         DuckgresSinkSchemaState.objects.filter(id=candidate.id).update(
-            backfill_run_uuid="run-1",
-            consecutive_failures=5,
-            first_failed_at=timezone.now(),
-            last_error="boom",
+            consecutive_failures=5, first_failed_at=timezone.now(), last_error="boom", backfill_run_uuid="run-1"
         )
 
         backfill_module.mark_primed(str(candidate.schema_id), run_uuid="run-1")

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill.py
@@ -333,10 +333,13 @@ class TestFailureStreak:
     def test_mark_primed_resets_streak(self):
         candidate = _sink_state(self._team(), _State.BACKFILLING)
         DuckgresSinkSchemaState.objects.filter(id=candidate.id).update(
-            consecutive_failures=5, first_failed_at=timezone.now(), last_error="boom"
+            backfill_run_uuid="run-1",
+            consecutive_failures=5,
+            first_failed_at=timezone.now(),
+            last_error="boom",
         )
 
-        backfill_module.mark_primed(str(candidate.schema_id))
+        backfill_module.mark_primed(str(candidate.schema_id), run_uuid="run-1")
 
         candidate.refresh_from_db()
         assert candidate.state == _State.PRIMED


### PR DESCRIPTION
## Problem

Master is red. `test_backfill.py::TestFailureStreak::test_mark_primed_resets_streak` fails with:

```
TypeError: mark_primed() missing 1 required keyword-only argument: 'run_uuid'
```

Two PRs landed back to back and collided semantically, which no merge conflict caught:

- #68785 (`d4891c22`) added the call site `mark_primed(str(candidate.schema_id))`.
- #69101 (`5e47e579`) then made `mark_primed` CAS on the run generation, giving it a required keyword-only `run_uuid`.

#69101's CI ran against a master that predated #68785, so nothing ever exercised the two together. Both are green in isolation and broken in combination.

Every open PR branched off master inherits the failure, so this blocks the rest of the duckgres sink stack.

## Changes

Pin the test to a run generation, matching how `mark_primed` is now called in production. The state row gets a `backfill_run_uuid`, and the call passes the matching `run_uuid` so the CAS actually matches.

```diff
 DuckgresSinkSchemaState.objects.filter(id=candidate.id).update(
-    consecutive_failures=5, first_failed_at=timezone.now(), last_error="boom"
+    backfill_run_uuid="run-1",
+    consecutive_failures=5,
+    first_failed_at=timezone.now(),
+    last_error="boom",
 )

-backfill_module.mark_primed(str(candidate.schema_id))
+backfill_module.mark_primed(str(candidate.schema_id), run_uuid="run-1")
```

Test-only. No production code changes.

> [!NOTE]
> The test's intent is unchanged: promotion to `PRIMED` resets the failure streak. It now just supplies the generation that `mark_primed` requires, rather than relying on the old unpinned signature.

## How did you test this code?

I (Claude) ran these automated tests. I did not do any manual testing.

- Reproduced the failure on a clean `origin/master` worktree with no local changes, confirming this is a master breakage and not a branch artifact.
- `test_backfill.py` on this branch: 29 passed (was 1 failed on master).
- Full `pipeline_v3/duckgres/` suite: 115 passed. On master the same run gave 114 passed, 1 failed, 1 error. The error was a teardown cascade from the failure, not a second defect. It passes in isolation on master.
- Mutation check, to confirm the test still earns its place rather than just satisfying the new signature: removing `**_STREAK_RESET_UPDATES` from `mark_primed` makes the test fail on the assertion, as it should.

No new test is added here. This restores an existing test that catches a real regression: a promotion that silently leaves `consecutive_failures` and `first_failed_at` set, which would keep a healed schema classified as failing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable. Test-only change with no user-facing or documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code, Opus 4.8) found this while bringing a stack of duckgres sink PRs up to date with master and driving their CI green. It surfaced when merging master into #68808: the merged tree failed a test that neither branch had touched. Running the same test against a clean `origin/master` checkout isolated it to master itself.

The fix was scoped deliberately. `mark_primed`'s new `run_uuid` requirement is correct and intentional (#69101 added it to stop a retired run's late promotion from flipping a newer run's row), so the production signature is left alone and the stale call site is updated instead. I considered giving `run_uuid` a default to unbreak the call site, and rejected it: a defaultable generation pin defeats the CAS that #69101 exists to enforce.

The commit was first made on the #68808 branch, then split out and cherry-picked onto master so it can land on its own rather than waiting behind that PR. #68808 was independently force-pushed mid-work, so nothing from that branch is carried here.

Skills invoked: `/django-migrations` (while resolving an unrelated `max_migration.txt` conflict on #68808; no migration is touched in this PR).

Worth a reviewer's eye: master's product-test shards were still in progress when this was opened, so the breakage may not have surfaced on the master run yet. It reproduces locally on `origin/master` at `c0067304c`.
