### PR TITLE
fix(hogql): defer snowflake.connector off the hogql.query import path

### DIFF
--- a/posthog/hogql/direct_sql/snowflake_adapter.py
+++ b/posthog/hogql/direct_sql/snowflake_adapter.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, cast
 
 import sqlparse
-import snowflake.connector
 from opentelemetry import trace
-from snowflake.connector.constants import FIELD_ID_TO_NAME
 from sqlparse import tokens as sqlparse_tokens
 
 from posthog.hogql.constants import HogQLDialect
@@ -15,6 +15,9 @@ from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.snowflake_connection_cache import cached_snowflake_connection
 
 if TYPE_CHECKING:
+    import snowflake.connector
+    import snowflake.connector.cursor
+
     from posthog.models.team import Team
 
     from products.warehouse_sources.backend.facade.models import ExternalDataSource
@@ -81,6 +84,10 @@ def snowflake_field_type_to_clickhouse_type(type_code: object | None, scale: obj
     # every column as String.
     if not isinstance(type_code, int):
         return "String"
+    from snowflake.connector.constants import (
+        FIELD_ID_TO_NAME,  # noqa: PLC0415 — keeps the heavy dep off the import path
+    )
+
     name = FIELD_ID_TO_NAME.get(type_code, "")
     if name == "FIXED":
         # NUMBER/DECIMAL/INT all report as FIXED; scale 0 (or absent) is an integer.
@@ -89,6 +96,8 @@ def snowflake_field_type_to_clickhouse_type(type_code: object | None, scale: obj
 
 
 def snowflake_error_to_message(error: Exception) -> str:
+    import snowflake.connector  # noqa: PLC0415 — keeps the heavy dep off the import path
+
     if isinstance(error, snowflake.connector.errors.Error):
         args = error.args
         if len(args) >= 2 and isinstance(args[1], str) and args[1].strip():
@@ -148,8 +157,8 @@ class SnowflakeAdapter:
     dialect: HogQLDialect | None = "snowflake"
 
     def validate_source_config(
-        self, source: "ExternalDataSource", team: "Team"
-    ) -> tuple["SnowflakeImplementation", "SnowflakeSourceConfig"]:
+        self, source: ExternalDataSource, team: Team
+    ) -> tuple[SnowflakeImplementation, SnowflakeSourceConfig]:
         from products.warehouse_sources.backend.facade.source_management import SnowflakeSource, SourceRegistry
         from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
@@ -179,6 +188,8 @@ class SnowflakeAdapter:
         MULTI_STATEMENT_COUNT=1 so the server refuses any stacked statement. A least-privilege
         SELECT-only role is recommended as defense in depth, but is not the boundary we rely on.
         """
+        import snowflake.connector  # noqa: PLC0415 — keeps the heavy dep off the import path
+
         source = request.source
         snowflake_implementation, source_config = self.validate_source_config(source, request.team)
         settings = request.settings

--- a/posthog/hogql/snowflake_connection_cache.py
+++ b/posthog/hogql/snowflake_connection_cache.py
@@ -26,11 +26,11 @@ from dataclasses import dataclass
 from time import monotonic
 from typing import TYPE_CHECKING
 
-import snowflake.connector
-
 from posthog.hogql.direct_query_metrics import SNOWFLAKE_CONNECTION_CACHE_TOTAL
 
 if TYPE_CHECKING:
+    import snowflake.connector
+
     from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SnowflakeSourceConfig
     from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.snowflake import (
         SnowflakeImplementation,
@@ -43,12 +43,16 @@ SNOWFLAKE_CONNECTION_CACHE_TTL_SECONDS = 1800
 # can't accumulate open sessions without limit.
 SNOWFLAKE_CONNECTION_CACHE_MAX_PER_THREAD = 8
 
+
 # Transport/connection-level failures mean the cached session is suspect; SQL-level
 # errors (ProgrammingError, IntegrityError) leave the connection healthy.
-_CONNECTION_LEVEL_ERRORS = (
-    snowflake.connector.errors.OperationalError,
-    snowflake.connector.errors.InterfaceError,
-)
+def _connection_level_errors() -> tuple[type[Exception], ...]:
+    import snowflake.connector  # noqa: PLC0415 — keeps the heavy dep off the import path
+
+    return (
+        snowflake.connector.errors.OperationalError,
+        snowflake.connector.errors.InterfaceError,
+    )
 
 
 @dataclass
@@ -156,7 +160,7 @@ def cached_snowflake_connection(
 
     try:
         yield connection
-    except _CONNECTION_LEVEL_ERRORS:
+    except _connection_level_errors():
         _evict(key)
         raise
 


### PR DESCRIPTION
## Problem

`posthog/hogql/direct_sql/snowflake_adapter.py` and `posthog/hogql/snowflake_connection_cache.py` imported `snowflake.connector` at module level. The direct_sql package loads with `posthog.hogql.query`, which every backend process (web workers, celery workers, every pytest process) imports at boot, so everyone paid the connector's import cost (~380ms including the pandas/pyarrow tail it drags in) even though only direct Snowflake queries ever use it.

## Changes

- `snowflake_adapter.py`: moved the connector imports to function scope (`snowflake_field_type_to_clickhouse_type`, `snowflake_error_to_message`, `SnowflakeAdapter.execute`), added `from __future__ import annotations` so the cursor type annotation stays lazy, and kept type-checker coverage via `TYPE_CHECKING` imports.
- `snowflake_connection_cache.py`: moved the connector import under `TYPE_CHECKING` and turned the module-level `_CONNECTION_LEVEL_ERRORS` tuple into a lazy `_connection_level_errors()` helper (only evaluated inside the context manager, where a connection has already been opened).

`snowflake` was already listed in `FORBIDDEN_AT_SETUP` in `posthog/test/test_startup_import_budget.py`; this change extends the same guarantee to the hogql.query path.

## How did you test this code?

- `pytest posthog/hogql/direct_sql/test/ posthog/hogql/test/test_direct_snowflake_query.py` passes.
- `pytest posthog/test/test_startup_import_budget.py` passes (8/8).
- Verified via a scripted check that importing `posthog.hogql.query` and `posthog.hogql.direct_sql` no longer puts `snowflake.connector` in `sys.modules`, that the adapter registry still registers all three engines, and that type mapping and error formatting behave identically once the connector is loaded.
- Measured single-file pytest collection wall time drop from ~11.0s to ~9.9s on the same machine.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal import layout only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found by PostHog Code (Claude) while profiling backend test boot with `python -X importtime`: snowflake.connector showed up as the second-largest subtree on the settings/hogql import path. Followed the repo's django-startup-time guidance (function-local imports with `# noqa: PLC0415` for heavy vendor SDKs).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*