### PR TITLE
fix(github): skip org-scoped 404s instead of failing the sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -60,6 +60,16 @@ class GithubEmptyRepositoryError(Exception):
     pass
 
 
+class GithubOrgNotFoundError(Exception):
+    """GitHub returns 404 on the org-scoped endpoints (``/orgs/{org}/teams`` and the members
+    fan-out) when the repository owner is a personal account rather than an organization, or the
+    token has no org access. There is nothing to sync in that case, so ``_fetch_page`` raises this on
+    org-scoped endpoints and the caller syncs zero rows — a benign skip, not a "repository not found"
+    that should fail the schema."""
+
+    pass
+
+
 @dataclasses.dataclass
 class GithubResumeConfig:
     next_url: str
@@ -460,6 +470,7 @@ def _fetch_page(
     headers: dict[str, str],
     logger: FilteringBoundLogger,
     egress_identity: GithubEgressIdentity | None = None,
+    skip_on_not_found: bool = False,
 ) -> requests.Response:
     # One gated + recorded GET through the shared egress client. The App path bills the shared
     # per-installation budget at BATCH (deferrable bulk); the PAT path (installation_id None) skips the
@@ -493,6 +504,12 @@ def _fetch_page(
     if _is_empty_repository_response(response):
         raise GithubEmptyRepositoryError()
 
+    # An org-scoped endpoint 404s when the repo owner is a user (no org) or the token lacks org
+    # access. Signal it so the caller syncs zero rows rather than failing the schema — a benign skip
+    # like an empty repository, not a real "repository not found".
+    if skip_on_not_found and response.status_code == 404:
+        raise GithubOrgNotFoundError()
+
     if not response.ok:
         logger.error(f"Github API error: status={response.status_code}, body={response.text}, url={page_url}")
         response.raise_for_status()
@@ -508,6 +525,7 @@ def _iter_pages(
     max_pages: int | None = None,
     page_cap_context: dict[str, Any] | None = None,
     egress_identity: GithubEgressIdentity | None = None,
+    skip_on_not_found: bool = False,
 ) -> Iterator[tuple[list[dict[str, Any]], str]]:
     """Yield (items, page_url) for each page of a paginated GitHub list,
     unwrapping the envelope and following the Link header. Stops at ``max_pages``,
@@ -515,7 +533,11 @@ def _iter_pages(
     envelope body simply ends iteration — there is nothing to truncate."""
     page_count = 0
     while True:
-        response = _fetch_page(url, headers, logger, egress_identity)
+        try:
+            response = _fetch_page(url, headers, logger, egress_identity, skip_on_not_found=skip_on_not_found)
+        except GithubOrgNotFoundError:
+            logger.debug(f"Github: org-scoped endpoint not found, syncing zero rows: url={url}")
+            return
         data = response.json()
         if response_data_path and isinstance(data, dict):
             data = data.get(response_data_path) or []
@@ -543,6 +565,7 @@ def _iter_child_for_parent(
     logger: FilteringBoundLogger,
     config: GithubEndpointConfig,
     egress_identity: GithubEgressIdentity | None = None,
+    skip_on_not_found: bool = False,
 ) -> Iterator[dict[str, Any]]:
     """Walk a fan-out child endpoint for one parent, substituting the parent's value into the
     child path placeholder (e.g. {run_id} for workflow_jobs, {team_slug} for team_members)."""
@@ -562,6 +585,7 @@ def _iter_child_for_parent(
         max_pages=config.max_pages_per_parent,
         page_cap_context={"repository": repository, fan_out_param: parent_value},
         egress_identity=egress_identity,
+        skip_on_not_found=skip_on_not_found,
     ):
         yield from items
 
@@ -594,6 +618,9 @@ def _fan_out_get_rows(
     child_config = GITHUB_ENDPOINTS[endpoint]
     assert child_config.fan_out_parent is not None  # guarded by the get_rows dispatch
     parent_config = GITHUB_ENDPOINTS[child_config.fan_out_parent]
+    # team_members fans out from the org-scoped teams parent; a 404 on either walk (user-owned repo,
+    # or a team deleted mid-sync) is a benign skip, not a schema failure.
+    org_scoped = endpoint in ORG_SCOPED_ENDPOINTS
     headers = _get_headers(personal_access_token, endpoint)
     batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
@@ -625,7 +652,12 @@ def _fan_out_get_rows(
         parent_url = _build_initial_url(parent_config, repository, {"per_page": parent_config.page_size})
 
     for parents, page_url in _iter_pages(
-        parent_url, headers, parent_config.response_data_path, logger, egress_identity=egress_identity
+        parent_url,
+        headers,
+        parent_config.response_data_path,
+        logger,
+        egress_identity=egress_identity,
+        skip_on_not_found=org_scoped,
     ):
         stop_after_this_page = _should_stop_desc(parents, "desc", parent_cursor_field, parent_cutoff)
 
@@ -642,7 +674,7 @@ def _fan_out_get_rows(
                 else None
             )
             for item in _iter_child_for_parent(
-                repository, parent_value, headers, logger, child_config, egress_identity
+                repository, parent_value, headers, logger, child_config, egress_identity, skip_on_not_found=org_scoped
             ):
                 batcher.batch(inject(item) if inject else item)
                 if batcher.should_yield():
@@ -711,11 +743,15 @@ def get_rows(
     else:
         url = _build_initial_url(config, repository, initial_params)
 
+    org_scoped = endpoint in ORG_SCOPED_ENDPOINTS
     while True:
         try:
-            response = _fetch_page(url, headers, logger, egress_identity)
+            response = _fetch_page(url, headers, logger, egress_identity, skip_on_not_found=org_scoped)
         except GithubEmptyRepositoryError:
             logger.debug(f"Github: repository has no commits (empty repository), syncing zero rows: url={url}")
+            break
+        except GithubOrgNotFoundError:
+            logger.debug(f"Github: no accessible org teams for {endpoint}, syncing zero rows: url={url}")
             break
 
         data = response.json()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -565,7 +565,6 @@ def _iter_child_for_parent(
     logger: FilteringBoundLogger,
     config: GithubEndpointConfig,
     egress_identity: GithubEgressIdentity | None = None,
-    skip_on_not_found: bool = False,
 ) -> Iterator[dict[str, Any]]:
     """Walk a fan-out child endpoint for one parent, substituting the parent's value into the
     child path placeholder (e.g. {run_id} for workflow_jobs, {team_slug} for team_members)."""
@@ -585,7 +584,6 @@ def _iter_child_for_parent(
         max_pages=config.max_pages_per_parent,
         page_cap_context={"repository": repository, fan_out_param: parent_value},
         egress_identity=egress_identity,
-        skip_on_not_found=skip_on_not_found,
     ):
         yield from items
 
@@ -618,9 +616,10 @@ def _fan_out_get_rows(
     child_config = GITHUB_ENDPOINTS[endpoint]
     assert child_config.fan_out_parent is not None  # guarded by the get_rows dispatch
     parent_config = GITHUB_ENDPOINTS[child_config.fan_out_parent]
-    # team_members fans out from the org-scoped teams parent; a 404 on either walk (user-owned repo,
-    # or a team deleted mid-sync) is a benign skip, not a schema failure.
-    org_scoped = endpoint in ORG_SCOPED_ENDPOINTS
+    # team_members fans out from the org-scoped teams parent, which 404s for a user-owned repo (no
+    # org). Skip only that parent walk — a 404 on a specific team's members is not this benign case
+    # and should still surface.
+    parent_org_scoped = child_config.fan_out_parent in ORG_SCOPED_ENDPOINTS
     headers = _get_headers(personal_access_token, endpoint)
     batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
@@ -657,7 +656,7 @@ def _fan_out_get_rows(
         parent_config.response_data_path,
         logger,
         egress_identity=egress_identity,
-        skip_on_not_found=org_scoped,
+        skip_on_not_found=parent_org_scoped,
     ):
         stop_after_this_page = _should_stop_desc(parents, "desc", parent_cursor_field, parent_cutoff)
 
@@ -674,7 +673,7 @@ def _fan_out_get_rows(
                 else None
             )
             for item in _iter_child_for_parent(
-                repository, parent_value, headers, logger, child_config, egress_identity, skip_on_not_found=org_scoped
+                repository, parent_value, headers, logger, child_config, egress_identity
             ):
                 batcher.batch(inject(item) if inject else item)
                 if batcher.should_yield():

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
@@ -29,6 +29,37 @@ def _instant_backoff():
         yield
 
 
+def _not_found_response() -> mock.Mock:
+    response = mock.Mock(spec=requests.Response)
+    response.status_code = 404
+    response.ok = False
+    response.headers = {}
+    response.text = "Not Found"
+    response.request = None
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Client Error: Not Found for url")
+    return response
+
+
+@pytest.mark.parametrize(
+    "skip_on_not_found,expected_exc",
+    [
+        (True, github.GithubOrgNotFoundError),
+        (False, requests.exceptions.HTTPError),
+    ],
+)
+def test_fetch_page_404_skips_only_for_org_scoped_endpoints(skip_on_not_found, expected_exc):
+    # An org-scoped endpoint (a user-owned repo has no org, so /orgs/{owner}/teams 404s) treats a 404
+    # as a benign skip; a repo-scoped one keeps it fatal so a genuinely missing repo still fails loud.
+    session = mock.Mock()
+    session.request.return_value = _not_found_response()
+
+    with mock.patch.object(github, "make_tracked_session", return_value=session):
+        with pytest.raises(expected_exc):
+            github._fetch_page(
+                "https://api.github.com/orgs/acme/teams", {}, mock.Mock(), skip_on_not_found=skip_on_not_found
+            )
+
+
 def test_fetch_page_retries_chunked_encoding_error():
     session = mock.Mock()
     session.request.side_effect = [requests.exceptions.ChunkedEncodingError("Connection broken"), _ok_response()]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
@@ -36,7 +36,9 @@ def _not_found_response() -> mock.Mock:
     response.headers = {}
     response.text = "Not Found"
     response.request = None
-    response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Client Error: Not Found for url")
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "404 Client Error: Not Found for url", response=response
+    )
     return response
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
@@ -82,7 +82,7 @@ def test_team_members_child_404_stays_fatal_after_parent_listed() -> None:
     def fetch_page(url: str, *_args: Any, **kwargs: Any) -> mock.Mock:
         if "/orgs/acme/teams/core/members" in url:
             assert kwargs.get("skip_on_not_found") is False
-            raise requests.exceptions.HTTPError("404 Client Error: Not Found for url", response=None)
+            raise requests.exceptions.HTTPError("404 Client Error: Not Found for url", response=requests.Response())
         if "/orgs/acme/teams" in url:
             return _response([{"id": 1, "slug": "core", "name": "Core"}])
         raise AssertionError(f"Unexpected URL: {url}")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
@@ -39,7 +39,9 @@ def _not_found_response() -> mock.Mock:
     response.headers = {}
     response.text = "Not Found"
     response.request = None
-    response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Client Error: Not Found for url")
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "404 Client Error: Not Found for url", response=response
+    )
     return response
 
 
@@ -80,7 +82,7 @@ def test_team_members_child_404_stays_fatal_after_parent_listed() -> None:
     def fetch_page(url: str, *_args: Any, **kwargs: Any) -> mock.Mock:
         if "/orgs/acme/teams/core/members" in url:
             assert kwargs.get("skip_on_not_found") is False
-            raise requests.exceptions.HTTPError("404 Client Error: Not Found for url")
+            raise requests.exceptions.HTTPError("404 Client Error: Not Found for url", response=None)
         if "/orgs/acme/teams" in url:
             return _response([{"id": 1, "slug": "core", "name": "Core"}])
         raise AssertionError(f"Unexpected URL: {url}")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
@@ -73,6 +73,31 @@ def test_org_scoped_404_syncs_zero_rows_while_repo_scoped_404_stays_fatal(endpoi
             assert list(rows) == []
 
 
+def test_team_members_child_404_stays_fatal_after_parent_listed() -> None:
+    # The org-scoped skip covers only the parent teams walk (user-owned repo, no org). Once the org
+    # resolves and a team is listed, a 404 on that team's members is unexpected and must surface, not
+    # silently drop the team's members.
+    def fetch_page(url: str, *_args: Any, **kwargs: Any) -> mock.Mock:
+        if "/orgs/acme/teams/core/members" in url:
+            assert kwargs.get("skip_on_not_found") is False
+            raise requests.exceptions.HTTPError("404 Client Error: Not Found for url")
+        if "/orgs/acme/teams" in url:
+            return _response([{"id": 1, "slug": "core", "name": "Core"}])
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with mock.patch.object(github, "_fetch_page", side_effect=fetch_page):
+        with pytest.raises(requests.exceptions.HTTPError):
+            list(
+                github.get_rows(
+                    personal_access_token="tok",
+                    repository="acme/widgets",
+                    endpoint="team_members",
+                    logger=mock.Mock(),
+                    resumable_source_manager=_no_resume(),
+                )
+            )
+
+
 def _collect(endpoint: str, responses_by_url: dict[str, mock.Mock]) -> list[dict[str, Any]]:
     with mock.patch.object(github, "_fetch_page", side_effect=_fetch_page_by_url(responses_by_url)):
         tables = list(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_teams.py
@@ -32,6 +32,47 @@ def _no_resume() -> mock.Mock:
     return manager
 
 
+def _not_found_response() -> mock.Mock:
+    response = mock.Mock(spec=requests.Response)
+    response.status_code = 404
+    response.ok = False
+    response.headers = {}
+    response.text = "Not Found"
+    response.request = None
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Client Error: Not Found for url")
+    return response
+
+
+@pytest.mark.parametrize(
+    "endpoint,expect_raise",
+    [
+        # Org-scoped: a 404 on /orgs/{owner}/teams (user-owned repo, or no org access) must sync zero
+        # rows, not fail the schema. teams walks it directly; team_members hits it via its fan-out parent.
+        ("teams", False),
+        ("team_members", False),
+        # Repo-scoped: a 404 is a genuinely missing/inaccessible repo and must stay fatal.
+        ("issues", True),
+    ],
+)
+def test_org_scoped_404_syncs_zero_rows_while_repo_scoped_404_stays_fatal(endpoint: str, expect_raise: bool) -> None:
+    session = mock.Mock()
+    session.request.return_value = _not_found_response()
+
+    with mock.patch.object(github, "make_tracked_session", return_value=session):
+        rows = github.get_rows(
+            personal_access_token="tok",
+            repository="acme/widgets",
+            endpoint=endpoint,
+            logger=mock.Mock(),
+            resumable_source_manager=_no_resume(),
+        )
+        if expect_raise:
+            with pytest.raises(requests.exceptions.HTTPError):
+                list(rows)
+        else:
+            assert list(rows) == []
+
+
 def _collect(endpoint: str, responses_by_url: dict[str, mock.Mock]) -> list[dict[str, Any]]:
     with mock.patch.object(github, "_fetch_page", side_effect=_fetch_page_by_url(responses_by_url)):
         tables = list(


### PR DESCRIPTION
## Problem

The GitHub data warehouse source surfaced a `NonRetryableException` in error tracking:

```
404 Client Error: Not Found for url: https://api.github.com/orgs/<org>/teams?per_page=100
```

([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f49fb-be79-72c0-ab18-1ccc71a18b9f))

The `teams` and `team_members` endpoints read `/orgs/{owner}/teams`, deriving the org from the repository owner. When the owner is a personal account rather than an organization (or the token lacks org access), GitHub returns 404. The code already documents this exact case: "a user-owned repo has no org, so /orgs/{owner}/teams 404s".

But at sync time that 404 hit `response.raise_for_status()` in `_fetch_page` and was classified as the non-retryable "Repository not found" error, failing the whole schema sync with a misleading message. A user-owned repo legitimately has no org teams, so this is a benign, expected state, not a config error worth failing and alerting on.

## Changes

Treat a 404 on org-scoped endpoints (`teams`, `team_members`) as a graceful zero-row skip, mirroring the existing empty-repository (409 `GithubEmptyRepositoryError`) handling.

- `_fetch_page` gains a `skip_on_not_found` flag. When set, a 404 raises the new `GithubOrgNotFoundError` instead of falling through to `raise_for_status()`.
- `get_rows` (standard path, used by `teams`) and `_fan_out_get_rows` / `_iter_pages` (fan-out path, used by `team_members` via its `teams` parent walk) pass the flag when the endpoint is org-scoped and catch the signal to sync zero rows.
- Repo-scoped 404s stay fatal, so a genuinely missing or inaccessible repository still fails loudly and remains non-retryable.

> [!NOTE]
> Scope is deliberately narrow: only `teams` / `team_members` (the endpoints in `ORG_SCOPED_ENDPOINTS`) get the graceful skip, and only for 404. No change to retry policy or to any other endpoint.

## How did you test this code?

Added regression tests (all run locally, `51 passed`):

- `test_github_fetch_page.py::test_fetch_page_404_skips_only_for_org_scoped_endpoints` - `_fetch_page` raises `GithubOrgNotFoundError` on a 404 when `skip_on_not_found=True`, and keeps raising `HTTPError` when it's off. Catches inverting or dropping the new branch.
- `test_github_teams.py::test_org_scoped_404_syncs_zero_rows_while_repo_scoped_404_stays_fatal` - end-to-end through `get_rows`: `teams` and `team_members` sync zero rows on a 404 (distinct code paths: the standard loop vs the fan-out parent walk), while `issues` (repo-scoped) still raises. Catches the reported bug and guards against the skip leaking to repo-scoped endpoints where it would swallow a real missing-repo error.

I (Claude) did not run the full sync against a live GitHub org; testing is the automated cases above plus the existing github source suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook by Claude (Claude Code). Confirmed the failing frame was `_fetch_page` in the github source, read the call path, and decided this was a fixable bug rather than a new `NonRetryableErrors` entry: the 404 here is a benign "no org teams for a user-owned repo" state, not a credential/repo error, so silencing it via non-retryable classification would keep failing a schema that should simply sync zero rows.

Considered widening `get_non_retryable_errors` instead, but that already maps a bare `404 Client Error` to "Repository not found" - which is exactly the misleading behavior we're fixing. The graceful-skip approach mirrors the existing empty-repository handling one level down, so repo-scoped 404s stay fatal.

Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
