### PR TITLE
feat(quill): presets-first mode for DateTimePicker (instant apply, rail footer, hidden calendar)

### DIFF
--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -61,7 +61,8 @@ Rules:
 
 - `value.range` is one of the offered presets or `CUSTOM_RANGE` for manual selection. Presets default to `quickRanges` (15 presets, "Last 5 minutes" → "Last 1 year"); pass `ranges` to offer your own `DateTimeRange[]` (any `CUSTOM_RANGE` entry is filtered out of the list). `ranges={[]}` hides the quick-ranges column entirely — for hosts that render their own preset list.
 - A `DateTimeRange` computes its start from "now" via `rangeSetter`; the end defaults to "now" unless `endSetter` is given (needed for closed periods like "Last month"). `name` is any string.
-- Changes are staged until `onApply` fires — don't treat intermediate calendar clicks as committed.
+- Changes are staged until `onApply` fires — don't treat intermediate calendar clicks as committed. `applyOnRangeSelect` opts quick-range clicks out of staging: picking a preset fires `onApply` immediately (calendar edits still stage).
+- `rangesFooter` pins host content below the quick-ranges list (e.g. a custom rolling-period input) and shows the rail even with `ranges={[]}`.
 - Dual-calendar layout appears at the `lg` breakpoint unless `compact` forces a single calendar.
 - `minDate`/`maxDate` are day-granular; time inputs are independent of those bounds.
 - `weekStartsOn` affects the calendar grid only, not quick-range math.

--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -63,6 +63,7 @@ Rules:
 - A `DateTimeRange` computes its start from "now" via `rangeSetter`; the end defaults to "now" unless `endSetter` is given (needed for closed periods like "Last month"). `name` is any string.
 - Changes are staged until `onApply` fires — don't treat intermediate calendar clicks as committed. `applyOnRangeSelect` opts quick-range clicks out of staging: picking a preset fires `onApply` immediately (calendar edits still stage).
 - `rangesFooter` pins host content below the quick-ranges list (e.g. a custom rolling-period input) and shows the rail even with `ranges={[]}`.
+- `showCalendar={false}` hides the calendar column entirely: the picker renders as a narrow vertical quick-ranges list, for presets-first hosts that reveal the calendar on demand (toggle it back on from a "Custom range" action in `rangesFooter`). Combined with `applyOnRangeSelect` the staging footer disappears too, since nothing is left to stage.
 - Dual-calendar layout appears at the `lg` breakpoint unless `compact` forces a single calendar.
 - `minDate`/`maxDate` are day-granular; time inputs are independent of those bounds.
 - `weekStartsOn` affects the calendar grid only, not quick-range math.

--- a/packages/quill/packages/components/src/date-time-picker.stories.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.stories.tsx
@@ -201,6 +201,26 @@ export const EmbeddedDayGranular: Story = {
     },
 }
 
+export const InstantPresetsWithRailFooter: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<DateTimeValue>({
+            start: startOfMonth(new Date()),
+            end: new Date(),
+            range: calendarRanges[0],
+        })
+        return (
+            <DateTimePicker
+                value={value}
+                onApply={setValue}
+                ranges={calendarRanges}
+                applyOnRangeSelect
+                rangesFooter={<span className="text-xs text-muted-foreground">Host content, e.g. a rolling input</span>}
+            />
+        )
+    },
+}
+
 export const WeekStartsThursday: Story = {
     args: baseArgs,
     render: () => {

--- a/packages/quill/packages/components/src/date-time-picker.stories.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.stories.tsx
@@ -221,6 +221,27 @@ export const InstantPresetsWithRailFooter: Story = {
     },
 }
 
+export const PresetsFirstRailOnly: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<DateTimeValue>({
+            start: startOfMonth(new Date()),
+            end: new Date(),
+            range: calendarRanges[0],
+        })
+        return (
+            <DateTimePicker
+                value={value}
+                onApply={setValue}
+                ranges={calendarRanges}
+                applyOnRangeSelect
+                showCalendar={false}
+                rangesFooter={<span className="text-xs text-muted-foreground">Custom range…</span>}
+            />
+        )
+    },
+}
+
 export const WeekStartsThursday: Story = {
     args: baseArgs,
     render: () => {

--- a/packages/quill/packages/components/src/date-time-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.test.tsx
@@ -57,6 +57,45 @@ describe('DateTimePicker', () => {
         expect(screen.queryByTitle('Last 7 days')).toBeNull()
     })
 
+    it('applies a quick range immediately when applyOnRangeSelect is set', async () => {
+        const onApply = jest.fn()
+        const lastMonth: DateTimeRange = {
+            id: 1,
+            name: 'Last month',
+            rangeSetter: () => new Date(2022, 11, 1),
+            endSetter: () => new Date(2022, 11, 31, 23, 59, 59),
+        }
+        render(<DateTimePicker value={VALUE} maxDate={MAX} onApply={onApply} ranges={[lastMonth]} applyOnRangeSelect />)
+
+        await userEvent.click(screen.getByTitle('Last month'))
+
+        expect(onApply).toHaveBeenCalledTimes(1)
+        const applied = onApply.mock.calls[0][0]
+        expect(applied.start).toEqual(new Date(2022, 11, 1))
+        expect(applied.range).toBe(lastMonth)
+    })
+
+    it('renders the rangesFooter in the rail, even with no presets', () => {
+        const { unmount } = render(
+            <DateTimePicker value={VALUE} maxDate={MAX} onApply={jest.fn()} rangesFooter={<span>Rolling input</span>} />
+        )
+        expect(screen.getByText('Rolling input')).toBeTruthy()
+        unmount()
+
+        // ranges={[]} hides the presets list but a footer alone must still show the rail
+        render(
+            <DateTimePicker
+                value={VALUE}
+                maxDate={MAX}
+                onApply={jest.fn()}
+                ranges={[]}
+                rangesFooter={<span>Rolling input</span>}
+            />
+        )
+        expect(screen.getByText('Rolling input')).toBeTruthy()
+        expect(screen.queryByTitle('Last 7 days')).toBeNull()
+    })
+
     it('applies both edges from a preset with an endSetter', async () => {
         const onApply = jest.fn()
         const lastMonth: DateTimeRange = {

--- a/packages/quill/packages/components/src/date-time-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.test.tsx
@@ -96,6 +96,16 @@ describe('DateTimePicker', () => {
         expect(screen.queryByTitle('Last 7 days')).toBeNull()
     })
 
+    it('renders only the vertical quick-ranges list with showCalendar={false}', () => {
+        const ranges: DateTimeRange[] = [{ id: 1, name: 'This month', rangeSetter: (d) => d }]
+        render(
+            <DateTimePicker value={VALUE} maxDate={MAX} onApply={jest.fn()} ranges={ranges} showCalendar={false} />
+        )
+
+        expect(screen.getByTitle('This month')).toBeTruthy()
+        expect(screen.queryByLabelText('Select Jan 10, 2023')).toBeNull()
+    })
+
     it('applies both edges from a preset with an endSetter', async () => {
         const onApply = jest.fn()
         const lastMonth: DateTimeRange = {

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -57,6 +57,10 @@ export interface DateTimePickerProps {
     compact?: boolean
     /** Quick-range presets to offer. Defaults to `quickRanges`; `CUSTOM_RANGE` entries are filtered out. */
     ranges?: DateTimeRange[]
+    /** Apply a quick range as soon as it's clicked instead of staging it for the Apply button. */
+    applyOnRangeSelect?: boolean
+    /** Host content pinned below the quick-ranges list (e.g. a custom rolling-period input). Shows the rail even with `ranges={[]}`. */
+    rangesFooter?: React.ReactNode
     /** Hide the "Choose date range / Quick ranges" header band when embedding in a host surface. */
     showHeader?: boolean
     /** Day-granular mode: hides the time segments and "Now", and drops time from the footer readout. */
@@ -76,12 +80,15 @@ export function DateTimePicker({
     onDateTimeSettings,
     compact = false,
     ranges = quickRanges,
+    applyOnRangeSelect = false,
+    rangesFooter,
     showHeader = true,
     showTime = true,
     className,
 }: DateTimePickerProps): React.ReactElement {
     const presetRanges = ranges.filter((r) => r.id !== CUSTOM_RANGE.id)
     const hasPresets = presetRanges.length > 0
+    const hasRail = hasPresets || rangesFooter != null
     const maxDate = maxDateProp ?? new Date()
     const hasExplicitMaxDate = maxDateProp !== undefined
     // The second calendar only renders at `lg`; below it (and in compact) there's
@@ -190,6 +197,9 @@ export function DateTimePicker({
         setLastSet(null)
         setRightViewing(nextEnd)
         setLeftViewing(subMonths(nextEnd, 1))
+        if (applyOnRangeSelect) {
+            onApply({ start: nextStart, end: nextEnd, range: next })
+        }
     }
 
     const dateTimeFormat = showTime ? DATE_TIME_FORMATS[dateFormat] : DATE_FORMATS[dateFormat]
@@ -206,7 +216,7 @@ export function DateTimePicker({
         >
             {/* Headers */}
             {!compact && showHeader && (
-                <div className={hasPresets ? 'hidden lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]' : 'hidden lg:grid'}>
+                <div className={hasRail ? 'hidden lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]' : 'hidden lg:grid'}>
                     <div className="flex items-center gap-2 px-2 py-1 bg-muted/30 border-b border-border rounded-tl-lg">
                         <span className="text-[10px] text-muted-foreground uppercase tracking-wide">Choose date range</span>
                         {(minDate || hasExplicitMaxDate) && (
@@ -217,7 +227,7 @@ export function DateTimePicker({
                             </div>
                         )}
                     </div>
-                    {hasPresets && (
+                    {hasRail && (
                         <div className="flex justify-start px-2 py-1 bg-muted/30 border-b border-l border-border rounded-tr-lg">
                             <span className="text-[10px] text-muted-foreground uppercase tracking-wide">Quick ranges</span>
                         </div>
@@ -226,7 +236,7 @@ export function DateTimePicker({
             )}
 
             {/* Body */}
-            <div className={compact || !hasPresets
+            <div className={compact || !hasRail
                 ? 'flex flex-col'
                 : 'flex flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]'
             }>
@@ -302,38 +312,45 @@ export function DateTimePicker({
                 </div>
 
                 {/* Quick ranges column */}
-                {hasPresets && (
+                {hasRail && (
                 <div className={compact
                     ? 'order-0 border-b border-border'
-                    : 'order-0 lg:order-none lg:relative lg:border-l lg:border-border border-b border-border lg:border-b-0'
+                    : 'order-0 lg:order-none lg:flex lg:flex-col lg:border-l lg:border-border border-b border-border lg:border-b-0'
                 }>
-                    <ScrollArea className={compact ? 'w-full' : 'w-full lg:absolute lg:inset-0'}>
-                        <ul className={compact
-                            ? 'flex flex-row p-2 gap-px max-h-[320px]'
-                            : 'flex flex-row lg:flex-col p-2 gap-px max-h-[320px]'
-                        }>
-                            {presetRanges.map((quick) => (
-                                <li key={quick.id} className={compact ? undefined : 'lg:w-full'}>
-                                    <Button
-                                        variant="default"
-                                        size="sm"
-                                        left
-                                        className={compact
-                                            ? 'whitespace-nowrap'
-                                            : 'whitespace-nowrap lg:w-full lg:justify-start'
-                                        }
-                                        aria-selected={range.id === quick.id}
-                                        aria-label={`Choose ${quick.name.toLowerCase()}`}
-                                        title={quick.name}
-                                        onClick={() => handleQuickRange(quick)}
-                                        data-attr={`date-time-picker-quick-range-${quick.name.toLowerCase().replace(/\s+/g, '-')}`}
-                                    >
-                                        {quick.name}
-                                    </Button>
-                                </li>
-                            ))}
-                        </ul>
-                    </ScrollArea>
+                    {hasPresets && (
+                        <div className={compact ? undefined : 'lg:relative lg:flex-1 lg:min-h-0'}>
+                            <ScrollArea className={compact ? 'w-full' : 'w-full lg:absolute lg:inset-0'}>
+                                <ul className={compact
+                                    ? 'flex flex-row p-2 gap-px max-h-[320px]'
+                                    : 'flex flex-row lg:flex-col p-2 gap-px max-h-[320px]'
+                                }>
+                                    {presetRanges.map((quick) => (
+                                        <li key={quick.id} className={compact ? undefined : 'lg:w-full'}>
+                                            <Button
+                                                variant="default"
+                                                size="sm"
+                                                left
+                                                className={compact
+                                                    ? 'whitespace-nowrap'
+                                                    : 'whitespace-nowrap lg:w-full lg:justify-start'
+                                                }
+                                                aria-selected={range.id === quick.id}
+                                                aria-label={`Choose ${quick.name.toLowerCase()}`}
+                                                title={quick.name}
+                                                onClick={() => handleQuickRange(quick)}
+                                                data-attr={`date-time-picker-quick-range-${quick.name.toLowerCase().replace(/\s+/g, '-')}`}
+                                            >
+                                                {quick.name}
+                                            </Button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </ScrollArea>
+                        </div>
+                    )}
+                    {rangesFooter != null && (
+                        <div className={hasPresets ? 'border-t border-border p-2' : 'p-2'}>{rangesFooter}</div>
+                    )}
                 </div>
                 )}
             </div>

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -65,6 +65,9 @@ export interface DateTimePickerProps {
     showHeader?: boolean
     /** Day-granular mode: hides the time segments and "Now", and drops time from the footer readout. */
     showTime?: boolean
+    /** Hide the calendar column: the picker renders as a narrow vertical quick-ranges list.
+     * For presets-first hosts that reveal the calendar on demand (e.g. behind a "Custom range" action). */
+    showCalendar?: boolean
     className?: string
 }
 
@@ -84,11 +87,14 @@ export function DateTimePicker({
     rangesFooter,
     showHeader = true,
     showTime = true,
+    showCalendar = true,
     className,
 }: DateTimePickerProps): React.ReactElement {
     const presetRanges = ranges.filter((r) => r.id !== CUSTOM_RANGE.id)
     const hasPresets = presetRanges.length > 0
     const hasRail = hasPresets || rangesFooter != null
+    // Rail-only mode: the rail is the whole component, so it lists vertically at every width.
+    const railOnly = !showCalendar
     const maxDate = maxDateProp ?? new Date()
     const hasExplicitMaxDate = maxDateProp !== undefined
     // The second calendar only renders at `lg`; below it (and in compact) there's
@@ -210,12 +216,17 @@ export function DateTimePicker({
         <div
             className={cn(
                 'bg-card text-foreground rounded-lg shadow-md ring-1 ring-foreground/10 overflow-hidden',
-                compact ? 'w-[15rem]' : 'w-[15rem] lg:w-full max-w-[42rem]',
+                compact || railOnly ? 'w-[15rem]' : 'w-[15rem] lg:w-full max-w-[42rem]',
                 className
             )}
         >
             {/* Headers */}
-            {!compact && showHeader && (
+            {railOnly && showHeader && hasRail && (
+                <div className="flex justify-start px-2 py-1 bg-muted/30 border-b border-border">
+                    <span className="text-[10px] text-muted-foreground uppercase tracking-wide">Quick ranges</span>
+                </div>
+            )}
+            {!compact && !railOnly && showHeader && (
                 <div className={hasRail ? 'hidden lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]' : 'hidden lg:grid'}>
                     <div className="flex items-center gap-2 px-2 py-1 bg-muted/30 border-b border-border rounded-tl-lg">
                         <span className="text-[10px] text-muted-foreground uppercase tracking-wide">Choose date range</span>
@@ -236,11 +247,12 @@ export function DateTimePicker({
             )}
 
             {/* Body */}
-            <div className={compact || !hasRail
+            <div className={compact || railOnly || !hasRail
                 ? 'flex flex-col'
                 : 'flex flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]'
             }>
                 {/* Calendars column */}
+                {!railOnly && (
                 <div className={compact ? 'order-1' : 'order-1 lg:order-none'}>
                     {/* Inputs */}
                     {!compact && (
@@ -310,29 +322,36 @@ export function DateTimePicker({
                         </div>
                     </div>
                 </div>
+                )}
 
                 {/* Quick ranges column */}
                 {hasRail && (
-                <div className={compact
+                <div className={compact && !railOnly
                     ? 'order-0 border-b border-border'
-                    : 'order-0 lg:order-none lg:flex lg:flex-col lg:border-l lg:border-border border-b border-border lg:border-b-0'
+                    : railOnly
+                      ? 'flex flex-col'
+                      : 'order-0 lg:order-none lg:flex lg:flex-col lg:border-l lg:border-border border-b border-border lg:border-b-0'
                 }>
                     {hasPresets && (
-                        <div className={compact ? undefined : 'lg:relative lg:flex-1 lg:min-h-0'}>
-                            <ScrollArea className={compact ? 'w-full' : 'w-full lg:absolute lg:inset-0'}>
-                                <ul className={compact
-                                    ? 'flex flex-row p-2 gap-px max-h-[320px]'
-                                    : 'flex flex-row lg:flex-col p-2 gap-px max-h-[320px]'
+                        <div className={compact || railOnly ? undefined : 'lg:relative lg:flex-1 lg:min-h-0'}>
+                            <ScrollArea className={compact || railOnly ? 'w-full' : 'w-full lg:absolute lg:inset-0'}>
+                                <ul className={railOnly
+                                    ? 'flex flex-col p-2 gap-px max-h-[320px]'
+                                    : compact
+                                      ? 'flex flex-row p-2 gap-px max-h-[320px]'
+                                      : 'flex flex-row lg:flex-col p-2 gap-px max-h-[320px]'
                                 }>
                                     {presetRanges.map((quick) => (
-                                        <li key={quick.id} className={compact ? undefined : 'lg:w-full'}>
+                                        <li key={quick.id} className={railOnly ? 'w-full' : compact ? undefined : 'lg:w-full'}>
                                             <Button
                                                 variant="default"
                                                 size="sm"
                                                 left
-                                                className={compact
-                                                    ? 'whitespace-nowrap'
-                                                    : 'whitespace-nowrap lg:w-full lg:justify-start'
+                                                className={railOnly
+                                                    ? 'whitespace-nowrap w-full justify-start'
+                                                    : compact
+                                                      ? 'whitespace-nowrap'
+                                                      : 'whitespace-nowrap lg:w-full lg:justify-start'
                                                 }
                                                 aria-selected={range.id === quick.id}
                                                 aria-label={`Choose ${quick.name.toLowerCase()}`}
@@ -355,6 +374,9 @@ export function DateTimePicker({
                 )}
             </div>
 
+            {/* Rail-only with instant presets has nothing to stage, so no footer chrome */}
+            {!(railOnly && applyOnRangeSelect) && (
+            <>
             <Separator />
 
             {/* Actions */}
@@ -378,6 +400,8 @@ export function DateTimePicker({
                     Apply
                 </Button>
             </div>
+            </>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The insight date filter exploration (#68359) is testing whether the quill `DateTimePicker` can be the whole filter popover. Three gaps block that:

- PostHog's date filter applies a preset the moment you click it. The picker stages everything until Apply, so presets cost an extra click.
- The insight filter has a rolling "Last N units" input that produces relative ranges (`-90d`). The picker has no place to host it.
- The filter's primary action is preset selection - the always-open dual-calendar surface is too heavy as a default. The calendar should be revealable on demand.

Stacked on #68398, which added `ranges`, `endSetter`, and the embed props this builds on.

## Changes

Three additive props on `DateTimePicker`, all defaulting to current behavior:

- `applyOnRangeSelect` - clicking a quick range fires `onApply` immediately with the computed range. Calendar and input edits still stage for the Apply button.
- `rangesFooter` - a `ReactNode` pinned below the quick-ranges list, for host content like a rolling-period input or a "Custom range" toggle. Providing it shows the rail even with `ranges={[]}`.
- `showCalendar` - with `false`, the calendar column disappears and the picker renders as a narrow vertical quick-ranges list (presets-first). Combined with `applyOnRangeSelect` the staging footer drops too, since nothing is left to stage. Hosts toggle it back on from a "Custom range" action in `rangesFooter`.

The rail column switched from an absolutely positioned scroll area to a flex column so the footer can pin to the bottom; the default rendering is unchanged. Stories `InstantPresetsWithRailFooter` and `PresetsFirstRailOnly` cover the new modes, AGENTS.md consumer guide updated.

## How did you test this code?

- Extended `date-time-picker.test.tsx` with 3 tests: `applyOnRangeSelect` firing `onApply` on preset click without touching Apply (catches the prop being ignored, which no staged-flow test would notice), `rangesFooter` rendering including with `ranges={[]}` (catches the rail-hiding gate from #68398 swallowing the footer), and `showCalendar={false}` rendering presets without any day cells (catches the calendar column leaking back in). All 7 tests in the file pass.
- Not manually tested in a running app yet - the consumer wiring lands on the #68359 branch next, and the new stories cover visual review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal component library only; `packages/quill/packages/components/AGENTS.md` updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session), directed by Sam, while exploring replacing the hand-rolled insight date filter popover with the stock quill picker. The consumer prototype lives on the #68359 branch.
- Skills invoked: /writing-tests.
- Decisions: instant apply is scoped to quick ranges only (calendar edits keep staging) since presets are self-describing while ranges under construction aren't; the footer is a plain `ReactNode` slot rather than a rolling-input feature in quill, keeping PostHog's relative-date vocabulary out of the design system; `showCalendar` was added after prototyping showed the always-open dual calendar is too heavy for a filter whose primary action is one-click presets (the PR was briefly closed when that read as a dead end, then reopened once it was clear the fix is a presets-first mode in the picker itself).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*