### PR TITLE
fix(logs): stop logs attributes probe sending malformed dateRange

### DIFF
--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -1068,6 +1068,20 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             return filter_group
         return {"type": "AND", "values": []}
 
+    def _parse_optional_filter_group(self, raw: str | None) -> PropertyGroupFilter | None:
+        """Parse an optional filterGroup query param, treating absent/empty as "no filter".
+
+        An empty dict never validates as a PropertyGroupFilter (type and values are required), and
+        get_model() reports the ValidationError to error tracking before raising. Skipping the parse
+        when nothing was sent avoids capturing a spurious handled exception on every filter-less call.
+        """
+        if not raw:
+            return None
+        try:
+            return self.get_model(json.loads(raw), PropertyGroupFilter)
+        except (json.JSONDecodeError, ValidationError, ValueError, ParseError):
+            return None
+
     def _filtered_logs_query(self, query_data: dict) -> LogsQuery:
         """The shared date-range + filters subset of LogsQuery used by aggregation actions."""
         date_range_data = query_data.get("dateRange")
@@ -1545,10 +1559,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             serviceNames = json.loads(request.GET.get("serviceNames", "[]"))
         except json.JSONDecodeError:
             serviceNames = []
-        try:
-            filterGroup = self.get_model(json.loads(request.GET.get("filterGroup", "{}")), PropertyGroupFilter)
-        except (json.JSONDecodeError, ValidationError, ValueError, ParseError):
-            filterGroup = None
+        filterGroup = self._parse_optional_filter_group(request.GET.get("filterGroup"))
 
         attributeType = request.GET.get("attribute_type", "log")
         # I don't know why went with 'log' and 'resource' not 'log_attribute' and 'log_resource_attribute'
@@ -1618,10 +1629,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
                 serviceNames = json.loads(request.GET.get("serviceNames", "[]"))
             except json.JSONDecodeError:
                 serviceNames = []
-            try:
-                filterGroup = self.get_model(json.loads(request.GET.get("filterGroup", "{}")), PropertyGroupFilter)
-            except (json.JSONDecodeError, ValidationError, ValueError, ParseError):
-                filterGroup = None
+            filterGroup = self._parse_optional_filter_group(request.GET.get("filterGroup"))
 
             attributeType = request.GET.get("attribute_type", "log")
             # I don't know why went with 'log' and 'resource' not 'log_attribute' and 'log_resource_attribute'

--- a/products/logs/backend/test/test_log_values_attributes.py
+++ b/products/logs/backend/test/test_log_values_attributes.py
@@ -2,6 +2,7 @@ import os
 import json
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -304,6 +305,20 @@ class TestLogValuesAttributesTimezones(ClickhouseTestMixin, APIBaseTest):
             trace_id_index, brokers_id_index, "trace_id should appear before brokers.0.id when searching for 'id'"
         )
         self.assertLess(brokers_id_index, pid_index, "brokers.0.id should appear before pid when searching for 'id'")
+
+    @patch("posthog.api.mixins.capture_exception")
+    def test_log_attributes_without_filter_group_does_not_capture_exception(self, mock_capture):
+        # An absent filterGroup must not report a handled PropertyGroupFilter ValidationError to error
+        # tracking: the old empty-dict default never validates and get_model() captures before raising.
+        query_params = {
+            "dateRange": '{"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}',
+            "attribute_type": "resource",
+        }
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/logs/attributes", query_params)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_capture.assert_not_called()
 
 
 class TestLogAttributesIlikeEscaping(ClickhouseTestMixin, APIBaseTest):

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
@@ -165,7 +165,7 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                         // object into the literal "[object Object]". The backend then fails to parse it
                         // and silently falls back to a 1h window, so the 90-day presence probe is wrong.
                         // JSON-encode dateRange instead (matches serviceFilterLogic).
-                        const url = combineUrl(`api/environments/${values.currentTeamId}/logs/attributes`, {
+                        const url = combineUrl(`api/projects/${values.currentTeamId}/logs/attributes`, {
                             attribute_type: 'resource',
                             dateRange: JSON.stringify(PRESENCE_LOOKBACK),
                             limit: 100,

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
@@ -1,14 +1,16 @@
 import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { combineUrl } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 
+import api from 'lib/api'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { UniversalFiltersGroup } from '~/types'
 
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
-import { logsAttributesRetrieve, logsFacetValuesCreate } from '../../../generated/api'
+import { logsFacetValuesCreate } from '../../../generated/api'
 import { _LogFacetValueApi, _LogPropertyFilterApi, _LogsFacetValuesBodyApi } from '../../../generated/api.schemas'
 import type { facetCountsLogicType } from './facetCountsLogicType'
 import { FACETS, FacetConfig } from './facets'
@@ -158,12 +160,19 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                         if (!values.currentTeamId) {
                             return []
                         }
-                        const response = await logsAttributesRetrieve(String(values.currentTeamId), {
+                        // Build the URL by hand rather than via the generated client: its fetch URL
+                        // builder serializes query params with String(value), turning the dateRange
+                        // object into the literal "[object Object]". The backend then fails to parse it
+                        // and silently falls back to a 1h window, so the 90-day presence probe is wrong.
+                        // JSON-encode dateRange instead (matches serviceFilterLogic).
+                        const url = combineUrl(`api/environments/${values.currentTeamId}/logs/attributes`, {
                             attribute_type: 'resource',
-                            dateRange: PRESENCE_LOOKBACK,
+                            dateRange: JSON.stringify(PRESENCE_LOOKBACK),
                             limit: 100,
-                        })
-                        return response.results.map((r) => r.name)
+                        }).url
+                        // nosemgrep: prefer-codegen-api
+                        const response = await api.get(url)
+                        return ((response.results ?? []) as { name: string }[]).map((r) => r.name)
                     },
                 },
             ],


### PR DESCRIPTION
## Problem

Opening the Logs page fires the FacetRail's resource-attribute presence probe, and that request goes out malformed:

```
GET /api/environments/:id/logs/attributes/?attribute_type=resource&dateRange=[object Object]&limit=100
```

Two separate bugs stack up here, surfaced by a support ticket from a new user setting up Logs with the Python SDK:

1. **`dateRange=[object Object]`.** The probe called the generated API client. Its `fetch` URL builder serializes query params with `String(value)`, so the `dateRange` object stringifies to the literal `[object Object]`. The backend can't parse that, catches the error, and silently falls back to a 1-hour window. The probe is meant to look back 90 days, so it quietly looks at the wrong window and can hide resource-attribute facets.

2. **Spurious captured exceptions.** The `attributes` and `values` handlers defaulted an absent `filterGroup` param to `"{}"`, then fed the empty dict to `get_model(..., PropertyGroupFilter)`. An empty dict never validates (both `type` and `values` are required), and `get_model()` reports the `ValidationError` to error tracking *before* raising. The caller catches it, so the request still succeeds, but every filter-less attributes/values call left a handled `ValidationError` in error tracking. This was the noisy, high-occurrence issue on the ticket.

## Changes

- **Frontend** (`facetCountsLogic.ts`): build the probe URL by hand with a JSON-encoded `dateRange`, matching the existing `serviceFilterLogic` pattern, instead of routing the object through the generated client that can't serialize it.
- **Backend** (`logs/.../views/api.py`): add `_parse_optional_filter_group` and use it in both the `attributes` and `values` handlers. An absent or empty `filterGroup` now returns `None` directly rather than attempting a doomed validation, so no handled exception is captured. Behavior when a real `filterGroup` is passed is unchanged.

> [!NOTE]
> No API schema change. The `filterGroup` query param is still parsed identically when present; only the absent case is short-circuited before it reaches `get_model()`.

## How did you test this code?

Added a backend regression test (`test_log_attributes_without_filter_group_does_not_capture_exception`) asserting a filter-less `/logs/attributes` request returns 200 and does not call `capture_exception`. No existing test covered capture behavior, which is the exact reported symptom.

I (Claude, via the PostHog Slack app) could not run the test suite or typecheck in this environment - it has no Python, pytest, or dev stack. `ruff check` and `ruff format --check` pass on the changed backend files. Please rely on CI for the full run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jon investigated a high-severity Logs support ticket via the PostHog Slack app (Claude Opus 4.8) and asked it to trace and fix the error. The agent used error tracking, session replay, and person data to pin the failing request to the FacetRail presence probe, then read the frontend/backend code paths to find both the `[object Object]` serialization bug and the empty-`filterGroup` capture noise.

Decisions worth flagging for reviewers:
- Fixed the frontend at the call site (hand-built URL like `serviceFilterLogic`) rather than changing the orval-generated client. The generated `fetch` URL builder can't JSON-serialize object query params, which is a codegen-template-level limitation affecting more than this endpoint - out of scope for a ticket fix.
- The backend change touches a DRF viewset. I was unable to invoke the repo's mandatory `/improving-drf-endpoints` and `/writing-tests` skills - they aren't registered in this harness - so please give the handler and test an extra look. The change is deliberately behavior-preserving on the request contract.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SHNXN4E7/p1783691150125239?thread_ts=1783691150.125239&cid=C09SHNXN4E7)*
