### PR TITLE
feat(data-warehouse): implement google_pagespeed_insights import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -42,389 +42,390 @@ the row lists both.
 
 ## Implemented sources
 
-| Source                   | Comm method                 | Primary library                                                 | Tracked transport           |
-| ------------------------ | --------------------------- | --------------------------------------------------------------- | --------------------------- |
-| adroll                   | HTTP                        | requests                                                        | ✅                          |
-| agilecrm                 | HTTP                        | requests                                                        | ✅                          |
-| aha                      | HTTP                        | requests                                                        | ✅                          |
-| aircall                  | HTTP                        | requests                                                        | ✅                          |
-| airtable                 | HTTP                        | requests                                                        | ✅                          |
-| algolia                  | HTTP                        | requests                                                        | ✅                          |
-| alguna                   | HTTP                        | requests                                                        | ✅                          |
-| alpha_vantage            | HTTP                        | requests                                                        | ✅                          |
-| amazon_ads               | HTTP                        | requests                                                        | ✅                          |
-| amplitude                | HTTP                        | requests                                                        | ✅                          |
-| anthropic                | HTTP                        | requests                                                        | ✅                          |
-| apify_dataset            | HTTP                        | requests                                                        | ✅                          |
-| apollo                   | HTTP                        | requests                                                        | ✅                          |
-| appfigures               | HTTP                        | requests                                                        | ✅                          |
-| appfollow                | HTTP                        | requests                                                        | ✅                          |
-| appsflyer                | HTTP (CSV reports)          | requests                                                        | ✅                          |
-| asana                    | HTTP                        | requests                                                        | ✅                          |
-| ashby                    | HTTP                        | requests                                                        | ✅                          |
-| assemblyai               | HTTP                        | requests                                                        | ✅                          |
-| attentive                | HTTP (webhook-first)        | requests (webhook management)                                   | ✅                          |
-| attio                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| aviationstack            | HTTP                        | requests                                                        | ✅                          |
-| aviator                  | HTTP                        | requests                                                        | ✅                          |
-| awin                     | HTTP                        | requests                                                        | ✅                          |
-| azure_devops             | HTTP                        | requests                                                        | ✅                          |
-| bamboohr                 | HTTP                        | requests                                                        | ✅                          |
-| beamer                   | HTTP                        | requests                                                        | ✅                          |
-| bigmailer                | HTTP                        | requests                                                        | ✅                          |
-| bigquery                 | HTTP + gRPC                 | google-cloud-bigquery + bigquery-storage                        | ✅ (HTTP + gRPC)            |
-| bing_ads                 | HTTP (vendor SDK, SOAP)     | bingads SDK                                                     | ⚠️                          |
-| bland_ai                 | HTTP                        | requests                                                        | ✅                          |
-| blogger                  | HTTP                        | requests                                                        | ✅                          |
-| bluetally                | HTTP                        | requests                                                        | ✅                          |
-| boldsign                 | HTTP                        | requests                                                        | ✅                          |
-| braintree                | HTTP (GraphQL)              | requests                                                        | ✅                          |
-| braze                    | HTTP                        | requests                                                        | ✅                          |
-| breezometer              | HTTP                        | requests                                                        | ✅                          |
-| brevo                    | HTTP                        | requests                                                        | ✅                          |
-| brex                     | HTTP                        | requests                                                        | ✅                          |
-| bugsnag                  | HTTP                        | requests                                                        | ✅                          |
-| buildbetter              | HTTP                        | requests                                                        | ✅                          |
-| buildkite                | HTTP                        | requests                                                        | ✅                          |
-| bunny                    | HTTP                        | requests                                                        | ✅                          |
-| buzzsprout               | HTTP                        | requests                                                        | ✅                          |
-| cal_com                  | HTTP                        | requests                                                        | ✅                          |
-| calendly                 | HTTP                        | requests                                                        | ✅                          |
-| callrail                 | HTTP                        | requests                                                        | ✅                          |
-| campaign_monitor         | HTTP                        | requests                                                        | ✅                          |
-| campayn                  | HTTP                        | requests                                                        | ✅                          |
-| canny                    | HTTP                        | requests                                                        | ✅                          |
-| capsule_crm              | HTTP                        | requests                                                        | ✅                          |
-| care_quality_commission  | HTTP                        | requests                                                        | ✅                          |
-| chameleon                | HTTP                        | requests                                                        | ✅                          |
-| chargebee                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| chargedesk               | HTTP                        | requests                                                        | ✅                          |
-| chargify                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| charthop                 | HTTP                        | requests                                                        | ✅                          |
-| checkout_com             | HTTP                        | requests                                                        | ✅                          |
-| churnkey                 | HTTP                        | requests                                                        | ✅                          |
-| coassemble               | HTTP                        | requests                                                        | ✅                          |
-| coda                     | HTTP                        | requests                                                        | ✅                          |
-| codefresh                | HTTP                        | requests                                                        | ✅                          |
-| coin_api                 | HTTP                        | requests                                                        | ✅                          |
-| coingecko                | HTTP                        | requests                                                        | ✅                          |
-| coinmarketcap            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| commercetools            | HTTP                        | requests                                                        | ✅                          |
-| concord                  | HTTP                        | requests                                                        | ✅                          |
-| configcat                | HTTP                        | requests                                                        | ✅                          |
-| confluence               | HTTP                        | requests                                                        | ✅                          |
-| chartmogul               | HTTP                        | requests                                                        | ✅                          |
-| circleci                 | HTTP                        | requests                                                        | ✅                          |
-| cimis                    | HTTP                        | requests                                                        | ✅                          |
-| cloudflare               | HTTP                        | requests                                                        | ✅                          |
-| clari                    | HTTP                        | requests                                                        | ✅                          |
-| clerk                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| clickhouse               | DB protocol (HTTP-based)    | clickhouse-connect / clickhouse-driver                          | ➖                          |
-| clickup                  | HTTP                        | requests                                                        | ✅                          |
-| clockify                 | HTTP                        | requests                                                        | ✅                          |
-| clockodo                 | HTTP                        | requests                                                        | ✅                          |
-| close                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| cloudbeds                | HTTP                        | requests                                                        | ✅                          |
-| convertkit               | HTTP                        | requests                                                        | ✅                          |
-| convex                   | HTTP                        | requests                                                        | ✅                          |
-| copper                   | HTTP                        | requests                                                        | ✅                          |
-| coupa                    | HTTP                        | requests                                                        | ✅                          |
-| crunchbase               | HTTP                        | requests                                                        | ✅                          |
-| culture_amp              | HTTP                        | requests                                                        | ✅                          |
-| cursor                   | HTTP                        | requests                                                        | ✅                          |
-| customer_io              | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
-| datadog                  | HTTP                        | requests                                                        | ✅                          |
-| decagon                  | HTTP                        | requests                                                        | ✅                          |
-| deel                     | HTTP                        | requests                                                        | ✅                          |
-| deepgram                 | HTTP                        | requests                                                        | ✅                          |
-| delighted                | HTTP                        | requests                                                        | ✅                          |
-| deno_deploy              | HTTP                        | requests                                                        | ✅                          |
-| devin_ai                 | HTTP                        | requests                                                        | ✅                          |
-| ding_connect             | HTTP                        | requests                                                        | ✅                          |
-| dixa                     | HTTP                        | requests                                                        | ✅                          |
-| dockerhub                | HTTP                        | requests                                                        | ✅                          |
-| docuseal                 | HTTP                        | requests                                                        | ✅                          |
-| doit                     | HTTP                        | requests                                                        | ✅                          |
-| dropbox_sign             | HTTP                        | requests                                                        | ✅                          |
-| drip                     | HTTP                        | requests                                                        | ✅                          |
-| e_conomic                | HTTP                        | requests                                                        | ✅                          |
-| easypost                 | HTTP                        | requests                                                        | ✅                          |
-| easypromos               | HTTP                        | requests                                                        | ✅                          |
-| elevenlabs               | HTTP                        | requests                                                        | ✅                          |
-| freshcaller              | HTTP                        | requests                                                        | ✅                          |
-| freshdesk                | HTTP                        | requests                                                        | ✅                          |
-| freshsales               | HTTP                        | requests                                                        | ✅                          |
-| freshservice             | HTTP                        | requests                                                        | ✅                          |
-| elasticemail             | HTTP                        | requests                                                        | ✅                          |
-| elasticsearch            | HTTP                        | requests                                                        | ✅                          |
-| emailoctopus             | HTTP                        | requests                                                        | ✅                          |
-| eventbrite               | HTTP                        | requests                                                        | ✅                          |
-| eventee                  | HTTP                        | requests                                                        | ✅                          |
-| eventzilla               | HTTP                        | requests                                                        | ✅                          |
-| everhour                 | HTTP                        | requests                                                        | ✅                          |
-| exchange_rates_api       | HTTP                        | requests                                                        | ✅                          |
-| ezofficeinventory        | HTTP                        | requests                                                        | ✅                          |
-| factorial                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| fastly                   | HTTP                        | requests                                                        | ✅                          |
-| fillout                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| finage                   | HTTP                        | requests                                                        | ✅                          |
-| financial_modelling      | HTTP                        | requests                                                        | ✅                          |
-| finnhub                  | HTTP                        | requests                                                        | ✅                          |
-| finnworlds               | HTTP                        | requests                                                        | ✅                          |
-| firecrawl                | HTTP                        | requests                                                        | ✅                          |
-| fleetio                  | HTTP                        | requests                                                        | ✅                          |
-| firehydrant              | HTTP                        | requests                                                        | ✅                          |
-| flexmail                 | HTTP                        | requests                                                        | ✅                          |
-| float_app                | HTTP                        | requests                                                        | ✅                          |
-| front                    | HTTP                        | requests                                                        | ✅                          |
-| fulcrum                  | HTTP                        | requests                                                        | ✅                          |
-| fullstory                | HTTP                        | requests                                                        | ✅                          |
-| gainsight_px             | HTTP                        | requests                                                        | ✅                          |
-| gitbook                  | HTTP                        | requests                                                        | ✅                          |
-| github                   | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
-| giphy                    | HTTP                        | requests                                                        | ✅                          |
-| gitlab                   | HTTP                        | requests                                                        | ✅                          |
-| gladly                   | HTTP                        | requests                                                        | ✅                          |
-| gnews                    | HTTP                        | requests                                                        | ✅                          |
-| gocardless               | HTTP                        | requests                                                        | ✅                          |
-| goldcast                 | HTTP                        | requests                                                        | ✅                          |
-| gong                     | HTTP                        | requests                                                        | ✅                          |
-| google_ads               | gRPC                        | google-ads (googleads.client)                                   | ✅                          |
-| google_analytics         | HTTP                        | requests (`AuthorizedSession` + `TrackedHTTPAdapter`)           | ✅                          |
-| google_sheets            | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
-| google_webfonts          | HTTP                        | requests                                                        | ✅                          |
-| granola                  | HTTP                        | requests                                                        | ✅                          |
-| gorgias                  | HTTP                        | requests                                                        | ✅                          |
-| greenhouse               | HTTP                        | requests                                                        | ✅                          |
-| gridly                   | HTTP                        | requests                                                        | ✅                          |
-| guardian                 | HTTP                        | requests                                                        | ✅                          |
-| guru                     | HTTP                        | requests                                                        | ✅                          |
-| harvey                   | HTTP                        | requests                                                        | ✅                          |
-| hatchet                  | HTTP                        | requests                                                        | ✅                          |
-| healthchecks             | HTTP                        | requests                                                        | ✅                          |
-| height                   | HTTP                        | requests                                                        | ✅                          |
-| hellobaton               | HTTP                        | requests                                                        | ✅                          |
-| hibob                    | HTTP                        | requests                                                        | ✅                          |
-| humanitix                | HTTP                        | requests                                                        | ✅                          |
-| hubplanner               | HTTP                        | requests                                                        | ✅                          |
-| hubspot                  | HTTP                        | requests                                                        | ✅                          |
-| hugging_face             | HTTP                        | requests                                                        | ✅                          |
-| huntr                    | HTTP                        | requests                                                        | ✅                          |
-| incident_io              | HTTP                        | requests                                                        | ✅                          |
-| inflowinventory          | HTTP                        | requests                                                        | ✅                          |
-| insightly                | HTTP                        | requests                                                        | ✅                          |
-| instatus                 | HTTP                        | requests                                                        | ✅                          |
-| intercom                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| intruder                 | HTTP                        | requests                                                        | ✅                          |
-| invoiced                 | HTTP                        | requests                                                        | ✅                          |
-| invoiceninja             | HTTP                        | requests                                                        | ✅                          |
-| ip2whois                 | HTTP                        | requests                                                        | ✅                          |
-| iterable                 | HTTP                        | requests                                                        | ✅                          |
-| jira                     | HTTP                        | requests                                                        | ✅                          |
-| jobnimbus                | HTTP                        | requests                                                        | ✅                          |
-| jotform                  | HTTP                        | requests                                                        | ✅                          |
-| judgeme_reviews          | HTTP                        | requests                                                        | ✅                          |
-| justcall                 | HTTP                        | requests                                                        | ✅                          |
-| justsift                 | HTTP                        | requests                                                        | ✅                          |
-| k6_cloud                 | HTTP                        | requests                                                        | ✅                          |
-| katana                   | HTTP                        | requests                                                        | ✅                          |
-| klaviyo                  | HTTP                        | requests                                                        | ✅                          |
-| lago                     | HTTP                        | requests                                                        | ✅                          |
-| launchdarkly             | HTTP                        | requests                                                        | ✅                          |
-| kustomer                 | HTTP                        | requests                                                        | ✅                          |
-| lattice                  | HTTP                        | requests                                                        | ✅                          |
-| leadfeeder               | HTTP                        | requests                                                        | ✅                          |
-| lemlist                  | HTTP                        | requests                                                        | ✅                          |
-| less_annoying_crm        | HTTP                        | requests                                                        | ✅                          |
-| lightspeed_retail        | HTTP                        | requests                                                        | ✅                          |
-| linear                   | HTTP                        | requests                                                        | ✅                          |
-| lever                    | HTTP                        | requests                                                        | ✅                          |
-| lingo_dev                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| linkedin_ads             | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
-| linkrunner               | HTTP                        | requests                                                        | ✅                          |
-| linode                   | HTTP                        | requests                                                        | ✅                          |
-| lob                      | HTTP                        | requests                                                        | ✅                          |
-| luma                     | HTTP                        | requests                                                        | ✅                          |
-| mailchimp                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| mailerlite               | HTTP                        | requests                                                        | ✅                          |
-| mailersend               | HTTP                        | requests                                                        | ✅                          |
-| mailgun                  | HTTP                        | requests                                                        | ✅                          |
-| mailjet                  | HTTP                        | requests                                                        | ✅                          |
-| mailosaur                | HTTP                        | requests                                                        | ✅                          |
-| mailtrap                 | HTTP                        | requests                                                        | ✅                          |
-| marketstack              | HTTP                        | requests                                                        | ✅                          |
-| matomo                   | HTTP                        | requests                                                        | ✅                          |
-| maxio                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| mention                  | HTTP                        | requests                                                        | ✅                          |
-| meta_ads                 | HTTP                        | requests                                                        | ✅                          |
-| metabase                 | HTTP                        | requests                                                        | ✅                          |
-| metorial                 | HTTP                        | requests                                                        | ✅                          |
-| mistral_ai               | HTTP                        | requests                                                        | ✅                          |
-| mixmax                   | HTTP                        | requests                                                        | ✅                          |
-| mixpanel                 | HTTP                        | requests                                                        | ✅                          |
-| mollie                   | HTTP                        | requests                                                        | ✅                          |
-| monday                   | HTTP (GraphQL)              | requests                                                        | ✅                          |
-| mongodb                  | DB protocol                 | pymongo                                                         | ➖                          |
-| mssql                    | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
-| mux                      | HTTP                        | requests                                                        | ✅                          |
-| my_hours                 | HTTP                        | requests                                                        | ✅                          |
-| mysql                    | DB protocol                 | pymysql                                                         | ➖                          |
-| n8n                      | HTTP                        | requests                                                        | ✅                          |
-| netlify                  | HTTP                        | requests                                                        | ✅                          |
-| new_york_times           | HTTP                        | requests                                                        | ✅                          |
-| news_api                 | HTTP                        | requests                                                        | ✅                          |
-| newsdata                 | HTTP                        | requests                                                        | ✅                          |
-| okta                     | HTTP                        | requests                                                        | ✅                          |
-| nocrm                    | HTTP                        | requests                                                        | ✅                          |
-| northpass_lms            | HTTP                        | requests                                                        | ✅                          |
-| notion                   | HTTP                        | requests                                                        | ✅                          |
-| omnisend                 | HTTP                        | requests                                                        | ✅                          |
-| oncehub                  | HTTP                        | requests                                                        | ✅                          |
-| onepagecrm               | HTTP                        | requests                                                        | ✅                          |
-| onfleet                  | HTTP (cursor pagination)    | requests                                                        | ✅                          |
-| open_exchange_rates      | HTTP                        | requests                                                        | ✅                          |
-| opinion_stage            | HTTP                        | requests                                                        | ✅                          |
-| orb                      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| openaq                   | HTTP                        | requests                                                        | ✅                          |
-| openfda                  | HTTP                        | requests                                                        | ✅                          |
-| openweather              | HTTP                        | requests                                                        | ✅                          |
-| ortto                    | HTTP                        | requests                                                        | ✅                          |
-| oura                     | HTTP                        | requests                                                        | ✅                          |
-| outbrain                 | HTTP                        | requests                                                        | ✅                          |
-| paddle                   | HTTP                        | requests                                                        | ✅                          |
-| optimizely               | HTTP                        | requests                                                        | ✅                          |
-| pagerduty                | HTTP                        | requests                                                        | ✅                          |
-| pandadoc                 | HTTP                        | requests                                                        | ✅                          |
-| paperform                | HTTP                        | requests                                                        | ✅                          |
-| papersign                | HTTP                        | requests                                                        | ✅                          |
-| partnerize               | HTTP                        | requests                                                        | ✅                          |
-| partnerstack             | HTTP                        | requests                                                        | ✅                          |
-| payfit                   | HTTP                        | requests                                                        | ✅                          |
-| paystack                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| pendo                    | HTTP                        | requests                                                        | ✅                          |
-| persistiq                | HTTP                        | requests                                                        | ✅                          |
-| persona                  | HTTP                        | requests                                                        | ✅                          |
-| personio                 | HTTP                        | requests                                                        | ✅                          |
-| pexels                   | HTTP                        | requests                                                        | ✅                          |
-| phyllo                   | HTTP                        | requests                                                        | ✅                          |
-| picqer                   | HTTP                        | requests                                                        | ✅                          |
-| pingdom                  | HTTP                        | requests                                                        | ✅                          |
-| pinterest_ads            | HTTP                        | requests                                                        | ✅                          |
-| pipedrive                | HTTP                        | requests                                                        | ✅                          |
-| pipeliner                | HTTP                        | requests                                                        | ✅                          |
-| plain                    | HTTP                        | requests                                                        | ✅                          |
-| planhat                  | HTTP                        | requests                                                        | ✅                          |
-| plausible                | HTTP                        | requests                                                        | ✅                          |
-| polar                    | HTTP                        | requests                                                        | ✅                          |
-| plaid                    | HTTP                        | requests                                                        | ✅                          |
-| postgres                 | DB protocol                 | psycopg                                                         | ➖                          |
-| postmark                 | HTTP                        | requests                                                        | ✅                          |
-| pretix                   | HTTP                        | requests                                                        | ✅                          |
-| printify                 | HTTP                        | requests                                                        | ✅                          |
-| productboard             | HTTP                        | requests                                                        | ✅                          |
-| pylon                    | HTTP                        | requests                                                        | ✅                          |
-| qualaroo                 | HTTP                        | requests                                                        | ✅                          |
-| recurly                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| ramp                     | HTTP                        | requests                                                        | ✅                          |
-| recharge                 | HTTP                        | requests                                                        | ✅                          |
-| recruitee                | HTTP                        | requests                                                        | ✅                          |
-| reddit_ads               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| redshift                 | DB protocol                 | psycopg (Postgres-compatible)                                   | ➖                          |
-| rentcast                 | HTTP                        | requests                                                        | ✅                          |
-| replicate                | HTTP                        | requests                                                        | ✅                          |
-| reply_io                 | HTTP                        | requests                                                        | ✅                          |
-| resend                   | HTTP                        | requests                                                        | ✅                          |
-| retently                 | HTTP                        | requests                                                        | ✅                          |
-| revenuecat               | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
-| rippling                 | HTTP                        | requests                                                        | ✅                          |
-| rocketlane               | HTTP                        | requests                                                        | ✅                          |
-| rollbar                  | HTTP                        | requests                                                        | ✅                          |
-| rootly                   | HTTP                        | requests                                                        | ✅                          |
-| rss                      | HTTP                        | requests                                                        | ✅                          |
-| ruddr                    | HTTP                        | requests                                                        | ✅                          |
-| safetyculture            | HTTP                        | requests                                                        | ✅                          |
-| salesforce               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| salesflare               | HTTP                        | requests                                                        | ✅                          |
-| salesloft                | HTTP                        | requests                                                        | ✅                          |
-| savvycal                 | HTTP                        | requests                                                        | ✅                          |
-| scale_ai                 | HTTP                        | requests                                                        | ✅                          |
-| scaleway                 | HTTP                        | requests                                                        | ✅                          |
-| secoda                   | HTTP                        | requests                                                        | ✅                          |
-| segment                  | HTTP                        | requests                                                        | ✅                          |
-| sendgrid                 | HTTP                        | requests                                                        | ✅                          |
-| sendowl                  | HTTP                        | requests                                                        | ✅                          |
-| sentry                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| servicenow               | HTTP                        | requests                                                        | ✅                          |
-| shippo                   | HTTP                        | requests                                                        | ✅                          |
-| shipstation              | HTTP                        | requests                                                        | ✅                          |
-| shopify                  | HTTP                        | requests                                                        | ✅                          |
-| shopwired                | HTTP                        | requests                                                        | ✅                          |
-| shortcut                 | HTTP                        | requests                                                        | ✅                          |
-| shortio                  | HTTP                        | requests                                                        | ✅                          |
-| simplecast               | HTTP                        | requests                                                        | ✅                          |
-| simplesat                | HTTP                        | requests                                                        | ✅                          |
-| skyvern                  | HTTP                        | requests                                                        | ✅                          |
-| slack                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| smaily                   | HTTP                        | requests                                                        | ✅                          |
-| smartreach               | HTTP                        | requests                                                        | ✅                          |
-| smartsheet               | HTTP                        | requests                                                        | ✅                          |
-| smartwaiver              | HTTP                        | requests                                                        | ✅                          |
-| snapchat_ads             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| snowflake                | DB protocol                 | snowflake-connector-python                                      | ➖                          |
-| solarwinds_service_desk  | HTTP                        | requests                                                        | ✅                          |
-| sparkpost                | HTTP                        | requests                                                        | ✅                          |
-| split_io                 | HTTP                        | requests                                                        | ✅                          |
-| square                   | HTTP                        | requests                                                        | ✅                          |
-| squarespace              | HTTP                        | requests                                                        | ✅                          |
-| statuspage               | HTTP                        | requests                                                        | ✅                          |
-| stigg                    | HTTP                        | requests                                                        | ✅                          |
-| stripe                   | HTTP (vendor SDK) + Webhook | stripe (StripeClient + RequestsClient) + `WebhookSourceManager` | ✅ (pull) / ➖ (webhook)    |
-| supabase                 | DB protocol                 | psycopg (delegates to PostgresSource)                           | ➖                          |
-| surveymonkey             | HTTP                        | requests                                                        | ✅                          |
-| surveysparrow            | HTTP                        | requests                                                        | ✅                          |
-| svix                     | HTTP                        | requests                                                        | ✅                          |
-| taboola                  | HTTP                        | requests                                                        | ✅                          |
-| tavus                    | HTTP                        | requests                                                        | ✅                          |
-| teamtailor               | HTTP                        | requests                                                        | ✅                          |
-| teamwork                 | HTTP                        | requests                                                        | ✅                          |
-| tempo                    | HTTP                        | requests                                                        | ✅                          |
-| temporalio               | gRPC (vendor SDK)           | temporalio (`Client`, Rust core via `temporalio.bridge`)        | ⚠️                          |
-| testrail                 | HTTP                        | requests                                                        | ✅                          |
-| thinkific                | HTTP                        | requests                                                        | ✅                          |
-| tickettailor             | HTTP                        | requests                                                        | ✅                          |
-| tiktok_ads               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| tmdb                     | HTTP                        | requests                                                        | ✅                          |
-| todoist                  | HTTP                        | requests                                                        | ✅                          |
-| together_ai              | HTTP                        | requests                                                        | ✅                          |
-| trello                   | HTTP                        | requests                                                        | ✅                          |
-| tremendous               | HTTP                        | requests                                                        | ✅                          |
-| trigger_dev              | HTTP                        | requests                                                        | ✅                          |
-| twelve_labs              | HTTP                        | requests                                                        | ✅                          |
-| twilio                   | HTTP                        | requests                                                        | ✅                          |
-| typeform                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| ubidots                  | HTTP                        | requests                                                        | ✅                          |
-| unleash                  | HTTP                        | requests                                                        | ✅                          |
-| upstash                  | HTTP                        | requests                                                        | ✅                          |
-| vantage                  | HTTP                        | requests                                                        | ✅                          |
-| vellum                   | HTTP                        | requests                                                        | ✅                          |
-| vercel                   | HTTP                        | requests                                                        | ✅                          |
-| vitally                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| webflow                  | HTTP                        | requests                                                        | ✅                          |
-| windmill                 | HTTP                        | requests                                                        | ✅                          |
-| woocommerce              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| wordpress                | HTTP                        | requests                                                        | ✅                          |
-| workable                 | HTTP                        | requests                                                        | ✅                          |
-| workos                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| wrike                    | HTTP                        | requests                                                        | ✅                          |
-| writesonic               | HTTP                        | requests                                                        | ✅                          |
-| wufoo                    | HTTP                        | requests                                                        | ✅                          |
-| zapier_supported_storage | HTTP                        | requests                                                        | ✅                          |
-| zendesk                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| zendesk_sell             | HTTP                        | requests                                                        | ✅                          |
-| zenloop                  | HTTP                        | requests                                                        | ✅                          |
-| zonka_feedback           | HTTP                        | requests                                                        | ✅                          |
-| zoom                     | HTTP                        | requests                                                        | ✅                          |
-| zuora                    | HTTP                        | requests                                                        | ✅                          |
+| Source                    | Comm method                 | Primary library                                                 | Tracked transport           |
+| ------------------------- | --------------------------- | --------------------------------------------------------------- | --------------------------- |
+| adroll                    | HTTP                        | requests                                                        | ✅                          |
+| agilecrm                  | HTTP                        | requests                                                        | ✅                          |
+| aha                       | HTTP                        | requests                                                        | ✅                          |
+| aircall                   | HTTP                        | requests                                                        | ✅                          |
+| airtable                  | HTTP                        | requests                                                        | ✅                          |
+| algolia                   | HTTP                        | requests                                                        | ✅                          |
+| alguna                    | HTTP                        | requests                                                        | ✅                          |
+| alpha_vantage             | HTTP                        | requests                                                        | ✅                          |
+| amazon_ads                | HTTP                        | requests                                                        | ✅                          |
+| amplitude                 | HTTP                        | requests                                                        | ✅                          |
+| anthropic                 | HTTP                        | requests                                                        | ✅                          |
+| apify_dataset             | HTTP                        | requests                                                        | ✅                          |
+| apollo                    | HTTP                        | requests                                                        | ✅                          |
+| appfigures                | HTTP                        | requests                                                        | ✅                          |
+| appfollow                 | HTTP                        | requests                                                        | ✅                          |
+| appsflyer                 | HTTP (CSV reports)          | requests                                                        | ✅                          |
+| asana                     | HTTP                        | requests                                                        | ✅                          |
+| ashby                     | HTTP                        | requests                                                        | ✅                          |
+| assemblyai                | HTTP                        | requests                                                        | ✅                          |
+| attentive                 | HTTP (webhook-first)        | requests (webhook management)                                   | ✅                          |
+| attio                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| aviationstack             | HTTP                        | requests                                                        | ✅                          |
+| aviator                   | HTTP                        | requests                                                        | ✅                          |
+| awin                      | HTTP                        | requests                                                        | ✅                          |
+| azure_devops              | HTTP                        | requests                                                        | ✅                          |
+| bamboohr                  | HTTP                        | requests                                                        | ✅                          |
+| beamer                    | HTTP                        | requests                                                        | ✅                          |
+| bigmailer                 | HTTP                        | requests                                                        | ✅                          |
+| bigquery                  | HTTP + gRPC                 | google-cloud-bigquery + bigquery-storage                        | ✅ (HTTP + gRPC)            |
+| bing_ads                  | HTTP (vendor SDK, SOAP)     | bingads SDK                                                     | ⚠️                          |
+| bland_ai                  | HTTP                        | requests                                                        | ✅                          |
+| blogger                   | HTTP                        | requests                                                        | ✅                          |
+| bluetally                 | HTTP                        | requests                                                        | ✅                          |
+| boldsign                  | HTTP                        | requests                                                        | ✅                          |
+| braintree                 | HTTP (GraphQL)              | requests                                                        | ✅                          |
+| braze                     | HTTP                        | requests                                                        | ✅                          |
+| breezometer               | HTTP                        | requests                                                        | ✅                          |
+| brevo                     | HTTP                        | requests                                                        | ✅                          |
+| brex                      | HTTP                        | requests                                                        | ✅                          |
+| bugsnag                   | HTTP                        | requests                                                        | ✅                          |
+| buildbetter               | HTTP                        | requests                                                        | ✅                          |
+| buildkite                 | HTTP                        | requests                                                        | ✅                          |
+| bunny                     | HTTP                        | requests                                                        | ✅                          |
+| buzzsprout                | HTTP                        | requests                                                        | ✅                          |
+| cal_com                   | HTTP                        | requests                                                        | ✅                          |
+| calendly                  | HTTP                        | requests                                                        | ✅                          |
+| callrail                  | HTTP                        | requests                                                        | ✅                          |
+| campaign_monitor          | HTTP                        | requests                                                        | ✅                          |
+| campayn                   | HTTP                        | requests                                                        | ✅                          |
+| canny                     | HTTP                        | requests                                                        | ✅                          |
+| capsule_crm               | HTTP                        | requests                                                        | ✅                          |
+| care_quality_commission   | HTTP                        | requests                                                        | ✅                          |
+| chameleon                 | HTTP                        | requests                                                        | ✅                          |
+| chargebee                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| chargedesk                | HTTP                        | requests                                                        | ✅                          |
+| chargify                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| charthop                  | HTTP                        | requests                                                        | ✅                          |
+| checkout_com              | HTTP                        | requests                                                        | ✅                          |
+| churnkey                  | HTTP                        | requests                                                        | ✅                          |
+| coassemble                | HTTP                        | requests                                                        | ✅                          |
+| coda                      | HTTP                        | requests                                                        | ✅                          |
+| codefresh                 | HTTP                        | requests                                                        | ✅                          |
+| coin_api                  | HTTP                        | requests                                                        | ✅                          |
+| coingecko                 | HTTP                        | requests                                                        | ✅                          |
+| coinmarketcap             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| commercetools             | HTTP                        | requests                                                        | ✅                          |
+| concord                   | HTTP                        | requests                                                        | ✅                          |
+| configcat                 | HTTP                        | requests                                                        | ✅                          |
+| confluence                | HTTP                        | requests                                                        | ✅                          |
+| chartmogul                | HTTP                        | requests                                                        | ✅                          |
+| circleci                  | HTTP                        | requests                                                        | ✅                          |
+| cimis                     | HTTP                        | requests                                                        | ✅                          |
+| cloudflare                | HTTP                        | requests                                                        | ✅                          |
+| clari                     | HTTP                        | requests                                                        | ✅                          |
+| clerk                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| clickhouse                | DB protocol (HTTP-based)    | clickhouse-connect / clickhouse-driver                          | ➖                          |
+| clickup                   | HTTP                        | requests                                                        | ✅                          |
+| clockify                  | HTTP                        | requests                                                        | ✅                          |
+| clockodo                  | HTTP                        | requests                                                        | ✅                          |
+| close                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| cloudbeds                 | HTTP                        | requests                                                        | ✅                          |
+| convertkit                | HTTP                        | requests                                                        | ✅                          |
+| convex                    | HTTP                        | requests                                                        | ✅                          |
+| copper                    | HTTP                        | requests                                                        | ✅                          |
+| coupa                     | HTTP                        | requests                                                        | ✅                          |
+| crunchbase                | HTTP                        | requests                                                        | ✅                          |
+| culture_amp               | HTTP                        | requests                                                        | ✅                          |
+| cursor                    | HTTP                        | requests                                                        | ✅                          |
+| customer_io               | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
+| datadog                   | HTTP                        | requests                                                        | ✅                          |
+| decagon                   | HTTP                        | requests                                                        | ✅                          |
+| deel                      | HTTP                        | requests                                                        | ✅                          |
+| deepgram                  | HTTP                        | requests                                                        | ✅                          |
+| delighted                 | HTTP                        | requests                                                        | ✅                          |
+| deno_deploy               | HTTP                        | requests                                                        | ✅                          |
+| devin_ai                  | HTTP                        | requests                                                        | ✅                          |
+| ding_connect              | HTTP                        | requests                                                        | ✅                          |
+| dixa                      | HTTP                        | requests                                                        | ✅                          |
+| dockerhub                 | HTTP                        | requests                                                        | ✅                          |
+| docuseal                  | HTTP                        | requests                                                        | ✅                          |
+| doit                      | HTTP                        | requests                                                        | ✅                          |
+| dropbox_sign              | HTTP                        | requests                                                        | ✅                          |
+| drip                      | HTTP                        | requests                                                        | ✅                          |
+| e_conomic                 | HTTP                        | requests                                                        | ✅                          |
+| easypost                  | HTTP                        | requests                                                        | ✅                          |
+| easypromos                | HTTP                        | requests                                                        | ✅                          |
+| elevenlabs                | HTTP                        | requests                                                        | ✅                          |
+| freshcaller               | HTTP                        | requests                                                        | ✅                          |
+| freshdesk                 | HTTP                        | requests                                                        | ✅                          |
+| freshsales                | HTTP                        | requests                                                        | ✅                          |
+| freshservice              | HTTP                        | requests                                                        | ✅                          |
+| elasticemail              | HTTP                        | requests                                                        | ✅                          |
+| elasticsearch             | HTTP                        | requests                                                        | ✅                          |
+| emailoctopus              | HTTP                        | requests                                                        | ✅                          |
+| eventbrite                | HTTP                        | requests                                                        | ✅                          |
+| eventee                   | HTTP                        | requests                                                        | ✅                          |
+| eventzilla                | HTTP                        | requests                                                        | ✅                          |
+| everhour                  | HTTP                        | requests                                                        | ✅                          |
+| exchange_rates_api        | HTTP                        | requests                                                        | ✅                          |
+| ezofficeinventory         | HTTP                        | requests                                                        | ✅                          |
+| factorial                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| fastly                    | HTTP                        | requests                                                        | ✅                          |
+| fillout                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| finage                    | HTTP                        | requests                                                        | ✅                          |
+| financial_modelling       | HTTP                        | requests                                                        | ✅                          |
+| finnhub                   | HTTP                        | requests                                                        | ✅                          |
+| finnworlds                | HTTP                        | requests                                                        | ✅                          |
+| firecrawl                 | HTTP                        | requests                                                        | ✅                          |
+| fleetio                   | HTTP                        | requests                                                        | ✅                          |
+| firehydrant               | HTTP                        | requests                                                        | ✅                          |
+| flexmail                  | HTTP                        | requests                                                        | ✅                          |
+| float_app                 | HTTP                        | requests                                                        | ✅                          |
+| front                     | HTTP                        | requests                                                        | ✅                          |
+| fulcrum                   | HTTP                        | requests                                                        | ✅                          |
+| fullstory                 | HTTP                        | requests                                                        | ✅                          |
+| gainsight_px              | HTTP                        | requests                                                        | ✅                          |
+| gitbook                   | HTTP                        | requests                                                        | ✅                          |
+| github                    | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
+| giphy                     | HTTP                        | requests                                                        | ✅                          |
+| gitlab                    | HTTP                        | requests                                                        | ✅                          |
+| gladly                    | HTTP                        | requests                                                        | ✅                          |
+| gnews                     | HTTP                        | requests                                                        | ✅                          |
+| gocardless                | HTTP                        | requests                                                        | ✅                          |
+| goldcast                  | HTTP                        | requests                                                        | ✅                          |
+| gong                      | HTTP                        | requests                                                        | ✅                          |
+| google_ads                | gRPC                        | google-ads (googleads.client)                                   | ✅                          |
+| google_analytics          | HTTP                        | requests (`AuthorizedSession` + `TrackedHTTPAdapter`)           | ✅                          |
+| google_pagespeed_insights | HTTP                        | requests                                                        | ✅                          |
+| google_sheets             | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
+| google_webfonts           | HTTP                        | requests                                                        | ✅                          |
+| granola                   | HTTP                        | requests                                                        | ✅                          |
+| gorgias                   | HTTP                        | requests                                                        | ✅                          |
+| greenhouse                | HTTP                        | requests                                                        | ✅                          |
+| gridly                    | HTTP                        | requests                                                        | ✅                          |
+| guardian                  | HTTP                        | requests                                                        | ✅                          |
+| guru                      | HTTP                        | requests                                                        | ✅                          |
+| harvey                    | HTTP                        | requests                                                        | ✅                          |
+| hatchet                   | HTTP                        | requests                                                        | ✅                          |
+| healthchecks              | HTTP                        | requests                                                        | ✅                          |
+| height                    | HTTP                        | requests                                                        | ✅                          |
+| hellobaton                | HTTP                        | requests                                                        | ✅                          |
+| hibob                     | HTTP                        | requests                                                        | ✅                          |
+| humanitix                 | HTTP                        | requests                                                        | ✅                          |
+| hubplanner                | HTTP                        | requests                                                        | ✅                          |
+| hubspot                   | HTTP                        | requests                                                        | ✅                          |
+| hugging_face              | HTTP                        | requests                                                        | ✅                          |
+| huntr                     | HTTP                        | requests                                                        | ✅                          |
+| incident_io               | HTTP                        | requests                                                        | ✅                          |
+| inflowinventory           | HTTP                        | requests                                                        | ✅                          |
+| insightly                 | HTTP                        | requests                                                        | ✅                          |
+| instatus                  | HTTP                        | requests                                                        | ✅                          |
+| intercom                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| intruder                  | HTTP                        | requests                                                        | ✅                          |
+| invoiced                  | HTTP                        | requests                                                        | ✅                          |
+| invoiceninja              | HTTP                        | requests                                                        | ✅                          |
+| ip2whois                  | HTTP                        | requests                                                        | ✅                          |
+| iterable                  | HTTP                        | requests                                                        | ✅                          |
+| jira                      | HTTP                        | requests                                                        | ✅                          |
+| jobnimbus                 | HTTP                        | requests                                                        | ✅                          |
+| jotform                   | HTTP                        | requests                                                        | ✅                          |
+| judgeme_reviews           | HTTP                        | requests                                                        | ✅                          |
+| justcall                  | HTTP                        | requests                                                        | ✅                          |
+| justsift                  | HTTP                        | requests                                                        | ✅                          |
+| k6_cloud                  | HTTP                        | requests                                                        | ✅                          |
+| katana                    | HTTP                        | requests                                                        | ✅                          |
+| klaviyo                   | HTTP                        | requests                                                        | ✅                          |
+| lago                      | HTTP                        | requests                                                        | ✅                          |
+| launchdarkly              | HTTP                        | requests                                                        | ✅                          |
+| kustomer                  | HTTP                        | requests                                                        | ✅                          |
+| lattice                   | HTTP                        | requests                                                        | ✅                          |
+| leadfeeder                | HTTP                        | requests                                                        | ✅                          |
+| lemlist                   | HTTP                        | requests                                                        | ✅                          |
+| less_annoying_crm         | HTTP                        | requests                                                        | ✅                          |
+| lightspeed_retail         | HTTP                        | requests                                                        | ✅                          |
+| linear                    | HTTP                        | requests                                                        | ✅                          |
+| lever                     | HTTP                        | requests                                                        | ✅                          |
+| lingo_dev                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| linkedin_ads              | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
+| linkrunner                | HTTP                        | requests                                                        | ✅                          |
+| linode                    | HTTP                        | requests                                                        | ✅                          |
+| lob                       | HTTP                        | requests                                                        | ✅                          |
+| luma                      | HTTP                        | requests                                                        | ✅                          |
+| mailchimp                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| mailerlite                | HTTP                        | requests                                                        | ✅                          |
+| mailersend                | HTTP                        | requests                                                        | ✅                          |
+| mailgun                   | HTTP                        | requests                                                        | ✅                          |
+| mailjet                   | HTTP                        | requests                                                        | ✅                          |
+| mailosaur                 | HTTP                        | requests                                                        | ✅                          |
+| mailtrap                  | HTTP                        | requests                                                        | ✅                          |
+| marketstack               | HTTP                        | requests                                                        | ✅                          |
+| matomo                    | HTTP                        | requests                                                        | ✅                          |
+| maxio                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| mention                   | HTTP                        | requests                                                        | ✅                          |
+| meta_ads                  | HTTP                        | requests                                                        | ✅                          |
+| metabase                  | HTTP                        | requests                                                        | ✅                          |
+| metorial                  | HTTP                        | requests                                                        | ✅                          |
+| mistral_ai                | HTTP                        | requests                                                        | ✅                          |
+| mixmax                    | HTTP                        | requests                                                        | ✅                          |
+| mixpanel                  | HTTP                        | requests                                                        | ✅                          |
+| mollie                    | HTTP                        | requests                                                        | ✅                          |
+| monday                    | HTTP (GraphQL)              | requests                                                        | ✅                          |
+| mongodb                   | DB protocol                 | pymongo                                                         | ➖                          |
+| mssql                     | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
+| mux                       | HTTP                        | requests                                                        | ✅                          |
+| my_hours                  | HTTP                        | requests                                                        | ✅                          |
+| mysql                     | DB protocol                 | pymysql                                                         | ➖                          |
+| n8n                       | HTTP                        | requests                                                        | ✅                          |
+| netlify                   | HTTP                        | requests                                                        | ✅                          |
+| new_york_times            | HTTP                        | requests                                                        | ✅                          |
+| news_api                  | HTTP                        | requests                                                        | ✅                          |
+| newsdata                  | HTTP                        | requests                                                        | ✅                          |
+| okta                      | HTTP                        | requests                                                        | ✅                          |
+| nocrm                     | HTTP                        | requests                                                        | ✅                          |
+| northpass_lms             | HTTP                        | requests                                                        | ✅                          |
+| notion                    | HTTP                        | requests                                                        | ✅                          |
+| omnisend                  | HTTP                        | requests                                                        | ✅                          |
+| oncehub                   | HTTP                        | requests                                                        | ✅                          |
+| onepagecrm                | HTTP                        | requests                                                        | ✅                          |
+| onfleet                   | HTTP (cursor pagination)    | requests                                                        | ✅                          |
+| open_exchange_rates       | HTTP                        | requests                                                        | ✅                          |
+| opinion_stage             | HTTP                        | requests                                                        | ✅                          |
+| orb                       | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| openaq                    | HTTP                        | requests                                                        | ✅                          |
+| openfda                   | HTTP                        | requests                                                        | ✅                          |
+| openweather               | HTTP                        | requests                                                        | ✅                          |
+| ortto                     | HTTP                        | requests                                                        | ✅                          |
+| oura                      | HTTP                        | requests                                                        | ✅                          |
+| outbrain                  | HTTP                        | requests                                                        | ✅                          |
+| paddle                    | HTTP                        | requests                                                        | ✅                          |
+| optimizely                | HTTP                        | requests                                                        | ✅                          |
+| pagerduty                 | HTTP                        | requests                                                        | ✅                          |
+| pandadoc                  | HTTP                        | requests                                                        | ✅                          |
+| paperform                 | HTTP                        | requests                                                        | ✅                          |
+| papersign                 | HTTP                        | requests                                                        | ✅                          |
+| partnerize                | HTTP                        | requests                                                        | ✅                          |
+| partnerstack              | HTTP                        | requests                                                        | ✅                          |
+| payfit                    | HTTP                        | requests                                                        | ✅                          |
+| paystack                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| pendo                     | HTTP                        | requests                                                        | ✅                          |
+| persistiq                 | HTTP                        | requests                                                        | ✅                          |
+| persona                   | HTTP                        | requests                                                        | ✅                          |
+| personio                  | HTTP                        | requests                                                        | ✅                          |
+| pexels                    | HTTP                        | requests                                                        | ✅                          |
+| phyllo                    | HTTP                        | requests                                                        | ✅                          |
+| picqer                    | HTTP                        | requests                                                        | ✅                          |
+| pingdom                   | HTTP                        | requests                                                        | ✅                          |
+| pinterest_ads             | HTTP                        | requests                                                        | ✅                          |
+| pipedrive                 | HTTP                        | requests                                                        | ✅                          |
+| pipeliner                 | HTTP                        | requests                                                        | ✅                          |
+| plain                     | HTTP                        | requests                                                        | ✅                          |
+| planhat                   | HTTP                        | requests                                                        | ✅                          |
+| plausible                 | HTTP                        | requests                                                        | ✅                          |
+| polar                     | HTTP                        | requests                                                        | ✅                          |
+| plaid                     | HTTP                        | requests                                                        | ✅                          |
+| postgres                  | DB protocol                 | psycopg                                                         | ➖                          |
+| postmark                  | HTTP                        | requests                                                        | ✅                          |
+| pretix                    | HTTP                        | requests                                                        | ✅                          |
+| printify                  | HTTP                        | requests                                                        | ✅                          |
+| productboard              | HTTP                        | requests                                                        | ✅                          |
+| pylon                     | HTTP                        | requests                                                        | ✅                          |
+| qualaroo                  | HTTP                        | requests                                                        | ✅                          |
+| recurly                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| ramp                      | HTTP                        | requests                                                        | ✅                          |
+| recharge                  | HTTP                        | requests                                                        | ✅                          |
+| recruitee                 | HTTP                        | requests                                                        | ✅                          |
+| reddit_ads                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| redshift                  | DB protocol                 | psycopg (Postgres-compatible)                                   | ➖                          |
+| rentcast                  | HTTP                        | requests                                                        | ✅                          |
+| replicate                 | HTTP                        | requests                                                        | ✅                          |
+| reply_io                  | HTTP                        | requests                                                        | ✅                          |
+| resend                    | HTTP                        | requests                                                        | ✅                          |
+| retently                  | HTTP                        | requests                                                        | ✅                          |
+| revenuecat                | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
+| rippling                  | HTTP                        | requests                                                        | ✅                          |
+| rocketlane                | HTTP                        | requests                                                        | ✅                          |
+| rollbar                   | HTTP                        | requests                                                        | ✅                          |
+| rootly                    | HTTP                        | requests                                                        | ✅                          |
+| rss                       | HTTP                        | requests                                                        | ✅                          |
+| ruddr                     | HTTP                        | requests                                                        | ✅                          |
+| safetyculture             | HTTP                        | requests                                                        | ✅                          |
+| salesforce                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| salesflare                | HTTP                        | requests                                                        | ✅                          |
+| salesloft                 | HTTP                        | requests                                                        | ✅                          |
+| savvycal                  | HTTP                        | requests                                                        | ✅                          |
+| scale_ai                  | HTTP                        | requests                                                        | ✅                          |
+| scaleway                  | HTTP                        | requests                                                        | ✅                          |
+| secoda                    | HTTP                        | requests                                                        | ✅                          |
+| segment                   | HTTP                        | requests                                                        | ✅                          |
+| sendgrid                  | HTTP                        | requests                                                        | ✅                          |
+| sendowl                   | HTTP                        | requests                                                        | ✅                          |
+| sentry                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| servicenow                | HTTP                        | requests                                                        | ✅                          |
+| shippo                    | HTTP                        | requests                                                        | ✅                          |
+| shipstation               | HTTP                        | requests                                                        | ✅                          |
+| shopify                   | HTTP                        | requests                                                        | ✅                          |
+| shopwired                 | HTTP                        | requests                                                        | ✅                          |
+| shortcut                  | HTTP                        | requests                                                        | ✅                          |
+| shortio                   | HTTP                        | requests                                                        | ✅                          |
+| simplecast                | HTTP                        | requests                                                        | ✅                          |
+| simplesat                 | HTTP                        | requests                                                        | ✅                          |
+| skyvern                   | HTTP                        | requests                                                        | ✅                          |
+| slack                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| smaily                    | HTTP                        | requests                                                        | ✅                          |
+| smartreach                | HTTP                        | requests                                                        | ✅                          |
+| smartsheet                | HTTP                        | requests                                                        | ✅                          |
+| smartwaiver               | HTTP                        | requests                                                        | ✅                          |
+| snapchat_ads              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| snowflake                 | DB protocol                 | snowflake-connector-python                                      | ➖                          |
+| solarwinds_service_desk   | HTTP                        | requests                                                        | ✅                          |
+| sparkpost                 | HTTP                        | requests                                                        | ✅                          |
+| split_io                  | HTTP                        | requests                                                        | ✅                          |
+| square                    | HTTP                        | requests                                                        | ✅                          |
+| squarespace               | HTTP                        | requests                                                        | ✅                          |
+| statuspage                | HTTP                        | requests                                                        | ✅                          |
+| stigg                     | HTTP                        | requests                                                        | ✅                          |
+| stripe                    | HTTP (vendor SDK) + Webhook | stripe (StripeClient + RequestsClient) + `WebhookSourceManager` | ✅ (pull) / ➖ (webhook)    |
+| supabase                  | DB protocol                 | psycopg (delegates to PostgresSource)                           | ➖                          |
+| surveymonkey              | HTTP                        | requests                                                        | ✅                          |
+| surveysparrow             | HTTP                        | requests                                                        | ✅                          |
+| svix                      | HTTP                        | requests                                                        | ✅                          |
+| taboola                   | HTTP                        | requests                                                        | ✅                          |
+| tavus                     | HTTP                        | requests                                                        | ✅                          |
+| teamtailor                | HTTP                        | requests                                                        | ✅                          |
+| teamwork                  | HTTP                        | requests                                                        | ✅                          |
+| tempo                     | HTTP                        | requests                                                        | ✅                          |
+| temporalio                | gRPC (vendor SDK)           | temporalio (`Client`, Rust core via `temporalio.bridge`)        | ⚠️                          |
+| testrail                  | HTTP                        | requests                                                        | ✅                          |
+| thinkific                 | HTTP                        | requests                                                        | ✅                          |
+| tickettailor              | HTTP                        | requests                                                        | ✅                          |
+| tiktok_ads                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| tmdb                      | HTTP                        | requests                                                        | ✅                          |
+| todoist                   | HTTP                        | requests                                                        | ✅                          |
+| together_ai               | HTTP                        | requests                                                        | ✅                          |
+| trello                    | HTTP                        | requests                                                        | ✅                          |
+| tremendous                | HTTP                        | requests                                                        | ✅                          |
+| trigger_dev               | HTTP                        | requests                                                        | ✅                          |
+| twelve_labs               | HTTP                        | requests                                                        | ✅                          |
+| twilio                    | HTTP                        | requests                                                        | ✅                          |
+| typeform                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| ubidots                   | HTTP                        | requests                                                        | ✅                          |
+| unleash                   | HTTP                        | requests                                                        | ✅                          |
+| upstash                   | HTTP                        | requests                                                        | ✅                          |
+| vantage                   | HTTP                        | requests                                                        | ✅                          |
+| vellum                    | HTTP                        | requests                                                        | ✅                          |
+| vercel                    | HTTP                        | requests                                                        | ✅                          |
+| vitally                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| webflow                   | HTTP                        | requests                                                        | ✅                          |
+| windmill                  | HTTP                        | requests                                                        | ✅                          |
+| woocommerce               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| wordpress                 | HTTP                        | requests                                                        | ✅                          |
+| workable                  | HTTP                        | requests                                                        | ✅                          |
+| workos                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| wrike                     | HTTP                        | requests                                                        | ✅                          |
+| writesonic                | HTTP                        | requests                                                        | ✅                          |
+| wufoo                     | HTTP                        | requests                                                        | ✅                          |
+| zapier_supported_storage  | HTTP                        | requests                                                        | ✅                          |
+| zendesk                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| zendesk_sell              | HTTP                        | requests                                                        | ✅                          |
+| zenloop                   | HTTP                        | requests                                                        | ✅                          |
+| zonka_feedback            | HTTP                        | requests                                                        | ✅                          |
+| zoom                      | HTTP                        | requests                                                        | ✅                          |
+| zuora                     | HTTP                        | requests                                                        | ✅                          |
 
 ### Notes on partially-tracked sources
 
@@ -583,7 +584,6 @@ doesn't conflict with concurrent PRs.
 - google_directory
 - google_drive
 - google_forms
-- google_pagespeed_insights
 - google_tasks
 - google_workspace_admin_reports
 - grafana

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -1573,7 +1573,8 @@ class GoogleFormsSourceConfig(config.Config):
 
 @config.config
 class GooglePageSpeedInsightsSourceConfig(config.Config):
-    pass
+    api_key: str
+    urls: str
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/canonical_descriptions.py
@@ -1,0 +1,37 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+# Injected by the connector on every row (not part of the raw API response).
+_INJECTED_COLUMNS = {
+    "requested_url": "The URL analyzed, exactly as configured on the source (not the final resolved URL, which can drift with redirects).",
+    "strategy": "The Lighthouse device profile the analysis ran under: `DESKTOP` or `MOBILE`.",
+    "analysis_timestamp": "ISO 8601 UTC timestamp derived from `analysisUTCTimestamp`; used as the partition key and append cursor.",
+}
+
+# Top-level fields of the PagespeedApiPagespeedResponseV5 document.
+_RESPONSE_COLUMNS = {
+    "kind": "The kind of result, always `pagespeedonline#result`.",
+    "id": "The final, canonicalized URL that was analyzed (after any redirects).",
+    "analysisUTCTimestamp": "The UTC timestamp of when the Lighthouse analysis was run, RFC 3339.",
+    "lighthouseResult": "The full Lighthouse report: category scores (performance, accessibility, best-practices, SEO), individual audits, and metrics.",
+    "loadingExperience": "Chrome UX Report (CrUX) field data for this specific URL, where available (real-world Core Web Vitals).",
+    "originLoadingExperience": "Chrome UX Report (CrUX) field data aggregated across the whole origin, where available.",
+    "version": "The Lighthouse version used to run the analysis.",
+    "captchaResult": "The captcha verification result for the request.",
+}
+
+_COLUMNS = {**_INJECTED_COLUMNS, **_RESPONSE_COLUMNS}
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "pagespeed_desktop": {
+        "description": "PageSpeed Insights / Lighthouse analysis under the desktop profile for a configured URL, from the Google PageSpeed Insights v5 API (runPagespeed). One row per URL per sync.",
+        "docs_url": "https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed",
+        "columns": _COLUMNS,
+    },
+    "pagespeed_mobile": {
+        "description": "PageSpeed Insights / Lighthouse analysis under the mobile profile for a configured URL, from the Google PageSpeed Insights v5 API (runPagespeed). One row per URL per sync.",
+        "docs_url": "https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed",
+        "columns": _COLUMNS,
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/google_pagespeed_insights.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/google_pagespeed_insights.py
@@ -1,0 +1,242 @@
+import re
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlencode, urlparse
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.settings import (
+    PAGESPEED_ENDPOINTS,
+    PageSpeedEndpointConfig,
+)
+
+# The PageSpeed Insights v5 API is a single GET endpoint that runs an on-demand Lighthouse analysis of
+# a supplied URL and returns a large nested JSON document. Auth is a Google Cloud API key on the `key`
+# query param. There is no pagination and no server-side change cursor, so every table is full-refresh
+# over the configured URL list (append is supported so users can accumulate a score time series).
+PAGESPEED_BASE_URL = "https://pagespeedonline.googleapis.com/pagespeedonline/v5/runPagespeed"
+
+# A Lighthouse run takes several seconds; give each request generous headroom before treating it as
+# a timeout worth retrying.
+REQUEST_TIMEOUT_SECONDS = 120
+MAX_RETRY_ATTEMPTS = 5
+
+# Each URL costs one full (slow) Lighthouse run per enabled table on every sync, so cap the config to
+# bound worker time and outbound fan-out — a malformed or abusive config can't tie up the pipeline.
+MAX_URLS = 50
+
+# Lighthouse categories requested on every call. `category` is a repeatable query param that enriches
+# the response with per-category scores. PWA is intentionally omitted: it was removed from Lighthouse
+# 12 (which PageSpeed Insights now runs) and requesting it can 400. This could not be curl-verified
+# without an API key, so the set is deliberately the four stable, widely-supported categories.
+CATEGORIES = ["PERFORMANCE", "ACCESSIBILITY", "BEST_PRACTICES", "SEO"]
+
+
+class PageSpeedRetryableError(Exception):
+    pass
+
+
+def parse_urls(raw: str | None) -> list[str]:
+    """Parse the user's free-text ``urls`` field into a de-duplicated list of URLs.
+
+    Each non-empty line is one URL. Raises ``ValueError`` with an actionable message on malformed
+    input (missing scheme/host, too many URLs) so the user can fix the config rather than getting a
+    silently empty sync. Duplicates are dropped (order preserved) so the same URL can't seed two rows
+    with the same primary key within a single sync.
+    """
+    if not raw:
+        raise ValueError("At least one URL is required.")
+
+    urls: list[str] = []
+    seen: set[str] = set()
+    for line_number, line in enumerate(raw.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        parsed = urlparse(stripped)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError(f"Line {line_number} ({stripped!r}) must be a full URL starting with http:// or https://.")
+
+        if stripped in seen:
+            continue
+        seen.add(stripped)
+        urls.append(stripped)
+
+        if len(urls) > MAX_URLS:
+            raise ValueError(f"Too many URLs: at most {MAX_URLS} are allowed per source.")
+
+    if not urls:
+        raise ValueError("At least one URL is required.")
+
+    return urls
+
+
+def _build_url(target_url: str, strategy: str, api_key: str) -> str:
+    # `category` is repeatable, so build an ordered list of (key, value) pairs — urlencode emits one
+    # `category=` param per entry, which is how the API wants multiple categories expressed.
+    params: list[tuple[str, str]] = [
+        ("url", target_url),
+        ("strategy", strategy),
+        ("key", api_key),
+        *[("category", category) for category in CATEGORIES],
+    ]
+    return f"{PAGESPEED_BASE_URL}?{urlencode(params)}"
+
+
+# The API key rides the `key` query param, so it ends up in `response.url`, which `raise_for_status()`
+# embeds in its message. Redact it so the key never reaches stored errors / logs. Match only the `key`
+# query param, not any field that merely contains "key".
+_KEY_RE = re.compile(r"([?&]key=)[^&\s]+", re.IGNORECASE)
+
+
+def _redact_key(text: str) -> str:
+    return _KEY_RE.sub(r"\1REDACTED", text)
+
+
+@retry(
+    retry=retry_if_exception_type((PageSpeedRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+    wait=wait_exponential_jitter(initial=2, max=60),
+    reraise=True,
+)
+def _fetch(
+    session: requests.Session,
+    api_key: str,
+    strategy: str,
+    target_url: str,
+    logger: FilteringBoundLogger,
+) -> dict[str, Any]:
+    url = _build_url(target_url, strategy, api_key)
+    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+
+    # 429 (rate/quota limit) and transient 5xx are retryable; back off and try again. A persistent
+    # per-URL analysis failure (e.g. a page that never loads) also surfaces as 5xx and will fail the
+    # sync loudly after retries — better than silently dropping a URL the user asked to track.
+    if response.status_code == 429 or response.status_code >= 500:
+        raise PageSpeedRetryableError(f"PageSpeed Insights API error (retryable): status={response.status_code}")
+
+    if not response.ok:
+        logger.error(f"PageSpeed Insights API error: status={response.status_code}, body={_redact_key(response.text)}")
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            # Re-raise with the `key` redacted so the API key never reaches stored errors / logs, keeping
+            # the `... for url: https://pagespeedonline.googleapis.com` prefix intact for non-retryable matching.
+            raise requests.HTTPError(_redact_key(str(exc)), response=exc.response) from None
+
+    return response.json()
+
+
+def _analysis_timestamp_to_iso(value: Any) -> str | None:
+    """Normalize the API's ``analysisUTCTimestamp`` (RFC 3339, e.g. ``2024-01-15T12:34:56.789Z``) to ISO 8601 UTC."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).isoformat()
+
+
+def _normalize_row(config: PageSpeedEndpointConfig, response: dict[str, Any], target_url: str) -> dict[str, Any] | None:
+    """Turn one API response into a flat row, stamping it with the requested URL, strategy, and timestamp.
+
+    We inject the *requested* URL (not the echoed ``id``, which is the final resolved URL and can drift
+    with redirects between syncs) so the ``[requested_url, analysis_timestamp]`` primary key stays
+    stable. The raw ``analysisUTCTimestamp`` is preserved; ``analysis_timestamp`` is the derived,
+    parseable copy used for partitioning and as the append cursor. Returns ``None`` when the timestamp
+    is present but unparseable, so a null key never flows into the merge.
+    """
+    row = dict(response)
+    row["requested_url"] = target_url
+    row["strategy"] = config.strategy
+
+    # `analysis_timestamp` derives from this field and is part of the primary key, so index directly: a
+    # missing field is a structural API change that should fail loudly with a `KeyError` rather than
+    # silently dropping every row. A present-but-malformed value still parses to `None` and is skipped.
+    analysis_timestamp = _analysis_timestamp_to_iso(response["analysisUTCTimestamp"])
+    if analysis_timestamp is None:
+        return None
+    row["analysis_timestamp"] = analysis_timestamp
+    return row
+
+
+def validate_credentials(api_key: str, urls_raw: str | None) -> tuple[bool, str | None]:
+    """Probe the runPagespeed endpoint with the first configured URL.
+
+    Google validates the API key before running Lighthouse, so an invalid/missing key returns 400
+    (``API key not valid``) and a project without the API enabled returns 403 (``PERMISSION_DENIED``)
+    quickly. A valid key runs the full analysis and returns 200, which can take several seconds.
+    """
+    try:
+        urls = parse_urls(urls_raw)
+    except ValueError as exc:
+        return False, str(exc)
+
+    url = _build_url(urls[0], "DESKTOP", api_key)
+    try:
+        response = make_tracked_session().get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+    except Exception:
+        return False, "Could not reach the Google PageSpeed Insights API. Please try again."
+
+    if response.status_code == 200:
+        return True, None
+    if response.status_code in (400, 403):
+        return False, (
+            "Invalid API key, or the PageSpeed Insights API is not enabled for your Google Cloud project. "
+            "Check the key and enable the PageSpeed Insights API, then reconnect."
+        )
+
+    return False, f"The PageSpeed Insights API returned an unexpected status code: {response.status_code}"
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    urls: list[str],
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    config = PAGESPEED_ENDPOINTS[endpoint]
+    # One session reused across every URL so urllib3 keeps the connection alive instead of re-handshaking.
+    session = make_tracked_session()
+
+    for target_url in urls:
+        response = _fetch(session, api_key, config.strategy, target_url, logger)
+        row = _normalize_row(config, response, target_url)
+        if row is not None:
+            yield [row]
+
+
+def google_pagespeed_insights_source(
+    api_key: str,
+    endpoint: str,
+    urls_raw: str | None,
+    logger: FilteringBoundLogger,
+) -> SourceResponse:
+    config = PAGESPEED_ENDPOINTS[endpoint]
+    urls = parse_urls(urls_raw)
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(api_key=api_key, endpoint=endpoint, urls=urls, logger=logger),
+        primary_keys=config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime",
+        partition_format="week",
+        partition_keys=[config.partition_key],
+        # One row per URL, each stamped with an analysis timestamp of ~now; rows arrive in config order.
+        sort_mode="asc",
+        # PageSpeed responses are large, deeply-nested JSON documents (~0.5-1 MiB each). Cap the
+        # per-chunk byte budget low so the source->Arrow conversion can't materialise an oversized
+        # table and OOM the worker when many URLs are configured.
+        chunk_size_bytes=50 * 1024 * 1024,
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/google_pagespeed_insights.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/google_pagespeed_insights.py
@@ -1,4 +1,5 @@
 import re
+import ipaddress
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from typing import Any
@@ -41,6 +42,28 @@ class PageSpeedRetryableError(Exception):
     pass
 
 
+# Hostname suffixes that only ever resolve inside a private network / to the loopback interface.
+_PRIVATE_HOST_SUFFIXES = (".localhost", ".local", ".internal")
+
+
+def _is_private_host(host: str) -> bool:
+    """True for hosts that name a private, loopback, link-local, or otherwise non-public address.
+
+    The runPagespeed fetch is executed by Google's servers (not PostHog's egress), so a private or
+    internal URL is unreachable there rather than a server-side request forgery against our network.
+    This rejection is defense-in-depth: it fails such URLs early with a clear message and keeps the
+    connector from being pointed at internal-looking hosts.
+    """
+    lowered = host.lower()
+    if lowered == "localhost" or lowered.endswith(_PRIVATE_HOST_SUFFIXES):
+        return True
+    try:
+        ip = ipaddress.ip_address(lowered)
+    except ValueError:
+        return False
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+
+
 def parse_urls(raw: str | None) -> list[str]:
     """Parse the user's free-text ``urls`` field into a de-duplicated list of URLs.
 
@@ -62,6 +85,12 @@ def parse_urls(raw: str | None) -> list[str]:
         parsed = urlparse(stripped)
         if parsed.scheme not in ("http", "https") or not parsed.netloc:
             raise ValueError(f"Line {line_number} ({stripped!r}) must be a full URL starting with http:// or https://.")
+
+        if parsed.hostname is None or _is_private_host(parsed.hostname):
+            raise ValueError(
+                f"Line {line_number} ({stripped!r}) points at a private, local, or non-public address, "
+                "which cannot be analyzed. Enter a publicly reachable URL."
+            )
 
         if stripped in seen:
             continue
@@ -113,7 +142,13 @@ def _fetch(
     logger: FilteringBoundLogger,
 ) -> dict[str, Any]:
     url = _build_url(target_url, strategy, api_key)
-    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+    try:
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+    except requests.RequestException as exc:
+        # Connection / SSL / timeout errors embed the full request URL (including `key=...`) in their
+        # message. `latest_error` stores `str(error)` after retries are exhausted, so re-raise the same
+        # exception type with the key redacted — preserving the type keeps retry classification intact.
+        raise type(exc)(_redact_key(str(exc))) from None
 
     # 429 (rate/quota limit) and transient 5xx are retryable; back off and try again. A persistent
     # per-URL analysis failure (e.g. a page that never loads) also surfaces as 5xx and will fail the
@@ -183,7 +218,7 @@ def validate_credentials(api_key: str, urls_raw: str | None) -> tuple[bool, str 
 
     url = _build_url(urls[0], "DESKTOP", api_key)
     try:
-        response = make_tracked_session().get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        response = make_tracked_session(redact_values=(api_key,)).get(url, timeout=REQUEST_TIMEOUT_SECONDS)
     except Exception:
         return False, "Could not reach the Google PageSpeed Insights API. Please try again."
 
@@ -206,7 +241,8 @@ def get_rows(
 ) -> Iterator[list[dict[str, Any]]]:
     config = PAGESPEED_ENDPOINTS[endpoint]
     # One session reused across every URL so urllib3 keeps the connection alive instead of re-handshaking.
-    session = make_tracked_session()
+    # `redact_values` masks the API key wherever the tracked transport logs or samples the request URL.
+    session = make_tracked_session(redact_values=(api_key,))
 
     for target_url in urls:
         response = _fetch(session, api_key, config.strategy, target_url, logger)
@@ -235,8 +271,10 @@ def google_pagespeed_insights_source(
         partition_keys=[config.partition_key],
         # One row per URL, each stamped with an analysis timestamp of ~now; rows arrive in config order.
         sort_mode="asc",
-        # PageSpeed responses are large, deeply-nested JSON documents (~0.5-1 MiB each). Cap the
-        # per-chunk byte budget low so the source->Arrow conversion can't materialise an oversized
-        # table and OOM the worker when many URLs are configured.
-        chunk_size_bytes=50 * 1024 * 1024,
+        # PageSpeed responses are large, deeply-nested JSON documents (~0.5-1 MiB each, larger for
+        # complex pages). We emit one row per URL, so keep the per-chunk byte budget below a single
+        # report: the batcher then flushes after roughly every report instead of accumulating the whole
+        # URL list into one oversized Arrow/Delta write that could OOM or time out the worker. The
+        # buffered footprint stays ~one report regardless of how many URLs are configured.
+        chunk_size_bytes=1 * 1024 * 1024,
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/google_pagespeed_insights.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/google_pagespeed_insights.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode, urlparse
 import requests
 from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from urllib3.util.retry import Retry
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
@@ -26,6 +27,17 @@ PAGESPEED_BASE_URL = "https://pagespeedonline.googleapis.com/pagespeedonline/v5/
 # a timeout worth retrying.
 REQUEST_TIMEOUT_SECONDS = 120
 MAX_RETRY_ATTEMPTS = 5
+
+# Credential validation runs synchronously on a web worker during source setup, so bound it more
+# tightly than a background sync: a single attempt with a shorter timeout. A valid key still runs a
+# full analysis before returning 200, so keep enough headroom for that while capping the worker hold.
+VALIDATION_TIMEOUT_SECONDS = 60
+
+# Disable adapter-level (urllib3) retries on the tracked session so the Tenacity policy on `_fetch`
+# is the only retry layer. Otherwise the two layers compound — up to `MAX_RETRY_ATTEMPTS` Tenacity
+# attempts each doing several urllib3 retries fans out to ~20 slow Lighthouse requests per URL, which
+# a user could weaponise with repeatedly-timing-out URLs to tie up import workers.
+_NO_ADAPTER_RETRIES = Retry(total=0)
 
 # Each URL costs one full (slow) Lighthouse run per enabled table on every sync, so cap the config to
 # bound worker time and outbound fan-out — a malformed or abusive config can't tie up the pipeline.
@@ -218,7 +230,9 @@ def validate_credentials(api_key: str, urls_raw: str | None) -> tuple[bool, str 
 
     url = _build_url(urls[0], "DESKTOP", api_key)
     try:
-        response = make_tracked_session(redact_values=(api_key,)).get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        response = make_tracked_session(retry=_NO_ADAPTER_RETRIES, redact_values=(api_key,)).get(
+            url, timeout=VALIDATION_TIMEOUT_SECONDS
+        )
     except Exception:
         return False, "Could not reach the Google PageSpeed Insights API. Please try again."
 
@@ -241,8 +255,10 @@ def get_rows(
 ) -> Iterator[list[dict[str, Any]]]:
     config = PAGESPEED_ENDPOINTS[endpoint]
     # One session reused across every URL so urllib3 keeps the connection alive instead of re-handshaking.
-    # `redact_values` masks the API key wherever the tracked transport logs or samples the request URL.
-    session = make_tracked_session(redact_values=(api_key,))
+    # Adapter-level retries are disabled so Tenacity on `_fetch` is the only retry layer (see
+    # `_NO_ADAPTER_RETRIES`). `redact_values` masks the API key wherever the tracked transport logs or
+    # samples the request URL.
+    session = make_tracked_session(retry=_NO_ADAPTER_RETRIES, redact_values=(api_key,))
 
     for target_url in urls:
         response = _fetch(session, api_key, config.strategy, target_url, logger)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/settings.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass, field
+from typing import Literal
+
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
+
+# Every row carries `analysis_timestamp`, a derived ISO 8601 UTC timestamp of when PageSpeed Insights
+# ran the Lighthouse analysis (parsed from the API's `analysisUTCTimestamp`). Each sync produces a
+# fresh analysis, so this value never changes for a given row and doubles as the append cursor and a
+# stable partition key.
+_ANALYSIS_INCREMENTAL_FIELDS: list[IncrementalField] = [
+    {
+        "label": "analysis_timestamp",
+        "type": IncrementalFieldType.DateTime,
+        "field": "analysis_timestamp",
+        "field_type": IncrementalFieldType.DateTime,
+    },
+]
+
+
+@dataclass
+class PageSpeedEndpointConfig:
+    name: str
+    # PageSpeed Insights runs the analysis under one device profile per request; each strategy is
+    # modelled as its own table so a user can sync only the profiles they care about (each call is a
+    # full, several-second Lighthouse run, so halving the profiles halves the quota spend).
+    strategy: Literal["DESKTOP", "MOBILE"]
+    incremental_fields: list[IncrementalField] = field(default_factory=lambda: list(_ANALYSIS_INCREMENTAL_FIELDS))
+    # `analysis_timestamp` alone is not unique table-wide because rows aggregate across every configured
+    # URL, so the requested URL is part of the key.
+    primary_keys: list[str] = field(default_factory=lambda: ["requested_url", "analysis_timestamp"])
+    # Stable datetime column used for partitioning (derived from the response's analysis timestamp).
+    partition_key: str = "analysis_timestamp"
+    should_sync_default: bool = True
+    description: str | None = None
+
+
+PAGESPEED_ENDPOINTS: dict[str, PageSpeedEndpointConfig] = {
+    "pagespeed_desktop": PageSpeedEndpointConfig(
+        name="pagespeed_desktop",
+        strategy="DESKTOP",
+        description="PageSpeed Insights / Lighthouse analysis under the desktop profile for each "
+        "configured URL. One row per URL per sync; use append sync to accumulate a time series of scores.",
+    ),
+    "pagespeed_mobile": PageSpeedEndpointConfig(
+        name="pagespeed_mobile",
+        strategy="MOBILE",
+        description="PageSpeed Insights / Lighthouse analysis under the mobile profile for each "
+        "configured URL. One row per URL per sync; use append sync to accumulate a time series of scores.",
+    ),
+}
+
+ENDPOINTS = tuple(PAGESPEED_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in PAGESPEED_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/source.py
@@ -1,21 +1,45 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
     GooglePageSpeedInsightsSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.google_pagespeed_insights import (
+    google_pagespeed_insights_source,
+    validate_credentials as validate_google_pagespeed_insights_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+    PAGESPEED_ENDPOINTS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class GooglePageSpeedInsightsSource(SimpleSource[GooglePageSpeedInsightsSourceConfig]):
+    # `get_schemas` iterates a static endpoint catalog with no I/O, so the table list is safe to render
+    # in public docs without credentials.
+    lists_tables_without_credentials = True
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.GOOGLEPAGESPEEDINSIGHTS
@@ -24,9 +48,101 @@ class GooglePageSpeedInsightsSource(SimpleSource[GooglePageSpeedInsightsSourceCo
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GOOGLE_PAGE_SPEED_INSIGHTS,
-            category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
+            category=DataWarehouseSourceCategory.ANALYTICS,
             label="Google PageSpeed Insights",
-            iconPath="/static/services/google_pagespeed_insights.png",
-            fields=cast(list[FieldType], []),
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            caption="""Enter your Google Cloud API key and the URLs you want to analyze to pull PageSpeed Insights (Lighthouse) scores into the PostHog Data warehouse.
+
+Create an API key in the [Google Cloud console](https://console.cloud.google.com/apis/credentials) and enable the **PageSpeed Insights API** for your project. A key raises your quota to 25,000 queries/day (400 per 100 seconds); without one, requests are heavily throttled.
+
+There is no list endpoint — every request runs a fresh, on-demand analysis of a single URL — so enter one URL per line (starting with `http://` or `https://`). For example:
+
+```
+https://posthog.com
+https://posthog.com/docs
+```
+
+Each analysis is a full Lighthouse run and can take several seconds. Each URL is analyzed once per selected table (desktop / mobile) per sync. To accumulate a history of scores over time, pick the **append** sync method on the table.
+""",
+            iconPath="/static/services/google_pagespeed_insights.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/google-pagespeed-insights",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="Your Google Cloud API key",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="urls",
+                        label="URLs",
+                        type=SourceFieldInputConfigType.TEXTAREA,
+                        required=True,
+                        placeholder="https://posthog.com\nhttps://posthog.com/docs",
+                        secret=False,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.canonical_descriptions import (  # noqa: PLC0415
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # An invalid key surfaces as a 400 (`API key not valid`) and a project without the API
+            # enabled as a 403 (`PERMISSION_DENIED`), both via `raise_for_status()`. Retrying can never
+            # satisfy a credential/enablement problem. Match the stable status text and base host (the
+            # `key` query param is redacted before the message reaches here).
+            "400 Client Error: Bad Request for url: https://pagespeedonline.googleapis.com": "Your API key is invalid, or the PageSpeed Insights API is not enabled for your Google Cloud project. Check the key and enable the API, then reconnect.",
+            "403 Client Error: Forbidden for url: https://pagespeedonline.googleapis.com": "Your API key does not have access to the PageSpeed Insights API. Enable the API for your Google Cloud project and check any key restrictions, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: GooglePageSpeedInsightsSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                # The API exposes no server-side change cursor (every request is a fresh analysis), so
+                # nothing is truly incremental. Append is supported: each sync re-runs the analysis and
+                # merge dedupes on `[requested_url, analysis_timestamp]`, accumulating a time series.
+                supports_incremental=False,
+                supports_append=True,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                should_sync_default=PAGESPEED_ENDPOINTS[endpoint].should_sync_default,
+                description=PAGESPEED_ENDPOINTS[endpoint].description,
+            )
+            for endpoint in ENDPOINTS
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: GooglePageSpeedInsightsSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        return validate_google_pagespeed_insights_credentials(config.api_key, config.urls)
+
+    def source_for_pipeline(self, config: GooglePageSpeedInsightsSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return google_pagespeed_insights_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            urls_raw=config.urls,
+            logger=inputs.logger,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights.py
@@ -1,0 +1,310 @@
+import json
+from typing import Any, Optional
+
+import pytest
+from unittest import mock
+
+import requests
+import structlog
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.google_pagespeed_insights import (
+    CATEGORIES,
+    MAX_URLS,
+    PAGESPEED_BASE_URL,
+    PageSpeedRetryableError,
+    _analysis_timestamp_to_iso,
+    _build_url,
+    _fetch,
+    _normalize_row,
+    _redact_key,
+    get_rows,
+    google_pagespeed_insights_source,
+    parse_urls,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.settings import (
+    PAGESPEED_ENDPOINTS,
+)
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.google_pagespeed_insights"
+
+
+def _response(status: int = 200, body: Optional[dict[str, Any]] = None) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.status_code = status
+    resp.ok = 200 <= status < 300
+    resp.json.return_value = body or {}
+    resp.text = json.dumps(body or {})
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            f"{status} Client Error for url: {PAGESPEED_BASE_URL}", response=requests.Response()
+        )
+    return resp
+
+
+class TestParseUrls:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("https://posthog.com", ["https://posthog.com"]),
+            ("  https://posthog.com  ", ["https://posthog.com"]),
+            ("https://posthog.com\nhttps://posthog.com/docs", ["https://posthog.com", "https://posthog.com/docs"]),
+            ("https://a.com\n\n  \nhttp://b.com", ["https://a.com", "http://b.com"]),
+            # Duplicates are dropped (order preserved) so one URL can't seed two rows with the same key.
+            ("https://a.com\nhttps://a.com", ["https://a.com"]),
+        ],
+    )
+    def test_valid(self, raw, expected):
+        assert parse_urls(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, "", "   \n  ", "posthog.com", "ftp://posthog.com", "not a url", "://missing-scheme"],
+    )
+    def test_invalid_raises(self, raw):
+        with pytest.raises(ValueError):
+            parse_urls(raw)
+
+    def test_rejects_too_many_urls(self):
+        raw = "\n".join(f"https://example.com/{i}" for i in range(MAX_URLS + 1))
+        with pytest.raises(ValueError, match="Too many URLs"):
+            parse_urls(raw)
+
+    def test_allows_max_urls(self):
+        raw = "\n".join(f"https://example.com/{i}" for i in range(MAX_URLS))
+        assert len(parse_urls(raw)) == MAX_URLS
+
+
+class TestBuildUrl:
+    def test_includes_url_strategy_key_and_repeated_categories(self):
+        url = _build_url("https://posthog.com", "MOBILE", "secret-key")
+
+        assert url.startswith(f"{PAGESPEED_BASE_URL}?")
+        assert "strategy=MOBILE" in url
+        assert "key=secret-key" in url
+        # The URL value is percent-encoded (Google expects it), so the raw scheme separator is escaped.
+        assert "url=https%3A%2F%2Fposthog.com" in url
+        # `category` is repeatable — one param per requested Lighthouse category.
+        assert url.count("category=") == len(CATEGORIES)
+
+
+class TestRedactKey:
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("https://x/runPagespeed?key=secret", "https://x/runPagespeed?key=REDACTED"),
+            (
+                "https://x/runPagespeed?url=a&key=secret&strategy=DESKTOP",
+                "https://x/runPagespeed?url=a&key=REDACTED&strategy=DESKTOP",
+            ),
+            # A field that merely contains "key" must not be redacted — only the `key` query param.
+            ("https://x/runPagespeed?pageToken=abc", "https://x/runPagespeed?pageToken=abc"),
+            ("no key here", "no key here"),
+        ],
+    )
+    def test_redact(self, text, expected):
+        assert _redact_key(text) == expected
+
+
+class TestAnalysisTimestampToIso:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("2024-01-15T12:34:56.789Z", "2024-01-15T12:34:56.789000+00:00"),
+            ("2024-01-15T12:34:56Z", "2024-01-15T12:34:56+00:00"),
+            # A non-UTC offset is normalized back to UTC.
+            ("2024-01-15T14:34:56+02:00", "2024-01-15T12:34:56+00:00"),
+            (None, None),
+            ("", None),
+            ("garbage", None),
+            (12345, None),
+        ],
+    )
+    def test_parse(self, value, expected):
+        assert _analysis_timestamp_to_iso(value) == expected
+
+
+class TestNormalizeRow:
+    def test_injects_requested_url_strategy_and_timestamp(self):
+        response = {
+            "analysisUTCTimestamp": "2024-01-15T12:34:56Z",
+            "id": "https://posthog.com/",
+            "lighthouseResult": {},
+        }
+        row = _normalize_row(PAGESPEED_ENDPOINTS["pagespeed_desktop"], response, "https://posthog.com")
+
+        assert row is not None
+        # The requested URL (not the echoed final `id`) is injected so the primary key stays stable.
+        assert row["requested_url"] == "https://posthog.com"
+        assert row["strategy"] == "DESKTOP"
+        assert row["analysis_timestamp"] == "2024-01-15T12:34:56+00:00"
+        # The raw response fields are preserved alongside the injected columns.
+        assert row["id"] == "https://posthog.com/"
+
+    def test_mobile_endpoint_stamps_mobile_strategy(self):
+        response = {"analysisUTCTimestamp": "2024-01-15T12:34:56Z"}
+        row = _normalize_row(PAGESPEED_ENDPOINTS["pagespeed_mobile"], response, "https://posthog.com")
+
+        assert row is not None
+        assert row["strategy"] == "MOBILE"
+
+    def test_unparseable_timestamp_returns_none(self):
+        # analysis_timestamp is part of the primary/partition key; a present-but-unparseable timestamp
+        # must not flow a null key into the merge.
+        response = {"analysisUTCTimestamp": "not-a-timestamp"}
+        assert _normalize_row(PAGESPEED_ENDPOINTS["pagespeed_desktop"], response, "https://posthog.com") is None
+
+    def test_missing_timestamp_field_raises(self):
+        # A missing timestamp field signals a structural API change and must fail loudly rather than
+        # silently dropping every row and reporting a successful zero-row sync.
+        with pytest.raises(KeyError):
+            _normalize_row(PAGESPEED_ENDPOINTS["pagespeed_desktop"], {"lighthouseResult": {}}, "https://posthog.com")
+
+
+# tenacity exposes the undecorated function via `__wrapped__`, so status classification can be
+# asserted without waiting through retry backoff.
+_fetch_once = _fetch.__wrapped__  # type: ignore[attr-defined]
+
+
+class TestFetch:
+    def test_success_returns_json(self):
+        session = mock.MagicMock()
+        session.get.return_value = _response(200, {"analysisUTCTimestamp": "2024-01-15T12:34:56Z"})
+
+        body = _fetch_once(session, "k", "DESKTOP", "https://posthog.com", structlog.get_logger())
+
+        assert body == {"analysisUTCTimestamp": "2024-01-15T12:34:56Z"}
+        session.get.assert_called_once()
+
+    @pytest.mark.parametrize("status", [429, 500, 503])
+    def test_retryable_statuses_raise_retryable(self, status):
+        session = mock.MagicMock()
+        session.get.return_value = _response(status)
+
+        with pytest.raises(PageSpeedRetryableError):
+            _fetch_once(session, "k", "DESKTOP", "https://posthog.com", structlog.get_logger())
+
+    @pytest.mark.parametrize("status", [400, 403, 404])
+    def test_client_error_raises_for_status(self, status):
+        session = mock.MagicMock()
+        session.get.return_value = _response(status)
+
+        with pytest.raises(requests.HTTPError):
+            _fetch_once(session, "k", "DESKTOP", "https://posthog.com", structlog.get_logger())
+
+    def test_error_message_redacts_key(self):
+        resp = mock.MagicMock()
+        resp.status_code = 400
+        resp.ok = False
+        resp.text = '{"error":{"message":"API key not valid."}}'
+        resp.raise_for_status.side_effect = requests.HTTPError(
+            "400 Client Error: Bad Request for url: "
+            "https://pagespeedonline.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://x&key=SUPERSECRETKEY",
+            response=requests.Response(),
+        )
+        session = mock.MagicMock()
+        session.get.return_value = resp
+
+        with pytest.raises(requests.HTTPError) as exc_info:
+            _fetch_once(session, "k", "DESKTOP", "https://posthog.com", structlog.get_logger())
+
+        message = str(exc_info.value)
+        assert "SUPERSECRETKEY" not in message
+        assert "key=REDACTED" in message
+        # The host prefix is preserved so non-retryable-error matching still works.
+        assert "for url: https://pagespeedonline.googleapis.com" in message
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        "status, expected_valid",
+        [(200, True), (400, False), (403, False), (500, False)],
+    )
+    def test_status_mapping(self, status, expected_valid):
+        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.return_value = _response(status)
+
+            is_valid, _ = validate_credentials("test-key", "https://posthog.com")
+
+        assert is_valid is expected_valid
+
+    def test_malformed_urls_is_invalid_without_request(self):
+        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+            is_valid, message = validate_credentials("test-key", "not-a-url")
+
+        assert is_valid is False
+        assert message is not None
+        mock_session.return_value.get.assert_not_called()
+
+    def test_network_error_is_invalid(self):
+        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.side_effect = Exception("boom")
+
+            is_valid, message = validate_credentials("test-key", "https://posthog.com")
+
+        assert is_valid is False
+        assert message is not None
+
+    def test_probes_first_url(self):
+        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.return_value = _response(200)
+
+            validate_credentials("test-key", "https://posthog.com\nhttps://example.com")
+
+            called_url = mock_session.return_value.get.call_args[0][0]
+
+        assert "url=https%3A%2F%2Fposthog.com" in called_url
+
+
+class TestGetRows:
+    def test_yields_one_batch_per_url_and_targets_each(self):
+        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.side_effect = [
+                _response(200, {"analysisUTCTimestamp": "2024-01-15T12:00:00Z"}),
+                _response(200, {"analysisUTCTimestamp": "2024-01-15T12:00:01Z"}),
+            ]
+
+            batches = list(
+                get_rows("test-key", "pagespeed_desktop", ["https://a.com", "https://b.com"], structlog.get_logger())
+            )
+
+        assert len(batches) == 2
+        assert batches[0][0]["requested_url"] == "https://a.com"
+        assert batches[1][0]["requested_url"] == "https://b.com"
+        assert all(batch[0]["strategy"] == "DESKTOP" for batch in batches)
+
+    def test_targets_requested_strategy(self):
+        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.return_value = _response(
+                200, {"analysisUTCTimestamp": "2024-01-15T12:00:00Z"}
+            )
+
+            list(get_rows("test-key", "pagespeed_mobile", ["https://a.com"], structlog.get_logger()))
+
+            called_url = mock_session.return_value.get.call_args[0][0]
+
+        assert "strategy=MOBILE" in called_url
+
+    def test_skips_rows_with_unparseable_timestamp(self):
+        with mock.patch(f"{MODULE}.make_tracked_session") as mock_session:
+            mock_session.return_value.get.return_value = _response(200, {"analysisUTCTimestamp": "garbage"})
+
+            batches = list(get_rows("test-key", "pagespeed_desktop", ["https://a.com"], structlog.get_logger()))
+
+        assert batches == []
+
+
+class TestSource:
+    @pytest.mark.parametrize("endpoint", list(PAGESPEED_ENDPOINTS))
+    def test_source_response_shape(self, endpoint):
+        response = google_pagespeed_insights_source("test-key", endpoint, "https://posthog.com", structlog.get_logger())
+
+        assert response.name == endpoint
+        assert response.primary_keys == ["requested_url", "analysis_timestamp"]
+        assert response.partition_mode == "datetime"
+        assert response.partition_keys == ["analysis_timestamp"]
+        assert response.sort_mode == "asc"
+
+    def test_invalid_urls_raise(self):
+        with pytest.raises(ValueError):
+            google_pagespeed_insights_source("test-key", "pagespeed_desktop", "garbage", structlog.get_logger())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights.py
@@ -65,6 +65,26 @@ class TestParseUrls:
         with pytest.raises(ValueError):
             parse_urls(raw)
 
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "http://localhost",
+            "http://127.0.0.1",
+            "http://10.0.0.1",
+            "http://192.168.1.1",
+            # Cloud metadata endpoint (link-local) — the classic SSRF target.
+            "http://169.254.169.254",
+            "http://[::1]",
+            "https://service.internal",
+            "https://printer.local",
+        ],
+    )
+    def test_rejects_private_hosts(self, raw):
+        # Defense-in-depth: private / loopback / internal hosts are rejected up front rather than
+        # handed to the connector, even though the actual fetch runs on Google's servers.
+        with pytest.raises(ValueError, match="cannot be analyzed"):
+            parse_urls(raw)
+
     def test_rejects_too_many_urls(self):
         raw = "\n".join(f"https://example.com/{i}" for i in range(MAX_URLS + 1))
         with pytest.raises(ValueError, match="Too many URLs"):
@@ -213,6 +233,24 @@ class TestFetch:
         assert "key=REDACTED" in message
         # The host prefix is preserved so non-retryable-error matching still works.
         assert "for url: https://pagespeedonline.googleapis.com" in message
+
+    @pytest.mark.parametrize("exc_type", [requests.ConnectionError, requests.ReadTimeout, requests.exceptions.SSLError])
+    def test_transport_error_redacts_key_and_preserves_type(self, exc_type):
+        # Transport failures (no HTTP response) embed the full request URL, including `key=...`, in
+        # their message. They must be re-raised redacted and with their original type so the key never
+        # reaches `latest_error` and retry classification is unchanged.
+        session = mock.MagicMock()
+        session.get.side_effect = exc_type(
+            "HTTPSConnectionPool(host='pagespeedonline.googleapis.com'): "
+            "url: /pagespeedonline/v5/runPagespeed?url=https://x&key=SUPERSECRETKEY"
+        )
+
+        with pytest.raises(exc_type) as exc_info:
+            _fetch_once(session, "k", "DESKTOP", "https://posthog.com", structlog.get_logger())
+
+        message = str(exc_info.value)
+        assert "SUPERSECRETKEY" not in message
+        assert "key=REDACTED" in message
 
 
 class TestValidateCredentials:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights_source.py
@@ -1,0 +1,148 @@
+import pytest
+from unittest import mock
+
+import structlog
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
+    GooglePageSpeedInsightsSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.settings import (
+    ENDPOINTS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.source import (
+    GooglePageSpeedInsightsSource,
+)
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+def _make_inputs(schema_name: str = "pagespeed_desktop") -> SourceInputs:
+    return SourceInputs(
+        schema_name=schema_name,
+        schema_id="schema-id",
+        source_id="source-id",
+        team_id=123,
+        should_use_incremental_field=False,
+        db_incremental_field_last_value=None,
+        db_incremental_field_earliest_value=None,
+        incremental_field=None,
+        incremental_field_type=None,
+        job_id="job-id",
+        logger=structlog.get_logger(),
+        reset_pipeline=False,
+    )
+
+
+class TestGooglePageSpeedInsightsSource:
+    def setup_method(self):
+        self.source = GooglePageSpeedInsightsSource()
+        self.team_id = 123
+        self.config = GooglePageSpeedInsightsSourceConfig(api_key="test-key", urls="https://posthog.com")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.GOOGLEPAGESPEEDINSIGHTS
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "GooglePageSpeedInsights"
+        assert config.label == "Google PageSpeed Insights"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is True
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/google-pagespeed-insights"
+
+    def test_get_source_config_fields(self):
+        fields = self.source.get_source_config.fields
+
+        by_name = {field.name: field for field in fields if isinstance(field, SourceFieldInputConfig)}
+        assert set(by_name) == {"api_key", "urls"}
+
+        api_key_field = by_name["api_key"]
+        assert api_key_field.type == SourceFieldInputConfigType.PASSWORD
+        assert api_key_field.required is True
+        assert api_key_field.secret is True
+
+        urls_field = by_name["urls"]
+        assert urls_field.type == SourceFieldInputConfigType.TEXTAREA
+        assert urls_field.required is True
+        assert urls_field.secret is False
+
+    def test_lists_tables_without_credentials(self):
+        # Static endpoint catalog with no I/O — must opt in so public docs render the table list.
+        assert self.source.lists_tables_without_credentials is True
+
+    def test_get_schemas_lists_all_endpoints(self):
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert {schema.name for schema in schemas} == set(ENDPOINTS)
+
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_get_schemas_supports_append_not_incremental(self, endpoint):
+        # The API has no server-side change cursor, so nothing is truly incremental; all tables support
+        # append so users can accumulate score snapshots over time.
+        schemas = {schema.name: schema for schema in self.source.get_schemas(self.config, self.team_id)}
+
+        assert schemas[endpoint].supports_incremental is False
+        assert schemas[endpoint].supports_append is True
+        assert [f["field"] for f in schemas[endpoint].incremental_fields] == ["analysis_timestamp"]
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["pagespeed_mobile"])
+
+        assert [schema.name for schema in schemas] == ["pagespeed_mobile"]
+
+    def test_get_schemas_filtered_unknown_name_returns_empty(self):
+        assert self.source.get_schemas(self.config, self.team_id, names=["nonexistent"]) == []
+
+    @pytest.mark.parametrize("status", ["400 Client Error: Bad Request", "403 Client Error: Forbidden"])
+    def test_non_retryable_errors_cover_auth_failures(self, status):
+        errors = self.source.get_non_retryable_errors()
+
+        assert any(status in key and "pagespeedonline.googleapis.com" in key for key in errors)
+
+    def test_documented_tables_render_without_credentials(self):
+        # Exercises the public-docs path: a credential-free placeholder config must list every table.
+        tables = self.source.get_documented_tables()
+
+        assert {table["name"] for table in tables} == set(ENDPOINTS)
+
+    def test_canonical_descriptions_cover_every_endpoint(self):
+        descriptions = self.source.get_canonical_descriptions()
+
+        assert set(descriptions) == set(ENDPOINTS)
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            ((True, None), True, None),
+            ((False, "Invalid API key"), False, "Invalid API key"),
+        ],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.source.validate_google_pagespeed_insights_credentials"
+    )
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id, "pagespeed_desktop")
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.api_key, self.config.urls)
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_pagespeed_insights.source.google_pagespeed_insights_source"
+    )
+    def test_source_for_pipeline_plumbs_args(self, mock_source):
+        inputs = _make_inputs(schema_name="pagespeed_mobile")
+
+        self.source.source_for_pipeline(self.config, inputs)
+
+        mock_source.assert_called_once_with(
+            api_key="test-key",
+            endpoint="pagespeed_mobile",
+            urls_raw="https://posthog.com",
+            logger=inputs.logger,
+        )


### PR DESCRIPTION
## Problem

We have a scaffolded but non-functional `google_pagespeed_insights` data warehouse source (registered as unreleased, empty `source.py`). This PR implements it end-to-end so teams can pull [Google PageSpeed Insights](https://developers.google.com/speed/docs/insights/v5/get-started) / Lighthouse scores (performance, accessibility, best-practices, SEO, plus the full Lighthouse report and Chrome UX Report field data) for their pages into the warehouse and track them over time alongside product data.

**Why:** the task was to take the merged stub for this source and make it actually sync, following the `implementing-warehouse-sources` skill contract.

## Changes

The PageSpeed Insights v5 API is a single `GET runPagespeed` endpoint that runs an on-demand Lighthouse analysis of one supplied URL and returns a large nested JSON document. There is no listable resource, no pagination, and no server-side change cursor, so this is a `SimpleSource` driven by a user-supplied URL list, modelled closely on the existing `breezometer` source (another single-point Google API connector).

- **Config:** `api_key` (Google Cloud API key, sent on the `key` query param) + `urls` (one per line, capped at 50 since each call is a slow full Lighthouse run).
- **Tables:** `pagespeed_desktop` and `pagespeed_mobile`. PageSpeed runs one device profile per request, so each strategy is its own table, letting users sync only the profiles they need to halve quota spend.
- **Rows:** one row per URL per sync. We inject `requested_url` (stable, as configured, not the echoed final URL) and `strategy`, and derive `analysis_timestamp` (ISO 8601 UTC from `analysisUTCTimestamp`) as the partition key and append cursor. Primary key is `[requested_url, analysis_timestamp]`.
- **Sync modes:** full refresh, plus append so users can accumulate a time series of scores (merge dedupes on the primary key). Nothing is marked incremental because the API exposes no server-side timestamp filter.
- **HTTP:** all traffic goes through `make_tracked_session()`. `tenacity` retries `429` / `5xx` with backoff. The `key` query param is redacted from error messages and logs. `get_non_retryable_errors()` maps `400` / `403` to actionable credential messages.
- **Docs metadata:** `lists_tables_without_credentials = True` (static endpoint catalog), plus `canonical_descriptions.py` sourced from the official API docs so the public Supported tables section renders.

> [!NOTE]
> The source is intentionally kept behind `unreleasedSource=True` with `releaseStatus=alpha`, as requested. The enum / schema / generated-config wiring was already merged on master, so this PR only fills the `GooglePageSpeedInsightsSourceConfig` fields (regenerated via `generate_source_configs`) and does not add a migration.

The user-facing posthog.com doc was written following the `documenting-warehouse-sources` skill (canonical template, shared snippets, `<SourceParameters />` + `<SourceTables />`, `sourceId: GooglePageSpeedInsights`, slug `google-pagespeed-insights` matching `docsUrl`). It lives in the **posthog.com** repo, which is not checked out here, so it still needs to land there and have `audit_source_docs` run against it.

## How did you test this code?

Automated tests only (I, Claude, could not run a live sync or curl the API without a Google Cloud API key):

- `test_google_pagespeed_insights.py` (transport) — URL parsing/validation/dedupe/cap, URL construction with repeated `category` params, key redaction, `analysisUTCTimestamp` parsing, row normalization (injected columns, unparseable-timestamp skip, missing-field `KeyError`), retryable vs client-error status classification, credential validation status mapping, and per-URL/per-strategy row emission.
- `test_google_pagespeed_insights_source.py` (source class) — `source_type`, config fields feeding the frontend form, schema list + append-not-incremental semantics, non-retryable error coverage, public-docs table rendering, canonical descriptions, and `validate_credentials` / `source_for_pipeline` arg plumbing.

All 67 pass. Also ran the shared `test_source_categories` and `test_source_config_generator` suites (green) to confirm the source is wired into the registry with a category and a correct generated config. `ruff check` / `ruff format` clean.

> [!WARNING]
> Endpoint behavior (accepted `category` enum, error-body shapes) could not be curl-verified without an API key. Conservative choices are documented in code comments: PWA is omitted from the requested categories because it was removed from Lighthouse 12, and a persistent per-URL failure fails the sync loudly rather than being silently skipped (a bad-key `400` can't be reliably distinguished from a bad-URL `400` without live verification).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8). Skills invoked while producing this PR: `/implementing-warehouse-sources`, `/documenting-warehouse-sources`, and `/writing-tests`.

Approach: surveyed the source contract and picked `breezometer` (a single-point Google Maps API connector driven by a user-supplied location list) as the closest reference, since PageSpeed has the same shape (no listable resource, full-refresh + append, a Google API key on the `key` query param, a derived stable timestamp as partition key). Modelled the two device strategies as separate tables rather than a config field so users can deselect a profile to save quota. Regenerated the source config via the management command, but reverted the generator's unrelated churn to other sources (stale formatting + field drift) and applied only the two intended lines to `generated_configs.py` to keep the diff scoped. Left `unreleasedSource=True` per the task even though the skill's default is to ship released.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
