### PR TITLE
fix(data-warehouse): clarify the error shown when a second same-type source needs a prefix

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -1857,7 +1857,9 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 if self.prefix_required(source_type):
                     return Response(
                         status=status.HTTP_400_BAD_REQUEST,
-                        data={"message": "Source type already exists. Prefix is required"},
+                        data={
+                            "message": "You already have a source of this type. Add a table prefix so this connection's tables don't clash with your existing source."
+                        },
                     )
             elif self.prefix_exists(source_type, prefix):
                 return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
@@ -3904,7 +3906,9 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             if self.prefix_required(source_type):
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,
-                    data={"message": "Source type already exists. Prefix is required"},
+                    data={
+                        "message": "You already have a source of this type. Add a table prefix so this connection's tables don't clash with your existing source."
+                    },
                 )
         elif self.prefix_exists(source_type, prefix):
             return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -1015,7 +1015,12 @@ class TestExternalDataSource(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), {"message": "Source type already exists. Prefix is required"})
+        self.assertEqual(
+            response.json(),
+            {
+                "message": "You already have a source of this type. Add a table prefix so this connection's tables don't clash with your existing source."
+            },
+        )
 
         # Create with prefix
         response = self.client.post(
@@ -1130,14 +1135,14 @@ class TestExternalDataSource(APIBaseTest):
                 [(None, False)],
                 "",
                 400,
-                "Source type already exists. Prefix is required",
+                "You already have a source of this type. Add a table prefix so this connection's tables don't clash with your existing source.",
             ),
             (
                 "no-prefix source (empty string) blocks another no-prefix",
                 [("", False)],
                 "",
                 400,
-                "Source type already exists. Prefix is required",
+                "You already have a source of this type. Add a table prefix so this connection's tables don't clash with your existing source.",
             ),
             (
                 "no-prefix source still allows a prefixed source",


### PR DESCRIPTION
## Problem

In the data-warehouse new-source onboarding flow, adding a second source of a type you already connected without a table prefix was rejected with **"Source type already exists. Prefix is required"**. That copy reads like a duplicate-source conflict error rather than a next step, and it appears inline under the *"Table prefix (optional)"* field — so users hit it after a retry and are left unsure what to do. Replay-based review of real onboarding sessions surfaced this as a recurring point of confusion (e.g. a source create that appeared to fail, then showed this message on retry).

## Changes

Replace the message in both the create path and the `source_prefix` pre-flight check with an actionable one that says what to do and why:

> You already have a source of this type. Add a table prefix so this connection's tables don't clash with your existing source.

This is a pure copy change — no behavior, schema, or validation-logic changes. Test assertions updated to match.

## How did you test this code?

- Updated the existing backend assertions in `test_external_data_source.py` to the new string (mechanical).
- Ran `ruff check` / `ruff format` over both touched files (clean).
- Could not run the DB-backed pytest suite in this environment (no local Postgres reachable); the changed tests only assert on the new literal, which now matches the endpoint output.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (PostHog Code) while reviewing anonymized summaries of real data-warehouse onboarding sessions for low-risk friction fixes. Invoked the `/improving-drf-endpoints` skill before editing the viewset; confirmed the change touches only error-message string literals, so no schema annotations were needed. Considered but rejected touching the Google Search Console connector error copy (already well-crafted and actionable) and adding connector search aliases (the mechanism exists but the observed search misses mapped to sources that don't exist yet, not findable-by-alias ones) — recorded as recommendations instead. Checked open PRs (including the maintainer's) for duplicates before opening this one.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
