### PR TITLE
feat(insights): extend drag-to-zoom to lifecycle and funnel-trends charts

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -360,7 +360,14 @@ export function InsightVizDisplay({
                     />
                 )
             case InsightType.FUNNELS:
-                return <Funnel inCardView={embedded} inSharedMode={inSharedMode} showPersonsModal={!inSharedMode} />
+                return (
+                    <Funnel
+                        context={context}
+                        inCardView={embedded}
+                        inSharedMode={inSharedMode}
+                        showPersonsModal={!inSharedMode}
+                    />
+                )
             case InsightType.RETENTION:
                 return (
                     <RetentionContainer

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.test.tsx
@@ -2,9 +2,18 @@ import '@testing-library/jest-dom'
 
 import { cleanup, configure, screen, waitFor } from '@testing-library/react'
 
-import { ensureJsdom, waitForHogChartTooltip } from '@posthog/quill-charts/testing'
+import { dragSelection, ensureJsdom, waitForHogChartTooltip } from '@posthog/quill-charts/testing'
 
-import { buildFunnelsQuery, chart, getHogChart, personsModal, renderInsight } from '~/test/insight-testing'
+import { FEATURE_FLAGS } from 'lib/constants'
+
+import {
+    buildFunnelsQuery,
+    chart,
+    getHogChart,
+    getQuerySource,
+    personsModal,
+    renderInsight,
+} from '~/test/insight-testing'
 import { buildAnnotation } from '~/test/insight-testing/test-data'
 import { AnnotationScope } from '~/types'
 
@@ -246,5 +255,38 @@ describe('FunnelLineChart', () => {
                 }
             }
         )
+    })
+
+    describe('drag-to-zoom', () => {
+        const zoomFlag = { [FEATURE_FLAGS.INSIGHT_DRAG_TO_ZOOM]: true }
+        const totalLabels = 5 // funnelTrendsSteps.default has 5 days/labels
+
+        it('reports the dragged range as day strings to context.onDateRangeZoom', async () => {
+            const onDateRangeZoom = jest.fn()
+            renderInsight({ query: buildFunnelsQuery(), context: { onDateRangeZoom }, featureFlags: zoomFlag })
+
+            const canvas = await screen.findByLabelText(/chart with/i)
+            dragSelection(canvas.parentElement!, 1, 3, totalLabels)
+
+            await waitFor(() => {
+                expect(onDateRangeZoom).toHaveBeenCalledWith('2024-06-11', '2024-06-13')
+            })
+        })
+
+        it('ignores drags when the drag-to-zoom flag is off', async () => {
+            const onDateRangeZoom = jest.fn()
+            renderInsight({
+                query: buildFunnelsQuery(),
+                context: { onDateRangeZoom },
+                featureFlags: { [FEATURE_FLAGS.INSIGHT_DRAG_TO_ZOOM]: false },
+            })
+
+            const canvas = await screen.findByLabelText(/chart with/i)
+            dragSelection(canvas.parentElement!, 1, 3, totalLabels)
+
+            // A regression dropping the flag gate would ship zoom to everyone.
+            expect(onDateRangeZoom).not.toHaveBeenCalled()
+            expect(getQuerySource().dateRange).toBeUndefined()
+        })
     })
 })

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -10,7 +10,7 @@ import type {
     TooltipContext,
 } from '@posthog/quill-charts'
 
-import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme, useDateRangeZoom } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -62,6 +62,7 @@ function resolveGroupTypeLabel(
 }
 
 export function FunnelLineChart({
+    context,
     inSharedMode,
     showPersonsModal: showPersonsModalProp = true,
 }: Omit<ChartParams, 'filters'>): JSX.Element | null {
@@ -211,6 +212,8 @@ export function FunnelLineChart({
         [clickDeps]
     )
 
+    const onDateRangeZoom = useDateRangeZoom(annotationDates, context?.onDateRangeZoom)
+
     const renderTooltip = useCallback(
         (ctx: TooltipContext<FunnelSeriesMeta>): JSX.Element => {
             if (quillTooltipEnabled) {
@@ -282,6 +285,7 @@ export function FunnelLineChart({
             config={chartConfig}
             tooltip={renderTooltip}
             onPointClick={showPersonsModal ? onPointClick : undefined}
+            onDateRangeZoom={onDateRangeZoom}
             className="LineGraph"
             dataAttr="trend-line-graph-funnel"
             onError={handleChartError}

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.test.tsx
@@ -2,10 +2,19 @@ import '@testing-library/jest-dom'
 
 import { cleanup, screen, waitFor } from '@testing-library/react'
 
-import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+import { dragSelection, setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { FEATURE_FLAGS } from 'lib/constants'
 
 import { LifecycleQuery, LifecycleQueryResponse, NodeKind } from '~/queries/schema/schema-general'
-import { chart, type InsightQuery, type MockResponse, personsModal, renderInsight } from '~/test/insight-testing'
+import {
+    chart,
+    getQuerySource,
+    type InsightQuery,
+    type MockResponse,
+    personsModal,
+    renderInsight,
+} from '~/test/insight-testing'
 
 let cleanupJsdom: () => void
 let cleanupRaf: () => void
@@ -152,5 +161,43 @@ describe('TrendsLifecycleChart', () => {
         } else {
             expect(screen.queryByTestId('hog-chart-timeseries-bar-legend')).not.toBeInTheDocument()
         }
+    })
+
+    describe('drag-to-zoom', () => {
+        const zoomFlag = { [FEATURE_FLAGS.INSIGHT_DRAG_TO_ZOOM]: true }
+
+        it('reports the dragged range as day strings to context.onDateRangeZoom', async () => {
+            const onDateRangeZoom = jest.fn()
+            renderInsight({
+                query: buildLifecycleQuery() as unknown as InsightQuery,
+                mocks: { additionalMockResponses: lifecycleMocks },
+                context: { onDateRangeZoom },
+                featureFlags: zoomFlag,
+            })
+
+            const canvas = await screen.findByLabelText(/chart with/i)
+            dragSelection(canvas.parentElement!, 1, 3, LIFECYCLE_LABELS.length)
+
+            await waitFor(() => {
+                expect(onDateRangeZoom).toHaveBeenCalledWith('2024-06-11', '2024-06-13')
+            })
+        })
+
+        it('ignores drags when the drag-to-zoom flag is off', async () => {
+            const onDateRangeZoom = jest.fn()
+            renderInsight({
+                query: buildLifecycleQuery() as unknown as InsightQuery,
+                mocks: { additionalMockResponses: lifecycleMocks },
+                context: { onDateRangeZoom },
+                featureFlags: { [FEATURE_FLAGS.INSIGHT_DRAG_TO_ZOOM]: false },
+            })
+
+            const canvas = await screen.findByLabelText(/chart with/i)
+            dragSelection(canvas.parentElement!, 1, 3, LIFECYCLE_LABELS.length)
+
+            // A regression dropping the flag gate would ship zoom to everyone.
+            expect(onDateRangeZoom).not.toHaveBeenCalled()
+            expect(getQuerySource().dateRange).toBeUndefined()
+        })
     })
 })

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { ChartLegendConfig, PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme, useDateRangeZoom } from 'lib/charts/hooks'
 import { getBarColorFromStatus } from 'lib/colors'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -183,6 +183,8 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
         [clickDeps]
     )
 
+    const onDateRangeZoom = useDateRangeZoom(currentPeriodResult?.days, context?.onDateRangeZoom)
+
     const renderTooltip = useCallback(
         (ctx: TooltipContext<TrendsSeriesMeta>) => {
             const sharedProps = {
@@ -244,6 +246,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
             theme={theme}
             tooltip={renderTooltip}
             onPointClick={canHandleClick ? onPointClick : undefined}
+            onDateRangeZoom={onDateRangeZoom}
             className="BarGraph"
             dataAttr="trend-lifecycle-graph"
             onError={handleChartError}


### PR DESCRIPTION
## Problem

[#69166](https://github.com/PostHog/posthog/pull/69166) added drag-to-zoom for trends line/bar charts behind the `insight-drag-to-zoom` flag. Other product analytics chart types that plot a real calendar-date x-axis didn't get it.

## Changes

- Wire `useDateRangeZoom` (the same hook trends charts already use) into `TrendsLifecycleChart` and `FunnelLineChart` (funnel trends-over-time view).
- Thread `context` through `Funnel`/`InsightVizDisplay` — it was being dropped before reaching the funnel viz, so `onDateRangeZoom` (and the empty-state overrides it also carries) never reached that component.
- Left stickiness and retention charts out of scope: their x-axis is a bucket/offset ("N days active" for stickiness, cohort day-offset for retention), not a calendar date — even though the underlying field is confusingly named `days`, the backend serves plain integers there for stickiness. Dragging a range on those charts wouldn't map to a valid date range.

## How did you test this code?

Added drag-to-zoom test cases to `TrendsLifecycleChart.test.tsx` and `FunnelLineChart.test.tsx`, mirroring the existing coverage in `TrendsLineChart.test.tsx`:
- reports the dragged range as day strings to `context.onDateRangeZoom` when the flag is on
- ignores drags when the flag is off (regression guard against shipping to everyone)

Ran the full `TrendsLifecycleChart`, `FunnelLineChart`, `TrendsLineChart`, `TrendsBarChart`, `funnels`, and `InsightViz` Jest suites locally — all 551+ tests pass. Did not run this manually in the browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal chart behavior gated by an existing, already-documented flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) built this after Sam asked me to survey which other charts could reuse the drag-to-zoom mechanism from #69166, then implement it for the product analytics insight types identified. Skills invoked: `/writing-tests` before adding the Jest coverage.

Along the way I found and fixed a test-writing mistake of my own: an initial lifecycle drag test grabbed the wrong DOM node for the drag gesture (the `data-attr` wrapper's parent instead of the interactive wrapper itself), which silently no-op'd the test. I also caught that stickiness charts don't actually have a calendar-date x-axis despite my own earlier research suggesting otherwise, and excluded them rather than wiring up a feature that wouldn't behave correctly.