### PR TITLE
fix(data-warehouse): make delta S3 commit safety explicit, gate unsafe rename behind a setting

### DIFF
--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -19,6 +19,12 @@ USE_LOCAL_SETUP = TEST or (DEBUG and len(os.getenv("OBJECT_STORAGE_ENDPOINT", "h
 
 PYARROW_DEBUG_LOGGING = get_from_env("PYARROW_DEBUG_LOGGING", False, type_cast=str_to_bool)
 
+# Rollback-only escape hatch: restores the legacy delta-rs unsafe-rename S3 backend,
+# which has no commit-conflict detection. Default (false) keeps conditional-put commits.
+DATA_WAREHOUSE_DELTA_S3_ALLOW_UNSAFE_RENAME = get_from_env(
+    "DATA_WAREHOUSE_DELTA_S3_ALLOW_UNSAFE_RENAME", False, type_cast=str_to_bool
+)
+
 # At-rest (compressed) byte budget per Delta partition. The auto-repartition controller rewrites a
 # table into a finer scheme once its largest partition exceeds this. delta-rs merges decompress the
 # whole target partition into an Arrow working set — roughly ~20x the at-rest size, and far more for

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -178,19 +178,23 @@ class DeltaTableHelper:
                 settings.OBJECT_STORAGE_ENDPOINT,
             )
 
-            return {
+            options = {
                 "aws_access_key_id": settings.DATAWAREHOUSE_LOCAL_ACCESS_KEY,
                 "aws_secret_access_key": settings.DATAWAREHOUSE_LOCAL_ACCESS_SECRET,
                 "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
                 "region_name": settings.DATAWAREHOUSE_LOCAL_BUCKET_REGION,
                 "AWS_DEFAULT_REGION": settings.DATAWAREHOUSE_LOCAL_BUCKET_REGION,
                 "AWS_ALLOW_HTTP": "true",
-                "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
             }
+        else:
+            options = {}
 
-        return {
-            "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
-        }
+        # Conditional puts make a clashing concurrent commit fail loudly instead of
+        # clobbering _delta_log; set explicitly so a library default change can't undo it.
+        options["conditional_put"] = "etag"
+        if settings.DATA_WAREHOUSE_DELTA_S3_ALLOW_UNSAFE_RENAME:
+            options["AWS_S3_ALLOW_UNSAFE_RENAME"] = "true"
+        return options
 
     async def _get_delta_table_uri(self) -> str:
         normalized_resource_name = NamingConvention.normalize_identifier(self._resource_name)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.test import override_settings
+
 import pyarrow as pa
 import deltalake
 import pyarrow.compute as pc
@@ -130,6 +132,36 @@ _COMMIT_LAYOUT_CASES: list[tuple[str, list[dict], dict, bool]] = [
         True,
     ),
 ]
+
+
+class TestStorageOptionsCommitSafety:
+    # Re-adding AWS_S3_ALLOW_UNSAFE_RENAME unconditionally would silently restore
+    # the legacy rename backend, which has no commit-conflict detection.
+    @parameterized.expand(
+        [
+            ("production_default_safe", False, False),
+            ("production_rollback_escape_hatch", False, True),
+            ("local_default_safe", True, False),
+        ]
+    )
+    def test_conditional_put_on_unsafe_rename_gated(
+        self, _case: str, use_local_setup: bool, allow_unsafe: bool
+    ) -> None:
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+
+        with (
+            override_settings(
+                USE_LOCAL_SETUP=use_local_setup,
+                DATA_WAREHOUSE_DELTA_S3_ALLOW_UNSAFE_RENAME=allow_unsafe,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.delta_table_helper.ensure_bucket_exists"
+            ),
+        ):
+            options = helper.get_storage_options()
+
+        assert options["conditional_put"] == "etag"
+        assert ("AWS_S3_ALLOW_UNSAFE_RENAME" in options) is allow_unsafe
 
 
 class TestHasCommitWithMetadata:


### PR DESCRIPTION
## Problem

Warehouse Delta writes set `AWS_S3_ALLOW_UNSAFE_RENAME: "true"` unconditionally in their storage options (`delta_table_helper.py`). That flag is a leftover from delta-rs versions that refused to write to S3 without either a DynamoDB locking provider or an explicit opt-in to unsafe renames.

Since the deltalake 1.4.0 upgrade (#45956, Feb 2026) the commit path no longer uses renames at all: the default S3 log store commits with a conditional put (put-if-absent), and delta-rs defaults `conditional_put` to `etag` for every S3-like store. I verified this against the delta-rs source at the `python-v1.4.0` tag: the log store factory falls through to the conditional-put default log store, and the legacy `S3StorageBackend` wrapper (the only thing the flag still enables) delegates `put_opts` straight through, so it changes nothing about commits.

What the flag does still do is harmful in the margins:

- it keeps the legacy wrapper wired in, whose `rename_if_not_exists` overwrites with no conflict detection and whose `copy_if_not_exists` is a literal `todo!()` panic
- it reads as "commit-conflict detection is disabled here", which misleads anyone auditing the v3 double-writer scenarios (it misled our own recent audit of the queue/lease system)
- it relies on a buried library default for a load-bearing safety property: if a future deltalake version changed the `conditional_put` default, we'd silently reopen unsafe renames with no signal

## Changes

- `_get_credentials` sets `conditional_put: "etag"` explicitly, in both the local-dev and production branches, so the safety property is pinned in our code rather than inherited from a library default.
- `AWS_S3_ALLOW_UNSAFE_RENAME` is no longer set unless the new `DATA_WAREHOUSE_DELTA_S3_ALLOW_UNSAFE_RENAME` env setting opts back in. Default off. Rollback is an env flip plus pod restart, no deploy.

With conditional puts, a concurrent writer's clashing commit fails loudly (`VersionAlreadyExists` / commit conflict) instead of silently clobbering a `_delta_log` version. That's the property this PR pins: the residual double-writer windows in v3 (lease lost mid-write, V2/V3 coexistence on rollback) now surface as retryable errors, not silent corruption. The pre-commit lease check lands separately in #69905, and in-flight #66663 (retry commit conflicts in place) becomes the natural recovery path on top of this.

> [!NOTE]
> No behavior change is expected for the commit path itself, on AWS S3 or on local SeaweedFS/MinIO — commits already go through conditional puts on deltalake 1.4.0. The observable change is that the legacy rename backend is no longer reachable by default, and any residual code path that did rely on unsafe renames would now fail loudly instead of overwriting. Hence the escape hatch.

Other `AWS_S3_ALLOW_UNSAFE_RENAME` call sites (data modeling `run_workflow.py`/`materialize_view.py`, ducklake storage) are deliberately out of scope; same reasoning applies and they can follow once this soaks.

## How did you test this code?

Automated tests only, run locally and green:

- `test_delta_table_helper.py::TestStorageOptionsCommitSafety` (3 parameterized cases): locks the safety property this PR exists for — `conditional_put=etag` present in prod and local options, unsafe rename absent by default and present only under the rollback setting. Catches someone re-adding the flag unconditionally, which no existing test would notice.
- Full `test_delta_table_helper.py` suite: 59 passed (includes real local Delta write/merge tests, which exercise the changed storage options end to end against the test object store).
- `hogli ci:preflight --fix` clean.

I (Claude) did not run a two-writer concurrency test against real AWS S3; the conditional-put behavior at the library level is verified from the delta-rs 1.4.0 source rather than empirically.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) as fix 3 of the pipelines v3 queue/lease audit estefania requested; she directed the fix selection. The audit initially framed this as "unsafe rename disables commit-conflict detection"; reading the delta-rs source at the `python-v1.4.0` tag (`crates/aws/src/storage.rs`, `crates/aws/src/lib.rs`, `crates/core/src/logstore/default_logstore.rs`) showed the 1.4.0 commit path is conditional-put regardless of the flag, so the PR was rescoped from "behavior fix" to "pin the property, remove the vestigial flag, add a rollback hatch" and the description written to match. Skill invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*