### PR TITLE
feat(inbox): add a Merge PR action to the report detail

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -251,6 +251,7 @@ import type {
     SessionGroupSummaryType,
     SessionSummariesConfig,
 } from 'products/session_summaries/frontend/types'
+import type { MergeResponseApi } from 'products/signals/frontend/generated/api.schemas'
 import type {
     ClaudeTaskRunCreateSchemaApi,
     TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi,
@@ -5188,6 +5189,11 @@ const api = {
             content: Record<string, any>[]
         ): Promise<SignalReportArtefact> {
             return await new ApiRequest().signalReportArtefact(reportId, artefactId).put({ data: { content } })
+        },
+        // Squash-merge the report's implementation PR, resolved from the given `commit` artefact.
+        // Backend: SignalReportArtefactViewSet.merge (GitHub's own merge rules are the guardrail).
+        async merge(reportId: SignalReport['id'], artefactId: string): Promise<MergeResponseApi> {
+            return await new ApiRequest().signalReportArtefact(reportId, artefactId).withAction('merge').create()
         },
     },
 

--- a/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
@@ -2,8 +2,8 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { type MouseEvent, useState } from 'react'
 
-import { IconArchive, IconMessage, IconPullRequest, IconUndo } from '@posthog/icons'
-import { lemonToast } from '@posthog/lemon-ui'
+import { IconArchive, IconCheckCircle, IconMessage, IconPullRequest, IconUndo } from '@posthog/icons'
+import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { urls } from 'scenes/urls'
@@ -57,8 +57,8 @@ function canCreateImplementationPr(report: SignalReport): boolean {
  * `useReportArchive` dialog flow. Callers render these inline or inside a menu.
  */
 export function useReportDetailActions(report: SignalReport): ReportDetailAction[] {
-    const { isCreatingPr } = useValues(inboxTaskKickoffLogic)
-    const { createPrFromReport } = useActions(inboxTaskKickoffLogic)
+    const { isCreatingPr, isMergingPr } = useValues(inboxTaskKickoffLogic)
+    const { createPrFromReport, mergePrFromReport } = useActions(inboxTaskKickoffLogic)
     const { reportArchived } = useActions(inboxBulkActionsLogic)
     const { activeTab } = useValues(inboxSceneLogic)
     const [isRestoring, setIsRestoring] = useState(false)
@@ -167,6 +167,35 @@ export function useReportDetailActions(report: SignalReport): ReportDetailAction
             onClick: () => {
                 captureInboxReportAction({ report, actionType: 'create_pr', surface: 'detail_pane' })
                 createPrFromReport(report)
+            },
+        })
+    }
+
+    // Offer Merge PR once an implementation PR exists (and the report isn't resolved/suppressed —
+    // those cases returned above). GitHub's own merge rules are the guardrail: an unmergeable /
+    // already-merged / closed PR is surfaced as a clean error on click rather than pre-hidden here.
+    if (report.implementation_pr_url) {
+        actions.push({
+            key: 'merge-pr',
+            label: 'Merge PR',
+            icon: <IconCheckCircle />,
+            loading: isMergingPr,
+            tooltip: "Squash-merge this report's pull request on GitHub",
+            onClick: () => {
+                // Merging ships code, so confirm first — mirrors the guardrail on other state-changing actions.
+                LemonDialog.open({
+                    title: 'Merge pull request?',
+                    description:
+                        "This squash-merges the report's pull request on GitHub. It can't be undone from here.",
+                    primaryButton: {
+                        children: 'Merge PR',
+                        onClick: () => {
+                            captureInboxReportAction({ report, actionType: 'merge_pr', surface: 'detail_pane' })
+                            mergePrFromReport(report)
+                        },
+                    },
+                    secondaryButton: { children: 'Cancel' },
+                })
             },
         })
     }

--- a/frontend/src/scenes/inbox/inboxAnalytics.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.ts
@@ -45,6 +45,7 @@ export type InboxReportActionType =
     | 'dismiss'
     | 'restore'
     | 'create_pr'
+    | 'merge_pr'
     | 'add_suggested_reviewer'
     | 'remove_suggested_reviewer'
 

--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -9,6 +9,7 @@ import { urls } from 'scenes/urls'
 import { OriginProduct } from 'products/posthog_ai/frontend/types/taskTypes'
 
 import type { inboxTaskKickoffLogicType } from './inboxTaskKickoffLogicType'
+import { inboxBulkActionsLogic } from './logics/inboxBulkActionsLogic'
 import { SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP, SignalReport, SignalReportTaskRelationship } from './types'
 
 // Cloud-adapted port of desktop `useDiscussReport` / `useCreatePrReport`. These are
@@ -90,16 +91,32 @@ async function createReportTask(
     router.actions.push(urls.taskDetail(task.id))
 }
 
+// The report's implementation PR is resolved server-side from its `commit` artefact's branch, so
+// merging is addressed by that artefact. Pick the newest commit artefact — its branch tip is the
+// current state of the work (the same one the "Files changed" diff renders). Returns null when the
+// report has no commit artefact yet (nothing to merge).
+async function resolveLatestCommitArtefactId(report: SignalReport): Promise<string | null> {
+    const { results } = await api.signalReports.artefacts(report.id, { limit: REPO_SELECTION_ARTEFACT_FETCH_LIMIT })
+    const commits = results.filter((a) => a.type === 'commit')
+    if (commits.length === 0) {
+        return null
+    }
+    return commits.reduce((latest, a) => (a.created_at > latest.created_at ? a : latest)).id
+}
+
 export const inboxTaskKickoffLogic = kea<inboxTaskKickoffLogicType>([
     path(['scenes', 'inbox', 'inboxTaskKickoffLogic']),
 
     actions({
         discussReport: (report: SignalReport, question?: string) => ({ report, question }),
         createPrFromReport: (report: SignalReport) => ({ report }),
+        mergePrFromReport: (report: SignalReport) => ({ report }),
         discussReportSuccess: true,
         discussReportFailure: true,
         createPrSuccess: true,
         createPrFailure: true,
+        mergePrSuccess: true,
+        mergePrFailure: true,
     }),
 
     reducers({
@@ -117,6 +134,14 @@ export const inboxTaskKickoffLogic = kea<inboxTaskKickoffLogicType>([
                 createPrFromReport: () => true,
                 createPrSuccess: () => false,
                 createPrFailure: () => false,
+            },
+        ],
+        isMergingPr: [
+            false,
+            {
+                mergePrFromReport: () => true,
+                mergePrSuccess: () => false,
+                mergePrFailure: () => false,
             },
         ],
     }),
@@ -144,6 +169,27 @@ export const inboxTaskKickoffLogic = kea<inboxTaskKickoffLogicType>([
             } catch (error: any) {
                 lemonToast.error(error?.detail || error?.message || 'Failed to start PR task')
                 actions.createPrFailure()
+            }
+        },
+        mergePrFromReport: async ({ report }) => {
+            try {
+                const commitArtefactId = await resolveLatestCommitArtefactId(report)
+                if (!commitArtefactId) {
+                    throw new Error('No commit was found for this report yet — the PR may not have landed any changes.')
+                }
+                await api.signalReports.merge(report.id, commitArtefactId)
+                lemonToast.success('Pull request merged')
+                // Merging resolves the report server-side once GitHub's merge webhook lands; broadcast so
+                // every mounted inbox list reconciles against the server (the report moves toward resolved).
+                inboxBulkActionsLogic.findMounted()?.actions.reportMerged()
+                actions.mergePrSuccess()
+            } catch (error: any) {
+                // The merge endpoint returns GitHub's rejection reason in the response body's `error`
+                // field (e.g. not mergeable / head moved), surfaced here rather than a generic message.
+                lemonToast.error(
+                    error?.data?.error || error?.detail || error?.message || 'Failed to merge pull request'
+                )
+                actions.mergePrFailure()
             }
         },
     })),

--- a/frontend/src/scenes/inbox/logics/inboxBulkActionsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxBulkActionsLogic.ts
@@ -45,6 +45,9 @@ export const inboxBulkActionsLogic = kea<inboxBulkActionsLogicType>([
         /** Broadcast that a single report was archived elsewhere (e.g. the detail pane), so every
          * mounted list reconciles itself. Persisting the change is the caller's responsibility. */
         reportArchived: true,
+        /** Broadcast that a report's implementation PR was merged from the detail pane, so every
+         * mounted list reconciles against the server (the report moves toward resolved). */
+        reportMerged: true,
     }),
 
     reducers({

--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -301,6 +301,8 @@ export const reportListLogic = kea<reportListLogicType>([
         // A single report archived elsewhere (e.g. the detail pane) – reconcile this tab against
         // the server so the report leaves Reports/Pull requests and joins Archived, counts included.
         [inboxBulkActionsLogic.actionTypes.reportArchived]: () => actions.refresh(),
+        // A report's PR merged from the detail pane – reconcile so it moves toward resolved server-side.
+        [inboxBulkActionsLogic.actionTypes.reportMerged]: () => actions.refresh(),
     })),
 
     events(({ actions }) => ({

--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -674,6 +674,12 @@ class GitHubIntegrationBase:
             "url": pr.get("html_url"),
             "state": pr.get("state"),
             "merged": pr.get("merged", False),
+            # GitHub computes mergeability asynchronously, so `mergeable` can be null on a freshly
+            # opened / just-updated PR until the check settles; `mergeable_state` (e.g. "clean",
+            # "blocked", "dirty", "unknown") is the finer-grained signal. Both are surfaced so a
+            # caller can gate a merge on the PR's live state.
+            "mergeable": pr.get("mergeable"),
+            "mergeable_state": pr.get("mergeable_state"),
             "draft": pr.get("draft", False),
             "head_branch": head.get("ref"),
             "base_branch": base.get("ref"),

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2952,6 +2952,42 @@ class GitHubIntegration(GitHubIntegrationBase):
                 "status_code": response.status_code,
             }
 
+    def merge_pull_request(self, repository: str, pull_number: int, merge_method: str = "squash") -> dict[str, Any]:
+        """Merge a pull request via ``PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge``.
+
+        ``repository`` may be ``owner/name`` or a bare name (resolved against the installation org).
+        Squash-merges by default. Never raises for a GitHub rejection: GitHub's own 405 (the PR is
+        not in a mergeable state), 409 (the head moved since the merge was requested) and 403
+        (insufficient permission) responses are the guardrail and are surfaced to the caller as
+        ``{"success": False, "status_code": ..., "error": ...}`` rather than re-implementing merge
+        policy here. Returns ``{"success": True, "sha": ...}`` (the merge commit SHA) on a 200.
+        """
+        repo_path = repository if "/" in repository else f"{self.organization()}/{repository}"
+        # `repository` reaches us from team-writable artefact content, and is interpolated into an
+        # authenticated PUT below — reject anything that isn't a plain ``owner/repo`` so a crafted
+        # value can't steer that authenticated write at a different GitHub endpoint.
+        if not _is_safe_github_repo_path(repo_path):
+            return {"success": False, "error": f"Invalid repository '{repository}'.", "status_code": 400}
+
+        try:
+            response = self.api_request(
+                "PUT",
+                f"/repos/{repo_path}/pulls/{pull_number}/merge",
+                endpoint="/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+                json_body={"merge_method": merge_method},
+            )
+        except GitHubIntegrationError:
+            # Don't let a slow/unreachable GitHub 500 the caller.
+            return {"success": False, "error": "Could not reach GitHub.", "status_code": 502}
+
+        if response.status_code == 200:
+            try:
+                data = response.json()
+            except ValueError:
+                data = {}
+            return {"success": True, "sha": data.get("sha")}
+        return {"success": False, "error": response.text, "status_code": response.status_code}
+
 
 class GitLabIntegrationError(Exception):
     pass

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -711,3 +711,19 @@ class CommitDiffResponseSerializer(serializers.Serializer):
         read_only=True,
         help_text="True when the diff was too large to return in full and has been truncated.",
     )
+
+
+class MergeResponseSerializer(serializers.Serializer):
+    """Response for the `commit` artefact merge endpoint — the outcome of merging the report's
+    implementation pull request via the team's GitHub integration."""
+
+    merged = serializers.BooleanField(
+        read_only=True,
+        help_text="True when the pull request was merged (or was already merged).",
+    )
+    sha = serializers.CharField(
+        read_only=True,
+        allow_null=True,
+        help_text="SHA of the merge commit GitHub created, when available. Null when GitHub did not "
+        "return one (e.g. the pull request was already merged).",
+    )

--- a/products/signals/backend/test/test_signal_report_artefact_api.py
+++ b/products/signals/backend/test/test_signal_report_artefact_api.py
@@ -2,7 +2,7 @@ import json
 import uuid
 
 from posthog.test.base import APIBaseTest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -660,6 +660,80 @@ class TestSignalReportArtefactViewSet(APIBaseTest):
         )
 
         response = self.client.get(self._detail_url(str(report.id), str(artefact.id)) + "diff/")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    # --- POST merge ---
+
+    def _commit_artefact(self) -> tuple[SignalReport, SignalReportArtefact]:
+        report = self._create_report()
+        artefact = self._create_artefact(
+            report,
+            artefact_type=SignalReportArtefact.ArtefactType.COMMIT,
+            content={"repository": "acme/repo", "branch": "fix-branch", "commit_sha": "deadbeef", "message": "fix"},
+        )
+        return report, artefact
+
+    def _mock_github(self, *, pr_state="open", merged=False, merge_result=None):
+        github = MagicMock()
+        github.parse_pull_request_url.return_value = ("acme", "repo", 7)
+        github.get_pull_request.return_value = {"success": True, "state": pr_state, "merged": merged}
+        github.merge_pull_request.return_value = merge_result or {"success": True, "sha": "merge-sha-123"}
+        return github
+
+    def test_merge_squash_merges_pr_and_returns_sha(self):
+        report, artefact = self._commit_artefact()
+        github = self._mock_github()
+        with (
+            patch("products.signals.backend.views.GitHubIntegration.first_for_team_repository", return_value=github),
+            patch(
+                "products.signals.backend.views.fetch_implementation_pr_urls_for_reports",
+                return_value={str(report.id): "https://github.com/acme/repo/pull/7"},
+            ),
+        ):
+            response = self.client.post(self._detail_url(str(report.id), str(artefact.id)) + "merge/")
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json() == {"merged": True, "sha": "merge-sha-123"}
+        github.merge_pull_request.assert_called_once_with("acme/repo", 7)
+
+    def test_merge_already_merged_pr_is_idempotent(self):
+        # An already-merged PR must not attempt a second merge — it returns success without calling GitHub.
+        report, artefact = self._commit_artefact()
+        github = self._mock_github(pr_state="closed", merged=True)
+        with (
+            patch("products.signals.backend.views.GitHubIntegration.first_for_team_repository", return_value=github),
+            patch(
+                "products.signals.backend.views.fetch_implementation_pr_urls_for_reports",
+                return_value={str(report.id): "https://github.com/acme/repo/pull/7"},
+            ),
+        ):
+            response = self.client.post(self._detail_url(str(report.id), str(artefact.id)) + "merge/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["merged"] is True
+        github.merge_pull_request.assert_not_called()
+
+    @parameterized.expand([("not_mergeable", 405), ("head_moved", 409), ("forbidden", 403)])
+    def test_merge_github_rejection_returns_409_not_500(self, _name, github_status):
+        # GitHub's own 405/409/403 are the guardrail: they must surface as a clean 409, never a 500.
+        report, artefact = self._commit_artefact()
+        github = self._mock_github(merge_result={"success": False, "status_code": github_status, "error": "nope"})
+        with (
+            patch("products.signals.backend.views.GitHubIntegration.first_for_team_repository", return_value=github),
+            patch(
+                "products.signals.backend.views.fetch_implementation_pr_urls_for_reports",
+                return_value={str(report.id): "https://github.com/acme/repo/pull/7"},
+            ),
+        ):
+            response = self.client.post(self._detail_url(str(report.id), str(artefact.id)) + "merge/")
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "error" in response.json()
+
+    def test_merge_non_commit_artefact_returns_400(self):
+        report = self._create_report()
+        artefact = self._create_artefact(report, artefact_type=SignalReportArtefact.ArtefactType.NOTE, content={})
+        response = self.client.post(self._detail_url(str(report.id), str(artefact.id)) + "merge/")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -87,6 +87,7 @@ from products.signals.backend.report_generation.resolve_reviewers import (
 )
 from products.signals.backend.serializers import (
     CommitDiffResponseSerializer,
+    MergeResponseSerializer,
     ReportSignalsResponseSerializer,
     SignalReportArtefactLogCreateSerializer,
     SignalReportArtefactLogUpdateSerializer,
@@ -2138,6 +2139,144 @@ class SignalReportArtefactViewSet(
                 "truncated": result.get("truncated", False),
             }
         )
+
+    def _resolve_pull_request_number(
+        self, github: GitHubIntegration, report_id: str, repository: str, branch: str
+    ) -> int | None:
+        """The PR number to merge for this commit artefact, or None if none can be found.
+
+        Prefer the report's recorded implementation PR link (the exact PR the pipeline opened); fall
+        back to the open PR whose head branch matches the commit's branch. Both `list_pull_requests`
+        and `parse_pull_request_url` reject/ignore anything unparseable, so a bad value yields None.
+        """
+        pr_url = fetch_implementation_pr_urls_for_reports([report_id]).get(report_id)
+        if pr_url:
+            parsed = github.parse_pull_request_url(pr_url)
+            if parsed is not None:
+                return parsed[2]
+        listing = github.list_pull_requests(repository)
+        if listing.get("success"):
+            for pr in listing.get("pull_requests", []):
+                if pr.get("head_branch") == branch:
+                    return pr.get("number")
+        return None
+
+    @extend_schema(
+        request=None,
+        responses={
+            200: OpenApiResponse(
+                response=MergeResponseSerializer,
+                description="The report's implementation pull request was merged (or was already merged).",
+            ),
+            400: OpenApiResponse(description="Artefact is not a commit, missing repository/branch, or no PR to merge."),
+            404: OpenApiResponse(description="Artefact not found, or no GitHub integration can access the repository."),
+            409: OpenApiResponse(
+                description="GitHub declined the merge (pull request not mergeable, already closed, or head moved)."
+            ),
+        },
+        summary="Merge the implementation pull request for a commit artefact",
+        description=(
+            "Squash-merge the pull request associated with a `commit` artefact's branch via the team's "
+            "GitHub integration. The pull request is resolved from the report's implementation PR link, "
+            "falling back to the open PR whose head branch matches the commit's branch. GitHub's own "
+            "merge rules are the guardrail: an unmergeable, already-merged, or closed pull request is "
+            "surfaced as a clean error, never a 500."
+        ),
+        parameters=[_REPORT_ID_PARAMETER],
+        operation_id="signals_report_artefacts_merge",
+    )
+    @action(detail=True, methods=["post"], url_path="merge", required_scopes=["task:write"])
+    def merge(self, request: Request, *args, **kwargs) -> Response:
+        artefact = cast(SignalReportArtefact, self.get_object())
+        if artefact.type != SignalReportArtefact.ArtefactType.COMMIT:
+            return Response(
+                {"error": f"Merging is only available for commit artefacts, not '{artefact.type}'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            content = json.loads(artefact.content)
+        except (json.JSONDecodeError, ValueError):
+            content = {}
+        if not isinstance(content, dict):
+            content = {}
+        repository = content.get("repository")
+        branch = content.get("branch")
+        if not repository or not branch:
+            return Response(
+                {"error": "Artefact is missing a repository or branch."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Same connection boundary as `diff`: bounded to repos the team's GitHub installation can
+        # access. Any `task:write` holder can already run agents against those repos, so no
+        # additional per-report merge permission is layered on — GitHub's own merge rules gate the
+        # actual merge below.
+        try:
+            github = GitHubIntegration.first_for_team_repository(self.team.id, repository)
+        except GitHubRateLimitError as e:
+            return github_rate_limited_response(e)
+        if github is None:
+            return Response(
+                {"error": f"No GitHub integration can access '{repository}'."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        report_id = str(artefact.report_id)
+        try:
+            pr_number = self._resolve_pull_request_number(github, report_id, repository, str(branch))
+        except GitHubRateLimitError as e:
+            return github_rate_limited_response(e)
+        if pr_number is None:
+            return Response(
+                {"error": f"No open pull request was found for branch '{branch}' in '{repository}'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Gate on the PR's live state so an already-merged / closed PR returns a clean message rather
+        # than leaning on GitHub's merge error. GitHub's own rejection stays the guardrail below.
+        try:
+            pr_status = github.get_pull_request(repository, pr_number)
+        except GitHubRateLimitError as e:
+            return github_rate_limited_response(e)
+        if pr_status.get("success"):
+            if pr_status.get("merged"):
+                # Idempotent: the report's PR already shipped, so treat as a successful no-op.
+                return Response({"merged": True, "sha": None})
+            if pr_status.get("state") != "open":
+                return Response(
+                    {"error": "This pull request is closed and cannot be merged."},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+        try:
+            result = github.merge_pull_request(repository, pr_number)
+        except GitHubRateLimitError as e:
+            return github_rate_limited_response(e)
+        if not result.get("success"):
+            status_code = result.get("status_code")
+            # GitHub returns 405 when the PR isn't mergeable and 409 when the head moved; surface both
+            # as a 409 with a clean reason rather than a 500, without re-implementing merge policy.
+            if status_code == 403:
+                message = "GitHub declined the merge — the integration lacks permission to merge in this repository."
+            elif status_code == 409:
+                message = (
+                    "GitHub could not merge this pull request — its branch moved since the merge was "
+                    "requested. Refresh and try again."
+                )
+            else:
+                message = (
+                    "GitHub could not merge this pull request — it isn't in a mergeable state "
+                    "(failing checks, conflicts, or branch protection)."
+                )
+            logger.warning(
+                "signals pr merge failed",
+                repository=repository,
+                branch=branch,
+                pr_number=pr_number,
+                status_code=status_code,
+            )
+            return Response({"error": message}, status=status.HTTP_409_CONFLICT)
+        return Response({"merged": True, "sha": result.get("sha")})
 
 
 class SignalUserAutonomyConfigView(APIView):

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -753,6 +753,20 @@ export interface CommitDiffResponseApi {
     readonly truncated: boolean
 }
 
+/**
+ * Response for the `commit` artefact merge endpoint — the outcome of merging the report's
+ * implementation pull request via the team's GitHub integration.
+ */
+export interface MergeResponseApi {
+    /** True when the pull request was merged (or was already merged). */
+    readonly merged: boolean
+    /**
+     * SHA of the merge commit GitHub created, when available. Null when GitHub did not return one (e.g. the pull request was already merged).
+     * @nullable
+     */
+    readonly sha: string | null
+}
+
 export interface SignalReportBulkStateRequestApi {
     /** Target state for the report. Use 'suppressed' to dismiss the report from the inbox, or 'potential' to snooze/reopen it for later review.
      *

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -19,6 +19,7 @@ import type {
     FleetFindingsSummaryApi,
     ForgetRequestApi,
     ForgetResponseApi,
+    MergeResponseApi,
     PaginatedPauseStateResponseListApi,
     PaginatedSignalReportArtefactListApi,
     PaginatedSignalReportListApi,
@@ -410,6 +411,26 @@ export const signalsReportArtefactsDiff = async (
     return apiMutator<CommitDiffResponseApi>(getSignalsReportArtefactsDiffUrl(projectId, reportId, id), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getSignalsReportArtefactsMergeUrl = (projectId: string, reportId: string, id: string) => {
+    return `/api/projects/${projectId}/signals/reports/${reportId}/artefacts/${id}/merge/`
+}
+
+/**
+ * Squash-merge the pull request associated with a `commit` artefact's branch via the team's GitHub integration. The pull request is resolved from the report's implementation PR link, falling back to the open PR whose head branch matches the commit's branch. GitHub's own merge rules are the guardrail: an unmergeable, already-merged, or closed pull request is surfaced as a clean error, never a 500.
+ * @summary Merge the implementation pull request for a commit artefact
+ */
+export const signalsReportArtefactsMerge = async (
+    projectId: string,
+    reportId: string,
+    id: string,
+    options?: RequestInit
+): Promise<MergeResponseApi> => {
+    return apiMutator<MergeResponseApi>(getSignalsReportArtefactsMergeUrl(projectId, reportId, id), {
+        ...options,
+        method: 'POST',
     })
 }
 

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -344,6 +344,9 @@ tools:
     signals-report-artefacts-diff:
         operation: signals_report_artefacts_diff
         enabled: false
+    signals-report-artefacts-merge:
+        operation: signals_report_artefacts_merge
+        enabled: false
     signals-reports-signals-retrieve:
         operation: signals_reports_signals_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -31577,6 +31577,20 @@ export namespace Schemas {
       scraping_status?: ScrapingStatusEnum | BlankEnum | null;
     }
 
+    /**
+     * Response for the `commit` artefact merge endpoint — the outcome of merging the report's
+     * implementation pull request via the team's GitHub integration.
+     */
+    export interface MergeResponse {
+      /** True when the pull request was merged (or was already merged). */
+      readonly merged: boolean;
+      /**
+         * SHA of the merge commit GitHub created, when available. Null when GitHub did not return one (e.g. the pull request was already merged).
+         * @nullable
+         */
+      readonly sha: string | null;
+    }
+
     export type MessageContextualTools = { [key: string]: unknown };
 
     /**


### PR DESCRIPTION
## Problem

An inbox report that already has an implementation PR open (via Create PR / auto-start) still needs someone to go to GitHub to merge it. There's no way to ship a report's fix from the inbox itself, so the detail pane can create a PR but can't close the loop.

## Changes

Add a "Merge PR" action to the report detail, mirroring the existing "Create PR" action and the shipped diff feature.

- **Backend integration** (`posthog/models/integration.py`, `github_integration_base.py`): new `GitHubIntegration.merge_pull_request(repository, pull_number, merge_method="squash")` calling `PUT /repos/{owner}/{repo}/pulls/{n}/merge` through the existing `api_request` transport. It validates the repo path (same `_is_safe_github_repo_path` guard as the diff path), returns `{success, sha}` on 200 and `{success, status_code, error}` otherwise, and never raises. The existing `get_pull_request` helper now also surfaces `mergeable` / `mergeable_state` so callers can read a PR's live state.
- **Backend endpoint** (`products/signals/backend/views.py`): a `POST .../artefacts/{id}/merge/` action on the artefact viewset, mirroring `diff`. It guards `type == commit`, reads `repository`/`branch` from the artefact, resolves the team's GitHub integration, resolves the PR number (report's implementation PR link first, then the open PR whose head branch matches the commit's branch), and merges. An already-merged PR is an idempotent no-op. GitHub's own 405/409/403 responses are surfaced as a clean 409, never a 500. New `MergeResponseSerializer` next to `CommitDiffResponseSerializer`.
- **Generated client**: regenerated to add `signalsReportArtefactsMerge` + `MergeResponseApi`; thin `api.signalReports.merge(...)` wrapper in `lib/api.ts`.
- **Frontend logic** (`inboxTaskKickoffLogic.ts`): `mergePrFromReport` action + `isMergingPr` flag mirroring `createPrFromReport`/`isCreatingPr`. It resolves the report's latest commit artefact, calls the merge endpoint, toasts success, and broadcasts `reportMerged` so mounted inbox lists reconcile toward resolved. GitHub's rejection reason (from the response body) is surfaced on failure.
- **Frontend UI** (`ReportDetailActions.tsx`): a `merge` entry in the actions-as-data list, offered when the report has an implementation PR and isn't resolved/suppressed. It's wrapped in a `LemonDialog.open` confirm since it ships code, and is disabled + spinner'd while in flight.

> [!NOTE]
> Safe defaults: squash merge, and any `task:write` holder may merge (the same scope that can already run agents against these repos). Merge policy is not re-implemented client- or server-side: GitHub's own merge rules are the guardrail, and its rejection reasons surface cleanly.

## How did you test this code?

Automated tests I (Claude) actually ran, all green locally (`hogli test products/signals/backend/test/test_signal_report_artefact_api.py -k merge`):

- `test_merge_squash_merges_pr_and_returns_sha` — happy path returns the merge SHA and calls GitHub once.
- `test_merge_already_merged_pr_is_idempotent` — an already-merged PR returns success without a second merge call.
- `test_merge_github_rejection_returns_409_not_500` (parameterized over 405 / 409 / 403) — GitHub rejections surface as a clean 409, never a 500. This is the core regression the endpoint exists to prevent.
- `test_merge_non_commit_artefact_returns_400` — the commit-type guard holds.

I did not manually click through the UI in a running app. Frontend typecheck passes for the touched files; the remaining inbox typecheck noise is pre-existing stale kea typegen on this base, resolved by CI's fresh typegen pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover the inbox report actions yet, so there's nothing to update here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael directed this; I (Claude) implemented it end to end against a verified spec. Skills invoked: `/improving-drf-endpoints` (viewset + serializer), `/adopting-generated-api-types` (the `lib/api` wrapper + generated client), and `/writing-tests` (gated the backend tests).

Design decisions worth flagging for review:

- **`get_pull_request` already existed** in `github_integration_base.py`, so rather than adding a duplicate I extended it with `mergeable`/`mergeable_state`. Only `merge_pull_request` is genuinely new.
- **Gating approach.** The spec described `get_pull_request` as gating the button. I leaned on the guardrail note ("GitHub's own 405/409/403 responses are the guardrail, do not re-implement merge policy"): the endpoint uses `get_pull_request` server-side only to short-circuit an already-merged / closed PR with a clean message, then lets GitHub's real merge response be the authority. The frontend offers the action whenever a PR exists and the report isn't resolved/suppressed, and surfaces GitHub's rejection reason on click rather than pre-fetching mergeability on every report view (which would add a GitHub call per detail open). If reviewers prefer hiding the action on non-mergeable PRs, that's a cheap follow-up (a GET status endpoint the detail logic reads).
- **Report-to-PR resolution.** The action is artefact-scoped (like `diff`), so the frontend resolves the report's latest commit artefact and the backend resolves the PR from the report's implementation PR link, falling back to the open PR whose head branch matches the commit branch.
