### PR TITLE
fix(tasks): validate repo accessibility before creating a wizard cloud run

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -56,9 +56,26 @@ OPENAI_SUPPORTED_MODELS = {"o4-mini", "gpt-5-mini", "gpt-5-nano", "gpt-5"}
 
 WIZARD_CLOUD_RUN_REQUESTS_TOTAL = Counter(
     "posthog_wizard_cloud_run_requests_total",
-    "Cloud-run wizard kickoff requests, by outcome (created/unavailable/invalid/permission_denied)",
+    "Cloud-run wizard kickoff requests, by outcome "
+    "(created/unavailable/invalid/permission_denied/repository_inaccessible)",
     labelnames=["outcome"],
 )
+
+# Pre-flight rejections carry their own outcome label so the probe's impact is measurable.
+CLOUD_RUN_PREFLIGHT_OUTCOME_CODES = frozenset({"repository_inaccessible"})
+
+
+def _cloud_run_validation_outcome(error: exceptions.ValidationError) -> str:
+    codes = error.get_codes()
+    if (
+        isinstance(codes, list)
+        and len(codes) == 1
+        and isinstance(codes[0], str)
+        and codes[0] in CLOUD_RUN_PREFLIGHT_OUTCOME_CODES
+    ):
+        return codes[0]
+    return "invalid"
+
 
 # Supported Gemini models
 GEMINI_SUPPORTED_MODELS = {
@@ -449,8 +466,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
         except exceptions.PermissionDenied:
             WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome="permission_denied").inc()
             raise
-        except exceptions.ValidationError:
-            WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome="invalid").inc()
+        except exceptions.ValidationError as e:
+            WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome=_cloud_run_validation_outcome(e)).inc()
             raise
         WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome="created").inc()
         return response
@@ -481,6 +498,10 @@ class SetupWizardViewSet(viewsets.ViewSet):
                 repository=repository,
                 branch=branch,
             )
+        except tasks_facade.WizardRepositoryInaccessibleError as e:
+            # Pre-flight probe confirmed the sandbox clone would fail; stable code so
+            # clients can distinguish this from generic input validation.
+            raise exceptions.ValidationError(str(e), code="repository_inaccessible")
         except ValueError as e:
             # e.g. the team/user has no GitHub integration with access to the repository.
             raise exceptions.ValidationError(str(e))

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -14,6 +14,8 @@ from posthog.cloud_utils import get_api_host
 from posthog.models import Organization, PersonalAPIKey, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
+from products.tasks.backend.facade import api as tasks_facade
+
 
 class SetupWizardTests(APIBaseTest):
     def setUp(self):
@@ -482,6 +484,23 @@ class SetupWizardCloudRunTests(APIBaseTest):
         assert kwargs["user_id"] == self.user.id
         assert kwargs["branch"] is None
         assert kwargs["team"].id == self.team.id
+
+    @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
+    def test_rejects_inaccessible_repository_with_stable_code(self, mock_create):
+        mock_create.side_effect = tasks_facade.WizardRepositoryInaccessibleError(
+            "PostHog's GitHub integration can't access acme/app."
+        )
+
+        response = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/app"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["code"] == "repository_inaccessible"
+        assert body["detail"] == "PostHog's GitHub integration can't access acme/app."
 
     @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
     def test_rejects_invalid_repository_format(self, mock_create):

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -48,6 +48,11 @@ from products.tasks.backend.logic.services.image_builder import (
     is_custom_images_enabled,
     read_spec_from_builder_sandbox,
 )
+from products.tasks.backend.logic.wizard_repo_probe import (
+    WizardRepoAccess,
+    WizardRepositoryInaccessibleError,
+    probe_wizard_repository_access,
+)
 from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
     Channel,
@@ -113,6 +118,7 @@ __all__ = [
     "TaskOriginProduct",
     "TaskRunEnvironment",
     "TaskRunStatus",
+    "WizardRepositoryInaccessibleError",
     "append_task_run_log",
     "beacon_task_presence",
     "bootstrap_task_run",
@@ -806,7 +812,17 @@ def create_wizard_cloud_run(
     The PR head branch is generated here (not by the agent) so the GitHub PR webhook can bind the
     opened PR back to this run by branch + repository — wizard PRs are bot-authored, which the
     agent-side PR attribution cannot match.
+
+    Raises :class:`WizardRepositoryInaccessibleError` when the pre-flight probe confirms the
+    team's GitHub installation cannot access ``repository`` — the sandbox clone would fail
+    identically after a full sandbox boot. A probe that cannot get a definitive answer
+    (timeouts, rate limits) fails open and the run is created.
     """
+    if probe_wizard_repository_access(team, repository) is WizardRepoAccess.INACCESSIBLE:
+        raise WizardRepositoryInaccessibleError(
+            f"PostHog's GitHub integration can't access {repository}. "
+            "Check the repository name, or grant the PostHog GitHub app access to it and try again."
+        )
     head_branch = generate_wizard_head_branch()
     prompt = build_wizard_pr_agent_prompt(head_branch)
     return create_and_run_task(

--- a/products/tasks/backend/logic/wizard_repo_probe.py
+++ b/products/tasks/backend/logic/wizard_repo_probe.py
@@ -1,0 +1,69 @@
+"""Pre-flight GitHub repository probe for wizard cloud runs.
+
+A wizard cloud run is bot-authored, so its sandbox clone authenticates with the team's
+first GitHub integration (see ``Task._build_task``). When that installation cannot access
+the requested repository, the run only fails minutes later inside the sandbox as a clone
+error ("remote: Repository not found"), burning a full sandbox boot. This probe performs
+the same access check up front, with the same credential resolution the clone will use,
+so the kickoff endpoint can reject a doomed run in seconds instead.
+"""
+
+import re
+import logging
+from enum import Enum
+
+from posthog.models.github_integration_base import GitHubIntegrationError
+from posthog.models.integration import GitHubIntegration, Integration
+from posthog.models.team import Team
+
+logger = logging.getLogger(__name__)
+
+_PROBE_SOURCE = "tasks"
+
+# Mirrors ``posthog.models.integration._GITHUB_REPO_PATH_RE``: a plain ``owner/repo`` only,
+# so team-supplied input (``..``, ``?``, ``#``) can never steer the authenticated GET below
+# to a different GitHub endpoint.
+_SAFE_REPO_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
+class WizardRepoAccess(Enum):
+    ACCESSIBLE = "accessible"
+    INACCESSIBLE = "inaccessible"
+    UNKNOWN = "unknown"
+
+
+class WizardRepositoryInaccessibleError(Exception):
+    """The repository doesn't exist or the team's GitHub installation cannot access it."""
+
+
+def probe_wizard_repository_access(team: Team, repository: str) -> WizardRepoAccess:
+    """Check whether the team's GitHub installation can access ``repository`` (``owner/repo``).
+
+    Resolves the integration exactly like ``Task._build_task`` binds ``github_integration``
+    for a bot-authored run (first team GitHub integration), so the answer matches what the
+    sandbox clone will experience. Fail-open by design: rate limits, timeouts, and any
+    unexpected response map to ``UNKNOWN`` — only a definitive 404 reports ``INACCESSIBLE``.
+    Never raises.
+    """
+    if not _SAFE_REPO_PATH_RE.fullmatch(repository) or ".." in repository:
+        # Not a name that can exist on GitHub — the clone would fail identically.
+        return WizardRepoAccess.INACCESSIBLE
+    try:
+        integration = Integration.objects.filter(team=team, kind="github").first()
+        if integration is None:
+            # No team installation to probe with; ``_build_task`` owns this case (user
+            # integration fallback or a hard "no GitHub integration" error).
+            return WizardRepoAccess.UNKNOWN
+        github = GitHubIntegration(integration, source=_PROBE_SOURCE)
+        response = github.api_request("GET", f"/repos/{repository}", endpoint="/repos/{owner}/{repo}")
+    except GitHubIntegrationError:
+        logger.warning("Wizard repo probe failed for team %s", team.id, exc_info=True)
+        return WizardRepoAccess.UNKNOWN
+    except Exception:
+        logger.exception("Unexpected wizard repo probe failure for team %s", team.id)
+        return WizardRepoAccess.UNKNOWN
+    if response.status_code == 200:
+        return WizardRepoAccess.ACCESSIBLE
+    if response.status_code == 404:
+        return WizardRepoAccess.INACCESSIBLE
+    return WizardRepoAccess.UNKNOWN

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -2,7 +2,7 @@ import importlib
 from datetime import timedelta
 from typing import ClassVar
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from django.utils import timezone as django_timezone
@@ -10,6 +10,8 @@ from django.utils import timezone as django_timezone
 from parameterized import parameterized
 
 from posthog.models import Integration, Organization, Team
+from posthog.models.github_integration_base import GitHubIntegrationError
+from posthog.models.integration import GitHubIntegration
 from posthog.models.user import User
 
 from products.tasks.backend.facade import (
@@ -463,3 +465,31 @@ class TestFacadeReadsAndMappers(TestCase):
         # overlap-clone-boot launch (before run_wizard) burns the prompt on an untouched repo
         # and the run never opens a PR. Wizard runs must pin the overlap boot off.
         self.assertIs(run.state.get("overlap_clone_boot_enabled"), False)
+
+    @parameterized.expand(
+        [
+            ("accessible", 200, True),
+            ("inaccessible", 404, False),
+            ("unknown_status", 502, True),
+            ("probe_error", None, True),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_probes_repository_access(self, _name, probe_status, run_created, _mock_workflow):
+        # The probe must block only a confirmed-inaccessible repo (the sandbox clone would
+        # fail after a full boot) and fail open on any indeterminate GitHub answer.
+        Integration.objects.create(team=self.team, kind="github", config={})
+        tasks_before = Task.objects.count()
+        if probe_status is None:
+            probe = patch.object(GitHubIntegration, "api_request", side_effect=GitHubIntegrationError("boom"))
+        else:
+            probe = patch.object(GitHubIntegration, "api_request", return_value=MagicMock(status_code=probe_status))
+        with probe:
+            if run_created:
+                created = facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
+                self.assertTrue(TaskRun.objects.filter(task_id=created.task_id).exists())
+            else:
+                with self.assertRaises(facade.WizardRepositoryInaccessibleError):
+                    facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
+                self.assertEqual(Task.objects.count(), tasks_before)
+                self.assertFalse(TaskRun.objects.exists())


### PR DESCRIPTION
## Problem

A wizard cloud run can be queued for a GitHub repository that doesn't exist or that the team's GitHub installation can't access.
The only validation today is the `owner/repo` format check on the endpoint and a "some GitHub integration exists" check in `Task._build_task`.
The failure then surfaces only ~10 minutes later inside the sandbox as `Failed to clone repository X: remote: Repository not found.` - a deterministic outcome that burns a full sandbox boot and leaves the user with an opaque error.

Closes GROW-146 (https://linear.app/posthog-team-growth/issue/GROW-146)

## Changes

- New `products/tasks/backend/logic/wizard_repo_probe.py`: a pre-flight probe that fetches `GET /repos/{owner}/{repo}` through the existing `GitHubIntegration` client (which routes via the `posthog/egress/github` transport), using the same credential resolution the sandbox clone will use for a bot-authored wizard run (first team GitHub integration, matching `Task._build_task`). It returns a tri-state: accessible (200), inaccessible (404), unknown (anything else - rate limits, timeouts, unexpected statuses). It never raises.
- `create_wizard_cloud_run` (tasks facade) probes before creating the Task/TaskRun and raises a typed `WizardRepositoryInaccessibleError` only on a definitive inaccessible answer. Unknown fails open, so a degraded GitHub API never blocks run creation.
- `POST /api/wizard/cloud_run` maps that error to a 400 with a stable machine-readable code `repository_inaccessible` and an actionable message (check the repository name, or grant the PostHog GitHub app access). The kickoff UI already surfaces the API error detail in a toast, so no frontend change is needed.
- The `posthog_wizard_cloud_run_requests_total` counter now labels these rejections with their own `repository_inaccessible` outcome so the probe's impact is measurable.

> [!NOTE]
> Fail-open by design: only a confirmed 404 blocks the run. Any indeterminate probe result (no team integration, rate limit, network error) preserves today's behavior.

## How did you test this code?

- `hogli test products/tasks/backend/tests/test_facade.py` - 37 passed. Added a parameterized facade test (accessible / inaccessible / unknown-status / probe-error) asserting run-created vs raised-and-no-Task/TaskRun-row. Catches a regression where the probe stops blocking confirmed-inaccessible repos, or worse, starts blocking on indeterminate answers - no existing test covered any pre-flight behavior.
- `hogli test posthog/api/wizard/test/test_http.py` - 28 passed. Added one wiring test asserting the facade error becomes a 400 with code `repository_inaccessible`, so clients can rely on the stable code.
- Mocked only the GitHub boundary (`GitHubIntegration.api_request`); no real network in tests.
- I (Claude) did not manually exercise a live cloud run kickoff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` cover the wizard cloud run endpoint; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Claude Opus 4.8) in an isolated worktree, directed by @fercgomes. Session: https://claude.ai/code/session_012LEMkKpdE7Z44V584tnCLH

- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`.
- Decisions: probed with the first team GitHub integration (identical to how `Task._build_task` binds `github_integration` for bot-authored runs) rather than scanning all installations - blocking matches exactly what the sandbox clone would experience. When no team integration exists the probe returns unknown and defers to `_build_task`'s existing user-integration fallback and error. Repo paths are re-validated against a strict `owner/repo` pattern before being interpolated into the authenticated GET, mirroring `_is_safe_github_repo_path`.
- The typed exception is exported through the tasks facade (`tasks_facade.WizardRepositoryInaccessibleError`) to respect the product isolation boundary; it deliberately does not live in `products/tasks/backend/exceptions.py`, which drags temporalio onto the import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LEMkKpdE7Z44V584tnCLH
