### PR TITLE
fix(test): deflake accounts usage-tab canvas snapshot

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -40,6 +40,12 @@ declare module 'storybook/internal/types' {
             /** If set, we'll wait for the given selector (or all selectors, if multiple) to be satisfied. */
             waitForSelector?: string | string[]
             /**
+             * Timeout (ms) for `waitForSelector`. Defaults to the global Playwright timeout. Raise it for
+             * stories whose selector gates on a genuinely slow async render (e.g. a chart canvas that the
+             * pre-snapshot resize tears down and re-renders) so a loaded CI runner doesn't flake.
+             */
+            waitForSelectorTimeout?: number
+            /**
              * By default we wait for images to have width as an indication the page is ready for screenshot testing
              * Some stories have broken images on purpose to test what the UI does
              * in those cases set `allowImagesWithoutWidth` to `true`
@@ -275,7 +281,11 @@ async function expectStoryToMatchSnapshot(
     // Allow ResizeObserver callbacks to fire and React to re-render with updated dimensions
     await page.waitForTimeout(300)
 
-    const { waitForLoadersToDisappear = true, waitForSelector } = storyContext.parameters?.testOptions ?? {}
+    const {
+        waitForLoadersToDisappear = true,
+        waitForSelector,
+        waitForSelectorTimeout,
+    } = storyContext.parameters?.testOptions ?? {}
 
     if (waitForLoadersToDisappear) {
         // The timeout allows loaders and toasts to disappear - toasts usually signify something wrong
@@ -286,10 +296,11 @@ async function expectStoryToMatchSnapshot(
         await page.waitForSelector(LOADER_SELECTORS.join(','), { state: 'hidden', timeout })
     }
 
+    const waitForSelectorOptions = waitForSelectorTimeout ? { timeout: waitForSelectorTimeout } : undefined
     if (typeof waitForSelector === 'string') {
-        await page.waitForSelector(waitForSelector)
+        await page.waitForSelector(waitForSelector, waitForSelectorOptions)
     } else if (Array.isArray(waitForSelector)) {
-        await Promise.all(waitForSelector.map((selector) => page.waitForSelector(selector)))
+        await Promise.all(waitForSelector.map((selector) => page.waitForSelector(selector, waitForSelectorOptions)))
     }
 
     // Snapshot both light and dark themes

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
@@ -398,6 +398,10 @@ export const RowExpandedUsagePopulated: Story = {
     parameters: {
         testOptions: {
             waitForSelector: ['[data-attr="accounts-refresh"]', '.DataVisualization canvas'],
+            // The pre-snapshot resize the test runner dispatches tears down the Chart.js canvas and
+            // re-renders it; under CI load that re-render can exceed the default 10s waitForSelector,
+            // so give this canvas gate the same headroom the play-fn wait already uses.
+            waitForSelectorTimeout: 30000,
         },
     },
     decorators: billingTabDecorators(
@@ -407,7 +411,7 @@ export const RowExpandedUsagePopulated: Story = {
     play: async ({ canvasElement }) => {
         await expandAndOpenTab(canvasElement, 'Usage')
         // Wait for the chart canvas to render before handing off to the snapshot.
-        // The play function timeout (~60s) is much more generous than waitForSelector (10s),
+        // The play function timeout (~60s) is much more generous than the default waitForSelector (10s),
         // so this prevents flaky timeouts under CI load.
         await waitFor(
             () => {


### PR DESCRIPTION
## Problem

The `Visual regression tests - chromium` shard intermittently fails on `Scenes-App/Customer Analytics/Accounts › RowExpandedUsagePopulated › play-test`:

```
page.waitForSelector: Timeout 10000ms exceeded  (test-runner.ts, waiting for '.DataVisualization canvas')
```

The story renders a Chart.js chart in the account's Usage tab. After `play` finishes, the visual-regression runner dispatches a `window.resize` (to settle `ResizeObserver`-driven layout) right before snapshotting. That resize tears down the chart canvas and re-renders it. Under CI load that re-render can take longer than the generic 10s `waitForSelector` default, so the meta-level gate times out and the shard fails.

This is a long-recurring flake in this area (see [#69464](https://github.com/PostHog/posthog/pull/69464), [#68004](https://github.com/PostHog/posthog/pull/68004), [#61487](https://github.com/PostHog/posthog/pull/61487)). The most recent attempt ([#69464](https://github.com/PostHog/posthog/pull/69464)) added a 30s wait inside the `play` function, but that runs *before* the pre-snapshot resize, so it can't cover the re-render that actually times out.

## Changes

- Add an opt-in `waitForSelectorTimeout` testOption to the storybook test runner (`common/storybook/.storybook/test-runner.ts`). When set, the post-visit `waitForSelector` gate uses it instead of the global 10s default.
- Set `waitForSelectorTimeout: 30000` on the canvas-gated `RowExpandedUsagePopulated` story, matching the headroom its play-fn wait already uses.

Default behavior is unchanged for every other story; this only raises the ceiling for a gate that legitimately waits on a slow async re-render.

## How did you test this code?

I (Claude) can't reproduce a load-dependent CI flake locally, so this is a targeted timeout fix rather than a logic change. The runner change is a narrow, backwards-compatible addition (new optional testOption; absent → prior behavior). No automated test added — this is test-harness plumbing, and the assertion it guards is the existing snapshot.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - Frank flagged the failing visual-regression check.

- Traced the failing shard's CI log to the exact story + selector, then read the test runner to find the pre-snapshot resize that re-renders the canvas after `play`. That's why the prior play-fn wait didn't fix it — the resize happens later, in `postVisit`.
- Chose a generic, opt-in `waitForSelectorTimeout` over hard-coding a per-story special case in the runner, so future slow-canvas stories can reuse it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
