### PR TITLE
chore(tests): speed up recorder-script bulk test and pytest session overhead

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -1,5 +1,4 @@
 import os
-import re
 import time
 import subprocess
 from collections.abc import Callable
@@ -161,23 +160,23 @@ def reset_clickhouse_tables():
 
     # Skip truncating tables ClickHouse reports as empty: each truncate costs a keeper
     # round-trip on replicated engines, and pure-Postgres sessions never write to these
-    # tables at all. Fail-safe filter — anything unparseable or with unknown total_rows
-    # (NULL for non-MergeTree engines) is still truncated.
-    known_empty = {
-        row[0]
-        for row in sync_execute(
+    # tables at all. Rather than parsing table names out of the statements, construct the
+    # expected statement from each empty table's name (the two forms our TRUNCATE_*_SQL
+    # constants produce) and exact-match. Fail-safe: any statement that doesn't match —
+    # ON CLUSTER clause, unexpected quoting, unknown total_rows (NULL for non-MergeTree
+    # engines) — is kept and truncated as before.
+    empty_table_truncates = {
+        form
+        for (name,) in sync_execute(
             "SELECT name FROM system.tables WHERE database = %(database)s AND total_rows = 0",
             {"database": settings.CLICKHOUSE_DATABASE},
         )
+        for form in (
+            f"TRUNCATE TABLE IF EXISTS {name}",
+            f"TRUNCATE TABLE IF EXISTS `{settings.CLICKHOUSE_DATABASE}`.`{name}`",
+        )
     }
-
-    def _truncate_target(statement: str) -> str | None:
-        match = re.search(r"TRUNCATE TABLE IF EXISTS\s+(\S+)", statement)
-        if not match:
-            return None
-        return match.group(1).strip("`").rsplit("`.`", 1)[-1].rsplit(".", 1)[-1].strip("`")
-
-    TABLES_TO_CREATE_DROP = [q for q in TABLES_TO_CREATE_DROP if _truncate_target(q) not in known_empty]
+    TABLES_TO_CREATE_DROP = [q for q in TABLES_TO_CREATE_DROP if q.strip() not in empty_table_truncates]
 
     run_clickhouse_statement_in_parallel(TABLES_TO_CREATE_DROP)
 

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 import subprocess
 from collections.abc import Callable
@@ -157,6 +158,26 @@ def reset_clickhouse_tables():
         )
         # Using `ON CLUSTER` takes x20 more time to drop the tables: https://github.com/ClickHouse/ClickHouse/issues/15473.
         TABLES_TO_CREATE_DROP += [f"DROP TABLE {table[0]}" for table in kafka_tables]
+
+    # Skip truncating tables ClickHouse reports as empty: each truncate costs a keeper
+    # round-trip on replicated engines, and pure-Postgres sessions never write to these
+    # tables at all. Fail-safe filter — anything unparseable or with unknown total_rows
+    # (NULL for non-MergeTree engines) is still truncated.
+    known_empty = {
+        row[0]
+        for row in sync_execute(
+            "SELECT name FROM system.tables WHERE database = %(database)s AND total_rows = 0",
+            {"database": settings.CLICKHOUSE_DATABASE},
+        )
+    }
+
+    def _truncate_target(statement: str) -> str | None:
+        match = re.search(r"TRUNCATE TABLE IF EXISTS\s+(\S+)", statement)
+        if not match:
+            return None
+        return match.group(1).strip("`").rsplit("`.`", 1)[-1].rsplit(".", 1)[-1].strip("`")
+
+    TABLES_TO_CREATE_DROP = [q for q in TABLES_TO_CREATE_DROP if _truncate_target(q) not in known_empty]
 
     run_clickhouse_statement_in_parallel(TABLES_TO_CREATE_DROP)
 

--- a/posthog/management/commands/test/test_set_recorder_script.py
+++ b/posthog/management/commands/test/test_set_recorder_script.py
@@ -1,6 +1,7 @@
 from io import StringIO
 
 from posthog.test.base import BaseTest
+from unittest import mock
 
 from django.core.management import call_command
 
@@ -139,12 +140,23 @@ class TestSetRecorderScriptCommand(BaseTest):
         )
 
         out = StringIO()
-        call_command(
-            "set_recorder_script",
-            "--script=test-recorder",
-            "--sample-rate=1.0",
-            stdout=out,
-        )
+        # team.save() fans out to unrelated post_save receivers that each do per-team work:
+        # the team-token cache write runs a full DRF serialization plus a cache write, and
+        # hog function / hog flow refresh each run their own DB query. Irrelevant to this
+        # command's batching behaviour, just 2500x avoidable overhead each — mock them out
+        # like any other unrelated side effect that isn't under test. With these mocked,
+        # each save is a single UPDATE, which is this test's floor.
+        with (
+            mock.patch("products.cdp.backend.tasks.hog_functions.refresh_affected_hog_functions.delay"),
+            mock.patch("products.workflows.backend.tasks.hog_flows.refresh_affected_hog_flows.delay"),
+            mock.patch("posthog.models.team.team.set_team_in_cache"),
+        ):
+            call_command(
+                "set_recorder_script",
+                "--script=test-recorder",
+                "--sample-rate=1.0",
+                stdout=out,
+            )
 
         output = out.getvalue()
         assert "Updated 1000 teams so far..." in output


### PR DESCRIPTION
## Problem

`test_bulk_updates_in_batches` in `test_set_recorder_script.py` was one of the slowest tests in the suite (~56s in CI, ~81s measured locally). Nearly all of that time went to unrelated `Team.post_save` receivers firing on each of the 2500 `team.save()` calls the management command performs — not to the batching behaviour the test asserts.

## Changes

- `test_bulk_updates_in_batches` now mocks three unrelated per-save side effects: the team-token cache write (a full DRF serialization + cache write per save — the dominant cost), and the hog function / hog flow refresh tasks (one DB query each per save). All assertions are untouched; with the mocks each save is a single UPDATE, which is the test's floor. Local wall time drops from ~81s to ~11s.
- `posthog/conftest.py`: session teardown now skips `TRUNCATE` for ClickHouse tables that ClickHouse reports as already empty (each truncate is a keeper round-trip on replicated engines). The filter is fail-safe: anything unparseable or with unknown `total_rows` is still truncated.

(An earlier revision of this branch also disabled faker's auto-loaded pytest plugin; that landed independently on master in #69941 with a better langsmith fix, so it was dropped here on rebase.)

## How did you test this code?

- Ran the target test before/after on the same hardware: ~81s → ~11s, passing.
- Ran the full `test_set_recorder_script.py` file (8 tests) with the mocks in place — all pass; sibling tests still exercise the real receiver paths.
- Verified per-save query profile with `CaptureQueriesContext`: exactly 1 UPDATE per save after the change.
- Timed `reset_clickhouse_tables()` directly before/after the empty-table skip (~0.98s → ~0.71s) and ran multiple full single-test sessions through the new setup/teardown path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored with PostHog Code (Claude Code harness) in an iterative measure-change-measure loop against a local dev stack (Postgres, ClickHouse, Redis, Zookeeper via docker compose).
- Diagnosed the hot path by capturing per-save SQL: the `set_team_in_cache` post_save receiver's DRF serialization dominated; the two eager Celery task receivers added 2 queries/save. Rejected alternatives: reducing the 2500-team count (would weaken the batching assertions) and changing the management command's deliberate save()-per-team behaviour.
- The conftest empty-table skip was verified fail-safe by direction: skipping only applies to tables ClickHouse itself reports as `total_rows = 0`; NULL/unknown/unparseable entries keep the old truncate path.

**Why:** part of an effort to bring down the slowest tests in the suite without deleting tests or weakening their assertions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*