### PR TITLE
feat(quill): add completed tone/token and ItemGroup combined

### DIFF
--- a/packages/quill/apps/storybook/stories/colors.stories.tsx
+++ b/packages/quill/apps/storybook/stories/colors.stories.tsx
@@ -224,6 +224,25 @@ export const AllColors: Story = {
                         usages={['Info (used for info actions, infos, etc.)`']}
                     />
 
+                    <ColorSwatch
+                        name="Completed"
+                        items={[
+                            {
+                                className: 'bg-completed',
+                                name: 'completed',
+                                tailwindClass: 'bg-completed',
+                                value: semanticColors.completed[0],
+                            },
+                            {
+                                className: 'text-completed-foreground',
+                                name: 'completed-foreground',
+                                tailwindClass: 'text-completed-foreground',
+                                value: semanticColors['completed-foreground'][0],
+                            },
+                        ]}
+                        usages={['Completed (terminal done state, e.g. merged PR states)']}
+                    />
+
                     <div className="p-2 font-mono bg-border text-foreground">
                         border/foreground: {semanticColors.border[0]}
                     </div>

--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -91,12 +91,12 @@ For a custom menu-like list inside a Popover (when DropdownMenu's open/close sem
 
 ### Status and labels
 
-| Component | Use when                                                              |
-| --------- | --------------------------------------------------------------------- |
-| Badge     | Semantic status text — variants info/warning/success/destructive      |
-| Chip      | Removable token (selected tags, active filters) — pair with ChipClose |
-| Dot       | Tiny presence/status indicator next to text; `pulse` for live state   |
-| Kbd       | Keyboard shortcut display, with KbdGroup for combos                   |
+| Component | Use when                                                                   |
+| --------- | -------------------------------------------------------------------------- |
+| Badge     | Semantic status text — variants info/warning/success/completed/destructive |
+| Chip      | Removable token (selected tags, active filters) — pair with ChipClose      |
+| Dot       | Tiny presence/status indicator next to text; `pulse` for live state        |
+| Kbd       | Keyboard shortcut display, with KbdGroup for combos                        |
 
 ### Form controls
 
@@ -133,7 +133,7 @@ Don't hand-roll `<p className="text-xs text-muted-foreground">` when `<Text size
 | Component    | Variants                                                 | Sizes                                                | Notes                                                                                                                  |
 | ------------ | -------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | Button       | default, primary, outline, destructive, link, link-muted | default, xs, sm, lg, icon, icon-xs, icon-sm, icon-lg | `loading` overlays a centered spinner and disables the button (width stays stable)                                     |
-| Badge        | default, info, destructive, warning, success             | —                                                    | Semantic status                                                                                                        |
+| Badge        | default, info, destructive, warning, success, completed  | —                                                    | Semantic status                                                                                                        |
 | Toggle       | default, outline                                         | default, sm, lg, icon                                |                                                                                                                        |
 | Chip         | outline                                                  | sm                                                   | Use with ChipClose                                                                                                     |
 | Separator    | —                                                        | —                                                    | orientation: horizontal/vertical                                                                                       |
@@ -680,6 +680,7 @@ Vertical: `<ButtonGroup orientation="vertical">`
 
 Item variants: default, outline, pressable, muted, menuItem
 Item sizes: default, sm, xs
+Item tones (the `tone` prop — named `tone`, not `color`, to avoid colliding with the DOM `color` attribute when Base UI render props are spread onto ItemCheckbox/ItemRadio): default, info, success, warning, completed, destructive — a semantic tint orthogonal to `variant`, designed to pair with `variant="pressable"` for colored clickable rows (e.g. `<Item variant="pressable" tone="success" render={<a href="…" />}>`)
 
 ### Avatar
 
@@ -1001,7 +1002,7 @@ Each container's CSS handles `flex-shrink: 0` and the per-context size via `svg:
 
 1. **Use Field for forms** — don't compose raw Label + Input, use Field > FieldLabel + Input + FieldDescription/FieldError
 2. **Wrap app with providers** — ThemeProvider at root, TooltipProvider if using tooltips, ToastProvider if using toasts
-3. **Badge variants are semantic** — info (blue), warning (yellow), success (green), destructive (red), default (neutral)
+3. **Badge variants are semantic** — info (blue), warning (yellow), success (green), completed (purple, terminal done state e.g. merged PRs), destructive (red), default (neutral)
 4. **Use `render` on triggers** — DialogTrigger, PopoverTrigger, TooltipTrigger, DrawerTrigger accept `render` to render as the child element
 5. **DropdownMenuItem has variants** — use `variant="destructive"` for dangerous actions; default is `"default"`
 6. **Prefer composition over props** — use CardHeader > CardTitle instead of `<Card title="...">`

--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -680,6 +680,7 @@ Vertical: `<ButtonGroup orientation="vertical">`
 
 Item variants: default, outline, pressable, muted, menuItem
 Item sizes: default, sm, xs
+`<ItemGroup>` spaces items with a gap by default; pass `combined` to merge them into one flush list (no gap, squared interior corners, collapsed shared borders, rounded outer corners — like CardGroup)
 Item tones (the `tone` prop — named `tone`, not `color`, to avoid colliding with the DOM `color` attribute when Base UI render props are spread onto ItemCheckbox/ItemRadio): default, info, success, warning, completed, destructive — a semantic tint orthogonal to `variant`, designed to pair with `variant="pressable"` for colored clickable rows (e.g. `<Item variant="pressable" tone="success" render={<a href="…" />}>`)
 
 ### Avatar

--- a/packages/quill/packages/primitives/src/badge.css
+++ b/packages/quill/packages/primitives/src/badge.css
@@ -63,4 +63,9 @@
         color: var(--success-foreground);
         background-color: var(--success);
     }
+
+    .quill-badge--variant-completed {
+        color: var(--completed-foreground);
+        background-color: var(--completed);
+    }
 }

--- a/packages/quill/packages/primitives/src/badge.stories.tsx
+++ b/packages/quill/packages/primitives/src/badge.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     argTypes: {
         variant: {
             control: 'select',
-            options: ['default', 'secondary', 'destructive', 'outline', 'ghost'],
+            options: ['default', 'info', 'destructive', 'warning', 'success', 'completed'],
         },
     },
 } satisfies Meta<typeof Badge>
@@ -28,6 +28,7 @@ export const Default = {
                 <Badge variant="destructive">Destructive</Badge>
                 <Badge variant="warning">Warning</Badge>
                 <Badge variant="success">Success</Badge>
+                <Badge variant="completed">Completed</Badge>
             </div>
         </div>
     ),

--- a/packages/quill/packages/primitives/src/badge.tsx
+++ b/packages/quill/packages/primitives/src/badge.tsx
@@ -16,6 +16,7 @@ const badgeVariants = cva(
                 destructive: 'quill-badge--variant-destructive',
                 warning: 'quill-badge--variant-warning',
                 success: 'quill-badge--variant-success',
+                completed: 'quill-badge--variant-completed',
             },
         },
         defaultVariants: {

--- a/packages/quill/packages/primitives/src/item.css
+++ b/packages/quill/packages/primitives/src/item.css
@@ -102,28 +102,48 @@
        `variant="pressable"`. Each sets a tint (pastel surface) + accent
        (readable foreground) pair, applied via shared rules below. */
     .quill-item--tone-info {
-        --quill-item-tint: color-mix(in oklab, var(--info) 12%, var(--card));
+        --quill-item-tint: color-mix(in oklab, var(--info) 50%, var(--card));
         --quill-item-accent: var(--info-foreground);
     }
 
+    :is(.dark, [theme='dark']) .quill-item--tone-info {
+        --quill-item-tint: color-mix(in oklab, var(--info) 60%, var(--card));
+    }
+
     .quill-item--tone-success {
-        --quill-item-tint: color-mix(in oklab, var(--success) 12%, var(--card));
+        --quill-item-tint: color-mix(in oklab, var(--success) 50%, var(--card));
         --quill-item-accent: var(--success-foreground);
     }
 
+    :is(.dark, [theme='dark']) .quill-item--tone-success {
+        --quill-item-tint: color-mix(in oklab, var(--success) 60%, var(--card));
+    }
+
     .quill-item--tone-warning {
-        --quill-item-tint: color-mix(in oklab, var(--warning) 12%, var(--card));
+        --quill-item-tint: color-mix(in oklab, var(--warning) 50%, var(--card));
         --quill-item-accent: var(--warning-foreground);
     }
 
+    :is(.dark, [theme='dark']) .quill-item--tone-warning {
+        --quill-item-tint: color-mix(in oklab, var(--warning) 60%, var(--card));
+    }
+
     .quill-item--tone-completed {
-        --quill-item-tint: color-mix(in oklab, var(--completed) 12%, var(--card));
+        --quill-item-tint: color-mix(in oklab, var(--completed) 50%, var(--card));
         --quill-item-accent: var(--completed-foreground);
     }
 
+    :is(.dark, [theme='dark']) .quill-item--tone-completed {
+        --quill-item-tint: color-mix(in oklab, var(--completed) 60%, var(--card));
+    }
+
     .quill-item--tone-destructive {
-        --quill-item-tint: color-mix(in oklab, var(--destructive) 12%, var(--card));
+        --quill-item-tint: color-mix(in oklab, var(--destructive) 50%, var(--card));
         --quill-item-accent: var(--destructive-foreground);
+    }
+
+    :is(.dark, [theme='dark']) .quill-item--tone-destructive {
+        --quill-item-tint: color-mix(in oklab, var(--destructive) 60%, var(--card));
     }
 
     .quill-item[data-tone] {

--- a/packages/quill/packages/primitives/src/item.css
+++ b/packages/quill/packages/primitives/src/item.css
@@ -34,6 +34,29 @@
         border: none;
     }
 
+    /*
+     * Combined ItemGroup — items sit flush as one merged list: no gap (set in
+     * JSX), interior corners squared, adjacent 1px borders collapsed into a
+     * single seam, and only the outer corners rounded. Mirrors CardGroup.
+     */
+    .quill-item-group[data-combined] > .quill-item {
+        border-radius: 0;
+    }
+
+    .quill-item-group[data-combined] > .quill-item:not(:first-child) {
+        margin-top: -1px;
+    }
+
+    .quill-item-group[data-combined] > .quill-item:first-child {
+        border-start-start-radius: var(--radius-sm);
+        border-start-end-radius: var(--radius-sm);
+    }
+
+    .quill-item-group[data-combined] > .quill-item:last-child {
+        border-end-start-radius: var(--radius-sm);
+        border-end-end-radius: var(--radius-sm);
+    }
+
     /* Variants */
     .quill-item--variant-default {
         border-color: var(--card);

--- a/packages/quill/packages/primitives/src/item.css
+++ b/packages/quill/packages/primitives/src/item.css
@@ -61,6 +61,7 @@
     }
 
     .quill-item--variant-pressable:not(:disabled):active {
+        border-width: 1px;
         box-shadow: var(--shadow-sm);
         translate: 0 1px;
     }
@@ -72,6 +73,44 @@
     .quill-item--variant-menu:hover {
         color: var(--foreground);
         background-color: var(--fill-hover);
+    }
+
+    /* Semantic tones — orthogonal to variant, designed to pair with
+       `variant="pressable"`. Each sets a tint (pastel surface) + accent
+       (readable foreground) pair, applied via shared rules below. */
+    .quill-item--tone-info {
+        --quill-item-tint: color-mix(in oklab, var(--info) 12%, var(--card));
+        --quill-item-accent: var(--info-foreground);
+    }
+
+    .quill-item--tone-success {
+        --quill-item-tint: color-mix(in oklab, var(--success) 12%, var(--card));
+        --quill-item-accent: var(--success-foreground);
+    }
+
+    .quill-item--tone-warning {
+        --quill-item-tint: color-mix(in oklab, var(--warning) 12%, var(--card));
+        --quill-item-accent: var(--warning-foreground);
+    }
+
+    .quill-item--tone-completed {
+        --quill-item-tint: color-mix(in oklab, var(--completed) 12%, var(--card));
+        --quill-item-accent: var(--completed-foreground);
+    }
+
+    .quill-item--tone-destructive {
+        --quill-item-tint: color-mix(in oklab, var(--destructive) 12%, var(--card));
+        --quill-item-accent: var(--destructive-foreground);
+    }
+
+    .quill-item[data-tone] {
+        background-color: var(--quill-item-tint);
+        border-color: color-mix(in oklab, var(--quill-item-accent) 50%, transparent);
+    }
+
+    /* Deepen the tint on hover for pressable toned items */
+    .quill-item--variant-pressable[data-tone]:hover {
+        background-color: color-mix(in oklab, var(--quill-item-accent) 12%, var(--card));
     }
 
     /* Sizes */
@@ -129,10 +168,6 @@
         object-fit: cover;
     }
 
-    .group\/item[role='link']:hover .quill-item__media {
-        color: var(--primary);
-    }
-
     /* ItemMedia pushes down slightly when description is present */
     .group\/item:has([data-slot='item-description']) .quill-item__media {
         align-self: flex-start;
@@ -142,10 +177,6 @@
     /* =========================================================================
        ItemContent
        ========================================================================= */
-    .quill-item__content {
-        /* gap handled by tailwind */
-    }
-
     .group\/item[data-size='xs'] .quill-item__content {
         gap: 0.125rem;
     }
@@ -183,11 +214,8 @@
         line-height: 1.375;
         text-underline-offset: 4px;
         -webkit-line-clamp: 1;
+        line-clamp: 1;
         -webkit-box-orient: vertical;
-    }
-
-    .group\/item[role='link']:hover .quill-item__title {
-        color: var(--primary);
     }
 
     .quill-item__description {
@@ -199,15 +227,12 @@
         color: var(--muted-foreground);
         text-align: start;
         -webkit-line-clamp: 2;
+        line-clamp: 2;
         -webkit-box-orient: vertical;
     }
 
     .quill-item__description > a {
         text-decoration: underline;
         text-underline-offset: 4px;
-    }
-
-    .quill-item__description > a:hover {
-        color: var(--primary);
     }
 }

--- a/packages/quill/packages/primitives/src/item.stories.tsx
+++ b/packages/quill/packages/primitives/src/item.stories.tsx
@@ -84,6 +84,47 @@ export const Pressable: Story = {
     ),
 } satisfies Story
 
+// Semantic `tone` is orthogonal to `variant` — here paired with `pressable`
+// (the right way to build a clickable, link-like row). Each renders as an <a>.
+export const Tones: Story = {
+    render: () => {
+        const tones = [
+            { tone: undefined, title: 'Default', description: 'Neutral pressable row' },
+            { tone: 'info' as const, title: 'Info', description: 'Informational status' },
+            { tone: 'success' as const, title: 'Success', description: 'Completed successfully' },
+            { tone: 'warning' as const, title: 'Warning', description: 'Needs attention' },
+            { tone: 'completed' as const, title: 'Completed', description: 'Merged / terminal state' },
+            { tone: 'destructive' as const, title: 'Destructive', description: 'Failed or removed' },
+        ]
+        return (
+            <ItemGroup className="max-w-sm">
+                {tones.map(({ tone, title, description }) => (
+                    <Item
+                        key={title}
+                        variant="pressable"
+                        tone={tone}
+                        render={
+                            // eslint-disable-next-line react/forbid-elements
+                            <a href="#">
+                                <ItemMedia variant="icon">
+                                    <BadgeCheckIcon className="size-5" />
+                                </ItemMedia>
+                                <ItemContent>
+                                    <ItemTitle>{title}</ItemTitle>
+                                    <ItemDescription>{description}</ItemDescription>
+                                </ItemContent>
+                                <ItemActions>
+                                    <ChevronRightIcon className="size-4" />
+                                </ItemActions>
+                            </a>
+                        }
+                    />
+                ))}
+            </ItemGroup>
+        )
+    },
+} satisfies Story
+
 export const Group: Story = {
     render: () => (
         <ItemGroup>

--- a/packages/quill/packages/primitives/src/item.stories.tsx
+++ b/packages/quill/packages/primitives/src/item.stories.tsx
@@ -128,7 +128,7 @@ export const Tones: Story = {
 export const Group: Story = {
     render: () => (
         <ItemGroup>
-            <ItemGroup>
+            <ItemGroup combined>
                 <Item variant="outline">
                     <ItemContent>
                         <ItemTitle>Basic Item</ItemTitle>

--- a/packages/quill/packages/primitives/src/item.tsx
+++ b/packages/quill/packages/primitives/src/item.tsx
@@ -9,13 +9,19 @@ import { cn } from './lib/utils'
 import { RadioIndicator } from './radio-group'
 import { Separator } from './separator'
 
-function ItemGroup({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
+function ItemGroup({
+    className,
+    combined = false,
+    ...props
+}: React.ComponentProps<'div'> & { combined?: boolean }): React.ReactElement {
     return (
         <div
             role="list"
             data-slot="item-group"
+            data-combined={combined ? '' : undefined}
             className={cn(
-                'quill-item-group group/item-group flex w-full flex-col gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2',
+                'quill-item-group group/item-group flex w-full flex-col',
+                combined ? 'gap-0' : 'gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2',
                 className
             )}
             {...props}

--- a/packages/quill/packages/primitives/src/item.tsx
+++ b/packages/quill/packages/primitives/src/item.tsx
@@ -45,10 +45,19 @@ const itemVariants = cva(
                 sm: 'quill-item--size-sm',
                 xs: 'quill-item--size-xs',
             },
+            tone: {
+                default: '',
+                info: 'quill-item--tone-info',
+                success: 'quill-item--tone-success',
+                warning: 'quill-item--tone-warning',
+                completed: 'quill-item--tone-completed',
+                destructive: 'quill-item--tone-destructive',
+            },
         },
         defaultVariants: {
             variant: 'default',
             size: 'default',
+            tone: 'default',
         },
     }
 )
@@ -57,6 +66,7 @@ function Item({
     className,
     variant = 'default',
     size = 'default',
+    tone = 'default',
     role,
     render,
     ...props
@@ -66,7 +76,8 @@ function Item({
         props: mergeProps<'div'>(
             {
                 'data-quill': '',
-                className: cn(itemVariants({ variant, size, className })),
+                'data-tone': tone && tone !== 'default' ? tone : undefined,
+                className: cn(itemVariants({ variant, size, tone, className })),
                 role: variant === 'pressable' ? 'link' : undefined,
             } as Omit<React.ComponentProps<'div'>, 'ref'>,
             props
@@ -76,6 +87,7 @@ function Item({
             slot: 'item',
             variant,
             size,
+            tone,
         },
     })
 }
@@ -196,7 +208,7 @@ function ItemMedia({
     )
 }
 
-const itemContentVariants = cva('quill-item__content flex flex-1 flex-col gap-1', {
+const itemContentVariants = cva('quill-item__content flex flex-1 flex-col gap-0.5', {
     variants: {
         variant: {
             default: '',

--- a/packages/quill/packages/primitives/src/styles/layers.css
+++ b/packages/quill/packages/primitives/src/styles/layers.css
@@ -90,6 +90,7 @@ body.is-desktop .quill-toggle,
 body.is-desktop .quill-accordion__trigger,
 body.is-desktop .quill-checkbox:not(:disabled),
 body.is-desktop .quill-field__label:has(> [data-slot='field']),
+body.is-desktop .quill-item--variant-pressable,
 body.is-desktop .group\/field:has(> [role='checkbox']) .quill-label {
     cursor: default;
 }

--- a/packages/quill/packages/tokens/src/colors.ts
+++ b/packages/quill/packages/tokens/src/colors.ts
@@ -135,7 +135,10 @@ export function buildSemanticColors(): Record<string, ColorTuple> {
         'warning-foreground': [oklch(0.476, 0.114, 61.907), oklch(0.77, 0.14, 99.29), 'text-warning-foreground'],
 
         info: [oklch(0.882, 0.059, 254.128), oklch(0.4242, 0.1982, 265.5, 0.4), 'bg-info'],
-        'info-foreground': [oklch(0.49, 0.02, 254), oklch(0.882, 0.059, 254.128), 'text-info-foreground'],
+        'info-foreground': [oklch(0.42, 0.03, 253.9), oklch(0.882, 0.059, 254.128), 'text-info-foreground'],
+
+        completed: [oklch(0.93, 0.05, 303.9), oklch(0.28, 0.05, 302.7), 'bg-completed'],
+        'completed-foreground': [oklch(0.46, 0.25, 287.35), oklch(0.81, 0.06, 301.45), 'text-completed-foreground'],
 
         // ── Borders & rings (theme-derived) ───────────
         border: [surface(0.9, 0.8, 'light'), surface(0.27, 1.2, 'dark'), 'border-border'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@base-ui/react':
-      specifier: 1.5.0
-      version: 1.5.0
+      specifier: 1.6.0
+      version: 1.6.0
     '@parcel/packager-ts':
       specifier: 2.16.4
       version: 2.16.4
@@ -552,7 +552,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dagrejs/dagre':
         specifier: ^1.1.5
         version: 1.1.5
@@ -2104,7 +2104,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/quill-tokens':
         specifier: workspace:^
         version: link:../tokens
@@ -2184,7 +2184,7 @@ importers:
     devDependencies:
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/quill-blocks':
         specifier: workspace:*
         version: link:../blocks
@@ -6104,8 +6104,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.5.0':
-    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -6121,8 +6121,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.2.9':
-    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
     peerDependencies:
       '@types/react': 18.3.27
       react: 18.3.1
@@ -6197,7 +6197,6 @@ packages:
 
   '@clickhouse/client-common@1.12.0':
     resolution: {integrity: sha512-cyI4n7u9jK30d9q1q0ceQ7IwJ/MtTs5HxoQfc8yHpN+ok5wqaU2jAtq5hpa1z7C7sS1pDy/ZOFmOzg1v1F683g==}
-    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.12.0':
     resolution: {integrity: sha512-vJUSX8THhTzlVn0WxPukVjOgNRaSoY02ubQkB0LpqNoHFxXuF5jQZZAYvGZWpBGbYQ/4gfPrqu8g4TX5UKeNxA==}
@@ -19839,7 +19838,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode.react@4.2.0:
@@ -20476,6 +20474,9 @@ packages:
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
@@ -22174,8 +22175,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.446.0:
-    resolution: {integrity: sha512-enWwsGqEA4dm5EomcWqLlGB+nwt6u7GX2ZraatZljCmQ2DeBPyyUmvWj8ucps1YslFImFbMluWoRiZ4BZuTrRw==}
+  unlayer-types@1.448.0:
+    resolution: {integrity: sha512-om9pYOaWS1rJHgChSmhXLUMaUEgw9TcBvpaHO66y60+NdVSMoMyKuUtcMX6/j3LXh/rENO5EEM4LVQpaWpHeDw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -25441,10 +25442,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@base-ui/react@1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.9(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@base-ui/utils': 0.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@floating-ui/utils': 0.2.11
       react: 18.3.1
@@ -25455,13 +25456,13 @@ snapshots:
       '@types/react': 18.3.27
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.9(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@base-ui/utils@0.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      reselect: 5.1.1
+      reselect: 5.2.0
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.27
@@ -42957,7 +42958,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.446.0
+      unlayer-types: 1.448.0
 
   react-grid-layout@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -43325,6 +43326,8 @@ snapshots:
   requires-port@1.0.0: {}
 
   reselect@5.1.1: {}
+
+  reselect@5.2.0: {}
 
   resize-observer-polyfill@1.5.1: {}
 
@@ -45276,7 +45279,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.446.0: {}
+  unlayer-types@1.448.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,7 +70,7 @@ catalog:
     # React types
     '@types/react': ^18.3.27
     '@types/react-dom': ^18.3.7
-    '@base-ui/react': 1.5.0
+    '@base-ui/react': 1.6.0
     # Other shared
     husky: ^7.0.4
     lint-staged: ~15.4.3


### PR DESCRIPTION
## Problem

Quill needed a purple semantic color for terminal "done" states (merged PRs and similar), Badge/Item had no way to express it, and `ItemGroup` couldn't render a flush merged list even though the docs already described a `combined` option.


<img width="447" height="495" alt="image" src="https://github.com/user-attachments/assets/31646aeb-9be8-44b4-ab38-96106eb224f4" />

<img width="429" height="471" alt="image" src="https://github.com/user-attachments/assets/9a9b2e69-26f9-40a7-b32a-8b7d98a309d2" />



## Changes

- New `completed` semantic color token (purple, light + dark) in `@posthog/quill-tokens`, surfaced in the token stories.
- Badge gains a `completed` variant.
- Item gains a `tone` prop (`info` / `success` / `warning` / `completed` / `destructive`) that tints pressable rows. It's named `tone`, not `color`, on purpose: `color` collides with the DOM `color` attribute when Base UI render props are spread onto `ItemCheckbox` / `ItemRadio`, which broke typechecking.
- `ItemGroup` gets a real `combined` prop: drops the gap and merges items into one flush list (squared interior corners, collapsed shared borders, rounded outer corners), mirroring `CardGroup`. Previously `ItemGroup` had no styling at all and the documented `combined` API did nothing.
- Pressable Item now respects the desktop-app cursor reset (`body.is-desktop` -> arrow, not pointer).
- Bumped `@base-ui/react` 1.5.0 -> 1.6.0.

> [!NOTE]
> The Base UI bump touches more than quill: `frontend/` also depends on `@base-ui/react` via the same `catalog:` entry (notably `TaxonomicFilter/menu/Combobox.tsx`). I reviewed the two 1.6.0 breaking changes — `alwaysSubmitOnEnter` → `submitOnItemClick` and the `OTPFieldPreview` → `OTPField` rename — and neither is used in this repo. `keepHighlight` (used by the TaxonomicFilter Autocomplete) is retained and got a focus-sync fix in 1.6.0, and `Combobox.tsx` typechecks clean.

Storybook: Primitives/Badge, Primitives/Item (Tones, Group), UI/Colors.

## How did you test this code?

Agent-run only, no manual browser testing by me (Claude):

- `tsc --noEmit` on `@posthog/quill-primitives` — no new errors (the 5 remaining are pre-existing in `progress.stories.tsx`, present on master).
- Built `@posthog/quill-tokens`, `-primitives`, `-components`, `-blocks` — all clean against Base UI 1.6.0.
- Frontend `typescript:check`: `Combobox.tsx` (the `keepHighlight` consumer) reports zero errors under 1.6.0, and no error anywhere references a base-ui prop. (The env can't run a fully clean frontend typecheck without kea typegen, so the run also surfaces pre-existing typegen noise unrelated to this change.)
- Verified generated CSS emits the `completed` vars and the `.quill-item-group[data-combined]` rules.

Please eyeball the Item stories in Storybook (tones + combined group) before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Adam) directed this; Claude Code (Opus 4.8) did the edits. A few decisions worth flagging for review:

- The Item semantic-color prop went through a naming change. It started as `color`, which typechecked fine in isolation but broke `ItemCheckbox` / `ItemRadio` because Base UI's render-prop spread carries a DOM `color` string that clashes with the CVA enum. Renamed to `tone` (Braid-style), which is collision-free.
- An earlier iteration exposed `--quill-item-tint` / `--quill-item-accent` as public CSS handles on the Item root. We pulled that back — a child painted with the item's own background just blends into the surface it sits on, so a bg handle is useless; the vars stay as internal plumbing for the tone backgrounds only.
- A parallel "pressable Card with hover shadow" experiment was scrapped in favor of `<Item variant="pressable">` as the canonical clickable-row pattern, so none of that landed here.
- On the Base UI bump: an automated review flagged `keepHighlight` as removed. It isn't (retained + fixed in 1.6.0), but it correctly caught that my first draft wrongly said "only quill consumes it." Corrected above.
- No repo skills were invoked (no migrations, DRF, or generated-type surfaces touched).
