### PR TITLE
feat(conversations): import zendesk ticket tags

### DIFF
--- a/products/conversations/backend/temporal/zendesk_import/activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/activities.py
@@ -21,8 +21,10 @@ with workflow.unsafe.imports_passed_through():
     from django.utils.dateparse import parse_datetime
     from django.utils.html import strip_tags
 
-    from posthog.models import Team
+    from posthog.models import Tag, Team
     from posthog.models.comment import Comment
+    from posthog.models.tag import tagify
+    from posthog.models.tagged_item import TaggedItem
     from posthog.sync import database_sync_to_async
     from posthog.temporal.common.heartbeat import Heartbeater
 
@@ -284,6 +286,8 @@ def _import_ticket_batch_sync(input: ImportBatchInput) -> ImportBatchOutput:
     ticket_comments_map: list[tuple[int, list[Comment], int, int]] = []
     # Maps index in tickets_to_create → index in ticket_data
     ticket_create_to_data_idx: list[int] = []
+    # (index in tickets_to_create, normalized tag names) — resolved to Tag rows in Phase 3
+    ticket_tags_map: list[tuple[int, list[str]]] = []
 
     for idx, (zendesk_ticket, comments) in enumerate(ticket_data):
         zendesk_id = int(zendesk_ticket["id"])
@@ -332,6 +336,11 @@ def _import_ticket_batch_sync(input: ImportBatchInput) -> ImportBatchOutput:
             create_idx = len(tickets_to_create)
             tickets_to_create.append(ticket)
             ticket_create_to_data_idx.append(idx)
+
+            # Zendesk tags are plain strings on the ticket payload; PostHog tags are per-team
+            # Tag rows, so normalize the same way the live tagging API does (tagify).
+            zendesk_tags = {tagify(_strip_nul(str(t)))[:255] for t in (zendesk_ticket.get("tags") or [])}
+            ticket_tags_map.append((create_idx, sorted(t for t in zendesk_tags if t)))
 
             comments_to_create: list[Comment] = []
             customer_message_count = 0
@@ -423,6 +432,12 @@ def _import_ticket_batch_sync(input: ImportBatchInput) -> ImportBatchOutput:
     if not tickets_to_create:
         return ImportBatchOutput(imported=0, skipped=skipped, failed=failed)
 
+    # Resolve Tag rows before the ticket transaction to keep its lock window narrow.
+    # get_or_create matches the live tagging path (set_tags_on_object); a Tag row left
+    # behind by a failed batch is harmless — it's reused on retry.
+    all_tag_names = {name for _, names in ticket_tags_map for name in names}
+    tags_by_name = {name: Tag.objects.get_or_create(name=name, team_id=team.id)[0] for name in all_tag_names}
+
     # Phase 3: Persist tickets + comments in a single transaction (no network I/O).
     # Ticket numbers are assigned under the same lock that guards bulk_create, so
     # concurrent batch activities can't collide on unique_ticket_number_per_team.
@@ -454,6 +469,17 @@ def _import_ticket_batch_sync(input: ImportBatchInput) -> ImportBatchOutput:
                 ticket_ts_updates.append(ticket_obj)
         if ticket_ts_updates:
             Ticket.objects.bulk_update(ticket_ts_updates, ["created_at", "updated_at"])
+
+        # Link tags now that tickets have IDs. bulk_create skips TaggedItem.save()/full_clean()
+        # on purpose — the same no-signals rule as the ticket/comment writes here.
+        tagged_items_to_create = [
+            TaggedItem(tag=tags_by_name[name], ticket=created_tickets[idx])
+            for idx, names in ticket_tags_map
+            if idx < len(created_tickets)
+            for name in names
+        ]
+        if tagged_items_to_create:
+            TaggedItem.objects.bulk_create(tagged_items_to_create, ignore_conflicts=True)
 
         # Set item_id on comments now that tickets have IDs, then bulk_create
         all_comments: list[Comment] = []

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
+from posthog.models import Tag
 from posthog.models.comment import Comment
 
 from products.conversations.backend.models import EmailChannel, Ticket, ZendeskImportJob
@@ -34,6 +35,7 @@ def _zd_ticket(
     created_at: str = "2020-01-02T03:04:05Z",
     updated_at: str = "2020-01-03T04:05:06Z",
     recipient: str | None = None,
+    tags: list[str] | None = None,
 ) -> dict[str, Any]:
     ticket: dict[str, Any] = {
         "id": tid,
@@ -46,6 +48,8 @@ def _zd_ticket(
     }
     if recipient is not None:
         ticket["recipient"] = recipient
+    if tags is not None:
+        ticket["tags"] = tags
     return ticket
 
 
@@ -332,6 +336,30 @@ class TestZendeskImportBatchActivity(BaseTest):
         self.assertEqual(existing.email_config_id, default.id)
         new_ticket = Ticket.objects.get(team=self.team, zendesk_ticket_id=402)
         self.assertEqual(new_ticket.email_config_id, default.id)
+
+    def test_import_applies_zendesk_tags(self) -> None:
+        # Zendesk tags must land as team-scoped Tag rows linked via TaggedItem: normalized
+        # like the live tagging API (lowercase/strip, empties dropped), reusing existing Tag
+        # rows instead of duplicating them, and untagged tickets stay untagged.
+        Tag.objects.create(name="billing", team=self.team)
+
+        self._run_batch(
+            [501, 502, 503],
+            tickets=[
+                _zd_ticket(501, 10, tags=["Billing", " URGENT ", "", "billing"]),
+                _zd_ticket(502, 10, tags=["billing"]),
+                _zd_ticket(503, 10),
+            ],
+            users={10: _zd_user(10, "requester@x.com")},
+            comments_by_ticket={},
+        )
+
+        by_zid = {t.zendesk_ticket_id: t for t in Ticket.objects.filter(team=self.team)}
+        self.assertEqual(set(by_zid[501].tagged_items.values_list("tag__name", flat=True)), {"billing", "urgent"})
+        self.assertEqual(set(by_zid[502].tagged_items.values_list("tag__name", flat=True)), {"billing"})
+        self.assertEqual(by_zid[503].tagged_items.count(), 0)
+        # One Tag row per name per team — the pre-existing "billing" is reused across tickets.
+        self.assertEqual(Tag.objects.filter(team=self.team).count(), 2)
 
     def test_staff_reply_with_unresolved_role_is_not_attributed_to_customer(self) -> None:
         # Reported bug: a public agent reply whose author role can't be resolved (role=None) was


### PR DESCRIPTION
## Problem

Zendesk tickets carry tags, and teams rely on them to categorize and filter their support queue. The historical Zendesk import fetches the full ticket payload (which includes the `tags` array) but silently discards it, so imported tickets arrive untagged and teams lose that categorization.

## Changes

Newly imported tickets now get their Zendesk tags, wired into PostHog's product-wide tag system (`Tag`/`TaggedItem`) rather than stored as loose strings:

- Each ticket's `tags` array from the Zendesk payload is normalized the same way the live tagging API does (`tagify`: lowercase + strip, empties dropped, deduped per ticket). No extra Zendesk API calls - the tags are already in the `show_many` response the import fetches.
- Tag names resolve to team-scoped `Tag` rows via `get_or_create`, matching the live apply path (`set_tags_on_object`): existing tags are reused, new ones created, never duplicated per team.
- `TaggedItem` links are bulk-created inside the import transaction after tickets get their IDs.

Because tags land in the shared tag system, imported tickets immediately work with everything tags already support: the ticket list's `tags`/`tags_all`/`tags_exclude` filters, tag display, and cross-product tag queries.

> [!NOTE]
> The `TaggedItem` links use `bulk_create`, which skips `save()`/`full_clean()` and signals on purpose - the same no-signals rule as every other historical write in this import. Tags are applied only to tickets the import creates; already-imported (skipped) tickets are deliberately untouched.

## How did you test this code?

- Added one test covering the matrix: normalization (`"Billing"`, `" URGENT "` → `billing`, `urgent`), empty tags dropped, a pre-existing team tag reused instead of duplicated, one `Tag` row shared across tickets in a batch, and untagged tickets staying untagged. No existing test exercised tags in the import, so this catches regressions in the mapping, normalization, or per-team dedupe.
- Ran the full `zendesk_import/tests/test_activities.py` suite locally: 25 passed.
- Manually verified on a local stack: ran an import against Zendesk and the newly imported tickets came in with their tags applied.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`.
- Scoping decision (confirmed with the driver): tags apply to newly imported tickets only. Backfilling tags onto already-imported tickets on re-import was considered and rejected - skipped tickets are never re-fetched from Zendesk today, so backfill would add a fetch to the skip path for a one-time repair.
- `Tag` rows are resolved with `get_or_create` before the ticket transaction to keep the lock window narrow; a `Tag` row left behind by a failed batch is harmless and reused on retry.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
