### PR TITLE
perf(web-analytics): raise stale-while-revalidate grace to 24h

### DIFF
--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -112,8 +112,12 @@ BACKGROUND_WARMING_TRIGGERS = frozenset(
 # arrives within minutes via the revalidation task (plus the hourly eager warmer for
 # warmed shapes) — the grace is the ceiling for revalidation failures and warmer
 # outages. Must stay well under the framework's 48h ClickHouse expiry buffer (rows must
-# still exist).
-STALE_WHILE_REVALIDATE_SECONDS = 6 * 60 * 60
+# still exist). 24h captures the dominant daily-checkin return cadence: measured over
+# 14 days of paths-tile traffic (same-shape return visits), the stale window catches
+# 10.8% of returns at 6h vs 31.5% at 24h, lifting instant paints from ~27% to ~48%;
+# beyond 24h the curve flattens (38.5% at 48h). Revalidation is what makes this size
+# safe — staleness is bounded by first-touch after a gap, not by the grace.
+STALE_WHILE_REVALIDATE_SECONDS = 24 * 60 * 60
 
 WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED = Counter(
     "web_analytics_lazy_precompute_stale_served_total",


### PR DESCRIPTION
## Problem

Stacked on #70080 (stale-while-revalidate). The shared grace defaults to 6h, but measured against 14 days of real paths-tile traffic (return visits keyed by a query-shape hash that excludes the time range), 6h captures only 10.8% of returns in the stale window. The dominant return cadence is daily (come back next morning), which mostly misses it.

## Changes

One constant: `STALE_WHILE_REVALIDATE_SECONDS` 6h -> 24h.

- Stale capture on eligible same-shape returns: 10.8% -> 31.5%; instant paints go from ~27% to ~48%. Beyond 24h the curve flattens (38.5% at 48h), and the 48h ClickHouse expiry buffer is the physical ceiling.
- #70080's revalidation is what makes 24h safe: a stale serve enqueues a background rebuild, so staleness is bounded by first-touch after a gap, not by the grace.

Traffic study with reproducible queries lives in the team notebook (Paths serve-stale: measured benefit and best timings).

## How did you test this code?

- Existing suite covers the mechanism; the grace pass-through assertions reference the constant symbolically, so no test churn. Ran the lazy precompute common suite (47 passed).
- No new test: a constant retune inside an already-tested invariant; a value assertion would be a change detector.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. This PR originally carried its own paths-only revalidation task plus a 46h grace; Lucas rejected 2-day staleness, and #70080 (authored in a parallel session) implemented revalidation generically across all lazy families, so this was restacked onto it and slimmed to the timing change the traffic study supports.
