### PR TITLE
chore(data-warehouse): drop hugging_face from scaffolded sources list

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -581,7 +581,6 @@ doesn't conflict with concurrent PRs.
 - hightouch
 - hoorayhr
 - hubplanner
-- hugging_face
 - humanitix
 - hyperspell
 - ikas


### PR DESCRIPTION
## Problem

The `hugging_face` warehouse source is fully implemented and already appears in the Implemented sources table in `SOURCES.md`, yet it was also still listed as a bullet in the Scaffolded sources section. A source should live in exactly one of the two lists. The stale scaffolded entry makes the inventory misleading and would show up as a false "no sync logic yet" for anyone scanning the file.

## Changes

Remove the leftover `- hugging_face` bullet from the Scaffolded sources list. The source keeps its row in the Implemented table (HTTP / requests / tracked transport ✅), which is the correct home now that its sync logic, tests, canonical descriptions, and icon are all shipped.

```diff
 - hubplanner
-- hugging_face
 - humanitix
```

No code paths change. This is a documentation-inventory correction only.

## How did you test this code?

No runtime behavior changes, so nothing to exercise at runtime. I re-ran the existing hugging_face source test suite locally to confirm the implementation it references is intact:

- `products/warehouse_sources/backend/temporal/data_imports/sources/hugging_face/tests/` — 40 passed.

I also sanity-checked the file: the source still has exactly one entry in the Implemented table and none in the Scaffolded list.

## Docs update

The user-facing posthog.com doc for this source was missing (its `docsUrl` pointed at a page that did not exist yet). I authored it in a companion PR: [posthog.com#18368](https://github.com/PostHog/posthog.com/pull/18368). That PR is a draft until the source is released to users (it currently ships with `unreleasedSource=True`).

## 🤖 Agent context

**Autonomy:** Fully autonomous

This was produced by Claude (Claude Code) while working through the `implementing-warehouse-sources` skill for the hugging_face source. On inspection the source turned out to be already implemented and merged to master (source split across `source.py` / `settings.py` / `hugging_face.py`, canonical descriptions, tests, PNG icon, enum + generated config wiring). I verified the implementation against the live Hugging Face Hub API with curl: the list endpoints return JSON arrays with `Link`-header cursor pagination, `createdAt` is present and immutable on all three streams (models, datasets, spaces), and a future-dated `createdAt_gte` cutoff is silently ignored, which confirms there is no server-side timestamp filter and full-refresh-only / `supports_incremental=False` is correct.

The only real discrepancies left were the duplicate `SOURCES.md` listing (fixed here) and the missing user-facing doc (companion posthog.com PR). I skipped the `feat(...)` title the task template suggested because the feature already exists on master; a `chore` inventory fix is the accurate description of this diff.

Skills invoked: `implementing-warehouse-sources`, `documenting-warehouse-sources`.
