### PR TITLE
feat(engineering-analytics): render stat tiles and cost trend with quill charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4827,9 +4827,9 @@ snapshots:
     replay-tabs-home-failure--not-found--light:
         hash: v1.k794b7964.63f4edcf1afa31941d7fd4fe1cf6b2233335e5396691f5abfbeb5f32a5e77079.fT5YLbBCAptU85nyVbgAYp7DeiCCV6_bPb894JVNQFU
     replay-tabs-home-filters-banner--product-analytics-over-limit--dark:
-        hash: v1.k794b7964.9ee25b6594b07076cff0c2d285096a7e2d2031e3d30e58d4d043c8e3e0d44447.0wsqTslGRLqaidPoW0-teojry4FMwKSiOqo9E6i6AG8
+        hash: v1.k794b7964.e43831aab10f34ebb833d39856c8285ca3ec054b018c07a8eea2dc6551d12119.w0JYkgk5ujwBybY8356Xe93bi6ky_z7Skt5wuoRPX1g
     replay-tabs-home-filters-banner--product-analytics-over-limit--light:
-        hash: v1.k794b7964.9e6e0a6b500bea8a289281eaadb397a36a19381074a6d72291d186c7dbc89837.O2Q9Dv4VQBJqT5IlxRTwoYrGw7cXNkhGd2ikmDmIrZc
+        hash: v1.k794b7964.3455a8a462eb913f7d478672c16b5fa56fd4591efcc09b5ad1119707842f80b3.FMUgEs84D1HWKB2fVtRZP_Dsk6HYgaz604k3bLZqwFI
     replay-tabs-home-filters-banner--product-analytics-under-limit--dark:
         hash: v1.k794b7964.c4cc11f519896f1493409b60c0a04da6023d71a83374094c29c2666c65c205cf.aabEMRgGPdgSlwx4q2x34yULwzqiBwz2CI6LUyV5eak
     replay-tabs-home-filters-banner--product-analytics-under-limit--light:
@@ -5522,10 +5522,14 @@ snapshots:
         hash: v1.k794b7964.c5aa3840807ca349309a893b884ebc767c8fab70a82127532c1dae27d13f9f3d.51y_th6-WoFAlLgiWfsu6KUr3rxWjZzAbV84FIikvXQ
     scenes-app-data-warehouse-sql-editor--top-tools-per-server--light:
         hash: v1.k794b7964.e6420f44b86930d43085b575192d3c26ac0401919a4af6f8d7bd1c799e964836.pZmiZ4w-9QbQ60TFc6Sx94NT0YmU4EULydWdqDqxDmY
+    scenes-app-engineering-analytics-repo-overview--repo-overview--dark:
+        hash: v1.k794b7964.33da23b1f44fdfb476c70040adf6a0e7cd3181d4ebc4104e3170f1168e87a762.FBj2-1IKmG64f7qR9LToBEf74I5uJ-wQVVSFZT1YTMA
+    scenes-app-engineering-analytics-repo-overview--repo-overview--light:
+        hash: v1.k794b7964.00d52e2e14ce7b78fb3e4cd387a816133386735f031a42f08af19e6e36d858f5.mgSfjwCtQfkr2xtrBUL8L-CPJX9vNKVwcN1ROVbFzo8
     scenes-app-engineering-analytics-test-health--flaky-test-leaderboard--dark:
-        hash: v1.k794b7964.11b690fa6779c138fc78a905c08701fa1c0d14ca740712bc737cb704be689518.p4XIRGrjbbNPexcT586n6Anw8Hvzjcjmd0FS1NOVQ5I
+        hash: v1.k794b7964.b80842e3c1fcc9321fbd781d1c7aa06bdd243479eff1b407ad94466b48625e7f.vSCnKb5GwJzPTNMCRmvYw6f3fYfPbJcDlNia1tEc22E
     scenes-app-engineering-analytics-test-health--flaky-test-leaderboard--light:
-        hash: v1.k794b7964.0c9580ba54e5d865a26157ce07d53efb14f3e6bb1039d22fc7d46a5b01217346.JWsdPaiMJDKrEjpDZ1wKeTH9bHP_8iWFRTOynGQi3FA
+        hash: v1.k794b7964.fcab5b35c3e2147beaf8445febe839a6a30952a8bcba3fa634d7a3d073d561a3.-OVkVjtyzLUrkMi_4lDd7F39UmQPWKEvPhnf47_BxoA
     scenes-app-error-project-unavailable--access-revoked--dark:
         hash: v1.k794b7964.30ace8f015100159e1dedbed07ff9f0b0b770535870d5c98ea764b10ff1f7621.dTVw9qLa7D_e7ZNme4tVuPZov-0Gg1o84aiDl5zihF0
     scenes-app-error-project-unavailable--access-revoked--light:

--- a/products/engineering_analytics/frontend/components/MetricTile.tsx
+++ b/products/engineering_analytics/frontend/components/MetricTile.tsx
@@ -1,9 +1,11 @@
-// Headline-metric tile: label · value (+suffix) · delta vs the previous window · caption.
-// Every entity page builds its stat strip from this tile.
+// Headline-metric tile: label · value · delta pill vs the previous window · caption, rendered
+// with quill's MetricCard inside the product's card chrome. Every entity page builds its stat
+// strip from this tile.
 
 import { ReactNode } from 'react'
 
 import { Tooltip } from '@posthog/lemon-ui'
+import { MetricCard, type MetricChange } from '@posthog/quill-charts'
 
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
 import { cn } from 'lib/utils/css-classes'
@@ -24,6 +26,7 @@ export function pointChange(current: number | null | undefined, previous: number
     return (current - previous) * 100
 }
 
+/** Compact inline delta for table cells — tiles use `MetricTile`'s `delta` prop instead. */
 export function DeltaBadge({
     value,
     unit = '%',
@@ -64,11 +67,36 @@ export function DeltaBadge({
     )
 }
 
+export interface TileDelta {
+    /** The delta to show; null (no baseline) and ±0 both hide the pill. */
+    value: number | null
+    unit?: string
+    /** For costs, durations, failures — a drop is the good direction. */
+    goodWhenDown?: boolean
+    precision?: number
+    /** What the delta compares against, shown on pill hover. */
+    vs?: string
+}
+
+/** DeltaBadge's display rules (rounding, ±0 suppression, >999 clamp) as a MetricCard change pill. */
+function deltaToChange(delta: TileDelta | undefined): MetricChange | null {
+    if (!delta || delta.value == null) {
+        return null
+    }
+    const precision = delta.precision ?? 0
+    const rounded = Number(delta.value.toFixed(precision))
+    if (rounded === 0) {
+        return null
+    }
+    // A near-zero baseline turns growth into a meaningless five-digit percentage — clamp the display.
+    const display = Math.abs(rounded) > 999 ? '>999' : Math.abs(rounded).toFixed(precision)
+    return { value: rounded, label: `${display}${delta.unit ?? '%'}` }
+}
+
 export function MetricTile({
     label,
     tooltip,
     value,
-    valueSuffix,
     delta,
     sub,
     className,
@@ -78,31 +106,34 @@ export function MetricTile({
     tooltip?: ReactNode
     /** Pre-formatted headline value; '—' for no data. */
     value: string
-    valueSuffix?: string
-    delta?: ReactNode
+    delta?: TileDelta
     /** Visible caption — only for an answer worth a glance (what's failing, why there's no value). */
     sub?: ReactNode
     className?: string
 }): JSX.Element {
-    const labelSpan = <span className="text-xs text-secondary">{label}</span>
+    const labelNode = tooltip ? (
+        <Tooltip title={tooltip}>
+            <span className="cursor-default">{label}</span>
+        </Tooltip>
+    ) : (
+        label
+    )
     return (
         <LemonCard
             hoverEffect={false}
-            className={cn('flex min-w-44 flex-1 flex-col justify-center gap-1 px-5 py-4', className)}
+            className={cn('flex min-w-44 flex-1 flex-col justify-center px-5 py-4', className)}
         >
-            {tooltip ? (
-                <Tooltip title={tooltip}>
-                    <span className="self-start cursor-default">{labelSpan}</span>
-                </Tooltip>
-            ) : (
-                labelSpan
-            )}
-            <span className="flex items-baseline gap-2">
-                <span className="text-2xl font-semibold leading-none tabular-nums">{value}</span>
-                {valueSuffix && <span className="text-xs font-medium text-tertiary">{valueSuffix}</span>}
-                {delta}
-            </span>
-            {sub && <span className="text-xs text-tertiary">{sub}</span>}
+            <MetricCard
+                title={labelNode}
+                // These tiles have no series data and often a non-numeric headline ("3 / 5", "2h 10m"),
+                // so the pre-formatted display string rides through MetricCard's formatter.
+                value={0}
+                formatValue={() => value}
+                change={deltaToChange(delta)}
+                goodDirection={delta?.goodWhenDown ? 'down' : 'up'}
+                changeTooltip={delta ? (delta.vs ?? 'vs the previous window') : undefined}
+                subtitle={sub}
+            />
         </LemonCard>
     )
 }

--- a/products/engineering_analytics/frontend/components/StatCard.tsx
+++ b/products/engineering_analytics/frontend/components/StatCard.tsx
@@ -1,5 +1,6 @@
 import { IconFilter } from '@posthog/icons'
 import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
+import { MetricCard } from '@posthog/quill-charts'
 
 import { cn } from 'lib/utils/css-classes'
 
@@ -42,13 +43,23 @@ export function StatCard({
                         active ? 'text-accent opacity-100' : 'text-tertiary opacity-0 group-hover:opacity-100'
                     )}
                 />
-                <div className={cn('text-xs', active ? 'font-medium text-accent' : 'text-secondary')}>{label}</div>
                 {loading ? (
-                    <LemonSkeleton className="h-8 w-20" />
+                    <>
+                        <div className={cn('text-sm font-medium', active ? 'text-accent' : 'text-secondary')}>
+                            {label}
+                        </div>
+                        <LemonSkeleton className="h-9 w-20" />
+                    </>
                 ) : (
-                    <div className="text-2xl font-bold leading-tight">{value}</div>
+                    <MetricCard
+                        title={<span className={active ? 'text-accent' : undefined}>{label}</span>}
+                        // Pre-formatted display string ('—' when no data yet) rides through the formatter.
+                        value={0}
+                        formatValue={() => value}
+                        change={null}
+                        subtitle={caption}
+                    />
                 )}
-                {caption && <div className="text-xs text-tertiary">{caption}</div>}
             </button>
         </Tooltip>
     )

--- a/products/engineering_analytics/frontend/scenes/PullRequestDetailScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/PullRequestDetailScene.tsx
@@ -725,24 +725,23 @@ export function PullRequestDetailScene(): JSX.Element {
                             label="Latest push"
                             tooltip="Workflows green on the newest commit, one verdict per workflow."
                             value={latestPushStats ? `${latestPushStats.green} / ${latestPushStats.total}` : '—'}
-                            valueSuffix={latestPushStats ? 'passing' : undefined}
                             sub={
                                 latestPushStats && latestPushStats.failingWorkflows.length > 0
                                     ? `${latestPushStats.failingWorkflows.slice(0, 3).join(', ')} failing`
                                     : latestPushStats && latestPushStats.running > 0
                                       ? `${latestPushStats.running} still running`
-                                      : undefined
+                                      : latestPushStats
+                                        ? 'passing'
+                                        : undefined
                             }
                         />
                         <MetricTile
                             label="Pushes"
                             tooltip="Commits that triggered CI on this pull request."
                             value={`${pushes}`}
-                            delta={
+                            sub={
                                 rerunCycles > 0 ? (
-                                    <span className="text-xs font-semibold text-warning-dark">
-                                        +{rerunCycles} re-runs
-                                    </span>
+                                    <span className="font-semibold text-warning-dark">+{rerunCycles} re-runs</span>
                                 ) : undefined
                             }
                         />

--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.stories.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.stories.tsx
@@ -1,0 +1,175 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import type {
+    GitHubSourceApi,
+    PullRequestListApi,
+    RepoOverviewApi,
+    WorkflowHealthItemApi,
+    WorkflowRunActivityApi,
+} from '../generated/api.schemas'
+
+const SOURCES: GitHubSourceApi[] = [{ id: 'src-1', repo: 'PostHog/posthog', prefix: '' }]
+
+// Deltas cover every pill state: pp up (good), % up (neutral), % up while good-is-down (bad), and
+// an hours drop (good) — the surface this scene's quill MetricCard migration changed.
+const OVERVIEW: RepoOverviewApi = {
+    run_count: 1284,
+    run_count_prev: 1122,
+    success_rate: 0.87,
+    success_rate_prev: 0.82,
+    rerun_cycles: 41,
+    rerun_cycles_prev: 30,
+    median_open_to_merge_seconds: 14 * 3600,
+    median_open_to_merge_seconds_prev: 19 * 3600,
+    billable_minutes: 5230,
+    billable_minutes_prev: 4890,
+    estimated_cost_usd: 412.5,
+    estimated_cost_usd_prev: 361.0,
+    jobs_available: true,
+    default_branch: 'master',
+    cost_series_granularity: 'day',
+    cost_series: [52.1, 47.8, 61.3, 58.9, 44.2, 49.5, 55.7].map((cost, i) => ({
+        bucket_start: `2026-06-${25 + i}T00:00:00Z`,
+        estimated_cost_usd: cost * 8,
+        merges: 8,
+        cost_per_merge_usd: cost,
+    })),
+}
+
+const ACTIVITY: WorkflowRunActivityApi = {
+    points: [520, 680, 1450, 760, 590, 2100, 830, 640].map((duration, i) => ({
+        run_id: 9000 + i,
+        conclusion: i === 5 ? 'failure' : 'success',
+        run_started_at: `2026-07-01T${String(8 + i * 2).padStart(2, '0')}:00:00Z`,
+        duration_seconds: duration,
+        head_branch: 'master',
+        pr_number: 0,
+    })),
+    truncated: false,
+    limit: 500,
+}
+
+function healthItem(
+    workflowName: string,
+    costUsd: number,
+    failures: number[],
+    successRate: number
+): WorkflowHealthItemApi {
+    return {
+        repo: { provider: 'github', owner: 'PostHog', name: 'posthog' },
+        workflow_name: workflowName,
+        run_count: 320,
+        success_rate: successRate,
+        success_rate_prev: successRate - 0.03,
+        p50_seconds: 540,
+        p95_seconds: 1680,
+        last_failure_at: failures.some((f) => f > 0) ? '2026-07-01T16:00:00Z' : null,
+        latest_run_failed: false,
+        latest_run_conclusion: 'success',
+        granularity: 'day',
+        billable_minutes: costUsd * 12,
+        estimated_cost_usd: costUsd,
+        rerun_cycles: 6,
+        buckets: failures.map((failed, i) => ({
+            bucket_start: `2026-06-${25 + i}T00:00:00Z`,
+            run_count: 44 + i,
+            completed: 40 + i,
+            successes: 40 + i - failed,
+            failures: failed,
+        })),
+    }
+}
+
+const WORKFLOW_HEALTH: WorkflowHealthItemApi[] = [
+    healthItem('Backend CI', 210.4, [2, 0, 4, 1, 0, 3, 1], 0.91),
+    healthItem('E2E - Playwright', 130.2, [5, 3, 6, 2, 4, 5, 3], 0.78),
+    healthItem('Frontend CI', 71.9, [0, 1, 0, 0, 2, 0, 1], 0.95),
+]
+
+const PULL_REQUESTS: PullRequestListApi = {
+    items: [
+        {
+            author: { handle: 'jane-dev', display_name: 'Jane Dev', avatar_url: '', is_bot: false },
+            repo: { provider: 'github', owner: 'PostHog', name: 'posthog' },
+            ci: { runs: 6, passing: 4, failing: 2, pending: 0, failing_workflows: ['Backend CI', 'E2E - Playwright'] },
+            number: 41231,
+            title: 'feat(insights): sticky breakdown legends',
+            state: 'open',
+            is_draft: false,
+            created_at: '2026-06-24T10:00:00Z',
+            merged_at: null,
+            open_to_merge_seconds: null,
+            labels: [],
+            pushes: 9,
+            rerun_cycles: 3,
+            estimated_cost_usd: 38.2,
+            billable_minutes: 410,
+        },
+        {
+            author: { handle: 'sam-eng', display_name: 'Sam Eng', avatar_url: '', is_bot: false },
+            repo: { provider: 'github', owner: 'PostHog', name: 'posthog' },
+            ci: { runs: 5, passing: 5, failing: 0, pending: 0 },
+            number: 41250,
+            title: 'fix(cohorts): handle empty cohort in query builder',
+            state: 'merged',
+            is_draft: false,
+            created_at: '2026-06-30T09:00:00Z',
+            merged_at: '2026-07-01T08:30:00Z',
+            open_to_merge_seconds: 84600,
+            labels: [],
+            pushes: 3,
+            rerun_cycles: 0,
+            estimated_cost_usd: 12.7,
+            billable_minutes: 130,
+        },
+    ],
+    truncated: false,
+    limit: 1000,
+}
+
+const meta: Meta = {
+    component: App,
+    title: 'Scenes-App/Engineering Analytics/Repo Overview',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2026-07-02',
+        featureFlags: [FEATURE_FLAGS.ENGINEERING_ANALYTICS],
+        testOptions: {
+            // The change pill only renders once the overview payload (and its deltas) has landed.
+            waitForSelector: '[data-attr="metric-card-change-pill"]',
+        },
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                'api/projects/:team_id/engineering_analytics/sources/': SOURCES,
+                'api/projects/:team_id/engineering_analytics/repo_overview/': OVERVIEW,
+                'api/projects/:team_id/engineering_analytics/master_failures/': [],
+                'api/projects/:team_id/engineering_analytics/repo_run_activity/': ACTIVITY,
+                'api/projects/:team_id/engineering_analytics/ci_cards/': {
+                    open_prs: 18,
+                    repos: 1,
+                    stuck: 3,
+                    failing_ci: 4,
+                },
+                'api/projects/:team_id/engineering_analytics/pull_requests/': PULL_REQUESTS,
+                'api/projects/:team_id/engineering_analytics/workflow_health/': WORKFLOW_HEALTH,
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const RepoOverview: Story = {
+    render: () => <App />,
+    parameters: { pageUrl: urls.engineeringAnalytics() },
+}

--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
@@ -6,18 +6,19 @@ import { combineUrl, router } from 'kea-router'
 
 import { IconBox } from '@posthog/icons'
 import { LemonCard, LemonSkeleton, LemonTable, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
+import { TimeSeriesLineChart, useChartTheme } from '@posthog/quill-charts'
 
-import { Sparkline } from 'lib/components/Sparkline'
 import { TZLabel } from 'lib/components/TZLabel'
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { CIAnalyticsLoadError } from '../components/CIAnalyticsLoadError'
 import { ConnectGitHubSource } from '../components/ConnectGitHubSource'
 import { EntityHeader } from '../components/EntityHeader'
 import { FailureLogGroups } from '../components/FailureLogs'
-import { DeltaBadge, MetricTile, percentChange, pointChange } from '../components/MetricTile'
+import { MetricTile, percentChange, pointChange } from '../components/MetricTile'
 import { PullRequestTable } from '../components/PullRequestTable'
 import { RunActivityChart, hasEnoughRunActivity } from '../components/RunActivityChart'
 import { ScopeBar, SourceScopeChip } from '../components/ScopeBar'
@@ -25,7 +26,7 @@ import { Section, SectionNav, scrollToSection } from '../components/Section'
 import { ShareRow } from '../components/ShareRow'
 import { WorkflowHealthTable } from '../components/WorkflowHealthTable'
 import type { MasterFailureGroupApi } from '../generated/api.schemas'
-import { compactCount, compactHours, compactHoursUnit, compactMinutes, compactUsd, percent } from '../lib/format'
+import { compactCount, compactHoursLabel, compactMinutes, compactUsd, percent } from '../lib/format'
 import { engineeringAnalyticsLogic } from './engineeringAnalyticsLogic'
 import { repoOverviewLogic } from './repoOverviewLogic'
 
@@ -86,11 +87,12 @@ function MasterStatusTile({
             className="flex min-w-44 flex-1 flex-col justify-center gap-1 px-5 py-4"
         >
             <Tooltip title="Workflows failing on the default branch in the last 24 hours.">
-                <span className="self-start cursor-default text-xs text-secondary">
+                <span className="self-start cursor-default text-sm font-medium">
                     {defaultBranch === 'main' ? 'Main' : 'Master'}
                 </span>
             </Tooltip>
-            <span className="flex items-center gap-2">
+            {/* Typography mirrors quill MetricCard so the tile sits flush in the stat strip. */}
+            <span className="mt-2 flex items-center gap-2">
                 <span
                     className="inline-block size-2.5 shrink-0 rounded-full"
                     // eslint-disable-next-line react/forbid-dom-props
@@ -98,7 +100,7 @@ function MasterStatusTile({
                 />
                 <span
                     className={cn(
-                        'text-2xl font-semibold leading-none',
+                        'text-4xl font-bold leading-none tracking-tight',
                         loading ? 'text-tertiary' : failing ? 'text-danger' : 'text-primary'
                     )}
                 >
@@ -261,6 +263,8 @@ export function RepoOverviewScene(): JSX.Element {
     } = useValues(engineeringAnalyticsLogic)
     const { loadOverview, loadMasterFailures, loadRepoActivity } = useActions(repoOverviewLogic)
     const { searchParams } = useValues(router)
+    const { timezone } = useValues(teamLogic)
+    const chartTheme = useChartTheme()
 
     // jobsAvailable reads false until the overview payload lands, so "not synced" messaging
     // during the initial fetch would misread as a broken setup — hold it back while loading.
@@ -299,17 +303,15 @@ export function RepoOverviewScene(): JSX.Element {
                     label="Pass rate"
                     tooltip="Workflow-level, across all branches."
                     value={percent(overview?.success_rate)}
-                    delta={
-                        <DeltaBadge
-                            value={pointChange(overview?.success_rate, overview?.success_rate_prev)}
-                            unit="pp"
-                        />
-                    }
+                    delta={{
+                        value: pointChange(overview?.success_rate, overview?.success_rate_prev),
+                        unit: 'pp',
+                    }}
                 />
                 <MetricTile
                     label="Runs"
                     value={compactCount(overview?.run_count)}
-                    delta={<DeltaBadge value={percentChange(overview?.run_count, overview?.run_count_prev)} />}
+                    delta={{ value: percentChange(overview?.run_count, overview?.run_count_prev) }}
                 />
                 <MetricTile
                     label="CI cost"
@@ -322,45 +324,38 @@ export function RepoOverviewScene(): JSX.Element {
                     }
                     value={jobsAvailable ? compactUsd(overview?.estimated_cost_usd) : '—'}
                     delta={
-                        jobsAvailable ? (
-                            <DeltaBadge
-                                value={percentChange(overview?.estimated_cost_usd, overview?.estimated_cost_usd_prev)}
-                                goodWhenDown
-                            />
-                        ) : undefined
+                        jobsAvailable
+                            ? {
+                                  value: percentChange(overview?.estimated_cost_usd, overview?.estimated_cost_usd_prev),
+                                  goodWhenDown: true,
+                              }
+                            : undefined
                     }
                     sub={jobsAvailable || overviewPending ? undefined : 'Job-level source not synced'}
                 />
                 <MetricTile
                     label="Median PR open→merge"
                     tooltip="Created to merged, over PRs merged in the window. Bots and drafts excluded."
-                    value={compactHours(overview?.median_open_to_merge_seconds)}
-                    valueSuffix={compactHoursUnit(overview?.median_open_to_merge_seconds)}
-                    delta={
-                        <DeltaBadge
-                            value={
-                                overview?.median_open_to_merge_seconds != null &&
-                                overview?.median_open_to_merge_seconds_prev != null
-                                    ? (overview.median_open_to_merge_seconds -
-                                          overview.median_open_to_merge_seconds_prev) /
-                                      3600
-                                    : null
-                            }
-                            unit="h"
-                            goodWhenDown
-                        />
-                    }
+                    value={compactHoursLabel(overview?.median_open_to_merge_seconds)}
+                    delta={{
+                        value:
+                            overview?.median_open_to_merge_seconds != null &&
+                            overview?.median_open_to_merge_seconds_prev != null
+                                ? (overview.median_open_to_merge_seconds - overview.median_open_to_merge_seconds_prev) /
+                                  3600
+                                : null,
+                        unit: 'h',
+                        goodWhenDown: true,
+                    }}
                 />
                 <MetricTile
                     label="Re-run cycles"
                     tooltip="Runs with attempt > 1 in the window."
                     value={compactCount(overview?.rerun_cycles)}
-                    delta={
-                        <DeltaBadge
-                            value={percentChange(overview?.rerun_cycles, overview?.rerun_cycles_prev)}
-                            goodWhenDown
-                        />
-                    }
+                    delta={{
+                        value: percentChange(overview?.rerun_cycles, overview?.rerun_cycles_prev),
+                        goodWhenDown: true,
+                    }}
                 />
             </div>
 
@@ -480,15 +475,25 @@ export function RepoOverviewScene(): JSX.Element {
                 ) : jobsAvailable && costPerMergeSeries ? (
                     <LemonCard hoverEffect={false} className="mb-2 p-4">
                         <h3 className="mb-1 text-xs font-semibold text-secondary">Cost per merged PR</h3>
-                        <Sparkline
-                            data={costPerMergeSeries.values}
-                            labels={costPerMergeSeries.labels}
-                            name="Cost per merged PR"
-                            type="line"
-                            className="h-24 w-full"
-                            renderLabel={(label) => label}
-                            renderTooltipValue={(value) => compactUsd(value)}
-                        />
+                        {/* Charts fill their container, so the wrapper pins an explicit height. */}
+                        <div className="h-32 w-full">
+                            <TimeSeriesLineChart
+                                series={[
+                                    {
+                                        key: 'cost_per_merge',
+                                        label: 'Cost per merged PR',
+                                        data: costPerMergeSeries.values,
+                                    },
+                                ]}
+                                labels={costPerMergeSeries.labels}
+                                theme={chartTheme}
+                                config={{
+                                    xAxis: { timezone, interval: costPerMergeSeries.interval },
+                                    yAxis: { format: 'currency', currency: 'USD' },
+                                    tooltip: { valueFormatter: (value) => compactUsd(value) },
+                                }}
+                            />
+                        </div>
                         <div className="mt-2 border-t border-primary pt-2 text-[11px] text-tertiary">
                             Estimated Depot CI cost per PR merged. Each point divides a trailing window's CI cost by its
                             merges (24 h, 7 d, or 4 w to match the grain), so quiet buckets don't punch holes in the

--- a/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/WorkflowRunsScene.tsx
@@ -336,7 +336,7 @@ export function WorkflowRunsScene(): JSX.Element {
                     value={
                         healthSummary.medianSeconds != null ? humanFriendlyDuration(healthSummary.medianSeconds) : '—'
                     }
-                    valueSuffix={
+                    sub={
                         healthSummary.p95Seconds != null
                             ? `→ ${humanFriendlyDuration(healthSummary.p95Seconds)} p95`
                             : undefined

--- a/products/engineering_analytics/frontend/scenes/repoOverviewLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/repoOverviewLogic.ts
@@ -212,17 +212,19 @@ export const repoOverviewLogic = kea<repoOverviewLogicType>([
         // up" chart. The backend delivers a trailing rolling ratio, so a null only means the whole
         // trailing window shipped nothing; plotted as 0 to keep the axis anchored. Null when the series
         // is empty (job source unsynced), so the section falls back to its existing empty state.
+        // Labels stay ISO — the quill time-series chart owns tick/tooltip date formatting.
         costPerMergeSeries: [
             (s) => [s.overview],
-            (overview): { values: number[]; labels: string[] } | null => {
+            (overview): { values: number[]; labels: string[]; interval: 'hour' | 'day' | 'week' } | null => {
                 const series = overview?.cost_series ?? []
                 if (!series.length) {
                     return null
                 }
-                const fmt = overview?.cost_series_granularity === 'hour' ? 'MMM D HH:mm' : 'MMM D'
+                const granularity = overview?.cost_series_granularity
                 return {
                     values: series.map((bucket) => bucket.cost_per_merge_usd ?? 0),
-                    labels: series.map((bucket) => dayjs(bucket.bucket_start).format(fmt)),
+                    labels: series.map((bucket) => bucket.bucket_start),
+                    interval: granularity === 'hour' ? 'hour' : granularity === 'week' ? 'week' : 'day',
                 }
             },
         ],


### PR DESCRIPTION
## Problem

The engineering analytics scenes hand-roll their stat tiles (`MetricTile`, `StatCard` with bespoke delta badges) and render the cost-per-merged-PR trend through the legacy Chart.js `Sparkline` wrapper. We're standardizing on the quill design system, so these surfaces should use `@posthog/quill-charts` like web analytics and mcp_analytics already do.

## Changes

- `MetricTile` and `StatCard` now render through quill's `MetricCard` (title/headline/change-pill/subtitle), keeping the product's card chrome, no-data `—` state, and delta semantics (`pp`/`h` units, good-when-down direction, ±0 suppression, >999% clamp) in a thin wrapper. `DeltaBadge` stays for table cells.
- The cost-per-merged-PR chart on the repo overview is now a quill `TimeSeriesLineChart`: the logic selector emits ISO bucket labels + interval so the chart owns date tick/tooltip formatting, with a currency y-axis and the existing compact-USD tooltip values.
- `MasterStatusTile` typography updated to match `MetricCard` so the stat strip stays visually uniform.
- `valueSuffix` folded into headline/caption at the few call sites that used it.

Not migrated (no quill equivalent yet): `RunActivityChart` (scatter + concurrency band + brush), `LifecycleStrip` (timeline), `FailureSparkline` (table-cell stacked bars), `ShareRow` (leaderboard rows).

## How did you test this code?

- `jest --testPathPattern='products/engineering_analytics'` — 7 suites, 116 tests pass.
- `tsgo --noEmit`: no new errors in the changed files (this environment lacks generated kea `*Type.ts` artifacts, so pre-existing implicit-any noise remains repo-wide).
- oxlint/oxfmt clean.
- Not manually verified in a running app — reviewers should eyeball the repo overview stat strip, PR/workflow detail tiles, PR-list/test-health filter cards, and the cost chart.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — internal UI component swap, no behavior/API change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (PostHog Code cloud task). Assessed all engineering analytics visualizations against `@posthog/quill-charts`, then migrated the two 'directly replaceable today' surfaces: stat tiles → `MetricCard` and the cost trend → `TimeSeriesLineChart`.
- Followed the established consumer patterns from `OverviewMetricCardGrid` (web analytics) and `KpiTiles` (mcp_analytics): consumer owns card chrome and layout, `MetricCard` owns typography/pill.
- Deliberately kept pre-formatted string headlines flowing through `formatValue` since several tiles are non-numeric ("3 / 5", durations) and none have series data yet; once endpoints return windowed series, `data`/`labels` unlock the sparkline upgrade with no further restructuring.
- Zero-delta pills are suppressed (web analytics precedent) instead of the old muted ±0 badge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*