### PR TITLE
feat(data-warehouse): implement zapier_supported_storage import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -417,6 +417,7 @@ the row lists both.
 | wrike                   | HTTP                        | requests                                                        | ✅                          |
 | writesonic              | HTTP                        | requests                                                        | ✅                          |
 | wufoo                   | HTTP                        | requests                                                        | ✅                          |
+| zapier_supported_storage | HTTP                       | requests                                                        | ✅                          |
 | zendesk                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | zendesk_sell            | HTTP                        | requests                                                        | ✅                          |
 | zenloop                 | HTTP                        | requests                                                        | ✅                          |
@@ -864,7 +865,6 @@ doesn't conflict with concurrent PRs.
 - yousign
 - youtube_analytics
 - youtube_data
-- zapier_supported_storage
 - zapsign
 - zellify
 - zendesk_sunshine

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -42,388 +42,388 @@ the row lists both.
 
 ## Implemented sources
 
-| Source                  | Comm method                 | Primary library                                                 | Tracked transport           |
-| ----------------------- | --------------------------- | --------------------------------------------------------------- | --------------------------- |
-| adroll                  | HTTP                        | requests                                                        | ✅                          |
-| agilecrm                | HTTP                        | requests                                                        | ✅                          |
-| aha                     | HTTP                        | requests                                                        | ✅                          |
-| aircall                 | HTTP                        | requests                                                        | ✅                          |
-| airtable                | HTTP                        | requests                                                        | ✅                          |
-| algolia                 | HTTP                        | requests                                                        | ✅                          |
-| alguna                  | HTTP                        | requests                                                        | ✅                          |
-| alpha_vantage           | HTTP                        | requests                                                        | ✅                          |
-| amazon_ads              | HTTP                        | requests                                                        | ✅                          |
-| amplitude               | HTTP                        | requests                                                        | ✅                          |
-| anthropic               | HTTP                        | requests                                                        | ✅                          |
-| apify_dataset           | HTTP                        | requests                                                        | ✅                          |
-| apollo                  | HTTP                        | requests                                                        | ✅                          |
-| appfigures              | HTTP                        | requests                                                        | ✅                          |
-| appfollow               | HTTP                        | requests                                                        | ✅                          |
-| appsflyer               | HTTP (CSV reports)          | requests                                                        | ✅                          |
-| asana                   | HTTP                        | requests                                                        | ✅                          |
-| ashby                   | HTTP                        | requests                                                        | ✅                          |
-| assemblyai              | HTTP                        | requests                                                        | ✅                          |
-| attentive               | HTTP (webhook-first)        | requests (webhook management)                                   | ✅                          |
-| attio                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| aviationstack           | HTTP                        | requests                                                        | ✅                          |
-| aviator                 | HTTP                        | requests                                                        | ✅                          |
-| awin                    | HTTP                        | requests                                                        | ✅                          |
-| azure_devops            | HTTP                        | requests                                                        | ✅                          |
-| bamboohr                | HTTP                        | requests                                                        | ✅                          |
-| beamer                  | HTTP                        | requests                                                        | ✅                          |
-| bigmailer               | HTTP                        | requests                                                        | ✅                          |
-| bigquery                | HTTP + gRPC                 | google-cloud-bigquery + bigquery-storage                        | ✅ (HTTP + gRPC)            |
-| bing_ads                | HTTP (vendor SDK, SOAP)     | bingads SDK                                                     | ⚠️                          |
-| bland_ai                | HTTP                        | requests                                                        | ✅                          |
-| blogger                 | HTTP                        | requests                                                        | ✅                          |
-| bluetally               | HTTP                        | requests                                                        | ✅                          |
-| boldsign                | HTTP                        | requests                                                        | ✅                          |
-| braintree               | HTTP (GraphQL)              | requests                                                        | ✅                          |
-| braze                   | HTTP                        | requests                                                        | ✅                          |
-| breezometer             | HTTP                        | requests                                                        | ✅                          |
-| brevo                   | HTTP                        | requests                                                        | ✅                          |
-| brex                    | HTTP                        | requests                                                        | ✅                          |
-| bugsnag                 | HTTP                        | requests                                                        | ✅                          |
-| buildbetter             | HTTP                        | requests                                                        | ✅                          |
-| buildkite               | HTTP                        | requests                                                        | ✅                          |
-| bunny                   | HTTP                        | requests                                                        | ✅                          |
-| buzzsprout              | HTTP                        | requests                                                        | ✅                          |
-| cal_com                 | HTTP                        | requests                                                        | ✅                          |
-| calendly                | HTTP                        | requests                                                        | ✅                          |
-| callrail                | HTTP                        | requests                                                        | ✅                          |
-| campaign_monitor        | HTTP                        | requests                                                        | ✅                          |
-| campayn                 | HTTP                        | requests                                                        | ✅                          |
-| canny                   | HTTP                        | requests                                                        | ✅                          |
-| capsule_crm             | HTTP                        | requests                                                        | ✅                          |
-| care_quality_commission | HTTP                        | requests                                                        | ✅                          |
-| chameleon               | HTTP                        | requests                                                        | ✅                          |
-| chargebee               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| chargedesk              | HTTP                        | requests                                                        | ✅                          |
-| chargify                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| charthop                | HTTP                        | requests                                                        | ✅                          |
-| checkout_com            | HTTP                        | requests                                                        | ✅                          |
-| churnkey                | HTTP                        | requests                                                        | ✅                          |
-| coassemble              | HTTP                        | requests                                                        | ✅                          |
-| coda                    | HTTP                        | requests                                                        | ✅                          |
-| codefresh               | HTTP                        | requests                                                        | ✅                          |
-| coin_api                | HTTP                        | requests                                                        | ✅                          |
-| coingecko               | HTTP                        | requests                                                        | ✅                          |
-| coinmarketcap           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| commercetools           | HTTP                        | requests                                                        | ✅                          |
-| concord                 | HTTP                        | requests                                                        | ✅                          |
-| configcat               | HTTP                        | requests                                                        | ✅                          |
-| confluence              | HTTP                        | requests                                                        | ✅                          |
-| chartmogul              | HTTP                        | requests                                                        | ✅                          |
-| circleci                | HTTP                        | requests                                                        | ✅                          |
-| cimis                   | HTTP                        | requests                                                        | ✅                          |
-| cloudflare              | HTTP                        | requests                                                        | ✅                          |
-| clari                   | HTTP                        | requests                                                        | ✅                          |
-| clerk                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| clickhouse              | DB protocol (HTTP-based)    | clickhouse-connect / clickhouse-driver                          | ➖                          |
-| clickup                 | HTTP                        | requests                                                        | ✅                          |
-| clockify                | HTTP                        | requests                                                        | ✅                          |
-| clockodo                | HTTP                        | requests                                                        | ✅                          |
-| close                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| cloudbeds               | HTTP                        | requests                                                        | ✅                          |
-| convertkit              | HTTP                        | requests                                                        | ✅                          |
-| convex                  | HTTP                        | requests                                                        | ✅                          |
-| copper                  | HTTP                        | requests                                                        | ✅                          |
-| coupa                   | HTTP                        | requests                                                        | ✅                          |
-| crunchbase              | HTTP                        | requests                                                        | ✅                          |
-| culture_amp             | HTTP                        | requests                                                        | ✅                          |
-| cursor                  | HTTP                        | requests                                                        | ✅                          |
-| customer_io             | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
-| datadog                 | HTTP                        | requests                                                        | ✅                          |
-| decagon                 | HTTP                        | requests                                                        | ✅                          |
-| deel                    | HTTP                        | requests                                                        | ✅                          |
-| deepgram                | HTTP                        | requests                                                        | ✅                          |
-| delighted               | HTTP                        | requests                                                        | ✅                          |
-| deno_deploy             | HTTP                        | requests                                                        | ✅                          |
-| devin_ai                | HTTP                        | requests                                                        | ✅                          |
-| ding_connect            | HTTP                        | requests                                                        | ✅                          |
-| dixa                    | HTTP                        | requests                                                        | ✅                          |
-| dockerhub               | HTTP                        | requests                                                        | ✅                          |
-| docuseal                | HTTP                        | requests                                                        | ✅                          |
-| doit                    | HTTP                        | requests                                                        | ✅                          |
-| dropbox_sign            | HTTP                        | requests                                                        | ✅                          |
-| drip                    | HTTP                        | requests                                                        | ✅                          |
-| e_conomic               | HTTP                        | requests                                                        | ✅                          |
-| easypost                | HTTP                        | requests                                                        | ✅                          |
-| easypromos              | HTTP                        | requests                                                        | ✅                          |
-| elevenlabs              | HTTP                        | requests                                                        | ✅                          |
-| freshcaller             | HTTP                        | requests                                                        | ✅                          |
-| freshdesk               | HTTP                        | requests                                                        | ✅                          |
-| freshsales              | HTTP                        | requests                                                        | ✅                          |
-| freshservice            | HTTP                        | requests                                                        | ✅                          |
-| elasticemail            | HTTP                        | requests                                                        | ✅                          |
-| elasticsearch           | HTTP                        | requests                                                        | ✅                          |
-| emailoctopus            | HTTP                        | requests                                                        | ✅                          |
-| eventbrite              | HTTP                        | requests                                                        | ✅                          |
-| eventee                 | HTTP                        | requests                                                        | ✅                          |
-| eventzilla              | HTTP                        | requests                                                        | ✅                          |
-| everhour                | HTTP                        | requests                                                        | ✅                          |
-| exchange_rates_api      | HTTP                        | requests                                                        | ✅                          |
-| ezofficeinventory       | HTTP                        | requests                                                        | ✅                          |
-| factorial               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| fastly                  | HTTP                        | requests                                                        | ✅                          |
-| fillout                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| finage                  | HTTP                        | requests                                                        | ✅                          |
-| financial_modelling     | HTTP                        | requests                                                        | ✅                          |
-| finnhub                 | HTTP                        | requests                                                        | ✅                          |
-| finnworlds              | HTTP                        | requests                                                        | ✅                          |
-| firecrawl               | HTTP                        | requests                                                        | ✅                          |
-| fleetio                 | HTTP                        | requests                                                        | ✅                          |
-| firehydrant             | HTTP                        | requests                                                        | ✅                          |
-| flexmail                | HTTP                        | requests                                                        | ✅                          |
-| float_app               | HTTP                        | requests                                                        | ✅                          |
-| front                   | HTTP                        | requests                                                        | ✅                          |
-| fulcrum                 | HTTP                        | requests                                                        | ✅                          |
-| fullstory               | HTTP                        | requests                                                        | ✅                          |
-| gainsight_px            | HTTP                        | requests                                                        | ✅                          |
-| gitbook                 | HTTP                        | requests                                                        | ✅                          |
-| github                  | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
-| giphy                   | HTTP                        | requests                                                        | ✅                          |
-| gitlab                  | HTTP                        | requests                                                        | ✅                          |
-| gladly                  | HTTP                        | requests                                                        | ✅                          |
-| gnews                   | HTTP                        | requests                                                        | ✅                          |
-| gocardless              | HTTP                        | requests                                                        | ✅                          |
-| goldcast                | HTTP                        | requests                                                        | ✅                          |
-| gong                    | HTTP                        | requests                                                        | ✅                          |
-| google_ads              | gRPC                        | google-ads (googleads.client)                                   | ✅                          |
-| google_analytics        | HTTP                        | requests (`AuthorizedSession` + `TrackedHTTPAdapter`)           | ✅                          |
-| google_sheets           | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
-| google_webfonts         | HTTP                        | requests                                                        | ✅                          |
-| granola                 | HTTP                        | requests                                                        | ✅                          |
-| gorgias                 | HTTP                        | requests                                                        | ✅                          |
-| greenhouse              | HTTP                        | requests                                                        | ✅                          |
-| gridly                  | HTTP                        | requests                                                        | ✅                          |
-| guardian                | HTTP                        | requests                                                        | ✅                          |
-| guru                    | HTTP                        | requests                                                        | ✅                          |
-| harvey                  | HTTP                        | requests                                                        | ✅                          |
-| hatchet                 | HTTP                        | requests                                                        | ✅                          |
-| healthchecks            | HTTP                        | requests                                                        | ✅                          |
-| height                  | HTTP                        | requests                                                        | ✅                          |
-| hellobaton              | HTTP                        | requests                                                        | ✅                          |
-| hibob                   | HTTP                        | requests                                                        | ✅                          |
-| humanitix               | HTTP                        | requests                                                        | ✅                          |
-| hubplanner              | HTTP                        | requests                                                        | ✅                          |
-| hubspot                 | HTTP                        | requests                                                        | ✅                          |
-| hugging_face            | HTTP                        | requests                                                        | ✅                          |
-| huntr                   | HTTP                        | requests                                                        | ✅                          |
-| incident_io             | HTTP                        | requests                                                        | ✅                          |
-| inflowinventory         | HTTP                        | requests                                                        | ✅                          |
-| insightly               | HTTP                        | requests                                                        | ✅                          |
-| instatus                | HTTP                        | requests                                                        | ✅                          |
-| intercom                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| intruder                | HTTP                        | requests                                                        | ✅                          |
-| invoiced                | HTTP                        | requests                                                        | ✅                          |
-| invoiceninja            | HTTP                        | requests                                                        | ✅                          |
-| ip2whois                | HTTP                        | requests                                                        | ✅                          |
-| iterable                | HTTP                        | requests                                                        | ✅                          |
-| jira                    | HTTP                        | requests                                                        | ✅                          |
-| jobnimbus               | HTTP                        | requests                                                        | ✅                          |
-| jotform                 | HTTP                        | requests                                                        | ✅                          |
-| judgeme_reviews         | HTTP                        | requests                                                        | ✅                          |
-| justcall                | HTTP                        | requests                                                        | ✅                          |
-| justsift                | HTTP                        | requests                                                        | ✅                          |
-| k6_cloud                | HTTP                        | requests                                                        | ✅                          |
-| katana                  | HTTP                        | requests                                                        | ✅                          |
-| klaviyo                 | HTTP                        | requests                                                        | ✅                          |
-| lago                    | HTTP                        | requests                                                        | ✅                          |
-| launchdarkly            | HTTP                        | requests                                                        | ✅                          |
-| kustomer                | HTTP                        | requests                                                        | ✅                          |
-| lattice                 | HTTP                        | requests                                                        | ✅                          |
-| leadfeeder              | HTTP                        | requests                                                        | ✅                          |
-| lemlist                 | HTTP                        | requests                                                        | ✅                          |
-| less_annoying_crm       | HTTP                        | requests                                                        | ✅                          |
-| lightspeed_retail       | HTTP                        | requests                                                        | ✅                          |
-| linear                  | HTTP                        | requests                                                        | ✅                          |
-| lever                   | HTTP                        | requests                                                        | ✅                          |
-| lingo_dev               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| linkedin_ads            | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
-| linkrunner              | HTTP                        | requests                                                        | ✅                          |
-| linode                  | HTTP                        | requests                                                        | ✅                          |
-| lob                     | HTTP                        | requests                                                        | ✅                          |
-| luma                    | HTTP                        | requests                                                        | ✅                          |
-| mailchimp               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| mailerlite              | HTTP                        | requests                                                        | ✅                          |
-| mailersend              | HTTP                        | requests                                                        | ✅                          |
-| mailgun                 | HTTP                        | requests                                                        | ✅                          |
-| mailjet                 | HTTP                        | requests                                                        | ✅                          |
-| mailosaur               | HTTP                        | requests                                                        | ✅                          |
-| mailtrap                | HTTP                        | requests                                                        | ✅                          |
-| marketstack             | HTTP                        | requests                                                        | ✅                          |
-| matomo                  | HTTP                        | requests                                                        | ✅                          |
-| maxio                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| mention                 | HTTP                        | requests                                                        | ✅                          |
-| meta_ads                | HTTP                        | requests                                                        | ✅                          |
-| metabase                | HTTP                        | requests                                                        | ✅                          |
-| metorial                | HTTP                        | requests                                                        | ✅                          |
-| mistral_ai              | HTTP                        | requests                                                        | ✅                          |
-| mixmax                  | HTTP                        | requests                                                        | ✅                          |
-| mixpanel                | HTTP                        | requests                                                        | ✅                          |
-| mollie                  | HTTP                        | requests                                                        | ✅                          |
-| monday                  | HTTP (GraphQL)              | requests                                                        | ✅                          |
-| mongodb                 | DB protocol                 | pymongo                                                         | ➖                          |
-| mssql                   | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
-| mux                     | HTTP                        | requests                                                        | ✅                          |
-| my_hours                | HTTP                        | requests                                                        | ✅                          |
-| mysql                   | DB protocol                 | pymysql                                                         | ➖                          |
-| n8n                     | HTTP                        | requests                                                        | ✅                          |
-| netlify                 | HTTP                        | requests                                                        | ✅                          |
-| new_york_times          | HTTP                        | requests                                                        | ✅                          |
-| news_api                | HTTP                        | requests                                                        | ✅                          |
-| newsdata                | HTTP                        | requests                                                        | ✅                          |
-| okta                    | HTTP                        | requests                                                        | ✅                          |
-| nocrm                   | HTTP                        | requests                                                        | ✅                          |
-| northpass_lms           | HTTP                        | requests                                                        | ✅                          |
-| notion                  | HTTP                        | requests                                                        | ✅                          |
-| omnisend                | HTTP                        | requests                                                        | ✅                          |
-| oncehub                 | HTTP                        | requests                                                        | ✅                          |
-| onepagecrm              | HTTP                        | requests                                                        | ✅                          |
-| onfleet                 | HTTP (cursor pagination)    | requests                                                        | ✅                          |
-| open_exchange_rates     | HTTP                        | requests                                                        | ✅                          |
-| opinion_stage           | HTTP                        | requests                                                        | ✅                          |
-| orb                     | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| openaq                  | HTTP                        | requests                                                        | ✅                          |
-| openfda                 | HTTP                        | requests                                                        | ✅                          |
-| openweather             | HTTP                        | requests                                                        | ✅                          |
-| ortto                   | HTTP                        | requests                                                        | ✅                          |
-| oura                    | HTTP                        | requests                                                        | ✅                          |
-| outbrain                | HTTP                        | requests                                                        | ✅                          |
-| paddle                  | HTTP                        | requests                                                        | ✅                          |
-| optimizely              | HTTP                        | requests                                                        | ✅                          |
-| pagerduty               | HTTP                        | requests                                                        | ✅                          |
-| pandadoc                | HTTP                        | requests                                                        | ✅                          |
-| paperform               | HTTP                        | requests                                                        | ✅                          |
-| papersign               | HTTP                        | requests                                                        | ✅                          |
-| partnerize              | HTTP                        | requests                                                        | ✅                          |
-| partnerstack            | HTTP                        | requests                                                        | ✅                          |
-| payfit                  | HTTP                        | requests                                                        | ✅                          |
-| paystack                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| pendo                   | HTTP                        | requests                                                        | ✅                          |
-| persistiq               | HTTP                        | requests                                                        | ✅                          |
-| persona                 | HTTP                        | requests                                                        | ✅                          |
-| personio                | HTTP                        | requests                                                        | ✅                          |
-| pexels                  | HTTP                        | requests                                                        | ✅                          |
-| phyllo                  | HTTP                        | requests                                                        | ✅                          |
-| picqer                  | HTTP                        | requests                                                        | ✅                          |
-| pingdom                 | HTTP                        | requests                                                        | ✅                          |
-| pinterest_ads           | HTTP                        | requests                                                        | ✅                          |
-| pipedrive               | HTTP                        | requests                                                        | ✅                          |
-| pipeliner               | HTTP                        | requests                                                        | ✅                          |
-| plain                   | HTTP                        | requests                                                        | ✅                          |
-| planhat                 | HTTP                        | requests                                                        | ✅                          |
-| plausible               | HTTP                        | requests                                                        | ✅                          |
-| polar                   | HTTP                        | requests                                                        | ✅                          |
-| plaid                   | HTTP                        | requests                                                        | ✅                          |
-| postgres                | DB protocol                 | psycopg                                                         | ➖                          |
-| postmark                | HTTP                        | requests                                                        | ✅                          |
-| pretix                  | HTTP                        | requests                                                        | ✅                          |
-| printify                | HTTP                        | requests                                                        | ✅                          |
-| productboard            | HTTP                        | requests                                                        | ✅                          |
-| pylon                   | HTTP                        | requests                                                        | ✅                          |
-| qualaroo                | HTTP                        | requests                                                        | ✅                          |
-| recurly                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| ramp                    | HTTP                        | requests                                                        | ✅                          |
-| recharge                | HTTP                        | requests                                                        | ✅                          |
-| recruitee               | HTTP                        | requests                                                        | ✅                          |
-| reddit_ads              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| redshift                | DB protocol                 | psycopg (Postgres-compatible)                                   | ➖                          |
-| rentcast                | HTTP                        | requests                                                        | ✅                          |
-| reply_io                | HTTP                        | requests                                                        | ✅                          |
-| resend                  | HTTP                        | requests                                                        | ✅                          |
-| retently                | HTTP                        | requests                                                        | ✅                          |
-| revenuecat              | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
-| rippling                | HTTP                        | requests                                                        | ✅                          |
-| rocketlane              | HTTP                        | requests                                                        | ✅                          |
-| rollbar                 | HTTP                        | requests                                                        | ✅                          |
-| rootly                  | HTTP                        | requests                                                        | ✅                          |
-| rss                     | HTTP                        | requests                                                        | ✅                          |
-| ruddr                   | HTTP                        | requests                                                        | ✅                          |
-| safetyculture           | HTTP                        | requests                                                        | ✅                          |
-| salesforce              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| salesflare              | HTTP                        | requests                                                        | ✅                          |
-| salesloft               | HTTP                        | requests                                                        | ✅                          |
-| savvycal                | HTTP                        | requests                                                        | ✅                          |
-| scale_ai                | HTTP                        | requests                                                        | ✅                          |
-| scaleway                | HTTP                        | requests                                                        | ✅                          |
-| secoda                  | HTTP                        | requests                                                        | ✅                          |
-| segment                 | HTTP                        | requests                                                        | ✅                          |
-| sendgrid                | HTTP                        | requests                                                        | ✅                          |
-| sendowl                 | HTTP                        | requests                                                        | ✅                          |
-| sentry                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| servicenow              | HTTP                        | requests                                                        | ✅                          |
-| shippo                  | HTTP                        | requests                                                        | ✅                          |
-| shipstation             | HTTP                        | requests                                                        | ✅                          |
-| shopify                 | HTTP                        | requests                                                        | ✅                          |
-| shopwired               | HTTP                        | requests                                                        | ✅                          |
-| shortcut                | HTTP                        | requests                                                        | ✅                          |
-| shortio                 | HTTP                        | requests                                                        | ✅                          |
-| simplecast              | HTTP                        | requests                                                        | ✅                          |
-| simplesat               | HTTP                        | requests                                                        | ✅                          |
-| skyvern                 | HTTP                        | requests                                                        | ✅                          |
-| slack                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| smaily                  | HTTP                        | requests                                                        | ✅                          |
-| smartreach              | HTTP                        | requests                                                        | ✅                          |
-| smartsheet              | HTTP                        | requests                                                        | ✅                          |
-| smartwaiver             | HTTP                        | requests                                                        | ✅                          |
-| snapchat_ads            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| snowflake               | DB protocol                 | snowflake-connector-python                                      | ➖                          |
-| solarwinds_service_desk | HTTP                        | requests                                                        | ✅                          |
-| sparkpost               | HTTP                        | requests                                                        | ✅                          |
-| split_io                | HTTP                        | requests                                                        | ✅                          |
-| square                  | HTTP                        | requests                                                        | ✅                          |
-| squarespace             | HTTP                        | requests                                                        | ✅                          |
-| statuspage              | HTTP                        | requests                                                        | ✅                          |
-| stigg                   | HTTP                        | requests                                                        | ✅                          |
-| stripe                  | HTTP (vendor SDK) + Webhook | stripe (StripeClient + RequestsClient) + `WebhookSourceManager` | ✅ (pull) / ➖ (webhook)    |
-| supabase                | DB protocol                 | psycopg (delegates to PostgresSource)                           | ➖                          |
-| surveymonkey            | HTTP                        | requests                                                        | ✅                          |
-| surveysparrow           | HTTP                        | requests                                                        | ✅                          |
-| svix                    | HTTP                        | requests                                                        | ✅                          |
-| taboola                 | HTTP                        | requests                                                        | ✅                          |
-| tavus                   | HTTP                        | requests                                                        | ✅                          |
-| teamtailor              | HTTP                        | requests                                                        | ✅                          |
-| teamwork                | HTTP                        | requests                                                        | ✅                          |
-| tempo                   | HTTP                        | requests                                                        | ✅                          |
-| temporalio              | gRPC (vendor SDK)           | temporalio (`Client`, Rust core via `temporalio.bridge`)        | ⚠️                          |
-| testrail                | HTTP                        | requests                                                        | ✅                          |
-| thinkific               | HTTP                        | requests                                                        | ✅                          |
-| tickettailor            | HTTP                        | requests                                                        | ✅                          |
-| tiktok_ads              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| tmdb                    | HTTP                        | requests                                                        | ✅                          |
-| todoist                 | HTTP                        | requests                                                        | ✅                          |
-| together_ai             | HTTP                        | requests                                                        | ✅                          |
-| trello                  | HTTP                        | requests                                                        | ✅                          |
-| tremendous              | HTTP                        | requests                                                        | ✅                          |
-| trigger_dev             | HTTP                        | requests                                                        | ✅                          |
-| twelve_labs             | HTTP                        | requests                                                        | ✅                          |
-| twilio                  | HTTP                        | requests                                                        | ✅                          |
-| typeform                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| ubidots                 | HTTP                        | requests                                                        | ✅                          |
-| unleash                 | HTTP                        | requests                                                        | ✅                          |
-| upstash                 | HTTP                        | requests                                                        | ✅                          |
-| vantage                 | HTTP                        | requests                                                        | ✅                          |
-| vellum                  | HTTP                        | requests                                                        | ✅                          |
-| vercel                  | HTTP                        | requests                                                        | ✅                          |
-| vitally                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| webflow                 | HTTP                        | requests                                                        | ✅                          |
-| windmill                | HTTP                        | requests                                                        | ✅                          |
-| woocommerce             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| wordpress               | HTTP                        | requests                                                        | ✅                          |
-| workable                | HTTP                        | requests                                                        | ✅                          |
-| workos                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| wrike                   | HTTP                        | requests                                                        | ✅                          |
-| writesonic              | HTTP                        | requests                                                        | ✅                          |
-| wufoo                   | HTTP                        | requests                                                        | ✅                          |
-| zapier_supported_storage | HTTP                       | requests                                                        | ✅                          |
-| zendesk                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
-| zendesk_sell            | HTTP                        | requests                                                        | ✅                          |
-| zenloop                 | HTTP                        | requests                                                        | ✅                          |
-| zonka_feedback          | HTTP                        | requests                                                        | ✅                          |
-| zoom                    | HTTP                        | requests                                                        | ✅                          |
-| zuora                   | HTTP                        | requests                                                        | ✅                          |
+| Source                   | Comm method                 | Primary library                                                 | Tracked transport           |
+| ------------------------ | --------------------------- | --------------------------------------------------------------- | --------------------------- |
+| adroll                   | HTTP                        | requests                                                        | ✅                          |
+| agilecrm                 | HTTP                        | requests                                                        | ✅                          |
+| aha                      | HTTP                        | requests                                                        | ✅                          |
+| aircall                  | HTTP                        | requests                                                        | ✅                          |
+| airtable                 | HTTP                        | requests                                                        | ✅                          |
+| algolia                  | HTTP                        | requests                                                        | ✅                          |
+| alguna                   | HTTP                        | requests                                                        | ✅                          |
+| alpha_vantage            | HTTP                        | requests                                                        | ✅                          |
+| amazon_ads               | HTTP                        | requests                                                        | ✅                          |
+| amplitude                | HTTP                        | requests                                                        | ✅                          |
+| anthropic                | HTTP                        | requests                                                        | ✅                          |
+| apify_dataset            | HTTP                        | requests                                                        | ✅                          |
+| apollo                   | HTTP                        | requests                                                        | ✅                          |
+| appfigures               | HTTP                        | requests                                                        | ✅                          |
+| appfollow                | HTTP                        | requests                                                        | ✅                          |
+| appsflyer                | HTTP (CSV reports)          | requests                                                        | ✅                          |
+| asana                    | HTTP                        | requests                                                        | ✅                          |
+| ashby                    | HTTP                        | requests                                                        | ✅                          |
+| assemblyai               | HTTP                        | requests                                                        | ✅                          |
+| attentive                | HTTP (webhook-first)        | requests (webhook management)                                   | ✅                          |
+| attio                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| aviationstack            | HTTP                        | requests                                                        | ✅                          |
+| aviator                  | HTTP                        | requests                                                        | ✅                          |
+| awin                     | HTTP                        | requests                                                        | ✅                          |
+| azure_devops             | HTTP                        | requests                                                        | ✅                          |
+| bamboohr                 | HTTP                        | requests                                                        | ✅                          |
+| beamer                   | HTTP                        | requests                                                        | ✅                          |
+| bigmailer                | HTTP                        | requests                                                        | ✅                          |
+| bigquery                 | HTTP + gRPC                 | google-cloud-bigquery + bigquery-storage                        | ✅ (HTTP + gRPC)            |
+| bing_ads                 | HTTP (vendor SDK, SOAP)     | bingads SDK                                                     | ⚠️                          |
+| bland_ai                 | HTTP                        | requests                                                        | ✅                          |
+| blogger                  | HTTP                        | requests                                                        | ✅                          |
+| bluetally                | HTTP                        | requests                                                        | ✅                          |
+| boldsign                 | HTTP                        | requests                                                        | ✅                          |
+| braintree                | HTTP (GraphQL)              | requests                                                        | ✅                          |
+| braze                    | HTTP                        | requests                                                        | ✅                          |
+| breezometer              | HTTP                        | requests                                                        | ✅                          |
+| brevo                    | HTTP                        | requests                                                        | ✅                          |
+| brex                     | HTTP                        | requests                                                        | ✅                          |
+| bugsnag                  | HTTP                        | requests                                                        | ✅                          |
+| buildbetter              | HTTP                        | requests                                                        | ✅                          |
+| buildkite                | HTTP                        | requests                                                        | ✅                          |
+| bunny                    | HTTP                        | requests                                                        | ✅                          |
+| buzzsprout               | HTTP                        | requests                                                        | ✅                          |
+| cal_com                  | HTTP                        | requests                                                        | ✅                          |
+| calendly                 | HTTP                        | requests                                                        | ✅                          |
+| callrail                 | HTTP                        | requests                                                        | ✅                          |
+| campaign_monitor         | HTTP                        | requests                                                        | ✅                          |
+| campayn                  | HTTP                        | requests                                                        | ✅                          |
+| canny                    | HTTP                        | requests                                                        | ✅                          |
+| capsule_crm              | HTTP                        | requests                                                        | ✅                          |
+| care_quality_commission  | HTTP                        | requests                                                        | ✅                          |
+| chameleon                | HTTP                        | requests                                                        | ✅                          |
+| chargebee                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| chargedesk               | HTTP                        | requests                                                        | ✅                          |
+| chargify                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| charthop                 | HTTP                        | requests                                                        | ✅                          |
+| checkout_com             | HTTP                        | requests                                                        | ✅                          |
+| churnkey                 | HTTP                        | requests                                                        | ✅                          |
+| coassemble               | HTTP                        | requests                                                        | ✅                          |
+| coda                     | HTTP                        | requests                                                        | ✅                          |
+| codefresh                | HTTP                        | requests                                                        | ✅                          |
+| coin_api                 | HTTP                        | requests                                                        | ✅                          |
+| coingecko                | HTTP                        | requests                                                        | ✅                          |
+| coinmarketcap            | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| commercetools            | HTTP                        | requests                                                        | ✅                          |
+| concord                  | HTTP                        | requests                                                        | ✅                          |
+| configcat                | HTTP                        | requests                                                        | ✅                          |
+| confluence               | HTTP                        | requests                                                        | ✅                          |
+| chartmogul               | HTTP                        | requests                                                        | ✅                          |
+| circleci                 | HTTP                        | requests                                                        | ✅                          |
+| cimis                    | HTTP                        | requests                                                        | ✅                          |
+| cloudflare               | HTTP                        | requests                                                        | ✅                          |
+| clari                    | HTTP                        | requests                                                        | ✅                          |
+| clerk                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| clickhouse               | DB protocol (HTTP-based)    | clickhouse-connect / clickhouse-driver                          | ➖                          |
+| clickup                  | HTTP                        | requests                                                        | ✅                          |
+| clockify                 | HTTP                        | requests                                                        | ✅                          |
+| clockodo                 | HTTP                        | requests                                                        | ✅                          |
+| close                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| cloudbeds                | HTTP                        | requests                                                        | ✅                          |
+| convertkit               | HTTP                        | requests                                                        | ✅                          |
+| convex                   | HTTP                        | requests                                                        | ✅                          |
+| copper                   | HTTP                        | requests                                                        | ✅                          |
+| coupa                    | HTTP                        | requests                                                        | ✅                          |
+| crunchbase               | HTTP                        | requests                                                        | ✅                          |
+| culture_amp              | HTTP                        | requests                                                        | ✅                          |
+| cursor                   | HTTP                        | requests                                                        | ✅                          |
+| customer_io              | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (App API) / ➖ (webhook) |
+| datadog                  | HTTP                        | requests                                                        | ✅                          |
+| decagon                  | HTTP                        | requests                                                        | ✅                          |
+| deel                     | HTTP                        | requests                                                        | ✅                          |
+| deepgram                 | HTTP                        | requests                                                        | ✅                          |
+| delighted                | HTTP                        | requests                                                        | ✅                          |
+| deno_deploy              | HTTP                        | requests                                                        | ✅                          |
+| devin_ai                 | HTTP                        | requests                                                        | ✅                          |
+| ding_connect             | HTTP                        | requests                                                        | ✅                          |
+| dixa                     | HTTP                        | requests                                                        | ✅                          |
+| dockerhub                | HTTP                        | requests                                                        | ✅                          |
+| docuseal                 | HTTP                        | requests                                                        | ✅                          |
+| doit                     | HTTP                        | requests                                                        | ✅                          |
+| dropbox_sign             | HTTP                        | requests                                                        | ✅                          |
+| drip                     | HTTP                        | requests                                                        | ✅                          |
+| e_conomic                | HTTP                        | requests                                                        | ✅                          |
+| easypost                 | HTTP                        | requests                                                        | ✅                          |
+| easypromos               | HTTP                        | requests                                                        | ✅                          |
+| elevenlabs               | HTTP                        | requests                                                        | ✅                          |
+| freshcaller              | HTTP                        | requests                                                        | ✅                          |
+| freshdesk                | HTTP                        | requests                                                        | ✅                          |
+| freshsales               | HTTP                        | requests                                                        | ✅                          |
+| freshservice             | HTTP                        | requests                                                        | ✅                          |
+| elasticemail             | HTTP                        | requests                                                        | ✅                          |
+| elasticsearch            | HTTP                        | requests                                                        | ✅                          |
+| emailoctopus             | HTTP                        | requests                                                        | ✅                          |
+| eventbrite               | HTTP                        | requests                                                        | ✅                          |
+| eventee                  | HTTP                        | requests                                                        | ✅                          |
+| eventzilla               | HTTP                        | requests                                                        | ✅                          |
+| everhour                 | HTTP                        | requests                                                        | ✅                          |
+| exchange_rates_api       | HTTP                        | requests                                                        | ✅                          |
+| ezofficeinventory        | HTTP                        | requests                                                        | ✅                          |
+| factorial                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| fastly                   | HTTP                        | requests                                                        | ✅                          |
+| fillout                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| finage                   | HTTP                        | requests                                                        | ✅                          |
+| financial_modelling      | HTTP                        | requests                                                        | ✅                          |
+| finnhub                  | HTTP                        | requests                                                        | ✅                          |
+| finnworlds               | HTTP                        | requests                                                        | ✅                          |
+| firecrawl                | HTTP                        | requests                                                        | ✅                          |
+| fleetio                  | HTTP                        | requests                                                        | ✅                          |
+| firehydrant              | HTTP                        | requests                                                        | ✅                          |
+| flexmail                 | HTTP                        | requests                                                        | ✅                          |
+| float_app                | HTTP                        | requests                                                        | ✅                          |
+| front                    | HTTP                        | requests                                                        | ✅                          |
+| fulcrum                  | HTTP                        | requests                                                        | ✅                          |
+| fullstory                | HTTP                        | requests                                                        | ✅                          |
+| gainsight_px             | HTTP                        | requests                                                        | ✅                          |
+| gitbook                  | HTTP                        | requests                                                        | ✅                          |
+| github                   | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
+| giphy                    | HTTP                        | requests                                                        | ✅                          |
+| gitlab                   | HTTP                        | requests                                                        | ✅                          |
+| gladly                   | HTTP                        | requests                                                        | ✅                          |
+| gnews                    | HTTP                        | requests                                                        | ✅                          |
+| gocardless               | HTTP                        | requests                                                        | ✅                          |
+| goldcast                 | HTTP                        | requests                                                        | ✅                          |
+| gong                     | HTTP                        | requests                                                        | ✅                          |
+| google_ads               | gRPC                        | google-ads (googleads.client)                                   | ✅                          |
+| google_analytics         | HTTP                        | requests (`AuthorizedSession` + `TrackedHTTPAdapter`)           | ✅                          |
+| google_sheets            | HTTP (vendor SDK)           | gspread                                                         | ✅                          |
+| google_webfonts          | HTTP                        | requests                                                        | ✅                          |
+| granola                  | HTTP                        | requests                                                        | ✅                          |
+| gorgias                  | HTTP                        | requests                                                        | ✅                          |
+| greenhouse               | HTTP                        | requests                                                        | ✅                          |
+| gridly                   | HTTP                        | requests                                                        | ✅                          |
+| guardian                 | HTTP                        | requests                                                        | ✅                          |
+| guru                     | HTTP                        | requests                                                        | ✅                          |
+| harvey                   | HTTP                        | requests                                                        | ✅                          |
+| hatchet                  | HTTP                        | requests                                                        | ✅                          |
+| healthchecks             | HTTP                        | requests                                                        | ✅                          |
+| height                   | HTTP                        | requests                                                        | ✅                          |
+| hellobaton               | HTTP                        | requests                                                        | ✅                          |
+| hibob                    | HTTP                        | requests                                                        | ✅                          |
+| humanitix                | HTTP                        | requests                                                        | ✅                          |
+| hubplanner               | HTTP                        | requests                                                        | ✅                          |
+| hubspot                  | HTTP                        | requests                                                        | ✅                          |
+| hugging_face             | HTTP                        | requests                                                        | ✅                          |
+| huntr                    | HTTP                        | requests                                                        | ✅                          |
+| incident_io              | HTTP                        | requests                                                        | ✅                          |
+| inflowinventory          | HTTP                        | requests                                                        | ✅                          |
+| insightly                | HTTP                        | requests                                                        | ✅                          |
+| instatus                 | HTTP                        | requests                                                        | ✅                          |
+| intercom                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| intruder                 | HTTP                        | requests                                                        | ✅                          |
+| invoiced                 | HTTP                        | requests                                                        | ✅                          |
+| invoiceninja             | HTTP                        | requests                                                        | ✅                          |
+| ip2whois                 | HTTP                        | requests                                                        | ✅                          |
+| iterable                 | HTTP                        | requests                                                        | ✅                          |
+| jira                     | HTTP                        | requests                                                        | ✅                          |
+| jobnimbus                | HTTP                        | requests                                                        | ✅                          |
+| jotform                  | HTTP                        | requests                                                        | ✅                          |
+| judgeme_reviews          | HTTP                        | requests                                                        | ✅                          |
+| justcall                 | HTTP                        | requests                                                        | ✅                          |
+| justsift                 | HTTP                        | requests                                                        | ✅                          |
+| k6_cloud                 | HTTP                        | requests                                                        | ✅                          |
+| katana                   | HTTP                        | requests                                                        | ✅                          |
+| klaviyo                  | HTTP                        | requests                                                        | ✅                          |
+| lago                     | HTTP                        | requests                                                        | ✅                          |
+| launchdarkly             | HTTP                        | requests                                                        | ✅                          |
+| kustomer                 | HTTP                        | requests                                                        | ✅                          |
+| lattice                  | HTTP                        | requests                                                        | ✅                          |
+| leadfeeder               | HTTP                        | requests                                                        | ✅                          |
+| lemlist                  | HTTP                        | requests                                                        | ✅                          |
+| less_annoying_crm        | HTTP                        | requests                                                        | ✅                          |
+| lightspeed_retail        | HTTP                        | requests                                                        | ✅                          |
+| linear                   | HTTP                        | requests                                                        | ✅                          |
+| lever                    | HTTP                        | requests                                                        | ✅                          |
+| lingo_dev                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| linkedin_ads             | HTTP (vendor SDK, RESTli)   | linkedin-api (RestliClient)                                     | ⚠️                          |
+| linkrunner               | HTTP                        | requests                                                        | ✅                          |
+| linode                   | HTTP                        | requests                                                        | ✅                          |
+| lob                      | HTTP                        | requests                                                        | ✅                          |
+| luma                     | HTTP                        | requests                                                        | ✅                          |
+| mailchimp                | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| mailerlite               | HTTP                        | requests                                                        | ✅                          |
+| mailersend               | HTTP                        | requests                                                        | ✅                          |
+| mailgun                  | HTTP                        | requests                                                        | ✅                          |
+| mailjet                  | HTTP                        | requests                                                        | ✅                          |
+| mailosaur                | HTTP                        | requests                                                        | ✅                          |
+| mailtrap                 | HTTP                        | requests                                                        | ✅                          |
+| marketstack              | HTTP                        | requests                                                        | ✅                          |
+| matomo                   | HTTP                        | requests                                                        | ✅                          |
+| maxio                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| mention                  | HTTP                        | requests                                                        | ✅                          |
+| meta_ads                 | HTTP                        | requests                                                        | ✅                          |
+| metabase                 | HTTP                        | requests                                                        | ✅                          |
+| metorial                 | HTTP                        | requests                                                        | ✅                          |
+| mistral_ai               | HTTP                        | requests                                                        | ✅                          |
+| mixmax                   | HTTP                        | requests                                                        | ✅                          |
+| mixpanel                 | HTTP                        | requests                                                        | ✅                          |
+| mollie                   | HTTP                        | requests                                                        | ✅                          |
+| monday                   | HTTP (GraphQL)              | requests                                                        | ✅                          |
+| mongodb                  | DB protocol                 | pymongo                                                         | ➖                          |
+| mssql                    | DB protocol                 | pyodbc / pymssql                                                | ➖                          |
+| mux                      | HTTP                        | requests                                                        | ✅                          |
+| my_hours                 | HTTP                        | requests                                                        | ✅                          |
+| mysql                    | DB protocol                 | pymysql                                                         | ➖                          |
+| n8n                      | HTTP                        | requests                                                        | ✅                          |
+| netlify                  | HTTP                        | requests                                                        | ✅                          |
+| new_york_times           | HTTP                        | requests                                                        | ✅                          |
+| news_api                 | HTTP                        | requests                                                        | ✅                          |
+| newsdata                 | HTTP                        | requests                                                        | ✅                          |
+| okta                     | HTTP                        | requests                                                        | ✅                          |
+| nocrm                    | HTTP                        | requests                                                        | ✅                          |
+| northpass_lms            | HTTP                        | requests                                                        | ✅                          |
+| notion                   | HTTP                        | requests                                                        | ✅                          |
+| omnisend                 | HTTP                        | requests                                                        | ✅                          |
+| oncehub                  | HTTP                        | requests                                                        | ✅                          |
+| onepagecrm               | HTTP                        | requests                                                        | ✅                          |
+| onfleet                  | HTTP (cursor pagination)    | requests                                                        | ✅                          |
+| open_exchange_rates      | HTTP                        | requests                                                        | ✅                          |
+| opinion_stage            | HTTP                        | requests                                                        | ✅                          |
+| orb                      | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| openaq                   | HTTP                        | requests                                                        | ✅                          |
+| openfda                  | HTTP                        | requests                                                        | ✅                          |
+| openweather              | HTTP                        | requests                                                        | ✅                          |
+| ortto                    | HTTP                        | requests                                                        | ✅                          |
+| oura                     | HTTP                        | requests                                                        | ✅                          |
+| outbrain                 | HTTP                        | requests                                                        | ✅                          |
+| paddle                   | HTTP                        | requests                                                        | ✅                          |
+| optimizely               | HTTP                        | requests                                                        | ✅                          |
+| pagerduty                | HTTP                        | requests                                                        | ✅                          |
+| pandadoc                 | HTTP                        | requests                                                        | ✅                          |
+| paperform                | HTTP                        | requests                                                        | ✅                          |
+| papersign                | HTTP                        | requests                                                        | ✅                          |
+| partnerize               | HTTP                        | requests                                                        | ✅                          |
+| partnerstack             | HTTP                        | requests                                                        | ✅                          |
+| payfit                   | HTTP                        | requests                                                        | ✅                          |
+| paystack                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| pendo                    | HTTP                        | requests                                                        | ✅                          |
+| persistiq                | HTTP                        | requests                                                        | ✅                          |
+| persona                  | HTTP                        | requests                                                        | ✅                          |
+| personio                 | HTTP                        | requests                                                        | ✅                          |
+| pexels                   | HTTP                        | requests                                                        | ✅                          |
+| phyllo                   | HTTP                        | requests                                                        | ✅                          |
+| picqer                   | HTTP                        | requests                                                        | ✅                          |
+| pingdom                  | HTTP                        | requests                                                        | ✅                          |
+| pinterest_ads            | HTTP                        | requests                                                        | ✅                          |
+| pipedrive                | HTTP                        | requests                                                        | ✅                          |
+| pipeliner                | HTTP                        | requests                                                        | ✅                          |
+| plain                    | HTTP                        | requests                                                        | ✅                          |
+| planhat                  | HTTP                        | requests                                                        | ✅                          |
+| plausible                | HTTP                        | requests                                                        | ✅                          |
+| polar                    | HTTP                        | requests                                                        | ✅                          |
+| plaid                    | HTTP                        | requests                                                        | ✅                          |
+| postgres                 | DB protocol                 | psycopg                                                         | ➖                          |
+| postmark                 | HTTP                        | requests                                                        | ✅                          |
+| pretix                   | HTTP                        | requests                                                        | ✅                          |
+| printify                 | HTTP                        | requests                                                        | ✅                          |
+| productboard             | HTTP                        | requests                                                        | ✅                          |
+| pylon                    | HTTP                        | requests                                                        | ✅                          |
+| qualaroo                 | HTTP                        | requests                                                        | ✅                          |
+| recurly                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| ramp                     | HTTP                        | requests                                                        | ✅                          |
+| recharge                 | HTTP                        | requests                                                        | ✅                          |
+| recruitee                | HTTP                        | requests                                                        | ✅                          |
+| reddit_ads               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| redshift                 | DB protocol                 | psycopg (Postgres-compatible)                                   | ➖                          |
+| rentcast                 | HTTP                        | requests                                                        | ✅                          |
+| reply_io                 | HTTP                        | requests                                                        | ✅                          |
+| resend                   | HTTP                        | requests                                                        | ✅                          |
+| retently                 | HTTP                        | requests                                                        | ✅                          |
+| revenuecat               | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
+| rippling                 | HTTP                        | requests                                                        | ✅                          |
+| rocketlane               | HTTP                        | requests                                                        | ✅                          |
+| rollbar                  | HTTP                        | requests                                                        | ✅                          |
+| rootly                   | HTTP                        | requests                                                        | ✅                          |
+| rss                      | HTTP                        | requests                                                        | ✅                          |
+| ruddr                    | HTTP                        | requests                                                        | ✅                          |
+| safetyculture            | HTTP                        | requests                                                        | ✅                          |
+| salesforce               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| salesflare               | HTTP                        | requests                                                        | ✅                          |
+| salesloft                | HTTP                        | requests                                                        | ✅                          |
+| savvycal                 | HTTP                        | requests                                                        | ✅                          |
+| scale_ai                 | HTTP                        | requests                                                        | ✅                          |
+| scaleway                 | HTTP                        | requests                                                        | ✅                          |
+| secoda                   | HTTP                        | requests                                                        | ✅                          |
+| segment                  | HTTP                        | requests                                                        | ✅                          |
+| sendgrid                 | HTTP                        | requests                                                        | ✅                          |
+| sendowl                  | HTTP                        | requests                                                        | ✅                          |
+| sentry                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| servicenow               | HTTP                        | requests                                                        | ✅                          |
+| shippo                   | HTTP                        | requests                                                        | ✅                          |
+| shipstation              | HTTP                        | requests                                                        | ✅                          |
+| shopify                  | HTTP                        | requests                                                        | ✅                          |
+| shopwired                | HTTP                        | requests                                                        | ✅                          |
+| shortcut                 | HTTP                        | requests                                                        | ✅                          |
+| shortio                  | HTTP                        | requests                                                        | ✅                          |
+| simplecast               | HTTP                        | requests                                                        | ✅                          |
+| simplesat                | HTTP                        | requests                                                        | ✅                          |
+| skyvern                  | HTTP                        | requests                                                        | ✅                          |
+| slack                    | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| smaily                   | HTTP                        | requests                                                        | ✅                          |
+| smartreach               | HTTP                        | requests                                                        | ✅                          |
+| smartsheet               | HTTP                        | requests                                                        | ✅                          |
+| smartwaiver              | HTTP                        | requests                                                        | ✅                          |
+| snapchat_ads             | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| snowflake                | DB protocol                 | snowflake-connector-python                                      | ➖                          |
+| solarwinds_service_desk  | HTTP                        | requests                                                        | ✅                          |
+| sparkpost                | HTTP                        | requests                                                        | ✅                          |
+| split_io                 | HTTP                        | requests                                                        | ✅                          |
+| square                   | HTTP                        | requests                                                        | ✅                          |
+| squarespace              | HTTP                        | requests                                                        | ✅                          |
+| statuspage               | HTTP                        | requests                                                        | ✅                          |
+| stigg                    | HTTP                        | requests                                                        | ✅                          |
+| stripe                   | HTTP (vendor SDK) + Webhook | stripe (StripeClient + RequestsClient) + `WebhookSourceManager` | ✅ (pull) / ➖ (webhook)    |
+| supabase                 | DB protocol                 | psycopg (delegates to PostgresSource)                           | ➖                          |
+| surveymonkey             | HTTP                        | requests                                                        | ✅                          |
+| surveysparrow            | HTTP                        | requests                                                        | ✅                          |
+| svix                     | HTTP                        | requests                                                        | ✅                          |
+| taboola                  | HTTP                        | requests                                                        | ✅                          |
+| tavus                    | HTTP                        | requests                                                        | ✅                          |
+| teamtailor               | HTTP                        | requests                                                        | ✅                          |
+| teamwork                 | HTTP                        | requests                                                        | ✅                          |
+| tempo                    | HTTP                        | requests                                                        | ✅                          |
+| temporalio               | gRPC (vendor SDK)           | temporalio (`Client`, Rust core via `temporalio.bridge`)        | ⚠️                          |
+| testrail                 | HTTP                        | requests                                                        | ✅                          |
+| thinkific                | HTTP                        | requests                                                        | ✅                          |
+| tickettailor             | HTTP                        | requests                                                        | ✅                          |
+| tiktok_ads               | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| tmdb                     | HTTP                        | requests                                                        | ✅                          |
+| todoist                  | HTTP                        | requests                                                        | ✅                          |
+| together_ai              | HTTP                        | requests                                                        | ✅                          |
+| trello                   | HTTP                        | requests                                                        | ✅                          |
+| tremendous               | HTTP                        | requests                                                        | ✅                          |
+| trigger_dev              | HTTP                        | requests                                                        | ✅                          |
+| twelve_labs              | HTTP                        | requests                                                        | ✅                          |
+| twilio                   | HTTP                        | requests                                                        | ✅                          |
+| typeform                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| ubidots                  | HTTP                        | requests                                                        | ✅                          |
+| unleash                  | HTTP                        | requests                                                        | ✅                          |
+| upstash                  | HTTP                        | requests                                                        | ✅                          |
+| vantage                  | HTTP                        | requests                                                        | ✅                          |
+| vellum                   | HTTP                        | requests                                                        | ✅                          |
+| vercel                   | HTTP                        | requests                                                        | ✅                          |
+| vitally                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| webflow                  | HTTP                        | requests                                                        | ✅                          |
+| windmill                 | HTTP                        | requests                                                        | ✅                          |
+| woocommerce              | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| wordpress                | HTTP                        | requests                                                        | ✅                          |
+| workable                 | HTTP                        | requests                                                        | ✅                          |
+| workos                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| wrike                    | HTTP                        | requests                                                        | ✅                          |
+| writesonic               | HTTP                        | requests                                                        | ✅                          |
+| wufoo                    | HTTP                        | requests                                                        | ✅                          |
+| zapier_supported_storage | HTTP                        | requests                                                        | ✅                          |
+| zendesk                  | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| zendesk_sell             | HTTP                        | requests                                                        | ✅                          |
+| zenloop                  | HTTP                        | requests                                                        | ✅                          |
+| zonka_feedback           | HTTP                        | requests                                                        | ✅                          |
+| zoom                     | HTTP                        | requests                                                        | ✅                          |
+| zuora                    | HTTP                        | requests                                                        | ✅                          |
 
 ### Notes on partially-tracked sources
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -4139,7 +4139,7 @@ class ZapSignSourceConfig(config.Config):
 
 @config.config
 class ZapierSupportedStorageSourceConfig(config.Config):
-    pass
+    secret: str
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/canonical_descriptions.py
@@ -1,0 +1,14 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "records": {
+        "description": "Every key/value pair in the Storage by Zapier store, one row per key.",
+        "docs_url": "https://help.zapier.com/hc/en-us/articles/8496293271053",
+        "columns": {
+            "key": "The store key (max 32 characters). Unique within the store.",
+            "value": "The value stored under the key, returned as a string (JSON-encoded when not already a string).",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/settings.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+
+from products.warehouse_sources.backend.types import IncrementalField
+
+
+@dataclass
+class ZapierSupportedStorageEndpointConfig:
+    name: str
+    primary_keys: list[str]
+    should_sync_default: bool = True
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+
+
+# Storage by Zapier exposes a single endpoint (`GET /api/records`) that returns the whole store
+# as one flat `{key: value}` JSON object. We materialize it as one row per key. The store carries
+# no created/updated timestamps and there is no list/pagination beyond fetching everything, so the
+# only sync mode possible is full refresh. `key` is unique within a store (a store is identified by
+# its secret, which is fixed per source connection), so it is a safe table-wide primary key.
+ZAPIER_SUPPORTED_STORAGE_ENDPOINTS: dict[str, ZapierSupportedStorageEndpointConfig] = {
+    "records": ZapierSupportedStorageEndpointConfig(
+        name="records",
+        primary_keys=["key"],
+    ),
+}
+
+ENDPOINTS = tuple(ZAPIER_SUPPORTED_STORAGE_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in ZAPIER_SUPPORTED_STORAGE_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/source.py
@@ -1,21 +1,51 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
     ZapierSupportedStorageSourceConfig,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+    ZAPIER_SUPPORTED_STORAGE_ENDPOINTS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.zapier_supported_storage import (
+    validate_credentials as validate_zapier_supported_storage_credentials,
+    zapier_supported_storage_source,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+_ENDPOINT_DESCRIPTIONS: dict[str, str] = {
+    "records": (
+        "Every key/value pair in the store, one row per key with columns {key, value}. Values are "
+        "returned as strings (JSON-encoded when not already a string). Full refresh only - the store "
+        "exposes no timestamps or pagination."
+    ),
+}
 
 
 @SourceRegistry.register
 class ZapierSupportedStorageSource(SimpleSource[ZapierSupportedStorageSourceConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.ZAPIERSUPPORTEDSTORAGE
@@ -25,8 +55,80 @@ class ZapierSupportedStorageSource(SimpleSource[ZapierSupportedStorageSourceConf
         return SourceConfig(
             name=SchemaExternalDataSourceType.ZAPIER_SUPPORTED_STORAGE,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
-            label="Zapier Supported Storage",
-            iconPath="/static/services/zapier_supported_storage.png",
-            fields=cast(list[FieldType], []),
+            label="Zapier (Storage by Zapier)",
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            caption="""Enter your Storage by Zapier store secret to pull your key/value store into the PostHog Data warehouse.
+
+The secret is the per-store UUID you use with the [Storage by Zapier](https://help.zapier.com/hc/en-us/articles/8496293271053) app (the `secret` value passed to `StoreClient`, or the `X-Secret` you send to `store.zapier.com`). It both identifies and authorizes the store, so treat it like a password.
+
+Only full-refresh syncing is supported: the store has no timestamps, so every sync pulls the whole store.
+""",
+            iconPath="/static/services/zapier_supported_storage.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/zapier-supported-storage",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="secret",
+                        label="Store secret",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.canonical_descriptions import (  # noqa: PLC0415
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # The store secret is the only credential; a 401 (missing/unknown secret) or 400 (not a
+            # valid UUID4) can never be fixed by retrying, so stop the sync.
+            "401 Client Error: Unauthorized for url: https://store.zapier.com": "Your Storage by Zapier secret is invalid. Copy the store secret exactly and reconnect.",
+            "400 Client Error: Bad Request for url: https://store.zapier.com": "Your Storage by Zapier secret must be a valid UUID4. Copy the store secret exactly and reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: ZapierSupportedStorageSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        def _build_schema(endpoint: str) -> SourceSchema:
+            return SourceSchema(
+                name=endpoint,
+                # The store carries no created/updated timestamps, so incremental sync is impossible.
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                should_sync_default=ZAPIER_SUPPORTED_STORAGE_ENDPOINTS[endpoint].should_sync_default,
+                description=_ENDPOINT_DESCRIPTIONS.get(endpoint),
+            )
+
+        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: ZapierSupportedStorageSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        return validate_zapier_supported_storage_credentials(config.secret)
+
+    def source_for_pipeline(self, config: ZapierSupportedStorageSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return zapier_supported_storage_source(
+            secret=config.secret,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
@@ -26,13 +26,8 @@ def _response(body: Any, status_code: int = 200) -> MagicMock:
     resp.ok = 200 <= status_code < 300
     resp.json.return_value = body
     resp.text = str(body)
-    resp.raise_for_status.side_effect = (
-        None
-        if resp.ok
-        else requests.HTTPError(
-            f"{status_code} Client Error for url: https://store.zapier.com/api/records", response=resp
-        )
-    )
+    resp.reason = "Bad Request"
+    resp.url = "https://store.zapier.com/api/records"
     return resp
 
 
@@ -75,18 +70,13 @@ class TestGetRows:
         rows = _rows_from_store({"k": stored_value})
         assert rows == [{"key": "k", "value": expected}]
 
-    def test_non_dict_payload_is_ignored(self) -> None:
-        # The endpoint always returns a flat object; a list/other shape is unexpected and must not
-        # crash the sync (it yields nothing rather than iterating the wrong structure).
-        assert _rows_from_store([1, 2, 3]) == []
-
 
 class TestFetchStore:
     def _fetch_once(self, response: MagicMock) -> Any:
         # Collapse the retry to a single attempt with no backoff so retryable-status tests don't sleep.
         session = MagicMock()
         session.get.return_value = response
-        fetch = _fetch_store.retry_with(stop=stop_after_attempt(1), wait=wait_none())
+        fetch = _fetch_store.retry_with(stop=stop_after_attempt(1), wait=wait_none())  # type: ignore[attr-defined]
         return fetch(session, "secret", MagicMock())
 
     @pytest.mark.parametrize("status", [429, 500, 502, 503])
@@ -95,10 +85,23 @@ class TestFetchStore:
             self._fetch_once(_response({}, status_code=status))
 
     @pytest.mark.parametrize("status", [400, 401, 403, 404])
-    def test_client_errors_propagate_and_are_not_retried(self, status: int) -> None:
-        # 4xx can't be fixed by retrying, so raise_for_status must surface immediately.
-        with pytest.raises(requests.HTTPError):
-            self._fetch_once(_response({}, status_code=status))
+    def test_client_errors_raise_scrubbed_http_error(self, status: int) -> None:
+        # 4xx can't be fixed by retrying, so an HTTPError must surface immediately. The message must
+        # keep the "<status> Client Error ... for url: https://store.zapier.com/api/records" prefix
+        # (get_non_retryable_errors matches on it) but never echo the response body, which can hold
+        # arbitrary store secrets and would otherwise leak into logs and latest_error.
+        secret_body = {"leaked": "super-secret-store-value"}
+        with pytest.raises(requests.HTTPError) as exc:
+            self._fetch_once(_response(secret_body, status_code=status))
+        message = str(exc.value)
+        assert "https://store.zapier.com/api/records" in message
+        assert "super-secret-store-value" not in message
+
+    def test_non_dict_payload_raises_retryable(self) -> None:
+        # A non-object payload (transient API/proxy response) must not complete a "successful" full
+        # refresh with zero rows and wipe previously synced records; it must raise so the sync retries.
+        with pytest.raises(ZapierSupportedStorageRetryableError):
+            self._fetch_once(_response([1, 2, 3]))
 
 
 class TestValidateCredentials:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
@@ -135,22 +135,26 @@ class TestValidateCredentials:
         assert error is not None and "boom" in error
 
 
-class TestSampleCaptureIsDisabled:
-    # Every response body is the store's arbitrary customer key/value contents, so both entry points
-    # must exclude their requests from HTTP sample capture. A regression to the default (capture=True)
-    # would persist customer store values to object storage, where the name-based scrubbers can't
-    # redact keys they don't recognize.
-    def test_get_rows_disables_capture(self) -> None:
+class TestSessionIsHardened:
+    # Both entry points send the store `secret` as the `X-Secret` header, and every response body is
+    # the store's arbitrary customer key/value contents. So both must (a) exclude their requests from
+    # HTTP sample capture - a regression to capture=True would persist customer store values to object
+    # storage where the name-based scrubbers can't redact unknown keys - and (b) disable redirects,
+    # since requests forwards custom headers across cross-host redirects and a regression to
+    # allow_redirects=True would let the secret leak to a redirect target.
+    def test_get_rows_disables_capture_and_redirects(self) -> None:
         with patch(f"{MODULE}.make_tracked_session") as factory:
             factory.return_value.get.return_value = _response({"a": "1"})
             list(get_rows(secret="s", logger=MagicMock()))
         assert factory.call_args.kwargs["capture"] is False
+        assert factory.call_args.kwargs["allow_redirects"] is False
 
-    def test_validate_credentials_disables_capture(self) -> None:
+    def test_validate_credentials_disables_capture_and_redirects(self) -> None:
         with patch(f"{MODULE}.make_tracked_session") as factory:
             factory.return_value.get.return_value = _response({}, status_code=200)
             validate_credentials("s")
         assert factory.call_args.kwargs["capture"] is False
+        assert factory.call_args.kwargs["allow_redirects"] is False
 
 
 class TestSourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
@@ -135,6 +135,24 @@ class TestValidateCredentials:
         assert error is not None and "boom" in error
 
 
+class TestSampleCaptureIsDisabled:
+    # Every response body is the store's arbitrary customer key/value contents, so both entry points
+    # must exclude their requests from HTTP sample capture. A regression to the default (capture=True)
+    # would persist customer store values to object storage, where the name-based scrubbers can't
+    # redact keys they don't recognize.
+    def test_get_rows_disables_capture(self) -> None:
+        with patch(f"{MODULE}.make_tracked_session") as factory:
+            factory.return_value.get.return_value = _response({"a": "1"})
+            list(get_rows(secret="s", logger=MagicMock()))
+        assert factory.call_args.kwargs["capture"] is False
+
+    def test_validate_credentials_disables_capture(self) -> None:
+        with patch(f"{MODULE}.make_tracked_session") as factory:
+            factory.return_value.get.return_value = _response({}, status_code=200)
+            validate_credentials("s")
+        assert factory.call_args.kwargs["capture"] is False
+
+
 class TestSourceResponse:
     def test_shape_is_full_refresh_keyed_by_store_key(self) -> None:
         response = zapier_supported_storage_source(secret="s", endpoint="records", logger=MagicMock())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage.py
@@ -1,0 +1,148 @@
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+import requests
+from tenacity import stop_after_attempt, wait_none
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.zapier_supported_storage import (
+    ZapierSupportedStorageRetryableError,
+    _fetch_store,
+    get_rows,
+    validate_credentials,
+    zapier_supported_storage_source,
+)
+
+MODULE = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.zapier_supported_storage"
+)
+
+
+def _response(body: Any, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.json.return_value = body
+    resp.text = str(body)
+    resp.raise_for_status.side_effect = (
+        None
+        if resp.ok
+        else requests.HTTPError(
+            f"{status_code} Client Error for url: https://store.zapier.com/api/records", response=resp
+        )
+    )
+    return resp
+
+
+def _rows_from_store(store: Any) -> list[dict[str, Any]]:
+    with patch(f"{MODULE}.make_tracked_session") as factory:
+        factory.return_value.get.return_value = _response(store)
+        tables = list(get_rows(secret="s", logger=MagicMock()))
+    out: list[dict[str, Any]] = []
+    for table in tables:
+        assert isinstance(table, pa.Table)
+        out.extend(table.to_pylist())
+    return out
+
+
+class TestGetRows:
+    def test_one_row_per_store_key(self) -> None:
+        rows = _rows_from_store({"a": "1", "b": "2"})
+        assert {r["key"] for r in rows} == {"a", "b"}
+        assert {(r["key"], r["value"]) for r in rows} == {("a", "1"), ("b", "2")}
+
+    def test_empty_store_yields_no_rows(self) -> None:
+        assert _rows_from_store({}) == []
+
+    @pytest.mark.parametrize(
+        ("stored_value", "expected"),
+        [
+            ("plain string", "plain string"),
+            (42, "42"),
+            (3.5, "3.5"),
+            (True, "true"),
+            ({"nested": 1}, '{"nested": 1}'),
+            ([1, 2, 3], "[1, 2, 3]"),
+            (None, None),
+        ],
+    )
+    def test_value_coerced_to_stable_string_type(self, stored_value: Any, expected: str | None) -> None:
+        # Storage by Zapier holds arbitrary JSON per key; the value column must be a single stable
+        # type so the Delta table doesn't get conflicting per-row schemas. Strings pass through,
+        # everything else is JSON-encoded, and a genuine null stays null.
+        rows = _rows_from_store({"k": stored_value})
+        assert rows == [{"key": "k", "value": expected}]
+
+    def test_non_dict_payload_is_ignored(self) -> None:
+        # The endpoint always returns a flat object; a list/other shape is unexpected and must not
+        # crash the sync (it yields nothing rather than iterating the wrong structure).
+        assert _rows_from_store([1, 2, 3]) == []
+
+
+class TestFetchStore:
+    def _fetch_once(self, response: MagicMock) -> Any:
+        # Collapse the retry to a single attempt with no backoff so retryable-status tests don't sleep.
+        session = MagicMock()
+        session.get.return_value = response
+        fetch = _fetch_store.retry_with(stop=stop_after_attempt(1), wait=wait_none())
+        return fetch(session, "secret", MagicMock())
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503])
+    def test_retryable_statuses_raise_retryable_error(self, status: int) -> None:
+        with pytest.raises(ZapierSupportedStorageRetryableError):
+            self._fetch_once(_response({}, status_code=status))
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404])
+    def test_client_errors_propagate_and_are_not_retried(self, status: int) -> None:
+        # 4xx can't be fixed by retrying, so raise_for_status must surface immediately.
+        with pytest.raises(requests.HTTPError):
+            self._fetch_once(_response({}, status_code=status))
+
+
+class TestValidateCredentials:
+    def _run(self, response: MagicMock | None = None, side_effect: Exception | None = None) -> tuple[bool, str | None]:
+        with patch(f"{MODULE}.make_tracked_session") as factory:
+            if side_effect is not None:
+                factory.return_value.get.side_effect = side_effect
+            else:
+                factory.return_value.get.return_value = response
+            return validate_credentials("some-secret")
+
+    def test_valid_secret(self) -> None:
+        assert self._run(_response({}, status_code=200)) == (True, None)
+
+    @pytest.mark.parametrize(
+        ("status", "fragment"),
+        [
+            (400, "valid UUID4"),
+            (401, "invalid"),
+            (500, "500"),
+        ],
+    )
+    def test_error_statuses_map_to_messages(self, status: int, fragment: str) -> None:
+        valid, error = self._run(_response({}, status_code=status))
+        assert valid is False
+        assert error is not None and fragment in error
+
+    def test_network_error_returns_message(self) -> None:
+        valid, error = self._run(side_effect=requests.ConnectionError("boom"))
+        assert valid is False
+        assert error is not None and "boom" in error
+
+
+class TestSourceResponse:
+    def test_shape_is_full_refresh_keyed_by_store_key(self) -> None:
+        response = zapier_supported_storage_source(secret="s", endpoint="records", logger=MagicMock())
+        assert response.name == "records"
+        assert response.primary_keys == ["key"]
+        # No timestamps to partition on - one full-refresh partition.
+        assert response.partition_count == 1
+        assert response.partition_keys is None
+
+    def test_items_is_lazy(self) -> None:
+        # Building the SourceResponse must not issue any request; only iterating items should.
+        with patch(f"{MODULE}.make_tracked_session") as factory:
+            zapier_supported_storage_source(secret="s", endpoint="records", logger=MagicMock())
+            factory.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/tests/test_zapier_supported_storage_source.py
@@ -1,0 +1,111 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
+    ZapierSupportedStorageSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.source import (
+    ZapierSupportedStorageSource,
+)
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.source"
+
+
+def _make_inputs(**overrides: Any) -> SourceInputs:
+    defaults: dict[str, Any] = {
+        "schema_name": "records",
+        "schema_id": "schema-1",
+        "source_id": "source-1",
+        "team_id": 123,
+        "should_use_incremental_field": False,
+        "db_incremental_field_last_value": None,
+        "db_incremental_field_earliest_value": None,
+        "incremental_field": None,
+        "incremental_field_type": None,
+        "job_id": "job-1",
+        "logger": mock.MagicMock(),
+        "reset_pipeline": False,
+    }
+    defaults.update(overrides)
+    return SourceInputs(**defaults)
+
+
+class TestZapierSupportedStorageSource:
+    def setup_method(self) -> None:
+        self.source = ZapierSupportedStorageSource()
+        self.team_id = 123
+        self.config = ZapierSupportedStorageSourceConfig(secret="abcdef01-2345-4678-9abc-def012345678")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.ZAPIERSUPPORTEDSTORAGE
+
+    def test_get_source_config_single_secret_field(self) -> None:
+        config = self.source.get_source_config
+
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is True
+        # docsUrl must match the doc filename so the posthog.com page resolves.
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/zapier-supported-storage"
+
+        fields = [f for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert [f.name for f in fields] == ["secret"]
+        secret = fields[0]
+        # The store secret is the sole credential and must be handled as a password/secret.
+        assert secret.type == SourceFieldInputConfigType.PASSWORD
+        assert secret.secret is True
+        assert secret.required is True
+
+    @pytest.mark.parametrize("expected_key", ["401 Client Error", "400 Client Error"])
+    def test_non_retryable_errors_cover_auth_and_malformed_secret(self, expected_key: str) -> None:
+        keys = self.source.get_non_retryable_errors()
+        assert any(expected_key in k for k in keys)
+
+    def test_get_schemas_single_full_refresh_table(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert {s.name for s in schemas} == set(ENDPOINTS) == {"records"}
+        # The store has no timestamps, so nothing supports incremental or append.
+        assert all(not s.supports_incremental and not s.supports_append for s in schemas)
+        assert all(s.incremental_fields == [] for s in schemas)
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        assert self.source.get_schemas(self.config, self.team_id, names=["records"])[0].name == "records"
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    def test_documented_tables_render_without_credentials(self) -> None:
+        # A static endpoint catalog opts into public docs; get_documented_tables must succeed with
+        # no credentials and surface the records table as full refresh.
+        assert self.source.lists_tables_without_credentials is True
+        tables = self.source.get_documented_tables()
+        assert [t["name"] for t in tables] == ["records"]
+        assert "Full refresh" in tables[0]["sync_methods"]
+
+    def test_canonical_descriptions_cover_every_endpoint(self) -> None:
+        assert set(self.source.get_canonical_descriptions().keys()) == set(ENDPOINTS)
+
+    @mock.patch(f"{MODULE}.validate_zapier_supported_storage_credentials")
+    def test_validate_credentials_delegates_with_secret(self, mock_validate: mock.MagicMock) -> None:
+        mock_validate.return_value = (True, None)
+
+        result = self.source.validate_credentials(self.config, self.team_id)
+
+        assert result == (True, None)
+        mock_validate.assert_called_once_with(self.config.secret)
+
+    @mock.patch(f"{MODULE}.zapier_supported_storage_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
+        inputs = _make_inputs(schema_name="records", team_id=99)
+
+        self.source.source_for_pipeline(self.config, inputs)
+
+        mock_source.assert_called_once_with(
+            secret=self.config.secret,
+            endpoint="records",
+            logger=inputs.logger,
+        )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterator
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 import requests
 from structlog.types import FilteringBoundLogger
@@ -58,14 +58,31 @@ def _fetch_store(session: requests.Session, secret: str, logger: FilteringBoundL
         )
 
     if not response.ok:
-        logger.error(f"Storage by Zapier API error: status={response.status_code}, body={response.text}")
-        response.raise_for_status()
+        # Never log response.text: the store holds arbitrary secret values and a 4xx body can echo
+        # store contents or request context, which would leak into operational logs. Log only status
+        # plus scheme/host/path (the URL carries no query string here, but stay defensive).
+        safe = urlsplit(response.url)
+        safe_url = f"{safe.scheme}://{safe.netloc}{safe.path}"
+        logger.error(f"Storage by Zapier API error: status={response.status_code}, url={safe_url}")
+        # raise_for_status() would attach the full response (body included) to the exception, which is
+        # surfaced as the schema's latest_error. Rebuild the error from scheme/host/path only so no
+        # response body reaches stored error state. The "<status> Client Error: <reason> for url:
+        # https://store.zapier.com" prefix stays stable for get_non_retryable_errors() matching.
+        raise requests.HTTPError(
+            f"{response.status_code} Client Error: {response.reason} for url: {safe_url}",
+            response=response,
+        )
 
     data = response.json()
-    # The endpoint always returns the whole store as a flat `{key: value}` object.
+    # The endpoint always returns the whole store as a flat `{key: value}` object. Treat any other
+    # shape as retryable rather than an empty store: returning `{}` here would let a transient API or
+    # proxy response complete a "successful" full refresh with zero rows and wipe previously synced
+    # records.
     if not isinstance(data, dict):
         logger.error(f"Storage by Zapier returned an unexpected payload shape: {type(data).__name__}")
-        return {}
+        raise ZapierSupportedStorageRetryableError(
+            f"Storage by Zapier returned an unexpected payload shape: {type(data).__name__}"
+        )
     return data
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
@@ -91,7 +91,9 @@ def get_rows(secret: str, logger: FilteringBoundLogger) -> Iterator[Any]:
     # capture=False: the entire response body is the store's arbitrary key/value contents, so HTTP
     # sample capture would serialize customer data to object storage where the name-based scrubbers
     # can't redact keys they don't recognize. Requests are still metered and logged.
-    session = make_tracked_session(redact_values=(secret,), capture=False)
+    # allow_redirects=False: the `X-Secret` header is a credential and requests does not strip custom
+    # headers when following cross-host redirects, so pin the credentialed request to store.zapier.com.
+    session = make_tracked_session(redact_values=(secret,), capture=False, allow_redirects=False)
 
     # The store is fetched in a single call - there is no pagination or list endpoint.
     store = _fetch_store(session, secret, logger)
@@ -131,7 +133,9 @@ def validate_credentials(secret: str) -> tuple[bool, str | None]:
     """
     # capture=False for the same reason as get_rows: even a single-key probe response echoes stored
     # customer data that the name-based sample-capture scrubbers can't be trusted to redact.
-    session = make_tracked_session(redact_values=(secret,), capture=False)
+    # allow_redirects=False pins the credentialed `X-Secret` request to store.zapier.com so the secret
+    # can't be forwarded to a cross-host redirect target.
+    session = make_tracked_session(redact_values=(secret,), capture=False, allow_redirects=False)
     # Limit the probe to a single key so we don't pull a whole store just to validate.
     url = f"{ZAPIER_SUPPORTED_STORAGE_URL}?{urlencode({'key': '__posthog_probe__'})}"
     try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
@@ -88,7 +88,10 @@ def _fetch_store(session: requests.Session, secret: str, logger: FilteringBoundL
 
 def get_rows(secret: str, logger: FilteringBoundLogger) -> Iterator[Any]:
     batcher = Batcher(logger=logger, chunk_size=5000, chunk_size_bytes=100 * 1024 * 1024)
-    session = make_tracked_session(redact_values=(secret,))
+    # capture=False: the entire response body is the store's arbitrary key/value contents, so HTTP
+    # sample capture would serialize customer data to object storage where the name-based scrubbers
+    # can't redact keys they don't recognize. Requests are still metered and logged.
+    session = make_tracked_session(redact_values=(secret,), capture=False)
 
     # The store is fetched in a single call - there is no pagination or list endpoint.
     store = _fetch_store(session, secret, logger)
@@ -126,7 +129,9 @@ def validate_credentials(secret: str) -> tuple[bool, str | None]:
     - 400: the secret is not a valid UUID4 (Storage by Zapier rejects malformed secrets outright).
     - 401: the secret is missing or does not resolve to a store (invalid).
     """
-    session = make_tracked_session(redact_values=(secret,))
+    # capture=False for the same reason as get_rows: even a single-key probe response echoes stored
+    # customer data that the name-based sample-capture scrubbers can't be trusted to redact.
+    session = make_tracked_session(redact_values=(secret,), capture=False)
     # Limit the probe to a single key so we don't pull a whole store just to validate.
     url = f"{ZAPIER_SUPPORTED_STORAGE_URL}?{urlencode({'key': '__posthog_probe__'})}"
     try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zapier_supported_storage/zapier_supported_storage.py
@@ -1,0 +1,129 @@
+import json
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.zapier_supported_storage.settings import (
+    ZAPIER_SUPPORTED_STORAGE_ENDPOINTS,
+)
+
+# The host is fixed (Storage by Zapier is a single global service). Only the per-store `secret`
+# varies, and it is sent as a header, so there is no host to interpolate and no SSRF surface.
+ZAPIER_SUPPORTED_STORAGE_URL = "https://store.zapier.com/api/records"
+
+
+class ZapierSupportedStorageRetryableError(Exception):
+    pass
+
+
+def _headers(secret: str) -> dict[str, str]:
+    return {"X-Secret": secret, "Accept": "application/json"}
+
+
+def _stringify_value(value: Any) -> str | None:
+    """Coerce a stored value to a string so the `value` column has one stable type.
+
+    Storage by Zapier holds arbitrary JSON per key (strings, numbers, objects, arrays). Keeping the
+    column a single type avoids schema-inference conflicts across rows in the Delta table; strings
+    pass through unchanged and everything else is JSON-encoded. `None` is preserved so a genuinely
+    null value stays null rather than becoming the literal string "null"."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+@retry(
+    retry=retry_if_exception_type(
+        (ZapierSupportedStorageRetryableError, requests.ReadTimeout, requests.ConnectionError)
+    ),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_store(session: requests.Session, secret: str, logger: FilteringBoundLogger) -> dict[str, Any]:
+    response = session.get(ZAPIER_SUPPORTED_STORAGE_URL, headers=_headers(secret), timeout=60)
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise ZapierSupportedStorageRetryableError(
+            f"Storage by Zapier API error (retryable): status={response.status_code}"
+        )
+
+    if not response.ok:
+        logger.error(f"Storage by Zapier API error: status={response.status_code}, body={response.text}")
+        response.raise_for_status()
+
+    data = response.json()
+    # The endpoint always returns the whole store as a flat `{key: value}` object.
+    if not isinstance(data, dict):
+        logger.error(f"Storage by Zapier returned an unexpected payload shape: {type(data).__name__}")
+        return {}
+    return data
+
+
+def get_rows(secret: str, logger: FilteringBoundLogger) -> Iterator[Any]:
+    batcher = Batcher(logger=logger, chunk_size=5000, chunk_size_bytes=100 * 1024 * 1024)
+    session = make_tracked_session(redact_values=(secret,))
+
+    # The store is fetched in a single call - there is no pagination or list endpoint.
+    store = _fetch_store(session, secret, logger)
+    for key, value in store.items():
+        batcher.batch({"key": key, "value": _stringify_value(value)})
+        if batcher.should_yield():
+            yield batcher.get_table()
+
+    if batcher.should_yield(include_incomplete_chunk=True):
+        yield batcher.get_table()
+
+
+def zapier_supported_storage_source(
+    secret: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> SourceResponse:
+    config = ZAPIER_SUPPORTED_STORAGE_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(secret=secret, logger=logger),
+        primary_keys=config.primary_keys,
+        # Full refresh only - the store exposes no timestamps to partition on.
+        partition_count=1,
+        partition_size=1,
+    )
+
+
+def validate_credentials(secret: str) -> tuple[bool, str | None]:
+    """Confirm the store secret is genuine with one cheap probe.
+
+    The secret both identifies and authorizes the store, so a single GET tells us everything:
+    - 200: the secret resolves to a store (valid).
+    - 400: the secret is not a valid UUID4 (Storage by Zapier rejects malformed secrets outright).
+    - 401: the secret is missing or does not resolve to a store (invalid).
+    """
+    session = make_tracked_session(redact_values=(secret,))
+    # Limit the probe to a single key so we don't pull a whole store just to validate.
+    url = f"{ZAPIER_SUPPORTED_STORAGE_URL}?{urlencode({'key': '__posthog_probe__'})}"
+    try:
+        response = session.get(url, headers=_headers(secret), timeout=10)
+    except requests.RequestException as exc:
+        return False, f"Could not reach Storage by Zapier: {exc}"
+
+    if response.ok:
+        return True, None
+    if response.status_code == 400:
+        return (
+            False,
+            "Your Storage by Zapier secret must be a valid UUID4. Copy the store secret exactly and reconnect.",
+        )
+    if response.status_code == 401:
+        return False, "Your Storage by Zapier secret is invalid. Copy the store secret exactly and reconnect."
+    return False, f"Storage by Zapier API returned status {response.status_code}"


### PR DESCRIPTION
## Problem

`zapier_supported_storage` (Storage by Zapier) was scaffolded as an unreleased stub with no sync logic. Storage by Zapier is a lightweight cloud key/value store people use to persist small bits of state between Zap runs and code steps. This wires it up end to end so users can pull a store into the PostHog data warehouse.

## Changes

Filled in the scaffolded source following the `implementing-warehouse-sources` skill and the standard `source.py` / `settings.py` / `zapier_supported_storage.py` split.

- **Transport** (`zapier_supported_storage.py`): a single `GET https://store.zapier.com/api/records` with the store secret sent as the `X-Secret` header, through the tracked HTTP session. The endpoint returns the whole store as one flat `{key: value}` object, so we materialize it as one row per key with a stable `value` column (strings pass through, other JSON is JSON-encoded, null stays null). `tenacity` retries on 429/5xx.
- **Source** (`source.py`): `SimpleSource` with a single required `secret` password field, `alpha` release, category Engineering & monitoring. `validate_credentials` does one cheap single-key probe and maps 200/400/401 to clear messages. `get_non_retryable_errors` stops the sync on 401/400. Canonical table/column descriptions added.
- **Schema** (`settings.py`): one `records` table, primary key `key`. Full refresh only.

> [!NOTE]
> Full refresh only, by design. The store exposes no created/updated timestamps and no pagination or list endpoint beyond fetching everything, so incremental sync is impossible and there is nothing stable to partition on. I verified the API shape and auth behavior with curl against the live service (401 with no secret, 400 on a non-UUID secret, 200 returning a flat key/value object).

Kept behind `unreleasedSource=True` with `releaseStatus=alpha` as requested. Used the existing committed `zapier_supported_storage.png` icon rather than adding a redundant SVG.

## How did you test this code?

Automated tests I (Claude) actually ran, all passing:

- `tests/test_zapier_supported_storage.py` (transport): value coercion across JSON types, one-row-per-key, non-dict payload guard, retryable (429/5xx) vs non-retryable (4xx) classification, credential status mapping, lazy `SourceResponse`.
- `tests/test_zapier_supported_storage_source.py` (source): source type, config field shape, schemas, credential/pipeline plumbing, credential-free documented-tables rendering.
- Re-ran `test_source_categories` (1506 passed) as a wiring guard, and confirmed the source registers, parses config, and lists documented tables via the registry.

I could not run a live end-to-end sync (no real store secret available), so behavior is verified against the documented and curl-observed API contract plus the unit tests above.

## Docs update

I authored the user-facing doc following the `documenting-warehouse-sources` skill (canonical template, shared snippets, `<SourceParameters />` + `<SourceTables />`, `sourceId: ZapierSupportedStorage`, slug `zapier-supported-storage` matching `docsUrl`). No posthog.com checkout was available in this environment, so the doc could not be committed here or run through `audit_source_docs` - it needs to land in the posthog.com repo at `contents/docs/cdp/sources/zapier-supported-storage.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) at Tom's direction. Skills invoked: `/implementing-warehouse-sources`, `/documenting-warehouse-sources`, `/writing-tests`.

Notable decisions:
- Chose `SimpleSource` (not `ResumableSource`): the store is a single call with no cursor, page token, or time window to persist, so there is nothing to resume from.
- The config generator regenerates the whole `generated_configs.py` and, on top of my one field, pulled in unrelated churn (Stripe/BigQuery config drift where master's generated file is stale, plus un-`ruff format`ed line wrapping). To keep the diff minimal I restored master's file and applied only the one-line `secret: str` change to `ZapierSupportedStorageSourceConfig`, matching exactly what the generator emits for a required password field.
- No enum/schema/migration wiring was touched - that already exists on master.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
