### PR TITLE
feat(web-analytics): gate session replay tile behind removal experiment

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -526,6 +526,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_PRECOMPUTE_TOGGLE: 'web-analytics-precompute-toggle', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_RECAP: 'web-analytics-recap', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_REGIONS_MAP: 'web-analytics-regions-map', // owner: @jordanm-posthog #team-web-analytics
+    WEB_ANALYTICS_REMOVE_REPLAY_TILE: 'web-analytics-remove-replay-tile', // owner: @lricoy #team-web-analytics multivariate=control,test
     WEB_ANALYTICS_SESSION_PROPERTY_CHARTS: 'web-analytics-session-property-charts', // owner: @lricoy #team-web-analytics
     WEB_ANALYTICS_SHARE_NUDGE_V2: 'web-analytics-share-nudge-v2', // owner: @jordanm-posthog #team-web-analytics multivariate=control,control_b,banner,export
     WEB_ANALYTICS_STREAK_CADENCE: 'web-analytics-streak-cadence', // owner: @jordanm-posthog #team-web-analytics multivariate=control,hybrid,daily-only,weekly-only

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1381,11 +1381,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                 const useTileHeaderV2 = featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_HEADER_V2] === 'test'
 
-                // Only read the removal experiment flag on the analytics tab, where the tile actually renders.
-                // allTiles is also built for the bot-analytics tab (then discarded), so an unconditional read
-                // there would enroll users neither variant affects and dilute the experiment metrics.
+                // Only read the removal experiment flag where the replay tile would actually render: the
+                // analytics tab with no conversion goal. allTiles is also built for the bot-analytics tab
+                // (then discarded), and the tile is hidden whenever a conversion goal is set, so reading the
+                // flag outside this path would enroll users neither variant affects and dilute the metrics.
                 const removeReplayTile =
                     productTab === ProductTab.ANALYTICS &&
+                    !conversionGoal &&
                     featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REMOVE_REPLAY_TILE] === 'test'
 
                 const includeHostMenuItem: LemonMenuItem | null =

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1381,6 +1381,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                 const useTileHeaderV2 = featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_HEADER_V2] === 'test'
 
+                // Only read the removal experiment flag on the analytics tab, where the tile actually renders.
+                // allTiles is also built for the bot-analytics tab (then discarded), so an unconditional read
+                // there would enroll users neither variant affects and dilute the experiment metrics.
+                const removeReplayTile =
+                    productTab === ProductTab.ANALYTICS &&
+                    featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REMOVE_REPLAY_TILE] === 'test'
+
                 const includeHostMenuItem: LemonMenuItem | null =
                     useTileHeaderV2 && featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_INCLUDE_HOST]
                         ? {
@@ -2343,7 +2350,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               },
                           }
                         : null,
-                    !conversionGoal && featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REMOVE_REPLAY_TILE] !== 'test'
+                    !conversionGoal && !removeReplayTile
                         ? {
                               kind: 'replay',
                               tileId: TileId.REPLAY,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -2343,7 +2343,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               },
                           }
                         : null,
-                    !conversionGoal
+                    !conversionGoal && featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REMOVE_REPLAY_TILE] !== 'test'
                         ? {
                               kind: 'replay',
                               tileId: TileId.REPLAY,


### PR DESCRIPTION
## Problem

The Web analytics dashboard renders a "Session replay" tile that mounts `sessionRecordingsPlaylistLogic` on every dashboard load to show just its top 5 recordings, so it runs a full session-recordings-list query each time the dashboard opens. Usage analysis shows the tile gets almost no genuine engagement (people reach replays via the left nav and the contextual "View recordings" cross-sell button instead), so we want to test removing it — but validate retention isn't affected before dropping it for good.

## Changes

- Add the `web-analytics-remove-replay-tile` feature flag (`control` / `test`) in `frontend/src/lib/constants.tsx`.
- Gate the `TileId.REPLAY` tile in `webAnalyticsLogic.tsx` so it renders only when the flag is not `test`. Default/absent flag keeps the tile (no behavior change for anyone not enrolled); the `test` variant removes it, which also stops the recordings-list query from running on those loads.

This is scaffolding for experiment [#382421](https://us.posthog.com/project/2/experiments/382421):
- Primary metric: web analytics return retention (7-day).
- Guardrail: reached Session replay (`/replay` pageviews) — should not drop.

## How did you test this code?

Not manually run by the agent (no dev stack in this environment). The change mirrors the existing `WEB_ANALYTICS_TILE_HEADER_V2 === 'test'` flag-gating pattern already used in the same selector, and the flag comparison is type-identical to it. CI typecheck/lint will cover the static checks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread investigating whether the Session Replay tile in Web analytics earns its query cost. The investigation found the tile is barely used, so the ask was to set up an A/B test for removing it and measure retention + whether anyone misses it.

- Skills invoked: `/creating-experiments`, `/configuring-experiment-analytics`.
- The experiment and its `web-analytics-remove-replay-tile` flag were created via MCP; this PR only wires the flag into the frontend. `control` was chosen as the tile-shown baseline so absent-flag behavior is unchanged.
- Left the Error tracking tile untouched — usage data showed it does get real engagement.

_Created from a [Slack thread](https://posthog.slack.com/archives/C05LJK1N3CP/p1783666821078089?thread_ts=1783666821.078089&cid=C05LJK1N3CP)._
