### PR TITLE
fix(activity): collapse nested event properties by default

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -484,6 +484,10 @@ snapshots:
         hash: v1.k794b7964.1c67bda02dd96cc1f8b0d9ea2f58a2b6e53c3030e99948f261748d9628bad020.OvR6CRtXmjrSYpRu6lb13hg5BA8J8e_qamrLA046Dus
     components-errors-error-display--with-cymbal-errors--light:
         hash: v1.k794b7964.25ff8cae17be5a1513f98e64ff90a8131c15f124c7c0913d592b0be8a2036211.vIpGHojabnc36XJMlwaTG3TFzIyPjUf1LTCMC-K0fo8
+    components-eventdetails--nested-properties--dark:
+        hash: v1.k794b7964.acbbd66bb3841f17a58d897e19c4b073fcbbf0452e959355276b012c7cd6b463.n89wKvwy5vfBtTTyqqi5InfW-EdZ8-pjfT0N1pRafQ0
+    components-eventdetails--nested-properties--light:
+        hash: v1.k794b7964.6f1c381cb3e974066a9b11169cf51b0ecaf39e636598a67e9a7d695bfcadd866.7oJQgvEiijwBqHCOAfPbYAKW6yAnMwtdzUbgdks_Xf0
     components-funneltooltip--default--dark:
         hash: v1.k794b7964.fac49a0f8c78321f545ec7d1a04452b27dae1abdf10d656d9fb232e8dbf8516c.eIr9U0bTAzMpVFiGMywP_O7jTeocwV2xZ8P7vr5nGhc
     components-funneltooltip--default--light:

--- a/frontend/src/scenes/activity/explore/EventDetails.stories.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.stories.tsx
@@ -1,0 +1,63 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { mswDecorator } from '~/mocks/browser'
+import { EventType } from '~/types'
+
+import { EventDetails } from './EventDetails'
+
+// An event whose properties include nested objects and arrays — the case that regressed to
+// rendering fully expanded inline. These call sites now pass `collapsible`, so the nested
+// values should render as collapsed JSON viewers rather than expanded nested tables.
+const eventWithNestedProperties: EventType = {
+    id: '0192a5c8-0000-0000-0000-000000000000',
+    uuid: '0192a5c8-0000-0000-0000-000000000000',
+    distinct_id: 'user-42',
+    event: 'checkout_completed',
+    timestamp: '2023-01-28T10:00:00.000Z',
+    elements: [],
+    properties: {
+        order_total: 129.99,
+        currency: 'USD',
+        coupon: 'WELCOME10',
+        billing: {
+            plan: 'enterprise',
+            seats: 42,
+            features: { sso: true, audit_log: true, sla: '99.99%' },
+        },
+        line_items: [
+            { sku: 'SKU-001', name: 'Widget', qty: 2, price: 19.99 },
+            { sku: 'SKU-002', name: 'Gadget', qty: 1, price: 89.99 },
+            { sku: 'SKU-003', name: 'Sticker pack', qty: 1, price: 0 },
+        ],
+        experiment_variants: ['pricing-v3', 'checkout-express', 'new-nav'],
+    },
+}
+
+const meta: Meta<typeof EventDetails> = {
+    component: EventDetails,
+    title: 'Components/EventDetails',
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:project_id/event_definitions/primary_properties/': { primary_properties: {} },
+            },
+        }),
+    ],
+    parameters: {
+        mockDate: '2023-01-28',
+        // The collapsed nested values render in a lazily-loaded JSON viewer; wait for it to mount
+        // so the snapshot captures the collapsed viewer rather than its loading skeleton.
+        testOptions: { waitForSelector: '.react-json-view' },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof EventDetails>
+
+export const NestedProperties: Story = {
+    render: () => (
+        <div className="w-[40rem]">
+            <EventDetails event={eventWithNestedProperties} />
+        </div>
+    ),
+}

--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -132,6 +132,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                     properties={properties}
                                     sortProperties
                                     tableProps={tableProps}
+                                    collapsible
                                 />
                             </div>
                         )
@@ -151,6 +152,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                     useDetectedPropertyType={true}
                                     tableProps={tableProps}
                                     searchable
+                                    collapsible
                                 />
                             </div>
                         )
@@ -170,6 +172,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                     useDetectedPropertyType={true}
                                     tableProps={tableProps}
                                     searchable
+                                    collapsible
                                 />
                             </div>
                         )
@@ -207,6 +210,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                             ? (event.event as KNOWN_PROMOTED_PROPERTY_PARENTS)
                                             : undefined
                                     }
+                                    collapsible
                                 />
                             </div>
                         )


### PR DESCRIPTION
## Problem

On the Activity page (event explorer / event details), nested array and object event properties render fully expanded inline. When an event has many nested properties this dominates the view and makes the properties list hard to read. A customer reported this as new behavior.

## Changes

Pass `collapsible` to the `PropertiesTable` instances in event details (`EventDetails.tsx`, which also backs session event details) so complex values render collapsed in a JSON viewer that expands on demand, matching the Person and Group property tabs.

## How did you test this code?

Not manually tested by the agent — frontend dependencies aren't installed in this environment, so I could not run the Jest suite, typecheck, or format. The change only adds an existing, already-tested prop (`collapsible`) to four call sites, mirroring the Person/Group usage. CI will run lint/typecheck/tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783683110269959?thread_ts=1783683110.269959&cid=C0ACRAMJUAG) investigating a report that nested event properties were newly expanded by default.

Root cause traced to #67364, which replaced a global feature flag (`toggle-property-arrays`, which had collapsed complex values everywhere `PropertiesTable` is used) with an opt-in `collapsible` prop. That PR wired the prop into Person, Group, and the properties notebook node, but not the event-details view — so for anyone who had the flag enabled, event properties flipped from collapsed to expanded. This PR restores the collapsed default on the Activity page by threading `collapsible` into the four event-details call sites.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783683110269959?thread_ts=1783683110.269959&cid=C0ACRAMJUAG)*
