### PR TITLE
chore(stamphog): post approval as app with comment plus bare token approval

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -122,12 +122,18 @@ jobs:
                   fi
 
                   if [ "$VERDICT" = "APPROVED" ]; then
-                    # Stamphog app approval, carrying the review body.
+                    # Stamphog app approval, carrying the review body. Best-effort:
+                    # the step runs under `set -e`, so a failure here (e.g. the App
+                    # install missing Pull-requests write, or a transient error)
+                    # would otherwise abort before the github-actions[bot] approval
+                    # below — the identity currently known to unblock PRs. Keep it
+                    # non-fatal and surface the failure as a warning instead.
                     gh api \
                       -X POST "repos/$REPO/pulls/$PR/reviews" \
                       "${SHA_ARGS[@]}" \
                       -f event=APPROVE \
-                      -f body="$REASONING"
+                      -f body="$REASONING" \
+                      || echo "::warning::stamphog app approval failed to post; continuing with the github-actions[bot] approval"
                     # Bodyless github-actions[bot] approval — kept alongside the
                     # app approval until we've confirmed which one unblocks PRs.
                     GH_TOKEN="$GH_TOKEN_APPROVE" gh api \

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -90,9 +90,14 @@ jobs:
             - name: Post review
               if: always()
               env:
-                  # Use GITHUB_TOKEN for approvals so github-actions[bot] is the
-                  # reviewer — its approvals count toward branch protection rules,
-                  # unlike GitHub App bot approvals which show author_association NONE.
+                  # Approvals are posted twice, on purpose. The Stamphog app
+                  # (GH_TOKEN) posts the review body as an approval so the
+                  # human-facing feedback carries the bot's own identity;
+                  # github-actions[bot] (GH_TOKEN_APPROVE) posts a second,
+                  # bodyless approval. We keep both while we confirm which
+                  # identity's approval actually counts toward branch protection
+                  # — GitHub App bot approvals have shown author_association NONE.
+                  # If the github-actions[bot] one proves redundant, drop it.
                   GH_TOKEN_APPROVE: ${{ github.token }}
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   # Derived from the token step so the sticky-comment author
@@ -117,11 +122,18 @@ jobs:
                   fi
 
                   if [ "$VERDICT" = "APPROVED" ]; then
-                    GH_TOKEN="$GH_TOKEN_APPROVE" gh api \
+                    # Stamphog app approval, carrying the review body.
+                    gh api \
                       -X POST "repos/$REPO/pulls/$PR/reviews" \
                       "${SHA_ARGS[@]}" \
                       -f event=APPROVE \
                       -f body="$REASONING"
+                    # Bodyless github-actions[bot] approval — kept alongside the
+                    # app approval until we've confirmed which one unblocks PRs.
+                    GH_TOKEN="$GH_TOKEN_APPROVE" gh api \
+                      -X POST "repos/$REPO/pulls/$PR/reviews" \
+                      "${SHA_ARGS[@]}" \
+                      -f event=APPROVE
                   else
                     # Non-approve verdicts share ONE sticky comment, updated in
                     # place, instead of a fresh COMMENT review per run. Review
@@ -346,7 +358,7 @@ jobs:
         steps:
             - name: Dismiss stale bot approvals
               env:
-                  # Same identity (github-actions[bot]) that posted the approval.
+                  # github.token can dismiss both bot identities' approvals.
                   GH_TOKEN: ${{ github.token }}
                   PR: ${{ github.event.pull_request.number }}
                   REPO: ${{ github.repository }}
@@ -354,11 +366,13 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  # Only dismiss APPROVED reviews made by github-actions[bot] —
-                  # human reviews and non-approval reviews are untouched.
+                  # Dismiss APPROVED reviews from either Stamphog identity —
+                  # github-actions[bot] (bodyless approval) and stamphog[bot]
+                  # (the app approval carrying the review body). Human reviews
+                  # and non-approval reviews are untouched.
                   mapfile -t REVIEW_IDS < <(
                       gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-                        --jq '.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED") | .id'
+                        --jq '.[] | select((.user.login == "github-actions[bot]" or .user.login == "stamphog[bot]") and .state == "APPROVED") | .id'
                   )
 
                   for id in "${REVIEW_IDS[@]}"; do

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -139,6 +139,9 @@ Final verdict → GitHub review (approve) or sticky comment (everything else)
 
 The bot never posts request-changes.
 Approvals are posted as real PR reviews (they must count toward branch protection).
+An approval is posted twice on purpose: the Stamphog app (`stamphog[bot]`) posts the review body as an approval, and `github-actions[bot]` posts a second, bodyless approval.
+We keep both while confirming which identity's approval actually satisfies branch protection — GitHub App bot approvals have shown `author_association: NONE`.
+If the `github-actions[bot]` one proves redundant, it can be dropped.
 Every other verdict (REFUSED, ESCALATE, WAIT, ERROR) goes into a single sticky comment that is updated in place on each run, with a counter of how many verdicts the comment has carried (failure notes append without bumping it) — repeated refusals don't stack up as separate review comments on the PR.
 
 ## Tiers

--- a/tools/pr-approval-agent/dismiss_check.py
+++ b/tools/pr-approval-agent/dismiss_check.py
@@ -36,7 +36,10 @@ from pathlib import Path
 
 from gates import is_trivial_at_dismiss_time
 
-BOT_LOGIN = "github-actions[bot]"
+# Both identities Stamphog approves under: github-actions[bot] posts a
+# bodyless approval, stamphog[bot] (the app) posts the approval carrying the
+# review body. Either counts as a prior bot approval for the delta check.
+BOT_LOGINS = {"github-actions[bot]", "stamphog[bot]"}
 
 
 class Reason(StrEnum):
@@ -136,14 +139,14 @@ def select_last_bot_approval(reviews: list[dict]) -> str | None:
     excluded; ties are broken by `submitted_at`.
     """
     bot_approvals = sorted(
-        (r for r in reviews if r.get("user", {}).get("login") == BOT_LOGIN and r.get("state") == "APPROVED"),
+        (r for r in reviews if r.get("user", {}).get("login") in BOT_LOGINS and r.get("state") == "APPROVED"),
         key=lambda r: r.get("submitted_at", ""),
     )
     return bot_approvals[-1].get("commit_id") if bot_approvals else None
 
 
 def find_last_approved_sha(repo: str, pr_number: int) -> str | None:
-    """Commit SHA of the most recent github-actions[bot] APPROVED review."""
+    """Commit SHA of the most recent Stamphog-bot APPROVED review."""
     reviews = json.loads(_run("gh", "api", f"repos/{repo}/pulls/{pr_number}/reviews", "--paginate"))
     return select_last_bot_approval(reviews)
 

--- a/tools/pr-approval-agent/test_dismiss_check.py
+++ b/tools/pr-approval-agent/test_dismiss_check.py
@@ -448,6 +448,13 @@ def test_select_last_bot_approval_ignores_bot_non_approval_states() -> None:
     assert select_last_bot_approval(reviews) == "sha-approved"
 
 
+def test_select_last_bot_approval_recognizes_app_identity() -> None:
+    # The Stamphog app posts the body-carrying approval as stamphog[bot]; it
+    # must count as a prior bot approval so dismiss-on-push can find its SHA.
+    reviews = [_review("stamphog[bot]", "APPROVED", "sha-app", "2026-01-01T00:00:00Z")]
+    assert select_last_bot_approval(reviews) == "sha-app"
+
+
 # ── main() error path ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

Stamphog approvals are currently posted only by `github-actions[bot]` (via the workflow `GITHUB_TOKEN`), on the theory that GitHub App bot approvals show `author_association: NONE` and don't count toward branch protection. We're not actually sure that's true, and we want the human-facing review body to carry the Stamphog app's own identity rather than a generic `github-actions[bot]`.

## Changes

On an `APPROVED` verdict, Stamphog now posts two approvals:

- The Stamphog app (`stamphog[bot]`) posts the approval carrying the review body (the reasoning). This is the review humans see.
- `github-actions[bot]` posts a second, bodyless approval, kept as belt-and-braces while we confirm which identity's approval actually unblocks PRs.

Dismiss-on-push and the last-approved-SHA lookup now recognize both identities, so a stale app approval can't outlive new commits.

> [!NOTE]
> If the `github-actions[bot]` approval turns out to be redundant, we can drop it later.

## How did you test this code?

I (Claude) ran the pure-function tests in `tools/pr-approval-agent/test_dismiss_check.py` and added one case asserting `select_last_bot_approval` recognizes a `stamphog[bot]` approval — this guards against regressing the SHA lookup back to `github-actions[bot]`-only, which would let a stale app approval survive a push. The git-fixture tests in that file can't run in this sandbox (`git commit` is blocked here) but are unaffected by the change. Also linted with ruff and validated the workflow YAML parses.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `tools/pr-approval-agent/README.md` to describe the two-approval behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code). Invoked the `/writing-tests` skill before adding the test case. The core change lives in `.github/workflows/pr-approval-agent.yml` (the `Post review` and `Dismiss stale bot approvals` steps); I extended `dismiss_check.py` so either bot identity counts as the prior approval for the delta check, since otherwise a `stamphog[bot]`-only approval would be missed on dismiss-on-push.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
