### PR TITLE
fix(tasks): stop writing error_message onto runs completed by inactivity timeout

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -3,6 +3,12 @@ from typing import Literal, get_args
 
 import posthoganalytics
 
+# TaskRun.state key set when a run completes because its inactivity timeout fired rather
+# than the agent finishing. Consumers (e.g. Slack updates) render these completions quietly;
+# the signal lives in state, not error_message, so a normal completion never carries an
+# error and never reads as a failure in UIs that surface error_message.
+TIMED_OUT_INACTIVITY_STATE_KEY = "timed_out_inactivity"
+
 SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
 AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG = "tasks-agent-proxy-keep-stream-open"
 MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -3,12 +3,6 @@ from typing import Literal, get_args
 
 import posthoganalytics
 
-# TaskRun.state key set when a run completes because its inactivity timeout fired rather
-# than the agent finishing. Consumers (e.g. Slack updates) render these completions quietly;
-# the signal lives in state, not error_message, so a normal completion never carries an
-# error and never reads as a failure in UIs that surface error_message.
-TIMED_OUT_INACTIVITY_STATE_KEY = "timed_out_inactivity"
-
 SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
 AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG = "tasks-agent-proxy-keep-stream-open"
 MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -10,6 +10,7 @@ from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import close_db_connections
 
 from products.tasks.backend.access import has_tasks_access
+from products.tasks.backend.constants import TIMED_OUT_INACTIVITY_STATE_KEY
 
 logger = get_logger(__name__)
 
@@ -135,7 +136,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
 
         if task_run.status == TaskRun.Status.COMPLETED:
             handler.update_reaction("hedgehog")
-            if task_run.error_message and "timed out" in task_run.error_message:
+            if _is_timed_out_completion(task_run):
                 handler.delete_progress()
                 return
             if pr_url:
@@ -158,6 +159,18 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
             handler.post_or_update_progress(stage, task_url)
     except Exception:
         logger.exception("post_slack_update_failed", run_id=input.run_id)
+
+
+def _is_timed_out_completion(task_run: Any) -> bool:
+    """An inactivity-timeout completion gets no completion card — the thread just went quiet.
+
+    The error_message check is a fallback for runs finalized before the state marker existed;
+    they carry the signal as "Run timed out due to inactivity" in error_message.
+    """
+    state = task_run.state if isinstance(task_run.state, dict) else {}
+    if state.get(TIMED_OUT_INACTIVITY_STATE_KEY):
+        return True
+    return bool(task_run.error_message and "timed out" in task_run.error_message)
 
 
 def _get_stage_from_status(status: str, stage: str | None = None) -> str:

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -164,11 +164,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
 
 
 def _is_timed_out_completion(task_run: Any) -> bool:
-    """An inactivity-timeout completion gets no completion card — the thread just went quiet.
-
-    The error_message check is a fallback for runs finalized before the state marker existed;
-    they carry the signal as "Run timed out due to inactivity" in error_message.
-    """
+    """The error_message check covers runs finalized before the state marker existed."""
     state = task_run.state if isinstance(task_run.state, dict) else {}
     if state.get(TIMED_OUT_INACTIVITY_STATE_KEY):
         return True

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -10,7 +10,9 @@ from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.utils import close_db_connections
 
 from products.tasks.backend.access import has_tasks_access
-from products.tasks.backend.constants import TIMED_OUT_INACTIVITY_STATE_KEY
+from products.tasks.backend.temporal.process_task.activities.update_task_run_status import (
+    TIMED_OUT_INACTIVITY_STATE_KEY,
+)
 
 logger = get_logger(__name__)
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -49,6 +49,27 @@ class TestUpdateTaskRunStatusActivity:
         assert test_task_run.error_message == error_msg
 
     @pytest.mark.django_db(transaction=True)
+    def test_timed_out_inactivity_sets_state_marker_without_error_message(self, activity_environment, test_task_run):
+        test_task_run.state = {**(test_task_run.state or {}), "existing_key": "kept"}
+        test_task_run.save(update_fields=["state"])
+
+        input_data = UpdateTaskRunStatusInput(
+            run_id=str(test_task_run.id),
+            status=TaskRun.Status.COMPLETED,
+            timed_out_inactivity=True,
+        )
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+        test_task_run.refresh_from_db()
+        assert test_task_run.status == TaskRun.Status.COMPLETED
+        # A timed-out run is a normal completion; error_message stays empty so nothing
+        # downstream renders it as a failure.
+        assert test_task_run.error_message is None
+        assert test_task_run.state.get("timed_out_inactivity") is True
+        # Merge, not replace: concurrent state keys survive the marker write.
+        assert test_task_run.state.get("existing_key") == "kept"
+
+    @pytest.mark.django_db(transaction=True)
     @patch("products.tasks.backend.models.TaskRun.publish_stream_state_event")
     def test_publishes_stream_state_event(self, mock_publish_stream_state_event, activity_environment, test_task_run):
         input_data = UpdateTaskRunStatusInput(run_id=str(test_task_run.id), status=TaskRun.Status.IN_PROGRESS)

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -62,11 +62,9 @@ class TestUpdateTaskRunStatusActivity:
 
         test_task_run.refresh_from_db()
         assert test_task_run.status == TaskRun.Status.COMPLETED
-        # A timed-out run is a normal completion; error_message stays empty so nothing
-        # downstream renders it as a failure.
         assert test_task_run.error_message is None
         assert test_task_run.state.get("timed_out_inactivity") is True
-        # Merge, not replace: concurrent state keys survive the marker write.
+        # Merge, not replace: pre-existing state keys survive the marker write.
         assert test_task_run.state.get("existing_key") == "kept"
 
     @pytest.mark.django_db(transaction=True)

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -7,11 +7,16 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
-from products.tasks.backend.constants import TIMED_OUT_INACTIVITY_STATE_KEY
 from products.tasks.backend.metrics import observe_wizard_run_unbound
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.metrics import record_run_token_usage
 from products.tasks.backend.temporal.observability import log_with_activity_context
+
+# TaskRun.state key set when a run completes because its inactivity timeout fired rather
+# than the agent finishing. Consumers (e.g. Slack updates) render these completions quietly;
+# the signal lives in state, not error_message, so a normal completion never carries an
+# error and never reads as a failure in UIs that surface error_message.
+TIMED_OUT_INACTIVITY_STATE_KEY = "timed_out_inactivity"
 
 
 @dataclass

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -7,6 +7,7 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
+from products.tasks.backend.constants import TIMED_OUT_INACTIVITY_STATE_KEY
 from products.tasks.backend.metrics import observe_wizard_run_unbound
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.metrics import record_run_token_usage
@@ -18,6 +19,7 @@ class UpdateTaskRunStatusInput:
     run_id: str
     status: str
     error_message: Optional[str] = None
+    timed_out_inactivity: bool = False
 
 
 @activity.defn
@@ -43,6 +45,10 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
 
     if input.error_message:
         task_run.error_message = input.error_message
+
+    if input.timed_out_inactivity:
+        # Atomic merge (not a plain assignment) so concurrent state writers aren't clobbered.
+        task_run.state = TaskRun.update_state_atomic(task_run.id, updates={TIMED_OUT_INACTIVITY_STATE_KEY: True})
 
     if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED]:
         task_run.completed_at = timezone.now()

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -12,10 +12,8 @@ from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.metrics import record_run_token_usage
 from products.tasks.backend.temporal.observability import log_with_activity_context
 
-# TaskRun.state key set when a run completes because its inactivity timeout fired rather
-# than the agent finishing. Consumers (e.g. Slack updates) render these completions quietly;
-# the signal lives in state, not error_message, so a normal completion never carries an
-# error and never reads as a failure in UIs that surface error_message.
+# TaskRun.state marker for runs completed by the inactivity timeout; kept out of
+# error_message so a normal completion never reads as a failure.
 TIMED_OUT_INACTIVITY_STATE_KEY = "timed_out_inactivity"
 
 
@@ -52,7 +50,7 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
         task_run.error_message = input.error_message
 
     if input.timed_out_inactivity:
-        # Atomic merge (not a plain assignment) so concurrent state writers aren't clobbered.
+        # Atomic merge so concurrent state writers aren't clobbered; reassigned so reads below see it.
         task_run.state = TaskRun.update_state_atomic(task_run.id, updates={TIMED_OUT_INACTIVITY_STATE_KEY: True})
 
     if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED]:

--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -292,7 +292,6 @@ class TestCIFollowUpLoop:
         assert all(msg == DEFAULT_CI_MESSAGE for msg in _ci_followup_calls)
         timeout_updates = [(s, e) for s, e, timed_out in _status_updates if timed_out]
         assert timeout_updates, f"expected an inactivity-timeout completion, got {_status_updates}"
-        # The idle timeout is a normal completion: no error_message on the run.
         assert timeout_updates == [("completed", None)]
 
     @pytest.mark.timeout(60, func_only=True)

--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -374,7 +374,7 @@ class TestCIFollowUpLoop:
 
         assert result.success is True
         assert _ci_followup_calls == []
-        completed_updates = [(s, e) for s, e in _status_updates if s == "completed" and e is None]
+        completed_updates = [(s, e) for s, e, _ in _status_updates if s == "completed" and e is None]
         assert len(completed_updates) >= 1
 
     @pytest.mark.timeout(90, func_only=True)

--- a/products/tasks/backend/temporal/process_task/tests/test_followup.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_followup.py
@@ -27,7 +27,7 @@ from products.tasks.backend.temporal.process_task.workflow import (
     ProcessTaskWorkflow,
 )
 
-_status_updates: list[tuple[str, str | None]] = []
+_status_updates: list[tuple[str, str | None, bool]] = []
 
 
 @activity.defn(name="get_task_processing_context")
@@ -46,7 +46,7 @@ def _mock_get_context(_input) -> TaskProcessingContext:
 
 @activity.defn(name="update_task_run_status")
 def _mock_update_status(input: UpdateTaskRunStatusInput) -> None:
-    _status_updates.append((input.status, input.error_message))
+    _status_updates.append((input.status, input.error_message, input.timed_out_inactivity))
 
 
 @activity.defn(name="prepare_sandbox_for_repository")
@@ -162,7 +162,7 @@ class TestFollowupDeliveryFailure:
 
         assert result.success is True
 
-        failed_updates = [(s, e) for s, e in _status_updates if s == "failed"]
+        failed_updates = [(s, e) for s, e, _ in _status_updates if s == "failed"]
         assert len(failed_updates) == 1
         assert failed_updates[0][1] == "Follow-up delivery failed: RuntimeError: Sandbox session is dead"
 
@@ -290,8 +290,10 @@ class TestCIFollowUpLoop:
         assert result.success is True
         assert len(_ci_followup_calls) == MAX_CI_REPETITIONS
         assert all(msg == DEFAULT_CI_MESSAGE for msg in _ci_followup_calls)
-        timeout_updates = [(s, e) for s, e in _status_updates if "timed out" in (e or "")]
+        timeout_updates = [(s, e) for s, e, timed_out in _status_updates if timed_out]
         assert timeout_updates, f"expected an inactivity-timeout completion, got {_status_updates}"
+        # The idle timeout is a normal completion: no error_message on the run.
+        assert timeout_updates == [("completed", None)]
 
     @pytest.mark.timeout(60, func_only=True)
     async def test_uses_ci_prompt_override_when_set(self):
@@ -347,7 +349,7 @@ class TestCIFollowUpLoop:
                 await handle.result()
 
         assert _ci_followup_calls == []
-        timeout_updates = [(s, e) for s, e in _status_updates if "timed out" in (e or "")]
+        timeout_updates = [(s, e) for s, e, timed_out in _status_updates if timed_out]
         assert timeout_updates, f"expected an inactivity-timeout completion, got {_status_updates}"
 
     @pytest.mark.timeout(60, func_only=True)

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -686,8 +686,6 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             if self._task_completed:
                 await self._update_task_run_status(self._completion_status, error_message=self._completion_error)
             elif timed_out:
-                # Inactivity timeout is a normal completion; the marker lives in run state, not
-                # error_message, so UIs surfacing error_message don't paint it as a failure.
                 await self._update_task_run_status("completed", timed_out_inactivity=True)
 
             # Close out the keep-it-green step so a finished run doesn't show a still-spinning CI step.

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -686,7 +686,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             if self._task_completed:
                 await self._update_task_run_status(self._completion_status, error_message=self._completion_error)
             elif timed_out:
-                await self._update_task_run_status("completed", error_message="Run timed out due to inactivity")
+                # Inactivity timeout is a normal completion; the marker lives in run state, not
+                # error_message, so UIs surfacing error_message don't paint it as a failure.
+                await self._update_task_run_status("completed", timed_out_inactivity=True)
 
             # Close out the keep-it-green step so a finished run doesn't show a still-spinning CI step.
             if self._pr_progress_emitted:
@@ -1292,7 +1294,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             )
 
     async def _update_task_run_status(
-        self, status: str, error_message: Optional[str] = None, run_id: Optional[str] = None
+        self,
+        status: str,
+        error_message: Optional[str] = None,
+        run_id: Optional[str] = None,
+        timed_out_inactivity: bool = False,
     ) -> None:
         await workflow.execute_activity(
             update_task_run_status,
@@ -1300,6 +1306,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 run_id=run_id if run_id is not None else self.context.run_id,
                 status=status,
                 error_message=error_message,
+                timed_out_inactivity=timed_out_inactivity,
             ),
             start_to_close_timeout=timedelta(minutes=1),
             retry_policy=RetryPolicy(maximum_attempts=3),

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -224,7 +224,6 @@ class TestPostSlackUpdate(TestCase):
 
     @parameterized.expand(
         [
-            # Timed-out completions carry the marker in run state, never in error_message.
             ({"state": {"timed_out_inactivity": True}, "error_message": None},),
             # Runs finalized before the state marker existed carry the signal in error_message.
             ({"error_message": "Run timed out due to inactivity"},),

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
+from parameterized import parameterized
+
 from products.slack_app.backend.slack_thread import SlackThreadHandler
 
 _post_slack_update_module = importlib.import_module(
@@ -220,18 +222,32 @@ class TestPostSlackUpdate(TestCase):
         mock_run.task.mark_slack_pr_notified.assert_called_once_with("https://github.com/org/repo/pull/1")
         mock_run.save.assert_not_called()
 
+    @parameterized.expand(
+        [
+            # Timed-out completions carry the marker in run state, never in error_message.
+            ({"state": {"timed_out_inactivity": True}, "error_message": None},),
+            # Runs finalized before the state marker existed carry the signal in error_message.
+            ({"error_message": "Run timed out due to inactivity"},),
+        ]
+    )
     @patch.object(SlackThreadHandler, "post_completion")
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_timed_out_run_silently_deletes_progress(
-        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_delete_progress, mock_post_completion
+        self,
+        run_kwargs,
+        mock_task_run_class,
+        mock_handler_init,
+        mock_update_reaction,
+        mock_delete_progress,
+        mock_post_completion,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
-            error_message="Run timed out due to inactivity",
             output={},
+            **run_kwargs,
         )
         mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
 


### PR DESCRIPTION
## Problem

When a cloud task run ends via the inactivity timeout, the workflow marks it `completed` but also stamps `error_message="Run timed out due to inactivity"` onto the row. The error message existed only as a sentinel for the Slack update to suppress the completion card, but any UI that surfaces `error_message` (desktop app, API consumers) paints a perfectly normal completion as a failure. Idle timeout is how most healthy interactive cloud runs end, so this mislabels a lot of successful runs.

## Changes

- The inactivity-timeout completion no longer writes `error_message`. The signal moves to a run-state marker: `state.timed_out_inactivity = true`, written by the `update_task_run_status` activity via the atomic state merge (new `timed_out_inactivity` flag on `UpdateTaskRunStatusInput`, default false, so in-flight workflows and the other constructors are unaffected).
- `post_slack_update` suppresses the completion card based on the marker, with a fallback on the old `error_message` substring for runs finalized before the marker existed. Slack behavior is unchanged.
- The shared key lives in `products/tasks/backend/constants.py` (`TIMED_OUT_INACTIVITY_STATE_KEY`) so writer and reader can't drift