### PR TITLE
feat(hogli): support dia browser cookies in metabase login

### DIFF
--- a/tools/hogli-commands/hogli_commands/metabase.py
+++ b/tools/hogli-commands/hogli_commands/metabase.py
@@ -24,6 +24,7 @@ import sys
 import json
 import time
 import webbrowser
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +40,7 @@ _CHROMIUM_PROFILE_ROOTS: dict[str, list[Path]] = {
     "chrome": [_HOME / "Library/Application Support/Google/Chrome"],
     "chromium": [_HOME / "Library/Application Support/Chromium"],
     "brave": [_HOME / "Library/Application Support/BraveSoftware/Brave-Browser"],
+    "dia": [_HOME / "Library/Application Support/Dia/User Data"],
 }
 
 REGIONS: dict[str, str] = {
@@ -52,7 +54,7 @@ REQUIRED_COOKIES: tuple[str, ...] = (
     "ph_int_auth-0",
     "ph_int_auth-1",
 )
-SUPPORTED_BROWSERS: tuple[str, ...] = ("chrome", "chromium", "brave", "firefox", "safari")
+SUPPORTED_BROWSERS: tuple[str, ...] = ("chrome", "chromium", "brave", "dia", "firefox", "safari")
 CACHE_DIR: Path = Path.home() / ".config" / "posthog" / "metabase"
 
 
@@ -67,7 +69,7 @@ def _format_cookie_header(cookies: dict[str, str]) -> str:
 def _enumerate_cookie_files(browser: str | None) -> list[tuple[str, Path]]:
     """Return (loader_name, cookie_file_path) pairs for every browser profile to try.
 
-    Chromium-family browsers (Chrome, Brave, Chromium) keep a `Cookies`
+    Chromium-family browsers (Chrome, Brave, Chromium, Dia) keep a `Cookies`
     SQLite db per profile (`Default`, `Profile 1`, ...). We glob each profile
     directory so users with multiple profiles (work + personal) don't have to
     care which one they logged in with.
@@ -104,11 +106,23 @@ def _load_cookies_from_browser(domain: str, browser: str | None) -> dict[str, st
     if browser is not None and browser not in SUPPORTED_BROWSERS:
         raise click.ClickException(f"Unsupported browser: {browser}")
 
+    def dia(domain_name: str, cookie_file: str | None = None) -> Iterable:
+        # Dia has no browser_cookie3 loader; it's Chromium-based but decrypts
+        # its cookie DB with its own Keychain entry, so build one from ChromiumBased.
+        return browser_cookie3.ChromiumBased(
+            browser="Dia",
+            cookie_file=cookie_file,
+            domain_name=domain_name,
+            osx_cookies=[],
+            osx_key_service="Dia Safe Storage",
+            osx_key_user="Dia",
+        ).load()
+
     targets = _enumerate_cookie_files(browser)
     found: dict[str, str] = {}
     errors: list[str] = []
     for loader_name, cookie_file in targets:
-        loader = getattr(browser_cookie3, loader_name, None)
+        loader = dia if loader_name == "dia" else getattr(browser_cookie3, loader_name, None)
         if loader is None:
             continue
         kwargs: dict = {"domain_name": domain}

--- a/tools/hogli-commands/hogli_commands/tests/test_metabase.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_metabase.py
@@ -84,6 +84,33 @@ def test_load_cookies_filters_to_required_names(monkeypatch: pytest.MonkeyPatch)
     }
 
 
+def test_load_cookies_dia_uses_chromium_based_with_dia_keychain(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_kwargs: dict = {}
+
+    class FakeChromiumBased:
+        def __init__(self, **kwargs: object) -> None:
+            seen_kwargs.update(kwargs)
+
+        def load(self) -> list[_FakeCookie]:
+            return [_FakeCookie("metabase.SESSION", "s")]
+
+    class FakeBC3:
+        ChromiumBased = FakeChromiumBased
+
+    import sys
+
+    monkeypatch.setitem(sys.modules, "browser_cookie3", FakeBC3)
+    monkeypatch.setattr(
+        metabase,
+        "_enumerate_cookie_files",
+        lambda browser: [("dia", Path("/fake/dia/Default/Cookies"))],
+    )
+    cookies = metabase._load_cookies_from_browser("metabase.prod-us.posthog.dev", "dia")
+    assert cookies == {"metabase.SESSION": "s"}
+    assert seen_kwargs["osx_key_service"] == "Dia Safe Storage"
+    assert seen_kwargs["cookie_file"] == "/fake/dia/Default/Cookies"
+
+
 def test_enumerate_cookie_files_globs_chromium_profiles(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     chrome_root = tmp_path / "Chrome"
     (chrome_root / "Default").mkdir(parents=True)


### PR DESCRIPTION
## Problem

`hogli metabase:login` scans Chrome, Chromium, Brave, Firefox, and Safari for the ALB + Metabase session cookies.
If you use Dia as your daily browser, you have to log in to Metabase via Chrome just so the CLI can find the cookies.

## Changes

- Adds Dia to the browsers `hogli metabase:login` / `metabase:cookie` scan, and as a `--browser dia` choice.
- Dia is Chromium-based but has no `browser_cookie3` loader, and the generic Chrome loader can't decrypt its cookie DB because Dia encrypts with its own macOS Keychain entry ("Dia Safe Storage"). The new loader builds a `browser_cookie3.ChromiumBased` with Dia's Keychain service and profile root (`~/Library/Application Support/Dia/User Data`).
- First read triggers the usual one-time Keychain prompt per profile, same as Chrome.

## How did you test this code?

- New unit test guarding the dia loader dispatch (without it, `--browser dia` silently finds nothing since `getattr(browser_cookie3, "dia")` is `None`) and the Keychain kwargs. Full `test_metabase.py` suite passes (28 tests).
- Manually verified on macOS with Dia installed: `hogli metabase:login --region us --browser dia` decrypts Dia's cookies and fast-paths an existing session without opening Chrome.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Verified Dia's cookie DB location and Keychain entry (`security find-generic-password -s "Dia Safe Storage"`) on a real install before wiring the loader, rather than pointing the stock Chrome loader at Dia's DB (which would fail decryption due to the differing Keychain key). Skills invoked: /writing-tests.
