### PR TITLE
fix(data-warehouse): retry Convex reads on mid-body connection breaks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
@@ -5,11 +5,14 @@ from collections.abc import Generator
 from typing import Any
 from urllib.parse import urlparse
 
+from requests import Response
 from requests.exceptions import (
+    ChunkedEncodingError,
     ConnectionError as RequestsConnectionError,
     HTTPError,
     RequestException,
 )
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import (
@@ -97,11 +100,25 @@ def _headers(deploy_key: str) -> dict[str, str]:
     }
 
 
+@retry(
+    retry=retry_if_exception_type(ChunkedEncodingError),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _convex_get(url: str, deploy_key: str, params: dict[str, Any], timeout: int) -> Response:
+    # requests reads the body eagerly (stream=False), so a connection broken mid-chunk surfaces
+    # here as ChunkedEncodingError — it happens after the response headers, so _CONVEX_RETRY (a
+    # urllib3 Retry, which only covers pre-response failures) never sees it. It's transient and
+    # every Convex read is an idempotent GET, so a fresh request re-fetches the page.
+    return make_tracked_session(retry=_CONVEX_RETRY).get(
+        url, headers=_headers(deploy_key), params=params, timeout=timeout
+    )
+
+
 def get_json_schemas(deploy_url: str, deploy_key: str) -> dict[str, Any]:
     url = f"{deploy_url.rstrip('/')}/api/json_schemas"
-    response = make_tracked_session(retry=_CONVEX_RETRY).get(
-        url, headers=_headers(deploy_key), params={"deltaSchema": "true", "format": "json"}, timeout=30
-    )
+    response = _convex_get(url, deploy_key, {"deltaSchema": "true", "format": "json"}, timeout=30)
     response.raise_for_status()
     return response.json()
 
@@ -134,9 +151,7 @@ def list_snapshot(
         if snapshot is not None:
             params["snapshot"] = snapshot
 
-        response = make_tracked_session(retry=_CONVEX_RETRY).get(
-            base_url, headers=_headers(deploy_key), params=params, timeout=60
-        )
+        response = _convex_get(base_url, deploy_key, params, timeout=60)
         response.raise_for_status()
         data = response.json()
 
@@ -196,9 +211,7 @@ def document_deltas(
     while True:
         params: dict[str, Any] = {"tableName": table_name, "cursor": current_cursor, "format": "json"}
 
-        response = make_tracked_session(retry=_CONVEX_RETRY).get(
-            base_url, headers=_headers(deploy_key), params=params, timeout=60
-        )
+        response = _convex_get(base_url, deploy_key, params, timeout=60)
 
         if response.status_code == 400:
             error_data = response.json()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import MagicMock, Mock, patch
 
 from parameterized import parameterized
-from requests.exceptions import HTTPError
+from requests.exceptions import ChunkedEncodingError, HTTPError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.convex.convex import (
@@ -13,6 +13,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.convex.con
     ConvexResumeConfig,
     InvalidDeployUrlError,
     InvalidWindowError,
+    _convex_get,
     convex_source,
     document_deltas,
     list_snapshot,
@@ -254,6 +255,25 @@ class TestDocumentDeltasResumable:
         assert first_params["cursor"] == 10
         # Discarding a poisoned cursor must not persist new state off the back of it.
         manager.save_state.assert_not_called()
+
+
+class TestConvexChunkedEncodingRetry:
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.convex.convex.make_tracked_session")
+    def test_document_deltas_retries_on_chunked_encoding_error(self, mock_get: Mock) -> None:
+        # A connection broken mid-body surfaces as ChunkedEncodingError after the response headers,
+        # past _CONVEX_RETRY's reach (urllib3 only retries pre-response failures). The reads are
+        # idempotent GETs, so a fresh request must re-fetch the page rather than fail the sync.
+        manager = _make_manager(can_resume=False)
+        mock_get.return_value.get.side_effect = [
+            ChunkedEncodingError("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)"),
+            _make_response({"values": [{"_id": "a"}], "cursor": 30, "hasMore": False}),
+        ]
+
+        with patch.object(_convex_get.retry, "sleep"):
+            batches = list(document_deltas("https://x.convex.cloud", "key", "t", 10, manager))
+
+        assert batches == [[{"_id": "a"}]]
+        assert mock_get.return_value.get.call_count == 2
 
 
 class TestConvexRetryPolicy:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -269,7 +269,9 @@ class TestConvexChunkedEncodingRetry:
             _make_response({"values": [{"_id": "a"}], "cursor": 30, "hasMore": False}),
         ]
 
-        with patch.object(_convex_get.retry, "sleep"):
+        # tenacity attaches the Retrying controller as `.retry`; stub its sleep so the backoff
+        # between attempts doesn't actually block the test.
+        with patch.object(_convex_get.retry, "sleep"):  # type: ignore[attr-defined]
             batches = list(document_deltas("https://x.convex.cloud", "key", "t", 10, manager))
 
         assert batches == [[{"_id": "a"}]]


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ChunkedEncodingError` raised from the Convex import source:

> `("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", ...)`

Issue: https://us.posthog.com/project/2/error_tracking/019f4bd6-a043-7db2-841e-eb1974570031

The stack originates in `convex.py` inside `document_deltas`, at the HTTP GET. The Convex source calls `make_tracked_session(...).get(...)` directly. `requests` reads the body eagerly (`stream=False`), so a connection broken mid-chunk surfaces as `ChunkedEncodingError` **after** the response headers arrive. That is past the reach of `_CONVEX_RETRY`, which is a urllib3 `Retry` and only covers failures before the response. So a transient mid-stream drop fails the whole sync instead of being retried.

This is a transient network error, not a credential/config/data problem, so it stays retryable (it does not belong in `NonRetryableErrors`). The gap is that our own retry layer never sees it.

## Changes

Wrap the Convex GETs in a small bounded `tenacity` retry on `ChunkedEncodingError` (5 attempts, exponential jitter backoff). Every Convex read is an idempotent GET, so a fresh request safely re-fetches the page.

This mirrors handling that already exists elsewhere in the same codebase for the identical failure mode:
- `sources/github/github.py` retries `ChunkedEncodingError` ("GitHub can break the connection mid-body on a chunked response ... a fresh GET re-fetches the page")
- `sources/awin/awin.py` retries it in its tenacity policy
- `sources/common/rest_source/rest_client.py` reissues on it ("`send` reads the body eagerly (stream=False), so a connection dropped mid-stream surfaces here as ChunkedEncodingError")

The existing `_CONVEX_RETRY` (Cloudflare-aware status/connection retry) is unchanged and still applies underneath; the new layer only adds coverage for the body-read drop it cannot catch.

> [!NOTE]
> Scope is strictly this error. No global retry-policy change, and nothing added to `NonRetryableErrors`.

## How did you test this code?

Added one regression test, `TestConvexChunkedEncodingRetry::test_document_deltas_retries_on_chunked_encoding_error`: it drives `document_deltas` to raise `ChunkedEncodingError` once then succeed, and asserts the sync completes and the GET was reissued. Nothing existing covered the body-read retry (the existing `TestConvexRetryPolicy` only covers urllib3 status-code handling), so removing the retry would newly fail this test.

I (Claude) ran the full Convex suite locally: `55 passed`. I did not perform any manual/live testing against a Convex deployment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) as part of automated error-tracking triage. I confirmed the issue in PostHog error tracking (pulled the full stack trace and confirmed the top in-app frame is `convex.py:document_deltas`), read the Convex source and the shared HTTP transport, and classified the error as a transient mid-stream connection drop rather than a user/upstream error. Rejected extending `NonRetryableErrors` (that would permanently kill syncs on a transient blip); chose a request-layer retry after finding the established `ChunkedEncodingError` retry convention in the github/awin sources and the shared REST client. Invoked the `/writing-tests` skill before adding the regression test. Checked open PRs (including the maintainer's own) for a duplicate and found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
