### PR TITLE
feat(aio): add config and tags to prompt management

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2020,6 +2020,10 @@ export class ApiRequest {
         return this.llmPromptByName(name, teamId).addPathComponent('duplicate')
     }
 
+    public llmPromptTagsByName(name: string, teamId?: TeamType['id']): ApiRequest {
+        return this.llmPromptByName(name, teamId).addPathComponent('tags')
+    }
+
     public llmPromptResolveByName(name: string, teamId?: TeamType['id']): ApiRequest {
         return this.llmPrompts(teamId).addPathComponent('resolve').addPathComponent('name').addPathComponent(name)
     }
@@ -7104,16 +7108,30 @@ const api = {
 
         async update(
             promptName: string,
-            data: { prompt: LLMPrompt['prompt']; base_version: number; version_description?: string }
+            data: {
+                prompt: LLMPrompt['prompt']
+                base_version: number
+                version_description?: string
+                config?: LLMPrompt['config']
+            }
         ): Promise<LLMPrompt> {
             return await new ApiRequest().llmPromptByName(promptName).update({ data })
+        },
+
+        async updateTagsByName(promptName: string, tags: string[]): Promise<LLMPrompt> {
+            return await new ApiRequest().llmPromptTagsByName(promptName).update({ data: { tags } })
         },
 
         async archiveByName(promptName: string): Promise<void> {
             await new ApiRequest().llmPromptArchiveByName(promptName).create({ data: {} })
         },
 
-        async create(data: { name: LLMPrompt['name']; prompt: LLMPrompt['prompt'] }): Promise<LLMPrompt> {
+        async create(data: {
+            name: LLMPrompt['name']
+            prompt: LLMPrompt['prompt']
+            config?: LLMPrompt['config']
+            tags?: string[]
+        }): Promise<LLMPrompt> {
             return await new ApiRequest().llmPrompts().create({ data })
         },
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7672,6 +7672,8 @@ export interface LLMPrompt {
     id: string
     name: string
     prompt: string
+    config?: Record<string, any> | null
+    tags?: string[]
     version: number
     version_description?: string | null
     created_by: UserBasicType
@@ -7688,6 +7690,8 @@ export interface LLMPromptPublic {
     id: string
     name: string
     prompt: string
+    config?: Record<string, any> | null
+    tags?: string[]
     version: number
     created_at: string
     updated_at: string

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -25,6 +25,7 @@ from posthog.api.llm_prompt_serializers import (
     LLMPromptResolveQuerySerializer,
     LLMPromptResolveResponseSerializer,
     LLMPromptSerializer,
+    LLMPromptUpdateTagsSerializer,
     LLMPromptVersionSummarySerializer,
 )
 from posthog.api.monitoring import monitor
@@ -42,6 +43,7 @@ from posthog.api.services.llm_prompt import (
     get_prompt_by_name_from_db,
     publish_prompt_version,
     resolve_versions_page,
+    update_prompt_tags,
 )
 from posthog.auth import (
     JwtAuthentication,
@@ -158,6 +160,9 @@ class LLMPromptViewSet(
     def _apply_content_mode(self, prompt: dict[str, Any], content_mode: str) -> dict[str, Any]:
         prompt = dict(prompt)
         prompt["outline"] = get_prompt_outline(prompt.get("prompt"))
+        # Cache entries written before config/tags existed don't carry the keys
+        prompt.setdefault("config", None)
+        prompt.setdefault("tags", [])
         if content_mode == "none":
             prompt.pop("prompt", None)
         elif content_mode == "preview":
@@ -291,6 +296,8 @@ class LLMPromptViewSet(
                 edits=payload.validated_data.get("edits"),
                 base_version=payload.validated_data["base_version"],
                 version_description=payload.validated_data.get("version_description"),
+                config=payload.validated_data.get("config"),
+                config_provided="config" in payload.validated_data,
             )
         except LLMPromptNotFoundError:
             return self._prompt_not_found_response(prompt_name)
@@ -408,6 +415,44 @@ class LLMPromptViewSet(
             request=request,
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(request=LLMPromptUpdateTagsSerializer, responses={200: LLMPromptSerializer})
+    @action(
+        methods=["PATCH"],
+        detail=False,
+        url_path=r"name/(?P<prompt_name>[^/]+)/tags",
+        required_scopes=["llm_prompt:write"],
+    )
+    @llma_track_latency("llma_prompts_update_tags")
+    @monitor(feature=None, endpoint="llma_prompts_update_tags", method="PATCH")
+    def update_tags(self, request: Request, prompt_name: str = "", **kwargs) -> Response:
+        auth_error = self._ensure_web_authenticated(request)
+        if auth_error is not None:
+            return auth_error
+
+        payload = LLMPromptUpdateTagsSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        try:
+            updated_prompt = update_prompt_tags(
+                self.team,
+                prompt_name=prompt_name,
+                tags=payload.validated_data["tags"],
+            )
+        except LLMPromptNotFoundError:
+            return self._prompt_not_found_response(prompt_name)
+
+        report_user_action(
+            cast(User, request.user),
+            "llma prompt tags updated",
+            {
+                "prompt_name": prompt_name,
+                "tags_count": len(payload.validated_data["tags"]),
+            },
+            team=self.team,
+            request=request,
+        )
+        return Response(self._serialize_prompt(updated_prompt))
 
     @extend_schema(request=LLMPromptDuplicateSerializer, responses={201: LLMPromptSerializer})
     @action(

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -6,6 +6,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from posthog.api.shared import UserBasicSerializer
+from posthog.models.tag import tagify
 
 from products.ai_observability.backend.models.llm_prompt import (
     LLMPrompt,
@@ -47,9 +48,12 @@ def validate_prompt_name_value(value: str) -> str:
     return value
 
 
+def _json_byte_size(value: Any) -> int:
+    return len(json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+
+
 def validate_prompt_payload_size(prompt_payload: Any) -> Any:
-    prompt_payload_bytes = len(json.dumps(prompt_payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
-    if prompt_payload_bytes > MAX_PROMPT_PAYLOAD_BYTES:
+    if _json_byte_size(prompt_payload) > MAX_PROMPT_PAYLOAD_BYTES:
         raise serializers.ValidationError(
             f"Prompt payload must be {MAX_PROMPT_PAYLOAD_BYTES} bytes or fewer.",
             code="max_size",
@@ -65,8 +69,7 @@ def validate_prompt_config_value(value: Any) -> Any:
             "Config must be a JSON object or null.",
             code="invalid_config",
         )
-    config_bytes = len(json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
-    if config_bytes > MAX_PROMPT_CONFIG_BYTES:
+    if _json_byte_size(value) > MAX_PROMPT_CONFIG_BYTES:
         raise serializers.ValidationError(
             f"Config must be {MAX_PROMPT_CONFIG_BYTES} bytes or fewer.",
             code="max_size",
@@ -78,7 +81,7 @@ def normalize_prompt_tags_value(tags: list[str]) -> list[str]:
     """Trim, lowercase, and dedupe tags while preserving their order."""
     normalized: list[str] = []
     for tag in tags:
-        cleaned = tag.strip().lower()
+        cleaned = tagify(tag)
         if cleaned and cleaned not in normalized:
             normalized.append(cleaned)
     if len(normalized) > MAX_PROMPT_TAGS:
@@ -89,11 +92,11 @@ def normalize_prompt_tags_value(tags: list[str]) -> list[str]:
     return normalized
 
 
-def build_prompt_tags_field() -> serializers.ListField:
+def build_prompt_tags_field(*, required: bool = False, help_text: str = PROMPT_TAGS_HELP) -> serializers.ListField:
     return serializers.ListField(
         child=serializers.CharField(max_length=MAX_PROMPT_TAG_LENGTH, allow_blank=True),
-        required=False,
-        help_text=PROMPT_TAGS_HELP,
+        required=required,
+        help_text=help_text,
     )
 
 
@@ -451,8 +454,8 @@ class LLMPromptPublicSerializer(serializers.Serializer):
 
 
 class LLMPromptUpdateTagsSerializer(serializers.Serializer):
-    tags = serializers.ListField(
-        child=serializers.CharField(max_length=MAX_PROMPT_TAG_LENGTH, allow_blank=True),
+    tags = build_prompt_tags_field(
+        required=True,
         help_text="Full list of tags to set on the prompt, replacing any existing tags. Applies to all versions.",
     )
 

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -22,6 +22,15 @@ class LLMPromptOutlineEntrySerializer(serializers.Serializer):
 RESERVED_PROMPT_NAMES = {"new"}
 DEFAULT_VERSION_PAGE_SIZE = 50
 MAX_PROMPT_PAYLOAD_BYTES = 1_000_000
+MAX_PROMPT_CONFIG_BYTES = 100_000
+MAX_PROMPT_TAGS = 50
+MAX_PROMPT_TAG_LENGTH = 255
+
+PROMPT_CONFIG_HELP = (
+    "Optional JSON object with arbitrary configuration for this prompt version "
+    "(e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime."
+)
+PROMPT_TAGS_HELP = "Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions."
 
 
 def validate_prompt_name_value(value: str) -> str:
@@ -46,6 +55,46 @@ def validate_prompt_payload_size(prompt_payload: Any) -> Any:
             code="max_size",
         )
     return prompt_payload
+
+
+def validate_prompt_config_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise serializers.ValidationError(
+            "Config must be a JSON object or null.",
+            code="invalid_config",
+        )
+    config_bytes = len(json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+    if config_bytes > MAX_PROMPT_CONFIG_BYTES:
+        raise serializers.ValidationError(
+            f"Config must be {MAX_PROMPT_CONFIG_BYTES} bytes or fewer.",
+            code="max_size",
+        )
+    return value
+
+
+def normalize_prompt_tags_value(tags: list[str]) -> list[str]:
+    """Trim, lowercase, and dedupe tags while preserving their order."""
+    normalized: list[str] = []
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in normalized:
+            normalized.append(cleaned)
+    if len(normalized) > MAX_PROMPT_TAGS:
+        raise serializers.ValidationError(
+            f"A prompt can have at most {MAX_PROMPT_TAGS} tags.",
+            code="max_tags",
+        )
+    return normalized
+
+
+def build_prompt_tags_field() -> serializers.ListField:
+    return serializers.ListField(
+        child=serializers.CharField(max_length=MAX_PROMPT_TAG_LENGTH, allow_blank=True),
+        required=False,
+        help_text=PROMPT_TAGS_HELP,
+    )
 
 
 CONTENT_MODE_CHOICES = ["full", "preview", "none"]
@@ -143,6 +192,15 @@ class LLMPromptPublishSerializer(serializers.Serializer):
             "Mutually exclusive with prompt."
         ),
     )
+    config = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text=(
+            f"{PROMPT_CONFIG_HELP} "
+            "If omitted, the new version keeps the config of the version it is published from. "
+            "Pass null to clear it."
+        ),
+    )
     base_version = serializers.IntegerField(
         min_value=1,
         help_text="Latest version you are editing from. Used for optimistic concurrency checks.",
@@ -156,6 +214,9 @@ class LLMPromptPublishSerializer(serializers.Serializer):
 
     def validate_prompt(self, value: Any) -> Any:
         return validate_prompt_payload_size(value)
+
+    def validate_config(self, value: Any) -> Any:
+        return validate_prompt_config_value(value)
 
     def validate_version_description(self, value: str) -> str | None:
         return value.strip() or None
@@ -171,8 +232,8 @@ class LLMPromptPublishSerializer(serializers.Serializer):
 
         if has_prompt and has_edits:
             raise serializers.ValidationError("Provide either 'prompt' or 'edits', not both.")
-        if not has_prompt and not has_edits:
-            raise serializers.ValidationError("Either 'prompt' or 'edits' is required.")
+        if not has_prompt and not has_edits and "config" not in attrs:
+            raise serializers.ValidationError("Either 'prompt', 'edits', or 'config' is required.")
 
         return attrs
 
@@ -184,6 +245,7 @@ class LLMPromptSerializer(serializers.ModelSerializer):
     version_count = serializers.SerializerMethodField()
     first_version_created_at = serializers.SerializerMethodField()
     outline = serializers.SerializerMethodField()
+    tags = build_prompt_tags_field()
 
     class Meta:
         model = LLMPrompt
@@ -191,6 +253,8 @@ class LLMPromptSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "prompt",
+            "config",
+            "tags",
             "version",
             "version_description",
             "created_by",
@@ -219,6 +283,7 @@ class LLMPromptSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             "name": {"help_text": "Unique prompt name using letters, numbers, hyphens, and underscores only."},
             "prompt": {"help_text": "Prompt payload as JSON or string data."},
+            "config": {"help_text": PROMPT_CONFIG_HELP},
             "version_description": {
                 "help_text": "Optional note describing what changed in this version. Set when the version is published."
             },
@@ -257,6 +322,12 @@ class LLMPromptSerializer(serializers.ModelSerializer):
     def validate_prompt(self, value: Any) -> Any:
         return validate_prompt_payload_size(value)
 
+    def validate_config(self, value: Any) -> Any:
+        return validate_prompt_config_value(value)
+
+    def validate_tags(self, value: list[str]) -> list[str]:
+        return normalize_prompt_tags_value(value)
+
     def validate_version_description(self, value: str | None) -> str | None:
         if value is None:
             return None
@@ -280,6 +351,12 @@ class LLMPromptSerializer(serializers.ModelSerializer):
         if "prompt" in attrs:
             raise serializers.ValidationError(
                 {"prompt": "Prompt content is versioned and cannot be updated in place. Create a new version instead."},
+                code="immutable",
+            )
+
+        if "config" in attrs:
+            raise serializers.ValidationError(
+                {"config": "Config is versioned and cannot be updated in place. Create a new version instead."},
                 code="immutable",
             )
 
@@ -353,6 +430,12 @@ class LLMPromptPublicSerializer(serializers.Serializer):
         required=False,
         help_text="First 160 characters of the prompt. Only present when 'content=preview'.",
     )
+    config = serializers.JSONField(
+        required=False,
+        allow_null=True,
+        help_text=PROMPT_CONFIG_HELP,
+    )
+    tags = build_prompt_tags_field()
     outline = LLMPromptOutlineEntrySerializer(
         many=True,
         help_text="Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents.",
@@ -365,6 +448,16 @@ class LLMPromptPublicSerializer(serializers.Serializer):
     latest_version = serializers.IntegerField()
     version_count = serializers.IntegerField()
     first_version_created_at = serializers.DateTimeField()
+
+
+class LLMPromptUpdateTagsSerializer(serializers.Serializer):
+    tags = serializers.ListField(
+        child=serializers.CharField(max_length=MAX_PROMPT_TAG_LENGTH, allow_blank=True),
+        help_text="Full list of tags to set on the prompt, replacing any existing tags. Applies to all versions.",
+    )
+
+    def validate_tags(self, value: list[str]) -> list[str]:
+        return normalize_prompt_tags_value(value)
 
 
 class LLMPromptDuplicateSerializer(serializers.Serializer):

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -148,6 +148,8 @@ def publish_prompt_version(
     edits: list[dict[str, str]] | None = None,
     base_version: int,
     version_description: str | None = None,
+    config: Any | None = None,
+    config_provided: bool = False,
 ) -> LLMPrompt:
     with transaction.atomic():
         current_latest = (
@@ -166,14 +168,21 @@ def publish_prompt_version(
 
         if edits is not None:
             resolved_payload = apply_prompt_edits(current_latest.prompt, edits)
-        else:
+        elif prompt_payload is not None:
             resolved_payload = prompt_payload
+        else:
+            # Config-only publish: keep the current prompt content
+            resolved_payload = current_latest.prompt
+
+        resolved_config = config if config_provided else current_latest.config
 
         LLMPrompt.objects.filter(pk=current_latest.pk).update(is_latest=False)
         published_prompt = LLMPrompt.objects.create(
             team=team,
             name=current_latest.name,
             prompt=resolved_payload,
+            config=resolved_config,
+            tags=list(current_latest.tags or []),
             version=current_latest.version + 1,
             is_latest=True,
             created_by=user,
@@ -226,6 +235,8 @@ def duplicate_prompt(
                 team=team,
                 name=new_name,
                 prompt=source_latest.prompt,
+                config=source_latest.config,
+                tags=list(source_latest.tags or []),
                 version=1,
                 is_latest=True,
                 created_by=user,
@@ -237,6 +248,35 @@ def duplicate_prompt(
 
     refreshed = get_active_prompt_queryset(team).filter(pk=new_prompt.pk).first()
     return refreshed if refreshed is not None else new_prompt
+
+
+def update_prompt_tags(team: Team, *, prompt_name: str, tags: list[str]) -> LLMPrompt:
+    """Set the prompt's tags without publishing a new version.
+
+    Tags are prompt-level: they are written to every non-deleted version row of the name
+    so that fetching any version returns the same tags.
+    """
+    with transaction.atomic():
+        current_latest = (
+            LLMPrompt.objects.select_for_update()
+            .filter(team=team, name=prompt_name, deleted=False, is_latest=True)
+            .order_by("-version", "-created_at", "-id")
+            .first()
+        )
+        if current_latest is None:
+            raise LLMPromptNotFoundError()
+
+        LLMPrompt.objects.filter(team=team, name=prompt_name, deleted=False).update(tags=tags)
+
+        # Bulk update() bypasses the post_save cache invalidation signal. Only the latest cache
+        # entry needs clearing: version-exact cache entries don't carry tags, they are merged
+        # in from the latest entry at read time.
+        transaction.on_commit(lambda: invalidate_prompt_latest_cache(team.id, prompt_name))
+
+    refreshed = get_active_prompt_queryset(team).filter(pk=current_latest.pk).first()
+    if refreshed is None:
+        raise LLMPromptNotFoundError()
+    return refreshed
 
 
 def archive_prompt(team: Team, prompt_name: str) -> list[int]:

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -1068,11 +1068,14 @@ class TestLLMPromptAPI(APIBaseTest):
         assert first_fetch.json()["config"] == {"model": "gpt-5"}
         assert first_fetch.json()["tags"] == ["old"]
 
-        update_response = self.client.patch(
-            f"/api/environments/{self.team.id}/llm_prompts/name/tagged-prompt/tags/",
-            data={"tags": ["fresh"]},
-            format="json",
-        )
+        # update_prompt_tags invalidates the cache via transaction.on_commit, which never fires
+        # inside a TestCase transaction, so execute the callback eagerly like the archive tests do
+        with patch("posthog.api.services.llm_prompt.transaction.on_commit", side_effect=lambda callback: callback()):
+            update_response = self.client.patch(
+                f"/api/environments/{self.team.id}/llm_prompts/name/tagged-prompt/tags/",
+                data={"tags": ["fresh"]},
+                format="json",
+            )
         assert update_response.status_code == status.HTTP_200_OK
 
         second_fetch = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/tagged-prompt/")

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -10,7 +10,14 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
 from posthog.api.llm_prompt import LLMPromptViewSet
-from posthog.api.llm_prompt_serializers import MAX_PROMPT_PAYLOAD_BYTES, LLMPromptDuplicateSerializer
+from posthog.api.llm_prompt_serializers import (
+    MAX_PROMPT_CONFIG_BYTES,
+    MAX_PROMPT_PAYLOAD_BYTES,
+    MAX_PROMPT_TAGS,
+    LLMPromptDuplicateSerializer,
+    LLMPromptPublishSerializer,
+    LLMPromptUpdateTagsSerializer,
+)
 from posthog.api.services.llm_prompt import MAX_PROMPT_VERSION
 from posthog.rate_limit import BurstRateThrottle, LLMPromptPublishBurstRateThrottle, SustainedRateThrottle
 
@@ -26,6 +33,8 @@ class TestLLMPromptAPI(APIBaseTest):
         version: int = 1,
         is_latest: bool = True,
         deleted: bool = False,
+        config: Any = None,
+        tags: list[str] | None = None,
     ) -> LLMPrompt:
         return LLMPrompt.objects.create(
             team=self.team,
@@ -34,6 +43,8 @@ class TestLLMPromptAPI(APIBaseTest):
             version=version,
             is_latest=is_latest,
             deleted=deleted,
+            config=config,
+            tags=tags or [],
             created_by=self.user,
         )
 
@@ -940,6 +951,197 @@ class TestLLMPromptAPI(APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()["name"] == "archived-name"
         assert response.json()["version"] == 1
+
+    def test_create_prompt_with_config_and_tags(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_prompts/",
+            data={
+                "name": "configured-prompt",
+                "prompt": "Prompt content",
+                "config": {"model": "gpt-5", "temperature": 0.2},
+                "tags": ["  Prod ", "prod", "Chatbot"],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["config"] == {"model": "gpt-5", "temperature": 0.2}
+        assert response.json()["tags"] == ["prod", "chatbot"]
+        created_prompt = LLMPrompt.objects.get(team=self.team, name="configured-prompt", deleted=False)
+        assert created_prompt.config == {"model": "gpt-5", "temperature": 0.2}
+        assert created_prompt.tags == ["prod", "chatbot"]
+
+    def test_create_prompt_rejects_non_object_config(self):
+        # Wiring guard: the create endpoint validates config through validate_prompt_config_value.
+        # The full invalid-config matrix runs without a DB in TestLLMPromptPublishSerializerValidationNoDB.
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_prompts/",
+            data={"name": "bad-config", "prompt": "Prompt content", "config": ["not", "an", "object"]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == "config"
+
+    def test_publish_config_semantics_across_versions(self):
+        self.create_prompt_version(name="configured-prompt", prompt="v1", config={"model": "gpt-4"}, tags=["chatbot"])
+
+        # Omitting config keeps the previous version's config; tags always carry over
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/configured-prompt/",
+            data={"prompt": "v2", "base_version": 1},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["config"] == {"model": "gpt-4"}
+        assert response.json()["tags"] == ["chatbot"]
+
+        # Providing config replaces it
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/configured-prompt/",
+            data={"prompt": "v3", "base_version": 2, "config": {"model": "gpt-5"}},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["config"] == {"model": "gpt-5"}
+
+        # Explicit null clears it
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/configured-prompt/",
+            data={"prompt": "v4", "base_version": 3, "config": None},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["config"] is None
+
+        # Historical versions keep their own config
+        assert LLMPrompt.objects.get(team=self.team, name="configured-prompt", version=3).config == {"model": "gpt-5"}
+
+    def test_publish_config_only_creates_new_version_with_same_prompt(self):
+        self.create_prompt_version(name="configured-prompt", prompt="stable content")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/configured-prompt/",
+            data={"base_version": 1, "config": {"temperature": 0.7}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["version"] == 2
+        assert response.json()["prompt"] == "stable content"
+        assert response.json()["config"] == {"temperature": 0.7}
+
+    def test_update_tags_endpoint_updates_all_versions_without_publishing(self):
+        self.create_prompt_version(name="tagged-prompt", version=1, is_latest=False, prompt="v1", tags=["old"])
+        self.create_prompt_version(name="tagged-prompt", version=2, is_latest=True, prompt="v2", tags=["old"])
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/tagged-prompt/tags/",
+            data={"tags": ["Alpha", " beta ", "alpha"]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["tags"] == ["alpha", "beta"]
+        assert response.json()["version"] == 2
+        assert response.json()["version_count"] == 2
+        tags_by_version = {
+            prompt.version: prompt.tags
+            for prompt in LLMPrompt.objects.filter(team=self.team, name="tagged-prompt", deleted=False)
+        }
+        assert tags_by_version == {1: ["alpha", "beta"], 2: ["alpha", "beta"]}
+
+    def test_update_tags_endpoint_returns_404_for_unknown_prompt(self):
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/nonexistent/tags/",
+            data={"tags": ["alpha"]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_fetch_prompt_by_name_reflects_tag_updates_despite_cache(self):
+        self.create_prompt_version(name="tagged-prompt", config={"model": "gpt-5"}, tags=["old"])
+
+        first_fetch = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/tagged-prompt/")
+        assert first_fetch.status_code == status.HTTP_200_OK
+        assert first_fetch.json()["config"] == {"model": "gpt-5"}
+        assert first_fetch.json()["tags"] == ["old"]
+
+        update_response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/tagged-prompt/tags/",
+            data={"tags": ["fresh"]},
+            format="json",
+        )
+        assert update_response.status_code == status.HTTP_200_OK
+
+        second_fetch = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/tagged-prompt/")
+        assert second_fetch.status_code == status.HTTP_200_OK
+        assert second_fetch.json()["tags"] == ["fresh"]
+
+    def test_fetch_historical_version_returns_version_config_and_current_tags(self):
+        self.create_prompt_version(name="configured-prompt", prompt="v1", config={"model": "gpt-4"}, tags=["chatbot"])
+        publish_response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/configured-prompt/",
+            data={"prompt": "v2", "base_version": 1, "config": {"model": "gpt-5"}},
+            format="json",
+        )
+        assert publish_response.status_code == status.HTTP_200_OK
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/configured-prompt/?version=1")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["config"] == {"model": "gpt-4"}
+        assert response.json()["tags"] == ["chatbot"]
+
+    def test_duplicate_prompt_copies_config_and_tags(self):
+        self.create_prompt_version(name="original", config={"model": "gpt-5"}, tags=["chatbot"])
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_prompts/name/original/duplicate/",
+            data={"new_name": "copy-of-original"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["config"] == {"model": "gpt-5"}
+        assert response.json()["tags"] == ["chatbot"]
+
+
+class TestLLMPromptPublishSerializerValidationNoDB(SimpleTestCase):
+    # validate_prompt_config_value and normalize_prompt_tags_value are pure functions (no context,
+    # no DB). The endpoints' use of them is guarded by test_create_prompt_rejects_non_object_config
+    # and test_update_tags_endpoint_updates_all_versions_without_publishing.
+    @parameterized.expand(
+        [
+            ("list", ["not", "an", "object"]),
+            ("string", "model=gpt-5"),
+            ("number", 42),
+        ]
+    )
+    def test_rejects_non_object_config(self, _label: str, bad_config: Any) -> None:
+        serializer = LLMPromptPublishSerializer(data={"base_version": 1, "config": bad_config})
+        assert not serializer.is_valid()
+        assert "config" in serializer.errors
+
+    def test_rejects_oversized_config(self) -> None:
+        oversized_config = {"data": "x" * (MAX_PROMPT_CONFIG_BYTES + 1)}
+        serializer = LLMPromptPublishSerializer(data={"base_version": 1, "config": oversized_config})
+        assert not serializer.is_valid()
+        assert "config" in serializer.errors
+
+    def test_accepts_config_only_publish(self) -> None:
+        serializer = LLMPromptPublishSerializer(data={"base_version": 1, "config": {"model": "gpt-5"}})
+        assert serializer.is_valid(), serializer.errors
+
+    def test_rejects_publish_without_prompt_edits_or_config(self) -> None:
+        serializer = LLMPromptPublishSerializer(data={"base_version": 1})
+        assert not serializer.is_valid()
+
+    def test_rejects_too_many_tags(self) -> None:
+        serializer = LLMPromptUpdateTagsSerializer(data={"tags": [f"tag-{i}" for i in range(MAX_PROMPT_TAGS + 1)]})
+        assert not serializer.is_valid()
+        assert "tags" in serializer.errors
 
 
 class TestLLMPromptDuplicateSerializerValidationNoDB(SimpleTestCase):

--- a/posthog/storage/llm_prompt_cache_payloads.py
+++ b/posthog/storage/llm_prompt_cache_payloads.py
@@ -24,6 +24,8 @@ def serialize_prompt(prompt: LLMPrompt, *, include_internal: bool = False) -> di
         "id": str(prompt.id),
         "name": prompt.name,
         "prompt": normalize_prompt_to_string(prompt.prompt),
+        "config": prompt.config,
+        "tags": list(prompt.tags or []),
         "version": prompt.version,
         "created_at": _serialize_timestamp(prompt.created_at),
         "updated_at": _serialize_timestamp(prompt.updated_at),
@@ -43,6 +45,7 @@ def serialize_prompt_version(prompt: LLMPrompt, *, include_internal: bool = Fals
         "id": str(prompt.id),
         "name": prompt.name,
         "prompt": normalize_prompt_to_string(prompt.prompt),
+        "config": prompt.config,
         "version": prompt.version,
         "created_at": _serialize_timestamp(prompt.created_at),
         "updated_at": _serialize_timestamp(prompt.updated_at),
@@ -67,6 +70,8 @@ def merge_prompt_version_history_metadata(
         "latest_version": latest_prompt["latest_version"],
         "version_count": latest_prompt["version_count"],
         "first_version_created_at": latest_prompt["first_version_created_at"],
+        # Tags are prompt-level, so version entries don't carry them; take the latest entry's
+        "tags": latest_prompt.get("tags", []),
     }
     generation_marker = latest_prompt.get(INTERNAL_FIRST_VERSION_ID_KEY)
     if isinstance(generation_marker, str):

--- a/posthog/storage/test/test_llm_prompt_cache.py
+++ b/posthog/storage/test/test_llm_prompt_cache.py
@@ -116,6 +116,8 @@ class TestLLMPromptCache(BaseTest):
                 "id",
                 "name",
                 "prompt",
+                "config",
+                "tags",
                 "version",
                 "created_at",
                 "updated_at",

--- a/products/ai_observability/backend/migrations/0022_llmprompt_config_tags.py
+++ b/products/ai_observability/backend/migrations/0022_llmprompt_config_tags.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ai_observability", "0021_add_zeabur_provider"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="llmprompt",
+            name="config",
+            field=models.JSONField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="llmprompt",
+            name="tags",
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/products/ai_observability/backend/migrations/max_migration.txt
+++ b/products/ai_observability/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0021_add_zeabur_provider
+0022_llmprompt_config_tags

--- a/products/ai_observability/backend/models/llm_prompt.py
+++ b/products/ai_observability/backend/models/llm_prompt.py
@@ -54,6 +54,13 @@ class LLMPrompt(UUIDModel):
     # The prompt content as JSON (currently a string, may expand to array of objects)
     prompt = models.JSONField()
 
+    # Arbitrary JSON object attached to this version (e.g. model, temperature, max tokens);
+    # returned alongside the prompt at fetch time so it can drive runtime behavior
+    config = models.JSONField(null=True, blank=True)
+
+    # Prompt-level labels; kept identical across all versions of a name so any version fetch sees them
+    tags = models.JSONField(default=list, blank=True)
+
     version = models.PositiveIntegerField(default=1)
     is_latest = models.BooleanField(default=True)
 

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -2013,6 +2013,13 @@ export interface LLMPromptListApi {
     readonly name: string
     /** Prompt payload as JSON or string data. */
     readonly prompt: unknown
+    /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. */
+    readonly config: unknown
+    /**
+     * Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.
+     * @items.maxLength 255
+     */
+    tags?: string[]
     readonly version: number
     /**
      * Optional note describing what changed in this version. Set when the version is published.
@@ -2050,6 +2057,13 @@ export interface LLMPromptApi {
     name: string
     /** Prompt payload as JSON or string data. */
     prompt: unknown
+    /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. */
+    config?: unknown
+    /**
+     * Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.
+     * @items.maxLength 255
+     */
+    tags?: string[]
     readonly version: number
     /**
      * Optional note describing what changed in this version. Set when the version is published.
@@ -2075,6 +2089,13 @@ export interface LLMPromptPublicApi {
     prompt?: unknown
     /** First 160 characters of the prompt. Only present when 'content=preview'. */
     prompt_preview?: string
+    /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. */
+    config?: unknown
+    /**
+     * Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.
+     * @items.maxLength 255
+     */
+    tags?: string[]
     /** Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents. */
     outline: LLMPromptOutlineEntryApi[]
     version: number
@@ -2099,6 +2120,8 @@ export interface PatchedLLMPromptPublishApi {
     prompt?: unknown
     /** List of find/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt. */
     edits?: LLMPromptEditOperationApi[]
+    /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. If omitted, the new version keeps the config of the version it is published from. Pass null to clear it. */
+    config?: unknown
     /**
      * Latest version you are editing from. Used for optimistic concurrency checks.
      * @minimum 1
@@ -2117,6 +2140,14 @@ export interface LLMPromptDuplicateApi {
      * @maxLength 255
      */
     new_name: string
+}
+
+export interface PatchedLLMPromptUpdateTagsApi {
+    /**
+     * Full list of tags to set on the prompt, replacing any existing tags. Applies to all versions.
+     * @items.maxLength 255
+     */
+    tags?: string[]
 }
 
 export interface LLMPromptVersionSummaryApi {

--- a/products/ai_observability/frontend/generated/api.ts
+++ b/products/ai_observability/frontend/generated/api.ts
@@ -74,6 +74,7 @@ import type {
     PatchedEvaluationApi,
     PatchedEvaluationReportUpdateApi,
     PatchedLLMPromptPublishApi,
+    PatchedLLMPromptUpdateTagsApi,
     PatchedLLMProviderKeyApi,
     PatchedParserRecipeApi,
     PatchedReviewQueueItemUpdateApi,
@@ -1964,6 +1965,24 @@ export const llmPromptsNameDuplicateCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(lLMPromptDuplicateApi),
+    })
+}
+
+export const getLlmPromptsNameTagsPartialUpdateUrl = (projectId: string, promptName: string) => {
+    return `/api/projects/${projectId}/llm_prompts/name/${promptName}/tags/`
+}
+
+export const llmPromptsNameTagsPartialUpdate = async (
+    projectId: string,
+    promptName: string,
+    patchedLLMPromptUpdateTagsApi?: PatchedLLMPromptUpdateTagsApi,
+    options?: RequestInit
+): Promise<LLMPromptApi> => {
+    return apiMutator<LLMPromptApi>(getLlmPromptsNameTagsPartialUpdateUrl(projectId, promptName), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedLLMPromptUpdateTagsApi),
     })
 }
 

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -1748,6 +1748,8 @@ export const LlmAnalyticsTranslateCreateBody = /* @__PURE__ */ zod.object({
 
 export const llmPromptsCreateBodyNameMax = 255
 
+export const llmPromptsCreateBodyTagsItemMax = 255
+
 export const llmPromptsCreateBodyVersionDescriptionMax = 400
 
 export const LlmPromptsCreateBody = /* @__PURE__ */ zod.object({
@@ -1756,6 +1758,16 @@ export const LlmPromptsCreateBody = /* @__PURE__ */ zod.object({
         .max(llmPromptsCreateBodyNameMax)
         .describe('Unique prompt name using letters, numbers, hyphens, and underscores only.'),
     prompt: zod.unknown().describe('Prompt payload as JSON or string data.'),
+    config: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime.'
+        ),
+    tags: zod
+        .array(zod.string().max(llmPromptsCreateBodyTagsItemMax))
+        .optional()
+        .describe('Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.'),
     version_description: zod
         .string()
         .max(llmPromptsCreateBodyVersionDescriptionMax)
@@ -1781,6 +1793,12 @@ export const LlmPromptsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             "List of find\/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt."
         ),
+    config: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. If omitted, the new version keeps the config of the version it is published from. Pass null to clear it.'
+        ),
     base_version: zod
         .number()
         .min(1)
@@ -1795,6 +1813,8 @@ export const LlmPromptsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
 
 export const llmPromptsNameArchiveCreateBodyNameMax = 255
 
+export const llmPromptsNameArchiveCreateBodyTagsItemMax = 255
+
 export const llmPromptsNameArchiveCreateBodyVersionDescriptionMax = 400
 
 export const LlmPromptsNameArchiveCreateBody = /* @__PURE__ */ zod.object({
@@ -1803,6 +1823,16 @@ export const LlmPromptsNameArchiveCreateBody = /* @__PURE__ */ zod.object({
         .max(llmPromptsNameArchiveCreateBodyNameMax)
         .describe('Unique prompt name using letters, numbers, hyphens, and underscores only.'),
     prompt: zod.unknown().describe('Prompt payload as JSON or string data.'),
+    config: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime.'
+        ),
+    tags: zod
+        .array(zod.string().max(llmPromptsNameArchiveCreateBodyTagsItemMax))
+        .optional()
+        .describe('Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.'),
     version_description: zod
         .string()
         .max(llmPromptsNameArchiveCreateBodyVersionDescriptionMax)
@@ -1819,6 +1849,15 @@ export const LlmPromptsNameDuplicateCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Name for the duplicated prompt. Must be unique and use only letters, numbers, hyphens, and underscores.'
         ),
+})
+
+export const llmPromptsNameTagsPartialUpdateBodyTagsItemMax = 255
+
+export const LlmPromptsNameTagsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    tags: zod
+        .array(zod.string().max(llmPromptsNameTagsPartialUpdateBodyTagsItemMax))
+        .optional()
+        .describe('Full list of tags to set on the prompt, replacing any existing tags. Applies to all versions.'),
 })
 
 export const taggersCreateBodyNameMax = 400

--- a/products/ai_observability/frontend/prompts/LLMPromptsScene.tsx
+++ b/products/ai_observability/frontend/prompts/LLMPromptsScene.tsx
@@ -6,6 +6,7 @@ import { Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { MemberSelect } from 'lib/components/MemberSelect'
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -57,12 +58,24 @@ export function LLMPromptsScene(): JSX.Element {
             title: 'Prompt',
             dataIndex: 'prompt',
             key: 'prompt',
-            width: '40%',
+            width: '30%',
             render: function renderPrompt(prompt) {
                 const displayValue = typeof prompt === 'string' ? prompt : JSON.stringify(prompt)
                 const truncated = displayValue.length > 100 ? displayValue.slice(0, 100) + '...' : displayValue
 
                 return <span className="text-muted font-mono text-sm">{truncated || <i>–</i>}</span>
+            },
+        },
+        {
+            title: 'Tags',
+            dataIndex: 'tags',
+            key: 'tags',
+            width: '10%',
+            render: function renderTags(_, prompt) {
+                if (!prompt.tags?.length) {
+                    return <span className="text-secondary">—</span>
+                }
+                return <ObjectTags tags={prompt.tags} staticOnly />
             },
         },
         {

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
@@ -372,12 +372,12 @@ describe('llmPromptLogic', () => {
         expect(updateSpy).not.toHaveBeenCalled()
 
         // Real edits open the review without hitting the API
-        logic.actions.setPromptFormValues({ prompt: 'My edited prompt.' })
+        logic.actions.setPromptFormValues({ prompt: 'My edited prompt.', config: '{"model": "gpt-5"}' })
         logic.actions.requestPublish()
         expect(logic.values.isPublishReviewOpen).toBe(true)
         expect(updateSpy).not.toHaveBeenCalled()
 
-        // Confirming from the review publishes with the typed description and closes it
+        // Confirming from the review publishes with the typed description and parsed config, then closes it
         logic.actions.setVersionDescription('Tightened the refusal criteria')
         logic.actions.submitPromptForm()
         await expectLogic(logic).toDispatchActions(['submitPromptFormSuccess'])
@@ -385,6 +385,7 @@ describe('llmPromptLogic', () => {
         expect(updateSpy).toHaveBeenCalledWith('my-test-prompt', {
             prompt: 'My edited prompt.',
             base_version: 2,
+            config: { model: 'gpt-5' },
             version_description: 'Tightened the refusal criteria',
         })
         expect(logic.values.isPublishReviewOpen).toBe(false)

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
@@ -9,7 +9,7 @@ import { EventsQuery, NodeKind, TracesQuery } from '~/queries/schema/schema-gene
 import { initKeaTests } from '~/test/init'
 import { LLMPrompt, LLMPromptResolveResponse, PropertyFilterType, PropertyOperator } from '~/types'
 
-import { PromptAnalyticsScope, PromptMode, llmPromptLogic } from './llmPromptLogic'
+import { PromptAnalyticsScope, PromptMode, ResolvedLLMPrompt, llmPromptLogic } from './llmPromptLogic'
 
 const mockPrompt = {
     id: 'prompt-version-2',
@@ -321,6 +321,53 @@ describe('llmPromptLogic', () => {
         dialogSpy.mock.calls[0][0].primaryButton?.onClick?.(undefined as any)
         expect(logic.values.mode).toBe(PromptMode.View)
         expect(logic.values.promptForm.prompt).toBe(mockPrompt.prompt)
+
+        // A config-only edit is also dirty and must get the same confirmation
+        logic.actions.setMode(PromptMode.Edit)
+        logic.actions.setPromptFormValues({ config: '{"model": "gpt-5"}' })
+        logic.actions.cancelEditing()
+        expect(logic.values.mode).toBe(PromptMode.Edit)
+        expect(dialogSpy).toHaveBeenCalledTimes(2)
+
+        logic.unmount()
+    })
+
+    it('applies tag saves optimistically and reverts on failure', async () => {
+        const { versions, has_more, ...promptFields } = mockPrompt
+        jest.spyOn(api.llmPrompts, 'resolveByName').mockResolvedValue({
+            prompt: { ...promptFields, tags: ['old'] },
+            versions,
+            has_more,
+        } as unknown as LLMPromptResolveResponse)
+
+        const logic = llmPromptLogic({ promptName: 'my-test-prompt' })
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['loadPromptSuccess'])
+
+        // Success: tags apply before the request resolves (so consecutive edits compose),
+        // then reconcile to the server-normalized list
+        let resolveUpdate: (prompt: LLMPrompt) => void = () => {}
+        jest.spyOn(api.llmPrompts, 'updateTagsByName').mockImplementationOnce(
+            () => new Promise<LLMPrompt>((resolve) => (resolveUpdate = resolve))
+        )
+        logic.actions.saveTags(['old', ' Fresh '])
+        expect((logic.values.prompt as ResolvedLLMPrompt).tags).toEqual(['old', ' Fresh '])
+        expect(logic.values.tagsSaving).toBe(true)
+
+        resolveUpdate({ ...promptFields, tags: ['old', 'fresh'] } as unknown as LLMPrompt)
+        await expectLogic(logic).toFinishAllListeners()
+        expect((logic.values.prompt as ResolvedLLMPrompt).tags).toEqual(['old', 'fresh'])
+        expect(logic.values.tagsSaving).toBe(false)
+
+        // Failure: reverts to the pre-save tags and clears the saving state
+        jest.spyOn(api.llmPrompts, 'updateTagsByName').mockRejectedValueOnce(
+            new ApiError('boom', 500, undefined, { detail: 'Server error' })
+        )
+        logic.actions.saveTags(['old', 'fresh', 'broken'])
+        expect((logic.values.prompt as ResolvedLLMPrompt).tags).toEqual(['old', 'fresh', 'broken'])
+        await expectLogic(logic).toFinishAllListeners()
+        expect((logic.values.prompt as ResolvedLLMPrompt).tags).toEqual(['old', 'fresh'])
+        expect(logic.values.tagsSaving).toBe(false)
 
         logic.unmount()
     })

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.test.ts
@@ -7,11 +7,13 @@ import api from '~/lib/api'
 import { ApiError } from '~/lib/api-error'
 import { EventsQuery, NodeKind, TracesQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { LLMPrompt, LLMPromptResolveResponse, PropertyFilterType, PropertyOperator } from '~/types'
+import { LLMPrompt, LLMPromptResolveResponse, PropertyFilterType, PropertyOperator, UserBasicType } from '~/types'
 
 import { PromptAnalyticsScope, PromptMode, ResolvedLLMPrompt, llmPromptLogic } from './llmPromptLogic'
 
-const mockPrompt = {
+const mockUser = { id: 1, email: 'test@example.com' } as UserBasicType
+
+const mockPrompt: ResolvedLLMPrompt = {
     id: 'prompt-version-2',
     name: 'my-test-prompt',
     prompt: 'You are a helpful assistant.',
@@ -23,19 +25,19 @@ const mockPrompt = {
     deleted: false,
     created_at: '2024-01-02T00:00:00Z',
     updated_at: '2024-01-02T00:00:00Z',
-    created_by: { id: 1, email: 'test@example.com' },
+    created_by: mockUser,
     versions: [
         {
             id: 'prompt-version-2',
             version: 2,
-            created_by: { id: 1, email: 'test@example.com' },
+            created_by: mockUser,
             created_at: '2024-01-02T00:00:00Z',
             is_latest: true,
         },
         {
             id: 'prompt-version-1',
             version: 1,
-            created_by: { id: 1, email: 'test@example.com' },
+            created_by: mockUser,
             created_at: '2024-01-01T00:00:00Z',
             is_latest: false,
         },

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -44,7 +44,14 @@ import {
 import type { llmPromptLogicType } from './llmPromptLogicType'
 import { llmPromptsLogic } from './llmPromptsLogic'
 import { LLM_PROMPTS_FORCE_RELOAD_PARAM } from './llmPromptsLogic'
-import { getApiErrorDetail, openDiscardChangesDialog, validatePromptName } from './utils'
+import {
+    formatPromptConfig,
+    getApiErrorDetail,
+    openDiscardChangesDialog,
+    parsePromptConfig,
+    validatePromptConfig,
+    validatePromptName,
+} from './utils'
 
 export enum PromptMode {
     View = 'view',
@@ -65,6 +72,9 @@ export interface PromptLogicProps {
 export interface PromptFormValues {
     name: string
     prompt: string
+    /** JSON object as text; empty string means no config */
+    config: string
+    tags: string[]
 }
 
 export interface ResolvedLLMPrompt extends LLMPrompt {
@@ -79,6 +89,8 @@ export function isPrompt(prompt: LLMPrompt | ResolvedLLMPrompt | PromptFormValue
 const DEFAULT_PROMPT_FORM_VALUES: PromptFormValues = {
     name: '',
     prompt: '',
+    config: '',
+    tags: [],
 }
 
 const PROMPT_FETCHED_EVENT = '$llm_prompt_fetched'
@@ -171,6 +183,8 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
         closePublishReview: true,
         setVersionDescription: (versionDescription: string) => ({ versionDescription }),
         setSnippetLanguage: (snippetLanguage: PromptSnippetLanguage) => ({ snippetLanguage }),
+        saveTags: (tags: string[]) => ({ tags }),
+        setTagsSaving: (tagsSaving: boolean) => ({ tagsSaving }),
     }),
 
     reducers(({ props }) => ({
@@ -268,6 +282,13 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 setSnippetLanguage: (_, { snippetLanguage }) => snippetLanguage,
             },
         ],
+        tagsSaving: [
+            false,
+            {
+                saveTags: () => true,
+                setTagsSaving: (_, { tagsSaving }) => tagsSaving,
+            },
+        ],
     })),
 
     loaders(({ props }) => ({
@@ -292,9 +313,10 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             defaults: DEFAULT_PROMPT_FORM_VALUES,
             options: { showErrorsOnTouch: true },
 
-            errors: ({ name, prompt }) => ({
+            errors: ({ name, prompt, config }) => ({
                 name: validatePromptName(name),
                 prompt: !prompt?.trim() ? 'Prompt content is required' : undefined,
+                config: validatePromptConfig(config),
             }),
 
             submit: async (formValues) => {
@@ -307,6 +329,8 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                         savedPrompt = await api.llmPrompts.create({
                             name: formValues.name,
                             prompt: formValues.prompt,
+                            config: parsePromptConfig(formValues.config),
+                            tags: formValues.tags,
                         })
                         llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
                         lemonToast.success('Prompt created successfully')
@@ -327,6 +351,8 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                         savedPrompt = await api.llmPrompts.update(props.promptName, {
                             prompt: formValues.prompt,
                             base_version: currentPrompt.latest_version,
+                            // Always sent so that clearing the config editor clears the config
+                            config: parsePromptConfig(formValues.config),
                             ...(versionDescription ? { version_description: versionDescription } : {}),
                         })
                         llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
@@ -410,9 +436,11 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             (s) => [s.promptForm, s.prompt, s.isNewPrompt],
             (promptForm, prompt, isNewPrompt): boolean => {
                 if (isNewPrompt) {
-                    return !!promptForm.name.trim() || !!promptForm.prompt.trim()
+                    return !!promptForm.name.trim() || !!promptForm.prompt.trim() || !!promptForm.config.trim()
                 }
-                return isPrompt(prompt) ? promptForm.prompt !== prompt.prompt : false
+                return isPrompt(prompt)
+                    ? promptForm.prompt !== prompt.prompt || promptForm.config !== formatPromptConfig(prompt.config)
+                    : false
             },
         ],
 
@@ -738,6 +766,25 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             }
         },
 
+        saveTags: async ({ tags }) => {
+            if (props.promptName === 'new' || !isPrompt(values.prompt)) {
+                actions.setTagsSaving(false)
+                return
+            }
+
+            try {
+                const updatedPrompt = await api.llmPrompts.updateTagsByName(props.promptName, tags)
+                if (isPrompt(values.prompt)) {
+                    actions.setPrompt({ ...values.prompt, tags: updatedPrompt.tags ?? [] })
+                }
+                llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
+            } catch (error) {
+                lemonToast.error(getApiErrorDetail(error) || 'Failed to update tags')
+            } finally {
+                actions.setTagsSaving(false)
+            }
+        },
+
         deletePrompt: async () => {
             if (props.promptName !== 'new' && values.prompt && isPrompt(values.prompt)) {
                 try {
@@ -911,6 +958,8 @@ function getPromptFormDefaults(prompt: LLMPrompt): PromptFormValues {
     return {
         name: prompt.name,
         prompt: prompt.prompt,
+        config: formatPromptConfig(prompt.config),
+        tags: prompt.tags ?? [],
     }
 }
 

--- a/products/ai_observability/frontend/prompts/llmPromptLogic.ts
+++ b/products/ai_observability/frontend/prompts/llmPromptLogic.ts
@@ -436,7 +436,12 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
             (s) => [s.promptForm, s.prompt, s.isNewPrompt],
             (promptForm, prompt, isNewPrompt): boolean => {
                 if (isNewPrompt) {
-                    return !!promptForm.name.trim() || !!promptForm.prompt.trim() || !!promptForm.config.trim()
+                    return (
+                        !!promptForm.name.trim() ||
+                        !!promptForm.prompt.trim() ||
+                        !!promptForm.config.trim() ||
+                        promptForm.tags.length > 0
+                    )
                 }
                 return isPrompt(prompt)
                     ? promptForm.prompt !== prompt.prompt || promptForm.config !== formatPromptConfig(prompt.config)
@@ -772,6 +777,12 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 return
             }
 
+            // Apply optimistically: the tag editor composes each edit from the current tags, so
+            // waiting for the response would make a second edit during an in-flight save start
+            // from a stale array and silently drop the first edit.
+            const previousTags = values.prompt.tags ?? []
+            actions.setPrompt({ ...values.prompt, tags })
+
             try {
                 const updatedPrompt = await api.llmPrompts.updateTagsByName(props.promptName, tags)
                 if (isPrompt(values.prompt)) {
@@ -779,6 +790,9 @@ export const llmPromptLogic = kea<llmPromptLogicType>([
                 }
                 llmPromptsLogic.findMounted()?.actions.loadPrompts(false)
             } catch (error) {
+                if (isPrompt(values.prompt)) {
+                    actions.setPrompt({ ...values.prompt, tags: previousTags })
+                }
                 lemonToast.error(getApiErrorDetail(error) || 'Failed to update tags')
             } finally {
                 actions.setTagsSaving(false)

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -16,6 +16,7 @@ import {
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { dayjs } from 'lib/dayjs'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -69,9 +70,9 @@ function PromptOutline({
 }
 
 export function PromptViewDetails(): JSX.Element {
-    const { prompt, isRenderingMarkdown, isDiffVisible, canCompareVersions, compareVersionOptions } =
+    const { prompt, isRenderingMarkdown, isDiffVisible, canCompareVersions, compareVersionOptions, tagsSaving } =
         useValues(llmPromptLogic)
-    const { toggleMarkdownRendering, setCompareVersion } = useActions(llmPromptLogic)
+    const { toggleMarkdownRendering, setCompareVersion, saveTags } = useActions(llmPromptLogic)
     const markdownContainerRef = useRef<HTMLDivElement>(null)
 
     if (!prompt || !isPrompt(prompt)) {
@@ -113,6 +114,17 @@ export function PromptViewDetails(): JSX.Element {
             <div>
                 <label className="text-xs font-semibold uppercase text-secondary">Name</label>
                 <p className="font-mono">{prompt.name}</p>
+            </div>
+
+            <div>
+                <label className="text-xs font-semibold uppercase text-secondary">Tags</label>
+                <ObjectTags
+                    className="mt-1"
+                    tags={prompt.tags ?? []}
+                    onChange={(tags) => saveTags(tags)}
+                    saving={tagsSaving}
+                    data-attr="llma-prompt-tags"
+                />
             </div>
 
             <div>
@@ -168,6 +180,17 @@ export function PromptViewDetails(): JSX.Element {
                     </pre>
                 )}
             </div>
+
+            {prompt.config ? (
+                <div>
+                    <label className="text-xs font-semibold uppercase text-secondary">Config</label>
+                    <div className="mt-1 max-w-3xl" data-attr="llma-prompt-config">
+                        <CodeSnippet language={Language.JSON} compact>
+                            {JSON.stringify(prompt.config, null, 2)}
+                        </CodeSnippet>
+                    </div>
+                </div>
+            ) : null}
 
             <div className="grid max-w-3xl gap-3 text-sm text-secondary sm:grid-cols-2">
                 <div>Published {dayjs(prompt.created_at).format('MMM D, YYYY h:mm A')}</div>
@@ -759,6 +782,38 @@ export function PromptEditForm({
                     ))}
                 </div>
             )}
+
+            <LemonField
+                name="config"
+                label="Config"
+                help={
+                    'Optional JSON object stored with this version and returned when fetching the prompt, e.g. {"model": "gpt-5", "temperature": 0.2}. Use it to change model parameters at runtime without deploying.'
+                }
+            >
+                <LemonTextArea
+                    placeholder={'{"model": "gpt-5", "temperature": 0.2, "max_tokens": 1024}'}
+                    minRows={3}
+                    className="font-mono"
+                    data-attr="llma-prompt-config-input"
+                />
+            </LemonField>
+
+            {isNewPrompt ? (
+                <LemonField
+                    name="tags"
+                    label="Tags"
+                    help="Tags apply to the prompt as a whole, across all of its versions."
+                >
+                    {({ value, onChange }) => (
+                        <ObjectTags
+                            tags={value || []}
+                            onChange={(tags) => onChange(tags)}
+                            saving={false}
+                            data-attr="llma-prompt-tags-input"
+                        />
+                    )}
+                </LemonField>
+            ) : null}
         </div>
     )
 }

--- a/products/ai_observability/frontend/prompts/utils.test.ts
+++ b/products/ai_observability/frontend/prompts/utils.test.ts
@@ -1,0 +1,17 @@
+import { validatePromptConfig } from './utils'
+
+describe('validatePromptConfig', () => {
+    // Guards the JSON-object contract with the API: arrays/scalars are rejected server-side,
+    // and an empty editor must not block publishing.
+    test.each([
+        ['empty string', '', undefined],
+        ['whitespace only', '   ', undefined],
+        ['valid object', '{"model": "gpt-5", "temperature": 0.2}', undefined],
+        ['array', '[1, 2]', 'Config must be a JSON object, e.g. {"model": "gpt-5", "temperature": 0.2}'],
+        ['scalar', '42', 'Config must be a JSON object, e.g. {"model": "gpt-5", "temperature": 0.2}'],
+        ['null literal', 'null', 'Config must be a JSON object, e.g. {"model": "gpt-5", "temperature": 0.2}'],
+        ['invalid JSON', '{model: gpt-5}', 'Config must be valid JSON'],
+    ])('%s', (_label, config, expected) => {
+        expect(validatePromptConfig(config)).toBe(expected)
+    })
+})

--- a/products/ai_observability/frontend/prompts/utils.ts
+++ b/products/ai_observability/frontend/prompts/utils.ts
@@ -18,6 +18,34 @@ export function validatePromptName(name: string | undefined): string | undefined
     return undefined
 }
 
+export function validatePromptConfig(config: string | undefined): string | undefined {
+    if (!config?.trim()) {
+        return undefined
+    }
+    try {
+        const parsed = JSON.parse(config)
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return 'Config must be a JSON object, e.g. {"model": "gpt-5", "temperature": 0.2}'
+        }
+    } catch {
+        return 'Config must be valid JSON'
+    }
+    return undefined
+}
+
+/** Parse the config editor's text into the API payload value. Empty text means "no config" (null). */
+export function parsePromptConfig(config: string | undefined): Record<string, any> | null {
+    if (!config?.trim()) {
+        return null
+    }
+    return JSON.parse(config)
+}
+
+/** Format a prompt's stored config for the JSON text editor. */
+export function formatPromptConfig(config: Record<string, any> | null | undefined): string {
+    return config ? JSON.stringify(config, null, 2) : ''
+}
+
 export function getApiErrorDetail(error: unknown): string | undefined {
     if (error !== null && typeof error === 'object' && 'detail' in error && typeof error.detail === 'string') {
         return error.detail

--- a/products/ai_observability/mcp/tools.yaml
+++ b/products/ai_observability/mcp/tools.yaml
@@ -32,6 +32,9 @@ tools:
     llm-analytics-parser-recipes-retrieve:
         operation: llm_analytics_parser_recipes_retrieve
         enabled: false
+    llm-prompts-name-tags-partial-update:
+        operation: llm_prompts_name_tags_partial_update
+        enabled: false
     llma-clustering-config-get:
         operation: llm_analytics_clustering_config_list
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -29775,6 +29775,13 @@ export namespace Schemas {
       name: string;
       /** Prompt payload as JSON or string data. */
       prompt: unknown;
+      /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. */
+      config?: unknown;
+      /**
+         * Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.
+         * @items.maxLength 255
+         */
+      tags?: string[];
       readonly version: number;
       /**
          * Optional note describing what changed in this version. Set when the version is published.
@@ -29814,6 +29821,13 @@ export namespace Schemas {
       readonly name: string;
       /** Prompt payload as JSON or string data. */
       readonly prompt: unknown;
+      /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. */
+      readonly config: unknown;
+      /**
+         * Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.
+         * @items.maxLength 255
+         */
+      tags?: string[];
       readonly version: number;
       /**
          * Optional note describing what changed in this version. Set when the version is published.
@@ -29840,6 +29854,13 @@ export namespace Schemas {
       prompt?: unknown;
       /** First 160 characters of the prompt. Only present when 'content=preview'. */
       prompt_preview?: string;
+      /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. */
+      config?: unknown;
+      /**
+         * Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.
+         * @items.maxLength 255
+         */
+      tags?: string[];
       /** Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents. */
       outline: LLMPromptOutlineEntry[];
       version: number;
@@ -40781,6 +40802,8 @@ export namespace Schemas {
       prompt?: unknown;
       /** List of find/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt. */
       edits?: LLMPromptEditOperation[];
+      /** Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. If omitted, the new version keeps the config of the version it is published from. Pass null to clear it. */
+      config?: unknown;
       /**
          * Latest version you are editing from. Used for optimistic concurrency checks.
          * @minimum 1
@@ -40791,6 +40814,14 @@ export namespace Schemas {
          * @maxLength 400
          */
       version_description?: string;
+    }
+
+    export interface PatchedLLMPromptUpdateTags {
+      /**
+         * Full list of tags to set on the prompt, replacing any existing tags. Applies to all versions.
+         * @items.maxLength 255
+         */
+      tags?: string[];
     }
 
     export interface PatchedLLMProviderKey {

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -1575,6 +1575,8 @@ export const LlmPromptsCreateParams = /* @__PURE__ */ zod.object({
 
 export const llmPromptsCreateBodyNameMax = 255
 
+export const llmPromptsCreateBodyTagsItemMax = 255
+
 export const llmPromptsCreateBodyVersionDescriptionMax = 400
 
 export const LlmPromptsCreateBody = /* @__PURE__ */ zod.object({
@@ -1583,6 +1585,16 @@ export const LlmPromptsCreateBody = /* @__PURE__ */ zod.object({
         .max(llmPromptsCreateBodyNameMax)
         .describe('Unique prompt name using letters, numbers, hyphens, and underscores only.'),
     prompt: zod.unknown().describe('Prompt payload as JSON or string data.'),
+    config: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime.'
+        ),
+    tags: zod
+        .array(zod.string().max(llmPromptsCreateBodyTagsItemMax))
+        .optional()
+        .describe('Tags attached to the prompt. Tags apply to the prompt as a whole, across all of its versions.'),
     version_description: zod
         .string()
         .max(llmPromptsCreateBodyVersionDescriptionMax)
@@ -1645,6 +1657,12 @@ export const LlmPromptsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
         .optional()
         .describe(
             "List of find/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt."
+        ),
+    config: zod
+        .unknown()
+        .optional()
+        .describe(
+            'Optional JSON object with arbitrary configuration for this prompt version (e.g. model, temperature, max tokens). Returned alongside the prompt when it is fetched at runtime. If omitted, the new version keeps the config of the version it is published from. Pass null to clear it.'
         ),
     base_version: zod
         .number()

--- a/services/mcp/src/tools/generated/ai_observability.ts
+++ b/services/mcp/src/tools/generated/ai_observability.ts
@@ -732,7 +732,7 @@ const llmaPersonalSpend = (): ToolBase<typeof LlmaPersonalSpendSchema, Schemas.P
     },
 })
 
-const LlmaPromptCreateSchema = LlmPromptsCreateBody
+const LlmaPromptCreateSchema = LlmPromptsCreateBody.omit({ config: true, tags: true })
 
 const llmaPromptCreate = (): ToolBase<typeof LlmaPromptCreateSchema, Schemas.LLMPrompt> => ({
     name: 'llma-prompt-create',
@@ -828,7 +828,7 @@ const llmaPromptList = (): ToolBase<
 })
 
 const LlmaPromptUpdateSchema = LlmPromptsNamePartialUpdateParams.omit({ project_id: true }).extend(
-    LlmPromptsNamePartialUpdateBody.shape
+    LlmPromptsNamePartialUpdateBody.omit({ config: true }).shape
 )
 
 const llmaPromptUpdate = (): ToolBase<typeof LlmaPromptUpdateSchema, Schemas.LLMPrompt> => ({


### PR DESCRIPTION
## Problem

Teams migrating from other prompt management tools (e.g. Langfuse) expect two capabilities the Prompts product doesn't have yet:

- **Config**: an arbitrary JSON object stored with each prompt version (model, max tokens, temperature, thinking level, ...) so runtime behavior can be changed from PostHog without deploying.
- **Tags**: a list of strings on a prompt for organizing and scanning the prompt list.

Requested via a user feedback ticket as the last blocker for a full migration to PostHog prompt management.

## Changes

Backend:

- New `config` (nullable JSON object, per version) and `tags` (string list, kept identical across all versions of a name) fields on `LLMPrompt`, with an additive migration.
- Create accepts `config` and `tags`. Publish (`PATCH .../llm_prompts/name/<name>/`) accepts `config`: omitted carries the previous version's config forward, `null` clears it, and a config-only publish (no prompt/edits) is now allowed. Tags always carry over to the new version.
- New `PATCH .../llm_prompts/name/<name>/tags/` action sets tags across all versions without publishing a new version (`llm_prompt:write` scope).
- Runtime fetch (`GET .../llm_prompts/name/<name>/`) returns `config` and `tags`, including through the HyperCache layer: version-exact cache entries carry the version's config, while tags merge in from the latest entry so tag edits don't require per-version invalidation. Duplicate copies both.
- Tags are normalized like the global tag system (trimmed, lowercased, deduped), capped at 50 tags / 255 chars each; config is capped at 100 KB and must be a JSON object.

Frontend:

- Prompt editor gains a Config JSON field (validated client-side) and, for new prompts, a Tags field.
- Prompt detail view shows the config and lets you edit tags inline (no version bump); the prompts list shows a Tags column.

Design note: tags are stored denormalized on the prompt rows rather than through `TaggedItem`, because prompt versioning stores one row per version (a `TaggedItem` FK would pin tags to a single version row) and matching the versioned-row semantics avoids a multi-phase migration on the shared tagged-items table.

## How did you test this code?

Automated tests only; this environment has no database or node runtime, so the new tests run in CI:

- `test_create_prompt_with_config_and_tags` / `test_create_prompt_rejects_non_object_config`: create-path wiring for the new fields and normalization (would catch the serializer not passing them through).
- `test_publish_config_semantics_across_versions` / `test_publish_config_only_creates_new_version_with_same_prompt`: the omit-carries-forward / null-clears / config-only-publish branches in `publish_prompt_version`.
- `test_update_tags_endpoint_updates_all_versions_without_publishing` (+404 case): the new endpoint updates every version row without bumping the version.
- `test_fetch_prompt_by_name_reflects_tag_updates_despite_cache`: bulk tag updates bypass the post_save signal, so this guards the explicit cache invalidation.
- `test_fetch_historical_version_returns_version_config_and_current_tags`: version-exact cache entries keep their own config while tags merge from the latest entry.
- `test_duplicate_prompt_copies_config_and_tags`: duplicate service copying the new fields.
- `TestLLMPromptPublishSerializerValidationNoDB`: no-DB validation matrix for config shape/size and tag count.
- Jest: extended the existing publish test to assert the parsed config is sent, and added a parameterized test for `validatePromptConfig` (rejecting arrays/scalars while allowing an empty editor).

Not run here (needs follow-up in CI or locally): `hogli build:openapi` to regenerate OpenAPI/frontend types from the serializer changes, and `pnpm --filter=@posthog/frontend format` / typecheck.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

posthog.com/docs/prompt-management lives in the website repo; the new `config`/`tags` API fields will need a docs follow-up there.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored with PostHog Code (Claude Code) from a user feedback ticket asking for Langfuse-style prompt configs and tags.
- Skills invoked: /improving-drf-endpoints, /django-migrations, /adopting-generated-api-types, /writing-tests.
- Considered wiring tags through the shared `TaggedItem` model, but rejected it: prompts store one row per version, so relational tags would attach to a single version row and need re-pointing on every publish, and extending `TaggedItem` requires a three-migration concurrent-index dance on a shared table. Denormalized tags synced across a name's rows match the product's versioning model (and Langfuse's own storage).
- Publish deliberately does not accept `tags` (tags are not versioned); the dedicated tags action is the only tag mutation path besides create.
- MCP `tools.yaml` (`llma-prompt-create` `include_params`) was intentionally left unchanged since MCP schema codegen couldn't run in this environment; exposing `config`/`tags` to the MCP create tool is a small follow-up.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*