### PR TITLE
fix(ci): correct langsmith pytest plugin disable to its real entry-point name

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,9 +7,11 @@ DJANGO_SETTINGS_MODULE = posthog.settings
 # --pytest-durations=0 disables the pytest-durations plugin by default; CI shard steps re-enable it explicitly
 # -p no:tach disables tach's pytest plugin: without --tach it builds the full import graph (~5-10s
 # per invocation) only to print a "could be skipped" hint. Opt back in with: pytest -p tach --tach
-# -p no:langsmith skips the langsmith pytest plugin (auto-registered by a transitive dependency,
-# ~0.8s of imports per invocation); nothing in this repo uses langsmith's pytest integration
-addopts = -p no:warnings -p no:tach -p no:langsmith --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
+# -p no:langsmith_plugin skips the langsmith pytest plugin (auto-registered by a transitive dependency,
+# ~0.8s of imports per invocation); nothing in this repo uses langsmith's pytest integration.
+# Note: the pytest11 entry point name is "langsmith_plugin" (module langsmith.pytest_plugin), not
+# "langsmith" — `-p no:langsmith` silently fails to match anything and the plugin still loads.
+addopts = -p no:warnings -p no:tach -p no:langsmith_plugin --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
 
 markers =
     ee


### PR DESCRIPTION
## Problem

`pytest.ini` has carried `-p no:langsmith` with a comment saying it saves ~0.8s of imports per pytest invocation. But the plugin's pytest11 entry point is actually named `langsmith_plugin` (module `langsmith.pytest_plugin`), so the disable silently matched nothing and the plugin, plus its heavy import tree (langsmith, opentelemetry SDK, httpx), kept loading in every test process.

## Changes

Renamed the disable to `-p no:langsmith_plugin` and updated the comment to record the entry-point-name gotcha so it doesn't regress.

## How did you test this code?

- Verified the entry point name via `importlib.metadata.entry_points(group="pytest11")`: the only langsmith entry is `langsmith_plugin = langsmith.pytest_plugin`.
- Profiled a pytest collection run with `python -X importtime`: before the fix langsmith modules imported (~220ms of self time in the tree); after the fix zero langsmith modules load.
- Measured single-file collection wall time (warm caches, same machine): ~11.8s before, ~11.0s after, consistent across repeated runs.
- Ran `pytest posthog/api/test/test_organization.py --collect-only` and a full test file to confirm nothing depends on the plugin.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, dev tooling only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found by PostHog Code (Claude) while profiling backend test boot time with `python -X importtime`. The comment claimed the plugin was disabled, but the import profile showed the full langsmith tree still loading; checking the installed pytest11 entry points revealed the name mismatch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*