### PR TITLE
fix(data-warehouse): re-verify group lease before v3 delta commits and post-load

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -354,7 +354,13 @@ def _mark_job_failed(export_signal: ExportSignalMessage, error: Exception) -> No
     _release_pipeline_lock_for_job(export_signal)
 
 
-def process_message(message: Any, progress_callback: Callable[[], None] | None = None) -> None:
+def process_message(
+    message: Any,
+    progress_callback: Callable[[], None] | None = None,
+    verify_ownership: Callable[[], None] | None = None,
+) -> None:
+    """Load one batch into Delta Lake. ``verify_ownership`` raises if the group lease was lost;
+    re-checked before each lasting side effect since the heartbeat only detects loss between beats."""
     export_signal = ExportSignalMessage.from_dict(message)
 
     # Reconnect stale app-DB connections up front so the ORM queries below don't burn all batch attempts.
@@ -413,6 +419,8 @@ def process_message(message: Any, progress_callback: Callable[[], None] | None =
                 run_uuid=export_signal.run_uuid,
                 batch_index=export_signal.batch_index,
             )
+            if verify_ownership is not None:
+                verify_ownership()
             _run_post_load_for_already_processed_batch(export_signal)
             _mark_job_completed(export_signal)
             return
@@ -523,6 +531,9 @@ def process_message(message: Any, progress_callback: Callable[[], None] | None =
         if existing_delta_table is not None:
             pa_table = evolve_pyarrow_schema(pa_table, existing_delta_table.schema())
 
+        if verify_ownership is not None:
+            verify_ownership()
+
         if cdc_write_mode == "scd2_append":
             logger.debug(
                 "writing_scd2_to_delta_lake",
@@ -601,6 +612,11 @@ def process_message(message: Any, progress_callback: Callable[[], None] | None =
                 schema_cdc_table_mode=schema.cdc_table_mode,
                 resource_name=export_signal.resource_name,
             )
+
+            # Minutes may have passed since the batch's write — re-check before post-load
+            # commits and job completion promote the staged cursor under a new owner.
+            if verify_ownership is not None:
+                verify_ownership()
 
             async_to_sync(run_post_load_operations)(
                 job=job,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -1,6 +1,7 @@
 from typing import Any
 
-from unittest.mock import MagicMock, patch
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pyarrow as pa
 from parameterized import parameterized
@@ -10,6 +11,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _apply_partitioning,
     _get_write_type,
     _promote_staged_cursor,
+    process_message,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.test_mocks import mock_delta_table
 
@@ -160,3 +162,101 @@ class TestPromoteStagedCursor:
         mock_objects.get.side_effect = ExternalDataSchema.DoesNotExist()
         signal = self._make_signal()
         _promote_staged_cursor(signal)
+
+
+class _LeaseLost(Exception):
+    pass
+
+
+def _message(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "team_id": 1,
+        "job_id": "job-1",
+        "schema_id": "schema-1",
+        "source_id": "source-1",
+        "resource_name": "res",
+        "run_uuid": "run-1",
+        "batch_index": 1,
+        "s3_path": "s3://bucket/path",
+        "row_count": 1,
+        "byte_size": 1,
+        "is_final_batch": False,
+        "total_batches": None,
+        "total_rows": None,
+        "sync_type": "incremental",
+        "data_folder": None,
+        "schema_path": None,
+        "primary_keys": ["id"],
+    }
+    base.update(overrides)
+    return base
+
+
+_PROCESSOR = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.processor"
+
+
+class TestProcessMessageOwnershipGate:
+    # If the check is dropped or moved after the side effect, a taken-over loader
+    # would still commit to Delta or mark the job COMPLETED.
+
+    @patch(f"{_PROCESSOR}.posthoganalytics")
+    @patch(f"{_PROCESSOR}.read_parquet", return_value=pa.table({"id": [1]}))
+    @patch(f"{_PROCESSOR}.is_batch_already_processed", return_value=False)
+    @patch(f"{_PROCESSOR}.DeltaTableHelper")
+    @patch(f"{_PROCESSOR}.ExternalDataJob")
+    @patch(f"{_PROCESSOR}.s3fs")
+    @patch(f"{_PROCESSOR}.close_old_connections")
+    def test_lost_ownership_blocks_delta_write(
+        self,
+        _close: MagicMock,
+        _s3fs: MagicMock,
+        mock_job_model: MagicMock,
+        mock_helper_cls: MagicMock,
+        _already: MagicMock,
+        _read: MagicMock,
+        _analytics: MagicMock,
+    ) -> None:
+        helper = mock_helper_cls.return_value
+        helper.get_delta_table = AsyncMock(return_value=None)
+        helper.write_to_deltalake = AsyncMock()
+        helper.write_scd2_to_deltalake = AsyncMock()
+        mock_job_model.objects.prefetch_related.return_value.get.return_value = MagicMock()
+
+        def verify_ownership() -> None:
+            raise _LeaseLost()
+
+        with pytest.raises(_LeaseLost):
+            process_message(_message(), verify_ownership=verify_ownership)
+
+        helper.write_to_deltalake.assert_not_called()
+        helper.write_scd2_to_deltalake.assert_not_called()
+
+    @patch(f"{_PROCESSOR}.posthoganalytics")
+    @patch(f"{_PROCESSOR}._mark_job_completed")
+    @patch(f"{_PROCESSOR}._run_post_load_for_already_processed_batch")
+    @patch(f"{_PROCESSOR}.is_batch_already_processed", return_value=True)
+    @patch(f"{_PROCESSOR}.DeltaTableHelper")
+    @patch(f"{_PROCESSOR}.ExternalDataJob")
+    @patch(f"{_PROCESSOR}.s3fs")
+    @patch(f"{_PROCESSOR}.close_old_connections")
+    def test_lost_ownership_blocks_final_batch_completion(
+        self,
+        _close: MagicMock,
+        _s3fs: MagicMock,
+        mock_job_model: MagicMock,
+        _helper_cls: MagicMock,
+        _already: MagicMock,
+        mock_post_load: MagicMock,
+        mock_mark_completed: MagicMock,
+        _analytics: MagicMock,
+    ) -> None:
+        mock_job_model.objects.prefetch_related.return_value.get.return_value = MagicMock()
+
+        def verify_ownership() -> None:
+            raise _LeaseLost()
+
+        with pytest.raises(_LeaseLost):
+            process_message(_message(is_final_batch=True), verify_ownership=verify_ownership)
+
+        mock_post_load.assert_not_called()
+        mock_mark_completed.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -8,7 +8,7 @@ polling, retry, and recovery mechanics to the v3 batch consumer engine.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from datetime import datetime
 from typing import Any
 
@@ -31,6 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     RETRY_BACKOFF_BASE_SECONDS,
     BatchConsumer as SharedBatchConsumer,
     BatchConsumerConfig,
+    OwnershipLostError,
     ProcessBatchFn,
     _group_by_key,
 )
@@ -51,6 +52,11 @@ from products.warehouse_sources_queue.backend.models import SourceBatchStatus
 logger = structlog.get_logger(__name__)
 
 ConsumerConfig = BatchConsumerConfig
+
+# Raises OwnershipLostError when this consumer no longer holds the group lease.
+VerifyOwnership = Callable[[], None]
+# Unlike the engine's ProcessBatchFn, the Delta sink also receives the per-batch ownership check.
+DeltaProcessBatchFn = Callable[[PendingBatch, VerifyOwnership | None], Coroutine[Any, Any, None]]
 
 # Ceiling for the queue-freshness probe, deliberately far below the sweep
 # timeout so a degraded probe can't starve the reconcile sweep it rides on.
@@ -323,15 +329,40 @@ class BatchConsumer(SharedBatchConsumer):
     def __init__(
         self,
         config: ConsumerConfig,
-        process_batch: ProcessBatchFn,
+        process_batch: DeltaProcessBatchFn,
         health_reporter: Callable[[], None] | None = None,
     ) -> None:
+        async def process_with_ownership_check(batch: PendingBatch) -> None:
+            await process_batch(batch, self._make_verify_ownership(batch))
+
         super().__init__(
             config=config,
-            process_batch=process_batch,
+            process_batch=process_with_ownership_check,
             adapter=DeltaBatchConsumerAdapter(),
             health_reporter=health_reporter,
         )
+
+    def _make_verify_ownership(self, batch: PendingBatch) -> Callable[[], None]:
+        """Sync ownership check for the worker thread: the engine's lease checks bracket
+        the batch but can't see a loss mid-write. Fails closed — an unverified lease is lost."""
+        database_url = self._config.database_url
+        connect_timeout = self._config.connect_timeout_seconds
+
+        def verify_ownership() -> None:
+            try:
+                owns = BatchQueue.verify_group_lease_sync(
+                    database_url,
+                    team_id=batch.team_id,
+                    schema_id=batch.schema_id,
+                    owner_token=self._owner_token,
+                    connect_timeout_seconds=connect_timeout,
+                )
+            except Exception as e:
+                raise OwnershipLostError("pre-commit lease verification query failed") from e
+            if not owns:
+                raise OwnershipLostError(f"group lease lost before commit for ({batch.team_id}, {batch.schema_id})")
+
+        return verify_ownership
 
 
 def _update_job_status_to_failed(*, job_id: str, team_id: int, error: str) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -652,6 +652,34 @@ class BatchQueue:
             return bool(row and row[0])
 
     @staticmethod
+    def verify_group_lease_sync(
+        database_url: str,
+        *,
+        team_id: int,
+        schema_id: str,
+        owner_token: str,
+        connect_timeout_seconds: int = 10,
+    ) -> bool:
+        """Sync counterpart of verify_advisory_lock: the Delta write runs in a worker thread
+        that can't share the group's async connection, so use a short-lived sync one."""
+        with psycopg.connect(database_url, autocommit=True, connect_timeout=connect_timeout_seconds) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT EXISTS (
+                        SELECT 1 FROM {LEASE_TABLE}
+                        WHERE team_id = %(team_id)s
+                          AND schema_id = %(schema_id)s
+                          AND owner_token = %(owner)s
+                          AND expires_at > now()
+                    )
+                    """,
+                    {"team_id": team_id, "schema_id": schema_id, "owner": owner_token},
+                )
+                row = cur.fetchone()
+                return bool(row and row[0])
+
+    @staticmethod
     async def get_stale_executing(
         conn: psycopg.AsyncConnection[Any],
         *,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/load.py
@@ -13,6 +13,8 @@ only needs to raise on failure.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from asgiref.sync import sync_to_async
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.processor import (
@@ -23,8 +25,10 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 )
 
 
-async def process_batch(batch: PendingBatch) -> None:
+async def process_batch(batch: PendingBatch, verify_ownership: Callable[[], None] | None = None) -> None:
     """Load a single batch into Delta Lake, reusing the existing processor."""
     # thread_sensitive=False: the default single-thread executor would cap the pod's
     # real parallelism at 1; process_message is self-contained, so cross-thread is safe.
-    await sync_to_async(process_message, thread_sensitive=False)(batch.to_export_signal())
+    await sync_to_async(process_message, thread_sensitive=False)(
+        batch.to_export_signal(), verify_ownership=verify_ownership
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -329,6 +329,8 @@ class TestProcessGroup:
     @pytest.mark.asyncio
     async def test_abandons_group_when_lease_lost_before_dispatch(self):
         consumer = _make_consumer()
+        process_mock = AsyncMock()
+        consumer._process_batch = process_mock
         batch = _make_batch()
 
         with (
@@ -346,7 +348,7 @@ class TestProcessGroup:
             await consumer._process_group((1, "schema-1"), [batch])
 
         # Another pod owns the group now — processing it here would double-write.
-        cast(AsyncMock, consumer._process_batch).assert_not_called()
+        process_mock.assert_not_called()
         mock_unlock.assert_called_once()
 
 
@@ -1340,6 +1342,47 @@ class TestOwnershipVerification:
 
         assert result is True
         mock_verify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_batch_receives_working_precommit_ownership_check(self):
+        # Guards the wiring: without a working check handed to the processor,
+        # a write could start (or post-load run) after a takeover.
+        config = ConsumerConfig(database_url="postgres://unused:unused@localhost/unused")
+        captured: dict[str, Any] = {}
+
+        async def fake_process(batch, verify_ownership=None):
+            captured["check"] = verify_ownership
+
+        consumer = BatchConsumer(config=config, process_batch=fake_process)
+        await consumer._process_batch(_make_batch())
+
+        check = captured["check"]
+        assert check is not None
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.verify_group_lease_sync",
+            return_value=True,
+        ):
+            check()
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.verify_group_lease_sync",
+                return_value=False,
+            ),
+            pytest.raises(OwnershipLostError),
+        ):
+            check()
+
+        # Fail-closed: an unverifiable lease must not be treated as owned.
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.verify_group_lease_sync",
+                side_effect=Exception("queue db unreachable"),
+            ),
+            pytest.raises(OwnershipLostError),
+        ):
+            check()
 
     @pytest.mark.asyncio
     async def test_heartbeat_stops_when_lease_renewal_fails(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -519,6 +519,31 @@ class TestBatchQueueLeaseRenewal:
 
 
 @pytest.mark.django_db(transaction=True)
+class TestVerifyGroupLeaseSync:
+    # Must agree with the async verify_advisory_lock predicate: a divergence
+    # (e.g. dropping the expiry check) silently disarms the pre-commit guard.
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "lease_expires_in,checked_owner,expected",
+        [
+            (300, OWNER_A, True),  # live lease, right owner
+            (-1, OWNER_A, False),  # expired lease
+            (300, OWNER_B, False),  # live lease held by someone else
+            (None, OWNER_A, False),  # no lease row at all
+        ],
+    )
+    async def test_matches_lease_state(self, conn, _db_url, lease_expires_in, checked_owner, expected):
+        if lease_expires_in is not None:
+            await _insert_lease(conn, team_id=1, schema_id="s1", owner=OWNER_A, expires_in_seconds=lease_expires_in)
+
+        owns = BatchQueue.verify_group_lease_sync(
+            _db_url, team_id=1, schema_id="s1", owner_token=checked_owner, connect_timeout_seconds=5
+        )
+
+        assert owns is expected
+
+
+@pytest.mark.django_db(transaction=True)
 class TestQueueFreshnessProbe:
     @pytest.mark.asyncio
     async def test_reports_only_batches_never_picked_up(self, conn):


### PR DESCRIPTION
## Problem

The v3 loader's group lease fences claiming and status writes, but not the work itself. The engine verifies ownership before dispatching a batch and again after the write returns, and the batch heartbeat renews the lease every ~100s while it runs. Two gaps remain:

- The heartbeat is an asyncio task that dies silently on any exception. Once it's dead, the lease expires (TTL 300s) with nobody noticing.
- Nothing re-checks the lease between dispatch and the Delta commit, or before final-batch post-load. A loader whose group was taken over (recovery sweep or lock takeover) can still commit to Delta, run post-load compaction, promote the staged incremental cursor, and mark the job COMPLETED while the new owner is already processing the same group.

That's the double-writer window behind duplicated/lost rows on schemas that hit a lease takeover mid-run.

## Changes

```mermaid
flowchart LR
    A[claim + lease] --> B[verify ownership] --> C[executing status] --> D[read parquet + enrich] --> E[delta commit] --> F[post-load + job COMPLETED] --> G[verify ownership] --> H[succeeded status]
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A,B,C,D,F,G,H phGray;
    class E phRed;
```

```mermaid
flowchart LR
    A[claim + lease] --> B[verify ownership] --> C[executing status] --> D[read parquet + enrich] --> V1{{verify ownership}} --> E[delta commit] --> V2{{verify ownership}} --> F[post-load + job COMPLETED] --> G[verify ownership] --> H[succeeded status]
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class A,B,C,D,E,F,G,H phGray;
    class V1,V2 phBlue;
```

- `process_message` accepts an optional `verify_ownership` callable and re-runs it immediately before each lasting side effect: the Delta write, final-batch post-load (which compacts and marks the job COMPLETED), and the already-processed final-batch completion path.
- The Delta `BatchConsumer` builds that callable per batch. It runs the same lease predicate as the engine's `verify_advisory_lock`, over a short-lived sync connection, because the write runs in a worker thread that can't share the group's async connection (`BatchQueue.verify_group_lease_sync`).
- Fail-closed on query errors, matching the engine's existing `_verify_ownership`: an unverifiable lease is treated as lost, the batch raises `OwnershipLostError`, and the engine abandons the group without writing status rows it may no longer own. The recovery sweep re-queues the batch for the live owner.
- The engine and the duckgres sink are untouched. The wiring lives in the Delta consumer subclass.

> [!NOTE]
> This narrows the double-writer window to the write that is already in flight when the lease is lost. It does not abort a running delta-rs commit (a sync thread can't be cancelled from the event loop). Making residual concurrent commits collide loudly instead of silently is a separate PR that removes `AWS_S3_ALLOW_UNSAFE_RENAME`.

## How did you test this code?

Automated tests only, all run locally and green:

- `test_jobs_db.py::TestVerifyGroupLeaseSync` (4 parameterized cases, real Postgres): catches the sync predicate diverging from the async `verify_advisory_lock` (e.g. dropping the `expires_at > now()` check would silently disarm the guard).
- `test_processor.py::TestProcessMessageOwnershipGate` (2 cases): catches the check being dropped or moved after the side effect. A raising `verify_ownership` must prevent `write_to_deltalake`/`write_scd2_to_deltalake` and, on the already-processed final-batch path, post-load and `_mark_job_completed`.
- `test_consumer.py::test_process_batch_receives_working_precommit_ownership_check`: catches the Delta consumer wiring being reverted, and locks in fail-closed on query errors.
- Full affected suites: `test_consumer.py` (62 passed), `test_jobs_db.py` (55 passed, ~7 min), `test_processor.py` (13 passed), `test_run_warehouse_sources_load.py` + `test_idempotency.py` (27 passed). One existing test (`test_abandons_group_when_lease_lost_before_dispatch`) reached into `consumer._process_batch` expecting the raw mock and was adapted to the wrapper.

Not covered (acknowledged): an integration test where the lease expires while a real Delta write is in flight, and the mid-run gate between the write and post-load on the non-idempotent path (mocking the full internal-schema pipeline there would be pure choreography).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) as fix 2 of the pipelines v3 queue/lease audit estefania requested; she directed the fix selection. The audit's adversarial verification found the unguarded window with three refutation passes over `batch_consumer.py`, `processor.py`, and `jobs_db.py`, then confirmed the silent heartbeat death (`except Exception: return`) by direct read. Skill invoked: `/writing-tests`.

Design decisions: the check is threaded through the Delta consumer subclass rather than the shared engine protocol, so the duckgres sink is untouched. The callable raises rather than returning bool so the processor stays engine-agnostic (no `OwnershipLostError` import in `load/`). Fail-closed on query errors was chosen for consistency with the engine's `_verify_ownership` precedent, accepting that a queue-DB blip costs a retry cycle instead of risking an unowned write. Related in-flight work: #69105 hardens the heartbeat itself; the unsafe-rename removal lands separately.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*