### PR TITLE
feat(data-warehouse): implement buildkite import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/source.py
@@ -38,6 +38,8 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 @SourceRegistry.register
 class BuildkiteSource(ResumableSource[BuildkiteSourceConfig, BuildkiteResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.BUILDKITE
@@ -55,6 +57,7 @@ class BuildkiteSource(ResumableSource[BuildkiteSourceConfig, BuildkiteResumeConf
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="Buildkite",
             releaseStatus=ReleaseStatus.ALPHA,
+            docsUrl="https://posthog.com/docs/cdp/sources/buildkite",
             caption="""Enter your Buildkite API access token and organization slug to sync your CI/CD data into the PostHog Data warehouse.
 
 You can create an API access token in your [Buildkite account settings](https://buildkite.com/user/api-access-tokens).


### PR DESCRIPTION
## Problem

We didn't have a Buildkite connector for the data warehouse. Buildkite is a CI/CD platform, and teams want to pull their organizations, pipelines, builds, and agents into PostHog to join CI health with product and usage data.

## Changes

Ships the Buildkite import source end to end. It's a `ResumableSource` over the Buildkite v2 REST API, kept behind `unreleasedSource=True` at `releaseStatus=alpha` while it settles.

- **Streams**: `organizations`, `pipelines`, `builds`, `agents`.
- **Auth**: Bearer API access token plus an organization slug. The token is the secret; the slug is not. `organization` is registered as a connection host field so retargeting it forces re-entry of the token.
- **Pagination**: page-number pagination driven by the `Link` header (`rel="next"`).
- **Incremental sync**: only `builds` exposes a genuine server-side timestamp filter (`created_from`), so it's the only incremental stream. It sorts newest-first (`sort_mode="desc"`) and maps the watermark to `created_from`. Organizations, pipelines, and agents are full refresh, since Buildkite exposes no server-side filter for them.
- **Resumability**: state is the next-page URL, saved after each batch is yielded (at page boundaries) so a crash re-yields the last page rather than skipping it; merge dedupes on the primary key.
- **Rate limits / retries**: `tenacity` backoff on 429 and transient 5xx. Buildkite's org-level limit is 200 req/min.
- **Non-retryable errors**: 401 (bad/revoked token) and 403 (missing read scope) fail the sync fast with actionable messages.
- **Docs wiring** (this PR's delta on top of the scaffold): set `docsUrl` to the posthog.com sources page and opt into the credential-free table catalog (`lists_tables_without_credentials = True`) so the docs render Supported tables. `get_schemas` is a static endpoint catalog with no I/O, so this is safe. Canonical column descriptions are curated from the Buildkite API docs.

All outbound HTTP goes through `make_tracked_session()`.

> [!NOTE]
> I could not curl-verify authenticated behavior (no Buildkite token available in this environment). An unauthenticated probe confirmed the base URL, the `Bearer` 401 path, and that `Link` and `RateLimit-*` are exposed response headers. The `created_from` filter, per-endpoint sort ordering, and exact scope names are taken from the Buildkite API docs and noted with conservative comments in the code. These should be smoke-tested against a live token before promoting past alpha.

## How did you test this code?

Automated tests I ran locally (all green):

- `products/warehouse_sources/backend/temporal/data_imports/sources/buildkite/tests/` (47 tests): source config, schemas, incremental support per endpoint, credential validation (200/401/403/404, per-schema vs source-create), pagination via `Link` header, resume-from-saved-state, save-state-after-batch at page boundaries, and `SourceResponse` shape per endpoint.
- `products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_categories.py` (1506 tests) to confirm the source's category wiring.

`ruff check` and `ruff format` pass on the changed file.

## Docs update

The user-facing doc lives in the posthog.com repo, not this one, so it can't land here. It needs to be added at `contents/docs/cdp/sources/buildkite.md` (matching `docsUrl`). Draft content:

<details>
<summary>contents/docs/cdp/sources/buildkite.md</summary>

```mdx
---
title: Linking Buildkite as a source
sidebar: Docs
showTitle: true
availability: { free: full, selfServe: full, enterprise: full }
sourceId: Buildkite
---

import SourceSetupIntro from "../_snippets/source-setup-intro.mdx"
import SyncModes from "../_snippets/sync-modes.mdx"
import TroubleshootingLink from "../_snippets/dw-troubleshooting-link.mdx"
import AlphaRelease from "../_snippets/alpha-release.mdx"

<AlphaRelease />

Buildkite is a CI/CD platform for running build and test pipelines. This connector syncs your organizations, pipelines, builds, and agents into the PostHog data warehouse so you can join CI health with product and usage data.

## Prerequisites

- A Buildkite account with access to the organization you want to sync.
- A Buildkite API access token. Create one in your [API access tokens settings](https://buildkite.com/user/api-access-tokens).

## Adding a data source

<SourceSetupIntro />

You'll need:

- **API access token**: create a token in [Buildkite account settings](https://buildkite.com/user/api-access-tokens). Grant these read scopes for the tables you want to sync:
  - `read_organizations`
  - `read_pipelines`
  - `read_builds`
  - `read_agents`
- **Organization slug**: the URL-friendly identifier for your organization (for example `my-organization` from `https://buildkite.com/my-organization`).

## Sync modes

<SyncModes />

Builds support incremental sync via Buildkite's `created_from` filter. Organizations, pipelines, and agents are full refresh only, since Buildkite doesn't expose a server-side timestamp filter for them.

## Configuration

<SourceParameters />

## Supported tables

<SourceTables />

## Troubleshooting

- **401 Unauthorized**: the token is invalid or revoked. Create a new token and reconnect.
- **403 Forbidden on a table**: the token is missing the read scope for that resource. Grant the matching `read_*` scope and reconnect.
- **Rate limits**: Buildkite applies an org-level limit of 200 requests per minute. The connector backs off and retries automatically on 429.

<TroubleshootingLink />
```

</details>

A `buildkite.png` icon is already present at `frontend/public/services/`. I did not add an SVG (no Logo.dev key available and I won't hardcode one).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored with Claude Code. Skills invoked: `/implementing-warehouse-sources` and `/documenting-warehouse-sources`.

The source scaffold (`source.py`, `settings.py`, `buildkite.py`, `canonical_descriptions.py`, tests, the `ExternalDataSourceType` enum, generated config, `schema-general.ts` entry, and the PNG icon) already existed in the base branch. I verified that implementation against the skill's architecture contract, ran the full test suite, and curl-probed the live API for the bits I could reach without a token. The remaining gaps were the public-docs wiring, which this PR closes: `docsUrl` and `lists_tables_without_credentials`. I chose not to churn the working transport/batcher code since it's correct and tested.
