### PR TITLE
chore(mcp): default NODE_ENV=development in local dev

### DIFF
--- a/services/mcp/.dev.vars.example
+++ b/services/mcp/.dev.vars.example
@@ -19,3 +19,9 @@ POSTHOG_UI_APPS_TOKEN=your_posthog_ui_apps_token_here
 # If not set, simply won't capture any analytics
 POSTHOG_ANALYTICS_API_KEY=local_api_key
 POSTHOG_ANALYTICS_HOST=http://localhost:8010
+
+# Enables dev-only conveniences like the `?token=` query-param auth fallback
+# (see extractBearerToken in src/lib/utils.ts). The hono dev loop (pnpm dev:hono)
+# defaults this on its own; `wrangler dev` (pnpm dev) only picks it up from here.
+# Never set in production - it would let tokens ride in URLs (logs, referrers).
+NODE_ENV=development

--- a/services/mcp/scripts/dev-hono.ts
+++ b/services/mcp/scripts/dev-hono.ts
@@ -22,6 +22,12 @@ if (existsSync(dotEnv)) {
     process.loadEnvFile(dotEnv)
 }
 
+// The runtime gates dev-only conveniences (e.g. the `?token=` query-param auth
+// fallback in extractBearerToken) on NODE_ENV, read dynamically from the process
+// env — the esbuild define only rewrites literal `process.env.NODE_ENV` accesses.
+// This script is always a dev loop, so default it for the spawned server.
+process.env.NODE_ENV ??= 'development'
+
 copyInstructions()
 
 // flox sets SSL_CERT_FILE; Node's TLS layer only reads NODE_EXTRA_CA_CERTS.


### PR DESCRIPTION
## Problem

Connecting a local MCP server (`http://localhost:8787/mcp?token=phx_...`) from an MCP client kicks off the OAuth flow even though the URL carries a token that should bypass auth entirely.

The `?token=` query-param fallback in `extractBearerToken` is gated on `NODE_ENV` being `development` or `test` (deliberately fail-closed so tokens never ride in URLs in production). But in the local hono build that gate never opens:

- the esbuild `define` only rewrites literal `process.env.NODE_ENV` accesses, while `lib/env.ts` reads the variable dynamically through a proxy
- the `cloudflare:workers` stub exports `env = undefined`, so the lookup falls through to the process environment, where nothing sets `NODE_ENV`

With the token ignored, the server answers 401 with the RFC 9728 `WWW-Authenticate: Bearer resource_metadata=...` challenge, which is exactly the signal that makes MCP clients start OAuth.

## Changes

- `scripts/dev-hono.ts` now defaults `NODE_ENV` to `development` for the spawned server (it's always a dev loop), respecting any value already set via `.dev.vars`, `.env`, or the shell
- `.dev.vars.example` documents the variable for the `wrangler dev` path, which reads `.dev.vars` natively

No production behavior changes. The Dockerfile pins `NODE_ENV=production` and the Workers deployment leaves it unset, so the fallback stays closed there either way.

## How did you test this code?

Reproduced live against the local hono dev server: `POST /mcp?token=phx_...` returned 401 with the OAuth challenge. After injecting `NODE_ENV=development` into the dev server's environment (the same mechanism this PR automates) and restarting, the identical `initialize` request returned 200 with a session id. No automated tests: this is dev-loop tooling with no runtime surface in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and authored with Claude Code. I asked why the local URL triggered OAuth, and Claude traced it from the live 401 through `extractBearerToken`, the env proxy, and the `cloudflare:workers` stub, then verified the fix end to end against the running dev server. Considered adding `NODE_ENV` to `wrangler.jsonc` vars instead, but rejected it because those vars also apply to the deployed Worker. No repo skills were invoked.
