### PR TITLE
fix(exports): stop importing playwright at failure_handler module level

### DIFF
--- a/products/exports/backend/tasks/failure_handler.py
+++ b/products/exports/backend/tasks/failure_handler.py
@@ -1,10 +1,10 @@
+import sys
 from ssl import SSLError
 
 from django.db import OperationalError
 
 from billiard.exceptions import SoftTimeLimitExceeded
 from clickhouse_driver.errors import SocketTimeoutError
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from rest_framework.exceptions import ValidationError
 from urllib3.exceptions import MaxRetryError, ProtocolError, ReadTimeoutError
 
@@ -126,7 +126,6 @@ USER_QUERY_ERRORS = (
 TIMEOUT_ERRORS = (
     SoftTimeLimitExceeded,
     TimeoutError,
-    PlaywrightTimeoutError,
     ExportCancelled,
 )
 
@@ -135,7 +134,20 @@ USER_QUERY_ERROR_NAMES = frozenset(cls.__name__ for cls in USER_QUERY_ERRORS)
 SYSTEM_ERROR_NAMES = frozenset(cls.__name__ for cls in EXCEPTIONS_TO_RETRY)
 # "TimeoutException" kept literally: historical ExportedAsset rows from the retired selenium
 # render path stored that exception name and must still classify as timeouts.
+# playwright's TimeoutError.__name__ is also "TimeoutError" (aliased on import), so it's already
+# covered here without needing the class itself.
 TIMEOUT_ERROR_NAMES = frozenset(cls.__name__ for cls in TIMEOUT_ERRORS) | {"TimeoutException"}
+
+
+def _is_playwright_timeout(exception: BaseException) -> bool:
+    # playwright is a heavy import (browser automation), only needed by the actual image-export
+    # path. isinstance() against it can't be a real match unless something has already imported
+    # playwright.sync_api (raising one requires it), so checking sys.modules first avoids paying
+    # the import cost on every failure-classification call.
+    playwright_sync_api = sys.modules.get("playwright.sync_api")
+    if playwright_sync_api is None:
+        return False
+    return isinstance(exception, playwright_sync_api.TimeoutError)
 
 
 def classify_failure_type(exception: Exception | str) -> str:
@@ -143,7 +155,7 @@ def classify_failure_type(exception: Exception | str) -> str:
     # these same tuples, so isinstance has identical coverage while avoiding false positives from
     # unrelated classes that merely share a name (django/pydantic ValidationError, builtin SyntaxError).
     if isinstance(exception, Exception):
-        if isinstance(exception, TIMEOUT_ERRORS):
+        if isinstance(exception, TIMEOUT_ERRORS) or _is_playwright_timeout(exception):
             return FAILURE_TYPE_TIMEOUT_GENERATION
         if isinstance(exception, USER_QUERY_ERRORS):
             return FAILURE_TYPE_USER

--- a/products/exports/backend/tasks/failure_handler.py
+++ b/products/exports/backend/tasks/failure_handler.py
@@ -143,11 +143,15 @@ def _is_playwright_timeout(exception: BaseException) -> bool:
     # playwright is a heavy import (browser automation), only needed by the actual image-export
     # path. isinstance() against it can't be a real match unless something has already imported
     # playwright.sync_api (raising one requires it), so checking sys.modules first avoids paying
-    # the import cost on every failure-classification call.
+    # the import cost on every failure-classification call. getattr with a default covers the
+    # window where another thread has started (but not finished) that first import: sys.modules
+    # holds a partially initialized module then, which may not expose TimeoutError yet — and an
+    # exception raised by playwright itself cannot predate its own module finishing import.
     playwright_sync_api = sys.modules.get("playwright.sync_api")
     if playwright_sync_api is None:
         return False
-    return isinstance(exception, playwright_sync_api.TimeoutError)
+    timeout_error = getattr(playwright_sync_api, "TimeoutError", None)
+    return timeout_error is not None and isinstance(exception, timeout_error)
 
 
 def classify_failure_type(exception: Exception | str) -> str:


### PR DESCRIPTION
## Problem

`products/exports/backend/tasks/failure_handler.py` imported `playwright.sync_api` at module level just to put `TimeoutError` in the timeout-classification tuple. The module is imported by `posthog.tasks.exporter`, temporal export workflows, and alert retry policies, so the whole browser-automation import tree loaded in every backend process even though only the image-export path ever raises a playwright error.

## Changes

- Dropped the module-level playwright import.
- Added `_is_playwright_timeout()`, which checks `sys.modules` for `playwright.sync_api` before doing the isinstance check. A playwright timeout can only exist in a process that already imported playwright to raise it, so the sys.modules gate can never miss a real match.
- The stored-name classification path needs no change: playwright's `TimeoutError.__name__` is `"TimeoutError"`, which the `TIMEOUT_ERROR_NAMES` set already contains via the builtin.

`image_exporter.py` keeps its own direct playwright imports; it is the path that actually drives a browser.

## How did you test this code?

- `pytest products/exports/backend/tasks/test/test_failure_handler.py` passes (48/48).
- Scripted check: importing the module no longer loads playwright; `classify_failure_type` returns `timeout_generation` for both a builtin `TimeoutError` and a real `playwright.sync_api.TimeoutError` (with playwright loaded), and `unknown` for unrelated exceptions, identical to before.
- Measured single-file pytest collection wall time drop from ~9.9s to ~7.2s on the same machine.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal import layout only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found by PostHog Code (Claude) while profiling backend test boot with `python -X importtime`; the playwright tree was one of the largest subtrees loaded on every process's boot path, reachable only through this one exception-tuple import.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*