### PR TITLE
feat(tasks): add channel membership and private channels

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -50,6 +50,7 @@ from products.tasks.backend.logic.services.image_builder import (
 from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
     Channel,
+    ChannelMembership,
     CodeInvite,
     CodeInviteRedemption,
     CodeWorkflowConfig,
@@ -4544,8 +4545,8 @@ def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
 
 
 def list_channels(team_id: int, user_id: int | None) -> list[contracts.ChannelDTO]:
-    """All live public channels plus the requester's personal channel (provisioned lazily),
-    personal first, then by name."""
+    """All live public channels plus the requester's personal channel (provisioned lazily) and
+    any private channels they're a member of. Personal first, then by name."""
     channels: list[Channel] = []
     if user_id is not None:
         channels.append(_ensure_personal_channel(team_id, user_id))
@@ -4554,7 +4555,90 @@ def list_channels(team_id: int, user_id: int | None) -> list[contracts.ChannelDT
         .select_related("created_by")
         .order_by("name")
     )
+    if user_id is not None:
+        member_channel_ids = ChannelMembership.objects.filter(team_id=team_id, user_id=user_id).values("channel_id")
+        channels.extend(
+            Channel.objects.filter(
+                team_id=team_id,
+                channel_type=Channel.ChannelType.PRIVATE,
+                deleted=False,
+                id__in=member_channel_ids,
+            )
+            .select_related("created_by")
+            .order_by("name")
+        )
     return [_channel_to_dto(channel) for channel in channels]
+
+
+def create_private_channel(team_id: int, user_id: int | None, *, name: str) -> contracts.ChannelDTO | None:
+    """Create a private channel, joining the creator as its first member. Unlike public channels,
+    private channels aren't resolve-or-create by name (they aren't uniquely named), so each call
+    creates a fresh channel. ``None`` for empty names."""
+    normalized = normalize_channel_name(name)
+    if not normalized:
+        return None
+    channel = Channel.objects.create(
+        team_id=team_id, name=normalized, channel_type=Channel.ChannelType.PRIVATE, created_by_id=user_id
+    )
+    if user_id is not None:
+        ChannelMembership.objects.get_or_create(team_id=team_id, channel=channel, user_id=user_id)
+    return _channel_to_dto(channel)
+
+
+def _channel_visible_to(channel: Channel, team_id: int, user_id: int | None) -> bool:
+    if channel.channel_type == Channel.ChannelType.PUBLIC:
+        return True
+    if channel.channel_type == Channel.ChannelType.PERSONAL:
+        return channel.created_by_id == user_id
+    return (
+        user_id is not None
+        and ChannelMembership.objects.filter(team_id=team_id, channel_id=channel.id, user_id=user_id).exists()
+    )
+
+
+def join_channel(channel_id: str | UUID, team_id: int, user_id: int | None) -> contracts.ChannelDTO | str:
+    """Add the requester to a public or private channel (idempotent). Returns the DTO, or an error
+    kind: ``not_found`` / ``personal`` / ``no_user``. Membership on a private channel is what makes
+    it visible in the requester's channel list."""
+    if user_id is None:
+        return "no_user"
+    channel = Channel.objects.select_related("created_by").filter(id=channel_id, team_id=team_id, deleted=False).first()
+    if channel is None:
+        return "not_found"
+    if channel.channel_type == Channel.ChannelType.PERSONAL:
+        return "personal"
+    ChannelMembership.objects.get_or_create(team_id=team_id, channel=channel, user_id=user_id)
+    return _channel_to_dto(channel)
+
+
+def leave_channel(channel_id: str | UUID, team_id: int, user_id: int | None) -> str:
+    """Remove the requester from a channel (idempotent). Returns ``ok`` / ``not_found`` /
+    ``personal`` / ``no_user``."""
+    if user_id is None:
+        return "no_user"
+    channel = Channel.objects.filter(id=channel_id, team_id=team_id, deleted=False).first()
+    if channel is None:
+        return "not_found"
+    if channel.channel_type == Channel.ChannelType.PERSONAL:
+        return "personal"
+    ChannelMembership.objects.filter(team_id=team_id, channel_id=channel_id, user_id=user_id).delete()
+    return "ok"
+
+
+def list_channel_members(
+    channel_id: str | UUID, team_id: int, user_id: int | None
+) -> list[contracts.TaskUserBasicInfo] | None:
+    """The members of a channel, oldest join first. ``None`` when the channel isn't visible to the
+    requester (missing, or a private channel they don't belong to)."""
+    channel = Channel.objects.filter(id=channel_id, team_id=team_id, deleted=False).first()
+    if channel is None or not _channel_visible_to(channel, team_id, user_id):
+        return None
+    memberships = (
+        ChannelMembership.objects.filter(team_id=team_id, channel_id=channel_id)
+        .select_related("user")
+        .order_by("created_at", "id")
+    )
+    return [info for membership in memberships if (info := _user_basic_info(membership.user)) is not None]
 
 
 def resolve_channel(team_id: int, user_id: int | None, *, name: str) -> contracts.ChannelDTO | None:

--- a/products/tasks/backend/migrations/0056_channelmembership_and_private_channels.py
+++ b/products/tasks/backend/migrations/0056_channelmembership_and_private_channels.py
@@ -1,0 +1,68 @@
+import django.utils.timezone
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1231_duckgresserverteam"),
+        ("tasks", "0055_task_artifact_registry"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="channel",
+            name="channel_type",
+            field=models.CharField(
+                choices=[("public", "Public"), ("personal", "Personal"), ("private", "Private")],
+                default="public",
+                max_length=16,
+            ),
+        ),
+        migrations.CreateModel(
+            name="ChannelMembership",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "channel",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, related_name="memberships", to="tasks.channel"
+                    ),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="posthog.team",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_task_channel_membership",
+                "constraints": [
+                    models.UniqueConstraint(fields=["channel", "user"], name="task_channel_membership_unique"),
+                ],
+            },
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0055_task_artifact_registry
+0056_channelmembership_and_private_channels

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -64,6 +64,7 @@ class Channel(TeamScopedRootMixin):
     class ChannelType(models.TextChoices):
         PUBLIC = "public", "Public"
         PERSONAL = "personal", "Personal"
+        PRIVATE = "private", "Private"
 
     PERSONAL_CHANNEL_NAME = "me"
 
@@ -100,6 +101,29 @@ class Channel(TeamScopedRootMixin):
 
     def __str__(self):
         return f"#{self.name}"
+
+
+class ChannelMembership(TeamScopedRootMixin, UUIDModel):
+    """A user's membership of a Channel — the canonical member list a channel carries and the
+    join/leave record behind it. Public channels are open feeds every teammate can see; private
+    channels are visible only to their members. Personal channels don't carry membership rows
+    (they are provisioned one-per-user)."""
+
+    # App-level scoping is enforced by TeamScopedRootMixin; db_constraint=False avoids locking
+    # the hot posthog_team / posthog_user tables (see Channel above for the full reasoning).
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+", db_constraint=False)
+    channel = models.ForeignKey(Channel, on_delete=models.CASCADE, related_name="memberships")
+    user = models.ForeignKey("posthog.User", on_delete=models.CASCADE, related_name="+", db_constraint=False)
+    created_at = models.DateTimeField(default=django_timezone.now)
+
+    class Meta:
+        db_table = "posthog_task_channel_membership"
+        constraints = [
+            models.UniqueConstraint(fields=["channel", "user"], name="task_channel_membership_unique"),
+        ]
+
+    def __str__(self):
+        return f"user {self.user_id} in {self.channel_id}"
 
 
 SLACK_NOTIFIED_PR_URL_STATE_KEY = "slack_notified_pr_url"

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1255,10 +1255,19 @@ class ChannelSerializer(DataclassSerializer):
 
 
 class ChannelWriteSerializer(serializers.Serializer):
-    """Request body for creating (resolve-or-create) or renaming a public channel."""
+    """Request body for creating (resolve-or-create) or renaming a channel."""
 
     name = serializers.CharField(
         max_length=128, help_text="Channel name, rendered as #<name>. Normalized to lowercase-dashed."
+    )
+    channel_type = serializers.ChoiceField(
+        choices=[("public", "Public"), ("private", "Private")],
+        default="public",
+        help_text=(
+            "Visibility of a newly created channel. 'public' resolves-or-creates the shared feed "
+            "with this name; 'private' always creates a new members-only channel with the creator "
+            "as its first member. Ignored when renaming."
+        ),
     )
 
 

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -21,6 +21,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskMentionSerializer,
     TaskThreadMessageSerializer,
     TaskThreadMessageWriteSerializer,
+    TaskUserBasicInfoSerializer,
 )
 
 
@@ -55,13 +56,21 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @extend_schema(
         request=ChannelWriteSerializer,
         responses={200: ChannelSerializer},
-        summary="Resolve or create a public channel",
-        description="Returns the existing public channel with the (normalized) name, creating it if needed.",
+        summary="Create a channel",
+        description=(
+            "Public (default): returns the existing public channel with the (normalized) name, "
+            "creating it if needed. Private: always creates a new members-only channel with the "
+            "requester as its first member."
+        ),
     )
     def create(self, request, **kwargs):
         serializer = ChannelWriteSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        channel = tasks_facade.resolve_channel(self.team_id, self._user_id(), name=serializer.validated_data["name"])
+        name = serializer.validated_data["name"]
+        if serializer.validated_data["channel_type"] == "private":
+            channel = tasks_facade.create_private_channel(self.team_id, self._user_id(), name=name)
+        else:
+            channel = tasks_facade.resolve_channel(self.team_id, self._user_id(), name=name)
         if channel is None:
             return Response({"detail": "Invalid channel name"}, status=status.HTTP_400_BAD_REQUEST)
         return Response(ChannelSerializer(channel).data)
@@ -93,6 +102,54 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if result == "personal":
             raise PermissionDenied("Personal channels cannot be deleted")
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        request=None,
+        responses={200: ChannelSerializer},
+        summary="Join a channel",
+        description="Adds the requester to a public or private channel (idempotent). Personal channels cannot be joined.",
+    )
+    @action(detail=True, methods=["post"], url_path="join", required_scopes=["task:write"])
+    def join(self, request, pk=None, **kwargs):
+        result = tasks_facade.join_channel(pk, self.team_id, self._user_id())
+        if result == "not_found":
+            raise NotFound()
+        if result == "personal":
+            raise PermissionDenied("Personal channels cannot be joined")
+        if result == "no_user":
+            raise PermissionDenied("Anonymous requests cannot join channels")
+        return Response(ChannelSerializer(result).data)
+
+    @extend_schema(
+        request=None,
+        responses={204: None},
+        summary="Leave a channel",
+        description="Removes the requester from a channel (idempotent). Personal channels cannot be left.",
+    )
+    @action(detail=True, methods=["post"], url_path="leave", required_scopes=["task:write"])
+    def leave(self, request, pk=None, **kwargs):
+        result = tasks_facade.leave_channel(pk, self.team_id, self._user_id())
+        if result == "not_found":
+            raise NotFound()
+        if result == "personal":
+            raise PermissionDenied("Personal channels cannot be left")
+        if result == "no_user":
+            raise PermissionDenied("Anonymous requests cannot leave channels")
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        responses={
+            200: OpenApiResponse(response=TaskUserBasicInfoSerializer(many=True), description="Channel members")
+        },
+        summary="List channel members",
+        description="Members of the channel, oldest join first. 404 for private channels the requester isn't in.",
+    )
+    @action(detail=True, methods=["get"], url_path="members", pagination_class=None)
+    def members(self, request, pk=None, **kwargs):
+        members = tasks_facade.list_channel_members(pk, self.team_id, self._user_id())
+        if members is None:
+            raise NotFound()
+        return Response(TaskUserBasicInfoSerializer(members, many=True).data)
 
 
 class TaskMentionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -63,6 +64,57 @@ class ChannelsAPITestCase(TestCase):
         self.assertEqual(first.json()["name"], "growth-ideas")
         second = self.client.post(self._channels_url(), {"name": "growth ideas"})
         self.assertEqual(second.json()["id"], first.json()["id"])
+
+    def _member_ids(self, client: APIClient, channel_id: str) -> list[int]:
+        return [m["id"] for m in client.get(f"{self._channels_url()}{channel_id}/members/").json()]
+
+    def test_private_channel_is_visible_only_to_its_members(self):
+        created = self.client.post(self._channels_url(), {"name": "secret plans", "channel_type": "private"})
+        self.assertEqual(created.status_code, status.HTTP_200_OK, created.content)
+        channel = created.json()
+        self.assertEqual(channel["channel_type"], "private")
+
+        # The creator is joined as the first member and sees the channel in their list.
+        self.assertIn(channel["id"], [c["id"] for c in self.client.get(self._channels_url()).json()])
+        self.assertEqual(self._member_ids(self.client, channel["id"]), [self.user.id])
+
+        # A teammate who isn't a member neither sees it listed nor can read its members.
+        other = APIClient()
+        other.force_authenticate(self.other_user)
+        self.assertNotIn(channel["id"], [c["id"] for c in other.get(self._channels_url()).json()])
+        self.assertEqual(
+            other.get(f"{self._channels_url()}{channel['id']}/members/").status_code, status.HTTP_404_NOT_FOUND
+        )
+
+    def test_joining_reveals_a_private_channel_and_leaving_hides_it(self):
+        channel_id = self.client.post(self._channels_url(), {"name": "secret", "channel_type": "private"}).json()["id"]
+        other = APIClient()
+        other.force_authenticate(self.other_user)
+
+        joined = other.post(f"{self._channels_url()}{channel_id}/join/")
+        self.assertEqual(joined.status_code, status.HTTP_200_OK, joined.content)
+        self.assertIn(channel_id, [c["id"] for c in other.get(self._channels_url()).json()])
+        self.assertCountEqual(self._member_ids(self.client, channel_id), [self.user.id, self.other_user.id])
+
+        left = other.post(f"{self._channels_url()}{channel_id}/leave/")
+        self.assertEqual(left.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertNotIn(channel_id, [c["id"] for c in other.get(self._channels_url()).json()])
+
+    def test_public_channel_join_is_idempotent(self):
+        channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
+        other = APIClient()
+        other.force_authenticate(self.other_user)
+        self.assertEqual(other.post(f"{self._channels_url()}{channel_id}/join/").status_code, status.HTTP_200_OK)
+        self.assertEqual(other.post(f"{self._channels_url()}{channel_id}/join/").status_code, status.HTTP_200_OK)
+        # Joining twice registers a single membership row, not two.
+        self.assertEqual(self._member_ids(self.client, channel_id), [self.other_user.id])
+
+    @parameterized.expand([("join",), ("leave",)])
+    def test_personal_channel_cannot_be_joined_or_left(self, action: str):
+        self.client.get(self._channels_url())
+        personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        response = self.client.post(f"{self._channels_url()}{personal.id}/{action}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_personal_channel_cannot_be_renamed_or_deleted(self):
         self.client.get(self._channels_url())

--- a/products/tasks/docs/CHANNELS.md
+++ b/products/tasks/docs/CHANNELS.md
@@ -13,6 +13,7 @@ class Channel(models.Model):
     class ChannelType(models.TextChoices):
         PUBLIC = "public", "Public"        # visible to the whole team
         PERSONAL = "personal", "Personal"  # the user's private "#me" channel
+        PRIVATE = "private", "Private"     # visible only to its members (ChannelMembership)
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+")
@@ -38,6 +39,26 @@ class Channel(models.Model):
                 condition=Q(channel_type="personal", deleted=False),
                 name="task_channel_team_user_personal_unique",
             ),
+        ]
+
+
+class ChannelMembership(models.Model):
+    """A user's membership of a Channel — the canonical member list a channel
+    carries, and the join/leave record behind it. Public channels are open feeds;
+    private channels are visible only to their members. Personal channels don't
+    carry membership rows (they are provisioned one-per-user)."""
+
+    id = models.UUIDField(primary_key=True, default=uuid7, editable=False)
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, related_name="+", db_constraint=False)
+    channel = models.ForeignKey("tasks.Channel", on_delete=models.CASCADE, related_name="memberships")
+    user = models.ForeignKey("posthog.User", on_delete=models.CASCADE, related_name="+", db_constraint=False)
+    created_at = models.DateTimeField(default=django_timezone.now)
+
+    class Meta:
+        db_table = "posthog_task_channel_membership"
+        constraints = [
+            # a user is a member of a channel at most once
+            models.UniqueConstraint(fields=["channel", "user"], name="task_channel_membership_unique"),
         ]
 
 
@@ -76,17 +97,34 @@ public channel is visible to every team member (multiplayer feed). Tasks in a
 personal channel remain visible only via the existing `created_by` rule.
 Thread messages inherit the task's visibility.
 
+Channel listing itself is member-gated for private channels: `GET
+/task_channels/` returns every public channel plus the requester's personal
+channel plus any private channels they belong to (a `ChannelMembership` row).
+A private channel a user isn't in is invisible to them, including its member
+list. Task-level visibility for private channels is still the existing
+`created_by` rule and is tightened in a follow-up.
+
 ## API
 
 ### `/api/projects/{id}/task_channels/`
 
-- `GET /` — list channels: all live public channels plus the requester's
-  personal channel. Listing lazily `get_or_create`s the personal `#me` channel,
-  so every user always has one.
-- `POST / {name}` — resolve-or-create a public channel by name
-  (`get_or_create`, so concurrent creates and name-bridging are race-safe).
+- `GET /` — list channels: all live public channels, the requester's personal
+  channel, and any private channels they're a member of. Listing lazily
+  `get_or_create`s the personal `#me` channel, so every user always has one.
+- `POST / {name, channel_type?}` — `channel_type` defaults to `public`:
+  resolve-or-create a public channel by name (`get_or_create`, so concurrent
+  creates and name-bridging are race-safe). `channel_type=private` always
+  creates a new members-only channel with the requester as its first member
+  (private channels aren't uniquely named, so this never resolves an existing one).
 - `PATCH /{id}/ {name}` — rename a public channel. Personal channels cannot be renamed.
 - `DELETE /{id}/` — soft-delete a public channel. Personal channels cannot be deleted.
+- `POST /{id}/join/` — add the requester to a public or private channel
+  (idempotent). Joining a private channel is what makes it appear in their
+  channel list. Personal channels cannot be joined.
+- `POST /{id}/leave/` — remove the requester from a channel (idempotent).
+  Personal channels cannot be left.
+- `GET /{id}/members/` — members of the channel, oldest join first. 404 for a
+  private channel the requester isn't a member of.
 
 ### Task endpoints
 
@@ -128,7 +166,11 @@ Thread messages inherit the task's visibility.
 
 ## Out of scope (v1)
 
-- Channel membership / invited private channels (only team-public + personal).
+- Invite-based access control for private channels — v1 membership is
+  self-service join/leave by channel id (the UUID is the capability); there is
+  no per-channel invite/admin/role model or member-management-by-others yet.
+- Tightening task-level visibility to private-channel membership (task visibility
+  still keys off `created_by`; only channel listing is member-gated so far).
 - Message editing and emoji reactions.
 - Real-time push for feed/thread updates (clients poll; SSE can come later).
 - Backfilling `channel` onto existing tasks.


### PR DESCRIPTION
## Problem

The channels architecture plan calls for unifying channel identity so the tasks-product `Channel` is the one canonical channel. A concrete first step it names is giving that canonical `Channel` an explicit member list plus the third visibility mode it's missing: `personal` / `public` / `private`.

Today a `Channel` is only ever public (open to the whole team) or personal (`#me`, one per user). There's no way to model a channel that only some teammates can see, and no member list to hang notifications, feed subscriptions, or private visibility off of.

This PR takes that one slice: channel membership and private channels. It's additive and non-breaking. Existing public and personal channels behave exactly as before.

## Changes

- **`ChannelMembership` model** (`posthog_task_channel_membership`) - a `team` / `channel` / `user` row, unique per `(channel, user)`. Both hot-table FKs use `db_constraint=False` (matching the sibling `Channel` model) to avoid locking `posthog_team` / `posthog_user`.
- **`PRIVATE` channel type** - a private channel appears in the channel list only for users who hold a membership row. Public and personal listing is unchanged.
- **Facade** (`products/tasks/backend/facade/api.py`) - `create_private_channel` (creates a fresh channel and joins the creator), `join_channel`, `leave_channel`, `list_channel_members`, and `list_channels` now also returns the requester's private channels.
- **Viewset** - `POST /task_channels/` gains an optional `channel_type` (`public` default, or `private`); new `POST /{id}/join/`, `POST /{id}/leave/`, and `GET /{id}/members/` actions.
- **Migration** `0056_channelmembership_and_private_channels` - `CreateModel` + a choices `AlterField` on `channel_type`.
- **Docs** - `products/tasks/docs/CHANNELS.md` updated (models, visibility, API, and the out-of-scope list, which previously deferred exactly this).

Design doc this advances: `PostHog/code` → `docs/plans/channels-architecture.md` (the "unify channel identity" workstream).

> [!NOTE]
> v1 membership is deliberately self-service: any teammate can join a public or private channel by its id (the UUID is the capability), and members can leave. Invite/admin/role-based access control, and tightening *task*-level visibility to private-channel membership, are left to the follow-up ADR the plan calls for. Only channel *listing* is member-gated here.

### Relationship to RBAC (deliberate)

This does **not** plug into PostHog's resource-level RBAC (`posthog/rbac/user_access_control.py`, `ee/api/rbac/`). `task` / `channel` are not in `ACCESS_CONTROL_RESOURCES` and the tasks product has never used `UserAccessControl` - visibility here is the product's own model in `products/tasks/backend/visibility.py` (`channel_type` + `created_by`), and this PR extends that model with membership rather than introducing a second access system. Baseline isolation still holds: `TeamAndOrgViewSetMixin` requires team membership and `TeamScopedRootMixin` scopes every row to the team, and the new `join` / `leave` actions reuse the existing `task:write` API scope. Promoting `channel` to a first-class RBAC resource (roles, access levels) is a bigger decision that belongs with the canonical-row ADR, since it also governs task visibility. Keeping channels on their own visibility model for now is intentional.

## How did you test this code?

I (Claude, `claude-opus-4-8`) added focused tests to `products/tasks/backend/tests/test_channels_api.py`:

- `test_private_channel_is_visible_only_to_its_members` - creator is auto-joined and sees it; a non-member neither lists it nor can read its members (404). Catches a regression where private channels leak into other users' lists or member reads.
- `test_joining_reveals_a_private_channel_and_leaving_hides_it` - membership drives visibility both ways.
- `test_public_channel_join_is_idempotent` - joining twice is one membership row, not two.
- `test_personal_channel_cannot_be_joined_or_left` (parameterized) - the personal-channel guard on both actions.

I could **not** run the Django/Postgres test suite in this sandbox: it has no Docker, so Postgres/ClickHouse aren't available, and the Python venv couldn't be built (uv can't self-update to the pinned `>=0.10.2` because GitHub egress is blocked). So these tests will first run in CI. What I did run locally: `ruff check` (clean) and `ruff format` on every changed file, and `python -m py_compile` on all of them. The migration was hand-written to byte-match Django's generator output (verified against the original `0045` rendering of the same field), since `makemigrations` couldn't run here. The check-openapi-types CI job will regenerate the frontend types for the new endpoints/field on this same-repo branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - Adam (@adamleithp) directed the work: read the channels-architecture plan, pick a feasible item from its "where to start" list, and implement it.

Authored by Claude Code (model `claude-opus-4-8`). Skills invoked while shaping this PR: `/improving-drf-endpoints` (schema annotations + `help_text` on the new serializer field and actions), `/django-migrations` (hot-table FK safety, the choices `AlterField`, hand-writing the migration safely), `/writing-tests` (the value/efficiency gate - the four tests above each name a distinct regression), and `/setup-web-tests` (attempted, to stand up a venv for running tests locally).

Decisions along the way:
- **Picked the membership slice of "unify channel identity"** over the artifact-registry or context-summarizer items. It's the one that lives entirely in `posthog/posthog`, is purely additive, and needs no cross-repo coordination. The artifact registry already has a task-scoped `TaskArtifact` model, and the plan's channel-scoped version depends on this identity work landing first.
- **Kept access control minimal on purpose.** Join-by-id rather than an invite system, and no RBAC integration, because "who can see/join a private channel" is exactly the question the plan says an ADR should settle. Wiring a half-designed permission model now would be the wrong kind of guess. Documented as out-of-scope, and the RBAC relationship is spelled out above.
- **Left task-level visibility alone.** Only channel listing is member-gated; task visibility still keys off `created_by`, so nothing about existing task access changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9hhMVNStnMoNaEDNVH2hZ