### PR TITLE
fix(notebooks): handle MathJax dynamic font load failure in LaTeX blocks

### DIFF
--- a/frontend/src/lib/components/UniversalFilters/constants.ts
+++ b/frontend/src/lib/components/UniversalFilters/constants.ts
@@ -1,0 +1,15 @@
+import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
+
+// Kept in a leaf module (instead of universalFiltersLogic) so consumers that only need the default
+// group don't import the logic's heavy dependency graph — the logic circularly imports back into
+// scenes/session-recordings, which caused "Cannot access 'DEFAULT_UNIVERSAL_GROUP_FILTER' before
+// initialization" TDZ errors on hot reload.
+export const DEFAULT_UNIVERSAL_GROUP_FILTER: UniversalFiltersGroup = {
+    type: FilterLogicalOperator.And,
+    values: [
+        {
+            type: FilterLogicalOperator.And,
+            values: [],
+        },
+    ],
+}

--- a/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
+++ b/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts
@@ -36,6 +36,7 @@ import {
     isQuickFilterItem,
     quickFilterToPropertyFilters,
 } from '../TaxonomicFilter/types'
+import { DEFAULT_UNIVERSAL_GROUP_FILTER } from './constants'
 import type { universalFiltersLogicType } from './universalFiltersLogicType'
 
 function isApplicableSavedFilter(
@@ -80,15 +81,7 @@ function isPropertyEditableTaxonomicGroupType(groupType: TaxonomicFilterGroupTyp
     )
 }
 
-export const DEFAULT_UNIVERSAL_GROUP_FILTER: UniversalFiltersGroup = {
-    type: FilterLogicalOperator.And,
-    values: [
-        {
-            type: FilterLogicalOperator.And,
-            values: [],
-        },
-    ],
-}
+export { DEFAULT_UNIVERSAL_GROUP_FILTER }
 
 export type UniversalFiltersLogicProps = {
     rootKey: string

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.test.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.test.tsx
@@ -1,0 +1,44 @@
+import { mathjax } from '@mathjax/src/mjs/mathjax.js'
+
+import { renderLatexToNode } from './NotebookNodeLatex'
+
+// Builds the retry signal MathJax throws (via retryAfter) when a glyph needs a dynamic font file:
+// an error carrying a `retry` promise that settles once the load finishes (or fails).
+const retrySignal = (retry: Promise<unknown>): Error => Object.assign(new Error('MathJax retry'), { retry })
+
+describe('renderLatexToNode', () => {
+    afterEach(() => {
+        ;(mathjax as any).__resetConvert()
+    })
+
+    it('resolves with the rendered node when no dynamic font load is needed', async () => {
+        const node = document.createElement('span')
+        ;(mathjax as any).__setConvert(() => node)
+
+        await expect(renderLatexToNode('E = mc^2')).resolves.toBe(node)
+    })
+
+    it('retries and resolves once the dynamic font file loads', async () => {
+        const node = document.createElement('span')
+        const convert = jest
+            .fn()
+            // First call: glyph needs the 'shapes' dynamic file, so convert throws a retry signal.
+            .mockImplementationOnce(() => {
+                throw retrySignal(Promise.resolve())
+            })
+            // Second call (after the load settles): rendering succeeds.
+            .mockImplementationOnce(() => node)
+        ;(mathjax as any).__setConvert(convert)
+
+        await expect(renderLatexToNode('\\bigstar')).resolves.toBe(node)
+        expect(convert).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects when a dynamic font file fails to load', async () => {
+        ;(mathjax as any).__setConvert(() => {
+            throw retrySignal(Promise.reject(new Error("dynamic file 'shapes' failed to load")))
+        })
+
+        await expect(renderLatexToNode('\\bigstar')).rejects.toThrow("dynamic file 'shapes' failed to load")
+    })
+})

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.tsx
@@ -83,8 +83,8 @@ const LatexComponent = ({
             .catch((err: unknown) => {
                 if (!cancelled) {
                     mathJaxDisplayDiv.innerHTML = '<span style="color:red">LaTeX error</span>'
+                    console.error('MathJax error:', err)
                 }
-                console.error('MathJax error:', err)
             })
 
         return () => {

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.tsx
@@ -52,19 +52,38 @@ const LatexComponent = ({
     useEffect(() => {
         const mathJaxDisplayDiv = containerRef.current // The div for displaying rendered MathJax
 
-        if (mathJaxDisplayDiv) {
-            if (!editing && content) {
-                try {
-                    mathJaxDisplayDiv.innerHTML = '' // Clear before rendering
-                    const math = mjxDocument.convert(content, { display: true })
+        if (!mathJaxDisplayDiv) {
+            return
+        }
+
+        if (editing || !content) {
+            mathJaxDisplayDiv.innerHTML = ''
+            return
+        }
+
+        // MathJax v4's modern SVG font loads glyph data lazily from "dynamic files" (e.g. 'shapes',
+        // 'arrows'). convert() defers those loads through the retry mechanism, so we render inside
+        // handleRetriesFor() to await them. A failed dynamic load rejects asynchronously, which a
+        // synchronous try/catch would miss, so we catch it here and fall back to a friendly message.
+        let cancelled = false
+        mathJaxDisplayDiv.innerHTML = '' // Clear before rendering
+        mathjax
+            .handleRetriesFor(() => mjxDocument.convert(content, { display: true }))
+            .then((math: Node) => {
+                if (!cancelled) {
+                    mathJaxDisplayDiv.innerHTML = ''
                     mathJaxDisplayDiv.appendChild(math)
-                } catch (err) {
-                    mathJaxDisplayDiv.innerHTML = '<span style="color:red">LaTeX error</span>'
-                    console.error('MathJax error:', err)
                 }
-            } else {
-                mathJaxDisplayDiv.innerHTML = ''
-            }
+            })
+            .catch((err: unknown) => {
+                if (!cancelled) {
+                    mathJaxDisplayDiv.innerHTML = '<span style="color:red">LaTeX error</span>'
+                }
+                console.error('MathJax error:', err)
+            })
+
+        return () => {
+            cancelled = true
         }
     }, [content, editing])
 

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLatex.tsx
@@ -22,6 +22,14 @@ const tex = new TeX({
 const svg = new SVG({ fontCache: 'none' })
 const mjxDocument = mathjax.document(document, { InputJax: tex, OutputJax: svg })
 
+// Renders LaTeX to an SVG node. MathJax v4's modern SVG font loads glyph data lazily from "dynamic
+// files" (e.g. 'shapes', 'arrows'); convert() defers those loads through the retry mechanism, so we
+// run it inside handleRetriesFor() to await them. The returned promise rejects if a dynamic file
+// fails to load, which is async and a synchronous try/catch would miss, so callers must catch it.
+export function renderLatexToNode(content: string): Promise<Node> {
+    return mathjax.handleRetriesFor(() => mjxDocument.convert(content, { display: true }))
+}
+
 interface NotebookNodeLatexAttributes extends CustomNotebookNodeAttributes {
     content: string
     editing: boolean
@@ -61,14 +69,11 @@ const LatexComponent = ({
             return
         }
 
-        // MathJax v4's modern SVG font loads glyph data lazily from "dynamic files" (e.g. 'shapes',
-        // 'arrows'). convert() defers those loads through the retry mechanism, so we render inside
-        // handleRetriesFor() to await them. A failed dynamic load rejects asynchronously, which a
-        // synchronous try/catch would miss, so we catch it here and fall back to a friendly message.
+        // A failed dynamic font load rejects asynchronously, so we catch it and fall back to a
+        // friendly message rather than letting it surface as an unhandled error. See renderLatexToNode.
         let cancelled = false
         mathJaxDisplayDiv.innerHTML = '' // Clear before rendering
-        mathjax
-            .handleRetriesFor(() => mjxDocument.convert(content, { display: true }))
+        renderLatexToNode(content)
             .then((math: Node) => {
                 if (!cancelled) {
                     mathJaxDisplayDiv.innerHTML = ''

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -9,7 +9,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
-import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/constants'
 import {
     isActionFilter,
     isEventFilter,

--- a/frontend/src/test/mocks/mathjaxMock.js
+++ b/frontend/src/test/mocks/mathjaxMock.js
@@ -1,10 +1,40 @@
+// Test double for @mathjax/src. handleRetriesFor mirrors the real Retries.js loop so tests can
+// exercise MathJax's dynamic-font retry flow: convert() may throw a retry signal (an error carrying
+// a `retry` promise), and once that promise settles the code is re-run (or the whole thing rejects).
+let convertImpl = () => document.createElement('span')
+
+function handleRetriesFor(code) {
+    return new Promise(function run(resolve, reject) {
+        const handleRetry = (err) => {
+            if (err && err.retry instanceof Promise) {
+                err.retry.then(() => run(resolve, reject)).catch(reject)
+            } else {
+                reject(err)
+            }
+        }
+        try {
+            const result = code()
+            if (result instanceof Promise) {
+                result.then(resolve).catch(handleRetry)
+            } else {
+                resolve(result)
+            }
+        } catch (err) {
+            handleRetry(err)
+        }
+    })
+}
+
 module.exports = {
     browserAdaptor: () => ({}),
     RegisterHTMLHandler: () => {},
     TeX: class {},
     SVG: class {},
     mathjax: {
-        document: () => ({ convert: () => document.createElement('span') }),
-        handleRetriesFor: (fn) => Promise.resolve().then(fn),
+        document: () => ({ convert: (...args) => convertImpl(...args) }),
+        handleRetriesFor,
+        // Test seam: let a test drive what convert() does (e.g. throw a retry signal, then succeed).
+        __setConvert: (fn) => (convertImpl = fn),
+        __resetConvert: () => (convertImpl = () => document.createElement('span')),
     },
 }

--- a/frontend/src/test/mocks/mathjaxMock.js
+++ b/frontend/src/test/mocks/mathjaxMock.js
@@ -3,5 +3,8 @@ module.exports = {
     RegisterHTMLHandler: () => {},
     TeX: class {},
     SVG: class {},
-    mathjax: { document: () => ({ convert: () => document.createElement('span') }) },
+    mathjax: {
+        document: () => ({ convert: () => document.createElement('span') }),
+        handleRetriesFor: (fn) => Promise.resolve().then(fn),
+    },
 }


### PR DESCRIPTION
## Problem

A LaTeX block in a notebook threw an unhandled "dynamic file 'shapes' failed to load" error while MathJax tried to render it (surfaced via error tracking).

MathJax v4's modern SVG font loads glyph data lazily from "dynamic files" (`shapes`, `arrows`, etc.). `NotebookNodeLatex` called `mjxDocument.convert()` synchronously, but when a glyph needs a dynamic file, `convert()` defers the load through MathJax's retry mechanism and resolves it asynchronously. A failed load therefore rejects asynchronously, where the surrounding synchronous `try/catch` could not catch it, so it surfaced as an unhandled error.

**Why:** raised from an error-tracking inbox item; a single unrenderable LaTeX block should degrade gracefully instead of throwing an unhandled error.

## Changes

- Render through `mathjax.handleRetriesFor()` so dynamic font loads are awaited before the node is appended.
- Catch the async rejection and fall back to the existing red "LaTeX error" message.
- A `cancelled` flag in the effect cleanup prevents writing to the container after unmount or a stale render.
- Updated the Jest MathJax mock to expose `handleRetriesFor`.

Also included (same branch, per follow-up in the thread): fixed a hot-reload crash `ReferenceError: Cannot access 'DEFAULT_UNIVERSAL_GROUP_FILTER' before initialization` in `sessionRecordingsPlaylistLogic`. The constant lived in `universalFiltersLogic`, whose import graph circles back into `scenes/session-recordings`; the playlist logic uses it at module level, so a flipped evaluation order during HMR hit the TDZ. It now lives in a leaf `UniversalFilters/constants.ts` module (re-exported from the logic for existing consumers).

## How did you test this code?

I (the agent) was not able to run the app or Jest in this environment. Changes verified by inspection against the `@mathjax/src@4.1.2` source: confirmed `mathjax.handleRetriesFor(code)` returns a Promise that awaits `err.retry` on deferred loads and rejects if a dynamic file ultimately fails to load, so the `.catch` path handles the reported failure. The mock was updated so existing notebook tests still resolve.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a Slack thread, directed by @mariusandra. No repo-specific skills were required; the fix touches only frontend rendering code. The error's repo was originally reported as `posthog/ai_notebooks`, but that is a Jupyter-notebook data repo — the actual MathJax rendering lives in this repo's `NotebookNodeLatex.tsx`, which is where the fix was made.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1783640146281539?thread_ts=1783640146.281539&cid=C0B8ZE81ZT7)*

