### PR TITLE
fix(warehouse): keep postgres pooler checkout-timeout retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -226,7 +226,11 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
 #   - ECHECKOUTRETRIES ("failed to check out a connection after multiple retries"): the pooler
 #     couldn't hand us a backend connection after retrying internally — its pool was momentarily
 #     exhausted or every backend was busy. A slot frees the moment another session returns one.
-# Both are the same transient class as the libpq drops above and recover on reconnect. Genuine
+#   - ECHECKOUTTIMEOUT ("unable to check out connection from the pool after <n>ms in Transaction
+#     mode"): the transaction-mode sibling of ECHECKOUTRETRIES — the pooler assigns a backend per
+#     transaction and couldn't check one out before its checkout timeout elapsed because the pool
+#     was saturated for the whole window. Clears the moment a session returns a connection.
+# These are all the same transient class as the libpq drops above and recover on reconnect. Genuine
 # XX000 internal errors (data corruption, etc.) carry a different code and stay non-recoverable.
 #
 # Supavisor also surfaces a backend socket that closed mid-session — after the client authenticated
@@ -239,6 +243,7 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
 _POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     "edbhandlerexited",
     "echeckoutretries",
+    "echeckouttimeout",
     "internal error (authenticated): :closed",
 )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1190,6 +1190,12 @@ class TestIsConnectionDroppedError:
             # retrying internally. Same transient pooler class as EDBHANDLEREXITED; recovers on
             # reconnect once a session returns a connection to the pool.
             psycopg.errors.InternalError_("(ECHECKOUTRETRIES) failed to check out a connection after multiple retries"),
+            # Transaction-mode sibling of ECHECKOUTRETRIES: Supavisor couldn't check out a backend
+            # from the pool before its checkout timeout elapsed. Same transient pooler-saturation
+            # class, also an XX000 InternalError_, matched on the "(ECHECKOUTTIMEOUT)" code.
+            psycopg.errors.InternalError_(
+                "(ECHECKOUTTIMEOUT) unable to check out connection from the pool after 60000ms in Transaction mode"
+            ),
             # Supavisor loses the backend socket mid-session (idle cull, restart, failover) and, once
             # the client is past auth, surfaces it as an XX000 InternalError_ "Internal error
             # (authenticated): :closed" — ":closed" being the Erlang gen_tcp peer-closed reason. No


### PR DESCRIPTION
## Problem

A Postgres data-warehouse sync surfaced this in error tracking:

```
InternalError_: (ECHECKOUTTIMEOUT) unable to check out connection from the pool after 60000ms in Transaction mode
```

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f4ae0-7d04-7bc1-9d52-8e69ed999ada

The stack originates in the postgres source (`sources/postgres/source.py` `source_for_pipeline` → `postgres.py` `postgres_source` → `psycopg` `cursor.execute`), so this is genuinely our code path failing during sync setup.

This is a Supavisor (Supabase's pooler) error. In transaction mode the pooler assigns a backend connection per transaction, and here it couldn't check one out before its checkout timeout elapsed because the pool was saturated for the whole window. It's the transaction-mode sibling of `(ECHECKOUTRETRIES)`, which we already treat as a transient pooler drop. Both clear the moment a session returns a connection to the pool, so both are transient and should stay retryable.

The bug: `_is_connection_dropped_error` only matched the pooler's `InternalError_` on the `EDBHANDLEREXITED` / `ECHECKOUTRETRIES` / `:closed` signatures, not `ECHECKOUTTIMEOUT`. So the setup loop's in-process reconnect never fired, and a transient pooler-saturation blip escaped to fail the whole sync activity and land in error tracking.

## Changes

Add the `echeckouttimeout` code to `_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, next to `echeckoutretries`. Now the setup-loop reconnect recognises it, retries in-process with bounded backoff, and the sync recovers instead of failing.

It stays retryable and is deliberately **not** added to `get_non_retryable_errors` - a checkout timeout is a transient capacity condition, not a customer misconfiguration.

Match is on the stable `echeckouttimeout` code, so the volatile millisecond value in the message doesn't affect it.

## How did you test this code?

Added one parameterized case to `TestIsConnectionDroppedError::test_connection_dropped_errors_are_detected` asserting the `(ECHECKOUTTIMEOUT)` `InternalError_` is detected as a transient drop. No existing case covered it (the siblings `EDBHANDLEREXITED`, `ECHECKOUTRETRIES`, and `:closed` were covered) - it guards against someone dropping the substring and re-breaking in-process recovery for this pooler error.

Ran the suite locally:

```
uv run pytest test_postgres.py::TestIsConnectionDroppedError -q
32 passed
```

I (Claude) could not exercise a live Supavisor transaction-mode pooler, so verification is the unit test plus tracing the setup-loop path (`postgres.py` ~3060, `_CONNECTION_DROPPED_ERROR_TYPES` → `_is_connection_dropped_error`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the issue in error tracking (exception type, message, stack frames, frequency), read the postgres source and its retry/backoff helpers, and decided this is a fixable-code case rather than a NonRetryableErrors addition: the error is transient pooler saturation that already has an in-process recovery path for its sibling `ECHECKOUTRETRIES`, so the fix is to make the checkout-timeout code take the same path. Checked open PRs (including the maintainer's) for a duplicate first; none addressed this. Invoked the `/writing-tests` skill before adding the regression case.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
