### PR TITLE
fix(mssql): surface a credentials error when the login is rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -31,7 +31,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mssql.mssq
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 MSSQLErrors = {
-    "Login failed for user": "Login failed for database",
+    # SQL Server error 18456 is an authentication failure (wrong username/password, or the login is
+    # disabled), not a problem with the database field. Surface the same wording the sibling SQL
+    # sources use and match the stable prefix, not the volatile "'<username>'." that follows it.
+    "Login failed for user": "Invalid user or password",
     "Adaptive Server is unavailable or does not exist": "Could not connect to SQL server - check server host and port",
     "connection timed out": "Could not connect to SQL server - check server firewall settings",
 }
@@ -57,7 +60,11 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # (security group doesn't allow PostHog's IPs, the instance is stopped, or the
             # hostname is wrong), not a momentary blip, so retrying the job won't recover it.
             "Adaptive Server is unavailable or does not exist": "Could not reach your SQL Server. Check that the server is running and reachable, and that PostHog's IP addresses are allowed through its firewall / security group.",
-            "Login failed for user": None,
+            # SQL Server error 18456 — the login was rejected (wrong username/password, or the login
+            # is disabled). Deterministic until the customer fixes the credentials, so retrying just
+            # replays the same rejection; surface the same actionable wording as the validation path
+            # instead of the raw driver string (which echoes the username back).
+            "Login failed for user": "Invalid user or password",
             # SQL Server error 229 — the login PostHog connects with was authenticated but lacks
             # SELECT permission on a table/view being synced. This is a server-side GRANT the
             # customer has to make (db_datareader or an explicit GRANT SELECT); retrying with the


### PR DESCRIPTION
## Problem

When SQL Server rejects a login (error 18456 - wrong username/password, or a disabled login), the MSSQL warehouse source mapped the driver error to the phrase "Login failed for database". That points users at the wrong thing: the failure is about their credentials, not the database field. Every sibling SQL source (Postgres, MySQL, Redshift, ClickHouse) already surfaces the same condition as "Invalid user or password", so MSSQL was the odd one out.

## Changes

Map SQL Server's `Login failed for user` to "Invalid user or password" instead, on both paths:

- the validation path (`MSSQLErrors`), used at source creation, and
- the streaming non-retryable map, which previously returned the raw driver string (it echoes the username back and is less actionable).

The match is on the stable `Login failed for user` prefix, so the volatile `'<username>'.` suffix never reaches the user-facing message.

```diff
-    "Login failed for user": "Login failed for database",
+    "Login failed for user": "Invalid user or password",
```

## How did you test this code?

Ran the MSSQL source test suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py` (89 passed). The existing non-retryable-classification tests still pass since the error key is unchanged. No new test added: the change is a message-copy fix with no logic change, and there was no existing assertion on the old string to update.

I (Claude) did not perform manual end-to-end testing against a live SQL Server.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a triage pass over recent data-warehouse source-creation failures. This message stood out because it was the only SQL source that mapped an auth failure to a database-oriented phrase. Chose to mirror the established sibling wording ("Invalid user or password") rather than invent new copy, and applied it to the streaming path too for consistency and to stop the raw driver string (which contains the username) from surfacing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
