### PR TITLE
chore(data-warehouse): drop persona from scaffolded sources list

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -691,7 +691,6 @@ doesn't conflict with concurrent PRs.
 - pennylane
 - perigon
 - perk
-- persona
 - pexels
 - phyllo
 - pinecone


### PR DESCRIPTION
## Problem

The persona data warehouse source is already implemented and merged: it has working sync logic (`persona.py`, `settings.py`, resumable pagination, incremental sync on `created_at`), canonical descriptions, an icon, and passing tests, and it's listed in the **Implemented sources** table of `SOURCES.md`.

But it was also still sitting in the **Scaffolded** bullet list further down the same file. A source can't be both implemented and scaffolded, so the inventory was internally inconsistent.

## Changes

Remove the stale `- persona` line from the Scaffolded list in `products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md`. Persona now appears only in the Implemented table, where it belongs.

No code or behavior changes.

## How did you test this code?

Nothing to test at runtime - this is a docs/inventory correction. For context I confirmed persona is genuinely implemented on master by running the existing suites locally:

- `products/warehouse_sources/backend/temporal/data_imports/sources/persona/tests/` - 48 passed
- `products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_categories.py` - 1506 passed (registry sees persona with a valid category)
- `ruff check` / `ruff format --check` on the persona source - clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label - no user-facing docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) was asked to implement the persona source end-to-end from what was described as an empty stub, following the `/implementing-warehouse-sources` skill. On inspecting the repo I found the source was already fully implemented and merged on master - my checkout's `source.py`, `settings.py`, `api_inventory.md`, and both test modules are byte-identical to upstream, and master has iterated further on `persona.py`/`canonical_descriptions.py` since my base snapshot. So there was no stub to fill in.

The only real, unmade fix I found was the double-listing in `SOURCES.md` (implemented table + scaffolded list), which is what this PR corrects. I deliberately did not open a `feat: implement persona` PR, since that would misrepresent already-merged work with a near-empty diff.

Skills consulted: `/implementing-warehouse-sources` (to understand the expected architecture and the SOURCES.md upkeep rule that this fix follows).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
