### PR TITLE
feat(posthog-code): seat purchase lockdown

### DIFF
--- a/products/tasks/backend/presentation/views/seat_api.py
+++ b/products/tasks/backend/presentation/views/seat_api.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import requests
 import structlog
+import posthoganalytics
 from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
@@ -25,6 +26,16 @@ from ee.settings import BILLING_SERVICE_URL
 
 # Duplicated in services/llm-gateway/src/llm_gateway/services/plan_resolver.py
 PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
+
+# Gates purchasing/upgrading/reactivating a pro seat as part of the transition to
+# usage-based billing. Free-seat provisioning (the auto-provision path for new users)
+# is never gated by this flag. Defaults to off (no lockdown) — including when the flag
+# can't be evaluated — so a flags outage never blocks seat provisioning.
+SEAT_PURCHASES_DISABLED_FLAG = "posthog-code-seat-purchases-disabled"
+
+SEAT_PURCHASES_DISABLED_MESSAGE = (
+    "PostHog Code seat subscriptions are no longer available for purchase. Switch to usage-based billing instead."
+)
 
 
 def _seat_priority(seat: dict[str, Any]) -> tuple[bool, int, float]:
@@ -60,6 +71,36 @@ def _is_org_admin(user: Any) -> bool:
     return OrganizationMembership.objects.filter(
         user=user, organization=org, level__gte=OrganizationMembership.Level.ADMIN
     ).exists()
+
+
+def _is_pro_plan_key(plan_key: Any) -> bool:
+    return isinstance(plan_key, str) and any(plan_key.startswith(p) for p in PRO_PLAN_PREFIXES)
+
+
+def _seat_purchases_disabled(user: User) -> bool:
+    """Evaluate the ``posthog-code-seat-purchases-disabled`` flag for ``user``.
+
+    Mirrors the org-scoped evaluation pattern in ``products/tasks/backend/access.py``
+    (``_is_tasks_flag_enabled``): person-level distinct_id plus, when available, an
+    ``organization`` group so release conditions can target orgs. Fails closed (flag
+    treated as off, i.e. purchases stay allowed) on any evaluation error, matching the
+    fail-safe try/except in ``products/tasks/backend/push_dispatcher.py``'s
+    ``_enqueue_inner`` — a flags outage must never block seat provisioning.
+    """
+    org = getattr(user, "organization", None)
+    kwargs: dict[str, Any] = {
+        "only_evaluate_locally": False,
+        "send_feature_flag_events": False,
+    }
+    if org is not None:
+        org_id = str(org.id)
+        kwargs["groups"] = {"organization": org_id}
+        kwargs["group_properties"] = {"organization": {"id": org_id}}
+    try:
+        return bool(posthoganalytics.feature_enabled(SEAT_PURCHASES_DISABLED_FLAG, str(user.distinct_id), **kwargs))
+    except Exception:
+        logger.warning("seat_api.purchases_disabled_flag_check_failed", user_id=user.id, exc_info=True)
+        return False
 
 
 class SeatViewSet(viewsets.ViewSet):
@@ -218,6 +259,9 @@ class SeatViewSet(viewsets.ViewSet):
             self._require_admin(request)
         self._require_org_member(request, str(body_distinct_id))
 
+        if _is_pro_plan_key(request.data.get("plan_key")) and _seat_purchases_disabled(cast(User, request.user)):
+            return Response({"detail": SEAT_PURCHASES_DISABLED_MESSAGE}, status=status.HTTP_403_FORBIDDEN)
+
         headers = self._get_billing_headers(request)
         if not headers:
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
@@ -316,6 +360,9 @@ class SeatViewSet(viewsets.ViewSet):
         if pk != "me":
             self._require_admin(request)
 
+        if _is_pro_plan_key(request.data.get("plan_key")) and _seat_purchases_disabled(cast(User, request.user)):
+            return Response({"detail": SEAT_PURCHASES_DISABLED_MESSAGE}, status=status.HTTP_403_FORBIDDEN)
+
         headers = self._get_billing_headers(request)
         if not headers:
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
@@ -352,6 +399,9 @@ class SeatViewSet(viewsets.ViewSet):
         """POST /api/seats/me/reactivate/ -> POST /api/v2/seats/{distinct_id}/reactivate/"""
         if pk != "me":
             self._require_admin(request)
+
+        if _seat_purchases_disabled(cast(User, request.user)):
+            return Response({"detail": SEAT_PURCHASES_DISABLED_MESSAGE}, status=status.HTTP_403_FORBIDDEN)
 
         headers = self._get_billing_headers(request)
         if not headers:

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -578,3 +578,197 @@ class TestSeatAPIKeyAccess(BaseSeatAPITest):
             headers={"authorization": f"Bearer {token}"},
         )
         assert response.status_code == status.HTTP_200_OK
+
+
+@patch("products.tasks.backend.presentation.views.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
+@patch("products.tasks.backend.presentation.views.seat_api.get_cached_instance_license", return_value=MagicMock())
+class TestSeatAPIPurchaseLockdown(BaseSeatAPITest):
+    """The ``posthog-code-seat-purchases-disabled`` flag blocks pro purchases/upgrades/reactivation."""
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=False)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_off_create_pro_seat_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_PRO_SEAT})
+        self._auth_as_member()
+        response = self.client.post(
+            "/api/seats/",
+            {
+                "product_key": "posthog_code",
+                "plan_key": "posthog-code-200-20260301",
+                "user_distinct_id": str(self.user.distinct_id),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=False)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_off_upgrade_to_pro_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_PRO_SEAT})
+        self._auth_as_member()
+        response = self.client.patch(
+            "/api/seats/me/",
+            {"product_key": "posthog_code", "plan_key": "posthog-code-200-20260301"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=False)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_off_reactivate_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_PRO_SEAT})
+        self._auth_as_member()
+        response = self.client.post("/api/seats/me/reactivate/", format="json")
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_create_pro_seat_returns_403(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        self._auth_as_member()
+        response = self.client.post(
+            "/api/seats/",
+            {
+                "product_key": "posthog_code",
+                "plan_key": "posthog-code-200-20260301",
+                "user_distinct_id": str(self.user.distinct_id),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"] == (
+            "PostHog Code seat subscriptions are no longer available for purchase. "
+            "Switch to usage-based billing instead."
+        )
+        mock_request.assert_not_called()
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_create_pro_v2_plan_returns_403(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        self._auth_as_member()
+        response = self.client.post(
+            "/api/seats/",
+            {
+                "product_key": "posthog_code",
+                "plan_key": "posthog-code-pro-200-20260422",
+                "user_distinct_id": str(self.user.distinct_id),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_upgrade_to_pro_returns_403(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        self._auth_as_member()
+        response = self.client.patch(
+            "/api/seats/me/",
+            {"product_key": "posthog_code", "plan_key": "posthog-code-200-20260301"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"] == (
+            "PostHog Code seat subscriptions are no longer available for purchase. "
+            "Switch to usage-based billing instead."
+        )
+        mock_request.assert_not_called()
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_reactivate_returns_403(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        self._auth_as_member()
+        response = self.client.post("/api/seats/me/reactivate/", format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"] == (
+            "PostHog Code seat subscriptions are no longer available for purchase. "
+            "Switch to usage-based billing instead."
+        )
+        mock_request.assert_not_called()
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_free_seat_create_still_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_FREE_SEAT})
+        self._auth_as_member()
+        response = self.client.post(
+            "/api/seats/",
+            {
+                "product_key": "posthog_code",
+                "plan_key": "posthog-code-free-20260301",
+                "user_distinct_id": str(self.user.distinct_id),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_downgrade_to_free_still_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_FREE_SEAT})
+        self._auth_as_member()
+        response = self.client.patch(
+            "/api/seats/me/",
+            {"product_key": "posthog_code", "plan_key": "posthog-code-free-20260301"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_cancel_still_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response(status_code=204)
+        self._auth_as_member()
+        response = self.client.delete("/api/seats/me/?product_key=posthog_code")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_list_still_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seats": [MOCK_PRO_SEAT]})
+        self._auth_as_admin()
+        response = self.client.get("/api/seats/?product_key=posthog_code")
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_on_retrieve_still_works(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_PRO_SEAT})
+        self._auth_as_member()
+        response = self.client.get("/api/seats/me/?product_key=posthog_code")
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch(
+        "products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled",
+        side_effect=Exception("flags service down"),
+    )
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_evaluation_exception_defaults_to_off(self, mock_request, _mock_flag, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_PRO_SEAT})
+        self._auth_as_member()
+        response = self.client.post(
+            "/api/seats/",
+            {
+                "product_key": "posthog_code",
+                "plan_key": "posthog-code-200-20260301",
+                "user_distinct_id": str(self.user.distinct_id),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("products.tasks.backend.presentation.views.seat_api.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.tasks.backend.presentation.views.seat_api.requests.request")
+    def test_flag_evaluated_with_distinct_id_and_org_group(self, mock_request, mock_flag, _mock_license, _mock_token):
+        self._auth_as_member()
+        self.client.post(
+            "/api/seats/",
+            {
+                "product_key": "posthog_code",
+                "plan_key": "posthog-code-200-20260301",
+                "user_distinct_id": str(self.user.distinct_id),
+            },
+            format="json",
+        )
+        args, kwargs = mock_flag.call_args
+        assert args[0] == "posthog-code-seat-purchases-disabled"
+        assert args[1] == str(self.user.distinct_id)
+        assert kwargs["groups"] == {"organization": str(self.organization.id)}


### PR DESCRIPTION
## Problem

At cutover, Code seat subscriptions stop being sold — selling a $200 seat that gets migrated (and refunded) days later is a bad experience. Pro-seat purchases need a kill switch that can flip any time before cutover, without a deploy and without touching free-seat auto-provisioning.

## Changes

- Purchase lockdown behind flag `posthog-code-seat-purchases-disabled` (default off): pro create, free→pro upgrade, and reactivate 403 with a "switch to usage-based instead" message. Free provisioning, list/get/cancel untouched. Flag evaluation failure = lockdown off — a flag hiccup can't break seat provisioning.
- No ordering constraint with the rest of the transition: stopping pro sales early is fine, so this can flip any time before cutover, independent of the gateway's premium-model toggle.

An earlier revision also added a `switch-to-usage-based` proxy endpoint; dropped — the transition is now a single hard-date migration run in billing, with no user-facing opt-in flow.

## How did you test this code?

Automated only: lockdown on/off matrix in `test_seat_api.py` (billing never called on rejections), flag-exception-as-off, distinct_id + org-group flag evaluation. File total: 57 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Originally lockdown + opt-in switch proxy; the proxy was removed when the direction changed from voluntary opt-in to a hard-date cutover. Flag evaluation mirrors `access.py`; fail-as-off mirrors `push_dispatcher.py`.
