### PR TITLE
feat(sharing): resolve public shares against the team's default access rules

### DIFF
--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -36,6 +36,8 @@ from products.dashboards.backend.models.dashboard_widget import DashboardWidget
 from products.exports.backend.models.exported_asset import ExportedAsset, get_render_access_token
 from products.product_analytics.backend.models.insight import Insight
 
+from ee.models.rbac.access_control import AccessControl
+
 
 def mock_exporter_template(test_func):
     """
@@ -1723,6 +1725,20 @@ class TestSharedLinkWarehouseExecution(APIBaseTest):
         tiles = response.json()["dashboard"]["tiles"]
         assert len(tiles) == 1
         assert tiles[0]["insight"]["result"], tiles[0]["insight"].get("result_error")
+
+    def test_shared_link_fails_closed_on_default_denied_table(self):
+        AccessControl.objects.create(team=self.team, resource="warehouse_objects", access_level="none")
+        config = SharingConfiguration.objects.create(team=self.team, insight=self.insight, enabled=True)
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/{self.insight.id}/"
+            f"?sharing_access_token={config.access_token}&refresh=blocking"
+        )
+
+        # A default of none is what an anonymous viewer resolves - the link fails closed even
+        # though members with grants could still query the table in-app.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert "You don't have access to table `governed_view`" in str(response.json())
 
     def test_shared_notebook_inline_warehouse_query_executes(self):
         from products.notebooks.backend.models import Notebook

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -148,6 +148,7 @@ from posthog.models.group_type_mapping import get_group_types_for_project
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team, WeekStartDay
 from posthog.ph_client import feature_enabled_or_false
+from posthog.rbac.team_default_access import TeamDefaultAccess, for_shared_link_user
 from posthog.rbac.user_access_control import NO_ACCESS_LEVEL, UserAccessControl
 from posthog.schema_enums import DatabaseSerializedFieldType, PersonsOnEventsMode, SessionTableVersion
 from posthog.scopes import APIScopeObject
@@ -217,6 +218,9 @@ class HogQLDatabaseSources:
     # Access-control decision, computed from a warmed UserAccessControl so build does no AC queries.
     user_access_control: Optional["UserAccessControl"]
     denied_system_table_names: set[str]  # node names under the "system" node to remove during build
+    # Default warehouse rules, preloaded for shared-link viewers - they resolve these instead of
+    # member/role rules (None for every other principal).
+    team_default_access: Optional["TeamDefaultAccess"]
     group_types: list[dict[str, Any]]
     saved_queries: list["DataWarehouseSavedQuery"]
     endpoint_saved_queries: list["DataWarehouseSavedQuery"]
@@ -537,6 +541,7 @@ class Database(BaseModel):
         self._data_warehouse_sync_warnings = {}
         self._serialization_errors: dict[str, str] = {}  # table_key -> error_message
         self.user_access_control: Optional[UserAccessControl] = None
+        self.team_default_access: Optional[TeamDefaultAccess] = None
 
     def get_timezone(self) -> str:
         return self._timezone or "UTC"
@@ -780,12 +785,17 @@ class Database(BaseModel):
     def _is_warehouse_table_denied(self, table: "DataWarehouseTable") -> bool:
         """
         Returns True if the user can't query this warehouse table.
-        Userless context (no UserAccessControl) fails closed - every table is denied.
+        Shared-link viewers resolve the table's default access (member/role rules don't bind an
+        anonymous viewer). Userless context (no UserAccessControl) fails closed - every table is denied.
         """
-        uac = self.user_access_control
-        if uac is not None and (
-            uac.is_organization_admin or uac.check_access_level_for_object(table, required_level="viewer")
-        ):
+        if self.team_default_access is not None:
+            allowed = not self.team_default_access.is_denied("warehouse_table", str(table.id))
+        else:
+            uac = self.user_access_control
+            allowed = uac is not None and (
+                uac.is_organization_admin or uac.check_access_level_for_object(table, required_level="viewer")
+            )
+        if allowed:
             return False
 
         # Add table names to denied tables so the query raises "You don't have access" instead of "Unknown table"
@@ -802,10 +812,14 @@ class Database(BaseModel):
         through a non-materialized view that references it.
         Userless context (no UserAccessControl) fails closed - every view is denied.
         """
-        uac = self.user_access_control
-        if uac is not None and (
-            uac.is_organization_admin or uac.check_access_level_for_object(saved_query, required_level="viewer")
-        ):
+        if self.team_default_access is not None:
+            allowed = not self.team_default_access.is_denied("warehouse_view", str(saved_query.id))
+        else:
+            uac = self.user_access_control
+            allowed = uac is not None and (
+                uac.is_organization_admin or uac.check_access_level_for_object(saved_query, required_level="viewer")
+            )
+        if allowed:
             return False
 
         # Add view names to denied tables so the query raises "You don't have access" instead of "Unknown table"
@@ -1317,6 +1331,15 @@ class Database(BaseModel):
                     except DataWarehouseSavedQuery.DoesNotExist:
                         event_modifier_saved_queries[name] = None
 
+        # Shared-link viewers resolve warehouse access against the team's default rules (no
+        # member/role rules to match). The snapshot is memoized on the principal, so a dashboard's
+        # tiles and their cache fingerprints all share one load per request.
+        team_default_access = (
+            for_shared_link_user(user, team)
+            if isinstance(user, SharedLinkUser) and is_hogql_warehouse_access_control_enabled
+            else None
+        )
+
         return HogQLDatabaseSources(
             team=team,
             user=user,
@@ -1324,15 +1347,13 @@ class Database(BaseModel):
             modifiers=modifiers,
             is_managed_viewset_enabled=is_managed_viewset_enabled,
             is_hogql_warehouse_access_control_enabled=is_hogql_warehouse_access_control_enabled,
-            # Principals that skip warehouse access control by design:
-            # - synthetic users (project-wide service tokens, bypass object-level RBAC)
-            # - shared-link users (publishing is the explicit access grant).
-            # System tables stay gated for both.
-            bypass_warehouse_access_control=bypass_warehouse_access_control
-            or isinstance(user, SyntheticUser | SharedLinkUser),
+            # Synthetic users (project-wide service tokens) bypass object-level RBAC by design, so
+            # they skip warehouse access control too. System tables stay gated for them.
+            bypass_warehouse_access_control=bypass_warehouse_access_control or isinstance(user, SyntheticUser),
             direct_connection_metadata=direct_connection_metadata,
             user_access_control=user_access_control,
             denied_system_table_names=denied_system_table_names,
+            team_default_access=team_default_access,
             group_types=group_types,
             saved_queries=saved_queries,
             endpoint_saved_queries=endpoint_saved_queries,
@@ -1374,6 +1395,7 @@ class Database(BaseModel):
 
         with timings.measure("filter_system_tables_for_user", emit_span=True):
             database._apply_system_table_access(sources.user_access_control, sources.denied_system_table_names)
+            database.team_default_access = sources.team_default_access
 
         with timings.measure("modifiers", emit_span=True):
             if not database._is_direct_query():

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -3,6 +3,8 @@ from typing import cast
 from posthog.test.base import BaseTest
 from unittest.mock import Mock, patch
 
+from parameterized import parameterized
+
 from posthog.schema import HogQLQuery
 
 from posthog.hogql import ast
@@ -773,7 +775,9 @@ class TestWarehouseViewAccessControl(BaseTest):
         assert "denied_view" not in database._denied_tables
         assert "allowed_view" not in database._denied_tables
 
-    def test_shared_link_user_skips_warehouse_view_acl_but_hides_system_tables(self):
+    def test_shared_link_user_ignores_member_rules_but_hides_system_tables(self):
+        # A member-specific deny doesn't bind an anonymous viewer - the link resolves the
+        # table's default access, and with no default rules that's editor.
         self._create_ac(
             resource="warehouse_view",
             resource_id=str(self.denied_view.id),
@@ -784,19 +788,36 @@ class TestWarehouseViewAccessControl(BaseTest):
 
         database = Database.create_for(team=self.team, user=viewer)
 
-        # A shared-link viewer executes without warehouse access control - the deny is skipped.
         assert "denied_view" not in database._denied_tables
         assert "allowed_view" not in database._denied_tables
-        # But scoped system tables stay hidden, exactly like a userless build.
+        # Scoped system tables stay hidden, exactly like a userless build.
         assert "system.dashboards" in database._denied_tables
+
+    @parameterized.expand([("object_default",), ("resource_default",)])
+    def test_shared_link_user_denied_by_default_rules(self, case: str):
+        if case == "object_default":
+            self._create_ac(resource="warehouse_view", resource_id=str(self.denied_view.id), access_level="none")
+        else:
+            self._create_ac(resource="warehouse_objects", access_level="none")
+        viewer = SharedLinkUser(SharingConfiguration(team=self.team, enabled=True))
+
+        database = Database.create_for(team=self.team, user=viewer)
+
+        # Default rules are exactly what an anonymous viewer resolves - a default none is
+        # enforced on the public link even though members with grants could still query.
+        assert "denied_view" in database._denied_tables
+        if case == "object_default":
+            assert "allowed_view" not in database._denied_tables
+        else:
+            assert "allowed_view" in database._denied_tables
 
     def test_shared_link_user_requires_enabled_configuration(self):
         with self.assertRaises(ValueError):
             SharedLinkUser(SharingConfiguration(team=self.team, enabled=False))
 
     def test_shared_link_cache_key_differs_from_denied_member(self):
-        # Resource-level deny: no per-object IDs land in the cache payload, so the restriction
-        # lists alone must keep the two principals' cache keys apart.
+        # Resource-level default deny: the shared viewer partitions on the team's default-rule
+        # state (shared_default_access payload key), the member on their restriction lists.
         self._create_ac(resource="warehouse_objects", access_level="none")
         query = HogQLQuery(query="SELECT id FROM denied_view")
         shared_user = cast(User, SharedLinkUser(SharingConfiguration(team=self.team, enabled=True)))
@@ -815,6 +836,21 @@ class TestWarehouseViewAccessControl(BaseTest):
             get_query_runner(events_query, self.team, user=shared_user).get_cache_key()
             == get_query_runner(events_query, self.team, user=self.user).get_cache_key()
         )
+
+    def test_shared_link_cache_key_changes_when_defaults_change(self):
+        query = HogQLQuery(query="SELECT id FROM allowed_view")
+        config = SharingConfiguration(team=self.team, enabled=True)
+        viewer_before = cast(User, SharedLinkUser(config))
+        key_before = get_query_runner(query, self.team, user=viewer_before).get_cache_key()
+
+        self._create_ac(resource="warehouse_objects", access_level="none")
+
+        # The shared fingerprint keys on the team's default-rule state, so a new default rule
+        # orphans every previously cached shared result - revocation propagates through the
+        # cache instead of waiting out the TTL. A fresh principal models the next request (the
+        # rules snapshot is memoized per principal, i.e. per request).
+        viewer_after = cast(User, SharedLinkUser(config))
+        assert get_query_runner(query, self.team, user=viewer_after).get_cache_key() != key_before
 
     def test_synthetic_principal_skips_warehouse_view_acl(self):
         self._create_ac(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -123,6 +123,7 @@ from posthog.hogql_queries.validation.validation import (
 from posthog.models import Team, User
 from posthog.models.team import WeekStartDay
 from posthog.models.team.event_retention import events_retention_months_for_team
+from posthog.rbac.team_default_access import TeamDefaultAccess, for_shared_link_user
 from posthog.rbac.user_access_control import WAREHOUSE_ACCESS_SCOPES, UserAccessControl, UserAccessControlError
 from posthog.schema_helpers import to_dict
 from posthog.scopes import APIScopeObject
@@ -1972,6 +1973,13 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 **kwargs,
             )[0]
 
+    def _shared_default_access(self) -> Optional[TeamDefaultAccess]:
+        """The request's default-rules snapshot for shared-link viewers - memoized on the
+        principal, so a dashboard's runners and their database builds share one load."""
+        if not isinstance(self.user, SharedLinkUser):
+            return None
+        return for_shared_link_user(self.user, self.team)
+
     def get_cache_payload(self) -> dict:
         # remove the tags key, these are used in the query log comment but shouldn't break caching
         # note: to_dict already strips custom_name from series (see schema_helpers.py)
@@ -2377,6 +2385,16 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
         if queried_resources == set():
             return payload
 
+        # Shared-link viewers' warehouse visibility is defined entirely by the team's default
+        # rules; keying on that rule-state partitions their entries from every member's and
+        # orphans them the moment an admin changes the defaults - revocation propagates through
+        # the cache instead of waiting out the TTL.
+        shared_default_access = self._shared_default_access()
+        if shared_default_access is not None and (
+            queried_resources is None or queried_resources & WAREHOUSE_ACCESS_SCOPES
+        ):
+            payload["shared_default_access"] = shared_default_access.cache_fingerprint()
+
         if restricted_objects := self._get_object_access_restrictions(queried_resources):
             payload["restricted_objects"] = restricted_objects
         if restricted_resources := self._get_resource_access_restrictions(queried_resources):
@@ -2409,9 +2427,9 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
 
         # Non-real principals (service tokens, shared-link viewers) are scope-gated on system tables;
         # partition on the readable scopes so a narrower token can't be served a broader principal's
-        # cached result. Warehouse scopes are excluded: these principals bypass warehouse access
-        # control (see Database.create_for), so warehouse tables are readable for them and listing
-        # them as restricted would collide with users who are genuinely denied those resources.
+        # cached result. Warehouse scopes are excluded here: service tokens bypass warehouse access
+        # control (see Database.create_for), and shared-link viewers partition on the team's default
+        # rules instead (the shared_default_access payload key in get_cache_payload).
         if not isinstance(user, User):
             if queried_resources is None:
                 return ["*"]

--- a/posthog/rbac/team_default_access.py
+++ b/posthog/rbac/team_default_access.py
@@ -1,0 +1,80 @@
+"""The team's default (member/role-agnostic) access control rules, as one preloaded snapshot.
+
+Anonymous shared-link viewers have no identity to match member or role rules against, so
+they resolve against the team's *default* rules only - the same "only default rules apply"
+treatment property access control gives `user=None`. Warehouse tables/views are today's
+consumer; the snapshot carries every resource's default rules so future consumers don't
+need their own loader. With no rules configured the global default for warehouse resources
+is `editor`, so public links keep working unless an admin explicitly sets a default of `none`.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from posthog.constants import AvailableFeature
+from posthog.rbac.user_access_control import (
+    RESOURCE_INHERITANCE_MAP,
+    access_level_satisfied_for_resource,
+    default_access_level,
+)
+from posthog.scopes import APIScopeObject
+from posthog.settings import EE_AVAILABLE
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+    from posthog.shared_link_user import SharedLinkUser
+
+try:
+    from ee.models.rbac.access_control import AccessControl
+except ImportError:
+    pass
+
+
+@dataclass(frozen=True)
+class TeamDefaultAccess:
+    """The team's default rules - rows with no member and no role attached - loaded once so
+    consumers stay query-free. Keyed (resource, resource_id), resource_id None for
+    resource-wide defaults."""
+
+    levels: dict[tuple[str, Optional[str]], str]
+
+    @classmethod
+    def load(cls, team: "Team") -> "TeamDefaultAccess":
+        # Without the access control feature no rules apply - resolution falls through to the
+        # global default (editor), mirroring UserAccessControl.access_controls_supported.
+        if not EE_AVAILABLE or not team.organization.is_feature_available(AvailableFeature.ACCESS_CONTROL):
+            return cls(levels={})
+
+        rows = AccessControl.objects.filter(
+            team=team,
+            organization_member=None,
+            role=None,
+        ).values_list("resource", "resource_id", "access_level")
+        return cls(levels={(resource, resource_id): level for resource, resource_id, level in rows})
+
+    def is_denied(self, resource: APIScopeObject, object_id: str) -> bool:
+        """Object default > resource default > parent resource default > global default (editor)."""
+        parent = RESOURCE_INHERITANCE_MAP.get(resource)
+        level = (
+            self.levels.get((resource, object_id))
+            or self.levels.get((resource, None))
+            or (self.levels.get((parent, None)) if parent is not None else None)
+            or default_access_level(resource)
+        )
+        return not access_level_satisfied_for_resource(resource, level, "viewer")
+
+    def cache_fingerprint(self) -> list[tuple[str, str, str]]:
+        """Canonical rule-state for the query-cache payload. Shared-link visibility is defined
+        entirely by these team-global rules, so keying on them partitions shared entries from
+        every member's and orphans them the moment an admin changes the defaults - revocation
+        propagates through the cache instead of waiting out the TTL. Covers all resources'
+        defaults: a non-warehouse rule change over-invalidates, which is rare and fail-safe."""
+        return sorted((resource, object_id or "", level) for (resource, object_id), level in self.levels.items())
+
+
+def for_shared_link_user(user: "SharedLinkUser", team: "Team") -> TeamDefaultAccess:
+    """The request's one snapshot: memoized on the principal, which is created once per request
+    and flows to every consumer - each tile's runner, each database build, the cache fingerprint."""
+    if user.team_default_access is None:
+        user.team_default_access = TeamDefaultAccess.load(team)
+    return user.team_default_access

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -104,6 +104,8 @@ RESOURCE_INHERITANCE_MAP: dict[APIScopeObject, APIScopeObject] = {
     "marketing_analytics": "web_analytics",
 }
 
+# Scopes enforced per warehouse object. Service tokens bypass these (see Database.create_for);
+# shared-link viewers resolve them against the team's default rules (see TeamDefaultAccess).
 WAREHOUSE_ACCESS_SCOPES: frozenset[str] = frozenset(
     {
         "warehouse_objects",

--- a/posthog/shared_link_user.py
+++ b/posthog/shared_link_user.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from django.contrib.auth.models import AnonymousUser
 
 if TYPE_CHECKING:
     from posthog.models.sharing_configuration import SharingConfiguration
+    from posthog.rbac.team_default_access import TeamDefaultAccess
 
 
 class SharedLinkUser(AnonymousUser):
-    """Anonymous viewer of a publicly shared dashboard/insight/notebook"""
+    """Anonymous viewer of a publicly shared dashboard/insight/notebook.
+
+    Warehouse tables resolve against the team's *default* access rules (member/role grants
+    don't bind an anonymous viewer) - see TeamDefaultAccess. System tables stay hidden.
+    """
 
     # Django's AnonymousUser has no email; query modifiers read user.email for internal-user tagging.
     email: str | None = None
@@ -21,6 +26,12 @@ class SharedLinkUser(AnonymousUser):
             raise ValueError("SharedLinkUser requires an enabled sharing configuration")
         super().__init__()
         self.sharing_configuration = sharing_configuration
+        # Request-scoped memo: this instance is created once per request and flows to every
+        # consumer (each tile's runner, each database build, the cache fingerprint), so the
+        # team's default access rules load once per request - mirrors how the view's
+        # user_access_control is reused across a dashboard's runners. Set lazily by
+        # posthog.rbac.team_default_access.for_shared_link_user.
+        self.team_default_access: Optional[TeamDefaultAccess] = None
         # Read by query analytics tagging (QueryRunner.run) and modifier resolution.
         self.distinct_id = f"shared-viewer-{sharing_configuration.team_id}"
 


### PR DESCRIPTION
## Problem

Stacked on #68311, amending its model per the review discussion there. Always-execute made every deny rule invisible to public links; the fail-closed alternative broke all warehouse sharing. The middle everyone was circling: **an anonymous viewer is a member with no grants** — resolve each warehouse table/view against the team's *default* access rules only, the same treatment property access control gives `user=None`.

The global default for warehouse resources is `editor`, so with no rules configured **nothing changes and no existing public dashboard breaks**. A default of `none` is now enforced on public links, member/role grants never leak to them, and admins get the recommended pattern for free: default `none` on warehouse objects + default `viewer` on curated safe views.

## Changes

- **`TeamDefaultAccess`** (`posthog/rbac/team_default_access.py`) — one snapshot of the team's default rules (rows with no member and no role), resolution `object default > resource default > parent default > global default`. Carries *all* resources' defaults — warehouse is today's consumer, future consumers don't need their own loader.
- **Preloaded once per request, like `user_access_control`** — memoized on the `SharedLinkUser` principal (created once per request, flows to every tile's runner and database build), so a 20-tile dashboard loads the rules once, shared by schema resolution *and* the cache fingerprint.
- **`Database.create_for`** — the shared-link principal now resolves defaults in `_is_warehouse_table_denied` / `_is_warehouse_view_denied`; **`SyntheticUser` keeps the bypass** (project-wide service tokens, unchanged).
- **Cache fingerprint keys on the rule-state** (`shared_default_access` payload key): shared entries partition from every member's, and adding a default rule orphans previously cached shared results — **revocation propagates through the cache** instead of waiting out the TTL. Queries touching no access-controlled tables keep sharing one entry across principals (warm event tiles preserved).
- System tables unchanged: still hidden entirely for shared links.

**Not in this PR (follow-ups):** the publish gate (#69743) should compile as the shared principal instead of the publisher, so "can't publish" matches "link won't render"; non-materialized permissive views still expand into their underlying tables (invoker rights), so the curated-views docs advice must say *materialized*.

## How did you test this code?

Test files updated (`test_hogql_access_control.py`, `test_sharing.py`): member-specific denies don't bind the link; object-level and resource-level default `none` deny (parameterized); denied member vs shared viewer cache keys never collide; a fresh principal's cache key changes when defaults change (revocation); warm event-tile sharing preserved; e2e token-API render fails closed on a default-denied table and still renders with no rules.

Honest caveat: the suite ran green against this design mid-development, but the final refactor (request-scoped memo + generalization to all resources) is lint/type-checked only — my local Docker died (OrbStack ENOSPC) before the last run. CI on this PR is the verification; I'll fix anything it surfaces.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Design iterations worth knowing: the resolver started warehouse-scoped with two rule maps and a bespoke fingerprint encoding — simplified to one `(resource, resource_id) -> level` map, then generalized to all resources for reuse. The preload started per-runner (still one query per tile); moved to the principal after review pointed at how `user_access_control` is preloaded once per request — the principal is the natural request-scoped carrier since every consumer already receives the same instance. The revocation test was corrected to build a fresh principal post-rule-change, since the memo is per-principal (= per request) by design.
