### PR TITLE
feat(tasks): pre-flight framework detectability for wizard cloud runs

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -57,12 +57,12 @@ OPENAI_SUPPORTED_MODELS = {"o4-mini", "gpt-5-mini", "gpt-5-nano", "gpt-5"}
 WIZARD_CLOUD_RUN_REQUESTS_TOTAL = Counter(
     "posthog_wizard_cloud_run_requests_total",
     "Cloud-run wizard kickoff requests, by outcome "
-    "(created/unavailable/invalid/permission_denied/repository_inaccessible)",
+    "(created/unavailable/invalid/permission_denied/repository_inaccessible/framework_undetectable)",
     labelnames=["outcome"],
 )
 
 # Pre-flight rejections carry their own outcome label so the probe's impact is measurable.
-CLOUD_RUN_PREFLIGHT_OUTCOME_CODES = frozenset({"repository_inaccessible"})
+CLOUD_RUN_PREFLIGHT_OUTCOME_CODES = frozenset({"repository_inaccessible", "framework_undetectable"})
 
 
 def _cloud_run_validation_outcome(error: exceptions.ValidationError) -> str:
@@ -502,6 +502,10 @@ class SetupWizardViewSet(viewsets.ViewSet):
             # Pre-flight probe confirmed the sandbox clone would fail; stable code so
             # clients can distinguish this from generic input validation.
             raise exceptions.ValidationError(str(e), code="repository_inaccessible")
+        except tasks_facade.WizardFrameworkUndetectableError as e:
+            # Pre-flight probe confirmed the wizard's framework auto-detection would fail;
+            # the local wizard (npx @posthog/wizard) is the fallback path.
+            raise exceptions.ValidationError(str(e), code="framework_undetectable")
         except ValueError as e:
             # e.g. the team/user has no GitHub integration with access to the repository.
             raise exceptions.ValidationError(str(e))

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.wizard.http import SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
@@ -485,11 +486,15 @@ class SetupWizardCloudRunTests(APIBaseTest):
         assert kwargs["branch"] is None
         assert kwargs["team"].id == self.team.id
 
+    @parameterized.expand(
+        [
+            ("repository_inaccessible", tasks_facade.WizardRepositoryInaccessibleError),
+            ("framework_undetectable", tasks_facade.WizardFrameworkUndetectableError),
+        ]
+    )
     @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
-    def test_rejects_inaccessible_repository_with_stable_code(self, mock_create):
-        mock_create.side_effect = tasks_facade.WizardRepositoryInaccessibleError(
-            "PostHog's GitHub integration can't access acme/app."
-        )
+    def test_preflight_rejections_return_stable_codes(self, expected_code, facade_error, mock_create):
+        mock_create.side_effect = facade_error("The pre-flight probe rejected acme/app.")
 
         response = self.client.post(
             self.CLOUD_RUN_URL,
@@ -499,8 +504,8 @@ class SetupWizardCloudRunTests(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         body = response.json()
-        assert body["code"] == "repository_inaccessible"
-        assert body["detail"] == "PostHog's GitHub integration can't access acme/app."
+        assert body["code"] == expected_code
+        assert body["detail"] == "The pre-flight probe rejected acme/app."
 
     @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
     def test_rejects_invalid_repository_format(self, mock_create):

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -49,9 +49,10 @@ from products.tasks.backend.logic.services.image_builder import (
     read_spec_from_builder_sandbox,
 )
 from products.tasks.backend.logic.wizard_repo_probe import (
+    WizardFrameworkUndetectableError,
     WizardRepoAccess,
     WizardRepositoryInaccessibleError,
-    probe_wizard_repository_access,
+    probe_wizard_repository,
 )
 from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
@@ -118,6 +119,7 @@ __all__ = [
     "TaskOriginProduct",
     "TaskRunEnvironment",
     "TaskRunStatus",
+    "WizardFrameworkUndetectableError",
     "WizardRepositoryInaccessibleError",
     "append_task_run_log",
     "beacon_task_presence",
@@ -814,14 +816,23 @@ def create_wizard_cloud_run(
     agent-side PR attribution cannot match.
 
     Raises :class:`WizardRepositoryInaccessibleError` when the pre-flight probe confirms the
-    team's GitHub installation cannot access ``repository`` — the sandbox clone would fail
-    identically after a full sandbox boot. A probe that cannot get a definitive answer
-    (timeouts, rate limits) fails open and the run is created.
+    team's GitHub installation cannot access ``repository``, and
+    :class:`WizardFrameworkUndetectableError` when the repository root confirmedly has no
+    manifest the wizard's framework auto-detection can use — in both cases the sandbox run
+    would fail identically after a full sandbox boot. A probe that cannot get a definitive
+    answer (timeouts, rate limits, listing failures) fails open and the run is created.
     """
-    if probe_wizard_repository_access(team, repository) is WizardRepoAccess.INACCESSIBLE:
+    probe = probe_wizard_repository(team, repository)
+    if probe.access is WizardRepoAccess.INACCESSIBLE:
         raise WizardRepositoryInaccessibleError(
             f"PostHog's GitHub integration can't access {repository}. "
             "Check the repository name, or grant the PostHog GitHub app access to it and try again."
+        )
+    if probe.framework_detectable is False:
+        raise WizardFrameworkUndetectableError(
+            f"The wizard couldn't detect a supported framework in {repository}: its root has no "
+            "manifest like package.json, pyproject.toml, requirements.txt, setup.py, Pipfile, or go.mod. "
+            "Run the wizard locally instead with `npx @posthog/wizard`."
         )
     head_branch = generate_wizard_head_branch()
     prompt = build_wizard_pr_agent_prompt(head_branch)

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -817,12 +817,12 @@ def create_wizard_cloud_run(
 
     Raises :class:`WizardRepositoryInaccessibleError` when the pre-flight probe confirms the
     team's GitHub installation cannot access ``repository``, and
-    :class:`WizardFrameworkUndetectableError` when the repository root confirmedly has no
-    manifest the wizard's framework auto-detection can use — in both cases the sandbox run
-    would fail identically after a full sandbox boot. A probe that cannot get a definitive
+    :class:`WizardFrameworkUndetectableError` when the root of ``branch`` (default branch
+    when not given) confirmedly has no manifest the wizard's framework auto-detection can
+    use — in both cases the sandbox run would fail identically after a full sandbox boot. A probe that cannot get a definitive
     answer (timeouts, rate limits, listing failures) fails open and the run is created.
     """
-    probe = probe_wizard_repository(team, repository)
+    probe = probe_wizard_repository(team, repository, branch=branch)
     if probe.access is WizardRepoAccess.INACCESSIBLE:
         raise WizardRepositoryInaccessibleError(
             f"PostHog's GitHub integration can't access {repository}. "

--- a/products/tasks/backend/logic/wizard_repo_probe.py
+++ b/products/tasks/backend/logic/wizard_repo_probe.py
@@ -67,15 +67,17 @@ class WizardRepoProbe:
     framework_detectable: bool | None = None
 
 
-def probe_wizard_repository(team: Team, repository: str) -> WizardRepoProbe:
+def probe_wizard_repository(team: Team, repository: str, branch: str | None = None) -> WizardRepoProbe:
     """Probe ``repository`` (``owner/repo``) with the team's GitHub installation.
 
     Resolves the integration exactly like ``Task._build_task`` binds ``github_integration``
     for a bot-authored run (first team GitHub integration), so the answer matches what the
-    sandbox clone will experience. Fail-open by design: rate limits, timeouts, and any
-    unexpected response map to ``UNKNOWN`` access / ``None`` detectability — only a
-    definitive 404 reports ``INACCESSIBLE``, and only a successful root listing with no
-    supported manifest reports ``framework_detectable=False``. Never raises.
+    sandbox clone will experience. ``branch`` is the ref the sandbox will check out; the
+    detectability listing must look at that ref's root, not the default branch's. Fail-open
+    by design: rate limits, timeouts, and any unexpected response map to ``UNKNOWN`` access /
+    ``None`` detectability — only a definitive 404 reports ``INACCESSIBLE``, and only a
+    successful root listing with no supported manifest reports ``framework_detectable=False``.
+    Never raises.
     """
     if not _SAFE_REPO_PATH_RE.fullmatch(repository) or ".." in repository:
         # Not a name that can exist on GitHub — the clone would fail identically.
@@ -100,21 +102,24 @@ def probe_wizard_repository(team: Team, repository: str) -> WizardRepoProbe:
         return WizardRepoProbe(access=WizardRepoAccess.UNKNOWN)
     return WizardRepoProbe(
         access=WizardRepoAccess.ACCESSIBLE,
-        framework_detectable=_root_framework_detectable(github, repository),
+        framework_detectable=_root_framework_detectable(github, repository, branch),
     )
 
 
-def _root_framework_detectable(github: GitHubIntegration, repository: str) -> bool | None:
+def _root_framework_detectable(github: GitHubIntegration, repository: str, branch: str | None) -> bool | None:
     """Whether the repo root holds any manifest the wizard's auto-detection can work from.
 
-    Conservative on purpose: any failure to list the root (error, non-200, unexpected
-    payload) returns ``None`` so uncertainty never blocks a run.
+    Lists the root of ``branch`` when given (the ref the sandbox checks out) and the
+    default branch otherwise. Conservative on purpose: any failure to list the root
+    (error, non-200, unexpected payload — including a nonexistent ref) returns ``None``
+    so uncertainty never blocks a run.
     """
     try:
         response = github.api_request(
             "GET",
             f"/repos/{repository}/contents",
             endpoint="/repos/{owner}/{repo}/contents/{path}",
+            params={"ref": branch} if branch else None,
         )
     except Exception:
         logger.warning("Wizard repo probe root listing failed for %s", repository, exc_info=True)

--- a/products/tasks/backend/logic/wizard_repo_probe.py
+++ b/products/tasks/backend/logic/wizard_repo_probe.py
@@ -6,10 +6,16 @@ the requested repository, the run only fails minutes later inside the sandbox as
 error ("remote: Repository not found"), burning a full sandbox boot. This probe performs
 the same access check up front, with the same credential resolution the clone will use,
 so the kickoff endpoint can reject a doomed run in seconds instead.
+
+The probe also mirrors the wizard CLI's framework auto-detection inputs: the CLI only
+looks at manifests at the repository root, so a root with none of them fails the run
+deterministically ("Could not auto-detect your framework for this project"). Deriving
+that from a single root listing lets the kickoff endpoint fail those runs up front too.
 """
 
 import re
 import logging
+from dataclasses import dataclass
 from enum import Enum
 
 from posthog.models.github_integration_base import GitHubIntegrationError
@@ -25,6 +31,19 @@ _PROBE_SOURCE = "tasks"
 # to a different GitHub endpoint.
 _SAFE_REPO_PATH_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
+# Root manifests the wizard CLI's framework auto-detection keys off (package.json deps and
+# Python/Go manifests). A root with none of these makes the sandbox run fail deterministically.
+WIZARD_DETECTABLE_MANIFEST_FILES = frozenset(
+    {
+        "package.json",
+        "pyproject.toml",
+        "requirements.txt",
+        "setup.py",
+        "Pipfile",
+        "go.mod",
+    }
+)
+
 
 class WizardRepoAccess(Enum):
     ACCESSIBLE = "accessible"
@@ -36,34 +55,77 @@ class WizardRepositoryInaccessibleError(Exception):
     """The repository doesn't exist or the team's GitHub installation cannot access it."""
 
 
-def probe_wizard_repository_access(team: Team, repository: str) -> WizardRepoAccess:
-    """Check whether the team's GitHub installation can access ``repository`` (``owner/repo``).
+class WizardFrameworkUndetectableError(Exception):
+    """The repository root has no manifest the wizard's framework auto-detection can use."""
+
+
+@dataclass(frozen=True)
+class WizardRepoProbe:
+    access: WizardRepoAccess
+    # None means "could not tell" (listing failed or wasn't attempted); only an explicit
+    # False - a successful root listing with no supported manifest - should block a run.
+    framework_detectable: bool | None = None
+
+
+def probe_wizard_repository(team: Team, repository: str) -> WizardRepoProbe:
+    """Probe ``repository`` (``owner/repo``) with the team's GitHub installation.
 
     Resolves the integration exactly like ``Task._build_task`` binds ``github_integration``
     for a bot-authored run (first team GitHub integration), so the answer matches what the
     sandbox clone will experience. Fail-open by design: rate limits, timeouts, and any
-    unexpected response map to ``UNKNOWN`` — only a definitive 404 reports ``INACCESSIBLE``.
-    Never raises.
+    unexpected response map to ``UNKNOWN`` access / ``None`` detectability — only a
+    definitive 404 reports ``INACCESSIBLE``, and only a successful root listing with no
+    supported manifest reports ``framework_detectable=False``. Never raises.
     """
     if not _SAFE_REPO_PATH_RE.fullmatch(repository) or ".." in repository:
         # Not a name that can exist on GitHub — the clone would fail identically.
-        return WizardRepoAccess.INACCESSIBLE
+        return WizardRepoProbe(access=WizardRepoAccess.INACCESSIBLE)
     try:
         integration = Integration.objects.filter(team=team, kind="github").first()
         if integration is None:
             # No team installation to probe with; ``_build_task`` owns this case (user
             # integration fallback or a hard "no GitHub integration" error).
-            return WizardRepoAccess.UNKNOWN
+            return WizardRepoProbe(access=WizardRepoAccess.UNKNOWN)
         github = GitHubIntegration(integration, source=_PROBE_SOURCE)
         response = github.api_request("GET", f"/repos/{repository}", endpoint="/repos/{owner}/{repo}")
     except GitHubIntegrationError:
         logger.warning("Wizard repo probe failed for team %s", team.id, exc_info=True)
-        return WizardRepoAccess.UNKNOWN
+        return WizardRepoProbe(access=WizardRepoAccess.UNKNOWN)
     except Exception:
         logger.exception("Unexpected wizard repo probe failure for team %s", team.id)
-        return WizardRepoAccess.UNKNOWN
-    if response.status_code == 200:
-        return WizardRepoAccess.ACCESSIBLE
+        return WizardRepoProbe(access=WizardRepoAccess.UNKNOWN)
     if response.status_code == 404:
-        return WizardRepoAccess.INACCESSIBLE
-    return WizardRepoAccess.UNKNOWN
+        return WizardRepoProbe(access=WizardRepoAccess.INACCESSIBLE)
+    if response.status_code != 200:
+        return WizardRepoProbe(access=WizardRepoAccess.UNKNOWN)
+    return WizardRepoProbe(
+        access=WizardRepoAccess.ACCESSIBLE,
+        framework_detectable=_root_framework_detectable(github, repository),
+    )
+
+
+def _root_framework_detectable(github: GitHubIntegration, repository: str) -> bool | None:
+    """Whether the repo root holds any manifest the wizard's auto-detection can work from.
+
+    Conservative on purpose: any failure to list the root (error, non-200, unexpected
+    payload) returns ``None`` so uncertainty never blocks a run.
+    """
+    try:
+        response = github.api_request(
+            "GET",
+            f"/repos/{repository}/contents",
+            endpoint="/repos/{owner}/{repo}/contents/{path}",
+        )
+    except Exception:
+        logger.warning("Wizard repo probe root listing failed for %s", repository, exc_info=True)
+        return None
+    if response.status_code != 200:
+        return None
+    try:
+        entries = response.json()
+    except Exception:
+        return None
+    if not isinstance(entries, list):
+        return None
+    names = {entry.get("name") for entry in entries if isinstance(entry, dict)}
+    return bool(names & WIZARD_DETECTABLE_MANIFEST_FILES)

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -493,3 +493,37 @@ class TestFacadeReadsAndMappers(TestCase):
                     facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
                 self.assertEqual(Task.objects.count(), tasks_before)
                 self.assertFalse(TaskRun.objects.exists())
+
+    @parameterized.expand(
+        [
+            ("manifest_present", [{"name": "package.json"}, {"name": "README.md"}], True),
+            ("no_root_manifest", [{"name": "README.md"}, {"name": "docs"}], False),
+            ("listing_error", GitHubIntegrationError("boom"), True),
+            ("listing_non_200", None, True),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_framework_detectability_preflight(
+        self, _name, listing, run_created, _mock_workflow
+    ):
+        # Blocking must require a *successful* root listing with no supported manifest —
+        # the deterministic "Could not auto-detect your framework" sandbox failure. Any
+        # listing uncertainty has to fail open.
+        Integration.objects.create(team=self.team, kind="github", config={})
+        tasks_before = Task.objects.count()
+        metadata_response = MagicMock(status_code=200)
+        if isinstance(listing, Exception):
+            contents_effect = listing
+        elif listing is None:
+            contents_effect = MagicMock(status_code=500)
+        else:
+            contents_effect = MagicMock(status_code=200, json=MagicMock(return_value=listing))
+        with patch.object(GitHubIntegration, "api_request", side_effect=[metadata_response, contents_effect]):
+            if run_created:
+                created = facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
+                self.assertTrue(TaskRun.objects.filter(task_id=created.task_id).exists())
+            else:
+                with self.assertRaises(facade.WizardFrameworkUndetectableError):
+                    facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
+                self.assertEqual(Task.objects.count(), tasks_before)
+                self.assertFalse(TaskRun.objects.exists())

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -527,3 +527,27 @@ class TestFacadeReadsAndMappers(TestCase):
                     facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
                 self.assertEqual(Task.objects.count(), tasks_before)
                 self.assertFalse(TaskRun.objects.exists())
+
+    @parameterized.expand(
+        [
+            ("default_branch", None, None),
+            ("explicit_branch", "develop", {"ref": "develop"}),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_detectability_lists_requested_branch(
+        self, _name, branch, expected_params, _mock_workflow
+    ):
+        # The sandbox checks out the requested branch, so detectability must be judged on
+        # that ref's root — listing the default branch instead can hard-block a run that
+        # would have succeeded.
+        Integration.objects.create(team=self.team, kind="github", config={})
+        metadata_response = MagicMock(status_code=200)
+        contents_response = MagicMock(status_code=200, json=MagicMock(return_value=[{"name": "package.json"}]))
+        with patch.object(
+            GitHubIntegration, "api_request", side_effect=[metadata_response, contents_response]
+        ) as api_request:
+            facade.create_wizard_cloud_run(
+                team=self.team, user_id=self.user.id, repository="acme-co/web", branch=branch
+            )
+        self.assertEqual(api_request.call_args_list[1].kwargs.get("params"), expected_params)


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #70076 (repo accessibility probe) - merge that PR first. This PR's base branch is `fcgomes/grow-146-wizard-repo-access-probe`.

## Problem

A meaningful share of recent wizard cloud run failures (4 of the last 12) are the wizard CLI aborting with `Could not auto-detect your framework for this project`.
The CLI's detection is root-manifest based (package.json deps, Python manifests), so this outcome is deterministic for repositories with no supported manifest at the repo root - yet users only learn it after a ~10 minute sandbox boot, and typically retry straight into the same failure.

Closes GROW-143 (https://linear.app/posthog-team-growth/issue/GROW-143)

## Changes

- The wizard repo probe (introduced in #70076) now makes one additional root-listing call (`GET /repos/{owner}/{repo}/contents`) when the repo is accessible, and derives manifest presence from it. `probe_wizard_repository` returns a `WizardRepoProbe` dataclass with the access tri-state plus `framework_detectable: bool | None`.
- Conservative blocking rule: a run is rejected only when the root listing **succeeded** and none of `package.json`, `pyproject.toml`, `requirements.txt`, `setup.py`, `Pipfile`, `go.mod` exist at the root. This mirrors the wizard CLI's own root-manifest detection, so a blocked run is one that would have failed in the sandbox anyway - just in ~2 seconds instead of ~10 minutes. Listing failure or any uncertainty fails open.
- `create_wizard_cloud_run` raises a typed `WizardFrameworkUndetectableError`; `POST /api/wizard/cloud_run` maps it to a 400 with stable code `framework_undetectable` and a message pointing at the local wizard (`npx @posthog/wizard`) as the fallback path.
- The `posthog_wizard_cloud_run_requests_total` counter labels these rejections with their own `framework_undetectable` outcome.

**Frontend:** no change needed. I inspected `wizardCloudRunLogic.ts` - its kickoff `catch` already surfaces `ApiError.detail` via `lemonToast.error(detail || ...)`, so the actionable message (including the local-wizard fallback) reaches the user as-is.

## How did you test this code?

- `hogli test products/tasks/backend/tests/test_facade.py` - 41 passed. Added a parameterized facade test (manifest present → run created; no root manifest → raises and no Task/TaskRun row; listing error → created; listing non-200 → created). Catches a regression where blocking stops requiring a successful listing (which would start rejecting healthy repos on GitHub hiccups) or stops blocking confirmed manifest-free roots.
- `hogli test posthog/api/wizard/test/test_http.py` - 29 passed. The PR A wiring test is now parameterized over both pre-flight rejections, asserting each maps to a 400 with its stable code.
- Mocked only the GitHub boundary (`GitHubIntegration.api_request`); no real network in tests.
- I (Claude) did not manually exercise a live cloud run kickoff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` cover the wizard cloud run endpoint; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Claude Opus 4.8) in an isolated worktree, directed by @fercgomes, stacked on #70076. Session: https://claude.ai/code/session_012LEMkKpdE7Z44V584tnCLH

- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`.
- Decisions: used the contents API root listing (single call, reuses the already-resolved integration) rather than the git trees API; presence of a manifest *name* at the root counts as detectable without checking the entry type, keeping the rule strictly conservative. Directories with >1000 root entries are a known contents-API edge - the listing degrades rather than erroring, which at worst allows a run (fail-open), never blocks one incorrectly.
- Considered surfacing the error code specially in the frontend, but the existing toast already renders the API detail string, so backend-only was the minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LEMkKpdE7Z44V584tnCLH
