### PR TITLE
fix(experiments): give precompute trend charts a flex parent so they render

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/PrecomputeTrends.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/PrecomputeTrends.tsx
@@ -21,7 +21,8 @@ function ChartCard({ title, children }: { title: string; children: React.ReactNo
     return (
         <div className="border rounded p-3 bg-surface-primary">
             <div className="text-xs text-muted mb-2">{title}</div>
-            <div className="h-48">{children}</div>
+            {/* Flex column: the chart root is `flex-1` and only gets height from a flex parent. */}
+            <div className="h-48 flex flex-col">{children}</div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The precompute trend charts (#69877) render blank in production: chart cards and the legend appear, but every canvas is empty.

## Changes

The quill chart root sizes itself with `flex-1`, which only resolves to a height inside a flex container. The chart wrapper was a plain block `div` with `h-48`, so every canvas rendered at 639x0 pixels. Added `flex flex-col` to the wrapper.

## How did you test this code?

Reproduced locally with Playwright against the dev stack, mocking the timeseries API: all eight canvases (main + hover layer per chart) measured height 0 in the DOM. After the fix, canvases measure 639x192 and all four charts paint correctly (verified via screenshot).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal staff tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Diagnosed by mocking the `precompute_timeseries` response in a Playwright session and dumping canvas dimensions from the DOM. The charts guide's sizing note ("flex-1 in a sized column") describes exactly this requirement; a follow-up to make the chart root resilient to block parents might be worth raising with the quill team.
