### PR TITLE
fix(ci): optimal_chunks product splits, drop warehouse shard override

### DIFF
--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -31,13 +31,13 @@ const { analyzeSchemaImpact, readBaseSchema } = require('./schema-impact')
 // fungible across products — bin-pack products into target-sized shards, and
 // multi-shard split any single product that overflows on its own.
 const PRODUCT_TARGET_WALL_SECONDS = 10 * 60
-// Per-product per-shard wall-clock target override. A product that runs a large temporal suite in
-// its own job (warehouse_sources) is split more aggressively so the long integration tests fan out
-// across more shards. Kept modest — every extra shard pays the full docker-stack + temporal-server
-// startup, so over-splitting trades runner cost for little wall-clock once startup dominates.
-const PRODUCT_TARGET_WALL_OVERRIDE = {
-    'warehouse-sources': 6 * 60,
-}
+// Fixed per-shard cost paid before any test runs: docker stack + temporal boot, dependency
+// install, and full-tree pytest collection. Measured from shards that received (nearly) zero
+// tests: ~3-4 min wall. Subtracted from the wall target to get each shard's test-work budget
+// (same Amdahl shape as the Django segments below), so a product that overflows is split by
+// what a shard can actually chew through — not by the bare wall target, which under-shards
+// exactly by the overhead share.
+const PRODUCT_SHARD_OVERHEAD_SECONDS = 4 * 60
 // Per-product cost within a runner: turbo dispatch, pytest collection, Django
 // init. First product pays ~45s, subsequent ~15s; use 60s as a conservative
 // average that also absorbs the amortized portion of runner startup.
@@ -440,7 +440,6 @@ function buildMatrix(products, durations) {
     for (const product of products) {
         const staleness = checkProductStaleness(product, durations)
         let raw = getProductDuration(product, durations) + PRODUCT_PER_PRODUCT_OVERHEAD_SECONDS
-        const targetWall = PRODUCT_TARGET_WALL_OVERRIDE[product] ?? PRODUCT_TARGET_WALL_SECONDS
 
         // Staleness guard: if .test_durations has poor coverage for this product,
         // use a file-count-based fallback to avoid under-sharding.
@@ -459,8 +458,8 @@ function buildMatrix(products, durations) {
             }
         }
 
-        if (raw > targetWall) {
-            const shards = Math.ceil(raw / targetWall)
+        if (raw > PRODUCT_TARGET_WALL_SECONDS) {
+            const shards = Math.ceil(raw / (PRODUCT_TARGET_WALL_SECONDS - PRODUCT_SHARD_OVERHEAD_SECONDS))
             console.error(`  ${product}: ${(raw / 60).toFixed(1)} min raw → split across ${shards} shards`)
             const filters = `--filter=@posthog/products-${product}`
             // optimal_chunks (PostHog pytest-split fork) makes the same contiguous,

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -463,11 +463,16 @@ function buildMatrix(products, durations) {
             const shards = Math.ceil(raw / targetWall)
             console.error(`  ${product}: ${(raw / 60).toFixed(1)} min raw → split across ${shards} shards`)
             const filters = `--filter=@posthog/products-${product}`
+            // optimal_chunks (PostHog pytest-split fork) makes the same contiguous,
+            // order-preserving cuts as duration_based_chunks but balances them
+            // optimally. The greedy rule in duration_based_chunks lets every shard
+            // overrun the per-shard average, which on skewed suites starves trailing
+            // shards down to zero tests (pytest exit 5, "no tests collected").
             for (let i = 1; i <= shards; i++) {
                 matrix.push({
                     group: `${product} (${i}/${shards})`,
                     filters,
-                    pytest_args: `-- --splits ${shards} --group ${i} --splitting-algorithm duration_based_chunks`,
+                    pytest_args: `-- --splits ${shards} --group ${i} --splitting-algorithm optimal_chunks`,
                 })
             }
         } else if (DEDICATED_BUCKET_PRODUCTS.has(product)) {

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -30,14 +30,13 @@ const { analyzeSchemaImpact, readBaseSchema } = require('./schema-impact')
 // Each product is atomic for packing, but unlike Django the test pool isn't
 // fungible across products — bin-pack products into target-sized shards, and
 // multi-shard split any single product that overflows on its own.
+// The target is a per-shard test-WORK budget, not a wall-clock promise: the fixed
+// per-shard setup (docker stack + temporal boot, deps, collection, ~3-4 min) is paid
+// identically by every shard, so it can't skew the split and deliberately stays out
+// of the shard-count math — folding it in only inflates counts (see #54280). Walls
+// land at target + setup, evenly across shards. JUnit de-taxing in
+// optimize_test_durations.py keeps that setup cost out of the timings themselves.
 const PRODUCT_TARGET_WALL_SECONDS = 10 * 60
-// Fixed per-shard cost paid before any test runs: docker stack + temporal boot, dependency
-// install, and full-tree pytest collection. Measured from shards that received (nearly) zero
-// tests: ~3-4 min wall. Subtracted from the wall target to get each shard's test-work budget
-// (same Amdahl shape as the Django segments below), so a product that overflows is split by
-// what a shard can actually chew through — not by the bare wall target, which under-shards
-// exactly by the overhead share.
-const PRODUCT_SHARD_OVERHEAD_SECONDS = 4 * 60
 // Per-product cost within a runner: turbo dispatch, pytest collection, Django
 // init. First product pays ~45s, subsequent ~15s; use 60s as a conservative
 // average that also absorbs the amortized portion of runner startup.
@@ -459,7 +458,7 @@ function buildMatrix(products, durations) {
         }
 
         if (raw > PRODUCT_TARGET_WALL_SECONDS) {
-            const shards = Math.ceil(raw / (PRODUCT_TARGET_WALL_SECONDS - PRODUCT_SHARD_OVERHEAD_SECONDS))
+            const shards = Math.ceil(raw / PRODUCT_TARGET_WALL_SECONDS)
             console.error(`  ${product}: ${(raw / 60).toFixed(1)} min raw → split across ${shards} shards`)
             const filters = `--filter=@posthog/products-${product}`
             // optimal_chunks (PostHog pytest-split fork) makes the same contiguous,


### PR DESCRIPTION
## Problem

Sharded product test jobs split their tests with pytest-split's default `duration_based_chunks`. That algorithm only advances to the next shard after the current one already exceeds the per-shard average, so every shard overshoots and trailing shards can end up with zero tests. When that happens pytest exits with code 5 ("no tests collected") and the job fails even though nothing is wrong with the PR.

warehouse-sources hit exactly this after its temporal suite moved into the product job (#67840): shard 12/12 got zero tests assigned and failed deterministically, blocking unrelated PRs (example: [failing job](https://github.com/PostHog/posthog/actions/runs/29072891227/job/86302637858), [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1783665857436269)).

The Django Core/Temporal segments already moved to `optimal_chunks` from our pytest-split fork (#64461) and have run on it for weeks. The product shard path in turbo-discover.js was simply never switched over.

## Changes

turbo-discover.js now emits `--splitting-algorithm optimal_chunks` for multi-shard products. Same contiguous, order-preserving cuts as before, but the cut points minimize the slowest shard, and the algorithm cannot produce an empty shard while there are more tests than shards. The fork is git-pinned in pyproject, so the flag is always available in CI.

The warehouse-sources 6-min target override is dropped, back to the uniform 10-min budget. The per-shard setup cost (docker + temporal boot, deps, collection) is paid identically by every shard, so it cannot skew the split, and JUnit de-taxing already keeps it out of the recorded timings. The target is a per-shard work budget, not a wall promise: walls land at target + setup, evenly across shards. With optimal_chunks keeping any shard count balanced, the aggressive override no longer buys anything: with fresh timings warehouse-sources sizes to about 3 shards at ~13 min wall instead of paying the full docker setup on 5-12 runners.

Complementary to #69871, which makes product jobs tolerate exit code 5 as a backstop.

## How did you test this code?

- Replayed both algorithms over the real durations data at 12 splits with the pytest-split library: `duration_based_chunks` reproduces the empty tail shard on the committed durations snapshot, `optimal_chunks` fills every shard and improves the makespan on every snapshot tried.
- Ran `pytest --collect-only` from products/warehouse_sources with the new flag for shard 12/12, which selects a healthy non-empty group.
- Ran the turbo-discover unit tests and a full local discover pass to confirm the emitted matrix carries the new flag.
- Verified the sizing on a live discover run: no other product's shard count changes, warehouse-sources drops from 12 to 7 shards under the stale-durations fallback and right-sizes to about 3 once the refreshed committed timings (#69887) land.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, CI-internal behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable) in an interactive session, directed by the assignee. No repo skills applied to this change.

Decisions along the way:

- Considered adding a runtime downgrade guard in the workflow (the pattern the Django segments use) so the flag falls back when the fork isn't installed. Dropped it per reviewer direction: the fork is pinned in pyproject and has soaked for weeks, so the matrix can hardcode the algorithm and the change stays a one-liner in the discover script, with no depot shadow mirroring needed.
- Briefly tried folding the per-shard setup cost into the shard-count math (Amdahl style, like the Django segments) before reverting it: #54280 deliberately keeps inflation out of the split count, setup is a per-shard constant that can't affect balance, and with optimal_chunks the split is even at any count. The override removal is the consistent end state instead.
- Verified empirically that turbo propagates a task's exit code (a pytest exit 5 surfaces as turbo exit 5), so the #69871 backstop works as intended alongside this.
- Also investigated why the split was so skewed in the first place: the failing run's discovery job logged a durations cache miss and fell back to the committed `.test_durations`, which predates the warehouse temporal move and trips the staleness fallback (hence 12 shards). Dispatched the timing-update workflow to refresh the cache and the committed fallback; the cache eviction pressure itself is a separate follow-up.
