### PR TITLE
fix(llm-gateway): raise wizard daily product cost cap

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -27,7 +27,7 @@ DEFAULT_USER_COST_LIMIT = UserCostLimit(
 DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "llm_gateway": ProductCostLimit(limit_usd=1000.0, window_seconds=86400),
     "ci": ProductCostLimit(limit_usd=1000.0, window_seconds=2592000),  # $1000 / 30 days
-    "wizard": ProductCostLimit(limit_usd=2000.0, window_seconds=86400),
+    "wizard": ProductCostLimit(limit_usd=10000.0, window_seconds=86400),
     "posthog_code": ProductCostLimit(limit_usd=5000.0, window_seconds=3600),
     "background_agents": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
     "django": ProductCostLimit(limit_usd=5000.0, window_seconds=86400),

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -152,7 +152,7 @@ class TestProductCostThrottle:
         ctx_wizard = make_context(product="wizard")
         ctx_posthog_code = make_context(product="posthog_code")
 
-        await throttle.record_cost(ctx_wizard, 2000.0)
+        await throttle.record_cost(ctx_wizard, 10000.0)
 
         result_wizard = await throttle.allow_request(ctx_wizard)
         result_posthog_code = await throttle.allow_request(ctx_posthog_code)


### PR DESCRIPTION
## Problem

The `wizard` product's daily cost cap in the LLM gateway is $2,000, the tightest daily cap of any product (compare `django` and `posthog_ai` at $5,000/day and `signals` at $25,000/day). Wizard's legitimate daily spend had grown to brush right up against that cap, and then jumped well past it, so the gateway now starts rejecting wizard requests partway through the day. This fired the `LLMGatewayProductCostLimitExceeded` alert in prod-us; the throttle itself was working as designed.

**Why:** wizard-backed LLM features go down for the rest of the day whenever the cap is hit, and current volume hits it well before the window resets.

Root cause of the jump: it wasn't more traffic, it was fatter requests. PostHog/wizard#851 (released in wizard v2.40.0) pinned the wizard's internal MCP connections to `?mode=tools` to work around the CLI-mode default from #69629, which puts the full ~252 named tool schemas back into every agent request. Per-generation input size roughly quadrupled at that release, and daily spend with it. The wizard team should follow up on shrinking that context again (the PR itself notes a proper CLI-mode migration is needed), but the cap also needs headroom: wizard was already touching $2,000/day on normal traffic before the regression.

## Changes

Raise the `wizard` entry in `DEFAULT_PRODUCT_COST_LIMITS` from $2,000/day to $10,000/day. That covers the current (inflated) daily pace and leaves sane headroom over the pre-regression baseline once the wizard's context size is fixed, while remaining a real guardrail (well under the `signals` cap). Per-user wizard spend is still bounded separately by `DEFAULT_USER_COST_LIMITS`, so this doesn't loosen protection against a single runaway user.

```diff
-    "wizard": ProductCostLimit(limit_usd=2000.0, window_seconds=86400),
+    "wizard": ProductCostLimit(limit_usd=10000.0, window_seconds=86400),
```

Also updated `test_different_products_have_separate_limits`, which records spend equal to the wizard cap to assert denial.

> [!NOTE]
> Deployments can still override this via the `LLM_GATEWAY_PRODUCT_COST_LIMITS` env var; this changes the built-in default. If Shared AI prefers a different ceiling, it's a one-line tweak.

## How did you test this code?

Ran the llm-gateway cost throttle suite: `uv run pytest tests/test_cost_throttles.py` in `services/llm-gateway` (83 passed). Also `ruff check` / `ruff format --check` on the touched files. No manual testing against a live gateway.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, the cap values aren't documented outside the config itself.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude via PostHog Code in response to the prod-us `LLMGatewayProductCostLimitExceeded` alert for the wizard product. After the initial cap raise, I investigated the spend pattern in AI observability data: hourly wizard cost stepped up sharply at the moment wizard v2.40.0 shipped, with request counts flat but per-generation input tokens jumping from a tight ~110k distribution to a tight ~500k distribution — pointing at PostHog/wizard#851 (tools-mode pin reintroducing all named MCP tool schemas into every request) rather than organic growth. Updated this description accordingly. I picked $10,000/day so the cap clears the current inflated pace and keeps generous headroom after the wizard-side fix; the exact number is Shared AI's call and easy to adjust.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
