### PR TITLE
feat(data-warehouse): implement together_ai import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/docs/together-ai.mdx
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/docs/together-ai.mdx
@@ -60,8 +60,8 @@ fits how often your Together AI activity changes.
 
 <SourceTables />
 
-The `models` table (Together AI's global model catalog) is not selected for sync by default, since it
-is the same for every account and large. Enable it if you want the catalog in your warehouse.
+The `models` table is Together AI's global model catalog. It's the same for every account and fairly
+large, so deselect it during setup if you don't need the catalog in your warehouse.
 
 ## Troubleshooting
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/docs/together-ai.mdx
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/docs/together-ai.mdx
@@ -1,0 +1,71 @@
+---
+title: Linking Together AI as a source
+sidebar: Docs
+showTitle: true
+availability: { free: full, selfServe: full, enterprise: full }
+sourceId: TogetherAI
+beta: true
+---
+
+<!--
+This is the user-facing posthog.com source doc. It lives here only because no posthog.com
+checkout was available when the source was implemented. Move it to
+`posthog.com/contents/docs/cdp/sources/together-ai.mdx` and delete this copy, then run
+`python manage.py audit_source_docs --docs-dir <posthog.com>/contents/docs/cdp/sources`.
+-->
+
+import SourceSetupIntro from '../_snippets/source-setup-intro.mdx'
+import SyncModes from '../_snippets/sync-modes.mdx'
+import TroubleshootingLink from '../_snippets/dw-troubleshooting-link.mdx'
+import AlphaRelease from '../_snippets/alpha-release.mdx'
+
+<AlphaRelease />
+
+[Together AI](https://www.together.ai) is an AI-native cloud for open-source model inference,
+fine-tuning, and GPU clusters. Linking it as a source syncs your platform data — fine-tuning jobs,
+batch inference jobs, uploaded files, deployed endpoints, and evaluations — into the PostHog Data
+warehouse, so you can join it with your product data (for example, correlating fine-tuning runs or
+model endpoints with in-product usage).
+
+## Prerequisites
+
+To connect Together AI, you need:
+
+- A Together AI account.
+- An API key generated from your Together AI account settings (used as a bearer token). The key is
+  account-wide, so no extra scopes are required.
+
+## Adding a data source
+
+<SourceSetupIntro />
+
+1. Open Together AI and go to your [API keys settings](https://api.together.xyz/settings/api-keys).
+2. Create a new API key and copy it.
+3. Paste the key into the **API key** field in PostHog.
+
+## Sync modes
+
+<SyncModes />
+
+Together AI's list endpoints have no pagination and no server-side "updated since" filter, so every
+table syncs as a **full refresh** — each sync re-reads the resource and merges on the primary key.
+These collections are small per account, so a full refresh is cheap. Schedule syncs at a cadence that
+fits how often your Together AI activity changes.
+
+## Configuration
+
+<SourceParameters />
+
+## Supported tables
+
+<SourceTables />
+
+The `models` table (Together AI's global model catalog) is not selected for sync by default, since it
+is the same for every account and large. Enable it if you want the catalog in your warehouse.
+
+## Troubleshooting
+
+- **"Invalid Together AI API key"** when connecting: the key is wrong or has been revoked. Generate a
+  new key in your Together AI API keys settings and re-enter it.
+
+<TroubleshootingLink />

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/docs/together-ai.mdx
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/docs/together-ai.mdx
@@ -16,6 +16,8 @@ checkout was available when the source was implemented. Move it to
 
 import SourceSetupIntro from '../_snippets/source-setup-intro.mdx'
 import SyncModes from '../_snippets/sync-modes.mdx'
+import SourceParameters from '../_snippets/source-parameters.mdx'
+import SourceTables from '../_snippets/source-tables.mdx'
 import TroubleshootingLink from '../_snippets/dw-troubleshooting-link.mdx'
 import AlphaRelease from '../_snippets/alpha-release.mdx'
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/together_ai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/together_ai/together_ai.py
@@ -5,6 +5,7 @@ from urllib.parse import urlsplit
 import requests
 from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from urllib3.util.retry import Retry
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
@@ -87,7 +88,11 @@ def _extract_rows(payload: Any, endpoint: str) -> list[dict[str, Any]]:
 
 def get_rows(api_key: str, endpoint: str, logger: FilteringBoundLogger) -> Iterator[list[dict[str, Any]]]:
     endpoint_config = TOGETHER_AI_ENDPOINTS[endpoint]
-    session = make_tracked_session(redact_values=(api_key,))
+    # Disable the session's built-in urllib3 retry layer: `_fetch` already retries 429/5xx (via
+    # `TogetherAIRetryableError`) and timeouts/connection errors through tenacity. Leaving the
+    # default `Retry(total=3)` in place would stack under tenacity's 5 attempts, so a rate-limited
+    # endpoint could see far more requests than intended instead of backing off cleanly.
+    session = make_tracked_session(redact_values=(api_key,), retry=Retry(total=0))
 
     url = f"{TOGETHER_AI_BASE_URL}{endpoint_config.path}"
     payload = _fetch(session, url, endpoint_config.params or None, _get_headers(api_key), logger)


### PR DESCRIPTION
## Problem

Together AI was scaffolded as a warehouse source but had no sync logic - the stub had empty fields and did nothing. Together AI is an AI-native cloud for open-source model inference and fine-tuning, and it exposes queryable historical entities (fine-tuning jobs, batch inference jobs, files, deployed endpoints, evaluations) that are useful to join against product data in the warehouse.

## Changes

This fills in the stub end-to-end following the `implementing-warehouse-sources` skill's `source.py` / `settings.py` / `together_ai.py` split.

Endpoints synced (all `GET /v1/<resource>` with Bearer API-key auth):

| Table | Path | Primary key | Notes |
| --- | --- | --- | --- |
| `fine_tunes` | `/fine-tunes` | `id` | wrapped `{"data": [...]}` |
| `batches` | `/batches` | `id` | bare array |
| `files` | `/files` | `id` | wrapped; `created_at` is a Unix int, so unpartitioned |
| `endpoints` | `/endpoints` | `id` | wrapped |
| `evaluations` | `/evaluation` | `workflow_id` | bare array; job id is `workflow_id`, not `id` |
| `models` | `/models` | `id` | bare array; global catalog, off by default, unpartitioned |

Key decisions:

- **`SimpleSource`, full refresh only.** No Together AI list endpoint exposes pagination or a server-side "updated since" filter, so incremental would re-fetch the whole collection every sync anyway. Collections are small per account, so a single full fetch per table is cheap. This matches the API research and keeps the source simple (no resume state to persist).
- **Response shape varies per endpoint.** Some endpoints wrap rows in `{"data": [...]}`, others return a bare top-level array. `settings.py` carries a per-endpoint `data_key` and the transport unwraps accordingly. A shape mismatch raises `ValueError` to bypass the retry budget (permanent contract violation).
- **Partitioning on stable `created_at` only** where the field is an ISO-8601 datetime. `files.created_at` and `models.created` are integer Unix timestamps the datetime partitioner can't parse, so those tables are unpartitioned. Never partition on a churning field.
- All outbound HTTP goes through `make_tracked_session()` with the bearer token in `redact_values`.
- `get_non_retryable_errors()` fails fast on 401/403 (a bad key can't be fixed by retrying).
- `lists_tables_without_credentials = True` since `get_schemas` is a static catalog, so the public docs render the Supported tables section.

Kept behind `unreleasedSource=True` with `releaseStatus=ALPHA` per the task scope.

> [!NOTE]
> API behavior (response shapes, absence of pagination/timestamp filters, `evaluations` keying on `workflow_id`) was verified against the current public Together AI API reference docs. It was **not** curl-verified against the live API - I don't have a Together AI API key in this environment. The parsing is conservative (explicit shape checks, unexpected shapes raise rather than silently drop rows), and the uncertainty is noted in code comments.

## How did you test this code?

Automated tests only (I did not run against the live Together AI API). Two new test modules, run with pytest:

- `tests/test_together_ai_source.py` - source type, config (alpha + unreleased, category, docsUrl), fields, schema listing (full refresh, `workflow_id` key for evaluations, `models` off by default), `validate_credentials` mapping and per-endpoint path probing, `source_for_pipeline` arg plumbing, non-retryable error matching, canonical descriptions coverage.
- `tests/test_together_ai.py` - URL building, `data_key` unwrap vs bare-array parsing, retryable (429/5xx) vs non-retryable (4xx) status handling, unexpected-shape `ValueError`, credential validation, single-request full-collection fetch, and per-endpoint `SourceResponse` partition shape.

All 47 new tests pass. The existing `test_source_categories` and `test_source_config_generator` suites (1521 tests) also pass, which confirms the category is set and the hand-written `generated_configs.py` entry matches generator output exactly.

> [!NOTE]
> Two things could not be completed in this environment and need follow-up:
> - **Config generator / schema build**: `pnpm run generate:source-configs` and `pnpm run schema:build` need a booting Django app (DB connection), which isn't available here. I hand-edited `TogetherAISourceConfig` in `generated_configs.py` to `api_key: str` - the exact output the generator produces for a single required password field, and the config-generator test passing (regenerate-and-compare) confirms it matches. No enum/schema migration was needed (the enum value already exists on master).
> - **Icon**: no `frontend/public/services/together_ai.svg` exists yet. Fetching a logo needs a Logo.dev key I don't have, so I did not commit a placeholder. `iconPath` still points at `together_ai.png`; the icon needs to be added before release. The source is hidden (`unreleasedSource=True`) so this doesn't affect users yet.
> - **Docs**: the user-facing doc was written per `documenting-warehouse-sources` but lives at `.../together_ai/docs/together-ai.mdx` in this repo since no posthog.com checkout was available. It needs to move to `posthog.com/contents/docs/cdp/sources/together-ai.mdx`, after which `audit_source_docs` should be run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Implemented by Claude (Opus 4.8) via PostHog Code. Skills invoked: `/implementing-warehouse-sources` (architecture contract, base-class choice, tracked transport, incremental rules) and `/documenting-warehouse-sources` (doc template + slug rule).

Reference sources studied: `bluetally` (closest analog - SimpleSource-shaped REST source with a static catalog and both test modules) and `klaviyo`. Together AI's API was researched from the current public reference docs to confirm each endpoint's response shape and the absence of pagination/timestamp filters. `ResumableSource` was considered and rejected: with no cursor or page token to persist, there is nothing to resume, so `SimpleSource` is correct. `models` was set off-by-default because it's a large global catalog identical for every account rather than account-specific data.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
