### PR TITLE
feat(signals): add team-wide Slack channel picker to inbox settings

### DIFF
--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -81,6 +81,7 @@ export type SlackChannelPickerProps = {
 }
 
 export function SlackChannelPicker({ onChange, value, integration, disabled }: SlackChannelPickerProps): JSX.Element {
+    const logic = slackIntegrationLogic({ id: integration.id })
     const {
         slackChannels,
         slackChannelsForPicker,
@@ -90,10 +91,8 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
         isMemberOfSlackChannel,
         isPrivateChannelWithoutAccess,
         getChannelRefreshButtonDisabledReason,
-    } = useValues(slackIntegrationLogic({ id: integration.id }))
-    const { loadAllSlackChannels, loadSlackChannelById, loadSlackChannelByIdSuccess } = useActions(
-        slackIntegrationLogic({ id: integration.id })
-    )
+    } = useValues(logic)
+    const { loadAllSlackChannels, loadSlackChannelById, loadSlackChannelByIdSuccess } = useActions(logic)
     const [localValue, setLocalValue] = useState<string | null>(null)
     // Gates the empty-val recovery reload: LemonInputSelect's setInputValue('') on blur and
     // after-select would otherwise flicker the "first page of channels" hint on every focus cycle.
@@ -134,10 +133,14 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
     }, [value, slackChannels])
 
     useEffect(() => {
-        if (!disabled) {
+        // Multiple pickers can mount for the same workspace (e.g. team + per-user channel), so skip
+        // the fetch when the shared logic already has channels or a load in flight. Read live logic
+        // values rather than the render closure: sibling pickers mount within the same commit, before
+        // the first one's dispatch is reflected in a re-render.
+        if (!disabled && !logic.values.slackChannels.length && !logic.values.allSlackChannelsLoading) {
             loadAllSlackChannels()
         }
-    }, [loadAllSlackChannels, disabled])
+    }, [logic, loadAllSlackChannels, disabled])
 
     // Workspaces with hundreds of channels can have the saved channel beyond the first page that
     // /channels returns. Without a direct lookup the channel never makes it into slackChannels, so

--- a/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
+++ b/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
@@ -8,6 +8,9 @@ import { SlackChannelPicker } from 'lib/integrations/SlackIntegrationHelpers'
 import { IconSlack } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
+import { IntegrationType } from '~/types'
+
+import { signalTeamConfigLogic } from '../../logics/signalTeamConfigLogic'
 import { userAutonomyLogic } from '../../logics/userAutonomyLogic'
 import { SignalReportPriority } from '../../types'
 
@@ -35,13 +38,48 @@ function ConnectSlackPrompt(): JSX.Element {
                 <div className="min-w-0">
                     <div className="font-medium text-sm text-default">Connect a Slack workspace</div>
                     <p className="text-xs text-secondary mt-0.5 mb-0 max-w-xl">
-                        Connect Slack to get pinged in your own channel when you're a suggested reviewer on a new inbox
-                        item.
+                        Connect Slack to post reports to a team channel and get pinged when you're a suggested reviewer.
                     </p>
                 </div>
             </div>
             <IconChevronRight className="size-4 shrink-0 text-muted transition-colors group-hover:text-default" />
         </Link>
+    )
+}
+
+/**
+ * Team-wide channel where every actionable report is posted regardless of the suggested reviewer,
+ * backed by `default_slack_notification_channel` on `signalTeamConfigLogic`. Clearing the channel
+ * disables the team default. The backend routes the team channel through the team's first Slack
+ * integration (`_get_team_slack_integration`), so we target `integrations[0]` here too.
+ */
+function TeamChannelCard({ integration }: { integration: IntegrationType }): JSX.Element {
+    const { teamConfig } = useValues(signalTeamConfigLogic)
+    const { setDefaultSlackNotificationChannel } = useActions(signalTeamConfigLogic)
+    const channel = teamConfig?.default_slack_notification_channel ?? null
+
+    return (
+        <div className="flex flex-col gap-3 rounded border bg-bg-light px-3 py-2.5">
+            <div className="flex items-start gap-3 min-w-0">
+                <IconSlack className="size-5 shrink-0 mt-0.5 grayscale" />
+                <div className="min-w-0">
+                    <div className="font-medium text-sm text-default">Notify the whole team</div>
+                    <p className="text-xs text-secondary mt-0.5 mb-0 max-w-xl">
+                        Post every report to one channel, whether or not a reviewer is suggested. PostHog must be in the
+                        channel – invite it with <code>/invite @PostHog</code>. Clear the channel to turn this off.
+                    </p>
+                </div>
+            </div>
+
+            <div className="flex flex-col gap-1 min-w-0 max-w-md border-t border-primary border-dashed pt-3">
+                <span className="text-xs text-secondary">Channel</span>
+                <SlackChannelPicker
+                    integration={integration}
+                    value={channel ?? undefined}
+                    onChange={(next) => setDefaultSlackNotificationChannel(next)}
+                />
+            </div>
+        </div>
     )
 }
 
@@ -52,21 +90,9 @@ function ConnectSlackPrompt(): JSX.Element {
  * enable toggle clears them to disable. Min-priority gates which reports ping.
  * Backed by the `slack_notification_*` fields on `userAutonomyLogic`.
  */
-export function SlackNotificationsSection(): JSX.Element {
-    useMountedLogic(integrationsLogic)
-    useMountedLogic(userAutonomyLogic)
-    const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
+function PerUserChannelCard({ integrations }: { integrations: IntegrationType[] }): JSX.Element {
     const { autonomyConfig, autonomyConfigLoading, slackPickersExpanded } = useValues(userAutonomyLogic)
     const { updateSlackNotifications, setSlackPickersExpanded } = useActions(userAutonomyLogic)
-
-    if (integrationsLoading && slackIntegrations === undefined) {
-        return <LemonSkeleton className="h-20 w-full" />
-    }
-
-    const integrations = slackIntegrations ?? []
-    if (integrations.length === 0) {
-        return <ConnectSlackPrompt />
-    }
 
     // Workspace is shared with the team default. Default to the only workspace, or the user's saved pick.
     const selectedIntegrationId = autonomyConfig?.slack_notification_integration_id ?? null
@@ -181,6 +207,30 @@ export function SlackNotificationsSection(): JSX.Element {
                     </div>
                 </div>
             )}
+        </div>
+    )
+}
+
+/** Slack inbox notification settings: a team-wide channel plus per-user reviewer pings. */
+export function SlackNotificationsSection(): JSX.Element {
+    useMountedLogic(integrationsLogic)
+    useMountedLogic(userAutonomyLogic)
+    useMountedLogic(signalTeamConfigLogic)
+    const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
+
+    if (integrationsLoading && slackIntegrations === undefined) {
+        return <LemonSkeleton className="h-20 w-full" />
+    }
+
+    const integrations = slackIntegrations ?? []
+    if (integrations.length === 0) {
+        return <ConnectSlackPrompt />
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            <TeamChannelCard integration={integrations[0]} />
+            <PerUserChannelCard integrations={integrations} />
         </div>
     )
 }

--- a/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
+++ b/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
@@ -1,4 +1,5 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
+import { ReactNode } from 'react'
 
 import { IconChevronRight } from '@posthog/icons'
 import { LemonSelect, LemonSkeleton, LemonSwitch, Link } from '@posthog/lemon-ui'
@@ -26,6 +27,19 @@ const MIN_PRIORITY_OPTIONS: { value: SignalReportPriority | typeof NOTIFY_ALL_VA
     { value: 'P4', label: 'P4 and above' },
 ]
 
+/** Icon + title + description header shared by all the Slack cards in this section. */
+function SlackCardHeader({ title, description }: { title: string; description: ReactNode }): JSX.Element {
+    return (
+        <div className="flex items-start gap-3 min-w-0">
+            <IconSlack className="size-5 shrink-0 mt-0.5 grayscale" />
+            <div className="min-w-0">
+                <div className="font-medium text-sm text-default">{title}</div>
+                <p className="text-xs text-secondary mt-0.5 mb-0 max-w-xl">{description}</p>
+            </div>
+        </div>
+    )
+}
+
 /** Shown when there's no Slack workspace connected – links out to integration settings. */
 function ConnectSlackPrompt(): JSX.Element {
     return (
@@ -33,15 +47,10 @@ function ConnectSlackPrompt(): JSX.Element {
             to={urls.settings('environment-integrations', 'integration-slack')}
             className="group flex items-center justify-between gap-3 rounded border bg-bg-light px-3 py-2.5 no-underline transition-colors hover:border-primary-3000 hover:bg-bg-3000"
         >
-            <div className="flex items-start gap-3 min-w-0">
-                <IconSlack className="size-5 shrink-0 mt-0.5 grayscale" />
-                <div className="min-w-0">
-                    <div className="font-medium text-sm text-default">Connect a Slack workspace</div>
-                    <p className="text-xs text-secondary mt-0.5 mb-0 max-w-xl">
-                        Connect Slack to post reports to a team channel and get pinged when you're a suggested reviewer.
-                    </p>
-                </div>
-            </div>
+            <SlackCardHeader
+                title="Connect a Slack workspace"
+                description="Connect Slack to post reports to a team channel and get pinged when you're a suggested reviewer."
+            />
             <IconChevronRight className="size-4 shrink-0 text-muted transition-colors group-hover:text-default" />
         </Link>
     )
@@ -55,28 +64,26 @@ function ConnectSlackPrompt(): JSX.Element {
  */
 function TeamChannelCard({ integration }: { integration: IntegrationType }): JSX.Element {
     const { teamConfig } = useValues(signalTeamConfigLogic)
-    const { setDefaultSlackNotificationChannel } = useActions(signalTeamConfigLogic)
-    const channel = teamConfig?.default_slack_notification_channel ?? null
+    const { patchTeamConfig } = useActions(signalTeamConfigLogic)
 
     return (
         <div className="flex flex-col gap-3 rounded border bg-bg-light px-3 py-2.5">
-            <div className="flex items-start gap-3 min-w-0">
-                <IconSlack className="size-5 shrink-0 mt-0.5 grayscale" />
-                <div className="min-w-0">
-                    <div className="font-medium text-sm text-default">Notify the whole team</div>
-                    <p className="text-xs text-secondary mt-0.5 mb-0 max-w-xl">
+            <SlackCardHeader
+                title="Notify the whole team"
+                description={
+                    <>
                         Post every report to one channel, whether or not a reviewer is suggested. PostHog must be in the
                         channel – invite it with <code>/invite @PostHog</code>. Clear the channel to turn this off.
-                    </p>
-                </div>
-            </div>
+                    </>
+                }
+            />
 
             <div className="flex flex-col gap-1 min-w-0 max-w-md border-t border-primary border-dashed pt-3">
                 <span className="text-xs text-secondary">Channel</span>
                 <SlackChannelPicker
                     integration={integration}
-                    value={channel ?? undefined}
-                    onChange={(next) => setDefaultSlackNotificationChannel(next)}
+                    value={teamConfig?.default_slack_notification_channel ?? undefined}
+                    onChange={(next) => patchTeamConfig({ default_slack_notification_channel: next })}
                 />
             </div>
         </div>
@@ -148,16 +155,15 @@ function PerUserChannelCard({ integrations }: { integrations: IntegrationType[] 
     return (
         <div className="flex flex-col gap-3 rounded border bg-bg-light px-3 py-2.5">
             <div className="flex items-start justify-between gap-4">
-                <div className="flex items-start gap-3 min-w-0">
-                    <IconSlack className="size-5 shrink-0 mt-0.5 grayscale" />
-                    <div className="min-w-0">
-                        <div className="font-medium text-sm text-default">Notify me directly</div>
-                        <p className="text-xs text-secondary mt-0.5 mb-0 max-w-xl">
+                <SlackCardHeader
+                    title="Notify me directly"
+                    description={
+                        <>
                             When you're a suggested reviewer, get pinged in your own channel. PostHog must be in the
                             channel – invite it with <code>/invite @PostHog</code>.
-                        </p>
-                    </div>
-                </div>
+                        </>
+                    }
+                />
                 <LemonSwitch
                     checked={showPickers}
                     onChange={onToggleEnabled}
@@ -215,6 +221,8 @@ function PerUserChannelCard({ integrations }: { integrations: IntegrationType[] 
 export function SlackNotificationsSection(): JSX.Element {
     useMountedLogic(integrationsLogic)
     useMountedLogic(userAutonomyLogic)
+    // Mounted here (not just in TeamChannelCard) so the team config fetch runs in
+    // parallel with the integrations load instead of waiting out the skeleton.
     useMountedLogic(signalTeamConfigLogic)
     const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
 

--- a/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
+++ b/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
@@ -1,5 +1,5 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 
 import { IconChevronRight } from '@posthog/icons'
 import { LemonSelect, LemonSkeleton, LemonSwitch, Link } from '@posthog/lemon-ui'
@@ -58,34 +58,58 @@ function ConnectSlackPrompt(): JSX.Element {
 
 /**
  * Team-wide channel where every actionable report is posted regardless of the suggested reviewer,
- * backed by `default_slack_notification_channel` on `signalTeamConfigLogic`. Clearing the channel
- * disables the team default. The backend routes the team channel through the team's first Slack
- * integration (`_get_team_slack_integration`), so we target `integrations[0]` here too.
+ * backed by `default_slack_notification_channel` on `signalTeamConfigLogic`. Toggling off (or
+ * clearing the channel) disables the team default. The backend routes the team channel through the
+ * team's first Slack integration (`_get_team_slack_integration`), so we target `integrations[0]`
+ * here too.
  */
 function TeamChannelCard({ integration }: { integration: IntegrationType }): JSX.Element {
-    const { teamConfig } = useValues(signalTeamConfigLogic)
+    const { teamConfig, teamConfigLoading } = useValues(signalTeamConfigLogic)
     const { patchTeamConfig } = useActions(signalTeamConfigLogic)
+    // Local view state: the toggle is on but no channel has been picked yet. A saved
+    // channel implies enabled on its own, so this only bridges the picking moment.
+    const [pickerExpanded, setPickerExpanded] = useState(false)
+
+    const channel = teamConfig?.default_slack_notification_channel ?? null
+    const showPicker = pickerExpanded || !!channel
+
+    const onToggleEnabled = (enabled: boolean): void => {
+        setPickerExpanded(enabled)
+        if (!enabled && channel) {
+            patchTeamConfig({ default_slack_notification_channel: null })
+        }
+    }
 
     return (
         <div className="flex flex-col gap-3 rounded border bg-bg-light px-3 py-2.5">
-            <SlackCardHeader
-                title="Notify the whole team"
-                description={
-                    <>
-                        Post every report to one channel, whether or not a reviewer is suggested. PostHog must be in the
-                        channel – invite it with <code>/invite @PostHog</code>. Clear the channel to turn this off.
-                    </>
-                }
-            />
-
-            <div className="flex flex-col gap-1 min-w-0 max-w-md border-t border-primary border-dashed pt-3">
-                <span className="text-xs text-secondary">Channel</span>
-                <SlackChannelPicker
-                    integration={integration}
-                    value={teamConfig?.default_slack_notification_channel ?? undefined}
-                    onChange={(next) => patchTeamConfig({ default_slack_notification_channel: next })}
+            <div className="flex items-start justify-between gap-4">
+                <SlackCardHeader
+                    title="Notify the whole team"
+                    description={
+                        <>
+                            Post every report to one channel, whether or not a reviewer is suggested. PostHog must be in
+                            the channel – invite it with <code>/invite @PostHog</code>.
+                        </>
+                    }
+                />
+                <LemonSwitch
+                    checked={showPicker}
+                    onChange={onToggleEnabled}
+                    disabled={teamConfigLoading && teamConfig === null}
+                    aria-label="Enable team-wide Slack notifications"
                 />
             </div>
+
+            {showPicker && (
+                <div className="flex flex-col gap-1 min-w-0 max-w-md border-t border-primary border-dashed pt-3">
+                    <span className="text-xs text-secondary">Channel</span>
+                    <SlackChannelPicker
+                        integration={integration}
+                        value={channel ?? undefined}
+                        onChange={(next) => patchTeamConfig({ default_slack_notification_channel: next })}
+                    />
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/inbox/components/shell/AgentSetupColumn.tsx
+++ b/frontend/src/scenes/inbox/components/shell/AgentSetupColumn.tsx
@@ -14,6 +14,7 @@ import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
 import { scoutFleetLogic } from '../../logics/scoutFleetLogic'
+import { signalTeamConfigLogic } from '../../logics/signalTeamConfigLogic'
 import { userAutonomyLogic } from '../../logics/userAutonomyLogic'
 import { signalSourcesLogic } from '../../signalSourcesLogic'
 import { ScoutsFleetSection } from '../config/scouts/ScoutsFleetSection'
@@ -245,10 +246,18 @@ function NotificationsWidget(): JSX.Element {
     useMountedLogic(userAutonomyLogic)
     const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
     const { autonomyConfig } = useValues(userAutonomyLogic)
+    const { teamConfig } = useValues(signalTeamConfigLogic)
     const { openSetupModal } = useActions(agentSetupModalLogic)
 
-    const channel = autonomyConfig?.slack_notification_channel ?? null
-    const notifying = (slackIntegrations?.length ?? 0) > 0 && !!channel
+    // Either target counts as set up: the team-wide channel catches every actionable report,
+    // the personal channel pings the suggested reviewer. The status names each configured one.
+    const teamChannel = teamConfig?.default_slack_notification_channel ?? null
+    const userChannel = autonomyConfig?.slack_notification_channel ?? null
+    const channelLabels = [
+        teamChannel ? `Team ${slackChannelDisplayName(teamChannel)}` : null,
+        userChannel ? `You ${slackChannelDisplayName(userChannel)}` : null,
+    ].filter(Boolean)
+    const notifying = (slackIntegrations?.length ?? 0) > 0 && channelLabels.length > 0
     return (
         <SetupWidgetCard
             icon={<IconSlack className="grayscale" />}
@@ -256,7 +265,7 @@ function NotificationsWidget(): JSX.Element {
             size="md"
             tone={notifying ? 'done' : 'todo'}
             loading={integrationsLoading && slackIntegrations === undefined}
-            status={notifying && channel ? `Slack ${slackChannelDisplayName(channel)}` : 'Not connected'}
+            status={notifying ? channelLabels.join(' · ') : 'Not connected'}
             onClick={() => openSetupModal('slack')}
         />
     )

--- a/frontend/src/scenes/inbox/logics/signalTeamConfigLogic.ts
+++ b/frontend/src/scenes/inbox/logics/signalTeamConfigLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -10,16 +10,20 @@ import type { signalTeamConfigLogicType } from './signalTeamConfigLogicType'
 
 /**
  * Team-level Self-driving config (singleton per team). Wraps the
- * `signals/team_config` endpoint via `api.signalTeamConfig`. The field surfaced
- * here is the team-wide default PR auto-start threshold, which seeds every
- * user's effective threshold until they set a personal override
- * (`userAutonomyLogic`). The backend field is non-nullable (P0–P4), so unlike
- * the per-user override there is no "Never" option here.
+ * `signals/team_config` endpoint via `api.signalTeamConfig`. Surfaces the
+ * team-wide default PR auto-start threshold (which seeds every user's effective
+ * threshold until they set a personal override in `userAutonomyLogic`) and the
+ * team-wide default Slack notification channel, where every actionable report is
+ * posted regardless of whether a suggested reviewer resolves. The auto-start
+ * field is non-nullable (P0–P4), so unlike the per-user override there is no
+ * "Never" option; the channel is nullable and `null` disables the team default.
  */
 export const signalTeamConfigLogic = kea<signalTeamConfigLogicType>([
     path(['scenes', 'inbox', 'logics', 'signalTeamConfigLogic']),
     actions({
         setDefaultAutostartPriority: (priority: SignalReportPriority) => ({ priority }),
+        // `channel` is the "<id>|#name" target the backend stores; `null` clears the team default.
+        setDefaultSlackNotificationChannel: (channel: string | null) => ({ channel }),
     }),
     loaders({
         teamConfig: [
@@ -32,12 +36,16 @@ export const signalTeamConfigLogic = kea<signalTeamConfigLogicType>([
         ],
     }),
     reducers({
-        // Optimistically reflect the chosen priority so the select doesn't flicker
-        // back to the stale value while the request is in flight.
+        // Optimistically reflect the chosen value so the control doesn't flicker
+        // back to the stale one while the request is in flight.
         teamConfig: {
             setDefaultAutostartPriority: (state, { priority }) => ({
                 ...(state ?? { default_autostart_priority: null }),
                 default_autostart_priority: priority,
+            }),
+            setDefaultSlackNotificationChannel: (state, { channel }) => ({
+                ...(state ?? { default_autostart_priority: null }),
+                default_slack_notification_channel: channel,
             }),
         },
     }),
@@ -53,5 +61,17 @@ export const signalTeamConfigLogic = kea<signalTeamConfigLogicType>([
                 actions.loadTeamConfig()
             }
         },
+        setDefaultSlackNotificationChannel: async ({ channel }) => {
+            try {
+                await api.signalTeamConfig.update({ default_slack_notification_channel: channel })
+            } catch (error: any) {
+                lemonToast.error(error?.detail ?? error?.message ?? 'Failed to update team Slack channel')
+            } finally {
+                actions.loadTeamConfig()
+            }
+        },
     })),
+    afterMount(({ actions }) => {
+        actions.loadTeamConfig()
+    }),
 ])

--- a/frontend/src/scenes/inbox/logics/signalTeamConfigLogic.ts
+++ b/frontend/src/scenes/inbox/logics/signalTeamConfigLogic.ts
@@ -5,7 +5,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 
-import type { SignalReportPriority, SignalTeamConfig } from '../types'
+import type { SignalTeamConfig } from '../types'
 import type { signalTeamConfigLogicType } from './signalTeamConfigLogicType'
 
 /**
@@ -21,9 +21,9 @@ import type { signalTeamConfigLogicType } from './signalTeamConfigLogicType'
 export const signalTeamConfigLogic = kea<signalTeamConfigLogicType>([
     path(['scenes', 'inbox', 'logics', 'signalTeamConfigLogic']),
     actions({
-        setDefaultAutostartPriority: (priority: SignalReportPriority) => ({ priority }),
-        // `channel` is the "<id>|#name" target the backend stores; `null` clears the team default.
-        setDefaultSlackNotificationChannel: (channel: string | null) => ({ channel }),
+        // Partial update of the singleton, e.g. `{ default_slack_notification_channel: null }`
+        // to clear the team channel. One action serves every patchable field.
+        patchTeamConfig: (patch: Partial<SignalTeamConfig>) => ({ patch }),
     }),
     loaders({
         teamConfig: [
@@ -36,37 +36,20 @@ export const signalTeamConfigLogic = kea<signalTeamConfigLogicType>([
         ],
     }),
     reducers({
-        // Optimistically reflect the chosen value so the control doesn't flicker
-        // back to the stale one while the request is in flight.
+        // Optimistically reflect the patched values so the controls don't flicker
+        // back to the stale ones while the request is in flight.
         teamConfig: {
-            setDefaultAutostartPriority: (state, { priority }) => ({
-                ...(state ?? { default_autostart_priority: null }),
-                default_autostart_priority: priority,
-            }),
-            setDefaultSlackNotificationChannel: (state, { channel }) => ({
-                ...(state ?? { default_autostart_priority: null }),
-                default_slack_notification_channel: channel,
-            }),
+            patchTeamConfig: (state, { patch }) => (state ? { ...state, ...patch } : state),
         },
     }),
     listeners(({ actions }) => ({
-        setDefaultAutostartPriority: async ({ priority }) => {
+        patchTeamConfig: async ({ patch }) => {
             try {
-                await api.signalTeamConfig.update({ default_autostart_priority: priority })
+                const config = await api.signalTeamConfig.update(patch)
+                actions.loadTeamConfigSuccess(config)
             } catch (error: any) {
-                lemonToast.error(
-                    error?.detail ?? error?.message ?? 'Failed to update team default auto-start threshold'
-                )
-            } finally {
-                actions.loadTeamConfig()
-            }
-        },
-        setDefaultSlackNotificationChannel: async ({ channel }) => {
-            try {
-                await api.signalTeamConfig.update({ default_slack_notification_channel: channel })
-            } catch (error: any) {
-                lemonToast.error(error?.detail ?? error?.message ?? 'Failed to update team Slack channel')
-            } finally {
+                lemonToast.error(error?.detail ?? error?.message ?? 'Failed to update team self-driving settings')
+                // Resync so the optimistic value doesn't linger after a failed update.
                 actions.loadTeamConfig()
             }
         },


### PR DESCRIPTION
## Problem

Came up from support ticket https://posthoghelp.zendesk.com/agent/tickets/61892 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/64118)

The team-default inbox Slack channel (`SignalTeamConfig.default_slack_notification_channel`) had no UI. It was only ever set automatically during Slack-app onboarding, or via the REST API. Teams that installed Slack before that onboarding shipped (or that want reports in a specific existing channel) had no self-serve way to route every report to one team channel. Surfaced by a support ticket.

## Changes

Adds a "Notify the whole team" card to the Slack section of inbox settings, above the per-user "Notify me directly" card: an enable toggle (mirroring the per-user card) plus a channel picker. Toggling off clears the team channel.

- `signalTeamConfigLogic` gets a generic `patchTeamConfig(patch)` action with an optimistic reducer. It reuses the POST response instead of refetching, and resyncs on error.
- `SlackNotificationsSection` is split into `TeamChannelCard` + `PerUserChannelCard` with a shared card header and a single "connect Slack" empty state.
- `SlackChannelPicker` now skips duplicate channel fetches when multiple pickers mount for the same workspace.
- The Connections rail's Notifications widget counts either channel (team or personal) as configured, and its status names each: `Team #reports · You #vojta`.

### Showcase


https://github.com/user-attachments/assets/256ea34e-277e-412d-8f67-7f9743111800



## How did you test this code?

- Manually clicked through the toggle, picker, and Connections widget flows (see the demo above).
- 24/24 existing Jest tests pass (`SlackChannelPicker.test.tsx`, `slackIntegrationLogic.test.ts`).
- oxlint + oxfmt clean, kea typegen regenerated, `tsgo` typecheck with zero errors in the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)
**Model:** Claude Code (Opus 4.8, Fable 5)
