### PR TITLE
feat(posthog-code): split seat-covered usage out of billed code credits

### DIFF
--- a/ee/settings.py
+++ b/ee/settings.py
@@ -77,6 +77,8 @@ MATERIALIZE_COLUMNS_BACKFILL_PERIOD_DAYS = get_from_env("MATERIALIZE_COLUMNS_BAC
 MATERIALIZE_COLUMNS_MAX_AT_ONCE = get_from_env("MATERIALIZE_COLUMNS_MAX_AT_ONCE", 100, type_cast=int)
 
 BILLING_SERVICE_URL = get_from_env("BILLING_SERVICE_URL", "https://billing.posthog.com")
+# PublicAPIKey for billing's non-org-scoped service endpoints (seat active-roster); provisioned in billing admin
+BILLING_SERVICE_API_KEY = get_from_env("BILLING_SERVICE_API_KEY", "")
 
 # Whether to enable the admin portal. Default false for self-hosted as if not setup properly can pose security issues.
 ADMIN_PORTAL_ENABLED = get_from_env("ADMIN_PORTAL_ENABLED", DEMO or DEBUG, type_cast=str_to_bool)

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4599,6 +4599,158 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         expected = [(self.org_1_team_1.id, expected_credits)] if expected_credits is not None else []
         self.assertEqual(result, expected)
 
+    @patch("posthog.tasks.usage_report.get_instance_region")
+    @patch("posthog.tasks.usage_report._get_posthog_code_seat_covered_team_distinct_id_pairs")
+    def test_posthog_code_seat_covered_generations_split_between_billed_and_seat_counters(
+        self, mock_seat_covered: MagicMock, mock_region: MagicMock
+    ) -> None:
+        """Generations matching a seat-covered (customer team, distinct_id) pair are excluded from
+        billed credits and counted in the seat-credits counter instead. Coverage is scoped to the
+        seat's org's teams: the same distinct_id generating in another org's team stays billed."""
+        from posthog.tasks.usage_report import get_posthog_code_credits_split_by_seat_coverage
+
+        mock_region.return_value = "US"
+        self._setup_teams()
+        analytics_org = Organization.objects.create(name="PostHog Analytics")
+        analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        self._setup_instance_group_mapping(analytics_team)
+        other_org = Organization.objects.create(name="Org without covered seats")
+        other_org_team = Team.objects.create(pk=4, organization=other_org, name="Team 1 org other")
+
+        # Seat granted by org_1 only — covers usage in org_1's team, not other_org's.
+        mock_seat_covered.return_value = {(self.org_1_team_1.id, "user_seat_covered")}
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        # Seat-covered pair (free/pro/alpha PostHog Code seat in org_1) — must not be billed.
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_seat_covered",
+            timestamp=period_start + relativedelta(hours=1),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_seat_covered",
+                "$ai_total_cost_usd": 2.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_code",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+        # Billable distinct_id (usage-plan seat or no seat at all) — must stay billed.
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_billable",
+            timestamp=period_start + relativedelta(hours=2),
+            properties={
+                "team_id": self.org_1_team_1.id,
+                "$ai_trace_id": "trace_billable",
+                "$ai_total_cost_usd": 3.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_code",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+        # Same covered user, but in an org that pays per-usage — the org_1 seat must not exempt it.
+        _create_event(
+            event="$ai_generation",
+            team=analytics_team,
+            distinct_id="user_seat_covered",
+            timestamp=period_start + relativedelta(hours=3),
+            properties={
+                "team_id": other_org_team.id,
+                "$ai_trace_id": "trace_other_org",
+                "$ai_total_cost_usd": 4.0,
+                "$ai_billable": True,
+                "ai_product": "posthog_code",
+                "$group_1": "https://us.posthog.com",
+            },
+        )
+
+        flush_persons_and_events()
+
+        split = get_posthog_code_credits_split_by_seat_coverage(period_start, period_end)
+
+        # 3.0 USD * 100 (no markup) = 300 — the seat-covered generation's cost is excluded;
+        # 4.0 USD * 100 = 400 — the covered user's usage in the uncovered org stays billed.
+        self.assertEqual(sorted(split["billed"]), [(self.org_1_team_1.id, 300), (other_org_team.id, 400)])
+        # 2.0 USD * 100 (no markup) = 200 — only the seat-covered pair's cost.
+        self.assertEqual(split["seat_covered"], [(self.org_1_team_1.id, 200)])
+        # One roster snapshot serves both counters.
+        mock_seat_covered.assert_called_once_with(period_start)
+
+    @patch("posthog.tasks.usage_report._get_posthog_code_seat_covered_team_distinct_id_pairs")
+    def test_posthog_code_credits_raises_when_seat_roster_fetch_fails(self, mock_seat_covered: MagicMock) -> None:
+        """A failed roster fetch must raise, not silently bill everyone or no one."""
+        from posthog.tasks.usage_report import (
+            get_posthog_code_credits_split_by_seat_coverage,
+            get_teams_with_posthog_code_credits_used_in_period,
+        )
+
+        mock_seat_covered.side_effect = Exception("billing service unavailable")
+        self._setup_teams()
+
+        period = get_previous_day(at=now() + relativedelta(days=1))
+        period_start, period_end = period
+
+        with self.assertRaises(Exception):
+            get_teams_with_posthog_code_credits_used_in_period(period_start, period_end)
+        with self.assertRaises(Exception):
+            get_posthog_code_credits_split_by_seat_coverage(period_start, period_end)
+
+    @patch("posthog.tasks.usage_report.get_cached_instance_license")
+    def test_posthog_code_seat_coverage_expands_roster_orgs_to_their_teams(self, mock_license: MagicMock) -> None:
+        """The billing roster is org-scoped; coverage applies to every team of the granting org and
+        to nothing else — orgs unknown to this region (the roster spans all regions) drop out."""
+        from posthog.tasks.usage_report import _get_posthog_code_seat_covered_team_distinct_id_pairs
+
+        mock_license.return_value = MagicMock(is_v2_license=True)
+        self._setup_teams()
+        org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
+        other_org = Organization.objects.create(name="Org without covered seats")
+        Team.objects.create(pk=5, organization=other_org, name="Team 1 org other")
+
+        with patch(
+            "products.tasks.backend.facade.billing.get_seat_covered_distinct_ids_by_org",
+            return_value={
+                str(self.org_1.id): {"user_a", "user_b"},
+                "00000000-0000-0000-0000-00000000dead": {"user_other_region"},
+            },
+        ):
+            pairs = _get_posthog_code_seat_covered_team_distinct_id_pairs(now())
+
+        self.assertEqual(
+            pairs,
+            {
+                (self.org_1_team_1.id, "user_a"),
+                (self.org_1_team_1.id, "user_b"),
+                (org_1_team_2.id, "user_a"),
+                (org_1_team_2.id, "user_b"),
+            },
+        )
+
+    @parameterized.expand(
+        [
+            ("no_license", None),
+            ("v1_license", MagicMock(is_v2_license=False)),
+        ]
+    )
+    @patch("posthog.tasks.usage_report.get_cached_instance_license")
+    def test_posthog_code_seat_coverage_is_empty_without_v2_license(
+        self, _name: str, license: MagicMock | None, mock_license: MagicMock
+    ) -> None:
+        """OSS/unlicensed instances have no billing relationship to query — everything stays
+        billable, matching pre-split behavior, and the billing service is never called."""
+        from posthog.tasks.usage_report import _get_posthog_code_seat_covered_team_distinct_id_pairs
+
+        mock_license.return_value = license
+
+        with patch("products.tasks.backend.facade.billing.get_seat_covered_distinct_ids_by_org") as mock_roster:
+            self.assertEqual(_get_posthog_code_seat_covered_team_distinct_id_pairs(now()), set())
+            mock_roster.assert_not_called()
+
     def test_has_non_zero_usage_counts_posthog_code_credits(self) -> None:
         """A posthog_code-only org must survive has_non_zero_usage so its report still reaches billing."""
         import dataclasses
@@ -4609,11 +4761,22 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         self.assertFalse(has_non_zero_usage(UsageReportCounters(**zero)))
         self.assertTrue(has_non_zero_usage(UsageReportCounters(**{**zero, "posthog_code_credits_used_in_period": 5})))
+        self.assertTrue(
+            has_non_zero_usage(UsageReportCounters(**{**zero, "posthog_code_seat_credits_used_in_period": 5}))
+        )
 
 
 class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
+
+        # Licensed tests run the real report path; the billing seat-roster fetch is an external
+        # service call that raises without BILLING_SERVICE_API_KEY, so pin the pre-split default.
+        seat_roster_patcher = patch(
+            "posthog.tasks.usage_report._get_posthog_code_seat_covered_team_distinct_id_pairs", return_value=set()
+        )
+        seat_roster_patcher.start()
+        self.addCleanup(seat_roster_patcher.stop)
 
         self.team2 = Team.objects.create(organization=self.organization)
 
@@ -4855,6 +5018,13 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
 class TestSendNoUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
+        # Licensed tests run the real report path; the billing seat-roster fetch is an external
+        # service call that raises without BILLING_SERVICE_API_KEY, so pin the pre-split default.
+        seat_roster_patcher = patch(
+            "posthog.tasks.usage_report._get_posthog_code_seat_covered_team_distinct_id_pairs", return_value=set()
+        )
+        seat_roster_patcher.start()
+        self.addCleanup(seat_roster_patcher.stop)
         materialize("events", "$exception_values")
 
     @freeze_time("2021-10-10T23:01:00Z")
@@ -4939,6 +5109,14 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
 
     def setUp(self) -> None:
         super().setUp()
+
+        # Licensed tests run the real report path; the billing seat-roster fetch is an external
+        # service call that raises without BILLING_SERVICE_API_KEY, so pin the pre-split default.
+        seat_roster_patcher = patch(
+            "posthog.tasks.usage_report._get_posthog_code_seat_covered_team_distinct_id_pairs", return_value=set()
+        )
+        seat_roster_patcher.start()
+        self.addCleanup(seat_roster_patcher.stop)
 
         # Create additional organizations with teams
         self.org2 = Organization.objects.create(name="Org 2")
@@ -5159,6 +5337,14 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
     def setUp(self) -> None:
         super().setUp()
         materialize("events", "$exception_values")
+
+        # The real report path hits the billing seat-roster fetch, an external service call that
+        # raises without BILLING_SERVICE_API_KEY, so pin the pre-split default (bill everyone).
+        seat_roster_patcher = patch(
+            "posthog.tasks.usage_report._get_posthog_code_seat_covered_team_distinct_id_pairs", return_value=set()
+        )
+        seat_roster_patcher.start()
+        self.addCleanup(seat_roster_patcher.stop)
 
         # Clear existing Django data
         Team.objects.all().delete()

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -6,7 +6,7 @@ import base64
 import logging
 import dataclasses
 from collections import Counter, defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, Optional, TypedDict, Union
 
@@ -229,7 +229,10 @@ class UsageReportCounters:
     signals_credits_used_in_period: int
 
     # PostHog Code Billing Credits (PostHog Code product usage — same cost math as ai_credits, scoped to ai_product='posthog_code')
+    # Billed: excludes seat-covered usage (free/pro/alpha seats, scoped to the granting org).
     posthog_code_credits_used_in_period: int
+    # Seat-covered complement — reporting only, deliberately not billed or quota-limited.
+    posthog_code_seat_credits_used_in_period: int
 
     # CDP Delivery
     hog_function_calls_in_period: int
@@ -1370,10 +1373,18 @@ def _get_teams_with_ai_credits_for_products(
     usage_report_tag: str,
     product_tag: Product = Product.MAX_AI,
     markup_percent: float = AI_COST_MARKUP_PERCENT,
+    excluded_team_distinct_id_pairs: Collection[tuple[int, str]] | None = None,
+    included_team_distinct_id_pairs: Collection[tuple[int, str]] | None = None,
 ) -> list[tuple[int, int]]:
     """
     Shared implementation for AI billing credit aggregation, whitelisting on the
     `ai_product` event property — only generations tagged with an `ai_products` value are billed.
+
+    `excluded_team_distinct_id_pairs`/`included_team_distinct_id_pairs` are mutually exclusive
+    filters on (customer team_id, distinct_id) — the team an event bills to and the calling user —
+    used to split PostHog Code credits between seat-covered and billable generations. Pairs rather
+    than bare distinct_ids because seat coverage is org-scoped: a user's covered seat in one org
+    must not exempt their usage in an org that pays per-usage.
 
     A billable $ai_generation (with positive cost) is billed when its trace is billable OR it has no
     trace. Products that emit a paired $ai_trace (e.g. posthog_ai) are billed only on a billable trace;
@@ -1399,6 +1410,13 @@ def _get_teams_with_ai_credits_for_products(
     Events are stored in team 1 (EU) or team 2 (US), with the actual team (on which we group by) in properties.
     We filter by the configured `instance` group column, which contains the region URL.
     """
+    assert not (excluded_team_distinct_id_pairs and included_team_distinct_id_pairs), (
+        "excluded_team_distinct_id_pairs and included_team_distinct_id_pairs are mutually exclusive"
+    )
+
+    if included_team_distinct_id_pairs is not None and not included_team_distinct_id_pairs:
+        return []
+
     region = get_instance_region()
 
     if region is None:
@@ -1415,11 +1433,35 @@ def _get_teams_with_ai_credits_for_products(
     if region_filter_params is None:
         return []
 
+    # Roster is a per-day snapshot, not per-event: a mid-day seat change attributes the whole
+    # day to whichever plan billing reports for that day.
+    seat_pair_filter_clause = ""
+    query_params: dict[str, Any] = {
+        "team_to_query": team_to_query,
+        "begin": begin,
+        "end": end,
+        "markup_multiplier": 1 + markup_percent,
+        "excluded_tools": AI_BILLING_EXCLUDED_TOOLS,
+        "ai_products": tuple(ai_products),
+        **region_filter_params,
+    }
+    if excluded_team_distinct_id_pairs:
+        seat_pair_filter_clause = (
+            "AND (JSONExtractInt(properties, 'team_id'), distinct_id) NOT IN %(excluded_team_distinct_id_pairs)s"
+        )
+        query_params["excluded_team_distinct_id_pairs"] = tuple(sorted(excluded_team_distinct_id_pairs))
+    elif included_team_distinct_id_pairs:
+        seat_pair_filter_clause = (
+            "AND (JSONExtractInt(properties, 'team_id'), distinct_id) IN %(included_team_distinct_id_pairs)s"
+        )
+        query_params["included_team_distinct_id_pairs"] = tuple(sorted(included_team_distinct_id_pairs))
+
     with tags_context(
         product=product_tag, feature=Feature.USAGE_REPORT, usage_report=usage_report_tag, kind="usage_report"
     ):
+        # nosemgrep: clickhouse-fstring-param-audit - seat_pair_filter_clause is one of two hardcoded literals; pairs go through %(...)s params
         results = sync_execute(
-            """
+            f"""
             WITH trace_analysis AS (
                 WITH %(excluded_tools)s AS excluded_tools
                 SELECT
@@ -1499,6 +1541,7 @@ def _get_teams_with_ai_credits_for_products(
                         AND timestamp < %(end)s
                         AND event = '$ai_generation'
                         AND JSONExtractString(properties, 'ai_product') IN %(ai_products)s
+                        {seat_pair_filter_clause}
                 )
                 WHERE
                     ai_billable = 1
@@ -1525,15 +1568,7 @@ def _get_teams_with_ai_credits_for_products(
             ORDER BY
                 ai_credits DESC
             """,
-            {
-                "team_to_query": team_to_query,
-                "begin": begin,
-                "end": end,
-                "markup_multiplier": 1 + markup_percent,
-                "excluded_tools": AI_BILLING_EXCLUDED_TOOLS,
-                "ai_products": tuple(ai_products),
-                **region_filter_params,
-            },
+            query_params,
             workload=Workload.OFFLINE,
             settings=CH_BILLING_SETTINGS,
             ch_user=ClickHouseUser.BILLING,
@@ -1581,6 +1616,77 @@ def get_signals_credited_refund_credits_for_org(
     return credited_refund_credits_for_org(organization_id, begin, end)
 
 
+def _get_posthog_code_seat_covered_team_distinct_id_pairs(begin: datetime) -> set[tuple[int, str]]:
+    """Seat-covered (customer team_id, distinct_id) pairs from the billing service's roster for the
+    report day.
+
+    Seat coverage is org-scoped — a user's covered seat in one org must not exempt their usage in
+    an org that pays per-usage — so the roster's organizations are expanded to their teams to match
+    the customer team id each event bills to. Roster orgs unknown to this region's database (the
+    roster spans all regions) have no local teams and drop out here.
+
+    OSS/unlicensed instances have no billing relationship to query — empty set, i.e. everything
+    stays billable, matching behavior before the seat split (mirrors send_report_to_billing_service's
+    license no-op).
+    """
+    if not settings.EE_AVAILABLE:
+        return set()
+
+    license = get_cached_instance_license()
+    if not license or not license.is_v2_license:
+        return set()
+
+    from products.tasks.backend.facade.billing import (  # noqa: PLC0415 — imports ee, an optional dependency
+        POSTHOG_CODE_PRODUCT_KEY,
+        get_seat_covered_distinct_ids_by_org,
+    )
+
+    covered_by_org = get_seat_covered_distinct_ids_by_org(POSTHOG_CODE_PRODUCT_KEY, begin.date())
+    if not covered_by_org:
+        return set()
+
+    team_ids_by_org: dict[str, list[int]] = {}
+    for team_id, organization_id in Team.objects.filter(organization_id__in=covered_by_org.keys()).values_list(
+        "id", "organization_id"
+    ):
+        team_ids_by_org.setdefault(str(organization_id), []).append(team_id)
+
+    return {
+        (team_id, distinct_id)
+        for organization_id, distinct_ids in covered_by_org.items()
+        for team_id in team_ids_by_org.get(organization_id, ())
+        for distinct_id in distinct_ids
+    }
+
+
+def _get_posthog_code_billed_credits(
+    begin: datetime, end: datetime, seat_covered_pairs: set[tuple[int, str]]
+) -> list[tuple[int, int]]:
+    return _get_teams_with_ai_credits_for_products(
+        begin,
+        end,
+        ai_products=POSTHOG_CODE_AI_PRODUCTS,
+        usage_report_tag="posthog_code_credits",
+        product_tag=Product.POSTHOG_CODE,
+        markup_percent=POSTHOG_CODE_COST_MARKUP_PERCENT,
+        excluded_team_distinct_id_pairs=seat_covered_pairs,
+    )
+
+
+def _get_posthog_code_seat_credits(
+    begin: datetime, end: datetime, seat_covered_pairs: set[tuple[int, str]]
+) -> list[tuple[int, int]]:
+    return _get_teams_with_ai_credits_for_products(
+        begin,
+        end,
+        ai_products=POSTHOG_CODE_AI_PRODUCTS,
+        usage_report_tag="posthog_code_seat_credits",
+        product_tag=Product.POSTHOG_CODE,
+        markup_percent=POSTHOG_CODE_COST_MARKUP_PERCENT,
+        included_team_distinct_id_pairs=seat_covered_pairs,
+    )
+
+
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_posthog_code_credits_used_in_period(
@@ -1589,16 +1695,45 @@ def get_teams_with_posthog_code_credits_used_in_period(
 ) -> list[tuple[int, int]]:
     """PostHog Code billing credits — only events tagged with ai_product='posthog_code'.
 
-    Billed as pure pass-through of model costs (no markup), unlike PostHog AI's 20%.
+    Billed as pure pass-through of model costs (no markup), unlike PostHog AI's 20%. Excludes
+    generations whose (customer team, distinct_id) is seat-covered (free/pro/alpha PostHog Code
+    seats, already paid for via the seat itself). Used by quota limiting; the usage report goes
+    through `get_posthog_code_credits_split_by_seat_coverage` instead so both of its counters
+    come from one roster snapshot.
+
+    If the billing seat roster fetch fails, this raises rather than falling back to billing
+    everyone (overbilling seat holders) or no one (undercounting usage) — the callers'
+    existing retry/error handling takes over from there.
     """
-    return _get_teams_with_ai_credits_for_products(
-        begin,
-        end,
-        ai_products=POSTHOG_CODE_AI_PRODUCTS,
-        usage_report_tag="posthog_code_credits",
-        product_tag=Product.POSTHOG_CODE,
-        markup_percent=POSTHOG_CODE_COST_MARKUP_PERCENT,
-    )
+    seat_covered_pairs = _get_posthog_code_seat_covered_team_distinct_id_pairs(begin)
+    return _get_posthog_code_billed_credits(begin, end, seat_covered_pairs)
+
+
+@timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
+def get_posthog_code_credits_split_by_seat_coverage(
+    begin: datetime,
+    end: datetime,
+) -> dict[str, list[tuple[int, int]]]:
+    """Both PostHog Code usage-report counters, split from ONE seat-roster snapshot so they are
+    exact complements — separate roster fetches could disagree and double-count or drop a
+    generation across the two.
+
+    `billed` excludes seat-covered (customer team, distinct_id) pairs; `seat_covered` is the
+    complement. The seat-covered side is not billed today: seat plans provide PostHog Code as a
+    $0 usage entitlement, and the counter exists purely for record/reporting/QA per the billing
+    team's request — do not wire it into billing_manager's update_billing_organization_usage or
+    quota limiting.
+
+    If the billing seat roster fetch fails, this raises rather than falling back to billing
+    everyone (overbilling seat holders) or no one (undercounting usage) — the usage-report task's
+    existing retry/error handling takes over from there.
+    """
+    seat_covered_pairs = _get_posthog_code_seat_covered_team_distinct_id_pairs(begin)
+    return {
+        "billed": _get_posthog_code_billed_credits(begin, end, seat_covered_pairs),
+        "seat_covered": _get_posthog_code_seat_credits(begin, end, seat_covered_pairs),
+    }
 
 
 dwh_pricing_free_period_start = datetime(2025, 10, 29, 0, 0, 0, tzinfo=UTC)
@@ -2316,6 +2451,7 @@ def has_non_zero_usage(report: UsageReportCounters) -> bool:
         or report.ai_credits_used_in_period > 0
         or report.signals_credits_used_in_period > 0
         or report.posthog_code_credits_used_in_period > 0
+        or report.posthog_code_seat_credits_used_in_period > 0
         or report.logs_bytes_in_period > 0
         or report.workflow_emails_sent_in_period > 0
         or report.workflow_push_sent_in_period > 0
@@ -2356,6 +2492,7 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
     exception_metrics_by_library, exception_metrics = get_teams_with_exceptions_captured_in_period(
         period_start, period_end
     )
+    posthog_code_credits_split = get_posthog_code_credits_split_by_seat_coverage(period_start, period_end)
 
     return {
         "teams_with_event_count_in_period": get_teams_with_billable_event_count_in_period(
@@ -2582,9 +2719,8 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_signals_credits_used_in_period": get_teams_with_signals_credits_used_in_period(
             period_start, period_end
         ),
-        "teams_with_posthog_code_credits_used_in_period": get_teams_with_posthog_code_credits_used_in_period(
-            period_start, period_end
-        ),
+        "teams_with_posthog_code_credits_used_in_period": posthog_code_credits_split["billed"],
+        "teams_with_posthog_code_seat_credits_used_in_period": posthog_code_credits_split["seat_covered"],
         "teams_with_active_hog_destinations_in_period": get_teams_with_active_hog_destinations_in_period(),
         "teams_with_active_hog_transformations_in_period": get_teams_with_active_hog_transformations_in_period(),
         "teams_with_workflow_emails_sent_in_period": get_teams_with_workflow_emails_sent_in_period(
@@ -2767,6 +2903,9 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         ai_credits_used_in_period=all_data["teams_with_ai_credits_used_in_period"].get(team.id, 0),
         signals_credits_used_in_period=all_data["teams_with_signals_credits_used_in_period"].get(team.id, 0),
         posthog_code_credits_used_in_period=all_data["teams_with_posthog_code_credits_used_in_period"].get(team.id, 0),
+        posthog_code_seat_credits_used_in_period=all_data["teams_with_posthog_code_seat_credits_used_in_period"].get(
+            team.id, 0
+        ),
         active_hog_destinations_in_period=all_data["teams_with_active_hog_destinations_in_period"].get(team.id, 0),
         active_hog_transformations_in_period=all_data["teams_with_active_hog_transformations_in_period"].get(
             team.id, 0

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -49,6 +49,7 @@ from posthog.constants import FlagRequestType
 from posthog.models.group_type_mapping import count_group_type_mappings_per_team
 from posthog.tasks.usage_report import (
     get_all_event_metrics_in_period,
+    get_posthog_code_credits_split_by_seat_coverage,
     get_teams_with_active_batch_exports_in_period,
     get_teams_with_active_external_data_schemas_in_period,
     get_teams_with_active_hog_destinations_in_period,
@@ -72,7 +73,6 @@ from posthog.tasks.usage_report import (
     get_teams_with_logs_records_in_period,
     get_teams_with_logs_retention_bytes_in_period,
     get_teams_with_mobile_billable_recording_count_in_period,
-    get_teams_with_posthog_code_credits_used_in_period,
     get_teams_with_query_metric,
     get_teams_with_recording_bytes_in_period,
     get_teams_with_recording_count_in_period,
@@ -441,8 +441,15 @@ QUERIES: list[QuerySpec] = [
         fn=get_teams_with_signals_credits_used_in_period,
     ),
     QuerySpec(
-        name="teams_with_posthog_code_credits_used_in_period",
-        fn=get_teams_with_posthog_code_credits_used_in_period,
+        name="posthog_code_credits_split",
+        fn=get_posthog_code_credits_split_by_seat_coverage,
+        output="multi",
+        # One spec (= one activity) on purpose: both counters must come from a single
+        # seat-roster snapshot so billed + seat-covered stay exact complements.
+        multi_keys_mapping={
+            "billed": "teams_with_posthog_code_credits_used_in_period",
+            "seat_covered": "teams_with_posthog_code_seat_credits_used_in_period",
+        },
     ),
     # ---- ClickHouse: workflows / messaging ----------------------------------
     QuerySpec(

--- a/products/tasks/backend/billing.py
+++ b/products/tasks/backend/billing.py
@@ -1,0 +1,83 @@
+"""PostHog Code billing — seat roster for the usage-report query split.
+
+Code usage bills through the org's `posthog_code_usage` subscription, but only for users on
+a usage-based plan: generations from seat-covered users (free/pro/alpha PostHog Code seats)
+are excluded from the billed `posthog_code_credits` counter at the query layer. The
+authoritative source for who held which seat on a given day is the billing service's
+ProductSeat table, exposed via its cross-org active-roster endpoint.
+
+Coverage is org-scoped: a seat covers a user's usage only in the organization that granted
+it, so the roster is grouped by organization rather than flattened into one distinct_id set —
+a covered seat in one org must not exempt the same user's usage in an org that pays per-usage.
+"""
+
+from datetime import date
+from typing import Any, TypedDict
+
+from django.conf import settings
+
+import requests
+from rest_framework.exceptions import NotAuthenticated
+from retry import retry
+
+from ee.billing.billing_manager import handle_billing_service_error
+from ee.settings import BILLING_SERVICE_URL
+
+POSTHOG_CODE_PRODUCT_KEY = "posthog_code"
+# $0 usage-entitlement seat plans; every other plan key (free/pro/alpha) is seat-covered.
+POSTHOG_CODE_USAGE_PLAN_KEY_PREFIX = "posthog-code-usage"
+
+
+class ActiveRosterSeat(TypedDict):
+    user_distinct_id: str
+    plan_key: str
+    status: str
+    organization_id: str
+
+
+@retry(tries=3, delay=1, backoff=2)
+def _fetch_active_roster_page(product_key: str, on_date: date, cursor: str | None) -> dict[str, Any]:
+    # Cross-org read, so billing's PublicAPIKey auth instead of the usual per-org JWT.
+    api_key = settings.BILLING_SERVICE_API_KEY
+    if not api_key:
+        raise NotAuthenticated("BILLING_SERVICE_API_KEY is not configured for billing service authentication")
+    params: dict[str, str] = {"product_key": product_key, "on_date": on_date.isoformat()}
+    if cursor:
+        params["cursor"] = cursor
+    res = requests.get(
+        f"{BILLING_SERVICE_URL}/api/public/seats/active-roster/",
+        params=params,
+        headers={"X-API-Key": api_key},
+        timeout=30,
+    )
+    handle_billing_service_error(res, valid_codes=(200,))
+    return res.json()
+
+
+def get_seat_covered_distinct_ids_by_org(product_key: str, on_date: date) -> dict[str, set[str]]:
+    """Distinct_ids whose usage on `on_date` is covered by a non-usage-plan seat, grouped by the
+    id (as a string) of the organization that granted the seat.
+
+    Raises on fetch failure or a malformed roster payload — callers must not swallow this: an
+    empty-roster default would bill every seat holder, a full-roster default would bill no one.
+    """
+    covered: dict[str, set[str]] = {}
+    cursor: str | None = None
+    while True:
+        page = _fetch_active_roster_page(product_key, on_date, cursor)
+        seats: list[ActiveRosterSeat] | None = page.get("results")
+        if not isinstance(seats, list):
+            raise ValueError(
+                f"Billing active-roster response for {product_key} on {on_date} has no 'results' list — "
+                "refusing to treat it as an empty roster"
+            )
+        for seat in seats:
+            # Direct indexing on purpose: a seat missing a required field raises instead of being
+            # silently misclassified as billable.
+            if seat["status"] != "active" or seat["plan_key"].startswith(POSTHOG_CODE_USAGE_PLAN_KEY_PREFIX):
+                continue
+            covered.setdefault(str(seat["organization_id"]), set()).add(seat["user_distinct_id"])
+        cursor = page.get("next")
+        if not cursor:
+            break
+    return covered

--- a/products/tasks/backend/facade/billing.py
+++ b/products/tasks/backend/facade/billing.py
@@ -1,0 +1,11 @@
+"""
+Facade re-exports for PostHog Code billing.
+
+The usage report (``posthog/tasks/usage_report.py``) excludes seat-covered generations from
+the billed ``posthog_code_credits`` counter using the seat roster fetched from the billing
+service; it imports the lookup from here rather than reaching the internal ``billing`` module.
+"""
+
+from products.tasks.backend.billing import POSTHOG_CODE_PRODUCT_KEY, get_seat_covered_distinct_ids_by_org
+
+__all__ = ["POSTHOG_CODE_PRODUCT_KEY", "get_seat_covered_distinct_ids_by_org"]

--- a/products/tasks/backend/tests/test_billing.py
+++ b/products/tasks/backend/tests/test_billing.py
@@ -1,0 +1,142 @@
+import datetime
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+import requests
+from rest_framework.exceptions import NotAuthenticated
+
+from products.tasks.backend.billing import get_seat_covered_distinct_ids_by_org
+
+
+@override_settings(BILLING_SERVICE_API_KEY="pk_test_roster_key")
+class TestActiveRoster(TestCase):
+    def test_missing_api_key_raises(self):
+        with override_settings(BILLING_SERVICE_API_KEY=""):
+            with self.assertRaises(NotAuthenticated):
+                get_seat_covered_distinct_ids_by_org("posthog_code", datetime.date(2026, 7, 9))
+
+    @patch("products.tasks.backend.billing.requests.get")
+    def test_partitions_seat_covered_from_usage_plan_and_groups_by_org(self, mock_get):
+        """Only non-usage-plan seats (free/pro/alpha) are seat-covered, grouped by the org that
+        granted the seat; usage-plan seats and distinct_ids absent from the roster stay billable."""
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "results": [
+                        {
+                            "user_distinct_id": "user_pro",
+                            "plan_key": "posthog-code-pro",
+                            "status": "active",
+                            "organization_id": "org_1",
+                        },
+                        {
+                            "user_distinct_id": "user_pro",
+                            "plan_key": "posthog-code-free",
+                            "status": "active",
+                            "organization_id": "org_3",
+                        },
+                        {
+                            "user_distinct_id": "user_usage_plan",
+                            "plan_key": "posthog-code-usage-20260709",
+                            "status": "active",
+                            "organization_id": "org_2",
+                        },
+                    ],
+                    "next": None,
+                }
+            ),
+        )
+
+        seat_covered = get_seat_covered_distinct_ids_by_org("posthog_code", datetime.date(2026, 7, 9))
+
+        # The same user can hold covered seats in several orgs — coverage stays per-org.
+        self.assertEqual(seat_covered, {"org_1": {"user_pro"}, "org_3": {"user_pro"}})
+
+    @patch("products.tasks.backend.billing.requests.get")
+    def test_roster_fetch_follows_pagination(self, mock_get):
+        mock_get.side_effect = [
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value={
+                        "results": [
+                            {
+                                "user_distinct_id": "user_1",
+                                "plan_key": "posthog-code-free",
+                                "status": "active",
+                                "organization_id": "org_1",
+                            }
+                        ],
+                        "next": "cursor_2",
+                    }
+                ),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(
+                    return_value={
+                        "results": [
+                            {
+                                "user_distinct_id": "user_2",
+                                "plan_key": "posthog-code-free",
+                                "status": "active",
+                                "organization_id": "org_1",
+                            }
+                        ],
+                        "next": None,
+                    }
+                ),
+            ),
+        ]
+
+        seat_covered = get_seat_covered_distinct_ids_by_org("posthog_code", datetime.date(2026, 7, 9))
+
+        self.assertEqual(seat_covered, {"org_1": {"user_1", "user_2"}})
+        self.assertEqual(mock_get.call_count, 2)
+        first_call_params = mock_get.call_args_list[0].kwargs["params"]
+        second_call_params = mock_get.call_args_list[1].kwargs["params"]
+        self.assertNotIn("cursor", first_call_params)
+        self.assertEqual(second_call_params["cursor"], "cursor_2")
+
+    @patch("products.tasks.backend.billing.requests.get")
+    def test_roster_fetch_raises_after_retries_exhausted(self, mock_get):
+        """A failing roster fetch must raise, not be treated as an empty (bill-everyone) or full
+        (bill-no-one) roster by callers."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("boom")
+
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            get_seat_covered_distinct_ids_by_org("posthog_code", datetime.date(2026, 7, 9))
+
+        self.assertEqual(mock_get.call_count, 3)  # retry tries on _fetch_active_roster_page
+
+    @patch("products.tasks.backend.billing.requests.get")
+    def test_response_without_results_list_raises(self, mock_get):
+        """A 200 whose body has no 'results' list is a contract violation and must raise — treating
+        it as an empty roster would silently bill every seat holder."""
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(return_value={"detail": "unexpected shape"}),
+        )
+
+        with self.assertRaises(ValueError):
+            get_seat_covered_distinct_ids_by_org("posthog_code", datetime.date(2026, 7, 9))
+
+    @patch("products.tasks.backend.billing.requests.get")
+    def test_seat_missing_required_field_raises(self, mock_get):
+        """A malformed seat (missing status/plan_key/organization_id) must raise instead of being
+        silently classified as billable or covered."""
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=MagicMock(
+                return_value={
+                    "results": [{"user_distinct_id": "user_1", "plan_key": "posthog-code-free"}],
+                    "next": None,
+                }
+            ),
+        )
+
+        with self.assertRaises(KeyError):
+            get_seat_covered_distinct_ids_by_org("posthog_code", datetime.date(2026, 7, 9))


### PR DESCRIPTION
## Problem

#69062 meters all Code generations into `posthog_code_credits`, but seat-covered usage (free/pro/alpha seats) is already paid for — billing the whole bucket through the new `posthog_code_usage` subscription would double-bill grandfathered subscribers. The split happens at the usage-report query layer using billing's authoritative seat records, not by stamping plan state onto events (stale caches would bake wrong attribution into immutable billing data).

## Changes

- `products/tasks/backend/billing.py` (new; product billing logic lives with the product, like `products/signals/backend/billing.py`): fetches the seat roster from billing (PostHog/billing#2033, paginated) and returns the seat-covered distinct_ids **grouped by granting org** — everything except `posthog-code-usage*` plans. Coverage is org-scoped so a covered seat in one org can't exempt the same user's usage in an org that pays per-usage. Auth via billing's PublicAPIKey (new `BILLING_SERVICE_API_KEY` env; the per-org JWT can't span customers). A failed fetch **or malformed roster payload** raises — never silently billed as all-covered or none-covered.
- `usage_report.py`: the billed Code counter excludes seat-covered `(customer team_id, distinct_id)` pairs (roster orgs expanded to their teams; parameterized tuple `NOT IN`; per-day roster snapshot). New `posthog_code_seat_credits_used_in_period` counter carries the complement for reporting/QA — not billed, not quota-limited. Both counters are computed by one split function from a **single roster snapshot** so they stay exact complements — in the celery path and as one `output="multi"` QuerySpec (= one activity) in the temporal path. The billed-only entry point survives unchanged for quota limiting. OSS/unlicensed instances skip the roster and keep pre-split behavior.

With this deployed (plus #69324's plan-scoped throttle), subscribing orgs to `posthog_code_usage` can never double-bill seat holders.

## How did you test this code?

Automated only: `products/tasks/backend/tests/test_billing.py` (org-grouped partition, pagination, missing-key/fetch-failure/malformed-payload raising — the regression being a silent over/under-bill) and `test_usage_report.py` cases (seat-covered excluded from billed / counted in seat counter, cross-org usage by a covered user stays billed, org→team roster expansion incl. other-region orgs dropping out, OSS no-op, roster failure propagates). Registry parity tests cover the temporal multi-spec wiring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

pi session (fable) with worker subagents, revised in driver review. Key decisions: query-layer attribution over event stamping (auditability); PublicAPIKey auth after a license-only-JWT assumption didn't hold; roster logic moved out of `billing_manager.py` into the product dir on review. Review round: rebased onto master (conflict with the signals refund helper), and addressed all three bot findings — org-scoped coverage pairs (cross-org bypass), roster payload shape validation, and a single-snapshot split function so the two counters can't drift apart.
