### PR TITLE
fix(growth): stop untouched push inline row breaking org saves

### DIFF
--- a/products/growth/backend/admin.py
+++ b/products/growth/backend/admin.py
@@ -195,12 +195,10 @@ class ProductPushCampaignInlineForm(ProductPushCampaignForm):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        # The extra "add" row must be able to submit an empty product. Without a blank
-        # choice its <select> defaults to the first ProductKey, so merely saving the
-        # Organization inserts a phantom campaign - and 500s on
-        # uniq_pending_product_push_per_org_product once that product is already queued.
+        # Without a blank choice the add row's <select> submits the first ProductKey,
+        # so every org save inserted a phantom campaign and 500ed once one was queued.
         product_key_field = self.fields["product_key"]
-        assert isinstance(product_key_field, forms.ChoiceField)  # replaced in ProductPushCampaignForm.__init__
+        assert isinstance(product_key_field, forms.ChoiceField)  # built in ProductPushCampaignForm.__init__
         product_key_field.choices = BLANK_CHOICE_DASH + list(product_key_field.choices)
 
 

--- a/products/growth/backend/admin.py
+++ b/products/growth/backend/admin.py
@@ -35,6 +35,11 @@ def humanize_product_key(product_key: str) -> str:
     return " ".join(parts)
 
 
+def product_key_choices() -> list[tuple[str, str]]:
+    """ProductKey values with humanized labels, for the admin dropdowns."""
+    return [(key.value, humanize_product_key(key.value)) for key in sorted(ProductKey, key=lambda k: k.value)]
+
+
 class ProductPushCampaignForm(forms.ModelForm):
     """TAM-facing form: product_key constrained to ProductKey at runtime (the model
     keeps a plain CharField so the enum can grow without migrations), and rows that
@@ -49,9 +54,7 @@ class ProductPushCampaignForm(forms.ModelForm):
         if "product_key" in self.fields:
             self.fields["product_key"] = forms.ChoiceField(
                 # Display humanized names but keep the raw ProductKey as the stored value.
-                choices=[
-                    (key.value, humanize_product_key(key.value)) for key in sorted(ProductKey, key=lambda k: k.value)
-                ],
+                choices=product_key_choices(),
                 label="Product",
                 help_text="Which product to promote in the org's in-app push card.",
             )
@@ -199,7 +202,7 @@ class ProductPushCampaignInlineForm(ProductPushCampaignForm):
         # so every org save inserted a phantom campaign and 500ed once one was queued.
         product_key_field = self.fields["product_key"]
         assert isinstance(product_key_field, forms.ChoiceField)  # built in ProductPushCampaignForm.__init__
-        product_key_field.choices = BLANK_CHOICE_DASH + list(product_key_field.choices)
+        product_key_field.choices = BLANK_CHOICE_DASH + product_key_choices()
 
 
 class ProductPushCampaignInline(admin.TabularInline):

--- a/products/growth/backend/admin.py
+++ b/products/growth/backend/admin.py
@@ -4,6 +4,7 @@ from typing import Any
 from django import forms
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
+from django.db.models.fields import BLANK_CHOICE_DASH
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.html import format_html
@@ -198,7 +199,9 @@ class ProductPushCampaignInlineForm(ProductPushCampaignForm):
         # choice its <select> defaults to the first ProductKey, so merely saving the
         # Organization inserts a phantom campaign - and 500s on
         # uniq_pending_product_push_per_org_product once that product is already queued.
-        self.fields["product_key"].choices = [("", "---------"), *self.fields["product_key"].choices]
+        product_key_field = self.fields["product_key"]
+        assert isinstance(product_key_field, forms.ChoiceField)  # replaced in ProductPushCampaignForm.__init__
+        product_key_field.choices = BLANK_CHOICE_DASH + list(product_key_field.choices)
 
 
 class ProductPushCampaignInline(admin.TabularInline):

--- a/products/growth/backend/admin.py
+++ b/products/growth/backend/admin.py
@@ -192,6 +192,14 @@ class ProductPushCampaignInlineForm(ProductPushCampaignForm):
         model = ProductPushCampaign
         exclude = ("organization",)
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # The extra "add" row must be able to submit an empty product. Without a blank
+        # choice its <select> defaults to the first ProductKey, so merely saving the
+        # Organization inserts a phantom campaign - and 500s on
+        # uniq_pending_product_push_per_org_product once that product is already queued.
+        self.fields["product_key"].choices = [("", "---------"), *self.fields["product_key"].choices]
+
 
 class ProductPushCampaignInline(admin.TabularInline):
     """An organization's push schedule and history on the Organization admin page.

--- a/products/growth/backend/tests/test_product_push_admin.py
+++ b/products/growth/backend/tests/test_product_push_admin.py
@@ -101,3 +101,37 @@ class TestProductPushCampaignAdmin(BaseTest):
         assert campaign.status == ProductPushCampaign.Status.SCHEDULED
         assert campaign.source == ProductPushCampaign.Source.TAM
         assert campaign.created_by == self.user
+
+    def test_untouched_inline_add_row_saves_nothing(self) -> None:
+        # The extra add row's <select> needs a blank first choice: browsers otherwise submit
+        # the first ProductKey, so every Organization save inserted a phantom campaign and
+        # 500ed on the pending-per-product constraint once that product was already queued.
+        ProductPushCampaign.objects.create(
+            organization=self.organization, product_key="actions", status=ProductPushCampaign.Status.SCHEDULED
+        )
+        inline = ProductPushCampaignInline(Organization, AdminSite())
+        request = self.request_factory.post("/admin/posthog/organization/")
+        request.user = self.user
+        formset_class = inline.get_formset(request, self.organization)
+        prefix = formset_class.get_default_prefix()
+
+        assert formset_class.form(instance=None).fields["product_key"].choices[0] == ("", "---------")
+
+        formset = formset_class(
+            instance=self.organization,
+            data={
+                f"{prefix}-TOTAL_FORMS": "1",
+                f"{prefix}-INITIAL_FORMS": "0",
+                f"{prefix}-MIN_NUM_FORMS": "0",
+                f"{prefix}-MAX_NUM_FORMS": "1000",
+                f"{prefix}-0-id": "",
+                f"{prefix}-0-product_key": "",
+                f"{prefix}-0-position": "0",
+                f"{prefix}-0-scheduled_for": "",
+                f"{prefix}-0-reason_text": "",
+            },
+        )
+
+        assert formset.is_valid(), formset.errors
+        assert formset.save() == []
+        assert ProductPushCampaign.objects.filter(organization=self.organization).count() == 1

--- a/products/growth/backend/tests/test_product_push_admin.py
+++ b/products/growth/backend/tests/test_product_push_admin.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from posthog.test.base import BaseTest
 
+from django import forms
 from django.contrib.admin import AdminSite
 from django.test import RequestFactory
 from django.urls import reverse
@@ -103,9 +104,8 @@ class TestProductPushCampaignAdmin(BaseTest):
         assert campaign.created_by == self.user
 
     def test_untouched_inline_add_row_saves_nothing(self) -> None:
-        # The extra add row's <select> needs a blank first choice: browsers otherwise submit
-        # the first ProductKey, so every Organization save inserted a phantom campaign and
-        # 500ed on the pending-per-product constraint once that product was already queued.
+        # Without a blank first choice, an untouched add row submits the first ProductKey
+        # and inserts a phantom campaign - a 500 once that product is already queued.
         ProductPushCampaign.objects.create(
             organization=self.organization, product_key="actions", status=ProductPushCampaign.Status.SCHEDULED
         )
@@ -115,7 +115,9 @@ class TestProductPushCampaignAdmin(BaseTest):
         formset_class = inline.get_formset(request, self.organization)
         prefix = formset_class.get_default_prefix()
 
-        assert formset_class.form(instance=None).fields["product_key"].choices[0] == ("", "---------")
+        product_key_field = formset_class.form(instance=None).fields["product_key"]
+        assert isinstance(product_key_field, forms.ChoiceField)
+        assert next(iter(product_key_field.choices)) == ("", "---------")
 
         formset = formset_class(
             instance=self.organization,

--- a/products/growth/backend/tests/test_product_push_admin.py
+++ b/products/growth/backend/tests/test_product_push_admin.py
@@ -4,12 +4,13 @@ from posthog.test.base import BaseTest
 
 from django import forms
 from django.contrib.admin import AdminSite
+from django.db.models.fields import BLANK_CHOICE_DASH
 from django.test import RequestFactory
 from django.urls import reverse
 
 from posthog.models.organization import Organization
 
-from products.growth.backend.admin import ProductPushCampaignAdmin, ProductPushCampaignInline
+from products.growth.backend.admin import ProductPushCampaignAdmin, ProductPushCampaignInline, product_key_choices
 from products.growth.backend.models import ProductPushCampaign
 
 
@@ -117,7 +118,7 @@ class TestProductPushCampaignAdmin(BaseTest):
 
         product_key_field = formset_class.form(instance=None).fields["product_key"]
         assert isinstance(product_key_field, forms.ChoiceField)
-        assert next(iter(product_key_field.choices)) == ("", "---------")
+        assert product_key_field.choices == BLANK_CHOICE_DASH + product_key_choices()
 
         formset = formset_class(
             instance=self.organization,


### PR DESCRIPTION
## Problem

Saving an Organization in Django admin 500s once the org has a scheduled or active product push campaign:

```
IntegrityError: duplicate key value violates unique constraint "uniq_pending_product_push_per_org_product"
```

The product push inline's extra add row renders `product_key` as a required select with **no blank option**, so browsers submit the first `ProductKey` (`actions`) even when the row was never touched. Every org save then inserts a phantom scheduled campaign. The first save creates it silently, the next one collides with the pending-per-product constraint, and the `IntegrityError` escapes as a 500 - blocking any edit to the org, including disabling/reactivating it.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019f4bae-8f45-7893-a1d1-a0a5190057b9) (internal), reported in Slack when reactivating an org kept 500ing.

## Changes

- Add a blank first choice to `product_key` on `ProductPushCampaignInlineForm`, so an untouched add row submits empty, counts as unchanged, and is skipped. Deliberately added rows still require picking a product.

> Not in this PR: Django doesn't validate conditional `UniqueConstraint`s in inline formsets, so a TAM *deliberately* adding a duplicate product would still 500. Worth a formset-level `clean()` as a follow-up, but this PR removes the way orgs get bricked by accident.

## How did you test this code?

Added `test_untouched_inline_add_row_saves_nothing` to `products/growth/backend/tests/test_product_push_admin.py` - an untouched extra row on an org that already has a scheduled `actions` campaign must validate and save nothing (previously it raised `IntegrityError`). No existing test covered the untouched-row path.

I (well, Claude) could not run the test locally - the local Docker VM refused to start - so CI is the gate here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code at Alex's direction, starting from a Slack report of an org that couldn't be reactivated. Root cause traced through error tracking to the inline's select defaulting to the first product. Considered fixing the base `ProductPushCampaignForm` instead, but the standalone add page genuinely wants a required choice - only the inline's always-present extra row needs to be able to submit nothing. Skills invoked: `/writing-tests`.
