### PR TITLE
feat(data-warehouse): list bugsnag tables in public docs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/source.py
@@ -36,6 +36,8 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 @SourceRegistry.register
 class BugsnagSource(ResumableSource[BugsnagSourceConfig, BugsnagResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.BUGSNAG

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/tests/test_bugsnag_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/tests/test_bugsnag_source.py
@@ -92,6 +92,18 @@ class TestBugsnagSource:
         schemas = self.source.get_schemas(MagicMock(), team_id=self.team_id, names=["errors", "projects"])
         assert {s.name for s in schemas} == {"errors", "projects"}
 
+    def test_publishes_table_catalog_for_public_docs(self) -> None:
+        # `lists_tables_without_credentials` gates whether the static endpoint catalog reaches the
+        # posthog.com "Supported tables" section. Dropping the flag (or making get_schemas require
+        # credentials) would silently empty that section, so assert the catalog flows through with
+        # canonical descriptions attached.
+        tables = self.source.get_documented_tables()
+        names = {t["name"] for t in tables}
+        assert set(ENDPOINTS).issubset(names)
+        errors = next(t for t in tables if t["name"] == "errors")
+        assert "Full refresh" in errors["sync_methods"]
+        assert errors["description"]
+
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.bugsnag.source.validate_bugsnag_credentials"
     )


### PR DESCRIPTION
## Problem

The Bugsnag (SmartBear) data warehouse source already ships full refresh sync end to end (organizations, projects, errors, events, releases, and the rest), but it never opted into publishing its table catalog to the public docs. Because `get_schemas` is a static endpoint catalog with no I/O, the posthog.com "Supported tables" section renders empty for Bugsnag instead of listing the tables a user can sync.

## Changes

- Set `lists_tables_without_credentials = True` on `BugsnagSource`. This is the same opt-in klaviyo, github, and ~150 other fixed-schema sources use. It lets the `public_source_configs` API call `get_documented_tables()` and return the endpoint catalog merged with the curated canonical descriptions, so the docs `<SourceTables />` component has data to render. It is safe here because `get_schemas` builds entirely from the endpoint constants with no network, DB, or credential access.

The rest of the Bugsnag source (form fields, `get_schemas`, `validate_credentials`, the resumable transport with Link-header pagination and tracked-session HTTP, `settings.py` endpoint catalog, canonical descriptions, `SOURCES.md`, the icon, and both test modules) already landed on master, so this PR is the one remaining item to complete it. The source stays behind `unreleasedSource=True` at `releaseStatus=ALPHA` while it ships full-refresh-only and awaits live-API verification.

> [!NOTE]
> The user-facing doc still needs to land in the posthog.com repo at `contents/docs/cdp/sources/bugsnag.md` (matching the `docsUrl`). No posthog.com checkout was available in this environment, so `audit_source_docs` could not be run here. Live-API curl verification of Bugsnag's pagination and time-filter behavior was also not possible without a Bugsnag auth token, which is why incremental sync stays off and the transport re-walks history conservatively (documented in the source comments).

## How did you test this code?

Automated only. I (Claude) ran the targeted suite:

```
hogli test products/warehouse_sources/backend/temporal/data_imports/sources/bugsnag/tests/
# 59 passed
```

The new test `test_publishes_table_catalog_for_public_docs` asserts `get_documented_tables()` returns every endpoint with a "Full refresh" sync method and a description. It catches the regression where the flag is dropped in a refactor (or `get_schemas` becomes credential-dependent), which would silently empty the public docs table section — no existing bugsnag test exercised `get_documented_tables()`. `ruff check`/`format` and `hogli ci:preflight` pass clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) working the "implement the bugsnag warehouse source" task. I invoked the `/implementing-warehouse-sources` and `/writing-tests` skills.

The task was framed around filling in a scaffolded stub, but on inspection the full Bugsnag implementation was already present and merged on `master` (verified via `gh api` that the default-branch `source.py` blob matched the local tree). Rather than duplicate merged work, I diffed the merged source against the task's requirements and the reference sources (klaviyo, github). The one genuine gap was the missing `lists_tables_without_credentials` opt-in, so that plus a guarding test is the entirety of this change. The environment's Python venv was missing Django, which I repaired with `uv sync --frozen` before running the tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
