### PR TITLE
fix(data-warehouse): recreate missing schedules on schema sync actions

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_schema.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_schema.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, cast
 from django.db import transaction
 
 import structlog
-import temporalio
+import temporalio.service
 from drf_spectacular.utils import extend_schema, extend_schema_field
 from rest_framework import filters, serializers, status, viewsets
 from rest_framework.exceptions import ValidationError
@@ -63,6 +63,32 @@ from products.warehouse_sources.backend.facade.source_management import (
 from products.warehouse_sources.backend.facade.types import ExternalDataSourceType, IncrementalFieldType
 
 logger = structlog.get_logger(__name__)
+
+# Message for sync actions hit on direct-query sources, which have no per-schema
+# Temporal schedules by design (supports_scheduled_sync is False).
+DIRECT_QUERY_NO_SCHEDULE_MESSAGE = "This table is queried directly from the source and cannot be synced on a schedule."
+
+
+def trigger_or_recreate_external_data_workflow(schema: ExternalDataSchema) -> None:
+    """Trigger the schema's sync schedule, (re)creating it first when it is missing.
+
+    A schema can exist without its Temporal schedule: source creation is not transactional,
+    so a request killed between committing the rows and creating the schedules leaves the
+    schema orphaned, and schemas resurrected after a soft-delete lose theirs too. Recreating
+    with an immediate trigger both runs the sync the user asked for and repairs the schedule
+    for future runs.
+    """
+    try:
+        trigger_external_data_workflow(schema)
+    except temporalio.service.RPCError as e:
+        if e.status != temporalio.service.RPCStatusCode.NOT_FOUND:
+            raise
+        logger.warning(
+            "Recreating missing external data sync schedule",
+            schema_id=str(schema.id),
+            team_id=schema.team_id,
+        )
+        sync_external_data_job_workflow(schema, create=True, should_sync=schema.should_sync)
 
 
 def source_supports_column_selection(source_type: str) -> bool:
@@ -1267,20 +1293,16 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def reload(self, request: Request, *args: Any, **kwargs: Any):
         instance: ExternalDataSchema = self.get_object()
 
+        if not instance.source.supports_scheduled_sync:
+            return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": DIRECT_QUERY_NO_SCHEDULE_MESSAGE})
+
         if is_any_external_data_schema_paused(self.team_id):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": "Monthly sync limit reached. Please increase your billing limit to resume syncing."},
             )
 
-        try:
-            trigger_external_data_workflow(instance)
-        except temporalio.service.RPCError as e:
-            logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
-
-        except Exception as e:
-            logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
-            raise
+        trigger_or_recreate_external_data_workflow(instance)
 
         instance.status = ExternalDataSchema.Status.RUNNING
         instance.save()
@@ -1289,6 +1311,9 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     @action(methods=["POST"], detail=True)
     def resync(self, request: Request, *args: Any, **kwargs: Any):
         instance: ExternalDataSchema = self.get_object()
+
+        if not instance.source.supports_scheduled_sync:
+            return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": DIRECT_QUERY_NO_SCHEDULE_MESSAGE})
 
         if is_any_external_data_schema_paused(self.team_id):
             return Response(
@@ -1326,14 +1351,11 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
         if cdc_resync:
             instance.initial_sync_complete = False
+
+        trigger_or_recreate_external_data_workflow(instance)
+
         instance.status = ExternalDataSchema.Status.RUNNING
         instance.save(update_fields=["status", "updated_at"])
-
-        try:
-            trigger_external_data_workflow(instance)
-        except temporalio.service.RPCError as e:
-            logger.exception(f"Could not trigger external data job for schema {instance.id}", exc_info=e)
-
         return Response(status=status.HTTP_200_OK)
 
     @action(methods=["POST"], detail=True)

--- a/products/data_warehouse/backend/tests/api/test_external_data_schema.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_schema.py
@@ -14,7 +14,7 @@ import pytest_asyncio
 from asgiref.sync import sync_to_async
 from parameterized import parameterized
 from rest_framework import status
-from temporalio.service import RPCError
+from temporalio.service import RPCError, RPCStatusCode
 
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
@@ -2877,6 +2877,96 @@ class TestCancelExternalDataSchema(APIBaseTest):
         assert response.status_code == 400
         assert response.json()["detail"] == "No running sync to cancel."
         mock_cancel.assert_not_called()
+
+
+_SCHEMA_VIEW_MODULE = "products.data_warehouse.backend.presentation.views.external_data_schema"
+
+
+class TestReloadAndResyncExternalDataSchema(APIBaseTest):
+    def _create_schema(self, access_method: str | None = None) -> ExternalDataSchema:
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"stripe_secret_key": "123"},
+            **({"access_method": access_method} if access_method else {}),
+        )
+        return ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        )
+
+    @parameterized.expand(["reload", "resync"])
+    def test_recreates_missing_schedule_and_marks_running(self, endpoint: str):
+        # A schema can exist without its Temporal schedule (interrupted source creation,
+        # resurrection after soft-delete). These endpoints used to swallow the NOT_FOUND and
+        # fake a Running status; they must now recreate the schedule with the schema's own
+        # should_sync, which also triggers the run the user asked for.
+        schema = self._create_schema()
+
+        with (
+            mock.patch(
+                f"{_SCHEMA_VIEW_MODULE}.trigger_external_data_workflow",
+                side_effect=RPCError("workflow not found", RPCStatusCode.NOT_FOUND, b""),
+            ),
+            mock.patch(f"{_SCHEMA_VIEW_MODULE}.sync_external_data_job_workflow") as mock_sync,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/{endpoint}/"
+            )
+
+        assert response.status_code == 200, response.content
+        mock_sync.assert_called_once()
+        args, kwargs = mock_sync.call_args
+        assert args[0].id == schema.id
+        assert kwargs == {"create": True, "should_sync": True}
+
+        schema.refresh_from_db()
+        assert schema.status == ExternalDataSchema.Status.RUNNING
+        if endpoint == "resync":
+            assert schema.sync_type_config.get("reset_pipeline") is True
+
+    @parameterized.expand(["reload", "resync"])
+    def test_rejects_direct_query_source(self, endpoint: str):
+        # Direct-query sources have no per-schema schedules by design, so triggering one is
+        # always a NOT_FOUND; these endpoints used to report 200 and a phantom Running status.
+        schema = self._create_schema(access_method=ExternalDataSource.AccessMethod.DIRECT)
+
+        with mock.patch(f"{_SCHEMA_VIEW_MODULE}.trigger_external_data_workflow") as mock_trigger:
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/{endpoint}/"
+            )
+
+        assert response.status_code == 400, response.content
+        mock_trigger.assert_not_called()
+        schema.refresh_from_db()
+        assert schema.status == ExternalDataSchema.Status.COMPLETED
+
+    @parameterized.expand(["reload", "resync"])
+    def test_does_not_mark_running_when_trigger_fails(self, endpoint: str):
+        # A Temporal failure other than a missing schedule must not leave the schema showing
+        # Running with no run started, and must surface as an error instead of a 200.
+        schema = self._create_schema()
+
+        client = HttpClient(raise_request_exception=False)
+        client.force_login(self.user)
+
+        with (
+            mock.patch(
+                f"{_SCHEMA_VIEW_MODULE}.trigger_external_data_workflow",
+                side_effect=RPCError("temporal unavailable", RPCStatusCode.UNAVAILABLE, b""),
+            ),
+            mock.patch(f"{_SCHEMA_VIEW_MODULE}.sync_external_data_job_workflow") as mock_sync,
+        ):
+            response = client.post(f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/{endpoint}/")
+
+        assert response.status_code == 500, response.content
+        mock_sync.assert_not_called()
+        schema.refresh_from_db()
+        assert schema.status == ExternalDataSchema.Status.COMPLETED
 
 
 class TestExternalDataSchemaAPIKeyScopes(APIBaseTest):


### PR DESCRIPTION
## Problem

Production logs show a steady stream of users hitting "Sync now" or "Full resync" on schemas whose per-schema Temporal schedule does not exist, across many projects (raised in #team-data-and-messaging via a support report; log investigation confirmed the pattern is recurring, with the confirmed trigger being a source-creation request killed mid-flight by a deploy rollout after the rows were committed but before schedules were created, plus schemas resurrected by discovery after a soft-delete).

The schema viewset's `reload` and `resync` actions made this state unrecoverable from the product:

- They trigger the schedule blind, catch the Temporal `NOT_FOUND`, log it, and swallow it.
- They then set the schema status to `Running` and return `200 OK`.

The user sees a sync that is forever "Running" while nothing runs, and retrying does the same thing. These swallowed failures also never reached error tracking.

## Changes

```mermaid
flowchart LR
    A{{"POST /reload or /resync"}} --> B["trigger schedule"]
    B -->|NOT_FOUND| C["log, swallow"]
    C --> D["status = Running, 200 OK"]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class C phRed;
    class B,D phGray;
```

```mermaid
flowchart LR
    A{{"POST /reload or /resync"}} -->|direct-query source| E["400, no trigger"]
    A --> B["trigger schedule"]
    B -->|NOT_FOUND| C["recreate schedule + immediate run"]
    B -->|ok| D["status = Running, 200 OK"]
    C --> D
    B -->|other error| F["propagate: error tracking + 500"]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class C phBlue;
    class F phRed;
    class B,D,E phGray;
```

- New `trigger_or_recreate_external_data_workflow` helper: on `NOT_FOUND` it recreates the schedule via `sync_external_data_job_workflow(create=True, should_sync=schema.should_sync)`, which also triggers the run the user asked for. This is the same heal pattern `ExternalDataSource.reload_schemas()` already uses at the source level.
- Direct-query sources now get a clear 400 from both actions instead of a guaranteed-to-fail blind trigger (they have no per-schema schedules by design, and `resync` previously also mutated their sync config before failing).
- Other Temporal errors propagate to the standard exception handler, so they reach error tracking and return a 500 instead of a silent 200.
- `Running` is only persisted after a successful trigger, in both actions.

> [!NOTE]
> Behavior change: a Temporal outage during reload/resync now returns a 500 instead of a 200 that did nothing. The recreated schedule's immediate run is billable, same as any user-triggered sync.

## How did you test this code?

Added `TestReloadAndResyncExternalDataSchema` to `products/data_warehouse/backend/tests/api/test_external_data_schema.py`, parameterized over both endpoints. No existing test exercised either endpoint. Each case guards a distinct regression:

- `test_recreates_missing_schedule_and_marks_running`: a missing schedule was previously a silent no-op with a fake Running status; asserts the recreate call (with the schema's own `should_sync`) and the 200 + Running outcome, plus `reset_pipeline` for resync.
- `test_rejects_direct_query_source`: direct-query schemas previously got the phantom Running treatment; asserts 400 and untouched status.
- `test_does_not_mark_running_when_trigger_fails`: a non-NOT_FOUND Temporal failure must not flip the schema to Running or return 200; asserts 500 and untouched status.

I (Claude) could not execute the DB-backed suite in the sandbox (no local Postgres); pytest collection passes and `hogli ci:preflight --fix` is clean apart from an OpenAPI-regen advisory that this change cannot trigger in substance (no serializer, decorator, or response-shape changes; `hogli build:openapi` also needs a DB). Relying on CI for the test run. No manual testing was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the failure behavior of these endpoints; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code cloud task) directed by the assignee, following a production log investigation: the creation-path "Could not trigger external data job" swallow blocks never fired in the retention window, while the schema-viewset NOT_FOUND variant fired repeatedly across projects, so the fix targets the sync actions rather than the creation path. The confirmed missing-schedule trigger was a deploy-interrupted creation request (request replayed onto a new ReplicaSet pod and rejected as a duplicate, rows committed, schedules never created).
- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`.
- Decisions: reused the existing NOT_FOUND heal pattern from `ExternalDataSource.reload_schemas()` instead of adding a reconciliation job; dropped manual `capture_exception` calls because the global `exception_reporting` hook already captures anything a view raises; left the actions' OpenAPI surface untouched (same codes and shapes) to keep this PR behavior-only.
- Companion PR: [#69866](https://github.com/PostHog/posthog/pull/69866) adds an admin-side "Recreate schedule" recovery action for support.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
