### PR TITLE
feat(customer-analytics): enable MCP tools for account relationships

### DIFF
--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -75,10 +75,10 @@ tools:
             idempotent: true
         title: Update account relationship definition
         description: >
-            Update fields on an existing Customer Analytics account relationship definition. Accepts a subset of
-            fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the
-            team), `description`, and `is_single_holder`. Changing `is_single_holder` does not end existing
-            assignments; it only affects future assigns.
+            Update fields on an existing Customer Analytics account relationship definition. Accepts a subset of fields;
+            unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team),
+            `description`, and `is_single_holder`. Changing `is_single_holder` does not end existing assignments; it
+            only affects future assigns.
         feature_flag: customer-analytics-csp
     account-relationship-definitions-retrieve:
         operation: account_relationship_definitions_retrieve
@@ -300,12 +300,12 @@ tools:
             idempotent: true
         title: Assign account relationship
         description: >
-            Assign a PostHog user to a relationship on a Customer Analytics account. Pass `definition` (the
-            relationship definition UUID — list or create with the account relationship definition tools) and `user`
-            (the numeric PostHog user id, which must be a member of the account's organization; resolve an email to an
-            id via `org-members-list`). If the user already actively holds the relationship on this account, the
-            existing assignment is returned unchanged. For single-holder definitions, assigning a new user automatically ends the current holder's
-            assignment.
+            Assign a PostHog user to a relationship on a Customer Analytics account. Pass `definition` (the relationship
+            definition UUID — list or create with the account relationship definition tools) and `user` (the numeric
+            PostHog user id, which must be a member of the account's organization; resolve an email to an id via
+            `org-members-list`). If the user already actively holds the relationship on this account, the existing
+            assignment is returned unchanged. For single-holder definitions, assigning a new user automatically ends the
+            current holder's assignment.
         feature_flag: customer-analytics-csp
     accounts-relationships-end-create:
         operation: accounts_relationships_end_create
@@ -338,9 +338,9 @@ tools:
             List the relationship assignments of a single Customer Analytics account — which PostHog users hold which
             relationship (CSM, Onboarding manager, ...) on it. Each result includes the assignment `id`, the
             relationship `definition`, the assigned `user` ({id, email}; null when the user was deleted), `started_at`,
-            and `ended_at` (null while active). By default only active assignments are returned; pass
-            `include_history: true` for the full timeline including ended ones. To query assignments across all
-            accounts in bulk, HogQL `system.account_relationships` covers the same data.
+            and `ended_at` (null while active). By default only active assignments are returned; pass `include_history:
+            true` for the full timeline including ended ones. To query assignments across all accounts in bulk, HogQL
+            `system.account_relationships` covers the same data.
         feature_flag: customer-analytics-csp
     accounts-retrieve:
         operation: accounts_retrieve

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -14,19 +14,88 @@ tools:
         enabled: false
     account-relationship-definitions-create:
         operation: account_relationship_definitions_create
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create account relationship definition
+        description: >
+            Create a Customer Analytics account relationship definition — a team-defined relationship type between a
+            PostHog user and an account, such as CSM or Onboarding manager. Provide `name` (required, unique within the
+            team), optional `description` explaining what the relationship means, and `is_single_holder` (default true)
+            controlling whether only one user can hold the relationship per account at a time. Definitions are
+            team-scoped and shared across all accounts; assign a user to a specific account with
+            `accounts-relationships-create`.
+        feature_flag: customer-analytics-csp
     account-relationship-definitions-destroy:
         operation: account_relationship_definitions_destroy
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete account relationship definition
+        description: >
+            Permanently delete a Customer Analytics account relationship definition by id. This also deletes every
+            assignment of the relationship — active and historical — across all accounts. To stop a single account's
+            assignment instead, use `accounts-relationships-end-create`.
+        feature_flag: customer-analytics-csp
     account-relationship-definitions-list:
         operation: account_relationship_definitions_list
-        enabled: false
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List account relationship definitions
+        description: >
+            List Customer Analytics account relationship definitions for the project. A definition is a team-defined
+            relationship type between a PostHog user and an account (e.g. CSM, Onboarding manager) with a `name`,
+            optional `description`, and `is_single_holder` flag (whether only one user can hold it per account at a
+            time). Definitions are team-scoped and shared across all accounts; the users assigned to a specific account
+            are managed via the account relationship tools. To query definitions in bulk, HogQL
+            `system.account_relationship_definitions` covers the same data.
+        feature_flag: customer-analytics-csp
     account-relationship-definitions-partial-update:
         operation: account_relationship_definitions_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update account relationship definition
+        description: >
+            Update fields on an existing Customer Analytics account relationship definition. Accepts a subset of
+            fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the
+            team), `description`, and `is_single_holder`. Changing `is_single_holder` does not end existing
+            assignments; it only affects future assigns.
+        feature_flag: customer-analytics-csp
     account-relationship-definitions-retrieve:
         operation: account_relationship_definitions_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get account relationship definition
+        description: >
+            Fetch a single Customer Analytics account relationship definition by id. Returns its `name`, optional
+            `description`, and `is_single_holder` flag. A definition is a team-defined relationship type between a
+            PostHog user and an account; the users holding it on a specific account are managed via the account
+            relationship tools.
+        feature_flag: customer-analytics-csp
     account-relationship-definitions-update:
         operation: account_relationship_definitions_update
         enabled: false
@@ -222,13 +291,57 @@ tools:
         feature_flag: customer-analytics-csp
     accounts-relationships-create:
         operation: accounts_relationships_create
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Assign account relationship
+        description: >
+            Assign a PostHog user to a relationship on a Customer Analytics account. Pass `definition` (the
+            relationship definition UUID — list or create with the account relationship definition tools) and `user`
+            (the numeric PostHog user id, which must be a member of the account's organization; resolve an email to an
+            id via `org-members-list`). If the user already actively holds the relationship on this account, the
+            existing assignment is returned unchanged. For single-holder definitions, assigning a new user automatically ends the current holder's
+            assignment.
+        feature_flag: customer-analytics-csp
     accounts-relationships-end-create:
         operation: accounts_relationships_end_create
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: End account relationship
+        description: >
+            End an active relationship assignment on a Customer Analytics account by the assignment `id` (from
+            `accounts-relationships-list`). The assignment is closed by setting `ended_at`, not deleted — it remains
+            visible in the account's history via `accounts-relationships-list` with `include_history`. Returns 404 if
+            the assignment does not exist or has already ended.
+        feature_flag: customer-analytics-csp
     accounts-relationships-list:
         operation: accounts_relationships_list
-        enabled: false
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List account relationships
+        description: >
+            List the relationship assignments of a single Customer Analytics account — which PostHog users hold which
+            relationship (CSM, Onboarding manager, ...) on it. Each result includes the assignment `id`, the
+            relationship `definition`, the assigned `user` ({id, email}; null when the user was deleted), `started_at`,
+            and `ended_at` (null while active). By default only active assignments are returned; pass
+            `include_history: true` for the full timeline including ended ones. To query assignments across all
+            accounts in bulk, HogQL `system.account_relationships` covers the same data.
+        feature_flag: customer-analytics-csp
     accounts-retrieve:
         operation: accounts_retrieve
         enabled: true

--- a/products/posthog_ai/skills/querying-posthog-data/SKILL.md
+++ b/products/posthog_ai/skills/querying-posthog-data/SKILL.md
@@ -38,7 +38,7 @@ Schema reference for PostHog's core system models, organized by domain:
 - [Batch exports](./references/models-batch-exports.md)
 - [Early Access Features](./references/models-early-access-features.md)
 - [Cohorts & Persons](./references/models-cohorts.md)
-- [Customer analytics custom properties (`system.custom_property_definitions`)](./references/models-customer-analytics.md)
+- [Customer analytics accounts, relationships (CSM, account owner) & custom properties (`system.accounts`, `system.account_relationships`)](./references/models-customer-analytics.md)
 - [Dashboards, Tiles & Insights](./references/models-dashboards-insights.md)
 - [Data Warehouse](./references/models-data-warehouse.md)
 - [Data Modeling Endpoints](./references/models-endpoints.md)

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-customer-analytics.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-customer-analytics.md
@@ -1,12 +1,71 @@
-# Customer analytics custom properties
+# Customer analytics accounts
 
-Custom properties let a team attach typed attributes to customer analytics accounts. A **definition** is the attribute's shape (its name and how it is typed and rendered); the per-account **values** are queried through `system.accounts` (see below). Definitions are team-scoped — one set per team, shared across all accounts.
+Customer analytics tracks **accounts** — the companies/organizations a team does business with — plus who owns them (relationships such as CSM or Account executive) and typed custom attributes.
 
-Prefer the typed `posthog:custom-property-definitions-*` MCP tools for writes; use HogQL for reads and aggregations.
+**Source of truth for account ownership questions** ("who is the CSM of X?", "which accounts does Y own?"): answer them from these tables, not from warehouse CRM columns (`salesforce.*`, `hubspot.*`, ...). Warehouse copies of ownership fields can lag behind reassignments made in PostHog.
 
-## CustomPropertyDefinition (`system.custom_property_definitions`)
+Prefer the typed `posthog:accounts-*`, `posthog:account-relationship-definitions-*`, and `posthog:custom-property-definitions-*` MCP tools for writes; use HogQL for reads and aggregations.
 
-Team-scoped definitions of custom account properties — the attribute side of the model. One row per property.
+## Account (`system.accounts`)
+
+One row per account.
+
+### Columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this account belongs to
+`name` | varchar | NOT NULL | Display name of the account
+`external_id` | varchar | NULL | Identifier of the account in the source system
+`properties` | json | NOT NULL | Account properties: role assignments `csm`, `account_executive`, `account_owner` (each `{id, email}` of a PostHog user) plus external system identifiers
+`stripe_customer_id` | varchar | NULL | Extracted from `properties`
+`hubspot_deal_id` | varchar | NULL | Extracted from `properties`
+`billing_id` | varchar | NULL | Extracted from `properties`
+`sfdc_id` | varchar | NULL | Extracted from `properties`
+`zendesk_id` | varchar | NULL | Extracted from `properties`
+`created_by_id` | integer | NULL | User who created the account record
+`created_at` | timestamptz | NOT NULL | When the account was created
+`updated_at` | timestamptz | NULL | When the account was last updated
+
+Lazy-joined fields: `tags` (tag names), `custom_properties` (see below), `relationships` (active assignments keyed by definition id), `notebooks`.
+
+## Account relationships (`system.account_relationship_definitions`, `system.account_relationships`)
+
+A **relationship definition** is a team-defined relationship type between a PostHog user and an account — CSM (customer success manager), Account executive, Onboarding manager, and so on. An **account relationship** is one assignment of a user to an account for a definition, with its effective range.
+
+### `system.account_relationship_definitions` columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this definition belongs to
+`name` | varchar(400) | NOT NULL | Relationship name (e.g. `CSM`); unique within the team
+`description` | text | NULL | What the relationship means
+`is_single_holder` | integer | NOT NULL | `1` if only one user can hold it per account at a time
+`created_by_id` | integer | NULL | User who created the definition
+`created_at` | timestamptz | NOT NULL | When the definition was created
+`updated_at` | timestamptz | NULL | When the definition was last updated
+
+### `system.account_relationships` columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key
+`team_id` | integer | NOT NULL | Team this assignment belongs to
+`definition_id` | uuid | NOT NULL | Join to `system.account_relationship_definitions.id`
+`account_id` | uuid | NOT NULL | Join to `system.accounts.id`
+`user_id` | integer | NULL | Assigned PostHog user id; NULL when the user was deleted
+`started_at` | timestamptz | NOT NULL | When the assignment became effective
+`ended_at` | timestamptz | NULL | When the assignment ended; **NULL while active**
+`created_by_id` | integer | NULL | User who made the assignment
+`created_at` | timestamptz | NOT NULL | When the assignment row was created
+
+### Important notes
+
+- Active assignments are `ended_at IS NULL`; ended rows are kept as history.
+- The role keys in `system.accounts.properties` (`csm`, `account_executive`, `account_owner`) mirror the active assignments and include the user's email; the relationships table has only `user_id`.
+
+## Custom properties (`system.custom_property_definitions`)
+
+Custom properties let a team attach typed attributes to accounts. A **definition** is the attribute's shape (its name and how it is typed and rendered); the per-account **values** are queried through `system.accounts` (see below). Definitions are team-scoped — one set per team, shared across all accounts.
 
 ### Columns
 
@@ -26,7 +85,7 @@ Column | Type | Nullable | Description
 - `is_big_number` surfaces as an integer (`0`/`1`), not a boolean.
 - `display_type` is the rendering hint; effective data type is string for `text`, numeric for `number`/`currency`/`percent`, datetime for `date`/`datetime`, and boolean for `boolean`.
 
-## Reading per-account values (`system.accounts.custom_properties`)
+### Reading per-account values (`system.accounts.custom_properties`)
 
 There is no standalone values table. An account's current value for a definition is read through a lazy join on `system.accounts`, keyed by the definition's `id`:
 
@@ -37,6 +96,45 @@ accounts.custom_properties.values.`<definition_id>`
 The `<definition_id>` is a `system.custom_property_definitions.id` (backtick-quoted, since it is a UUID). Only the current value is returned — superseded (soft-deleted) values are excluded — and it is team-isolated via the accounts row.
 
 ## Common query patterns
+
+**Who is the CSM (or any relationship holder) of an account:**
+
+```sql
+SELECT a.name, d.name AS relationship, r.user_id, r.started_at
+FROM system.account_relationships r
+JOIN system.account_relationship_definitions d ON d.id = r.definition_id
+JOIN system.accounts a ON a.id = r.account_id
+WHERE a.name ILIKE '%acme%' AND r.ended_at IS NULL
+```
+
+Shortcut when the email is enough — the role keys on `properties` mirror active assignments:
+
+```sql
+SELECT name, properties.csm.email AS csm_email
+FROM system.accounts
+WHERE name ILIKE '%acme%'
+```
+
+**All accounts a user holds a relationship on:**
+
+```sql
+SELECT a.name, d.name AS relationship
+FROM system.account_relationships r
+JOIN system.account_relationship_definitions d ON d.id = r.definition_id
+JOIN system.accounts a ON a.id = r.account_id
+WHERE r.user_id = 12345 AND r.ended_at IS NULL
+ORDER BY a.name
+```
+
+**Assignment history of an account (including ended assignments):**
+
+```sql
+SELECT d.name AS relationship, r.user_id, r.started_at, r.ended_at
+FROM system.account_relationships r
+JOIN system.account_relationship_definitions d ON d.id = r.definition_id
+WHERE r.account_id = '0192f000-0000-7000-8000-000000000000'
+ORDER BY r.started_at DESC
+```
 
 **List all custom property definitions for a team:**
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1,4 +1,79 @@
 {
+    "account-relationship-definitions-create": {
+        "description": "Create a Customer Analytics account relationship definition — a team-defined relationship type between a PostHog user and an account, such as CSM or Onboarding manager. Provide `name` (required, unique within the team), optional `description` explaining what the relationship means, and `is_single_holder` (default true) controlling whether only one user can hold the relationship per account at a time. Definitions are team-scoped and shared across all accounts; assign a user to a specific account with `accounts-relationships-create`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create account relationship definition",
+        "title": "Create account relationship definition",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-destroy": {
+        "description": "Permanently delete a Customer Analytics account relationship definition by id. This also deletes every assignment of the relationship — active and historical — across all accounts. To stop a single account's assignment instead, use `accounts-relationships-end-create`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete account relationship definition",
+        "title": "Delete account relationship definition",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-list": {
+        "description": "List Customer Analytics account relationship definitions for the project. A definition is a team-defined relationship type between a PostHog user and an account (e.g. CSM, Onboarding manager) with a `name`, optional `description`, and `is_single_holder` flag (whether only one user can hold it per account at a time). Definitions are team-scoped and shared across all accounts; the users assigned to a specific account are managed via the account relationship tools. To query definitions in bulk, HogQL `system.account_relationship_definitions` covers the same data.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List account relationship definitions",
+        "title": "List account relationship definitions",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-partial-update": {
+        "description": "Update fields on an existing Customer Analytics account relationship definition. Accepts a subset of fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team), `description`, and `is_single_holder`. Changing `is_single_holder` does not end existing assignments; it only affects future assigns.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update account relationship definition",
+        "title": "Update account relationship definition",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-retrieve": {
+        "description": "Fetch a single Customer Analytics account relationship definition by id. Returns its `name`, optional `description`, and `is_single_holder` flag. A definition is a team-defined relationship type between a PostHog user and an account; the users holding it on a specific account are managed via the account relationship tools.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get account relationship definition",
+        "title": "Get account relationship definition",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
     "accounts-create": {
         "description": "Create a new Customer Analytics account. An account is a logical container for assigning ownership across the customer-success org. Provide `name` (required), optional `external_id` (CRM ID or similar), optional `properties` to set role assignments (`csm`, `account_executive`, `account_owner`) and external system identifiers (`stripe_customer_id`, `hubspot_deal_id`, `billing_id`, `sfdc_id`, `zendesk_id`), and optional `tags` to categorize the account.",
         "category": "Customer analytics",
@@ -146,6 +221,51 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-relationships-create": {
+        "description": "Assign a PostHog user to a relationship on a Customer Analytics account. Pass `definition` (the relationship definition UUID — list or create with the account relationship definition tools) and `user` (the numeric PostHog user id, which must be a member of the account's organization; resolve an email to an id via `org-members-list`). If the user already actively holds the relationship on this account, the existing assignment is returned unchanged. For single-holder definitions, assigning a new user automatically ends the current holder's assignment.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Assign account relationship",
+        "title": "Assign account relationship",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-relationships-end-create": {
+        "description": "End an active relationship assignment on a Customer Analytics account by the assignment `id` (from `accounts-relationships-list`). The assignment is closed by setting `ended_at`, not deleted — it remains visible in the account's history via `accounts-relationships-list` with `include_history`. Returns 404 if the assignment does not exist or has already ended.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "End account relationship",
+        "title": "End account relationship",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-relationships-list": {
+        "description": "List the relationship assignments of a single Customer Analytics account — which PostHog users hold which relationship (CSM, Onboarding manager, ...) on it. Each result includes the assignment `id`, the relationship `definition`, the assigned `user` ({id, email}; null when the user was deleted), `started_at`, and `ended_at` (null while active). By default only active assignments are returned; pass `include_history: true` for the full timeline including ended ones. To query assignments across all accounts in bulk, HogQL `system.account_relationships` covers the same data.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List account relationships",
+        "title": "List account relationships",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         },
         "feature_flag": "customer-analytics-csp"
     },

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1,4 +1,79 @@
 {
+    "account-relationship-definitions-create": {
+        "description": "Create a Customer Analytics account relationship definition — a team-defined relationship type between a PostHog user and an account, such as CSM or Onboarding manager. Provide `name` (required, unique within the team), optional `description` explaining what the relationship means, and `is_single_holder` (default true) controlling whether only one user can hold the relationship per account at a time. Definitions are team-scoped and shared across all accounts; assign a user to a specific account with `accounts-relationships-create`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create account relationship definition",
+        "title": "Create account relationship definition",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-destroy": {
+        "description": "Permanently delete a Customer Analytics account relationship definition by id. This also deletes every assignment of the relationship — active and historical — across all accounts. To stop a single account's assignment instead, use `accounts-relationships-end-create`.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete account relationship definition",
+        "title": "Delete account relationship definition",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-list": {
+        "description": "List Customer Analytics account relationship definitions for the project. A definition is a team-defined relationship type between a PostHog user and an account (e.g. CSM, Onboarding manager) with a `name`, optional `description`, and `is_single_holder` flag (whether only one user can hold it per account at a time). Definitions are team-scoped and shared across all accounts; the users assigned to a specific account are managed via the account relationship tools. To query definitions in bulk, HogQL `system.account_relationship_definitions` covers the same data.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List account relationship definitions",
+        "title": "List account relationship definitions",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-partial-update": {
+        "description": "Update fields on an existing Customer Analytics account relationship definition. Accepts a subset of fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team), `description`, and `is_single_holder`. Changing `is_single_holder` does not end existing assignments; it only affects future assigns.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update account relationship definition",
+        "title": "Update account relationship definition",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "account-relationship-definitions-retrieve": {
+        "description": "Fetch a single Customer Analytics account relationship definition by id. Returns its `name`, optional `description`, and `is_single_holder` flag. A definition is a team-defined relationship type between a PostHog user and an account; the users holding it on a specific account are managed via the account relationship tools.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get account relationship definition",
+        "title": "Get account relationship definition",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
     "accounts-create": {
         "description": "Create a new Customer Analytics account. An account is a logical container for assigning ownership across the customer-success org. Provide `name` (required), optional `external_id` (CRM ID or similar), optional `properties` to set role assignments (`csm`, `account_executive`, `account_owner`) and external system identifiers (`stripe_customer_id`, `hubspot_deal_id`, `billing_id`, `sfdc_id`, `zendesk_id`), and optional `tags` to categorize the account.",
         "category": "Customer analytics",
@@ -146,6 +221,51 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-relationships-create": {
+        "description": "Assign a PostHog user to a relationship on a Customer Analytics account. Pass `definition` (the relationship definition UUID — list or create with the account relationship definition tools) and `user` (the numeric PostHog user id, which must be a member of the account's organization; resolve an email to an id via `org-members-list`). If the user already actively holds the relationship on this account, the existing assignment is returned unchanged. For single-holder definitions, assigning a new user automatically ends the current holder's assignment.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Assign account relationship",
+        "title": "Assign account relationship",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-relationships-end-create": {
+        "description": "End an active relationship assignment on a Customer Analytics account by the assignment `id` (from `accounts-relationships-list`). The assignment is closed by setting `ended_at`, not deleted — it remains visible in the account's history via `accounts-relationships-list` with `include_history`. Returns 404 if the assignment does not exist or has already ended.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "End account relationship",
+        "title": "End account relationship",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "accounts-relationships-list": {
+        "description": "List the relationship assignments of a single Customer Analytics account — which PostHog users hold which relationship (CSM, Onboarding manager, ...) on it. Each result includes the assignment `id`, the relationship `definition`, the assigned `user` ({id, email}; null when the user was deleted), `started_at`, and `ended_at` (null while active). By default only active assignments are returned; pass `include_history: true` for the full timeline including ended ones. To query assignments across all accounts in bulk, HogQL `system.account_relationships` covers the same data.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List account relationships",
+        "title": "List account relationships",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         },
         "feature_flag": "customer-analytics-csp"
     },

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -3,10 +3,107 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 29 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+export const AccountRelationshipDefinitionsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AccountRelationshipDefinitionsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const AccountRelationshipDefinitionsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const accountRelationshipDefinitionsCreateBodyNameMax = 400
+
+export const accountRelationshipDefinitionsCreateBodyIsSingleHolderDefault = true
+
+export const AccountRelationshipDefinitionsCreateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(accountRelationshipDefinitionsCreateBodyNameMax)
+            .describe('Human-readable name of the relationship. Unique within the team.'),
+        description: zod
+            .string()
+            .nullish()
+            .describe(
+                "What this relationship means, e.g. 'The customer success manager responsible for this account'."
+            ),
+        is_single_holder: zod
+            .boolean()
+            .default(accountRelationshipDefinitionsCreateBodyIsSingleHolderDefault)
+            .describe(
+                'Whether only one user can hold this relationship per account at a time, e.g. a single CSM per account.'
+            ),
+    })
+    .describe('A team-defined account relationship type (CSM, Onboarding manager, ...).')
+
+export const AccountRelationshipDefinitionsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AccountRelationshipDefinitionsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const accountRelationshipDefinitionsPartialUpdateBodyNameMax = 400
+
+export const AccountRelationshipDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(accountRelationshipDefinitionsPartialUpdateBodyNameMax)
+            .optional()
+            .describe('Human-readable name of the relationship. Unique within the team.'),
+        description: zod
+            .string()
+            .nullish()
+            .describe(
+                "What this relationship means, e.g. 'The customer success manager responsible for this account'."
+            ),
+        is_single_holder: zod
+            .boolean()
+            .optional()
+            .describe(
+                'Whether only one user can hold this relationship per account at a time, e.g. a single CSM per account.'
+            ),
+    })
+    .describe('A team-defined account relationship type (CSM, Onboarding manager, ...).')
+
+export const AccountRelationshipDefinitionsDestroyParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
 
 export const AccountsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -185,6 +282,48 @@ export const AccountsNotebooksDestroyParams = /* @__PURE__ */ zod.object({
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
     short_id: zod.string(),
+})
+
+export const AccountsRelationshipsListParams = /* @__PURE__ */ zod.object({
+    account_id: zod.string().describe('UUID of the parent account.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AccountsRelationshipsListQueryParams = /* @__PURE__ */ zod.object({
+    include_history: zod
+        .boolean()
+        .optional()
+        .describe('Include ended assignments (the full timeline), not just active ones.'),
+})
+
+export const AccountsRelationshipsCreateParams = /* @__PURE__ */ zod.object({
+    account_id: zod.string().describe('UUID of the parent account.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AccountsRelationshipsCreateBody = /* @__PURE__ */ zod
+    .object({
+        definition: zod.string().describe('Id of the relationship definition to assign.'),
+        user: zod.number().describe("PostHog user id of the assignee. Must be a member of the account's organization."),
+    })
+    .describe('Input for assigning a user to an account relationship.')
+
+export const AccountsRelationshipsEndCreateParams = /* @__PURE__ */ zod.object({
+    account_id: zod.string().describe('UUID of the parent account.'),
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
 })
 
 export const AccountsRetrieveParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -3,6 +3,12 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    AccountRelationshipDefinitionsCreateBody,
+    AccountRelationshipDefinitionsDestroyParams,
+    AccountRelationshipDefinitionsListQueryParams,
+    AccountRelationshipDefinitionsPartialUpdateBody,
+    AccountRelationshipDefinitionsPartialUpdateParams,
+    AccountRelationshipDefinitionsRetrieveParams,
     AccountsCreateBody,
     AccountsCustomPropertyValuesCreateBody,
     AccountsCustomPropertyValuesCreateParams,
@@ -17,6 +23,11 @@ import {
     AccountsNotebooksRetrieveParams,
     AccountsPartialUpdateBody,
     AccountsPartialUpdateParams,
+    AccountsRelationshipsCreateBody,
+    AccountsRelationshipsCreateParams,
+    AccountsRelationshipsEndCreateParams,
+    AccountsRelationshipsListParams,
+    AccountsRelationshipsListQueryParams,
     AccountsRetrieveParams,
     CustomPropertyDefinitionsCreateBody,
     CustomPropertyDefinitionsDestroyParams,
@@ -36,6 +47,128 @@ import {
 import { UsageMetricFiltersSchema } from '@/schema/tool-inputs'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const AccountRelationshipDefinitionsCreateSchema = AccountRelationshipDefinitionsCreateBody
+
+const accountRelationshipDefinitionsCreate = (): ToolBase<
+    typeof AccountRelationshipDefinitionsCreateSchema,
+    Schemas.AccountRelationshipDefinition
+> => ({
+    name: 'account-relationship-definitions-create',
+    schema: AccountRelationshipDefinitionsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountRelationshipDefinitionsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.is_single_holder !== undefined) {
+            body['is_single_holder'] = params.is_single_holder
+        }
+        const result = await context.api.request<Schemas.AccountRelationshipDefinition>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/account_relationship_definitions/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AccountRelationshipDefinitionsDestroySchema = AccountRelationshipDefinitionsDestroyParams.omit({
+    project_id: true,
+})
+
+const accountRelationshipDefinitionsDestroy = (): ToolBase<
+    typeof AccountRelationshipDefinitionsDestroySchema,
+    unknown
+> => ({
+    name: 'account-relationship-definitions-destroy',
+    schema: AccountRelationshipDefinitionsDestroySchema,
+    handler: async (context: Context, params: z.infer<typeof AccountRelationshipDefinitionsDestroySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/account_relationship_definitions/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const AccountRelationshipDefinitionsListSchema = AccountRelationshipDefinitionsListQueryParams
+
+const accountRelationshipDefinitionsList = (): ToolBase<
+    typeof AccountRelationshipDefinitionsListSchema,
+    WithPostHogUrl<Schemas.PaginatedAccountRelationshipDefinitionList>
+> => ({
+    name: 'account-relationship-definitions-list',
+    schema: AccountRelationshipDefinitionsListSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountRelationshipDefinitionsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAccountRelationshipDefinitionList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/account_relationship_definitions/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return await withPostHogUrl(context, result, '/customer-analytics')
+    },
+})
+
+const AccountRelationshipDefinitionsPartialUpdateSchema = AccountRelationshipDefinitionsPartialUpdateParams.omit({
+    project_id: true,
+}).extend(AccountRelationshipDefinitionsPartialUpdateBody.shape)
+
+const accountRelationshipDefinitionsPartialUpdate = (): ToolBase<
+    typeof AccountRelationshipDefinitionsPartialUpdateSchema,
+    Schemas.AccountRelationshipDefinition
+> => ({
+    name: 'account-relationship-definitions-partial-update',
+    schema: AccountRelationshipDefinitionsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountRelationshipDefinitionsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        if (params.is_single_holder !== undefined) {
+            body['is_single_holder'] = params.is_single_holder
+        }
+        const result = await context.api.request<Schemas.AccountRelationshipDefinition>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/account_relationship_definitions/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AccountRelationshipDefinitionsRetrieveSchema = AccountRelationshipDefinitionsRetrieveParams.omit({
+    project_id: true,
+})
+
+const accountRelationshipDefinitionsRetrieve = (): ToolBase<
+    typeof AccountRelationshipDefinitionsRetrieveSchema,
+    Schemas.AccountRelationshipDefinition
+> => ({
+    name: 'account-relationship-definitions-retrieve',
+    schema: AccountRelationshipDefinitionsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountRelationshipDefinitionsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AccountRelationshipDefinition>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/account_relationship_definitions/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
 
 const AccountsCreateSchema = AccountsCreateBody.extend({
     properties: AccountsCreateBody.shape['properties'].describe(
@@ -283,6 +416,75 @@ const accountsPartialUpdate = (): ToolBase<typeof AccountsPartialUpdateSchema, S
             body,
         })
         return result
+    },
+})
+
+const AccountsRelationshipsCreateSchema = AccountsRelationshipsCreateParams.omit({ project_id: true }).extend(
+    AccountsRelationshipsCreateBody.shape
+)
+
+const accountsRelationshipsCreate = (): ToolBase<
+    typeof AccountsRelationshipsCreateSchema,
+    Schemas.AccountRelationship
+> => ({
+    name: 'accounts-relationships-create',
+    schema: AccountsRelationshipsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountsRelationshipsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.definition !== undefined) {
+            body['definition'] = params.definition
+        }
+        if (params.user !== undefined) {
+            body['user'] = params.user
+        }
+        const result = await context.api.request<Schemas.AccountRelationship>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/accounts/${encodeURIComponent(String(params.account_id))}/relationships/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AccountsRelationshipsEndCreateSchema = AccountsRelationshipsEndCreateParams.omit({ project_id: true })
+
+const accountsRelationshipsEndCreate = (): ToolBase<
+    typeof AccountsRelationshipsEndCreateSchema,
+    Schemas.AccountRelationship
+> => ({
+    name: 'accounts-relationships-end-create',
+    schema: AccountsRelationshipsEndCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountsRelationshipsEndCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AccountRelationship>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/accounts/${encodeURIComponent(String(params.account_id))}/relationships/${encodeURIComponent(String(params.id))}/end/`,
+        })
+        return result
+    },
+})
+
+const AccountsRelationshipsListSchema = AccountsRelationshipsListParams.omit({ project_id: true }).extend(
+    AccountsRelationshipsListQueryParams.shape
+)
+
+const accountsRelationshipsList = (): ToolBase<
+    typeof AccountsRelationshipsListSchema,
+    WithPostHogUrl<Schemas.AccountRelationship[]>
+> => ({
+    name: 'accounts-relationships-list',
+    schema: AccountsRelationshipsListSchema,
+    handler: async (context: Context, params: z.infer<typeof AccountsRelationshipsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AccountRelationship[]>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/accounts/${encodeURIComponent(String(params.account_id))}/relationships/`,
+            query: {
+                include_history: params.include_history,
+            },
+        })
+        return await withPostHogUrl(context, result, '/customer-analytics')
     },
 })
 
@@ -591,6 +793,11 @@ const usageMetricsRetrieve = (): ToolBase<typeof UsageMetricsRetrieveSchema, Sch
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'account-relationship-definitions-create': accountRelationshipDefinitionsCreate,
+    'account-relationship-definitions-destroy': accountRelationshipDefinitionsDestroy,
+    'account-relationship-definitions-list': accountRelationshipDefinitionsList,
+    'account-relationship-definitions-partial-update': accountRelationshipDefinitionsPartialUpdate,
+    'account-relationship-definitions-retrieve': accountRelationshipDefinitionsRetrieve,
     'accounts-create': accountsCreate,
     'accounts-custom-property-values-create': accountsCustomPropertyValuesCreate,
     'accounts-custom-property-values-list': accountsCustomPropertyValuesList,
@@ -601,6 +808,9 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'accounts-notebooks-list': accountsNotebooksList,
     'accounts-notebooks-retrieve': accountsNotebooksRetrieve,
     'accounts-partial-update': accountsPartialUpdate,
+    'accounts-relationships-create': accountsRelationshipsCreate,
+    'accounts-relationships-end-create': accountsRelationshipsEndCreate,
+    'accounts-relationships-list': accountsRelationshipsList,
     'accounts-retrieve': accountsRetrieve,
     'custom-property-definitions-create': customPropertyDefinitionsCreate,
     'custom-property-definitions-destroy': customPropertyDefinitionsDestroy,


### PR DESCRIPTION
## Problem

There are no MCP tools for Customer analytics account relationships or relationship definitions — agents can't read or manage CSM-style assignments on accounts.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Enable MCP tools for relationship definitions: list, retrieve, create, partial-update, destroy
- Enable MCP tools for account relationships: list, assign (create), end
- Match existing account tool conventions: `account:read`/`account:write` scopes, `customer-analytics-csp` flag gate, PUT variants stay disabled
- Document assign/end semantics in tool descriptions: assign is an upsert, single-holder definitions auto-end the previous holder, end preserves history
- Regenerate MCP handlers, schemas, and tool definitions

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

`lint-tool-names` plus the `tool-references` and `generate-tools` vitest suites (104 tests). No new tests — YAML config and regenerated code only.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code). Started as an MCP coverage audit of Customer analytics, then enabled the relationship tooling. Skills invoked: /implementing-mcp-tools, /pr-description. No backend changes were needed — serializers and viewsets already had full schema annotations, so this is YAML config plus regenerated artifacts. Verified `org-members-list` returns the numeric `user.id` before referencing it in the assign tool's description.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
