### PR TITLE
feat(ci): open the boot GC window before django.setup via early pytest plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,8 +8,10 @@ import pytest
 # phase only adds pauses (seconds on a full-tree CI shard collection). Run the boot
 # with GC off, then freeze the survivors into the permanent generation so the
 # collector never rescans them during the test phase. Tests themselves run with GC
-# enabled as usual. (django.setup() runs in pytest-django's load_initial_conftests,
-# before conftest files load, so it stays outside the window.)
+# enabled as usual. The window normally opens even earlier, in the pytest_boot_gc
+# plugin (`-p pytest_boot_gc` in pytest.ini), so that django.setup() — which
+# pytest-django runs before conftest files load — sits inside it too; the disable
+# here is the fallback for runs that don't load that plugin (e.g. ee/pytest.ini).
 gc.disable()
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,9 @@ DJANGO_SETTINGS_MODULE = posthog.settings
 # per invocation) only to print a "could be skipped" hint. Opt back in with: pytest -p tach --tach
 # -p no:langsmith skips the langsmith pytest plugin (auto-registered by a transitive dependency,
 # ~0.8s of imports per invocation); nothing in this repo uses langsmith's pytest integration
-addopts = -p no:warnings -p no:tach -p no:langsmith --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
+# -p pytest_boot_gc opens the boot GC window (gc.disable) before pytest-django runs
+# django.setup(), which happens before conftest files load; the root conftest closes it
+addopts = -p no:warnings -p no:tach -p no:langsmith -p pytest_boot_gc --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
 
 markers =
     ee

--- a/pytest_boot_gc.py
+++ b/pytest_boot_gc.py
@@ -1,0 +1,15 @@
+"""Early-loaded pytest plugin (see `-p pytest_boot_gc` in pytest.ini) that opens the
+boot GC window before django.setup() runs.
+
+The boot window itself — freeze + re-enable + thresholds — lives in the root
+conftest.py (`_end_gc_boot_window`). But conftest files load *after*
+pytest-django's load_initial_conftests has run django.setup(), so the several
+million permanent allocations of settings + app population still paid automatic
+GC pauses (~0.2s per process). `-p` plugins load before initial conftests, which
+puts django.setup() inside the window too. Everything here must stay import-light:
+this module runs before any of the test session's real setup.
+"""
+
+import gc
+
+gc.disable()


### PR DESCRIPTION
## Problem

The root `conftest.py` runs the test-session boot with GC disabled (then freezes survivors), but conftest files only load after pytest-django's `load_initial_conftests` has already run `django.setup()`. So the most allocation-heavy part of boot, settings plus app population, still ran with automatic GC on and paid ~0.2s of collector pauses per pytest process. The conftest comment explicitly noted django.setup() sat outside the window.

## Changes

- New `pytest_boot_gc.py` at the repo root: an import-light plugin whose entire body is `gc.disable()`.
- `pytest.ini`: load it with `-p pytest_boot_gc` in addopts. `-p` plugins load before initial conftests, which puts django.setup() inside the GC window.
- `conftest.py`: comment updated; its own `gc.disable()` stays as the fallback for runs that don't load the plugin (e.g. `ee/pytest.ini`). The existing `_end_gc_boot_window` freeze/re-enable machinery is unchanged.

Measured `django.setup()` directly: ~2.2s with GC on vs ~2.0s with GC off, consistent across runs.

## How did you test this code?

- `pytest posthog/test/test_startup_import_budget.py` passes (8/8).
- Ran collection plus two full test files (`test_ses_provider.py`, `test_failure_handler.py`) end to end; all pass, confirming the window still closes and unfreezes correctly.
- Measured single-file pytest collection wall time drop from ~5.6s to ~5.2s on the same machine.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The GC boot window is documented in `docs/internal/django-startup-time.md`; the conftest and plugin comments describe the new split. Happy to extend the doc if reviewers prefer.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Built by PostHog Code (Claude) while profiling backend test boot. The /django-startup-time skill's own notes pointed at the boot GC window; A/B timing django.setup() with and without GC confirmed the gap, and an early `-p` plugin is the only hook that runs before pytest-django's setup.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*