### PR TITLE
fix(bigquery): stop capturing missing-table errors from the row-count probe

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -638,6 +638,23 @@ def _has_duplicate_primary_keys(table: bigquery.Table, client: bigquery.Client, 
     return False
 
 
+def _is_missing_table_or_dataset(error: Exception) -> bool:
+    """True for a table/dataset that's absent from the region the query job runs in.
+
+    BigQuery raises a `NotFound` whose `str()` is "Not found: Table <id> was not found in
+    location EU" (or "Not found: Dataset ..." / "... was not found in location ...") when the
+    table was deleted or renamed after schema discovery selected it, or lives in a different
+    region than the one we query. That's a user-side condition the main read path already
+    surfaces non-retryably (see `BigQuerySource.get_non_retryable_errors`), so the best-effort
+    row-count probe shouldn't also capture it as error-tracking noise. Distinct from the
+    transient "Not found: Job" lookup race, which is retried before reaching here.
+    """
+    if not isinstance(error, NotFound):
+        return False
+    message = str(error)
+    return "was not found in location" in message or "Not found: Table" in message or "Not found: Dataset" in message
+
+
 def _get_rows_to_sync(
     table: bigquery.Table,
     client: bigquery.Client,
@@ -683,7 +700,8 @@ def _get_rows_to_sync(
         return 0
     except Exception as e:
         logger.debug(f"_get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
-        capture_exception(e)
+        if not _is_missing_table_or_dataset(e):
+            capture_exception(e)
 
         return 0
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -425,6 +425,63 @@ def test_bigquery_get_rows_to_sync_retries_transient_job_not_found(mock_sleep):
     mock_capture.assert_not_called()
 
 
+def test_bigquery_get_rows_to_sync_skips_capture_when_table_missing():
+    # A table deleted/renamed after schema discovery (or absent from the queried region) makes the
+    # COUNT query raise a terminal NotFound. The main read path already surfaces this non-retryably,
+    # so the best-effort probe must fall back to 0 without capturing error-tracking noise.
+    table = mock.MagicMock(project="proj", dataset_id="ds", table_id="t")
+    table.schema = [SimpleNamespace(name="age", field_type="INTEGER")]
+    client = mock.MagicMock()
+    job = mock.MagicMock()
+    job.result.side_effect = NotFound("404 Not found: Table proj:ds.t was not found in location EU")
+    client.query.return_value = job
+
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery.capture_exception"
+    ) as mock_capture:
+        result = _get_rows_to_sync(
+            table=table,
+            client=client,
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+            logger=mock.MagicMock(),
+            row_filters=[
+                ValidatedRowFilter(column="age", operator="IN", value=[21, 30], category=ColumnTypeCategory.INTEGER)
+            ],
+        )
+
+    assert result == 0
+    mock_capture.assert_not_called()
+
+
+def test_bigquery_get_rows_to_sync_captures_unexpected_error():
+    # A NotFound is only skipped for the missing-table/region wording; an unrelated failure must
+    # still be captured so genuine bugs stay visible.
+    table = mock.MagicMock(project="proj", dataset_id="ds", table_id="t")
+    table.schema = [SimpleNamespace(name="age", field_type="INTEGER")]
+    client = mock.MagicMock()
+    job = mock.MagicMock()
+    job.result.side_effect = ValueError("something unexpected")
+    client.query.return_value = job
+
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery.capture_exception"
+    ) as mock_capture:
+        result = _get_rows_to_sync(
+            table=table,
+            client=client,
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+            logger=mock.MagicMock(),
+            row_filters=[
+                ValidatedRowFilter(column="age", operator="IN", value=[21, 30], category=ColumnTypeCategory.INTEGER)
+            ],
+        )
+
+    assert result == 0
+    mock_capture.assert_called_once()
+
+
 def test_bigquery_get_query_in_filter_expands_to_one_param_per_value():
     bq_table = mock.MagicMock(dataset_id="ds", table_id="t")
     bq_table.schema = [SimpleNamespace(name="age", field_type="INTEGER")]


### PR DESCRIPTION
## Problem

Error tracking surfaced a BigQuery `NotFound` from the import pipeline:

> Not found: Table `<project>:<dataset>.<table>` was not found in location EU

The deepest in-app frame is `_run` in `bigquery.py`, reachable only through `_get_rows_to_sync` (the best-effort probe that computes `rows_to_sync` for progress reporting). That helper wraps its work in a broad `except Exception` that calls `capture_exception(e)` on everything before falling back to `0`.

The failure itself is a user-side condition: a table deleted or renamed after schema discovery selected it (common with dbt-managed datasets), or one that lives in a different region than the one we query. It is already classified non-retryable on the main read path. Both `"Not found: Table"` and `"was not found in location"` are keys in `BigQuerySource.get_non_retryable_errors`, so the sync correctly stops and the customer gets an actionable message. The only thing left over is redundant error-tracking noise from the row-count probe capturing a condition we already handle.

## Changes

Skip `capture_exception` in `_get_rows_to_sync` for a `NotFound` whose message is the missing-table / missing-dataset / wrong-region wording, and fall back to `0` as before. Every other unexpected failure is still captured, so genuine bugs stay visible.

This mirrors the graceful-skip pattern already used elsewhere in the same file (`_has_duplicate_primary_keys` skips capture for `resourcesExceeded`, `delete_all_temp_destination_tables` logs quietly for `Forbidden`/`NotFound`/`RefreshError`).

> [!NOTE]
> This does not change retry behavior. Retry classification runs on the propagating failure from the main read path, not on this swallowed capture. The sync still stops with the existing friendly message. The change only removes the duplicate capture.

The transient `"Not found: Job"` lookup race is unaffected: it is retried by `_with_job_not_found_retry` before this handler runs, and its wording is deliberately excluded from the new predicate.

## How did you test this code?

Added two cases to `test_source.py`:

- `test_bigquery_get_rows_to_sync_skips_capture_when_table_missing` - the reported `NotFound` returns `0` and does not call `capture_exception`. Guards against reintroducing the noise.
- `test_bigquery_get_rows_to_sync_captures_unexpected_error` - an unrelated error is still captured, so the skip stays narrow.

The existing `test_bigquery_get_rows_to_sync_retries_transient_job_not_found` continues to cover the transient job race (retried, not skipped).

I (Claude) could not run the Python suite in this sandbox (Django and pytest aren't installed in the environment). `ruff check` and `ruff format` pass on both files, and I verified the new predicate's branch logic in isolation. The new tests follow the exact structure of the adjacent passing `_get_rows_to_sync` tests.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue by Claude (Claude Code). Traced the captured exception to the single `capture_exception` in `_get_rows_to_sync`, confirmed the underlying condition is already non-retryable via `get_non_retryable_errors`, and concluded the fix is a scoped graceful-skip rather than a new `NonRetryableErrors` entry (both matching substrings already exist there). Invoked `/writing-tests` before adding the regression cases. No duplicate open PR addresses this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
