### PR TITLE
fix(cdp): fall back to the node vm when the rust vm ffi boundary throws

### DIFF
--- a/nodejs/src/cdp/hog-transformations/rust-vm-executor.test.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-executor.test.ts
@@ -104,6 +104,13 @@ describe('RustVmExecutor', () => {
         await expect(executor.execute(createExampleInvocation(), [])).resolves.toBeNull()
     })
 
+    it('falls back to the node vm when the ffi boundary throws instead of returning an error', async () => {
+        // e.g. globals containing NaN/Infinity, which serde_json can't represent.
+        mockHogvmNode.executeBatch.mockRejectedValue(new Error('Failed to convert js number to serde_json::Number'))
+
+        await expect(executor.execute(createExampleInvocation(), [])).resolves.toBeNull()
+    })
+
     it('falls back to the node vm when the native addon is unavailable', async () => {
         mockHogvmNode.init.mockImplementation(() => {
             throw new Error('addon not built')

--- a/nodejs/src/cdp/hog-transformations/rust-vm-executor.test.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-executor.test.ts
@@ -1,3 +1,5 @@
+import { logger } from '~/common/utils/logger'
+
 import { createExampleInvocation } from '../_tests/fixtures'
 import { resetHogvmNodeModuleCacheForTests } from './rust-vm'
 import { RustVmExecutor } from './rust-vm-executor'
@@ -109,6 +111,19 @@ describe('RustVmExecutor', () => {
         mockHogvmNode.executeBatch.mockRejectedValue(new Error('Failed to convert js number to serde_json::Number'))
 
         await expect(executor.execute(createExampleInvocation(), [])).resolves.toBeNull()
+    })
+
+    it('redacts sensitive values from fallback logs', async () => {
+        // Marshalling errors and panic messages can embed values from the invocation globals.
+        const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {})
+        mockHogvmNode.executeBatch.mockRejectedValue(new Error('failed to convert value "secret-token" at inputs'))
+
+        await expect(executor.execute(createExampleInvocation(), ['secret-token'])).resolves.toBeNull()
+
+        const fallbackCalls = warnSpy.mock.calls.filter((call) => String(call[1]).includes('fell back'))
+        expect(fallbackCalls).toHaveLength(1)
+        expect(JSON.stringify(fallbackCalls)).not.toContain('secret-token')
+        expect(JSON.stringify(fallbackCalls)).toContain('***REDACTED***')
     })
 
     it('falls back to the node vm when the native addon is unavailable', async () => {

--- a/nodejs/src/cdp/hog-transformations/rust-vm-executor.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-executor.ts
@@ -45,12 +45,33 @@ export class RustVmExecutor {
      * event-loop yielding the Node path has. Concurrent events therefore execute in parallel on
      * worker threads; batching many events into one call (rayon fan-out) is a possible follow-up.
      */
+    /**
+     * Count and log a fallback so every node-vm handoff is attributable to a function. Returns
+     * null for the caller to pass through.
+     */
+    private fallback(
+        outcome: 'fallback_unsupported' | 'fallback_exception' | 'fallback_empty_result',
+        invocation: CyclotronJobInvocationHogFunction,
+        error: unknown
+    ): null {
+        rustVmExecution.inc({ outcome })
+        logger.warn('🦀', 'Rust HogVM invocation fell back to the node vm', {
+            outcome,
+            functionId: invocation.functionId,
+            teamId: invocation.teamId,
+            error: error !== undefined ? String(error) : undefined,
+        })
+        return null
+    }
+
     public async execute(
         invocation: CyclotronJobInvocationHogFunction,
         sensitiveValues: string[]
     ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction> | null> {
         const module_ = this.getModule()
         if (!module_) {
+            // No per-invocation log: a missing addon affects every invocation and the loader
+            // already warned once with the load error.
             rustVmExecution.inc({ outcome: 'fallback_unavailable' })
             return null
         }
@@ -61,25 +82,20 @@ export class RustVmExecutor {
                 maxSteps: RUST_MAX_STEPS,
             })
         } catch (error) {
-            // A throw here is the FFI boundary, not the program — e.g. globals containing NaN or
-            // Infinity, which serde_json can't represent. The Node VM takes the JS objects
-            // directly and can run these, so fall back rather than fail the transformation.
-            rustVmExecution.inc({ outcome: 'fallback_exception' })
-            logger.warn('🦀', 'Rust HogVM invocation threw, falling back to the node vm', {
-                functionId: invocation.functionId,
-                teamId: invocation.teamId,
-                error: String(error),
-            })
-            return null
+            // A throw here is the boundary or the native side, not the program's own error path —
+            // marshalling failures (e.g. globals containing NaN or Infinity, which serde_json
+            // can't represent), rust panics, addon bugs. Deliberately broad: the node vm can run
+            // all of these, so correctness wins and the invocation falls back — while the warn log
+            // and the fallback_exception outcome carry the error so native faults stay visible
+            // rather than being silently healed.
+            return this.fallback('fallback_exception', invocation, error)
         }
         if (!rust) {
-            rustVmExecution.inc({ outcome: 'fallback_unavailable' })
-            return null
+            return this.fallback('fallback_empty_result', invocation, undefined)
         }
 
         if (rust.error && isUnsupportedByRustVm(rust.error)) {
-            rustVmExecution.inc({ outcome: 'fallback_unsupported' })
-            return null
+            return this.fallback('fallback_unsupported', invocation, rust.error)
         }
 
         const durationMs = rust.durationUs / 1000

--- a/nodejs/src/cdp/hog-transformations/rust-vm-executor.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-executor.ts
@@ -1,6 +1,8 @@
 import { DateTime } from 'luxon'
 import { Counter, Histogram } from 'prom-client'
 
+import { logger } from '~/common/utils/logger'
+
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from '../types'
 import { createAddLogFunction, sanitizeLogMessage } from '../utils'
 import { createInvocationResult } from '../utils/invocation-utils'
@@ -53,9 +55,23 @@ export class RustVmExecutor {
             return null
         }
 
-        const [rust] = await module_.executeBatch(invocation.hogFunction.bytecode, [invocation.state.globals], {
-            maxSteps: RUST_MAX_STEPS,
-        })
+        let rust
+        try {
+            ;[rust] = await module_.executeBatch(invocation.hogFunction.bytecode, [invocation.state.globals], {
+                maxSteps: RUST_MAX_STEPS,
+            })
+        } catch (error) {
+            // A throw here is the FFI boundary, not the program — e.g. globals containing NaN or
+            // Infinity, which serde_json can't represent. The Node VM takes the JS objects
+            // directly and can run these, so fall back rather than fail the transformation.
+            rustVmExecution.inc({ outcome: 'fallback_exception' })
+            logger.warn('🦀', 'Rust HogVM invocation threw, falling back to the node vm', {
+                functionId: invocation.functionId,
+                teamId: invocation.teamId,
+                error: String(error),
+            })
+            return null
+        }
         if (!rust) {
             rustVmExecution.inc({ outcome: 'fallback_unavailable' })
             return null

--- a/nodejs/src/cdp/hog-transformations/rust-vm-executor.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-executor.ts
@@ -36,6 +36,28 @@ export class RustVmExecutor {
     }
 
     /**
+     * Count and log a fallback so every node-vm handoff is attributable to a function. Returns
+     * null for the caller to pass through.
+     */
+    private fallback(
+        outcome: 'fallback_unsupported' | 'fallback_exception' | 'fallback_empty_result',
+        invocation: CyclotronJobInvocationHogFunction,
+        sensitiveValues: string[],
+        error: unknown
+    ): null {
+        rustVmExecution.inc({ outcome })
+        logger.warn('🦀', 'Rust HogVM invocation fell back to the node vm', {
+            outcome,
+            functionId: invocation.functionId,
+            teamId: invocation.teamId,
+            // Same redaction as hog print logs: marshalling errors and panic messages can embed
+            // values from the invocation globals, which include secret inputs.
+            error: error !== undefined ? sanitizeLogMessage([String(error)], sensitiveValues) : undefined,
+        })
+        return null
+    }
+
+    /**
      * Execute one transformation invocation on the Rust VM. Returns null when the Node VM must
      * run it instead.
      *
@@ -45,25 +67,6 @@ export class RustVmExecutor {
      * event-loop yielding the Node path has. Concurrent events therefore execute in parallel on
      * worker threads; batching many events into one call (rayon fan-out) is a possible follow-up.
      */
-    /**
-     * Count and log a fallback so every node-vm handoff is attributable to a function. Returns
-     * null for the caller to pass through.
-     */
-    private fallback(
-        outcome: 'fallback_unsupported' | 'fallback_exception' | 'fallback_empty_result',
-        invocation: CyclotronJobInvocationHogFunction,
-        error: unknown
-    ): null {
-        rustVmExecution.inc({ outcome })
-        logger.warn('🦀', 'Rust HogVM invocation fell back to the node vm', {
-            outcome,
-            functionId: invocation.functionId,
-            teamId: invocation.teamId,
-            error: error !== undefined ? String(error) : undefined,
-        })
-        return null
-    }
-
     public async execute(
         invocation: CyclotronJobInvocationHogFunction,
         sensitiveValues: string[]
@@ -88,14 +91,14 @@ export class RustVmExecutor {
             // all of these, so correctness wins and the invocation falls back — while the warn log
             // and the fallback_exception outcome carry the error so native faults stay visible
             // rather than being silently healed.
-            return this.fallback('fallback_exception', invocation, error)
+            return this.fallback('fallback_exception', invocation, sensitiveValues, error)
         }
         if (!rust) {
-            return this.fallback('fallback_empty_result', invocation, undefined)
+            return this.fallback('fallback_empty_result', invocation, sensitiveValues, undefined)
         }
 
         if (rust.error && isUnsupportedByRustVm(rust.error)) {
-            return this.fallback('fallback_unsupported', invocation, rust.error)
+            return this.fallback('fallback_unsupported', invocation, sensitiveValues, rust.error)
         }
 
         const durationMs = rust.durationUs / 1000


### PR DESCRIPTION
## Problem

`hog_transformation_unexpected_errors_total` is firing in prod-eu since the rust hogvm rollout (#69605 + PostHog/charts#13068): `Error: Failed to convert js number to serde_json::Number`.

Events whose globals contain `NaN` or `Infinity` fail serde_json conversion at the napi boundary, before the rust vm runs. That surfaces as a thrown exception rather than an error result, so the unsupported-program fallback never sees it — the throw escapes to the transformer's catch-all and the transformation is skipped for those events (event survives, marked `$transformations_failed`). The node vm handles these events fine since it takes the JS objects directly with no serialization.

## Changes

- Catch throws around the napi call in `RustVmExecutor.execute` and return null, handing the invocation to the node vm like the other fallback cases.
- New `outcome="fallback_exception"` label on `hogvm_rust_execution_total`, plus a warn log with function/team for visibility.

## How did you test this code?

I'm an agent; checks I ran:

- New regression test: a rejected `executeBatch` promise (the serde error shape) falls back to null instead of throwing. Existing suite: 10/10 pass.
- Root cause confirmed from prod-eu Loki: `Failed to convert js number to serde_json::Number` on function `0194f980-4afc-0000-8dea-b554a260e180` (team 5386), matching the metric spike exactly.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed; internal executor behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Claude Fable 5), directed by the assignee, after tracing the prod-eu alert to the FFI marshalling gap in the fallback contract.
- A longer-term option is coercing non-finite numbers on the rust side of the boundary; falling back keeps node-vm semantics for these events (NaN stays a number) and matches the existing fallback philosophy. #70070 (executeSync follow-up) will need the same guard after this merges.
