### PR TITLE
feat(insights): require opt-in for deprecated dashboards field on token auth

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/utils.test.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.test.ts
@@ -31,6 +31,21 @@ describe('getQueryBasedInsightModel', () => {
             [3],
         ],
         ['leaves dashboards undefined when neither field is present', {}, undefined],
+        [
+            'derives dashboards from dashboard_tiles when dashboards is null',
+            { dashboards: null, dashboard_tiles: [{ id: 10, dashboard_id: 1 }] },
+            [1],
+        ],
+        [
+            'excludes soft-deleted tiles when deriving dashboards',
+            {
+                dashboard_tiles: [
+                    { id: 10, dashboard_id: 1 },
+                    { id: 11, dashboard_id: 2, deleted: true },
+                ],
+            },
+            [1],
+        ],
     ])('%s', (_name, input, expected) => {
         const result = getQueryBasedInsightModel(input as Partial<InsightModel>)
         expect(result.dashboards).toEqual(expected)

--- a/frontend/src/queries/nodes/InsightViz/utils.test.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.test.ts
@@ -22,7 +22,12 @@ describe('getQueryBasedInsightModel', () => {
     it.each([
         [
             'derives dashboards from dashboard_tiles when the response omits the deprecated field',
-            { dashboard_tiles: [{ id: 10, dashboard_id: 1 }, { id: 11, dashboard_id: 2 }] },
+            {
+                dashboard_tiles: [
+                    { id: 10, dashboard_id: 1 },
+                    { id: 11, dashboard_id: 2 },
+                ],
+            },
             [1, 2],
         ],
         [

--- a/frontend/src/queries/nodes/InsightViz/utils.test.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.test.ts
@@ -1,4 +1,6 @@
-import { extractValidationErrorCode } from '~/queries/nodes/InsightViz/utils'
+import { InsightModel } from '~/types'
+
+import { extractValidationErrorCode, getQueryBasedInsightModel } from './utils'
 
 describe('extractValidationErrorCode', () => {
     test.each([
@@ -13,5 +15,24 @@ describe('extractValidationErrorCode', () => {
         ['no error', null, null],
     ])('%s', (_name, error, expected) => {
         expect(extractValidationErrorCode(error)).toBe(expected)
+    })
+})
+
+describe('getQueryBasedInsightModel', () => {
+    it.each([
+        [
+            'derives dashboards from dashboard_tiles when the response omits the deprecated field',
+            { dashboard_tiles: [{ id: 10, dashboard_id: 1 }, { id: 11, dashboard_id: 2 }] },
+            [1, 2],
+        ],
+        [
+            'keeps the server-provided dashboards value when present',
+            { dashboards: [3], dashboard_tiles: [{ id: 10, dashboard_id: 1 }] },
+            [3],
+        ],
+        ['leaves dashboards undefined when neither field is present', {}, undefined],
+    ])('%s', (_name, input, expected) => {
+        const result = getQueryBasedInsightModel(input as Partial<InsightModel>)
+        expect(result.dashboards).toEqual(expected)
     })
 })

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -90,14 +90,15 @@ type ReturnInsightModel<T> = T extends InsightModel
 /** Get an insight with `query` only. Eventual `filters` will be converted.  */
 export function getQueryBasedInsightModel<T extends InputInsightModel>(insight: T): ReturnInsightModel<T> {
     const { filters, ...baseInsight } = insight
+    // The API is phasing out the deprecated `dashboards` field (already omitted for token
+    // callers, eventually for all); derive it from `dashboard_tiles` so remaining readers
+    // keep working regardless of whether the response still carries it.
+    const dashboards =
+        insight.dashboards ??
+        insight.dashboard_tiles?.filter((tile) => !tile.deleted).map((tile) => tile.dashboard_id)
     return {
         ...baseInsight,
-        // The API is phasing out the deprecated `dashboards` field (already omitted for token
-        // callers, eventually for all); derive it from `dashboard_tiles` so remaining readers
-        // keep working regardless of whether the response still carries it.
-        ...(insight.dashboards == null && insight.dashboard_tiles
-            ? { dashboards: insight.dashboard_tiles.filter((tile) => !tile.deleted).map((tile) => tile.dashboard_id) }
-            : {}),
+        ...(dashboards ? { dashboards } : {}),
         query: getQueryFromInsightLike(insight),
     } as unknown as ReturnInsightModel<T>
 }

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -95,8 +95,8 @@ export function getQueryBasedInsightModel<T extends InputInsightModel>(insight: 
         // The API is phasing out the deprecated `dashboards` field (already omitted for token
         // callers, eventually for all); derive it from `dashboard_tiles` so remaining readers
         // keep working regardless of whether the response still carries it.
-        ...(insight.dashboards === undefined && insight.dashboard_tiles
-            ? { dashboards: insight.dashboard_tiles.map((tile) => tile.dashboard_id) }
+        ...(insight.dashboards == null && insight.dashboard_tiles
+            ? { dashboards: insight.dashboard_tiles.filter((tile) => !tile.deleted).map((tile) => tile.dashboard_id) }
             : {}),
         query: getQueryFromInsightLike(insight),
     } as unknown as ReturnInsightModel<T>

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -94,8 +94,7 @@ export function getQueryBasedInsightModel<T extends InputInsightModel>(insight: 
     // callers, eventually for all); derive it from `dashboard_tiles` so remaining readers
     // keep working regardless of whether the response still carries it.
     const dashboards =
-        insight.dashboards ??
-        insight.dashboard_tiles?.filter((tile) => !tile.deleted).map((tile) => tile.dashboard_id)
+        insight.dashboards ?? insight.dashboard_tiles?.filter((tile) => !tile.deleted).map((tile) => tile.dashboard_id)
     return {
         ...baseInsight,
         ...(dashboards ? { dashboards } : {}),

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -90,7 +90,16 @@ type ReturnInsightModel<T> = T extends InsightModel
 /** Get an insight with `query` only. Eventual `filters` will be converted.  */
 export function getQueryBasedInsightModel<T extends InputInsightModel>(insight: T): ReturnInsightModel<T> {
     const { filters, ...baseInsight } = insight
-    return { ...baseInsight, query: getQueryFromInsightLike(insight) } as unknown as ReturnInsightModel<T>
+    return {
+        ...baseInsight,
+        // The API is phasing out the deprecated `dashboards` field (already omitted for token
+        // callers, eventually for all); derive it from `dashboard_tiles` so remaining readers
+        // keep working regardless of whether the response still carries it.
+        ...(insight.dashboards === undefined && insight.dashboard_tiles
+            ? { dashboards: insight.dashboard_tiles.map((tile) => tile.dashboard_id) }
+            : {}),
+        query: getQueryFromInsightLike(insight),
+    } as unknown as ReturnInsightModel<T>
 }
 
 /** Get a `query` from an object that potentially has `filters` instead of a `query`.  */

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -1182,6 +1182,18 @@ def custom_postprocessing_hook(result, generator, request, public):
             name: _fix_pydantic_schema_for_openapi(schema) for name, schema in result["components"]["schemas"].items()
         }
 
+    # The deprecated insight `dashboards` field is gated behind an opt-in query parameter, so it
+    # can be absent from any insight payload — but drf-spectacular always marks read-only fields
+    # as required, which would make strict generated clients reject gated responses. Un-require
+    # it wherever it appears alongside its replacement, `dashboard_tiles`.
+    for schema in ((result.get("components") or {}).get("schemas") or {}).values():
+        properties = schema.get("properties") if isinstance(schema, dict) else None
+        if not isinstance(properties, dict) or "dashboards" not in properties or "dashboard_tiles" not in properties:
+            continue
+        required = schema.get("required")
+        if isinstance(required, list) and "dashboards" in required:
+            schema["required"] = [field for field in required if field != "dashboards"]
+
     # Apply the same cleanup to parameter, requestBody, and response schemas at the operation
     # level — single-entry allOf wrappers and vestigial bounds also surface there.  Today
     # every response schema we emit is a ``$ref`` to a component, so the response walk is a

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -928,6 +928,22 @@ def _fix_pydantic_schema_for_openapi(schema):
     return schema
 
 
+def _unrequire_deprecated_dashboards_field(schema):
+    """
+    The deprecated insight `dashboards` field is gated behind an opt-in query parameter, so it
+    can be absent from any insight payload — but drf-spectacular always marks read-only fields
+    as required, which would make strict generated clients reject gated responses. Un-require
+    it wherever it appears alongside its replacement, `dashboard_tiles`.
+    """
+    properties = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(properties, dict) or not {"dashboards", "dashboard_tiles"} <= properties.keys():
+        return schema
+    required = schema.get("required")
+    if isinstance(required, list) and "dashboards" in required:
+        schema["required"] = [field for field in required if field != "dashboards"]
+    return schema
+
+
 def lint_spec_consistency_hook(result, generator, request, public):
     """Postprocessing hook that emits drf-spectacular warnings for spec self-inconsistencies.
 
@@ -1179,20 +1195,9 @@ def custom_postprocessing_hook(result, generator, request, public):
     # Apply OpenAPI 3.1 schema cleanup to all component schemas.
     if "components" in result and "schemas" in result["components"]:
         result["components"]["schemas"] = {
-            name: _fix_pydantic_schema_for_openapi(schema) for name, schema in result["components"]["schemas"].items()
+            name: _unrequire_deprecated_dashboards_field(_fix_pydantic_schema_for_openapi(schema))
+            for name, schema in result["components"]["schemas"].items()
         }
-
-    # The deprecated insight `dashboards` field is gated behind an opt-in query parameter, so it
-    # can be absent from any insight payload — but drf-spectacular always marks read-only fields
-    # as required, which would make strict generated clients reject gated responses. Un-require
-    # it wherever it appears alongside its replacement, `dashboard_tiles`.
-    for schema in ((result.get("components") or {}).get("schemas") or {}).values():
-        properties = schema.get("properties") if isinstance(schema, dict) else None
-        if not isinstance(properties, dict) or "dashboards" not in properties or "dashboard_tiles" not in properties:
-            continue
-        required = schema.get("required")
-        if isinstance(required, list) and "dashboards" in required:
-            schema["required"] = [field for field in required if field != "dashboards"]
 
     # Apply the same cleanup to parameter, requestBody, and response schemas at the operation
     # level — single-entry allOf wrappers and vestigial bounds also surface there.  Today

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -14,6 +14,13 @@ from posthog.utils_cors import CORS_ALLOWED_TRACING_HEADERS
 logger = structlog.get_logger(__name__)
 
 ####
+# Deprecated insight `dashboards` field: two-phase removal. While False (phase 1), every caller
+# still receives the field and usage is metered by access method; flipping to True (phase 2)
+# enforces the `include_dashboards` opt-in for non-first-party callers. Env-toggleable so the
+# enforcement can be reverted without a code change.
+INSIGHT_DASHBOARDS_OPT_IN_ENFORCED = get_from_env("INSIGHT_DASHBOARDS_OPT_IN_ENFORCED", False, type_cast=str_to_bool)
+
+####
 # django-axes
 
 # lockout after too many attempts

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -141,6 +141,7 @@ from products.notifications.backend.facade.api import (
     has_been_dispatched,
 )
 from products.product_analytics.backend.api.insight import (
+    INCLUDE_DASHBOARDS_PARAMETER,
     DashboardTileBasicSerializer,
     InsightSerializer,
     InsightViewSet,
@@ -2114,6 +2115,9 @@ class DashboardSubscribeNudgeResponseSerializer(serializers.Serializer):
             ),
         ],
     ),
+    # Dashboards nest insight payloads, so the deprecated-`dashboards`-field opt-in applies to
+    # `tiles[].insight` here too.
+    retrieve=extend_schema(parameters=[INCLUDE_DASHBOARDS_PARAMETER]),
     partial_update=extend_schema(request=PatchedDashboardOpenApiSerializer),
 )
 class DashboardsViewSet(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2115,10 +2115,12 @@ class DashboardSubscribeNudgeResponseSerializer(serializers.Serializer):
             ),
         ],
     ),
-    # Dashboards nest insight payloads, so the deprecated-`dashboards`-field opt-in applies to
-    # `tiles[].insight` here too.
+    # Dashboards nest insight payloads via `tiles[].insight`, so the deprecated-`dashboards`-field
+    # opt-in applies here too — on every action whose response uses DashboardSerializer.
+    create=extend_schema(parameters=[INCLUDE_DASHBOARDS_PARAMETER]),
     retrieve=extend_schema(parameters=[INCLUDE_DASHBOARDS_PARAMETER]),
-    partial_update=extend_schema(request=PatchedDashboardOpenApiSerializer),
+    update=extend_schema(parameters=[INCLUDE_DASHBOARDS_PARAMETER]),
+    partial_update=extend_schema(request=PatchedDashboardOpenApiSerializer, parameters=[INCLUDE_DASHBOARDS_PARAMETER]),
 )
 class DashboardsViewSet(
     TeamAndOrgViewSetMixin,

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -8210,9 +8210,9 @@ export interface InsightApi {
      *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *         Session-authenticated (web app) requests receive this field; other callers (personal API
-     *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
-     *         receive it.
+     *         This field may be omitted from responses: once opt-in enforcement is enabled, API-token
+     *         callers (personal API keys, OAuth) only receive it when passing the
+     *         `include_dashboards=true` query parameter. Do not rely on it being present.
      *
      * @deprecated
      */
@@ -9283,6 +9283,10 @@ export type DashboardsRetrieveParams = {
      */
     filters_override?: string
     format?: DashboardsRetrieveFormat
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
     /**
      * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -9268,6 +9268,10 @@ export const DashboardsListFormat = {
 
 export type DashboardsCreateParams = {
     format?: DashboardsCreateFormat
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
 }
 
 export type DashboardsCreateFormat = (typeof DashboardsCreateFormat)[keyof typeof DashboardsCreateFormat]
@@ -9302,6 +9306,10 @@ export const DashboardsRetrieveFormat = {
 
 export type DashboardsUpdateParams = {
     format?: DashboardsUpdateFormat
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
 }
 
 export type DashboardsUpdateFormat = (typeof DashboardsUpdateFormat)[keyof typeof DashboardsUpdateFormat]
@@ -9313,6 +9321,10 @@ export const DashboardsUpdateFormat = {
 
 export type DashboardsPartialUpdateParams = {
     format?: DashboardsPartialUpdateFormat
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
 }
 
 export type DashboardsPartialUpdateFormat =

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -8210,8 +8210,9 @@ export interface InsightApi {
      *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
-     *         is omitted from responses otherwise.
+     *         Session-authenticated (web app) requests receive this field; other callers (personal API
+     *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
+     *         receive it.
      *
      * @deprecated
      */

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -8207,9 +8207,14 @@ export interface InsightApi {
     order?: number | null
     deleted?: boolean
     /**
+     *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *          */
+     *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
+     *         is omitted from responses otherwise.
+     *
+     * @deprecated
+     */
     dashboards?: number[]
     /**
      *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -336,7 +336,8 @@ INCLUDE_DASHBOARDS_PARAM = "include_dashboards"
 DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER = Counter(
     "posthog_api_insight_deprecated_dashboards_field_used_total",
     "Times the deprecated insight `dashboards` field was served in an insight payload (usage=read) "
-    "or accepted as write input (usage=write), by authentication method.",
+    "or applied as an effective write that changed an insight's dashboards (usage=write), by "
+    "authentication method. No-op writes (unchanged dashboard list) are not counted.",
     labelnames=["usage", "access_method"],
 )
 
@@ -372,8 +373,13 @@ def should_serve_deprecated_dashboards_field(context: dict) -> bool:
 
 
 def _record_deprecated_dashboards_field_used(context: dict, usage: str) -> None:
+    request = context.get("request")
+    if request is None:
+        # Internal serialization (exports, subscriptions, my_last_viewed) has no requesting
+        # client to migrate, so it shouldn't count toward the token-caller removal signal.
+        return
     DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
-        usage=usage, access_method=_dashboards_field_access_method(context.get("request"))
+        usage=usage, access_method=_dashboards_field_access_method(request)
     ).inc()
 
 
@@ -1079,10 +1085,11 @@ class InsightSerializer(InsightBasicSerializer):
         # we store them and can use that list to correct the response
         # and avoid refreshing from the DB
         #
-        # `after_dashboard_changes` is only populated when this request itself wrote `dashboards`
-        # (see _update_insight_dashboards), so a caller that isn't opted into the deprecated field
-        # for reads still needs to see the corrected value for the write it just made.
-        if self.context.get("after_dashboard_changes"):
+        # `after_dashboard_changes` is only set (even to an empty list) when this request itself
+        # wrote `dashboards` (see _update_insight_dashboards), so a caller that isn't opted into
+        # the deprecated field for reads still needs to see the corrected value for the write it
+        # just made — including the "removed from all dashboards" case.
+        if "after_dashboard_changes" in self.context:
             representation["dashboards"] = [
                 described_dashboard["id"] for described_dashboard in self.context["after_dashboard_changes"]
             ]

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -343,6 +343,8 @@ DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER = Counter(
 
 def _dashboards_field_access_method(request: Request | None) -> str:
     authenticator = getattr(request, "successful_authenticator", None)
+    # An unresolved authenticator (no DRF auth ran) is treated as session below: it's not a
+    # token caller we're trying to migrate off the field, so keep serving it.
     if authenticator is None:
         return "no_authenticator"
     if isinstance(authenticator, SessionAuthentication):
@@ -363,14 +365,16 @@ def should_serve_deprecated_dashboards_field(context: dict) -> bool:
     if request is None:
         # Internal serialization (exports, subscriptions) has no requesting client to migrate.
         return True
-    authenticator = getattr(request, "successful_authenticator", None)
-    # An unresolved authenticator (no DRF auth ran) fails open as session: it's not a token
-    # caller we're trying to migrate off the field, so keep serving it. See
-    # _dashboards_field_access_method for the corresponding metric label.
-    is_session = authenticator is None or isinstance(authenticator, SessionAuthentication)
+    is_session = _dashboards_field_access_method(request) in ("no_authenticator", "session")
     query_params = getattr(request, "query_params", None)
     opted_in = query_params is not None and str_to_bool(query_params.get(INCLUDE_DASHBOARDS_PARAM, "0"))
     return is_session or opted_in
+
+
+def _record_deprecated_dashboards_field_used(context: dict, usage: str) -> None:
+    DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
+        usage=usage, access_method=_dashboards_field_access_method(context.get("request"))
+    ).inc()
 
 
 @extend_schema_serializer(exclude_fields=["filters", "saved"], deprecate_fields=["dashboards"])
@@ -433,9 +437,7 @@ class InsightBasicSerializer(
         representation = super().to_representation(instance)
 
         if should_serve_deprecated_dashboards_field(self.context):
-            DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
-                usage="read", access_method=_dashboards_field_access_method(self.context.get("request"))
-            ).inc()
+            _record_deprecated_dashboards_field_used(self.context, usage="read")
             representation["dashboards"] = [tile["dashboard_id"] for tile in representation["dashboard_tiles"]]
         else:
             representation.pop("dashboards", None)
@@ -703,9 +705,7 @@ class InsightSerializer(InsightBasicSerializer):
                     raise serializers.ValidationError("Dashboard not found")
 
             if target_dashboards:
-                DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
-                    usage="write", access_method=_dashboards_field_access_method(self.context.get("request"))
-                ).inc()
+                _record_deprecated_dashboards_field_used(self.context, usage="write")
 
         insight = Insight.objects.create(
             team_id=team_id,
@@ -936,9 +936,7 @@ class InsightSerializer(InsightBasicSerializer):
                     request=self.context["request"],
                 )
 
-        DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
-            usage="write", access_method=_dashboards_field_access_method(self.context.get("request"))
-        ).inc()
+        _record_deprecated_dashboards_field_used(self.context, usage="write")
 
         self.context["after_dashboard_changes"] = [describe_change(d) for d in dashboards if not d.deleted]
 

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from functools import lru_cache
 from typing import Any, Union, cast
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Count, Exists, F, Max, OuterRef, Prefetch, QuerySet, Subquery
 from django.db.models.query_utils import Q
@@ -361,20 +362,33 @@ def _is_internal_serialization_context(context: dict) -> bool:
     return context.get("request") is None
 
 
+def _is_first_party_request(request: Request) -> bool:
+    authenticator = getattr(request, "successful_authenticator", None)
+    # Session (and unresolved-auth) requests come from the web app; sharing-token requests render
+    # PostHog's own shared/exporter frontend. Both are our surfaces, not external integrations,
+    # so they keep the field until the frontend fully migrates to dashboard_tiles.
+    return authenticator is None or isinstance(
+        authenticator,
+        SessionAuthentication | SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication,
+    )
+
+
 def should_serve_deprecated_dashboards_field(context: dict) -> bool:
     """
-    The insight `dashboards` field is deprecated in favor of `dashboard_tiles`, but computing it
-    for every response keeps every caller coupled to it. The web app still reads and writes it,
-    so session-authenticated requests keep receiving it until the frontend migrates; every other
-    caller must opt in with `?include_dashboards=true`.
+    The insight `dashboards` field is deprecated in favor of `dashboard_tiles`. Removal is
+    two-phase: while INSIGHT_DASHBOARDS_OPT_IN_ENFORCED is off, every caller still receives the
+    field and reads are metered by access method so remaining usage can drain; once enforced,
+    non-first-party callers must opt in with `?include_dashboards=true`.
     """
     if _is_internal_serialization_context(context):
         return True
     request = context["request"]
-    is_session = _dashboards_field_access_method(request) in ("no_authenticator", "session")
+    if _is_first_party_request(request):
+        return True
     query_params = getattr(request, "query_params", None)
-    opted_in = query_params is not None and str_to_bool(query_params.get(INCLUDE_DASHBOARDS_PARAM, "0"))
-    return is_session or opted_in
+    if query_params is not None and str_to_bool(query_params.get(INCLUDE_DASHBOARDS_PARAM, "0")):
+        return True
+    return not settings.INSIGHT_DASHBOARDS_OPT_IN_ENFORCED
 
 
 def _record_deprecated_dashboards_field_used(context: dict, usage: str) -> None:
@@ -565,9 +579,9 @@ class InsightSerializer(InsightBasicSerializer):
         help_text="""
         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
         A dashboard ID for each of the dashboards that this insight is displayed on.
-        Session-authenticated (web app) requests receive this field; other callers (personal API
-        keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
-        receive it.
+        This field may be omitted from responses: once opt-in enforcement is enabled, API-token
+        callers (personal API keys, OAuth) only receive it when passing the
+        `include_dashboards=true` query parameter. Do not rely on it being present.
         """,
         many=True,
         required=False,
@@ -1396,8 +1410,9 @@ INCLUDE_DASHBOARDS_PARAMETER = OpenApiParameter(
     name=INCLUDE_DASHBOARDS_PARAM,
     type=OpenApiTypes.BOOL,
     description=(
-        "Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token "
-        "callers no longer receive it by default; use `dashboard_tiles` instead."
+        "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in "
+        "enforcement is enabled, API-token callers stop receiving it by default; use "
+        "`dashboard_tiles` instead."
     ),
 )
 

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -343,6 +343,13 @@ DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER = Counter(
 )
 
 
+# Access methods that are our own surfaces (web app, shared/exporter frontend) rather than
+# external integrations. Unresolved auth ("no_authenticator") comes from the web app too. These
+# keep receiving the deprecated `dashboards` field until the frontend fully migrates to
+# dashboard_tiles, regardless of opt-in enforcement.
+_FIRST_PARTY_ACCESS_METHODS = frozenset({"no_authenticator", "session", "sharing_token"})
+
+
 def _dashboards_field_access_method(request: Request | None) -> str:
     authenticator = getattr(request, "successful_authenticator", None)
     # An unresolved authenticator (no DRF auth ran) is treated as session below: it's not a
@@ -351,6 +358,8 @@ def _dashboards_field_access_method(request: Request | None) -> str:
         return "no_authenticator"
     if isinstance(authenticator, SessionAuthentication):
         return "session"
+    if isinstance(authenticator, SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication):
+        return "sharing_token"
     if isinstance(authenticator, PersonalAPIKeyAuthentication):
         return "personal_api_key"
     return type(authenticator).__name__
@@ -362,15 +371,8 @@ def _is_internal_serialization_context(context: dict) -> bool:
     return context.get("request") is None
 
 
-def _is_first_party_request(request: Request) -> bool:
-    authenticator = getattr(request, "successful_authenticator", None)
-    # Session (and unresolved-auth) requests come from the web app; sharing-token requests render
-    # PostHog's own shared/exporter frontend. Both are our surfaces, not external integrations,
-    # so they keep the field until the frontend fully migrates to dashboard_tiles.
-    return authenticator is None or isinstance(
-        authenticator,
-        SessionAuthentication | SharingAccessTokenAuthentication | SharingPasswordProtectedAuthentication,
-    )
+def _is_first_party_request(request: Request | None) -> bool:
+    return _dashboards_field_access_method(request) in _FIRST_PARTY_ACCESS_METHODS
 
 
 def should_serve_deprecated_dashboards_field(context: dict) -> bool:
@@ -448,7 +450,12 @@ class InsightBasicSerializer(
 
     @extend_schema_field(serializers.ListField(child=serializers.IntegerField()))
     def get_dashboards(self, instance: Insight) -> list[int]:
-        return [tile.dashboard_id for tile in instance.dashboard_tiles.all()]
+        # `to_representation` below always recomputes this field when serving it, so this only
+        # backs schema generation and any other caller of the method field directly. Excludes
+        # soft-deleted tiles to match that recomputation — filtered in Python, not with
+        # .exclude(), since a chained queryset bypasses the dashboard_tiles prefetch cache and
+        # reintroduces a per-insight query.
+        return [tile.dashboard_id for tile in instance.dashboard_tiles.all() if not tile.deleted]
 
     @extend_schema_field(serializers.DateTimeField(allow_null=True))
     def get_last_viewed_at(self, instance: Insight):

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -355,6 +355,12 @@ def _dashboards_field_access_method(request: Request | None) -> str:
     return type(authenticator).__name__
 
 
+def _is_internal_serialization_context(context: dict) -> bool:
+    # Internal serialization (exports, subscriptions, my_last_viewed) has no requesting client to
+    # migrate, so it's exempt from both the opt-in gate and the deprecation-usage counter.
+    return context.get("request") is None
+
+
 def should_serve_deprecated_dashboards_field(context: dict) -> bool:
     """
     The insight `dashboards` field is deprecated in favor of `dashboard_tiles`, but computing it
@@ -362,10 +368,9 @@ def should_serve_deprecated_dashboards_field(context: dict) -> bool:
     so session-authenticated requests keep receiving it until the frontend migrates; every other
     caller must opt in with `?include_dashboards=true`.
     """
-    request = context.get("request")
-    if request is None:
-        # Internal serialization (exports, subscriptions) has no requesting client to migrate.
+    if _is_internal_serialization_context(context):
         return True
+    request = context["request"]
     is_session = _dashboards_field_access_method(request) in ("no_authenticator", "session")
     query_params = getattr(request, "query_params", None)
     opted_in = query_params is not None and str_to_bool(query_params.get(INCLUDE_DASHBOARDS_PARAM, "0"))
@@ -373,13 +378,10 @@ def should_serve_deprecated_dashboards_field(context: dict) -> bool:
 
 
 def _record_deprecated_dashboards_field_used(context: dict, usage: str) -> None:
-    request = context.get("request")
-    if request is None:
-        # Internal serialization (exports, subscriptions, my_last_viewed) has no requesting
-        # client to migrate, so it shouldn't count toward the token-caller removal signal.
+    if _is_internal_serialization_context(context):
         return
     DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
-        usage=usage, access_method=_dashboards_field_access_method(request)
+        usage=usage, access_method=_dashboards_field_access_method(context["request"])
     ).inc()
 
 

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -52,7 +52,12 @@ from posthog.api.services.query import process_query_dict, process_query_model
 from posthog.api.shared import SearchMatchTypeSerializerMixin, UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.api.utils import action, format_paginated_url
-from posthog.auth import SharingAccessTokenAuthentication, SharingPasswordProtectedAuthentication
+from posthog.auth import (
+    PersonalAPIKeyAuthentication,
+    SessionAuthentication,
+    SharingAccessTokenAuthentication,
+    SharingPasswordProtectedAuthentication,
+)
 from posthog.caching.fetch_from_cache import InsightResult, fetch_cached_response_by_key
 from posthog.clickhouse.cancel import cancel_query_on_cluster
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
@@ -326,7 +331,50 @@ class DashboardTileBasicSerializer(serializers.ModelSerializer):
         fields = ["id", "dashboard_id", "deleted"]
 
 
-@extend_schema_serializer(exclude_fields=["filters", "saved"])
+INCLUDE_DASHBOARDS_PARAM = "include_dashboards"
+
+DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER = Counter(
+    "posthog_api_insight_deprecated_dashboards_field_used_total",
+    "Times the deprecated insight `dashboards` field was served in an insight payload (usage=read) "
+    "or accepted as write input (usage=write), by authentication method.",
+    labelnames=["usage", "access_method"],
+)
+
+
+def _dashboards_field_access_method(request: Request | None) -> str:
+    authenticator = getattr(request, "successful_authenticator", None)
+    if authenticator is None or isinstance(authenticator, SessionAuthentication):
+        return "session"
+    if isinstance(authenticator, PersonalAPIKeyAuthentication):
+        return "personal_api_key"
+    return type(authenticator).__name__
+
+
+def should_serve_deprecated_dashboards_field(context: dict) -> bool:
+    """
+    The insight `dashboards` field is deprecated in favor of `dashboard_tiles`, but computing it
+    for every response keeps every caller coupled to it. The web app still reads and writes it,
+    so session-authenticated requests keep receiving it until the frontend migrates; every other
+    caller must opt in with `?include_dashboards=true`. Serving is metered per insight payload so
+    remaining usage is visible before the field is removed.
+    """
+    request = context.get("request")
+    if request is None:
+        # Internal serialization (exports, subscriptions) has no requesting client to migrate.
+        return True
+    authenticator = getattr(request, "successful_authenticator", None)
+    is_session = authenticator is None or isinstance(authenticator, SessionAuthentication)
+    query_params = getattr(request, "query_params", None)
+    opted_in = query_params is not None and str_to_bool(query_params.get(INCLUDE_DASHBOARDS_PARAM, "0"))
+    if is_session or opted_in:
+        DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
+            usage="read", access_method=_dashboards_field_access_method(request)
+        ).inc()
+        return True
+    return False
+
+
+@extend_schema_serializer(exclude_fields=["filters", "saved"], deprecate_fields=["dashboards"])
 class InsightBasicSerializer(
     SearchMatchTypeSerializerMixin,
     TaggedItemSerializerMixin,
@@ -385,7 +433,10 @@ class InsightBasicSerializer(
     def to_representation(self, instance):
         representation = super().to_representation(instance)
 
-        representation["dashboards"] = [tile["dashboard_id"] for tile in representation["dashboard_tiles"]]
+        if should_serve_deprecated_dashboards_field(self.context):
+            representation["dashboards"] = [tile["dashboard_id"] for tile in representation["dashboard_tiles"]]
+        else:
+            representation.pop("dashboards", None)
 
         if instance.query is not None or instance.query_from_filters is not None:
             representation["filters"] = {}
@@ -466,6 +517,7 @@ class InsightFilterOverrideContext(BaseModel):
     )
 
 
+@extend_schema_serializer(deprecate_fields=["dashboards"])
 class InsightSerializer(InsightBasicSerializer):
     result = serializers.SerializerMethodField()
     hasMore = serializers.SerializerMethodField()
@@ -501,6 +553,8 @@ class InsightSerializer(InsightBasicSerializer):
         help_text="""
         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
         A dashboard ID for each of the dashboards that this insight is displayed on.
+        Only returned to API-token callers when `include_dashboards=true` is passed; the field
+        is omitted from responses otherwise.
         """,
         many=True,
         required=False,
@@ -596,6 +650,9 @@ class InsightSerializer(InsightBasicSerializer):
 
         new_dashboards = attrs.get("dashboards")
         if new_dashboards is not None:
+            DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
+                usage="write", access_method=_dashboards_field_access_method(self.context.get("request"))
+            ).inc()
             team = self.context["get_team"]()
             existing_dashboard_ids: set[int] = set()
             if self.instance is not None:
@@ -1014,7 +1071,7 @@ class InsightSerializer(InsightBasicSerializer):
         # when they have just been updated
         # we store them and can use that list to correct the response
         # and avoid refreshing from the DB
-        if self.context.get("after_dashboard_changes"):
+        if self.context.get("after_dashboard_changes") and "dashboards" in representation:
             representation["dashboards"] = [
                 described_dashboard["id"] for described_dashboard in self.context["after_dashboard_changes"]
             ]
@@ -1315,6 +1372,15 @@ INSIGHT_ID_PATH_PARAMETER = OpenApiParameter(
     description="Numeric primary key or 8-character `short_id` (for example `AaVQ8Ijw`) identifying the insight.",
 )
 
+INCLUDE_DASHBOARDS_PARAMETER = OpenApiParameter(
+    name=INCLUDE_DASHBOARDS_PARAM,
+    type=OpenApiTypes.BOOL,
+    description=(
+        "Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token "
+        "callers no longer receive it by default; use `dashboard_tiles` instead."
+    ),
+)
+
 
 INSIGHT_VIEWED_MAX_IDS = 2500
 
@@ -1398,6 +1464,7 @@ Background calculation can be tracked using the `query_status` response field.""
                 type=OpenApiTypes.BOOL,
                 description="Return basic insight metadata only (no results, faster).",
             ),
+            INCLUDE_DASHBOARDS_PARAMETER,
             OpenApiParameter(
                 name="search",
                 type=OpenApiTypes.STR,
@@ -1474,6 +1541,7 @@ Background calculation can be tracked using the `query_status` response field.""
             ),
         ]
     ),
+    retrieve=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER, INCLUDE_DASHBOARDS_PARAMETER]),
     update=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER]),
     partial_update=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER]),
     destroy=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER]),

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -460,7 +460,11 @@ class InsightBasicSerializer(
 
         if should_serve_deprecated_dashboards_field(self.context):
             _record_deprecated_dashboards_field_used(self.context, usage="read")
-            representation["dashboards"] = [tile["dashboard_id"] for tile in representation["dashboard_tiles"]]
+            # Exclude soft-deleted tiles, matching the write-echo correction and the frontend's
+            # dashboard_tiles-based derivation.
+            representation["dashboards"] = [
+                tile["dashboard_id"] for tile in representation["dashboard_tiles"] if not tile.get("deleted")
+            ]
         else:
             representation.pop("dashboards", None)
 

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -343,7 +343,9 @@ DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER = Counter(
 
 def _dashboards_field_access_method(request: Request | None) -> str:
     authenticator = getattr(request, "successful_authenticator", None)
-    if authenticator is None or isinstance(authenticator, SessionAuthentication):
+    if authenticator is None:
+        return "no_authenticator"
+    if isinstance(authenticator, SessionAuthentication):
         return "session"
     if isinstance(authenticator, PersonalAPIKeyAuthentication):
         return "personal_api_key"
@@ -355,23 +357,20 @@ def should_serve_deprecated_dashboards_field(context: dict) -> bool:
     The insight `dashboards` field is deprecated in favor of `dashboard_tiles`, but computing it
     for every response keeps every caller coupled to it. The web app still reads and writes it,
     so session-authenticated requests keep receiving it until the frontend migrates; every other
-    caller must opt in with `?include_dashboards=true`. Serving is metered per insight payload so
-    remaining usage is visible before the field is removed.
+    caller must opt in with `?include_dashboards=true`.
     """
     request = context.get("request")
     if request is None:
         # Internal serialization (exports, subscriptions) has no requesting client to migrate.
         return True
     authenticator = getattr(request, "successful_authenticator", None)
+    # An unresolved authenticator (no DRF auth ran) fails open as session: it's not a token
+    # caller we're trying to migrate off the field, so keep serving it. See
+    # _dashboards_field_access_method for the corresponding metric label.
     is_session = authenticator is None or isinstance(authenticator, SessionAuthentication)
     query_params = getattr(request, "query_params", None)
     opted_in = query_params is not None and str_to_bool(query_params.get(INCLUDE_DASHBOARDS_PARAM, "0"))
-    if is_session or opted_in:
-        DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
-            usage="read", access_method=_dashboards_field_access_method(request)
-        ).inc()
-        return True
-    return False
+    return is_session or opted_in
 
 
 @extend_schema_serializer(exclude_fields=["filters", "saved"], deprecate_fields=["dashboards"])
@@ -434,6 +433,9 @@ class InsightBasicSerializer(
         representation = super().to_representation(instance)
 
         if should_serve_deprecated_dashboards_field(self.context):
+            DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
+                usage="read", access_method=_dashboards_field_access_method(self.context.get("request"))
+            ).inc()
             representation["dashboards"] = [tile["dashboard_id"] for tile in representation["dashboard_tiles"]]
         else:
             representation.pop("dashboards", None)
@@ -553,8 +555,9 @@ class InsightSerializer(InsightBasicSerializer):
         help_text="""
         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
         A dashboard ID for each of the dashboards that this insight is displayed on.
-        Only returned to API-token callers when `include_dashboards=true` is passed; the field
-        is omitted from responses otherwise.
+        Session-authenticated (web app) requests receive this field; other callers (personal API
+        keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
+        receive it.
         """,
         many=True,
         required=False,
@@ -650,9 +653,6 @@ class InsightSerializer(InsightBasicSerializer):
 
         new_dashboards = attrs.get("dashboards")
         if new_dashboards is not None:
-            DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
-                usage="write", access_method=_dashboards_field_access_method(self.context.get("request"))
-            ).inc()
             team = self.context["get_team"]()
             existing_dashboard_ids: set[int] = set()
             if self.instance is not None:
@@ -701,6 +701,11 @@ class InsightSerializer(InsightBasicSerializer):
 
                 if dashboard.team_id != team_id:
                     raise serializers.ValidationError("Dashboard not found")
+
+            if target_dashboards:
+                DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
+                    usage="write", access_method=_dashboards_field_access_method(self.context.get("request"))
+                ).inc()
 
         insight = Insight.objects.create(
             team_id=team_id,
@@ -931,6 +936,10 @@ class InsightSerializer(InsightBasicSerializer):
                     request=self.context["request"],
                 )
 
+        DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER.labels(
+            usage="write", access_method=_dashboards_field_access_method(self.context.get("request"))
+        ).inc()
+
         self.context["after_dashboard_changes"] = [describe_change(d) for d in dashboards if not d.deleted]
 
     @extend_schema_field(OpenApiTypes.ANY)
@@ -1071,7 +1080,11 @@ class InsightSerializer(InsightBasicSerializer):
         # when they have just been updated
         # we store them and can use that list to correct the response
         # and avoid refreshing from the DB
-        if self.context.get("after_dashboard_changes") and "dashboards" in representation:
+        #
+        # `after_dashboard_changes` is only populated when this request itself wrote `dashboards`
+        # (see _update_insight_dashboards), so a caller that isn't opted into the deprecated field
+        # for reads still needs to see the corrected value for the write it just made.
+        if self.context.get("after_dashboard_changes"):
             representation["dashboards"] = [
                 described_dashboard["id"] for described_dashboard in self.context["after_dashboard_changes"]
             ]
@@ -1541,9 +1554,10 @@ Background calculation can be tracked using the `query_status` response field.""
             ),
         ]
     ),
+    create=extend_schema(parameters=[INCLUDE_DASHBOARDS_PARAMETER]),
     retrieve=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER, INCLUDE_DASHBOARDS_PARAMETER]),
-    update=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER]),
-    partial_update=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER]),
+    update=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER, INCLUDE_DASHBOARDS_PARAMETER]),
+    partial_update=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER, INCLUDE_DASHBOARDS_PARAMETER]),
     destroy=extend_schema(parameters=[INSIGHT_ID_PATH_PARAMETER]),
 )
 class InsightViewSet(

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -337,8 +337,8 @@ INCLUDE_DASHBOARDS_PARAM = "include_dashboards"
 DEPRECATED_DASHBOARDS_FIELD_USED_COUNTER = Counter(
     "posthog_api_insight_deprecated_dashboards_field_used_total",
     "Times the deprecated insight `dashboards` field was served in an insight payload (usage=read) "
-    "or applied as an effective write that changed an insight's dashboards (usage=write), by "
-    "authentication method. No-op writes (unchanged dashboard list) are not counted.",
+    "or accepted as write input on a permitted create/update (usage=write, including no-op writes), "
+    "by authentication method. Rejected requests are not counted.",
     labelnames=["usage", "access_method"],
 )
 
@@ -737,8 +737,9 @@ class InsightSerializer(InsightBasicSerializer):
                 if dashboard.team_id != team_id:
                     raise serializers.ValidationError("Dashboard not found")
 
-            if target_dashboards:
-                _record_deprecated_dashboards_field_used(self.context, usage="write")
+            # Counts the field being accepted as write input (even an empty list), after
+            # permission checks so rejected requests don't inflate the metric.
+            _record_deprecated_dashboards_field_used(self.context, usage="write")
 
         insight = Insight.objects.create(
             team_id=team_id,
@@ -897,6 +898,10 @@ class InsightSerializer(InsightBasicSerializer):
         return []
 
     def _update_insight_dashboards(self, dashboards: list[Dashboard], instance: Insight) -> None:
+        # Counts the field being accepted as write input — before the no-op early return, so
+        # integrations that round-trip an unchanged dashboards list still register as writers.
+        _record_deprecated_dashboards_field_used(self.context, usage="write")
+
         old_dashboard_ids = [tile.dashboard_id for tile in instance.dashboard_tiles.all()]
         new_dashboard_ids = [d.id for d in dashboards if not d.deleted]
 
@@ -968,8 +973,6 @@ class InsightSerializer(InsightBasicSerializer):
                     team=instance.team,
                     request=self.context["request"],
                 )
-
-        _record_deprecated_dashboards_field_used(self.context, usage="write")
 
         self.context["after_dashboard_changes"] = [describe_change(d) for d in dashboards if not d.deleted]
 
@@ -1834,6 +1837,7 @@ class InsightViewSet(
                 description="Maximum number of insights to return. Defaults to 10. Capped at 100.",
                 required=False,
             ),
+            INCLUDE_DASHBOARDS_PARAMETER,
         ],
         responses={200: TrendingInsightSerializer(many=True)},
         description=(

--- a/products/product_analytics/backend/api/test/test_deprecated_dashboards_field.py
+++ b/products/product_analytics/backend/api/test/test_deprecated_dashboards_field.py
@@ -64,23 +64,25 @@ class TestDeprecatedDashboardsFieldAPI(APIBaseTest):
             secure_value=hash_key_value(token),
             scopes=["insight:read"],
         )
-        self.token_auth = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+        self.bearer = f"Bearer {token}"
 
     @override_settings(INSIGHT_DASHBOARDS_OPT_IN_ENFORCED=True)
     def test_enforced_personal_api_key_must_opt_in_to_deprecated_dashboards_field(self):
         url = f"/api/projects/{self.team.id}/insights/{self.insight.id}/"
 
-        default_response = self.client.get(url, **self.token_auth)
+        default_response = self.client.get(url, HTTP_AUTHORIZATION=self.bearer)
         assert default_response.status_code == status.HTTP_200_OK
         assert "dashboards" not in default_response.json()
         assert [tile["dashboard_id"] for tile in default_response.json()["dashboard_tiles"]] == [self.dashboard.id]
 
-        opted_in_response = self.client.get(url, {"include_dashboards": "true"}, **self.token_auth)
+        opted_in_response = self.client.get(url, {"include_dashboards": "true"}, HTTP_AUTHORIZATION=self.bearer)
         assert opted_in_response.status_code == status.HTTP_200_OK
         assert opted_in_response.json()["dashboards"] == [self.dashboard.id]
 
     def test_unenforced_personal_api_key_still_receives_deprecated_dashboards_field(self):
-        response = self.client.get(f"/api/projects/{self.team.id}/insights/{self.insight.id}/", **self.token_auth)
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/{self.insight.id}/", HTTP_AUTHORIZATION=self.bearer
+        )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["dashboards"] == [self.dashboard.id]
 

--- a/products/product_analytics/backend/api/test/test_deprecated_dashboards_field.py
+++ b/products/product_analytics/backend/api/test/test_deprecated_dashboards_field.py
@@ -1,7 +1,7 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 from rest_framework import status
@@ -29,16 +29,26 @@ class TestShouldServeDeprecatedDashboardsField(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("session_auth", SessionAuthentication(), {}, True),
-            ("no_authenticator_is_session", None, {}, True),
-            ("personal_api_key_without_opt_in", PersonalAPIKeyAuthentication(), {}, False),
-            ("personal_api_key_with_opt_in", PersonalAPIKeyAuthentication(), {"include_dashboards": "true"}, True),
-            ("sharing_token_without_opt_in", SharingAccessTokenAuthentication(), {}, False),
+            ("session_auth", SessionAuthentication(), {}, False, True),
+            ("no_authenticator_is_first_party", None, {}, True, True),
+            ("sharing_token_is_first_party", SharingAccessTokenAuthentication(), {}, True, True),
+            ("personal_api_key_unenforced_phase", PersonalAPIKeyAuthentication(), {}, False, True),
+            ("personal_api_key_enforced_without_opt_in", PersonalAPIKeyAuthentication(), {}, True, False),
+            (
+                "personal_api_key_enforced_with_opt_in",
+                PersonalAPIKeyAuthentication(),
+                {"include_dashboards": "true"},
+                True,
+                True,
+            ),
         ]
     )
-    def test_serving_by_access_method_and_opt_in(self, _name, authenticator, query_params, expected):
+    def test_serving_by_access_method_opt_in_and_enforcement(
+        self, _name, authenticator, query_params, enforced, expected
+    ):
         context = {"request": _fake_request(authenticator, query_params)}
-        assert should_serve_deprecated_dashboards_field(context) is expected
+        with override_settings(INSIGHT_DASHBOARDS_OPT_IN_ENFORCED=enforced):
+            assert should_serve_deprecated_dashboards_field(context) is expected
 
 
 class TestDeprecatedDashboardsFieldAPI(APIBaseTest):
@@ -56,7 +66,8 @@ class TestDeprecatedDashboardsFieldAPI(APIBaseTest):
         )
         self.token_auth = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
-    def test_personal_api_key_must_opt_in_to_deprecated_dashboards_field(self):
+    @override_settings(INSIGHT_DASHBOARDS_OPT_IN_ENFORCED=True)
+    def test_enforced_personal_api_key_must_opt_in_to_deprecated_dashboards_field(self):
         url = f"/api/projects/{self.team.id}/insights/{self.insight.id}/"
 
         default_response = self.client.get(url, **self.token_auth)
@@ -67,6 +78,11 @@ class TestDeprecatedDashboardsFieldAPI(APIBaseTest):
         opted_in_response = self.client.get(url, {"include_dashboards": "true"}, **self.token_auth)
         assert opted_in_response.status_code == status.HTTP_200_OK
         assert opted_in_response.json()["dashboards"] == [self.dashboard.id]
+
+    def test_unenforced_personal_api_key_still_receives_deprecated_dashboards_field(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/{self.insight.id}/", **self.token_auth)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["dashboards"] == [self.dashboard.id]
 
     def test_session_auth_still_receives_deprecated_dashboards_field(self):
         response = self.client.get(f"/api/projects/{self.team.id}/insights/{self.insight.id}/")

--- a/products/product_analytics/backend/api/test/test_deprecated_dashboards_field.py
+++ b/products/product_analytics/backend/api/test/test_deprecated_dashboards_field.py
@@ -1,0 +1,74 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.auth import PersonalAPIKeyAuthentication, SessionAuthentication, SharingAccessTokenAuthentication
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.utils import generate_random_token_personal, hash_key_value
+
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
+from products.product_analytics.backend.api.insight import should_serve_deprecated_dashboards_field
+from products.product_analytics.backend.models.insight import Insight
+
+
+def _fake_request(authenticator: object | None, query_params: dict[str, str] | None = None) -> MagicMock:
+    request = MagicMock()
+    request.successful_authenticator = authenticator
+    request.query_params = query_params or {}
+    return request
+
+
+class TestShouldServeDeprecatedDashboardsField(SimpleTestCase):
+    def test_serves_when_no_request_in_context(self):
+        assert should_serve_deprecated_dashboards_field({}) is True
+
+    @parameterized.expand(
+        [
+            ("session_auth", SessionAuthentication(), {}, True),
+            ("no_authenticator_is_session", None, {}, True),
+            ("personal_api_key_without_opt_in", PersonalAPIKeyAuthentication(), {}, False),
+            ("personal_api_key_with_opt_in", PersonalAPIKeyAuthentication(), {"include_dashboards": "true"}, True),
+            ("sharing_token_without_opt_in", SharingAccessTokenAuthentication(), {}, False),
+        ]
+    )
+    def test_serving_by_access_method_and_opt_in(self, _name, authenticator, query_params, expected):
+        context = {"request": _fake_request(authenticator, query_params)}
+        assert should_serve_deprecated_dashboards_field(context) is expected
+
+
+class TestDeprecatedDashboardsFieldAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.dashboard = Dashboard.objects.create(team=self.team, name="dash")
+        self.insight = Insight.objects.create(team=self.team, name="insight", saved=True)
+        DashboardTile.objects.create(insight=self.insight, dashboard=self.dashboard)
+        token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="test",
+            secure_value=hash_key_value(token),
+            scopes=["insight:read"],
+        )
+        self.token_auth = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def test_personal_api_key_must_opt_in_to_deprecated_dashboards_field(self):
+        url = f"/api/projects/{self.team.id}/insights/{self.insight.id}/"
+
+        default_response = self.client.get(url, **self.token_auth)
+        assert default_response.status_code == status.HTTP_200_OK
+        assert "dashboards" not in default_response.json()
+        assert [tile["dashboard_id"] for tile in default_response.json()["dashboard_tiles"]] == [self.dashboard.id]
+
+        opted_in_response = self.client.get(url, {"include_dashboards": "true"}, **self.token_auth)
+        assert opted_in_response.status_code == status.HTTP_200_OK
+        assert opted_in_response.json()["dashboards"] == [self.dashboard.id]
+
+    def test_session_auth_still_receives_deprecated_dashboards_field(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/{self.insight.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["dashboards"] == [self.dashboard.id]

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7608,9 +7608,14 @@ export interface InsightApi {
     order?: number | null
     deleted?: boolean
     /**
+     *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *          */
+     *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
+     *         is omitted from responses otherwise.
+     *
+     * @deprecated
+     */
     dashboards?: number[]
     /**
      *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
@@ -7730,9 +7735,14 @@ export interface PatchedInsightApi {
     order?: number | null
     deleted?: boolean
     /**
+     *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *          */
+     *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
+     *         is omitted from responses otherwise.
+     *
+     * @deprecated
+     */
     dashboards?: number[]
     /**
      *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
@@ -7969,6 +7979,7 @@ export interface TrendingInsightApi {
      */
     derived_name?: string | null
     query?: unknown
+    /** @deprecated */
     readonly dashboards: readonly number[]
     readonly dashboard_tiles: readonly DashboardTileBasicApi[]
     /**
@@ -8127,6 +8138,10 @@ export type InsightsListParams = {
     favorited?: boolean
     format?: InsightsListFormat
     /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
+    /**
      * Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.
      */
     insight?: InsightsListInsight
@@ -8232,6 +8247,10 @@ export type InsightsRetrieveParams = {
      * When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
     /**
      *
      * Whether to refresh the insight, how aggresively, and if sync or async:

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7611,8 +7611,9 @@ export interface InsightApi {
      *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
-     *         is omitted from responses otherwise.
+     *         Session-authenticated (web app) requests receive this field; other callers (personal API
+     *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
+     *         receive it.
      *
      * @deprecated
      */
@@ -7738,8 +7739,9 @@ export interface PatchedInsightApi {
      *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
-     *         is omitted from responses otherwise.
+     *         Session-authenticated (web app) requests receive this field; other callers (personal API
+     *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
+     *         receive it.
      *
      * @deprecated
      */
@@ -8226,6 +8228,10 @@ export const InsightsListRefresh = {
 
 export type InsightsCreateParams = {
     format?: InsightsCreateFormat
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
 }
 
 export type InsightsCreateFormat = (typeof InsightsCreateFormat)[keyof typeof InsightsCreateFormat]
@@ -8290,6 +8296,10 @@ export const InsightsRetrieveRefresh = {
 
 export type InsightsUpdateParams = {
     format?: InsightsUpdateFormat
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
 }
 
 export type InsightsUpdateFormat = (typeof InsightsUpdateFormat)[keyof typeof InsightsUpdateFormat]
@@ -8301,6 +8311,10 @@ export const InsightsUpdateFormat = {
 
 export type InsightsPartialUpdateParams = {
     format?: InsightsPartialUpdateFormat
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
 }
 
 export type InsightsPartialUpdateFormat = (typeof InsightsPartialUpdateFormat)[keyof typeof InsightsPartialUpdateFormat]

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7611,9 +7611,9 @@ export interface InsightApi {
      *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *         Session-authenticated (web app) requests receive this field; other callers (personal API
-     *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
-     *         receive it.
+     *         This field may be omitted from responses: once opt-in enforcement is enabled, API-token
+     *         callers (personal API keys, OAuth) only receive it when passing the
+     *         `include_dashboards=true` query parameter. Do not rely on it being present.
      *
      * @deprecated
      */
@@ -7739,9 +7739,9 @@ export interface PatchedInsightApi {
      *
      *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
      *         A dashboard ID for each of the dashboards that this insight is displayed on.
-     *         Session-authenticated (web app) requests receive this field; other callers (personal API
-     *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
-     *         receive it.
+     *         This field may be omitted from responses: once opt-in enforcement is enabled, API-token
+     *         callers (personal API keys, OAuth) only receive it when passing the
+     *         `include_dashboards=true` query parameter. Do not rely on it being present.
      *
      * @deprecated
      */
@@ -7982,7 +7982,7 @@ export interface TrendingInsightApi {
     derived_name?: string | null
     query?: unknown
     /** @deprecated */
-    readonly dashboards: readonly number[]
+    readonly dashboards?: readonly number[]
     readonly dashboard_tiles: readonly DashboardTileBasicApi[]
     /**
      * @maxLength 400
@@ -8140,7 +8140,7 @@ export type InsightsListParams = {
     favorited?: boolean
     format?: InsightsListFormat
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean
     /**
@@ -8229,7 +8229,7 @@ export const InsightsListRefresh = {
 export type InsightsCreateParams = {
     format?: InsightsCreateFormat
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean
 }
@@ -8254,7 +8254,7 @@ export type InsightsRetrieveParams = {
      */
     from_dashboard?: number
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean
     /**
@@ -8297,7 +8297,7 @@ export const InsightsRetrieveRefresh = {
 export type InsightsUpdateParams = {
     format?: InsightsUpdateFormat
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean
 }
@@ -8312,7 +8312,7 @@ export const InsightsUpdateFormat = {
 export type InsightsPartialUpdateParams = {
     format?: InsightsPartialUpdateFormat
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean
 }

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -8489,6 +8489,10 @@ export type InsightsTrendingRetrieveParams = {
     days?: number
     format?: InsightsTrendingRetrieveFormat
     /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean
+    /**
      * Maximum number of insights to return. Defaults to 10. Capped at 100.
      */
     limit?: number

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -65118,6 +65118,10 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsCreateParams = {
     format?: EnvironmentsDashboardsCreateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type EnvironmentsDashboardsCreateFormat = typeof EnvironmentsDashboardsCreateFormat[keyof typeof EnvironmentsDashboardsCreateFormat];
@@ -65154,6 +65158,10 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsUpdateParams = {
     format?: EnvironmentsDashboardsUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type EnvironmentsDashboardsUpdateFormat = typeof EnvironmentsDashboardsUpdateFormat[keyof typeof EnvironmentsDashboardsUpdateFormat];
@@ -65166,6 +65174,10 @@ export namespace Schemas {
 
     export type EnvironmentsDashboardsPartialUpdateParams = {
     format?: EnvironmentsDashboardsPartialUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type EnvironmentsDashboardsPartialUpdateFormat = typeof EnvironmentsDashboardsPartialUpdateFormat[keyof typeof EnvironmentsDashboardsPartialUpdateFormat];
@@ -71624,6 +71636,10 @@ export namespace Schemas {
 
     export type DashboardsCreateParams = {
     format?: DashboardsCreateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type DashboardsCreateFormat = typeof DashboardsCreateFormat[keyof typeof DashboardsCreateFormat];
@@ -71660,6 +71676,10 @@ export namespace Schemas {
 
     export type DashboardsUpdateParams = {
     format?: DashboardsUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type DashboardsUpdateFormat = typeof DashboardsUpdateFormat[keyof typeof DashboardsUpdateFormat];
@@ -71672,6 +71692,10 @@ export namespace Schemas {
 
     export type DashboardsPartialUpdateParams = {
     format?: DashboardsPartialUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type DashboardsPartialUpdateFormat = typeof DashboardsPartialUpdateFormat[keyof typeof DashboardsPartialUpdateFormat];

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7808,9 +7808,9 @@ export namespace Schemas {
          *
        *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
        *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *         Session-authenticated (web app) requests receive this field; other callers (personal API
-       *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
-       *         receive it.
+       *         This field may be omitted from responses: once opt-in enforcement is enabled, API-token
+       *         callers (personal API keys, OAuth) only receive it when passing the
+       *         `include_dashboards=true` query parameter. Do not rely on it being present.
        *
          * @deprecated
          */
@@ -41215,7 +41215,7 @@ export namespace Schemas {
       derived_name?: string | null;
       query?: unknown;
       /** @deprecated */
-      readonly dashboards: readonly number[];
+      readonly dashboards?: readonly number[];
       readonly dashboard_tiles: readonly DashboardTileBasic[];
       /**
          * @maxLength 400
@@ -44895,9 +44895,9 @@ export namespace Schemas {
          *
        *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
        *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *         Session-authenticated (web app) requests receive this field; other callers (personal API
-       *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
-       *         receive it.
+       *         This field may be omitted from responses: once opt-in enforcement is enabled, API-token
+       *         callers (personal API keys, OAuth) only receive it when passing the
+       *         `include_dashboards=true` query parameter. Do not rely on it being present.
        *
          * @deprecated
          */
@@ -65135,6 +65135,10 @@ export namespace Schemas {
     filters_override?: string;
     format?: EnvironmentsDashboardsRetrieveFormat;
     /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
+    /**
      * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
@@ -67087,7 +67091,7 @@ export namespace Schemas {
     favorited?: boolean;
     format?: EnvironmentsInsightsListFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     /**
@@ -67179,7 +67183,7 @@ export namespace Schemas {
     export type EnvironmentsInsightsCreateParams = {
     format?: EnvironmentsInsightsCreateFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     };
@@ -67216,7 +67220,7 @@ export namespace Schemas {
      */
     from_dashboard?: number;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     /**
@@ -67261,7 +67265,7 @@ export namespace Schemas {
     export type EnvironmentsInsightsUpdateParams = {
     format?: EnvironmentsInsightsUpdateFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     };
@@ -67277,7 +67281,7 @@ export namespace Schemas {
     export type EnvironmentsInsightsPartialUpdateParams = {
     format?: EnvironmentsInsightsPartialUpdateFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     };
@@ -71637,6 +71641,10 @@ export namespace Schemas {
     filters_override?: string;
     format?: DashboardsRetrieveFormat;
     /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
+    /**
      * Object (or pre-encoded JSON string) to override dashboard variables for this request only (not persisted). Format: {"<variable_id>": {"code_name": "<code_name>", "variableId": "<variable_id>", "value": <new_value>}}. Each entry must include `code_name` — partial entries are silently dropped. The simplest workflow is to call `dashboard-get` first, copy the matching entry from the response, and mutate `value`. Top-level keys replace; nested values are not deep-merged. Ignored when accessed via a sharing token.
      */
     variables_override?: string;
@@ -74690,7 +74698,7 @@ export namespace Schemas {
     favorited?: boolean;
     format?: InsightsListFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     /**
@@ -74782,7 +74790,7 @@ export namespace Schemas {
     export type InsightsCreateParams = {
     format?: InsightsCreateFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     };
@@ -74819,7 +74827,7 @@ export namespace Schemas {
      */
     from_dashboard?: number;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     /**
@@ -74864,7 +74872,7 @@ export namespace Schemas {
     export type InsightsUpdateParams = {
     format?: InsightsUpdateFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     };
@@ -74880,7 +74888,7 @@ export namespace Schemas {
     export type InsightsPartialUpdateParams = {
     format?: InsightsPartialUpdateFormat;
     /**
-     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
      */
     include_dashboards?: boolean;
     };

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7808,8 +7808,9 @@ export namespace Schemas {
          *
        *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
        *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
-       *         is omitted from responses otherwise.
+       *         Session-authenticated (web app) requests receive this field; other callers (personal API
+       *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
+       *         receive it.
        *
          * @deprecated
          */
@@ -44894,8 +44895,9 @@ export namespace Schemas {
          *
        *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
        *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
-       *         is omitted from responses otherwise.
+       *         Session-authenticated (web app) requests receive this field; other callers (personal API
+       *         keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to
+       *         receive it.
        *
          * @deprecated
          */
@@ -67176,6 +67178,10 @@ export namespace Schemas {
 
     export type EnvironmentsInsightsCreateParams = {
     format?: EnvironmentsInsightsCreateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type EnvironmentsInsightsCreateFormat = typeof EnvironmentsInsightsCreateFormat[keyof typeof EnvironmentsInsightsCreateFormat];
@@ -67254,6 +67260,10 @@ export namespace Schemas {
 
     export type EnvironmentsInsightsUpdateParams = {
     format?: EnvironmentsInsightsUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type EnvironmentsInsightsUpdateFormat = typeof EnvironmentsInsightsUpdateFormat[keyof typeof EnvironmentsInsightsUpdateFormat];
@@ -67266,6 +67276,10 @@ export namespace Schemas {
 
     export type EnvironmentsInsightsPartialUpdateParams = {
     format?: EnvironmentsInsightsPartialUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type EnvironmentsInsightsPartialUpdateFormat = typeof EnvironmentsInsightsPartialUpdateFormat[keyof typeof EnvironmentsInsightsPartialUpdateFormat];
@@ -74767,6 +74781,10 @@ export namespace Schemas {
 
     export type InsightsCreateParams = {
     format?: InsightsCreateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type InsightsCreateFormat = typeof InsightsCreateFormat[keyof typeof InsightsCreateFormat];
@@ -74845,6 +74863,10 @@ export namespace Schemas {
 
     export type InsightsUpdateParams = {
     format?: InsightsUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type InsightsUpdateFormat = typeof InsightsUpdateFormat[keyof typeof InsightsUpdateFormat];
@@ -74857,6 +74879,10 @@ export namespace Schemas {
 
     export type InsightsPartialUpdateParams = {
     format?: InsightsPartialUpdateFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     };
 
     export type InsightsPartialUpdateFormat = typeof InsightsPartialUpdateFormat[keyof typeof InsightsPartialUpdateFormat];

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7805,9 +7805,14 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
+         *
        *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
        *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *          */
+       *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
+       *         is omitted from responses otherwise.
+       *
+         * @deprecated
+         */
       dashboards?: number[];
       /**
        *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
@@ -41208,6 +41213,7 @@ export namespace Schemas {
          */
       derived_name?: string | null;
       query?: unknown;
+      /** @deprecated */
       readonly dashboards: readonly number[];
       readonly dashboard_tiles: readonly DashboardTileBasic[];
       /**
@@ -44885,9 +44891,14 @@ export namespace Schemas {
       order?: number | null;
       deleted?: boolean;
       /**
+         *
        *         DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.
        *         A dashboard ID for each of the dashboards that this insight is displayed on.
-       *          */
+       *         Only returned to API-token callers when `include_dashboards=true` is passed; the field
+       *         is omitted from responses otherwise.
+       *
+         * @deprecated
+         */
       dashboards?: number[];
       /**
        *     A dashboard tile ID and dashboard_id for each of the dashboards that this insight is displayed on.
@@ -67074,6 +67085,10 @@ export namespace Schemas {
     favorited?: boolean;
     format?: EnvironmentsInsightsListFormat;
     /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
+    /**
      * Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.
      */
     insight?: EnvironmentsInsightsListInsight;
@@ -67194,6 +67209,10 @@ export namespace Schemas {
      * When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     /**
      *
      * Whether to refresh the insight, how aggresively, and if sync or async:
@@ -74657,6 +74676,10 @@ export namespace Schemas {
     favorited?: boolean;
     format?: InsightsListFormat;
     /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
+    /**
      * Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.
      */
     insight?: InsightsListInsight;
@@ -74777,6 +74800,10 @@ export namespace Schemas {
      * When set, the specified dashboard's filters and date range override will be applied.
      */
     from_dashboard?: number;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     /**
      *
      * Whether to refresh the insight, how aggresively, and if sync or async:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -67473,6 +67473,10 @@ export namespace Schemas {
     days?: number;
     format?: EnvironmentsInsightsTrendingRetrieveFormat;
     /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
+    /**
      * Maximum number of insights to return. Defaults to 10. Capped at 100.
      */
     limit?: number;
@@ -75091,6 +75095,10 @@ export namespace Schemas {
      */
     days?: number;
     format?: InsightsTrendingRetrieveFormat;
+    /**
+     * Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.
+     */
+    include_dashboards?: boolean;
     /**
      * Maximum number of insights to return. Defaults to 10. Capped at 100.
      */

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -44,6 +44,12 @@ export const DashboardsCreateParams = /* @__PURE__ */ zod.object({
 
 export const DashboardsCreateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
+        ),
 })
 
 export const dashboardsCreateBodyNameMax = 400
@@ -122,6 +128,12 @@ export const DashboardsPartialUpdateParams = /* @__PURE__ */ zod.object({
 
 export const DashboardsPartialUpdateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
+        ),
 })
 
 export const dashboardsPartialUpdateBodyNameMax = 400

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -97,6 +97,12 @@ export const DashboardsRetrieveQueryParams = /* @__PURE__ */ zod.object({
             'Object (or pre-encoded JSON string) to override dashboard filters for this request only (not persisted). Top-level keys replace; nested values are not deep-merged — pass the complete value for any key you override. Accepts the same keys as the dashboard filters schema (e.g., `date_from`, `date_to`, `properties`). Ignored when accessed via a sharing token.'
         ),
     format: zod.enum(['json', 'txt']).optional(),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
+        ),
     variables_override: zod
         .string()
         .optional()

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -416,6 +416,12 @@ export const InsightsTrendingRetrieveQueryParams = /* @__PURE__ */ zod.object({
             "Time window in days to compute view counts over. Defaults to 7. Larger windows surface consistently popular insights; smaller windows surface what's hot right now."
         ),
     format: zod.enum(['csv', 'json']).optional(),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
+        ),
     limit: zod.number().optional().describe('Maximum number of insights to return. Defaults to 10. Capped at 100.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -188,6 +188,12 @@ export const InsightsCreateParams = /* @__PURE__ */ zod.object({
 
 export const InsightsCreateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['csv', 'json']).optional(),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
+        ),
 })
 
 export const insightsCreateBodyNameMax = 400
@@ -209,7 +215,7 @@ export const InsightsCreateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Only returned to API-token callers when `include_dashboards=true` is passed; the field\n        is omitted from responses otherwise.\n        '
+                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Session-authenticated (web app) requests receive this field; other callers (personal API\n        keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to\n        receive it.\n        '
             ),
         description: zod.string().max(insightsCreateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),
@@ -302,6 +308,12 @@ export const InsightsPartialUpdateParams = /* @__PURE__ */ zod.object({
 
 export const InsightsPartialUpdateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['csv', 'json']).optional(),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
+        ),
 })
 
 export const insightsPartialUpdateBodyNameMax = 400
@@ -323,7 +335,7 @@ export const InsightsPartialUpdateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Only returned to API-token callers when `include_dashboards=true` is passed; the field\n        is omitted from responses otherwise.\n        '
+                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Session-authenticated (web app) requests receive this field; other callers (personal API\n        keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to\n        receive it.\n        '
             ),
         description: zod.string().max(insightsPartialUpdateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -109,6 +109,12 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
         .optional()
         .describe('Include this parameter (any value) to restrict results to insights marked as favorited.'),
     format: zod.enum(['csv', 'json']).optional(),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
+        ),
     insight: zod
         .enum(['FUNNELS', 'JSON', 'LIFECYCLE', 'PATHS', 'RETENTION', 'SQL', 'STICKINESS', 'TRENDS'])
         .optional()
@@ -203,7 +209,7 @@ export const InsightsCreateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        '
+                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Only returned to API-token callers when `include_dashboards=true` is passed; the field\n        is omitted from responses otherwise.\n        '
             ),
         description: zod.string().max(insightsCreateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),
@@ -246,6 +252,12 @@ export const InsightsRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .optional()
         .describe(
             "\nOnly if loading an insight in the context of a dashboard: The relevant dashboard's ID.\nWhen set, the specified dashboard's filters and date range override will be applied."
+        ),
+    include_dashboards: zod
+        .boolean()
+        .optional()
+        .describe(
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
         ),
     refresh: zod
         .enum([
@@ -311,7 +323,7 @@ export const InsightsPartialUpdateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        '
+                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Only returned to API-token callers when `include_dashboards=true` is passed; the field\n        is omitted from responses otherwise.\n        '
             ),
         description: zod.string().max(insightsPartialUpdateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),

--- a/services/mcp/src/generated/product_analytics/api.ts
+++ b/services/mcp/src/generated/product_analytics/api.ts
@@ -113,7 +113,7 @@ export const InsightsListQueryParams = /* @__PURE__ */ zod.object({
         .boolean()
         .optional()
         .describe(
-            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
         ),
     insight: zod
         .enum(['FUNNELS', 'JSON', 'LIFECYCLE', 'PATHS', 'RETENTION', 'SQL', 'STICKINESS', 'TRENDS'])
@@ -192,7 +192,7 @@ export const InsightsCreateQueryParams = /* @__PURE__ */ zod.object({
         .boolean()
         .optional()
         .describe(
-            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
         ),
 })
 
@@ -215,7 +215,7 @@ export const InsightsCreateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Session-authenticated (web app) requests receive this field; other callers (personal API\n        keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to\n        receive it.\n        '
+                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        This field may be omitted from responses: once opt-in enforcement is enabled, API-token\n        callers (personal API keys, OAuth) only receive it when passing the\n        `include_dashboards=true` query parameter. Do not rely on it being present.\n        '
             ),
         description: zod.string().max(insightsCreateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),
@@ -263,7 +263,7 @@ export const InsightsRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .boolean()
         .optional()
         .describe(
-            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
         ),
     refresh: zod
         .enum([
@@ -312,7 +312,7 @@ export const InsightsPartialUpdateQueryParams = /* @__PURE__ */ zod.object({
         .boolean()
         .optional()
         .describe(
-            'Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.'
+            'Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.'
         ),
 })
 
@@ -335,7 +335,7 @@ export const InsightsPartialUpdateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        Session-authenticated (web app) requests receive this field; other callers (personal API\n        keys, OAuth, sharing tokens) must pass the `include_dashboards=true` query parameter to\n        receive it.\n        '
+                '\n        DEPRECATED. Will be removed in a future release. Use dashboard_tiles instead.\n        A dashboard ID for each of the dashboards that this insight is displayed on.\n        This field may be omitted from responses: once opt-in enforcement is enabled, API-token\n        callers (personal API keys, OAuth) only receive it when passing the\n        `include_dashboards=true` query parameter. Do not rely on it being present.\n        '
             ),
         description: zod.string().max(insightsPartialUpdateBodyDescriptionMax).nullish(),
         tags: zod.array(zod.unknown()).optional(),

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -223,6 +223,7 @@ const dashboardGet = (): ToolBase<typeof DashboardGetSchema, WithPostHogUrl<Sche
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/`,
             query: {
                 filters_override: params.filters_override,
+                include_dashboards: params.include_dashboards,
                 variables_override: params.variables_override,
             },
         })

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -6,6 +6,7 @@ import {
     DashboardsCopyTileCreateBody,
     DashboardsCopyTileCreateParams,
     DashboardsCreateBody,
+    DashboardsCreateQueryParams,
     DashboardsCreateTextTileCreateBody,
     DashboardsCreateTextTileCreateParams,
     DashboardsDeleteTileBody,
@@ -16,6 +17,7 @@ import {
     DashboardsMoveTilePartialUpdateParams,
     DashboardsPartialUpdateBody,
     DashboardsPartialUpdateParams,
+    DashboardsPartialUpdateQueryParams,
     DashboardsReorderTilesCreateBody,
     DashboardsReorderTilesCreateParams,
     DashboardsRetrieveParams,
@@ -35,7 +37,7 @@ import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
-const DashboardCreateSchema = DashboardsCreateBody
+const DashboardCreateSchema = DashboardsCreateQueryParams.omit({ format: true }).extend(DashboardsCreateBody.shape)
 
 const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUrl<Schemas.Dashboard>> => ({
     name: 'dashboard-create',
@@ -80,6 +82,9 @@ const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUr
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/`,
             body,
+            query: {
+                include_dashboards: params.include_dashboards,
+            },
         })
         const filtered = omitResponseFields(result, [
             'effective_restriction_level',
@@ -359,6 +364,7 @@ const dashboardTileCopy = (): ToolBase<typeof DashboardTileCopySchema, WithPostH
 })
 
 const DashboardUpdateSchema = DashboardsPartialUpdateParams.omit({ project_id: true })
+    .extend(DashboardsPartialUpdateQueryParams.omit({ format: true }).shape)
     .extend(DashboardsPartialUpdateBody.shape)
     .extend({ id: z.preprocess(castStringToInt, DashboardsPartialUpdateParams.shape['id']) })
 
@@ -411,6 +417,9 @@ const dashboardUpdate = (): ToolBase<typeof DashboardUpdateSchema, WithPostHogUr
             method: 'PATCH',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/`,
             body,
+            query: {
+                include_dashboards: params.include_dashboards,
+            },
         })
         const filtered = omitResponseFields(result, [
             'effective_restriction_level',

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -288,6 +288,7 @@ const insightGet = (): ToolBase<typeof InsightGetSchema, WithPostHogUrl<Schemas.
             path: `/api/projects/${encodeURIComponent(String(projectId))}/insights/${encodeURIComponent(String(params.id))}/`,
             query: {
                 filters_override: params.filters_override,
+                include_dashboards: params.include_dashboards,
                 variables_override: params.variables_override,
             },
         })
@@ -447,6 +448,7 @@ const insightsList = (): ToolBase<typeof InsightsListSchema, WithPostHogUrl<Sche
                 date_from: params.date_from,
                 date_to: params.date_to,
                 favorited: params.favorited,
+                include_dashboards: params.include_dashboards,
                 insight: params.insight,
                 last_viewed_date_from: params.last_viewed_date_from,
                 last_viewed_date_to: params.last_viewed_date_to,

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -510,6 +510,7 @@ const insightsTrendingRetrieve = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/insights/trending/`,
             query: {
                 days: params.days,
+                include_dashboards: params.include_dashboards,
                 limit: params.limit,
                 offset: params.offset,
             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "description": "Serializer mixin that handles tags for objects.",
     "properties": {
         "breakdown_colors": {
             "description": "Custom color mapping for breakdown values."
@@ -23,6 +22,10 @@
         },
         "description": {
             "type": "string"
+        },
+        "include_dashboards": {
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
+            "type": "boolean"
         },
         "name": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-get.json
@@ -20,6 +20,10 @@
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
+        "include_dashboards": {
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
+            "type": "boolean"
+        },
         "variables_override": {
             "anyOf": [
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
@@ -57,6 +57,10 @@
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
+        "include_dashboards": {
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
+            "type": "boolean"
+        },
         "name": {
             "anyOf": [
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-get.json
@@ -27,6 +27,10 @@
             ],
             "description": "Numeric primary key or 8-character `short_id` (for example `AaVQ8Ijw`) identifying the insight."
         },
+        "include_dashboards": {
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.",
+            "type": "boolean"
+        },
         "variables_override": {
             "anyOf": [
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-get.json
@@ -28,7 +28,7 @@
             "description": "Numeric primary key or 8-character `short_id` (for example `AaVQ8Ijw`) identifying the insight."
         },
         "include_dashboards": {
-            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.",
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
             "type": "boolean"
         },
         "variables_override": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insights-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insights-list.json
@@ -29,6 +29,10 @@
             "description": "Include this parameter (any value) to restrict results to insights marked as favorited.",
             "type": "boolean"
         },
+        "include_dashboards": {
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.",
+            "type": "boolean"
+        },
         "insight": {
             "description": "Restrict to a single insight type. `JSON` matches non-wrapper query insights; `SQL` matches HogQL queries.",
             "enum": ["FUNNELS", "JSON", "LIFECYCLE", "PATHS", "RETENTION", "SQL", "STICKINESS", "TRENDS"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insights-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insights-list.json
@@ -30,7 +30,7 @@
             "type": "boolean"
         },
         "include_dashboards": {
-            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. API-token callers no longer receive it by default; use `dashboard_tiles` instead.",
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
             "type": "boolean"
         },
         "insight": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insights-trending-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insights-trending-retrieve.json
@@ -5,6 +5,10 @@
             "description": "Time window in days to compute view counts over. Defaults to 7. Larger windows surface consistently popular insights; smaller windows surface what's hot right now.",
             "type": "number"
         },
+        "include_dashboards": {
+            "description": "Opt in to receiving the deprecated `dashboards` field in insight payloads. Once opt-in enforcement is enabled, API-token callers stop receiving it by default; use `dashboard_tiles` instead.",
+            "type": "boolean"
+        },
         "limit": {
             "description": "Maximum number of insights to return. Defaults to 10. Capped at 100.",
             "type": "number"


### PR DESCRIPTION
## Problem

The insight `dashboards` field has been deprecated in favor of `dashboard_tiles` for a long time, but every insight payload still carries it, so every caller stays coupled to it and we can never remove it. We also have no visibility into who still uses it.

## Changes

- **Two-phase removal, behavior-neutral on deploy.** Phase 1 (this PR's default): every caller still receives the field, and reads/writes are metered by access method so remaining token usage is measurable. Phase 2 (flip `INSIGHT_DASHBOARDS_OPT_IN_ENFORCED`, env-toggleable so it doubles as a kill switch): API-token callers (personal API keys, OAuth) must pass `?include_dashboards=true` to receive it — declared on insight list/retrieve, the write actions, and dashboards retrieve (which nests insight payloads).
- First-party surfaces are exempt from enforcement: session auth (web app) and sharing tokens (shared dashboards / exporter render PostHog's own frontend) keep receiving the field until the frontend fully migrates.
- The OpenAPI postprocessing hook marks `dashboards` as not-required wherever it appears alongside `dashboard_tiles`, so strict generated clients tolerate its absence once enforcement flips.
- The frontend no longer depends on the response carrying it: `getQueryBasedInsightModel` — the boundary every insight response passes through (directly, via `insightsApi`, via `getQueryBasedDashboard`, or in the dashboard tile-stream reducer) — now derives `dashboards` from `dashboard_tiles` when the response omits it. Once this has deployed, flipping session auth to opt-in (and later removing the field) is a follow-up one-liner in `should_serve_deprecated_dashboards_field`.
- Usage is metered with a Prometheus counter (`posthog_api_insight_deprecated_dashboards_field_used_total`, labels: `usage=read|write`, `access_method`) so remaining consumers are measurable before removal.
- The field and the opt-in query parameter are marked `deprecated` in the OpenAPI schema (`extend_schema_serializer(deprecate_fields=...)`), and the field's help text documents the opt-in.
- Writing `dashboards` (adding an insight to dashboards) is unchanged, but metered.

## How did you test this code?

- New no-DB `SimpleTestCase` covering the serve-gate matrix (session / sharing token / personal API key × enforcement on/off × opt-in) — catches the regression where the gate silently starts serving/omitting for the wrong auth method or the wrong phase. 7 tests, pass locally.
- New `APIBaseTest` wiring tests: with enforcement on, a personal-API-key GET omits `dashboards` unless `include_dashboards=true`; with the default (unenforced) settings both token and session GETs still include it — catches the viewset/serializer wiring breaking. Could not run locally (no database in the authoring environment); existing session-auth insight tests extensively assert `dashboards` in responses and double-cover the web path.
- New jest cases for `getQueryBasedInsightModel`: derives `dashboards` from `dashboard_tiles` when the response omits it, and keeps a server-provided value untouched — this is the guard that lets the backend stop serving the field to web without breaking remaining readers. Could not run locally (no node_modules in the authoring environment).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

API reference is generated from the OpenAPI schema, which now carries the deprecation markers and the new parameter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code session). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`. Origin: while tracing dashboard endpoint serialization cost we noticed the legacy `dashboards` field is computed for every caller; the direction chosen was opt-in for token callers + metric + docs deprecation now, web-app migration to `dashboard_tiles` as a follow-up (blocking web outright would break the current frontend, which still reads and writes the field).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


