### PR TITLE
fix(mcp): temporarily drop tool domains from the exec command reference

### DIFF
--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -88,9 +88,9 @@ export class InstructionsFormatter {
      *
      *  `keepEnvContext` is the escape hatch for clients that report
      *  `supportsInstructions` but don't actually surface the `instructions`
-     *  payload to the model (Claude web/desktop): it retains the full env-context
-     *  (tool-domain index, project metadata, group types) here even though
-     *  `stripEnvContext` is set, so it still reaches the agent.
+     *  payload to the model (Claude web/desktop): it retains the env-context
+     *  (project metadata, group types) here even though `stripEnvContext` is
+     *  set, so it still reaches the agent.
      *
      *  SIZE BUDGET: the serialized exec tool entry must stay under 32,600 chars —
      *  clients (e.g. Claude web/desktop) silently drop tools past ~32,768, which
@@ -122,14 +122,14 @@ export class InstructionsFormatter {
                   guidelines: ctx.guidelines,
                   queryTools: ctx.queryTools,
                   featureFlags: ctx.featureFlags,
-                  ...(opts.keepEnvContext
-                      ? { tools: ctx.tools, metadata: ctx.metadata, groupTypes: ctx.groupTypes }
-                      : {}),
+                  ...(opts.keepEnvContext ? { metadata: ctx.metadata, groupTypes: ctx.groupTypes } : {}),
               }
-            : ctx
-        // Compact tool domains: the command reference rides inside a tool schema,
-        // where the pipe-separated form buys back budget over the bullet list.
-        return this.compose(sections, renderCtx, { compact: false, compactToolDomains: true })
+            : { ...ctx, tools: undefined }
+        // Tool domains are temporarily omitted from the command reference while we
+        // probe claude.ai's per-tool size cap (it silently drops oversized entries);
+        // agents still discover domains at runtime via the `search` command, and
+        // `instructions`-honoring clients keep the compact domain index there.
+        return this.compose(sections, renderCtx, { compact: false })
     }
 
     /** The agent-feedback section is only useful when the `agent-feedback` tool
@@ -139,13 +139,8 @@ export class InstructionsFormatter {
         return featureFlags?.['mcp-feedback-tool'] === true
     }
 
-    private compose(
-        sections: string[],
-        ctx: InstructionsContext,
-        opts: { compact: boolean; compactToolDomains?: boolean }
-    ): string {
-        const renderToolDomains =
-            opts.compact || opts.compactToolDomains ? buildToolDomainsCompact : buildToolDomainsBlock
+    private compose(sections: string[], ctx: InstructionsContext, opts: { compact: boolean }): string {
+        const renderToolDomains = opts.compact ? buildToolDomainsCompact : buildToolDomainsBlock
         // `{query_tools}` only appears in non-compact sections (the exec command
         // reference and tools-mode instructions); compact mode surfaces queries
         // via the single `query` tool domain instead.

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -148,7 +148,7 @@ Only fall back to `tools` if you have no idea which domain to search, or if `sea
 
 PostHog tools have lowercase kebab-case naming. Tools are organized by category:
 
-dashboard|execute-sql|feature-flag|query
+
 Typical action names: list/retrieve/get/create/update/delete/query.
 Example tool names: execute-sql, experiment-create, feature-flag-get-all.
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -1086,11 +1086,12 @@ describe('exec tool', () => {
             expect(execTool.description.length).toBeLessThanOrEqual(2048)
         })
 
-        // The `{tool_domains}` and `{query_tools}` placeholders in the exec
-        // tool's `command` description are filled from the passed tool set. A
+        // The `{query_tools}` placeholder in the exec tool's `command`
+        // description is filled from the passed tool set; tool domains are
+        // temporarily omitted while probing claude.ai's per-tool size cap. A
         // fixed fake set keeps this hermetic — adding or renaming a real tool
         // can't flip it.
-        it('interpolates the tool-domain and query-tool blocks into the command description', () => {
+        it('interpolates the query-tool block and omits tool domains in the command description', () => {
             const toolInfos = [
                 { name: 'experiment-create', category: 'Experiments' },
                 { name: 'experiment-delete', category: 'Experiments' },
@@ -1115,12 +1116,9 @@ describe('exec tool', () => {
             expect(commandDescription).not.toContain('{tool_domains}')
             expect(commandDescription).not.toContain('{query_tools}')
 
-            // The command reference renders domains in the compact pipe form (size budget).
             const domainsBlock = buildToolDomainsCompact(toolInfos)
             const queryToolsBlock = buildQueryToolsBlock(queryToolInfos)
-            expect(domainsBlock).toContain('experiment')
-            expect(domainsBlock).toContain('query')
-            expect(commandDescription).toContain(domainsBlock)
+            expect(commandDescription).not.toContain(domainsBlock)
             expect(commandDescription).toContain(queryToolsBlock)
         })
     })

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -169,14 +169,14 @@ describe('InstructionsFormatter', () => {
             expect(result).not.toContain('Using the `posthog` tool')
         })
 
-        it('embeds env-context, tool-domain list, and query-tool catalog when stripEnvContext is false', () => {
+        it('embeds env-context and query-tool catalog when stripEnvContext is false', () => {
             const formatter = new InstructionsFormatter()
             const result = formatter.buildExecCommandReference(fullCtx, { stripEnvContext: false })
             expect(result).toContain("The user's name is Jane Doe")
             expect(result).toContain('Defined group types: organization')
-            // Tool domains render in the compact pipe-separated form inside the
-            // command reference to conserve the exec tool entry's size budget.
-            expect(result).toContain('dashboard|execute-sql|feature-flag|query')
+            // Tool domains are temporarily omitted from the command reference while
+            // probing claude.ai's per-tool size cap; discovery rides on `search`.
+            expect(result).not.toContain('dashboard|execute-sql')
             expect(result).toContain('- `query-trends` — time series')
         })
 
@@ -190,16 +190,17 @@ describe('InstructionsFormatter', () => {
             expect(result).not.toContain('dashboard|execute-sql')
         })
 
-        it('keeps the full env-context even when stripEnvContext is set, when keepEnvContext is set', () => {
+        it('keeps the env-context even when stripEnvContext is set, when keepEnvContext is set', () => {
             const formatter = new InstructionsFormatter()
             const result = formatter.buildExecCommandReference(fullCtx, {
                 stripEnvContext: true,
                 keepEnvContext: true,
             })
-            // The whole env-context (tool domains, project metadata, group types)
-            // survives for clients (Claude web/desktop) that ignore the `instructions`
-            // payload, so it still reaches the model via the command reference.
-            expect(result).toContain('dashboard|execute-sql|feature-flag|query')
+            // Project metadata and group types survive for clients (Claude
+            // web/desktop) that ignore the `instructions` payload, so they still
+            // reach the model via the command reference. Tool domains are
+            // temporarily omitted (size-cap probe).
+            expect(result).not.toContain('dashboard|execute-sql')
             expect(result).toContain("The user's name is Jane Doe")
             expect(result).toContain('Defined group types: organization')
         })
@@ -270,7 +271,7 @@ describe('InstructionsFormatter', () => {
                 expect(instructions).toBe('')
                 expect(commandReference).toContain('- `query-trends` — time series')
                 expect(commandReference).toContain("The user's name is Jane Doe")
-                expect(commandReference).toContain('dashboard|execute-sql|feature-flag|query')
+                expect(commandReference).not.toContain('dashboard|execute-sql')
                 expect(commandReference).toContain('Defined group types: organization')
             }
         })


### PR DESCRIPTION
## Problem

#69896 trimmed the exec tool entry under 32,768 chars, but Claude web/desktop still doesn't surface `exec`. A mitm capture of Claude Desktop pinned where it disappears: the app's backend MCP proxy (`claude.ai/v1/toolbox/shttp/mcp/...`) receives `exec` (32.6k serialized) + `render-ui` from our tools/list, yet claude.ai's connector registry (`mcp/v2/bootstrap`) — the source the conversation actually uses — holds only `render-ui`. The filtering is inside claude.ai, and in the captured session no registry tool larger than ~10.4k chars survived across any connector (Figma, Slack, Drive included), so the per-tool cap is somewhere between ~10.4k and ~32.6k — lower than the 2^15 we assumed.

## Changes

While we probe the real threshold, shave the next-largest removable block from the exec `command` parameter description: the tool-domain index.

- `buildExecCommandReference` no longer passes `tools` into the render context, in both the `keepEnvContext` (Claude web/desktop) and non-stripped (Codex) paths. Project metadata and group types stay.
- The now-unused `compactToolDomains` option on `compose` is removed.
- Agents lose nothing at runtime: domain discovery rides on the `search` command, and `instructions`-honoring clients (Claude Code) keep the compact domain index in the `instructions` payload, which is untouched.

Worst-case serialized entry drops from 32,526 to **30,850** chars; a realistic session entry lands around 26k.

> [!NOTE]
> This is a temporary, reversible probe step — revert (or re-add domains under a measured budget) once the actual claude.ai cap is established by testing against a connector serving progressively smaller entries.

## How did you test this code?

- Updated the existing formatter/exec assertions (domains now absent from the command reference, query catalog still present) and regenerated the prompt snapshots — no new tests; the size-budget test from #69896 still guards the ceiling and now measures 30,850.
- Full `services/mcp` unit suite: 2,045 passed, 0 failed. `tsgo --noEmit` clean.
- Not done by the agent: the live claude.ai reconnect check — after deploy, refresh the PostHog connector in Claude web/desktop and see whether `exec` survives the registry; that's the measurement this PR exists for.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, prompt composition only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code, continuing the investigation from #69896. The mitm evidence (Proxyman HAR export, parsed with the proxyman CLI + scripts) showed claude.ai's registry filtering `exec` after a successful fetch, with a survival ceiling around 10.4k chars in the captured session.
- The removal was requested explicitly as a temporary step; the working-tree change was started by the reviewer and completed by the agent (docstring, dead option removal, test/snapshot updates).
- Decisions: domains dropped from both exec-reference paths (not just chat hosts) to keep one code path; `instructions` payload and tools-mode prompts untouched.
