### PR TITLE
fix(web-analytics): fail preagg quorum waits after 2s instead of 600s

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -87,6 +87,9 @@ PREAGGREGATION_INSERT_QUORUM: str | int = 0 if TEST or DEBUG else "auto"
 # a broken quorum cost two seconds instead of ten minutes. A false positive is
 # cheap: the part is already written, the retry re-insert is idempotent under
 # ReplacingMergeTree, and the caller falls back to the live query meanwhile.
+# A quorum-wait expiry raises code 319 UNKNOWN_STATUS_OF_INSERT ("client must
+# retry"), which is deliberately absent from NON_RETRYABLE_CLICKHOUSE_ERROR_CODES —
+# distinct from 159 TIMEOUT_EXCEEDED (max_execution_time), which stays non-retryable.
 PREAGGREGATION_INSERT_QUORUM_TIMEOUT_MS = 2 * 1000
 
 

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -78,6 +78,17 @@ DEFAULT_CH_START_GRACE_PERIOD_SECONDS = 60  # 1 minute
 # replica writes immediately but ClickHouse still blocks on the quorum protocol).
 PREAGGREGATION_INSERT_QUORUM: str | int = 0 if TEST or DEBUG else "auto"
 
+# How long a quorum INSERT waits for replica acknowledgements before failing.
+# ClickHouse's default is 600s, which turns any quorum breakage (dead replica,
+# stale registration, ZK trouble) into ten-minute request hangs; the executor is
+# built to treat failed inserts as retryable and callers fall back to the live
+# query, so failing fast is strictly better. Part replication between two healthy
+# colocated replicas is sub-second; 2s keeps a spurious-timeout margin while making
+# a broken quorum cost two seconds instead of ten minutes. A false positive is
+# cheap: the part is already written, the retry re-insert is idempotent under
+# ReplacingMergeTree, and the caller falls back to the live query meanwhile.
+PREAGGREGATION_INSERT_QUORUM_TIMEOUT_MS = 2 * 1000
+
 
 # Mirrors the `lazy_computation.executed` structured log so the same outcomes
 # (`success` / `timeout` / `non_retryable_error` / `max_retries_exceeded`) are
@@ -148,6 +159,7 @@ def _get_insert_settings(team_id: int, *, spill_to_disk: bool = False) -> dict:
         {
             "max_execution_time": HOGQL_INCREASED_MAX_EXECUTION_TIME,
             "insert_quorum": PREAGGREGATION_INSERT_QUORUM,
+            "insert_quorum_timeout": PREAGGREGATION_INSERT_QUORUM_TIMEOUT_MS,
             # The executor marks a job READY as soon as the INSERT returns, so rows must be on the
             # shards by then — not sitting in the initiator's async distribution queue, where they
             # become visible to readers only minutes later. We set this per-insert rather than

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -34,6 +34,7 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     EXPIRY_BUFFER_SECONDS,
     NON_RETRYABLE_CLICKHOUSE_ERROR_CODES,
     PREAGGREGATION_INSERT_QUORUM,
+    PREAGGREGATION_INSERT_QUORUM_TIMEOUT_MS,
     LazyComputationExecutor,
     LazyComputationResult,
     LazyComputationTable,
@@ -2833,6 +2834,9 @@ class TestInsertSettings(BaseTest):
         # must be set per-query — a missing value here means readers race the distribution queue.
         assert settings["insert_distributed_sync"] == 1
         assert settings["insert_quorum"] == PREAGGREGATION_INSERT_QUORUM
+        # Quorum breakage (dead replica, stale ZK registration) must fail fast and fall back,
+        # not hold the request for ClickHouse's 600s default quorum wait.
+        assert settings["insert_quorum_timeout"] == PREAGGREGATION_INSERT_QUORUM_TIMEOUT_MS
         assert settings["load_balancing"] == "in_order"
         assert settings["max_execution_time"] == HOGQL_INCREASED_MAX_EXECUTION_TIME
         assert "readonly" not in settings


### PR DESCRIPTION
## Problem

Preaggregation quorum inserts inherit ClickHouse's default `insert_quorum_timeout` of 600s. When quorum becomes unreachable (dead replica, stale ZooKeeper registration, ZK trouble), every insert — and the dashboard request waiting on it — hangs for ten minutes before failing. Today's aux node replacement demonstrated it fleet-wide: ghost replica registrations made quorum unreachable and inserts sat in `system.processes` for 539s+ doing nothing while tiles hung.

## Changes

Set `insert_quorum_timeout` to **2s** on preaggregation inserts. Part replication between two healthy colocated replicas is sub-second, so 2s keeps a spurious-timeout margin while turning a broken quorum from a ten-minute hang into a two-second failure that flows into the executor's existing retry/fallback machinery (failed inserts are retryable; every caller falls back to the live query). A false positive is cheap: the part is already written, a retried insert is idempotent under ReplacingMergeTree, and the user is served meanwhile.

Companion to #69974 (`insert_quorum: auto → 2`), which prevents the specific ghost-registration failure; this PR bounds the damage of any quorum breakage regardless of cause.

## How did you test this code?

Extended the insert-settings test to assert the timeout is applied. Framework suite passes (134).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a — behavior documented inline.

## 🤖 Agent context

**Autonomy:** Human-approved hardening

Split out of #69974 at the DRI's request so the quorum-semantics change and the timeout change can be reviewed and rolled out independently.
