### PR TITLE
chore(llm-gateway): document wizard product cost budget sizing

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -27,6 +27,7 @@ DEFAULT_USER_COST_LIMIT = UserCostLimit(
 DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "llm_gateway": ProductCostLimit(limit_usd=1000.0, window_seconds=86400),
     "ci": ProductCostLimit(limit_usd=1000.0, window_seconds=2592000),  # $1000 / 30 days
+    # Shared by all wizard runs; sized for full onboarding cloud-run rollout (env-overridable via product_cost_limits)
     "wizard": ProductCostLimit(limit_usd=10000.0, window_seconds=86400),
     "posthog_code": ProductCostLimit(limit_usd=5000.0, window_seconds=3600),
     "background_agents": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),


### PR DESCRIPTION
## Problem

Wizard cloud runs (onboarding) were hard-failing mid-run with `Request rejected (429)` from the LLM gateway. 7 of 12 recent onboarding cloud-run failures traced to this. Root cause: all wizard runs globally share one `product_cost` budget in `DEFAULT_PRODUCT_COST_LIMITS`, and at ~50% rollout of onboarding cloud runs the daily budget exhausted in clusters, failing unrelated teams' runs in the same hour windows. At 100% rollout that volume doubles.

The budget raise itself already landed in #69958 ($2,000/day to $10,000/day), which covers full-rollout volume with headroom, and gateway telemetry shows wizard `product_cost` denials dropped to zero once it landed. What's left is that the config line carries no context: limits in this dict get resized repeatedly (e.g. #61892, #65532 for other products), and the wizard value itself was just raised in #69958, with the rationale living only in PR descriptions.

Closes GROW-141
https://linear.app/posthog-team-growth/issue/GROW-141

## Changes

One-line comment on the wizard entry in `DEFAULT_PRODUCT_COST_LIMITS` recording what the budget is sized for (full onboarding cloud-run rollout, shared by all wizard runs) and that it is env-overridable via `product_cost_limits` (`LLM_GATEWAY_PRODUCT_COST_LIMITS`) without a deploy.

> [!NOTE]
> Possible follow-up: per-team scoping or autoscaling this budget with run volume. Today one product-wide bucket means unrelated teams fail together when it saturates. GROW-142 separately covers making the wizard CLI retry 429s instead of hard-exiting the run.

## How did you test this code?

Comment-only change, no behavior change.

- `uv run pytest tests/test_cost_throttles.py tests/test_rate_limiting.py tests/test_redis_limiter.py -q` in `services/llm-gateway`: 116 passed.
- `ruff check --fix` / `ruff format` on the touched file and `hogli ci:preflight --fix`: clean.
- No new tests: there is nothing to assert beyond the constant itself, and the existing cost throttle suite already covers the limit behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed. The gateway README documents `DEFAULT_PRODUCT_COST_LIMITS` with a generic example and doesn't state per-product numbers.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code, directed by @fercgomes via a workflow task for GROW-141. The task asked to raise the wizard budget 3x for the onboarding cloud-run rollout. While implementing I (Claude) found #69958 had merged the same morning raising it 5x, and production telemetry confirmed wizard `product_cost` denials stopped once it landed, so I scoped this PR down to the sizing-rationale comment instead of churning the value again. Verified spend projections against AI observability data before deciding no further raise was needed. Skills invoked: the PostHog data-querying skill (telemetry verification). No code-shaping skills applied since the diff is a comment.

