### PR TITLE
feat(llm-gateway): gate premium models behind usage-based plans

### DIFF
--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -153,6 +153,12 @@ All OpenAI, Anthropic, OpenRouter, and Fireworks AI chat models are supported.
 OpenRouter and Fireworks models use the OpenAI-compatible `/v1/chat/completions` endpoint with model prefixes (`openrouter/` and `fireworks_ai/`).
 The `/v1/models` endpoint returns provider-specific model IDs from LiteLLM's model map.
 
+### Premium model plan gate
+
+Products can opt into requiring a usage-based plan for premium models. Set `LLM_GATEWAY_PREMIUM_MODEL_GATE_ENABLED=true` to activate the policy for opted-in products; it is disabled by default. `LLM_GATEWAY_PREMIUM_MODELS` configures the canonical premium model IDs and defaults to `claude-fable-5`.
+
+When active, completion requests from other plans receive a 403 response, and anonymous or non-usage-based `/v1/models` responses omit premium models. Bedrock IDs that route to a configured premium model follow the same policy.
+
 ## OpenAI organization
 
 Set `LLM_GATEWAY_OPENAI_ORGANIZATION` to attribute all outbound OpenAI traffic

--- a/services/llm-gateway/src/llm_gateway/api/models.py
+++ b/services/llm-gateway/src/llm_gateway/api/models.py
@@ -1,12 +1,20 @@
 from typing import Literal
 
-from fastapi import APIRouter
+import structlog
+from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
+from llm_gateway.auth.service import get_auth_service
 from llm_gateway.products.config import validate_product
 from llm_gateway.services.model_registry import get_available_models
+from llm_gateway.services.plan_resolver import resolve_plan_info
+from llm_gateway.services.premium_model_policy import (
+    is_model_allowed_by_premium_policy,
+    is_premium_model_gate_active,
+)
 
 models_router = APIRouter(tags=["models"])
+logger = structlog.get_logger(__name__)
 
 CREATED_TIMESTAMP = 1669766400  # Nov 30, 2022 - ChatGPT release date - we don't have data on this so just return a default for the field to match OpenAI's API
 
@@ -48,8 +56,23 @@ class ModelsResponse(BaseModel):
     models: list[ModelObject] = []  # Alias for `data` — codex-acp expects this field
 
 
-def _build_response(product: str) -> ModelsResponse:
+async def _resolve_optional_plan_key(request: Request, product: str) -> str | None:
+    try:
+        user = await get_auth_service().authenticate_request(request, request.app.state.db_pool)
+    except Exception:
+        logger.warning("models_optional_auth_failed", product=product, exc_info=True)
+        return None
+    if user is None:
+        return None
+    plan_info = await resolve_plan_info(request, user.user_id, product)
+    return plan_info.plan_key
+
+
+async def _build_response(request: Request, product: str) -> ModelsResponse:
     models = get_available_models(product)
+    if is_premium_model_gate_active(product):
+        plan_key = await _resolve_optional_plan_key(request, product)
+        models = [m for m in models if is_model_allowed_by_premium_policy(product, m.id, plan_key)]
     model_objects = [
         ModelObject(
             id=m.id,
@@ -66,11 +89,11 @@ def _build_response(product: str) -> ModelsResponse:
 
 
 @models_router.get("/v1/models")
-async def list_models() -> ModelsResponse:
-    return _build_response("llm_gateway")
+async def list_models(request: Request) -> ModelsResponse:
+    return await _build_response(request, "llm_gateway")
 
 
 @models_router.get("/{product}/v1/models")
-async def list_models_for_product(product: str) -> ModelsResponse:
-    validate_product(product)
-    return _build_response(product)
+async def list_models_for_product(product: str, request: Request) -> ModelsResponse:
+    resolved_product = validate_product(product)
+    return await _build_response(request, resolved_product)

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -187,6 +187,17 @@ class Settings(BaseSettings):
 
     posthog_api_base_url: str = "https://us.posthog.com"
     plan_cache_ttl: int = 900  # 15 minutes
+
+    # Premium (fable-tier) model IDs
+    # Restricted in some billing plans when premium_model_gate_enabled=True
+    premium_models: list[str] = ["claude-fable-5"]
+
+    # Turns the premium-model plan gate on/off. One ordering constraint: only
+    # flip this on AFTER the usage-based opt-in flow is live, so nobody loses
+    # premium models without a path to get them back. Also the instant
+    # rollback lever - flip off to restore premium models without a deploy.
+    premium_model_gate_enabled: bool = False
+
     # Billing recomputes quota at most hourly, so we tolerate slight overage rather than
     # a Django roundtrip on every billable request.
     quota_cache_ttl: int = 300  # 5 minutes

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import asyncpg
 import structlog
@@ -26,6 +26,7 @@ from llm_gateway.request_context import (
     set_throttle_context,
 )
 from llm_gateway.services.plan_resolver import PlanInfo, resolve_plan_info
+from llm_gateway.services.premium_model_policy import is_model_allowed_by_premium_policy
 from llm_gateway.services.quota_resolver import QuotaResourceStatus, resolve_quota_status
 
 logger = structlog.get_logger(__name__)
@@ -76,14 +77,18 @@ async def get_cached_body(request: Request) -> bytes | None:
 
 
 async def get_request_json(request: Request) -> dict[str, Any] | None:
-    body = await get_cached_body(request)
-    if not body:
-        return None
-    try:
-        data = json.loads(body)
-        return data if isinstance(data, dict) else None
-    except (json.JSONDecodeError, TypeError):
-        return None
+    """Get the parsed JSON object, caching both valid and invalid results."""
+    if not hasattr(request.state, "_cached_json"):
+        body = await get_cached_body(request)
+        if not body:
+            request.state._cached_json = None
+        else:
+            try:
+                data = json.loads(body)
+                request.state._cached_json = data if isinstance(data, dict) else None
+            except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+                request.state._cached_json = None
+    return cast(dict[str, Any] | None, request.state._cached_json)
 
 
 async def get_model_from_request(request: Request) -> str | None:
@@ -133,14 +138,8 @@ async def _extract_end_user_id_from_body(request: Request) -> str | None:
     For OpenAI-compatible endpoints, this is the top-level `user` field.
     For Anthropic endpoints, this is `metadata.user_id`.
     """
-    body = await get_cached_body(request)
-    if not body:
-        return None
-    try:
-        data = json.loads(body)
-    except (json.JSONDecodeError, TypeError):
-        return None
-    if not isinstance(data, dict):
+    data = await get_request_json(request)
+    if data is None:
         return None
 
     user_id = data.get("user")
@@ -181,6 +180,12 @@ async def resolve_plan_and_quota(
     return plan_info, QuotaResourceStatus(limited=False)
 
 
+_PREMIUM_MODEL_GATE_DETAIL_TEMPLATE = (
+    "{model} requires usage-based billing. Switch to a usage-based plan at "
+    "https://app.posthog.com/organization/billing to use premium models."
+)
+
+
 async def enforce_throttles(
     request: Request,
     user: Annotated[AuthenticatedUser, Depends(enforce_product_access)],
@@ -201,6 +206,13 @@ async def enforce_throttles(
         team_id=user.team_id,
         product=product,
     )
+
+    model = await get_model_from_request(request)
+    if not is_model_allowed_by_premium_policy(product, model, plan_info.plan_key):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_PREMIUM_MODEL_GATE_DETAIL_TEMPLATE.format(model=model),
+        )
 
     context = ThrottleContext(
         user=user,

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -48,6 +48,9 @@ class ProductConfig:
     # seat-covered (free/pro/alpha) users are excluded from the org's billed usage
     # counter at the usage-report layer, so they must not be blocked by it either.
     credit_bucket_scope: Literal["all_users", "usage_based_plans"] = "all_users"
+    # Opts this product into the premium-model plan gate. When the environment-controlled
+    # gate is enabled, premium models require a usage-based plan.
+    premium_models_gated: bool = False
 
 
 BEDROCK_MODELS = BEDROCK_MODEL_IDS
@@ -115,6 +118,9 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         # subscription (seat-covered usage is excluded at the usage-report layer), so
         # only those users should be blocked when the org's usage limit is reached.
         credit_bucket_scope="usage_based_plans",
+        # Premium models require a usage-based plan when the environment-controlled
+        # premium-model gate is enabled.
+        premium_models_gated=True,
     ),
     # PostHog-initiated internal task runs (Task.internal=True without a more specific
     # origin route — e.g. the repo-selection agent). Deliberately unbilled: this is

--- a/services/llm-gateway/src/llm_gateway/services/premium_model_policy.py
+++ b/services/llm-gateway/src/llm_gateway/services/premium_model_policy.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from llm_gateway.bedrock import ANTHROPIC_TO_BEDROCK_MODEL_MAP
+from llm_gateway.config import get_settings
+from llm_gateway.products.config import get_product_config
+from llm_gateway.services.plan_resolver import is_usage_based_plan
+
+
+def is_premium_model_gate_active(product: str) -> bool:
+    config = get_product_config(product)
+    settings = get_settings()
+    return bool(config and config.premium_models_gated and settings.premium_model_gate_enabled)
+
+
+def _premium_model_prefixes() -> tuple[str, ...]:
+    prefixes: set[str] = set()
+    for configured_model in get_settings().premium_models:
+        model = configured_model.strip().lower()
+        if not model:
+            continue
+        prefixes.add(model)
+        region_map = ANTHROPIC_TO_BEDROCK_MODEL_MAP.get(model)
+        if region_map:
+            prefixes.update(alias.lower() for alias in region_map.values())
+    return tuple(prefixes)
+
+
+def is_model_allowed_by_premium_policy(product: str, model: str | None, plan_key: str | None) -> bool:
+    if not is_premium_model_gate_active(product) or not model:
+        return True
+
+    normalized_model = model.lower()
+    if not normalized_model.startswith(_premium_model_prefixes()):
+        return True
+
+    return is_usage_based_plan(plan_key)

--- a/services/llm-gateway/tests/test_dependencies.py
+++ b/services/llm-gateway/tests/test_dependencies.py
@@ -3,9 +3,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException, Request
-from starlette.datastructures import Headers
 
 from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.config import get_settings
 from llm_gateway.dependencies import (
     _extract_end_user_id_from_body,
     enforce_throttles,
@@ -14,25 +14,33 @@ from llm_gateway.dependencies import (
 )
 from llm_gateway.rate_limiting.throttles import ThrottleContext, ThrottleResult
 from llm_gateway.services.plan_resolver import PlanInfo
+from llm_gateway.services.premium_model_policy import is_model_allowed_by_premium_policy
 from llm_gateway.services.quota_resolver import QuotaResourceStatus
 
 
-def _make_request(body: dict | None = None, headers: dict[str, str] | None = None) -> Request:
-    request = MagicMock(spec=Request)
-    request.state = MagicMock()
-    del request.state._cached_body
-    request.headers = Headers(headers or {})
+def _make_request(
+    body: object | None = None,
+    headers: dict[str, str] | None = None,
+    path: str = "/",
+) -> Request:
+    raw = json.dumps(body).encode() if body is not None else b""
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [(key.lower().encode(), value.encode()) for key, value in (headers or {}).items()],
+        "client": None,
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "state": {},
+    }
 
-    if body is not None:
-        raw = json.dumps(body).encode()
-    else:
-        raw = None
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": raw, "more_body": False}
 
-    async def fake_body():
-        return raw
-
-    request.body = fake_body
-    return request
+    return Request(scope, receive)
 
 
 def _make_user(auth_method: str = "personal_api_key", user_id: int = 1) -> AuthenticatedUser:
@@ -93,14 +101,7 @@ class TestExtractEndUserIdFromBody:
 
     @pytest.mark.asyncio
     async def test_returns_none_for_non_dict_json_body(self) -> None:
-        request = MagicMock(spec=Request)
-        request.state = MagicMock()
-        del request.state._cached_body
-
-        async def fake_body():
-            return b'["not", "a", "dict"]'
-
-        request.body = fake_body
+        request = _make_request(["not", "a", "dict"])
         assert await _extract_end_user_id_from_body(request) is None
 
 
@@ -132,9 +133,7 @@ class TestEnforceThrottles:
         auth_method: str = "personal_api_key",
         user_id: int = 1,
     ) -> ThrottleContext:
-        request = _make_request(body)
-        request.url = MagicMock()
-        request.url.path = "/openai/v1/chat/completions"
+        request = _make_request(body, path="/openai/v1/chat/completions")
         user = _make_user(auth_method=auth_method, user_id=user_id)
 
         captured_context: ThrottleContext | None = None
@@ -203,6 +202,65 @@ class TestEnforceThrottles:
         )
         assert context.end_user_id is None
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-fable-5", "us.anthropic.claude-fable-5", "eu.anthropic.claude-fable-5"],
+    )
+    async def test_non_usage_plan_premium_request_is_denied_before_throttles(self, model: str) -> None:
+        request = _make_request(
+            {"model": model, "messages": []},
+            path="/posthog_code/v1/messages",
+        )
+        runner = MagicMock()
+        runner.check = AsyncMock(return_value=ThrottleResult.allow())
+        plan_and_quota = AsyncMock(
+            return_value=(
+                PlanInfo(plan_key="posthog-code-pro-200-20260301", seat_created_at=None),
+                QuotaResourceStatus(limited=False),
+            )
+        )
+
+        with (
+            patch.object(get_settings(), "premium_model_gate_enabled", True),
+            patch("llm_gateway.dependencies.ensure_costs_fresh"),
+            patch("llm_gateway.dependencies.resolve_plan_and_quota", plan_and_quota),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await enforce_throttles(request=request, user=_make_user("oauth_access_token"), runner=runner)
+
+        assert exc_info.value.status_code == 403
+        runner.check.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_usage_plan_premium_request_reaches_throttles(self) -> None:
+        request = _make_request(
+            {"model": "claude-fable-5", "messages": []},
+            path="/posthog_code/v1/messages",
+        )
+        runner = MagicMock()
+        runner.check = AsyncMock(return_value=ThrottleResult.allow())
+        plan_and_quota = AsyncMock(
+            return_value=(
+                PlanInfo(plan_key="posthog-code-usage-20260709", seat_created_at=None),
+                QuotaResourceStatus(limited=False),
+            )
+        )
+
+        with (
+            patch.object(get_settings(), "premium_model_gate_enabled", True),
+            patch("llm_gateway.dependencies.ensure_costs_fresh"),
+            patch("llm_gateway.dependencies.resolve_plan_and_quota", plan_and_quota),
+        ):
+            result = await enforce_throttles(
+                request=request,
+                user=_make_user("oauth_access_token"),
+                runner=runner,
+            )
+
+        assert result.user_id == 1
+        runner.check.assert_awaited_once()
+
 
 class TestResolvePlanAndQuota:
     """The quota resolver roundtrip runs for bucket-billed products (against the
@@ -238,3 +296,33 @@ class TestResolvePlanAndQuota:
 
         quota_mock.assert_not_awaited()
         assert quota_status.limited is False
+
+
+class TestPremiumModelPolicy:
+    @pytest.mark.parametrize(
+        ("product", "model", "plan_key", "expected"),
+        [
+            ("posthog_code", "claude-fable-5", None, False),
+            ("posthog_code", "claude-fable-5", "posthog-code-free-20260301", False),
+            ("posthog_code", "claude-fable-5", "posthog-code-pro-200-20260301", False),
+            ("posthog_code", "claude-fable-5", "posthog-code-usage-20260709", True),
+            ("posthog_code", "us.anthropic.claude-fable-5", None, False),
+            ("posthog_code", "eu.anthropic.claude-fable-5", None, False),
+            ("posthog_code", "claude-sonnet-4-6", None, True),
+            ("posthog_ai", "claude-fable-5", None, True),
+            ("posthog_code", None, None, True),
+        ],
+    )
+    def test_gate_on_applies_shared_model_policy(
+        self,
+        product: str,
+        model: str | None,
+        plan_key: str | None,
+        expected: bool,
+    ) -> None:
+        with patch.object(get_settings(), "premium_model_gate_enabled", True):
+            assert is_model_allowed_by_premium_policy(product, model, plan_key) is expected
+
+    def test_gate_off_allows_premium_model(self) -> None:
+        with patch.object(get_settings(), "premium_model_gate_enabled", False):
+            assert is_model_allowed_by_premium_policy("posthog_code", "claude-fable-5", None) is True

--- a/services/llm-gateway/tests/test_models_api.py
+++ b/services/llm-gateway/tests/test_models_api.py
@@ -1,15 +1,23 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from llm_gateway.config import get_settings
 from llm_gateway.rate_limiting.model_cost_service import ModelCost, ModelCostService
 from llm_gateway.services.model_registry import ModelRegistryService
+from llm_gateway.services.plan_resolver import PlanInfo
 
 MOCK_COST_DATA: dict[str, ModelCost] = {
     "gpt-4o": {
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
+        "supports_vision": True,
+        "mode": "chat",
+    },
+    "claude-fable-5": {
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 200000,
         "supports_vision": True,
         "mode": "chat",
     },
@@ -241,3 +249,106 @@ class TestResponsesModeModels:
             assert response.status_code == 200
             model_ids = {m["id"] for m in response.json()["data"]}
             assert "gpt-5.3-codex" in model_ids
+
+
+class TestPremiumModelGateOnModelsEndpoint:
+    def _set_plan(self, client: TestClient, plan_key: str | None) -> None:
+        client.app.state.plan_resolver.get_plan = AsyncMock(
+            return_value=PlanInfo(plan_key=plan_key, seat_created_at=None)
+        )
+
+    def test_gate_off_includes_fable_for_unauthenticated(self, client: TestClient):
+        with patch.object(get_settings(), "premium_model_gate_enabled", False):
+            response = client.get("/posthog_code/v1/models")
+
+        model_ids = {m["id"] for m in response.json()["data"]}
+        assert "claude-fable-5" in model_ids
+
+    def test_gate_off_does_no_auth_or_plan_work(self, client: TestClient):
+        # Gate-disabled listings remain static and anonymous without auth or plan I/O.
+        with (
+            patch.object(get_settings(), "premium_model_gate_enabled", False),
+            patch("llm_gateway.api.models.get_auth_service") as mock_auth,
+            patch("llm_gateway.api.models.resolve_plan_info") as mock_plan,
+        ):
+            response = client.get("/posthog_code/v1/models", headers={"Authorization": "Bearer phx_test"})
+
+        assert response.status_code == 200
+        mock_auth.assert_not_called()
+        mock_plan.assert_not_called()
+
+    def test_ungated_product_does_no_auth_or_plan_work_even_when_gate_on(self, client: TestClient):
+        with (
+            patch.object(get_settings(), "premium_model_gate_enabled", True),
+            patch("llm_gateway.api.models.get_auth_service") as mock_auth,
+            patch("llm_gateway.api.models.resolve_plan_info") as mock_plan,
+        ):
+            response = client.get("/v1/models", headers={"Authorization": "Bearer phx_test"})
+
+        assert response.status_code == 200
+        mock_auth.assert_not_called()
+        mock_plan.assert_not_called()
+
+    def test_gate_on_omits_fable_for_unauthenticated(self, client: TestClient):
+        with patch.object(get_settings(), "premium_model_gate_enabled", True):
+            response = client.get("/posthog_code/v1/models")
+
+        model_ids = {m["id"] for m in response.json()["data"]}
+        assert "claude-fable-5" not in model_ids
+
+    @pytest.mark.parametrize(
+        "plan_key",
+        [None, "posthog-code-free-20260301", "posthog-code-pro-200-20260301"],
+        ids=["none", "free", "pro"],
+    )
+    def test_gate_on_omits_fable_for_non_usage_based_plan(self, authenticated_client: TestClient, plan_key):
+        self._set_plan(authenticated_client, plan_key)
+        with patch.object(get_settings(), "premium_model_gate_enabled", True):
+            response = authenticated_client.get(
+                "/posthog_code/v1/models", headers={"Authorization": "Bearer phx_test_key"}
+            )
+
+        model_ids = {m["id"] for m in response.json()["data"]}
+        assert "claude-fable-5" not in model_ids
+
+    @pytest.mark.parametrize("product", ["posthog_code", "array", "twig"])
+    def test_gate_on_includes_fable_for_usage_based_plan(self, authenticated_client: TestClient, product: str):
+        self._set_plan(authenticated_client, "posthog-code-usage-20260709")
+        with patch.object(get_settings(), "premium_model_gate_enabled", True):
+            response = authenticated_client.get(
+                f"/{product}/v1/models", headers={"Authorization": "Bearer phx_test_key"}
+            )
+
+        model_ids = {m["id"] for m in response.json()["data"]}
+        assert "claude-fable-5" in model_ids
+
+    def test_gate_on_unaffected_products_keep_fable(self, client: TestClient):
+        # llm_gateway doesn't opt into premium_models_gated, so it's unaffected by
+        # the gate regardless of flag state or plan.
+        with patch.object(get_settings(), "premium_model_gate_enabled", True):
+            response = client.get("/llm_gateway/v1/models")
+
+        model_ids = {m["id"] for m in response.json()["data"]}
+        assert "claude-fable-5" in model_ids
+
+    def test_unauthenticated_request_still_succeeds(self, client: TestClient):
+        with patch.object(get_settings(), "premium_model_gate_enabled", True):
+            response = client.get("/posthog_code/v1/models")
+
+        assert response.status_code == 200
+
+    def test_auth_failure_falls_back_to_anonymous_model_list(self, client: TestClient):
+        auth_service = MagicMock()
+        auth_service.authenticate_request = AsyncMock(side_effect=RuntimeError("database unavailable"))
+        with (
+            patch.object(get_settings(), "premium_model_gate_enabled", True),
+            patch("llm_gateway.api.models.get_auth_service", return_value=auth_service),
+        ):
+            response = client.get(
+                "/posthog_code/v1/models",
+                headers={"Authorization": "Bearer phx_test_key"},
+            )
+
+        assert response.status_code == 200
+        model_ids = {m["id"] for m in response.json()["data"]}
+        assert "claude-fable-5" not in model_ids

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -34,6 +34,19 @@ class TestGetProductConfig:
         config = get_product_config("unknown_product")
         assert config is None
 
+    def test_posthog_code_opts_into_premium_model_gate(self):
+        config = get_product_config("posthog_code")
+        assert config is not None
+        assert config.premium_models_gated is True
+
+    @pytest.mark.parametrize("product", [p for p in PRODUCTS if p != "posthog_code"])
+    def test_other_products_do_not_opt_into_premium_model_gate(self, product: str):
+        # posthog_ai included: it allows any model but is deliberately unaffected
+        # by the posthog_code-specific premium-model plan gate.
+        config = get_product_config(product)
+        assert config is not None
+        assert config.premium_models_gated is False
+
 
 class TestCheckProductAccess:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Fable is being removed from seat-based Code subscriptions — premium models will require a usage-based plan. The flip must be toggleable (timed with user comms) and shouldn't require client UI changes.

## Changes

- New env toggle `LLM_GATEWAY_PREMIUM_MODEL_GATE_ENABLED` (default off = today's behavior), matching this service's convention — deliberately not the gateway's first feature-flag evaluation. One ordering constraint at cutover: flip on only after the usage-based opt-in flow is verified live, so nobody loses fable without a path to get it back. Doubles as the instant rollback lever (flip off, no deploy).
- Completion path: after plan resolution, a premium model on a gated product (`posthog_code` only, via `ProductConfig.premium_models_gated`) 403s unless the plan is usage-based. Not fail-open on unknown plan: the off-by-default setting is the safety valve; failing open would let broken plan resolution hand out premium models free.
- `/v1/models` filters premium models for non-usage-based/anonymous callers when the gate is on — so dynamic model pickers (the Code app) need zero UI work. Auth is lazy behind pure-settings checks: gate off (or ungated product) stays byte-identical to today — anonymous, static, zero I/O (pinned by test). Never 401s.

## How did you test this code?

Automated only: new cases across `test_dependencies.py` / `test_models_api.py` / `test_product_config.py` — deny/allow matrix per plan, ungated products unaffected, and two regression tests pinning the zero-I/O property. Gateway suite: 1223 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

pi session (fable) with worker subagents, tightened across three driver-review passes: a bespoke feature-flag evaluator was replaced with the env-var convention; an eager optional-auth route dependency was made lazy; the leftover one-line auth wrapper was deleted in favor of calling `authenticate_request` directly.
