### PR TITLE
fix(supabase): map pooler auth and tenant errors during validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -85,6 +85,29 @@ PostgresErrors = {
         "database project is paused or deleted, or the pooler username/host is wrong. Check that "
         "your database is active and the connection details are correct."
     ),
+    # Supabase/Supavisor's shared regional pooler (aws-0-<region>.pooler.supabase.com) can't
+    # identify the project from SNI, so the pooler username must embed the project ref (for example
+    # "postgres.<project-ref>"). A plain "postgres" username leaves it nothing to route on and it
+    # rejects the connection with "FATAL: (ENOIDENTIFIER) no tenant identifier provided".
+    # `get_non_retryable_errors` already handles this on the streaming path; map it here too so
+    # validation returns an actionable message instead of the generic fallback.
+    "no tenant identifier provided": (
+        'Your connection pooler couldn\'t identify your project ("no tenant identifier provided"). '
+        "On the shared pooler host the username must include your project ref (for example "
+        '"postgres.<project-ref>"). Update the username to the pooler username shown in your '
+        "Supabase dashboard and try again."
+    ),
+    # Some poolers (for example Supabase's transaction pooler on port 6543) reject bad credentials
+    # during the SASL/SCRAM exchange with "FATAL: SASL authentication failed" instead of libpq's
+    # "password authentication failed for user", so none of the password keys above substring-match
+    # it. `get_non_retryable_errors` already handles this on the streaming path; map it here too so
+    # validation returns an actionable message instead of the generic fallback.
+    "SASL authentication failed": (
+        'Your database rejected the credentials during authentication ("SASL authentication '
+        'failed"). This usually means the username or password is wrong. Some connection poolers '
+        "(for example Supabase's transaction pooler) also require a pooler-specific username such "
+        "as postgres.<project-ref>. Check your credentials and try again."
+    ),
     "could not translate host name": "Could not connect to the host",
     # libpq prefixes a DNS-resolution failure with "could not translate host name ..." (matched
     # above), but the same getaddrinfo failure also surfaces as the raw socket wording with no such

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2708,6 +2708,27 @@ class TestValidateCredentialsErrorMapping:
                 "database project is paused or deleted, or the pooler username/host is wrong. Check that "
                 "your database is active and the connection details are correct.",
             ),
+            # Supabase's transaction pooler (port 6543) rejects bad credentials during the
+            # SASL/SCRAM exchange rather than with libpq's "password authentication failed".
+            (
+                'connection failed: connection to server at "10.0.0.1", port 6543 failed: '
+                "FATAL:  SASL authentication failed",
+                'Your database rejected the credentials during authentication ("SASL '
+                'authentication failed"). This usually means the username or password is wrong. '
+                "Some connection poolers (for example Supabase's transaction pooler) also require a "
+                "pooler-specific username such as postgres.<project-ref>. Check your credentials "
+                "and try again.",
+            ),
+            # Supabase/Supavisor's shared pooler rejects a connection whose username carries no
+            # project ref with "(ENOIDENTIFIER) no tenant identifier provided".
+            (
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL:  (ENOIDENTIFIER) no tenant identifier provided (external_id or sni_hostname required)",
+                "Your connection pooler couldn't identify your project (\"no tenant identifier "
+                'provided"). On the shared pooler host the username must include your project ref '
+                '(for example "postgres.<project-ref>"). Update the username to the pooler username '
+                "shown in your Supabase dashboard and try again.",
+            ),
             # Invalid SSL-negotiation response — the host/port isn't a Postgres server speaking SSL.
             (
                 'connection failed: connection to server at "66.33.22.254", port 41667 failed: '


### PR DESCRIPTION
## Problem

Supabase sources run through the shared Postgres credential-validation path. When someone connects through a Supabase pooler and gets it slightly wrong, the pooler rejects the connection in two ways that plain PostgreSQL never produces:

- the shared session pooler rejects a username with no project ref (a bare `postgres` instead of `postgres.<project-ref>`) with `(ENOIDENTIFIER) no tenant identifier provided`, and
- the transaction pooler rejects bad credentials during the SASL/SCRAM exchange with `SASL authentication failed` rather than libpq's `password authentication failed for user`.

The streaming (sync) path already classifies both and returns actionable, Supabase-aware messages. The validation path that runs at source creation did not, so these two cases fell through to the generic "Could not connect to Supabase. Please check all connection details are valid." fallback, which tells the user nothing about the actual fix and also gets captured as error-tracking noise.

## Changes

Mirror the two mappings the streaming path already has into the validation-time `PostgresErrors` map, worded for setup time (no "re-enable the sync"). Both match on a stable fragment and never echo the host, port, or username back.

The generic fallback still catches everything else, so this only narrows the unactionable bucket.

## How did you test this code?

Extended the existing parameterized `TestValidateCredentialsErrorMapping::test_operational_errors_map_to_friendly_messages` with two cases (SASL rejection, missing tenant identifier). Before this change neither error had a case there, so a regression that dropped the new mappings would silently fall back to the generic message uncaught. Ran `pytest ...postgres/test_postgres.py::TestValidateCredentialsErrorMapping` locally (15 passed). Test fixtures use synthetic hosts, not real values.

I (Claude) did not run a live connection against a Supabase pooler.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a triage pass over recent data-warehouse source-creation failures. The Supabase failures were mostly already well-handled (the direct-host IPv6 hint, the paused-project tenant-not-found message, the project-URL-as-host detection). The gap was the generic fallback bucket. Root-caused it to an asymmetry: the streaming path had these two pooler classifications but the validation path did not. Chose to reuse the existing streaming wording (adjusted for setup context) rather than write new copy, and implemented it in the shared Postgres map since Supabase validates through it and the streaming counterparts already live there.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
