### PR TITLE
feat(data-warehouse): add recreate schedule admin action for schemas

### DIFF
--- a/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
+++ b/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
@@ -331,11 +331,12 @@
             <p class="help">
                 If the schedule is missing entirely (pause/unpause/sync fail with "workflow not found",
                 typically after an interrupted source creation), recreate it below. This also works as a
-                repair when the schedule exists: it is updated in place and triggered.
+                repair when the schedule exists: it is updated in place. No run is triggered; kick one
+                off with "Trigger sync" below, which is non-billable by default.
             </p>
             <div class="partitioning-controls">
-                <button type="submit" form="recreate-schedule-action-form" class="deletelink"
-                        onclick="return confirm('Recreate the Temporal schedule for this schema? This always triggers an immediate BILLABLE sync run, even if sync is disabled or the schedule is paused.');">
+                <button type="submit" form="recreate-schedule-action-form" class="default"
+                        onclick="return confirm('Recreate the Temporal schedule for this schema? No sync run is triggered.');">
                     Recreate schedule
                 </button>
             </div>

--- a/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
+++ b/posthog/templates/admin/data_warehouse/externaldataschema/change_form.html
@@ -91,6 +91,9 @@
     <form id="unpause-schedule-action-form" method="post" action="{{ unpause_schedule_url }}" style="display:none;">
         {% csrf_token %}
     </form>
+    <form id="recreate-schedule-action-form" method="post" action="{{ recreate_schedule_url }}" style="display:none;">
+        {% csrf_token %}
+    </form>
 {% endblock %}
 
 {# Suppress the default bottom submit_row — we render it inside `after_field_sets` #}
@@ -323,6 +326,17 @@
                 <button type="submit" form="unpause-schedule-action-form" class="default"
                         onclick="return confirm('Unpause the Temporal schedule for this schema?');">
                     Unpause schedule
+                </button>
+            </div>
+            <p class="help">
+                If the schedule is missing entirely (pause/unpause/sync fail with "workflow not found",
+                typically after an interrupted source creation), recreate it below. This also works as a
+                repair when the schedule exists: it is updated in place and triggered.
+            </p>
+            <div class="partitioning-controls">
+                <button type="submit" form="recreate-schedule-action-form" class="deletelink"
+                        onclick="return confirm('Recreate the Temporal schedule for this schema? This always triggers an immediate BILLABLE sync run, even if sync is disabled or the schedule is paused.');">
+                    Recreate schedule
                 </button>
             </div>
         </div>

--- a/products/data_warehouse/backend/logic/data_load/service.py
+++ b/products/data_warehouse/backend/logic/data_load/service.py
@@ -152,18 +152,30 @@ def to_temporal_schedule(
 
 
 def sync_external_data_job_workflow(
-    external_data_schema: ExternalDataSchema, create: bool = False, should_sync: bool = True
+    external_data_schema: ExternalDataSchema,
+    create: bool = False,
+    should_sync: bool = True,
+    trigger_immediately: bool = True,
 ) -> ExternalDataSchema:
+    """Create or update the schema's Temporal schedule.
+
+    Runs fired through the schedule use its stored action, whose `billable` is always True,
+    so callers that must not bill (e.g. admin recovery) pass trigger_immediately=False and
+    start their own ad-hoc run if one is needed.
+    """
     temporal = sync_connect()
 
     schedule = get_sync_schedule(external_data_schema, should_sync=should_sync)
 
     if create:
         try:
-            create_schedule(temporal, id=str(external_data_schema.id), schedule=schedule, trigger_immediately=True)
+            create_schedule(
+                temporal, id=str(external_data_schema.id), schedule=schedule, trigger_immediately=trigger_immediately
+            )
         except ScheduleAlreadyRunningError:
             update_schedule(temporal, id=str(external_data_schema.id), schedule=schedule)
-            trigger_schedule(temporal, schedule_id=str(external_data_schema.id))
+            if trigger_immediately:
+                trigger_schedule(temporal, schedule_id=str(external_data_schema.id))
     else:
         update_schedule(temporal, id=str(external_data_schema.id), schedule=schedule)
 

--- a/products/data_warehouse/backend/tests/test_data_load_service.py
+++ b/products/data_warehouse/backend/tests/test_data_load_service.py
@@ -1,0 +1,70 @@
+import uuid
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+from temporalio.client import ScheduleAlreadyRunningError
+
+from products.data_warehouse.backend.logic.data_load.service import sync_external_data_job_workflow
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+
+_SERVICE_MODULE = "products.data_warehouse.backend.logic.data_load.service"
+
+
+class TestSyncExternalDataJobWorkflow(BaseTest):
+    def _schema(self) -> ExternalDataSchema:
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Postgres",
+        )
+        return ExternalDataSchema.objects.create(
+            team_id=self.team.pk, source=source, name="public.users", should_sync=True
+        )
+
+    @parameterized.expand(
+        [
+            ("fresh_create", False),
+            ("schedule_already_exists", True),
+        ]
+    )
+    def test_create_without_trigger_never_fires_a_run(self, _name: str, already_exists: bool) -> None:
+        # trigger_immediately=False exists for admin recovery: runs fired through the schedule
+        # use its stored action, which is always billable, so recreating a schedule must not
+        # fire one in either the fresh-create or the already-exists fallback branch.
+        schema = self._schema()
+
+        with (
+            patch(f"{_SERVICE_MODULE}.sync_connect"),
+            patch(
+                f"{_SERVICE_MODULE}.create_schedule",
+                side_effect=ScheduleAlreadyRunningError if already_exists else None,
+            ) as mock_create,
+            patch(f"{_SERVICE_MODULE}.update_schedule") as mock_update,
+            patch(f"{_SERVICE_MODULE}.trigger_schedule") as mock_trigger,
+        ):
+            sync_external_data_job_workflow(schema, create=True, trigger_immediately=False)
+
+        assert mock_create.call_args.kwargs["trigger_immediately"] is False
+        if already_exists:
+            mock_update.assert_called_once()
+        mock_trigger.assert_not_called()
+
+    def test_create_triggers_immediately_by_default(self) -> None:
+        # Every pre-existing create=True caller (enabling sync on a schema, the reload/resync
+        # heal) relies on the created schedule firing its first run right away.
+        schema = self._schema()
+
+        with (
+            patch(f"{_SERVICE_MODULE}.sync_connect"),
+            patch(f"{_SERVICE_MODULE}.create_schedule") as mock_create,
+            patch(f"{_SERVICE_MODULE}.trigger_schedule") as mock_trigger,
+        ):
+            sync_external_data_job_workflow(schema, create=True)
+
+        assert mock_create.call_args.kwargs["trigger_immediately"] is True
+        mock_trigger.assert_not_called()

--- a/products/warehouse_sources/backend/admin/external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_schema_admin.py
@@ -513,9 +513,11 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
         if request.method != "POST":
             return redirect(_change_url(schema_id))
 
-        try:
-            schema = ExternalDataSchema.objects.select_related("source").get(id=schema_id)
-        except ExternalDataSchema.DoesNotExist:
+        # Resolve through the admin's scoped object path (get_queryset) rather than a bare
+        # manager .get(), so any queryset scoping applies to this action exactly as it does
+        # to the change form.
+        schema = self.get_object(request, str(schema_id))
+        if schema is None:
             messages.error(request, f"Schema {schema_id} not found.")
             return redirect(reverse("admin:warehouse_sources_externaldataschema_changelist"))
 

--- a/products/warehouse_sources/backend/admin/external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_schema_admin.py
@@ -507,7 +507,9 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
         # Recovery for schemas whose per-schema Temporal schedule is missing (e.g. the source
         # creation request was killed between committing the rows and creating the schedules,
         # or the schema was resurrected after a soft-delete). Safe on an existing schedule too:
-        # sync_external_data_job_workflow falls back to update + trigger when it already exists.
+        # sync_external_data_job_workflow falls back to updating it in place. Deliberately does
+        # NOT trigger a run: the schedule's stored action is always billable, so operators kick
+        # off an immediate run with the (non-billable by default) "Trigger sync" action instead.
         if request.method != "POST":
             return redirect(_change_url(schema_id))
 
@@ -528,7 +530,9 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
             return redirect(_change_url(schema_id))
 
         try:
-            sync_external_data_job_workflow(schema, create=True, should_sync=schema.should_sync)
+            sync_external_data_job_workflow(
+                schema, create=True, should_sync=schema.should_sync, trigger_immediately=False
+            )
         except Exception as e:
             messages.error(request, f"Failed to recreate schedule: {e}")
             return redirect(_change_url(schema_id))
@@ -540,7 +544,8 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
         )
         messages.success(
             request,
-            f"Recreated Temporal schedule for {schema.name} and triggered an immediate billable run.{paused_note}",
+            f"Recreated Temporal schedule for {schema.name}. No run was triggered; "
+            f'use "Trigger sync" for an immediate non-billable run.{paused_note}',
         )
         return redirect(_change_url(schema_id))
 

--- a/products/warehouse_sources/backend/admin/external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/admin/external_data_schema_admin.py
@@ -16,7 +16,11 @@ from temporalio.common import WorkflowIDReusePolicy
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.utils import ExternalDataWorkflowInputs
 
-from products.data_warehouse.backend.facade.api import pause_external_data_schedule, unpause_external_data_schedule
+from products.data_warehouse.backend.facade.api import (
+    pause_external_data_schedule,
+    sync_external_data_job_workflow,
+    unpause_external_data_schedule,
+)
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
@@ -147,6 +151,11 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
                 "<uuid:schema_id>/unpause-schedule/",
                 self.admin_site.admin_view(self.unpause_schedule_view),
                 name="external_data_schema_unpause_schedule",
+            ),
+            path(
+                "<uuid:schema_id>/recreate-schedule/",
+                self.admin_site.admin_view(self.recreate_schedule_view),
+                name="external_data_schema_recreate_schedule",
             ),
         ]
         return custom_urls + urls
@@ -494,6 +503,47 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
             messages.error(request, f"Failed to unpause schedule: {e}")
         return redirect(_change_url(schema_id))
 
+    def recreate_schedule_view(self, request, schema_id):
+        # Recovery for schemas whose per-schema Temporal schedule is missing (e.g. the source
+        # creation request was killed between committing the rows and creating the schedules,
+        # or the schema was resurrected after a soft-delete). Safe on an existing schedule too:
+        # sync_external_data_job_workflow falls back to update + trigger when it already exists.
+        if request.method != "POST":
+            return redirect(_change_url(schema_id))
+
+        try:
+            schema = ExternalDataSchema.objects.select_related("source").get(id=schema_id)
+        except ExternalDataSchema.DoesNotExist:
+            messages.error(request, f"Schema {schema_id} not found.")
+            return redirect(reverse("admin:warehouse_sources_externaldataschema_changelist"))
+
+        if not self.has_change_permission(request, schema):
+            raise PermissionDenied
+
+        if not schema.source.supports_scheduled_sync:
+            messages.error(
+                request,
+                "This source is queried directly and does not use per-schema sync schedules.",
+            )
+            return redirect(_change_url(schema_id))
+
+        try:
+            sync_external_data_job_workflow(schema, create=True, should_sync=schema.should_sync)
+        except Exception as e:
+            messages.error(request, f"Failed to recreate schedule: {e}")
+            return redirect(_change_url(schema_id))
+
+        paused_note = (
+            " The schedule was created paused because sync is disabled for this schema."
+            if not schema.should_sync
+            else ""
+        )
+        messages.success(
+            request,
+            f"Recreated Temporal schedule for {schema.name} and triggered an immediate billable run.{paused_note}",
+        )
+        return redirect(_change_url(schema_id))
+
     def change_view(self, request, object_id, form_url="", extra_context=None):
         extra_context = extra_context or {}
         obj = self.get_object(request, object_id)
@@ -535,6 +585,9 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
             extra_context["pause_schedule_url"] = reverse("admin:external_data_schema_pause_schedule", args=[obj.id])
             extra_context["unpause_schedule_url"] = reverse(
                 "admin:external_data_schema_unpause_schedule", args=[obj.id]
+            )
+            extra_context["recreate_schedule_url"] = reverse(
+                "admin:external_data_schema_recreate_schedule", args=[obj.id]
             )
 
             # CDC schemas stream via a source-level extraction schedule; the per-schema schedule

--- a/products/warehouse_sources/backend/tests/test_external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/tests/test_external_data_schema_admin.py
@@ -281,3 +281,71 @@ class TestExternalDataSchemaAdmin(BaseTest):
         schema.refresh_from_db()
         assert "partition_mode_override" not in schema.sync_type_config
         mock_start.assert_not_called()
+
+    @parameterized.expand([(True,), (False,)])
+    def test_recreate_schedule_passes_should_sync_through(self, should_sync: bool) -> None:
+        # Guards the recovery action for schemas left without a Temporal schedule: it must
+        # recreate with the schema's own should_sync so a disabled schema comes back paused
+        # instead of silently starting recurring billable syncs.
+        schema = self._schema(should_sync=should_sync)
+
+        with patch(f"{_ADMIN_MODULE}.sync_external_data_job_workflow") as mock_sync:
+            response = self.admin.recreate_schedule_view(self._request("post"), schema.id)
+
+        assert response.status_code == 302
+        assert str(schema.id) in response.url
+        mock_sync.assert_called_once_with(schema, create=True, should_sync=should_sync)
+
+    def test_recreate_schedule_get_does_not_recreate(self) -> None:
+        schema = self._schema()
+
+        with patch(f"{_ADMIN_MODULE}.sync_external_data_job_workflow") as mock_sync:
+            response = self.admin.recreate_schedule_view(self._request("get"), schema.id)
+
+        assert response.status_code == 302
+        mock_sync.assert_not_called()
+
+    def test_recreate_schedule_denies_without_change_permission(self) -> None:
+        schema = self._schema()
+
+        with (
+            patch(f"{_ADMIN_MODULE}.sync_external_data_job_workflow") as mock_sync,
+            patch.object(self.admin, "has_change_permission", return_value=False),
+        ):
+            with self.assertRaises(PermissionDenied):
+                self.admin.recreate_schedule_view(self._request("post"), schema.id)
+
+        mock_sync.assert_not_called()
+
+    def test_recreate_schedule_rejects_direct_query_source(self) -> None:
+        # Direct-query sources have no per-schema schedules by design; recreating one would
+        # start scheduled syncs on a source that is only ever queried live.
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+        )
+        schema = ExternalDataSchema.objects.create(team_id=self.team.pk, source=source, name="public.users")
+
+        with patch(f"{_ADMIN_MODULE}.sync_external_data_job_workflow") as mock_sync:
+            response = self.admin.recreate_schedule_view(self._request("post"), schema.id)
+
+        assert response.status_code == 302
+        assert str(schema.id) in response.url
+        mock_sync.assert_not_called()
+
+    def test_recreate_schedule_temporal_failure_flashes_error(self) -> None:
+        # A Temporal outage must surface as an admin flash message, not a 500.
+        schema = self._schema()
+
+        with patch(
+            f"{_ADMIN_MODULE}.sync_external_data_job_workflow",
+            side_effect=Exception("connect failed"),
+        ):
+            response = self.admin.recreate_schedule_view(self._request("post"), schema.id)
+
+        assert response.status_code == 302
+        assert str(schema.id) in response.url

--- a/products/warehouse_sources/backend/tests/test_external_data_schema_admin.py
+++ b/products/warehouse_sources/backend/tests/test_external_data_schema_admin.py
@@ -286,7 +286,9 @@ class TestExternalDataSchemaAdmin(BaseTest):
     def test_recreate_schedule_passes_should_sync_through(self, should_sync: bool) -> None:
         # Guards the recovery action for schemas left without a Temporal schedule: it must
         # recreate with the schema's own should_sync so a disabled schema comes back paused
-        # instead of silently starting recurring billable syncs.
+        # instead of silently starting recurring syncs, and it must not trigger a run (runs
+        # fired through the schedule are always billable; operators use "Trigger sync" for a
+        # non-billable one).
         schema = self._schema(should_sync=should_sync)
 
         with patch(f"{_ADMIN_MODULE}.sync_external_data_job_workflow") as mock_sync:
@@ -294,7 +296,7 @@ class TestExternalDataSchemaAdmin(BaseTest):
 
         assert response.status_code == 302
         assert str(schema.id) in response.url
-        mock_sync.assert_called_once_with(schema, create=True, should_sync=should_sync)
+        mock_sync.assert_called_once_with(schema, create=True, should_sync=should_sync, trigger_immediately=False)
 
     def test_recreate_schedule_get_does_not_recreate(self) -> None:
         schema = self._schema()


### PR DESCRIPTION
## Problem

An `ExternalDataSchema` can end up with no per-schema Temporal schedule at all, most commonly when the source creation request is interrupted after the rows are committed but before schedules are created (there is no transaction around creation), or when a soft-deleted schema is later resurrected by schema discovery. When that happens, every existing admin action on the schema is a dead end. Pause, unpause, trigger sync, and repartition all assume the schedule exists and fail with a Temporal `NOT_FOUND` flash error. Nothing in the admin (or anywhere else operator-facing) can create the schedule.

**Why:** support needs a one-click recovery for sources stuck in this state today, independently of the upstream fixes to how schedules go missing.

## Changes

- New "Recreate schedule" action on `ExternalDataSchemaAdmin` (URL + view + button in the Schedule section of the change form).
- Calls `sync_external_data_job_workflow(schema, create=True, should_sync=schema.should_sync, trigger_immediately=False)` via the data warehouse facade. Safe when the schedule already exists (falls back to updating it in place), and a disabled schema comes back paused rather than silently resuming recurring syncs.
- `sync_external_data_job_workflow` gains a `trigger_immediately` flag (default `True`, so every existing caller keeps its behavior). Runs fired through a schedule use its stored action, whose `billable` input is always `True` and cannot be overridden per trigger, so the recovery action deliberately triggers **no run at all**. Operators kick one off with the existing "Trigger sync" action, which starts ad-hoc runs that are non-billable by default.
- Direct-query sources are rejected with a flash error, since they have no per-schema schedules by design.

## How did you test this code?

Tests in `products/warehouse_sources/backend/tests/test_external_data_schema_admin.py`, each guarding a distinct regression no existing test covers:

- `test_recreate_schedule_passes_should_sync_through` (parameterized True/False): the recreated schedule must carry the schema's own `should_sync` and must not trigger a run (`trigger_immediately=False`), otherwise recreating a schedule would fire a billable sync or resume syncs the user turned off.
- `test_recreate_schedule_get_does_not_recreate`: no mutation on GET.
- `test_recreate_schedule_denies_without_change_permission`: permission gate, mirroring the repartition action.
- `test_recreate_schedule_rejects_direct_query_source`: never create a per-schema schedule for a direct-query source.
- `test_recreate_schedule_temporal_failure_flashes_error`: a Temporal outage surfaces as a flash message, not a 500.

New `products/data_warehouse/backend/tests/test_data_load_service.py` covers the service-level flag, since the admin tests mock the service:

- `test_create_without_trigger_never_fires_a_run` (parameterized over fresh-create and already-exists branches): `trigger_immediately=False` must not fire a run in either branch, or admin recreations silently bill customers.
- `test_create_triggers_immediately_by_default`: every pre-existing `create=True` caller (enabling sync on a schema) relies on the first run firing right away.

I (Claude) could not execute the DB-backed test suite in the sandbox (no local Postgres); pytest collection of both files passes and `hogli ci:preflight --fix` is clean, so relying on CI for the run. No manual testing was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal admin tooling only, no user-facing docs to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code cloud task) directed by the assignee, following a production log investigation that confirmed schemas exist with no Temporal schedule and that all existing admin actions fail with `NOT_FOUND` in that state.
- Skills invoked: `/improving-drf-endpoints` (no DRF surface ended up changing here, admin views only), `/writing-tests`.
- Decisions: the first cut triggered an immediate run on recreate, which was necessarily billable because a schedule's stored action carries `billable=True` and a trigger cannot override it. After review feedback that an admin recovery must not bill the customer, the action was changed to create/repair the schedule without any run, with the new `trigger_immediately` service flag, pointing operators at the existing non-billable "Trigger sync" action instead.
- Scope decision: this PR is deliberately the recovery tool only. The root-cause fix (schema-level reload/resync self-healing missing schedules instead of swallowing the error) ships separately as [#69868](https://github.com/PostHog/posthog/pull/69868).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
