### PR TITLE
feat(web-analytics): revalidate in background on stale precompute reads

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -787,7 +787,7 @@ class LazyComputationExecutor:
     - ttl_schedule: TtlSchedule controlling how long lazy-computed data persists per time range
     - stale_pending_threshold_seconds: How long before a PENDING job is considered stale
     - ch_start_grace_period_seconds: Grace period before declaring "not started" as stale
-    - serve_stale_grace_seconds: When set, a request that would otherwise compute inline
+    - stale_while_revalidate_seconds: When set, a request that would otherwise compute inline
       (or block on another executor's pending jobs) is served from READY jobs that expired
       within the last N seconds — complete-but-stale data, returned immediately with
       `stale=True`. Must stay well under EXPIRY_BUFFER_SECONDS (48h) so the underlying
@@ -803,10 +803,10 @@ class LazyComputationExecutor:
         ttl_schedule: TtlSchedule = DEFAULT_TTL_SCHEDULE,
         stale_pending_threshold_seconds: float = DEFAULT_STALE_PENDING_THRESHOLD_SECONDS,
         ch_start_grace_period_seconds: float = DEFAULT_CH_START_GRACE_PERIOD_SECONDS,
-        serve_stale_grace_seconds: float | None = None,
+        stale_while_revalidate_seconds: float | None = None,
     ) -> None:
-        if serve_stale_grace_seconds is not None and serve_stale_grace_seconds >= EXPIRY_BUFFER_SECONDS:
-            raise ValueError("serve_stale_grace_seconds must be below EXPIRY_BUFFER_SECONDS")
+        if stale_while_revalidate_seconds is not None and stale_while_revalidate_seconds >= EXPIRY_BUFFER_SECONDS:
+            raise ValueError("stale_while_revalidate_seconds must be below EXPIRY_BUFFER_SECONDS")
         self.wait_timeout_seconds = wait_timeout_seconds
         self.poll_interval_seconds = poll_interval_seconds
         self.max_poll_interval_seconds = max_poll_interval_seconds
@@ -814,7 +814,7 @@ class LazyComputationExecutor:
         self.ttl_schedule = ttl_schedule
         self.stale_pending_threshold_seconds = stale_pending_threshold_seconds
         self.ch_start_grace_period_seconds = ch_start_grace_period_seconds
-        self.serve_stale_grace_seconds = serve_stale_grace_seconds
+        self.stale_while_revalidate_seconds = stale_while_revalidate_seconds
 
     def execute(
         self,
@@ -906,13 +906,13 @@ class LazyComputationExecutor:
                 # fully cover the range, return them immediately — complete-but-stale beats
                 # blocking. Whoever refreshes (the warmer, or a request after the grace)
                 # replaces the data; `filter_overlapping_jobs` always prefers newer jobs.
-                if self.serve_stale_grace_seconds is not None and (ttl_ranges or pending_jobs):
+                if self.stale_while_revalidate_seconds is not None and (ttl_ranges or pending_jobs):
                     graced = find_existing_jobs(
-                        team, query_hash, start, end, expired_grace_seconds=self.serve_stale_grace_seconds
+                        team, query_hash, start, end, expired_grace_seconds=self.stale_while_revalidate_seconds
                     )
                     graced_ready = self._filter_by_freshness(
                         [j for j in graced if j.status == PreaggregationJob.Status.READY],
-                        grace_seconds=self.serve_stale_grace_seconds,
+                        grace_seconds=self.stale_while_revalidate_seconds,
                     )
                     # Coverage must be checked on the overlap-filtered set that will actually
                     # be returned: the filter prefers newer jobs, so a newer narrow job can
@@ -1177,7 +1177,7 @@ def ensure_precomputed(
     query_type: str | None = None,
     spill_to_disk: bool = False,
     wait_timeout_seconds: float | None = None,
-    serve_stale_grace_seconds: float | None = None,
+    stale_while_revalidate_seconds: float | None = None,
 ) -> LazyComputationResult:
     """
     Ensure lazy-computed data exists for the given query and time range.
@@ -1223,11 +1223,13 @@ def ensure_precomputed(
                       persists as a READY job even when the overall call times out,
                       so repeated calls converge. Use a small value for user-facing
                       requests that have a cheap fallback path.
-        serve_stale_grace_seconds: When set, requests that would otherwise compute
-                      inline or wait are served from READY jobs expired within the
-                      last N seconds (result comes back with `stale=True`). Only for
-                      user-facing callers with a refresh mechanism (e.g. an hourly
-                      warmer); background refreshers must leave this unset or they
+        stale_while_revalidate_seconds: Mirrors the HTTP `stale-while-revalidate`
+                      cache directive (RFC 5861): when set, requests that would
+                      otherwise compute inline or wait are served from READY jobs
+                      expired within the last N seconds (result comes back with
+                      `stale=True`), and the caller is expected to revalidate in the
+                      background. Only for user-facing callers with a refresh
+                      mechanism; background refreshers must leave this unset or they
                       would serve stale to themselves and never recompute.
 
     Returns:
@@ -1321,7 +1323,7 @@ def ensure_precomputed(
     executor = LazyComputationExecutor(
         ttl_schedule=ttl_schedule,
         wait_timeout_seconds=wait_timeout_seconds if wait_timeout_seconds is not None else DEFAULT_WAIT_TIMEOUT_SECONDS,
-        serve_stale_grace_seconds=serve_stale_grace_seconds,
+        stale_while_revalidate_seconds=stale_while_revalidate_seconds,
     )
     return executor.execute(team, query_info, time_range_start, time_range_end, run_insert=_run_manual_insert)
 

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -1701,7 +1701,9 @@ class TestComputationExecutorExecute(BaseTest):
             ("beyond_grace", 9, False),
         ]
     )
-    def test_stale_ready_job_serve_stale_by_grace(self, _name: str, expired_hours_ago: int, served: bool) -> None:
+    def test_stale_ready_job_served_within_stale_while_revalidate(
+        self, _name: str, expired_hours_ago: int, served: bool
+    ) -> None:
         query_info, query_hash = self._make_query_info()
 
         stale_job = PreaggregationJob.objects.create(
@@ -1717,7 +1719,7 @@ class TestComputationExecutorExecute(BaseTest):
         )
 
         executor = LazyComputationExecutor(
-            ttl_schedule=TtlSchedule.from_seconds(60 * 60), serve_stale_grace_seconds=6 * 60 * 60
+            ttl_schedule=TtlSchedule.from_seconds(60 * 60), stale_while_revalidate_seconds=6 * 60 * 60
         )
         insert_count = [0]
 
@@ -1739,7 +1741,7 @@ class TestComputationExecutorExecute(BaseTest):
             assert stale_job.id not in result.job_ids
             assert insert_count[0] == 1
 
-    def test_serve_stale_rechecks_coverage_after_overlap_filtering(self):
+    def test_stale_while_revalidate_rechecks_coverage_after_overlap_filtering(self):
         query_info, query_hash = self._make_query_info()
 
         now = django_timezone.now()
@@ -1762,7 +1764,7 @@ class TestComputationExecutorExecute(BaseTest):
             PreaggregationJob.objects.filter(id=job.id).update(created_at=now - timedelta(hours=created_ago_h))
 
         executor = LazyComputationExecutor(
-            ttl_schedule=TtlSchedule.from_seconds(60 * 60), serve_stale_grace_seconds=6 * 60 * 60
+            ttl_schedule=TtlSchedule.from_seconds(60 * 60), stale_while_revalidate_seconds=6 * 60 * 60
         )
         insert_count = [0]
 
@@ -1778,11 +1780,11 @@ class TestComputationExecutorExecute(BaseTest):
         assert result.stale is False, "gappy filtered coverage must not be served as a stale hit"
         assert insert_count[0] > 0
 
-    def test_serve_stale_grace_must_stay_under_expiry_buffer(self):
+    def test_stale_while_revalidate_must_stay_under_expiry_buffer(self):
         # A grace at/above EXPIRY_BUFFER_SECONDS could return PG jobs whose ClickHouse
         # rows were already TTL-deleted — silent empty reads. Constructor must refuse.
         with self.assertRaises(ValueError):
-            LazyComputationExecutor(serve_stale_grace_seconds=EXPIRY_BUFFER_SECONDS)
+            LazyComputationExecutor(stale_while_revalidate_seconds=EXPIRY_BUFFER_SECONDS)
 
     def test_fresh_ready_job_is_reused(self):
         query_info, query_hash = self._make_query_info()

--- a/products/web_analytics/backend/hogql_queries/test/test_web_goals_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_goals_lazy_precompute.py
@@ -245,3 +245,27 @@ class TestWebGoalsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
 
         # The live slice is hard-coded `[:5]` in `web_goals.py`'s `to_query`.
         assert MAX_ACTIONS == 5
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_stale_served_enqueues_background_revalidation(self):
+        # Without the `result.stale` hook this family would serve stale for the whole
+        # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
+        from products.web_analytics.backend.hogql_queries.web_goals_lazy_precompute import execute_lazy_precomputed_read
+
+        self._create_action("goal")
+        with (
+            self._enable_lazy(),
+            patch(
+                "products.web_analytics.backend.hogql_queries.web_goals_lazy_precompute.ensure_web_goals_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[], stale=True),
+            ),
+            patch(
+                "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
+            ) as delay,
+        ):
+            runner = self._runner(self._build_query())
+            execute_lazy_precomputed_read(runner)
+
+        assert delay.call_count == 1
+        assert delay.call_args.kwargs["team_id"] == self.team.pk

--- a/products/web_analytics/backend/hogql_queries/test/test_web_goals_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_goals_lazy_precompute.py
@@ -250,11 +250,14 @@ class TestWebGoalsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     def test_stale_served_enqueues_background_revalidation(self):
         # Without the `result.stale` hook this family would serve stale for the whole
         # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from posthog.clickhouse.query_tagging import reset_query_tags, tags_context
+
         from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
         from products.web_analytics.backend.hogql_queries.web_goals_lazy_precompute import execute_lazy_precomputed_read
 
         self._create_action("goal")
         with (
+            tags_context(),
             self._enable_lazy(),
             patch(
                 "products.web_analytics.backend.hogql_queries.web_goals_lazy_precompute.ensure_web_goals_precomputed",
@@ -264,6 +267,7 @@ class TestWebGoalsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
             ) as delay,
         ):
+            reset_query_tags()
             runner = self._runner(self._build_query())
             execute_lazy_precomputed_read(runner)
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
@@ -28,6 +28,7 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     LazyComputationResult,
     TtlSchedule,
 )
+from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
     OOM_PIN_TTL_SECONDS,
     REVALIDATION_TRIGGER,
@@ -454,6 +455,9 @@ class TestWebEnsurePrecomputed(BaseTest):
             # CACHE_WARMUP feature gate must classify it as background, or it would
             # persist stale rows into the insight cache under a fresh timestamp.
             ("insight_warmer", {"trigger": "warmingV2", "feature": Feature.CACHE_WARMUP}),
+            # The lazy modules re-stamp feature=QUERY before ensuring, clobbering the
+            # warmer's CACHE_WARMUP tag — the trigger alone must classify as background.
+            ("insight_warmer_feature_clobbered", {"trigger": "warmingV2", "feature": Feature.QUERY}),
             ("unknown_future_warmer", {"feature": Feature.CACHE_WARMUP}),
         ]
     )
@@ -488,19 +492,35 @@ class TestStaleRevalidationEnqueue(BaseTest):
             ".revalidate_web_analytics_precompute.delay"
         )
 
-    def test_handle_stale_served_tags_read_and_enqueues_once_per_request(self):
-        # Two stale ensures in one request (current + compare period) must tag the read
-        # and mint exactly one revalidation task — one re-run covers both periods.
+    def test_handle_stale_served_tags_read_and_debounces_same_shape(self):
+        # Repeated stale serves of the same shape (current + compare period, or a user
+        # hammering forced refresh) must tag the read and mint exactly one revalidation
+        # task within the debounce window.
         runner = WebOverviewQueryRunner(team=self.team, query=self.query)
         reset_query_tags()
         with self._delay_patch() as delay:
-            handle_stale_served(runner=runner, family="web_overview")
-            handle_stale_served(runner=runner, family="web_overview")
+            for _ in range(3):
+                handle_stale_served(runner=runner, family="web_overview")
         assert get_query_tag_value("precompute_stale") is True
         assert delay.call_count == 1
         payload = delay.call_args.kwargs
         assert payload["team_id"] == self.team.pk
         assert payload["query"]["kind"] == "WebOverviewQuery"
+
+    def test_distinct_stale_shapes_each_get_a_revalidation(self):
+        # The debounce is per (team, family, shape), not per request: a second stale
+        # family in the same request context must still get its own refresh, or its
+        # data stays stale until a warmer happens to cover it.
+        overview_runner = WebOverviewQueryRunner(team=self.team, query=self.query)
+        stats_query = WebStatsTableQuery(
+            dateRange=DateRange(date_from="-7d"), properties=[], breakdownBy=WebStatsBreakdown.PAGE
+        )
+        stats_runner = WebStatsTableQueryRunner(team=self.team, query=stats_query)
+        reset_query_tags()
+        with self._delay_patch() as delay:
+            handle_stale_served(runner=overview_runner, family="web_overview")
+            handle_stale_served(runner=stats_runner, family="web_stats")
+        assert delay.call_count == 2
 
     def test_broker_failure_does_not_break_the_stale_read_path(self):
         # handle_stale_served runs inside the families' read try/except before the stale

--- a/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
@@ -21,7 +21,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 
 from posthog import redis
-from posthog.clickhouse.query_tagging import get_query_tag_value, reset_query_tags, tags_context
+from posthog.clickhouse.query_tagging import Feature, get_query_tag_value, reset_query_tags, tags_context
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
@@ -445,27 +445,32 @@ class TestWebEnsurePrecomputed(BaseTest):
     @parameterized.expand(
         [
             ("user_request", None),
-            ("eager_warmer", "webAnalyticsEagerBaselineWarming"),
-            ("replay_warmer", "webAnalyticsQueryWarming"),
+            ("eager_warmer", {"trigger": "webAnalyticsEagerBaselineWarming"}),
+            ("replay_warmer", {"trigger": "webAnalyticsQueryWarming"}),
             # The revalidation task itself must never get the grace — a re-run that can
             # be served stale would never refresh anything and freeze the cache.
-            ("stale_revalidation", REVALIDATION_TRIGGER),
+            ("stale_revalidation", {"trigger": REVALIDATION_TRIGGER}),
+            # The generic insight cache warmer isn't in the named trigger set — the
+            # CACHE_WARMUP feature gate must classify it as background, or it would
+            # persist stale rows into the insight cache under a fresh timestamp.
+            ("insight_warmer", {"trigger": "warmingV2", "feature": Feature.CACHE_WARMUP}),
+            ("unknown_future_warmer", {"feature": Feature.CACHE_WARMUP}),
         ]
     )
     @mock.patch(f"{_COMMON}.ensure_precomputed")
-    def test_stale_while_revalidate_grace_by_trigger(self, _name, trigger, mock_ensure):
+    def test_stale_while_revalidate_grace_by_trigger(self, _name, tags, mock_ensure):
         mock_ensure.return_value = LazyComputationResult(ready=True, job_ids=[])
         reset_query_tags()
-        if trigger is not None:
-            with tags_context(trigger=trigger):
+        if tags is not None:
+            with tags_context(**tags):
                 web_ensure_precomputed(team=self.team, ttl_seconds={"default": 3600}, table=None)
         else:
             web_ensure_precomputed(team=self.team, ttl_seconds={"default": 3600}, table=None)
         grace = mock_ensure.call_args.kwargs["stale_while_revalidate_seconds"]
-        if trigger is None:
+        if tags is None:
             assert grace == STALE_WHILE_REVALIDATE_SECONDS
         else:
-            assert grace is None, f"background trigger {trigger} must not be served stale"
+            assert grace is None, f"background context {tags} must not be served stale"
 
 
 class TestStaleRevalidationEnqueue(BaseTest):
@@ -496,3 +501,14 @@ class TestStaleRevalidationEnqueue(BaseTest):
         payload = delay.call_args.kwargs
         assert payload["team_id"] == self.team.pk
         assert payload["query"]["kind"] == "WebOverviewQuery"
+
+    def test_broker_failure_does_not_break_the_stale_read_path(self):
+        # handle_stale_served runs inside the families' read try/except before the stale
+        # rows are read — a broker outage raising out of it would discard the stale
+        # result and fall back to the expensive live query, inverting SWR's purpose.
+        runner = WebOverviewQueryRunner(team=self.team, query=self.query)
+        reset_query_tags()
+        with self._delay_patch() as delay:
+            delay.side_effect = Exception("broker down")
+            handle_stale_served(runner=runner, family="web_overview")
+        assert get_query_tag_value("precompute_stale") is True

--- a/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from django.test import override_settings
 
+from parameterized import parameterized
 from structlog.contextvars import get_contextvars
 
 from posthog.schema import (
@@ -20,7 +21,7 @@ from posthog.schema import (
 from posthog.hogql import ast
 
 from posthog import redis
-from posthog.clickhouse.query_tagging import get_query_tag_value
+from posthog.clickhouse.query_tagging import get_query_tag_value, reset_query_tags, tags_context
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
@@ -29,14 +30,19 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
 )
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
     OOM_PIN_TTL_SECONDS,
+    REVALIDATION_TRIGGER,
     SESSION_SETTLING_SECONDS,
+    STALE_WHILE_REVALIDATE_SECONDS,
     PerQueryOptedOut,
     PerQueryOptInNotSet,
     TooManyFilters,
     UnsupportedFilterKey,
     _oom_pin_key,
+    _swr_revalidate_key,
     check_common_eligibility,
     compute_filters_eligibility_hash,
+    enqueue_stale_revalidation,
+    handle_stale_served,
     host_filter_expr,
     is_precompute_enabled_for_team,
     is_precompute_unrestricted_for_team,
@@ -437,3 +443,68 @@ class TestWebEnsurePrecomputed(BaseTest):
         assert isinstance(passed, TtlSchedule)
         assert passed.max_window_days == 1
         assert passed.default_ttl_seconds == 3600
+
+    @parameterized.expand(
+        [
+            ("user_request", None),
+            ("eager_warmer", "webAnalyticsEagerBaselineWarming"),
+            ("replay_warmer", "webAnalyticsQueryWarming"),
+            # The revalidation task itself must never get the grace — a re-run that can
+            # be served stale would never refresh anything and freeze the cache.
+            ("stale_revalidation", REVALIDATION_TRIGGER),
+        ]
+    )
+    @mock.patch(f"{_COMMON}.ensure_precomputed")
+    def test_stale_while_revalidate_grace_by_trigger(self, _name, trigger, mock_ensure):
+        mock_ensure.return_value = LazyComputationResult(ready=True, job_ids=[])
+        reset_query_tags()
+        if trigger is not None:
+            with tags_context(trigger=trigger):
+                web_ensure_precomputed(team=self.team, ttl_seconds={"default": 3600}, table=None)
+        else:
+            web_ensure_precomputed(team=self.team, ttl_seconds={"default": 3600}, table=None)
+        grace = mock_ensure.call_args.kwargs["stale_while_revalidate_seconds"]
+        if trigger is None:
+            assert grace == STALE_WHILE_REVALIDATE_SECONDS
+        else:
+            assert grace is None, f"background trigger {trigger} must not be served stale"
+
+
+class TestStaleRevalidationEnqueue(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.query = WebOverviewQuery(dateRange=DateRange(date_from="-7d"), properties=[])
+
+    def tearDown(self):
+        redis.get_client().delete(_swr_revalidate_key(self.team, self.query))
+        reset_query_tags()
+        super().tearDown()
+
+    def _delay_patch(self):
+        return mock.patch(
+            "products.web_analytics.backend.tasks.lazy_precompute_revalidation"
+            ".revalidate_web_analytics_precompute.delay"
+        )
+
+    def test_enqueues_once_within_debounce_window(self):
+        with self._delay_patch() as delay:
+            enqueue_stale_revalidation(team=self.team, query=self.query, family="web_overview")
+            enqueue_stale_revalidation(team=self.team, query=self.query, family="web_overview")
+        assert delay.call_count == 1
+        payload = delay.call_args.kwargs
+        assert payload["team_id"] == self.team.pk
+        assert payload["query"]["kind"] == "WebOverviewQuery"
+
+    @mock.patch(f"{_COMMON}.redis.get_client", side_effect=Exception("redis down"))
+    def test_redis_error_fails_closed_without_raising(self, _client):
+        with self._delay_patch() as delay:
+            enqueue_stale_revalidation(team=self.team, query=self.query, family="web_overview")
+        assert delay.call_count == 0
+
+    def test_handle_stale_served_tags_read_and_enqueues(self):
+        runner = WebOverviewQueryRunner(team=self.team, query=self.query)
+        reset_query_tags()
+        with self._delay_patch() as delay:
+            handle_stale_served(runner=runner, family="web_overview")
+        assert get_query_tag_value("precompute_stale") is True
+        assert delay.call_count == 1

--- a/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
@@ -38,10 +38,8 @@ from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common imp
     TooManyFilters,
     UnsupportedFilterKey,
     _oom_pin_key,
-    _swr_revalidate_key,
     check_common_eligibility,
     compute_filters_eligibility_hash,
-    enqueue_stale_revalidation,
     handle_stale_served,
     host_filter_expr,
     is_precompute_enabled_for_team,
@@ -476,7 +474,6 @@ class TestStaleRevalidationEnqueue(BaseTest):
         self.query = WebOverviewQuery(dateRange=DateRange(date_from="-7d"), properties=[])
 
     def tearDown(self):
-        redis.get_client().delete(_swr_revalidate_key(self.team, self.query))
         reset_query_tags()
         super().tearDown()
 
@@ -486,25 +483,16 @@ class TestStaleRevalidationEnqueue(BaseTest):
             ".revalidate_web_analytics_precompute.delay"
         )
 
-    def test_enqueues_once_within_debounce_window(self):
-        with self._delay_patch() as delay:
-            enqueue_stale_revalidation(team=self.team, query=self.query, family="web_overview")
-            enqueue_stale_revalidation(team=self.team, query=self.query, family="web_overview")
-        assert delay.call_count == 1
-        payload = delay.call_args.kwargs
-        assert payload["team_id"] == self.team.pk
-        assert payload["query"]["kind"] == "WebOverviewQuery"
-
-    @mock.patch(f"{_COMMON}.redis.get_client", side_effect=Exception("redis down"))
-    def test_redis_error_fails_closed_without_raising(self, _client):
-        with self._delay_patch() as delay:
-            enqueue_stale_revalidation(team=self.team, query=self.query, family="web_overview")
-        assert delay.call_count == 0
-
-    def test_handle_stale_served_tags_read_and_enqueues(self):
+    def test_handle_stale_served_tags_read_and_enqueues_once_per_request(self):
+        # Two stale ensures in one request (current + compare period) must tag the read
+        # and mint exactly one revalidation task — one re-run covers both periods.
         runner = WebOverviewQueryRunner(team=self.team, query=self.query)
         reset_query_tags()
         with self._delay_patch() as delay:
             handle_stale_served(runner=runner, family="web_overview")
+            handle_stale_served(runner=runner, family="web_overview")
         assert get_query_tag_value("precompute_stale") is True
         assert delay.call_count == 1
+        payload = delay.call_args.kwargs
+        assert payload["team_id"] == self.team.pk
+        assert payload["query"]["kind"] == "WebOverviewQuery"

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -665,3 +665,28 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_UNRESTRICTED_TEAM_IDS=[self.team.pk]):
             self._run(self._build_query(opt_in_precompute=False))
         assert PreaggregationJob.objects.filter(team_id=self.team.pk).count() == 0
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_stale_served_enqueues_background_revalidation(self):
+        # Without the `result.stale` hook this family would serve stale for the whole
+        # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
+        from products.web_analytics.backend.hogql_queries.web_overview_lazy_precompute import (
+            execute_lazy_precomputed_read,
+        )
+
+        with (
+            self._enable_lazy(),
+            patch(
+                "products.web_analytics.backend.hogql_queries.web_overview_lazy_precompute.ensure_web_overview_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[], stale=True),
+            ),
+            patch(
+                "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
+            ) as delay,
+        ):
+            runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
+            execute_lazy_precomputed_read(runner)
+
+        assert delay.call_count == 1
+        assert delay.call_args.kwargs["team_id"] == self.team.pk

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -670,12 +670,15 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     def test_stale_served_enqueues_background_revalidation(self):
         # Without the `result.stale` hook this family would serve stale for the whole
         # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from posthog.clickhouse.query_tagging import reset_query_tags, tags_context
+
         from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
         from products.web_analytics.backend.hogql_queries.web_overview_lazy_precompute import (
             execute_lazy_precomputed_read,
         )
 
         with (
+            tags_context(),
             self._enable_lazy(),
             patch(
                 "products.web_analytics.backend.hogql_queries.web_overview_lazy_precompute.ensure_web_overview_precomputed",
@@ -685,6 +688,7 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
             ) as delay,
         ):
+            reset_query_tags()
             runner = WebOverviewQueryRunner(team=self.team, query=self._build_query())
             execute_lazy_precomputed_read(runner)
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
@@ -306,3 +306,28 @@ class TestWebStatsFrustrationLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 "errors": row[3][0],
             }
         return out
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_stale_served_enqueues_background_revalidation(self):
+        # Without the `result.stale` hook this family would serve stale for the whole
+        # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
+        from products.web_analytics.backend.hogql_queries.web_stats_frustration_lazy_precompute import (
+            execute_lazy_precomputed_read,
+        )
+
+        with (
+            self._enable_lazy(),
+            patch(
+                "products.web_analytics.backend.hogql_queries.web_stats_frustration_lazy_precompute.ensure_web_stats_frustration_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[], stale=True),
+            ),
+            patch(
+                "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
+            ) as delay,
+        ):
+            runner = self._runner(self._build_query())
+            execute_lazy_precomputed_read(runner, limit=10, offset=0)
+
+        assert delay.call_count == 1
+        assert delay.call_args.kwargs["team_id"] == self.team.pk

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_frustration_lazy_precompute.py
@@ -311,12 +311,15 @@ class TestWebStatsFrustrationLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     def test_stale_served_enqueues_background_revalidation(self):
         # Without the `result.stale` hook this family would serve stale for the whole
         # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from posthog.clickhouse.query_tagging import reset_query_tags, tags_context
+
         from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
         from products.web_analytics.backend.hogql_queries.web_stats_frustration_lazy_precompute import (
             execute_lazy_precomputed_read,
         )
 
         with (
+            tags_context(),
             self._enable_lazy(),
             patch(
                 "products.web_analytics.backend.hogql_queries.web_stats_frustration_lazy_precompute.ensure_web_stats_frustration_precomputed",
@@ -326,6 +329,7 @@ class TestWebStatsFrustrationLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
             ) as delay,
         ):
+            reset_query_tags()
             runner = self._runner(self._build_query())
             execute_lazy_precomputed_read(runner, limit=10, offset=0)
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
@@ -710,3 +710,26 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         # Visitors are monotonically non-increasing on the returned page.
         visitors = [row[1][0] for row in lazy_metrics]
         assert visitors == sorted(visitors, reverse=True), f"first page not ordered by visitors desc: {visitors}"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_stale_served_enqueues_background_revalidation(self):
+        # Without the `result.stale` hook this family would serve stale for the whole
+        # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
+        from products.web_analytics.backend.hogql_queries.web_stats_lazy_precompute import execute_lazy_precomputed_read
+
+        with (
+            self._enable_lazy(),
+            patch(
+                "products.web_analytics.backend.hogql_queries.web_stats_lazy_precompute.ensure_web_stats_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[], stale=True),
+            ),
+            patch(
+                "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
+            ) as delay,
+        ):
+            runner = WebStatsTableQueryRunner(team=self.team, query=self._build_query())
+            execute_lazy_precomputed_read(runner)
+
+        assert delay.call_count == 1
+        assert delay.call_args.kwargs["team_id"] == self.team.pk

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
@@ -715,10 +715,13 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     def test_stale_served_enqueues_background_revalidation(self):
         # Without the `result.stale` hook this family would serve stale for the whole
         # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from posthog.clickhouse.query_tagging import reset_query_tags, tags_context
+
         from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
         from products.web_analytics.backend.hogql_queries.web_stats_lazy_precompute import execute_lazy_precomputed_read
 
         with (
+            tags_context(),
             self._enable_lazy(),
             patch(
                 "products.web_analytics.backend.hogql_queries.web_stats_lazy_precompute.ensure_web_stats_precomputed",
@@ -728,6 +731,7 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
             ) as delay,
         ):
+            reset_query_tags()
             runner = WebStatsTableQueryRunner(team=self.team, query=self._build_query())
             execute_lazy_precomputed_read(runner)
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
@@ -771,6 +771,9 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             ("user_request", None),
             ("eager_warmer", "webAnalyticsEagerBaselineWarming"),
             ("replay_warmer", "webAnalyticsQueryWarming"),
+            # The SWR revalidation task's re-run must count as background too, or it
+            # would be served stale itself and never refresh anything.
+            ("stale_revalidation", "webAnalyticsStaleRevalidation"),
         ]
     )
     @freeze_time("2024-01-15T12:00:00Z")
@@ -796,16 +799,13 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                     runner, datetime(2024, 1, 1, tzinfo=UTC), datetime(2024, 1, 8, tzinfo=UTC)
                 )
 
+        # The stale-while-revalidate grace is applied centrally by web_ensure_precomputed
+        # (see test_web_lazy_precompute_common), so only the wait budget is paths policy.
         budget = ensure_mock.call_args.kwargs["wait_timeout_seconds"]
-        grace = ensure_mock.call_args.kwargs["stale_while_revalidate_seconds"]
         if trigger is None:
             assert budget == mod.PATHS_USER_ENSURE_WAIT_SECONDS
-            assert grace == mod.PATHS_USER_STALE_GRACE_SECONDS
         else:
-            # Warmers keep the full budget AND must never serve stale to themselves —
-            # they are the refresh mechanism the stale path relies on.
-            assert budget is None, f"warmer trigger {trigger} must keep the framework default budget"
-            assert grace is None, f"warmer trigger {trigger} must not serve stale"
+            assert budget is None, f"background trigger {trigger} must keep the framework default budget"
 
     @parameterized.expand(
         [

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_paths_lazy_precompute.py
@@ -797,7 +797,7 @@ class TestWebStatsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 )
 
         budget = ensure_mock.call_args.kwargs["wait_timeout_seconds"]
-        grace = ensure_mock.call_args.kwargs["serve_stale_grace_seconds"]
+        grace = ensure_mock.call_args.kwargs["stale_while_revalidate_seconds"]
         if trigger is None:
             assert budget == mod.PATHS_USER_ENSURE_WAIT_SECONDS
             assert grace == mod.PATHS_USER_STALE_GRACE_SECONDS

--- a/products/web_analytics/backend/hogql_queries/test/test_web_vitals_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_vitals_paths_lazy_precompute.py
@@ -303,12 +303,15 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
     def test_stale_served_enqueues_background_revalidation(self):
         # Without the `result.stale` hook this family would serve stale for the whole
         # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from posthog.clickhouse.query_tagging import reset_query_tags, tags_context
+
         from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
         from products.web_analytics.backend.hogql_queries.web_vitals_paths_lazy_precompute import (
             execute_lazy_precomputed_read,
         )
 
         with (
+            tags_context(),
             self._enable_lazy(),
             patch(
                 "products.web_analytics.backend.hogql_queries.web_vitals_paths_lazy_precompute.ensure_web_vitals_paths_precomputed",
@@ -318,6 +321,7 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
                 "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
             ) as delay,
         ):
+            reset_query_tags()
             runner = WebVitalsPathBreakdownQueryRunner(team=self.team, query=self._build_query())
             execute_lazy_precomputed_read(runner)
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_vitals_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_vitals_paths_lazy_precompute.py
@@ -298,3 +298,28 @@ class TestWebVitalsPathsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
 
         poor_items = response.results[0].poor
         assert len(poor_items) == 20, f"expected exactly 20 paths in poor band, got {len(poor_items)}"
+
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_stale_served_enqueues_background_revalidation(self):
+        # Without the `result.stale` hook this family would serve stale for the whole
+        # 6h grace and never refresh (the revalidate half of stale-while-revalidate).
+        from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
+        from products.web_analytics.backend.hogql_queries.web_vitals_paths_lazy_precompute import (
+            execute_lazy_precomputed_read,
+        )
+
+        with (
+            self._enable_lazy(),
+            patch(
+                "products.web_analytics.backend.hogql_queries.web_vitals_paths_lazy_precompute.ensure_web_vitals_paths_precomputed",
+                return_value=LazyComputationResult(ready=True, job_ids=[], stale=True),
+            ),
+            patch(
+                "products.web_analytics.backend.tasks.lazy_precompute_revalidation.revalidate_web_analytics_precompute.delay"
+            ) as delay,
+        ):
+            runner = WebVitalsPathBreakdownQueryRunner(team=self.team, query=self._build_query())
+            execute_lazy_precomputed_read(runner)
+
+        assert delay.call_count == 1
+        assert delay.call_args.kwargs["team_id"] == self.team.pk

--- a/products/web_analytics/backend/hogql_queries/web_goals_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_goals_lazy_precompute.py
@@ -485,8 +485,8 @@ def execute_lazy_precomputed_read(runner: "WebGoalsQueryRunner") -> Optional[dic
                     )
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
                     if prev_result.stale:
-                        # Debounced with the current-period enqueue; one revalidation
-                        # re-runs the whole query, covering both periods.
+                        # handle_stale_served enqueues at most once per request; one
+                        # revalidation re-runs the whole query, covering both periods.
                         handle_stale_served(runner=runner, family=_FAMILY)
                     if not prev_result.ready:
                         logger.info(

--- a/products/web_analytics/backend/hogql_queries/web_goals_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_goals_lazy_precompute.py
@@ -45,6 +45,7 @@ from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common imp
     ceil_utc_day,
     check_common_eligibility,
     floor_utc_day,
+    handle_stale_served,
     host_filter_expr,
     log_eligibility_outcome,
     test_account_filter_expr,
@@ -55,6 +56,8 @@ if TYPE_CHECKING:
     from products.web_analytics.backend.hogql_queries.web_goals import WebGoalsQueryRunner
 
 logger = structlog.get_logger(__name__)
+
+_FAMILY = "web_goals"
 
 
 # Sentinel action_id used for the per-hour denominator row. Real Django
@@ -446,6 +449,8 @@ def execute_lazy_precomputed_read(runner: "WebGoalsQueryRunner") -> Optional[dic
             job_count=len(result.job_ids),
             ensure_duration_ms=ensure_duration_ms,
         )
+        if result.stale:
+            handle_stale_served(runner=runner, family=_FAMILY)
 
         if not result.job_ids or not result.ready:
             return None
@@ -479,6 +484,10 @@ def execute_lazy_precomputed_read(runner: "WebGoalsQueryRunner") -> Optional[dic
                         time_range_end=prev_range_end,
                     )
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
+                    if prev_result.stale:
+                        # Debounced with the current-period enqueue; one revalidation
+                        # re-runs the whole query, covering both periods.
+                        handle_stale_served(runner=runner, family=_FAMILY)
                     if not prev_result.ready:
                         logger.info(
                             "web_goals_lazy_precompute_previous_not_ready",

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -28,7 +28,7 @@ from posthog.hogql.property import property_to_expr
 from posthog.hogql.transforms.preaggregated_table_transformation import is_integer_timezone
 
 from posthog import redis
-from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
+from posthog.clickhouse.query_tagging import Feature, get_query_tag_value, tag_queries
 from posthog.models import Team
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
@@ -93,7 +93,11 @@ REVALIDATION_TRIGGER = "webAnalyticsStaleRevalidation"
 
 # Requests tagged with any of these triggers ARE the refresh mechanism: they must never
 # be served stale (they'd freeze the cache serving stale to themselves) and they keep
-# the framework's full wait budget.
+# the framework's full wait budget. This named set is the belt; the primary gate in
+# `is_background_warming_request` is the CACHE_WARMUP feature tag, which classifies
+# refreshers by category — including warmers this module doesn't know by name (e.g.
+# the generic insight cache warmer, trigger "warmingV2"), which would otherwise be
+# served stale and persist it into the insight cache under a fresh timestamp.
 BACKGROUND_WARMING_TRIGGERS = frozenset(
     {
         "webAnalyticsEagerBaselineWarming",
@@ -123,20 +127,40 @@ WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUED = Counter(
     labelnames=["family"],
 )
 
+WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUE_FAILED = Counter(
+    "web_analytics_lazy_precompute_revalidation_enqueue_failed_total",
+    "Revalidation enqueues that failed (e.g. broker unavailable); the stale read is still served.",
+    labelnames=["family"],
+)
+
 
 def is_background_warming_request() -> bool:
+    if get_query_tag_value("feature") == Feature.CACHE_WARMUP:
+        return True
     return get_query_tag_value("trigger") in BACKGROUND_WARMING_TRIGGERS
 
 
 def enqueue_stale_revalidation(*, team: Team, query: Any, family: str) -> None:
-    """Enqueue a background re-run of `query` so a stale-served read gets fresh data next time."""
+    """Enqueue a background re-run of `query` so a stale-served read gets fresh data next time.
+
+    Best-effort: this runs on the user-facing read path before the stale rows are read,
+    so a broker outage must degrade to "serve stale, warmer converges" — never abort the
+    read into the expensive live fallback.
+    """
     # The task module imports this module (for the trigger constant), so the reverse
     # import must stay local to avoid a cycle.
     from products.web_analytics.backend.tasks.lazy_precompute_revalidation import (  # noqa: PLC0415
         revalidate_web_analytics_precompute,
     )
 
-    revalidate_web_analytics_precompute.delay(team_id=team.id, query=query.model_dump(mode="json", exclude_none=True))
+    try:
+        revalidate_web_analytics_precompute.delay(
+            team_id=team.id, query=query.model_dump(mode="json", exclude_none=True)
+        )
+    except Exception:
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUE_FAILED.labels(family=family).inc()
+        logger.warning("web_precompute.swr_revalidation_enqueue_failed", team_id=team.id, family=family, exc_info=True)
+        return
     WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUED.labels(family=family).inc()
     logger.info("web_precompute.swr_revalidation_enqueued", team_id=team.id, family=family)
 

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -19,6 +19,7 @@ from django.conf import settings
 
 import structlog
 import posthoganalytics
+from prometheus_client import Counter
 
 from posthog.schema import EventPropertyFilter, PropertyOperator, SessionsV2JoinMode
 
@@ -27,6 +28,7 @@ from posthog.hogql.property import property_to_expr
 from posthog.hogql.transforms.preaggregated_table_transformation import is_integer_timezone
 
 from posthog import redis
+from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.models import Team
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
@@ -72,14 +74,134 @@ def pin_team_oom(team_id: int) -> None:
         logger.warning("web_precompute.oom_pin_failed", team_id=team_id, exc_info=True)
 
 
+# --- Stale-while-revalidate (RFC 5861) -------------------------------------------------
+#
+# The lazy executor's `stale_while_revalidate_seconds` is the *serve* half: user-facing
+# requests whose windows expired within the grace get their complete-but-stale rows
+# instantly instead of recomputing inline. The helpers below are the *revalidate* half:
+# a stale hit enqueues a debounced Celery task that re-runs the query in the background
+# so the next fetch is fresh, instead of relying solely on the hourly eager warmer
+# (which only covers warmed query shapes).
+
+# The trigger tag the revalidation task runs under. Lives here, next to the trigger set,
+# so the two cannot drift apart.
+REVALIDATION_TRIGGER = "webAnalyticsStaleRevalidation"
+
+# Requests tagged with any of these triggers ARE the refresh mechanism: they must never
+# be served stale (they'd freeze the cache serving stale to themselves) and they keep
+# the framework's full wait budget.
+BACKGROUND_WARMING_TRIGGERS = frozenset(
+    {
+        "webAnalyticsEagerBaselineWarming",
+        "webAnalyticsQueryWarming",
+        REVALIDATION_TRIGGER,
+    }
+)
+
+# Stale-while-revalidate window for *user-facing* requests: windows that expired within
+# this grace are served from their existing (complete-but-stale) rows instantly instead
+# of recomputing inline, and a background revalidation is enqueued. Refresh normally
+# arrives within the debounce window via the revalidation task (plus the hourly eager
+# warmer for warmed shapes) — the grace is the ceiling for revalidation failures and
+# warmer outages. Must stay well under the framework's 48h ClickHouse expiry buffer
+# (rows must still exist).
+STALE_WHILE_REVALIDATE_SECONDS = 6 * 60 * 60
+
+# Debounce on enqueueing the revalidation task, keyed per (team, query shape). Must
+# exceed the worst-case task duration (two ensure phases x 180s framework budget + the
+# read, ~7min) so a running revalidation can't be double-enqueued; short enough that a
+# failed revalidation is retried by the next stale hit well within the 6h grace.
+REVALIDATION_DEBOUNCE_SECONDS = 15 * 60
+
+SWR_REVALIDATE_REDIS_PREFIX = "web_analytics:swr_revalidate:"
+
+WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED = Counter(
+    "web_analytics_lazy_precompute_stale_served_total",
+    "Reads served from expired-within-grace jobs instead of recomputing inline (stale-while-revalidate).",
+    labelnames=["family"],
+)
+
+WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUED = Counter(
+    "web_analytics_lazy_precompute_revalidation_enqueued_total",
+    "Background revalidation tasks enqueued after a stale-served read.",
+    labelnames=["family"],
+)
+
+WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_DEBOUNCED = Counter(
+    "web_analytics_lazy_precompute_revalidation_debounced_total",
+    "Stale-served reads that skipped enqueueing because a revalidation was already pending.",
+    labelnames=["family"],
+)
+
+
+def is_background_warming_request() -> bool:
+    return get_query_tag_value("trigger") in BACKGROUND_WARMING_TRIGGERS
+
+
+def _swr_revalidate_key(team: Team, query: Any) -> str:
+    # The eligibility hash fragments along the same dimensions as the precompute cache
+    # key (filters, date range, breakdown, ...) while ignoring volatile fields
+    # (modifiers, pagination), so one key debounces exactly one job shape.
+    return f"{SWR_REVALIDATE_REDIS_PREFIX}{team.id}:{compute_filters_eligibility_hash(query, team.timezone)}"
+
+
+def enqueue_stale_revalidation(*, team: Team, query: Any, family: str) -> None:
+    """Enqueue a background re-run of `query` so a stale-served read gets fresh data next time.
+
+    Debounced per (team, query shape); fails closed — a Redis error enqueues nothing
+    (the hourly warmer still refreshes warmed shapes, and the next stale hit retries).
+    """
+    try:
+        acquired = redis.get_client().set(
+            _swr_revalidate_key(team, query), "1", nx=True, ex=REVALIDATION_DEBOUNCE_SECONDS
+        )
+    except Exception:
+        logger.warning("web_precompute.swr_debounce_failed", team_id=team.id, family=family, exc_info=True)
+        return
+    if not acquired:
+        WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_DEBOUNCED.labels(family=family).inc()
+        return
+
+    # The task module imports this module (for the trigger + debounce constants), so the
+    # reverse import must stay local to avoid a cycle.
+    from products.web_analytics.backend.tasks.lazy_precompute_revalidation import (  # noqa: PLC0415
+        revalidate_web_analytics_precompute,
+    )
+
+    revalidate_web_analytics_precompute.delay(team_id=team.id, query=query.model_dump(mode="json", exclude_none=True))
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUED.labels(family=family).inc()
+    logger.info("web_precompute.swr_revalidation_enqueued", team_id=team.id, family=family)
+
+
+def handle_stale_served(*, runner: Any, family: str) -> None:
+    """Everything a read path does when an ensure came back `stale=True`.
+
+    Counts the stale-served read, tags the upcoming read query so query_log can split
+    stale-served vs fresh reads, and enqueues the debounced background revalidation.
+    """
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED.labels(family=family).inc()
+    tag_queries(precompute_stale=True)
+    enqueue_stale_revalidation(team=runner.team, query=runner.query, family=family)
+
+
 def web_ensure_precomputed(*, team: Team, **kwargs: Any) -> LazyComputationResult:
-    """`ensure_precomputed` for web analytics, with reactive per-team OOM capping.
+    """`ensure_precomputed` for web analytics, with reactive per-team OOM capping and
+    the web-wide stale-while-revalidate policy.
 
     A team runs uncapped until one of its precompute inserts OOMs; that pins it so later
     requests build their TTL schedule with a 1-day `max_window_days` cap (job width bounded
     at any window age). The request that hits the OOM still fails here and falls back to the
     live query — the cap only takes effect next time.
+
+    Every user-facing call gets the stale-while-revalidate grace by default; requests
+    tagged with a background warming trigger never do (they are the refresh mechanism
+    and would serve stale to themselves). Callers that see `stale=True` must hand the
+    result to `handle_stale_served` so the background revalidation actually happens.
     """
+    if "stale_while_revalidate_seconds" not in kwargs:
+        kwargs["stale_while_revalidate_seconds"] = (
+            None if is_background_warming_request() else STALE_WHILE_REVALIDATE_SECONDS
+        )
     pinned = is_team_oom_pinned(team.id)
     if "ttl_seconds" in kwargs:
         existing = kwargs["ttl_seconds"]

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -102,6 +102,12 @@ BACKGROUND_WARMING_TRIGGERS = frozenset(
     {
         "webAnalyticsEagerBaselineWarming",
         "webAnalyticsQueryWarming",
+        # The generic insight cache warmer. Its Feature.CACHE_WARMUP tag does NOT
+        # survive to the ensure call (the lazy modules re-stamp feature=QUERY before
+        # ensuring), but the trigger does — without it here, warmer runs would be
+        # served stale and persist stale rows into the insight cache as a fresh
+        # blocking result.
+        "warmingV2",
         REVALIDATION_TRIGGER,
     }
 )
@@ -140,12 +146,20 @@ def is_background_warming_request() -> bool:
     return get_query_tag_value("trigger") in BACKGROUND_WARMING_TRIGGERS
 
 
+# One revalidation per (team, family, query shape) per window: a dashboard burst — or a
+# user hammering forced refresh on a stale tile — fires many stale serves for the same
+# shape and they must collapse to a single background rebuild. Keyed per shape (not per
+# request) so two different stale families in one request each still get their refresh.
+REVALIDATION_DEBOUNCE_SECONDS = 10 * 60
+
+
 def enqueue_stale_revalidation(*, team: Team, query: Any, family: str) -> None:
     """Enqueue a background re-run of `query` so a stale-served read gets fresh data next time.
 
-    Best-effort: this runs on the user-facing read path before the stale rows are read,
-    so a broker outage must degrade to "serve stale, warmer converges" — never abort the
-    read into the expensive live fallback.
+    Debounced via Redis per (team, family, query shape). Best-effort: this runs on the
+    user-facing read path before the stale rows are read, so a Redis or broker outage
+    must degrade to "serve stale, warmer converges" — never abort the read into the
+    expensive live fallback.
     """
     # The task module imports this module (for the trigger constant), so the reverse
     # import must stay local to avoid a cycle.
@@ -154,6 +168,9 @@ def enqueue_stale_revalidation(*, team: Team, query: Any, family: str) -> None:
     )
 
     try:
+        debounce_key = f"web_swr_reval:{team.id}:{family}:{compute_filters_eligibility_hash(query, team.timezone)[:16]}"
+        if not redis.get_client().set(debounce_key, "1", ex=REVALIDATION_DEBOUNCE_SECONDS, nx=True):
+            return
         revalidate_web_analytics_precompute.delay(
             team_id=team.id, query=query.model_dump(mode="json", exclude_none=True)
         )
@@ -169,16 +186,14 @@ def handle_stale_served(*, runner: Any, family: str) -> None:
     """Everything a read path does when an ensure came back `stale=True`.
 
     Counts the stale-served read, tags the upcoming read query so query_log can split
-    stale-served vs fresh reads, and enqueues the background revalidation. Enqueues at
-    most once per request: the `precompute_stale` tag it sets doubles as the marker, so
-    a compare-period ensure coming back stale after the current-period one doesn't mint
-    a second task for the same query (one re-run covers both periods).
+    stale-served vs fresh reads, and enqueues the background revalidation. The enqueue
+    is debounced per (team, family, query shape) in Redis — a compare-period ensure
+    coming back stale after the current-period one collapses to one task (one re-run
+    covers both periods), while a *different* stale family in the same request still
+    gets its own refresh.
     """
     WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED.labels(family=family).inc()
-    already_handled = get_query_tag_value("precompute_stale") is True
     tag_queries(precompute_stale=True)
-    if already_handled:
-        return
     enqueue_stale_revalidation(team=runner.team, query=runner.query, family=family)
 
 

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -79,9 +79,13 @@ def pin_team_oom(team_id: int) -> None:
 # The lazy executor's `stale_while_revalidate_seconds` is the *serve* half: user-facing
 # requests whose windows expired within the grace get their complete-but-stale rows
 # instantly instead of recomputing inline. The helpers below are the *revalidate* half:
-# a stale hit enqueues a debounced Celery task that re-runs the query in the background
-# so the next fetch is fresh, instead of relying solely on the hourly eager warmer
-# (which only covers warmed query shapes).
+# a stale hit enqueues a Celery task that re-runs the query in the background so the
+# next fetch is fresh, instead of relying solely on the hourly eager warmer (which only
+# covers warmed query shapes). Duplicate enqueues need no dedup layer: the HogQL result
+# cache fronts these queries (stale hits are rare per shape), the framework's PENDING-job
+# unique index collapses concurrent recomputes to one insert, and the ANALYTICS_LIMITED
+# queue plus task `expires` pace and shed anything redundant — the same load profile the
+# pre-serve-stale inline path already tolerated at user-request concurrency.
 
 # The trigger tag the revalidation task runs under. Lives here, next to the trigger set,
 # so the two cannot drift apart.
@@ -101,19 +105,11 @@ BACKGROUND_WARMING_TRIGGERS = frozenset(
 # Stale-while-revalidate window for *user-facing* requests: windows that expired within
 # this grace are served from their existing (complete-but-stale) rows instantly instead
 # of recomputing inline, and a background revalidation is enqueued. Refresh normally
-# arrives within the debounce window via the revalidation task (plus the hourly eager
-# warmer for warmed shapes) — the grace is the ceiling for revalidation failures and
-# warmer outages. Must stay well under the framework's 48h ClickHouse expiry buffer
-# (rows must still exist).
+# arrives within minutes via the revalidation task (plus the hourly eager warmer for
+# warmed shapes) — the grace is the ceiling for revalidation failures and warmer
+# outages. Must stay well under the framework's 48h ClickHouse expiry buffer (rows must
+# still exist).
 STALE_WHILE_REVALIDATE_SECONDS = 6 * 60 * 60
-
-# Debounce on enqueueing the revalidation task, keyed per (team, query shape). Must
-# exceed the worst-case task duration (two ensure phases x 180s framework budget + the
-# read, ~7min) so a running revalidation can't be double-enqueued; short enough that a
-# failed revalidation is retried by the next stale hit well within the 6h grace.
-REVALIDATION_DEBOUNCE_SECONDS = 15 * 60
-
-SWR_REVALIDATE_REDIS_PREFIX = "web_analytics:swr_revalidate:"
 
 WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED = Counter(
     "web_analytics_lazy_precompute_stale_served_total",
@@ -127,43 +123,15 @@ WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUED = Counter(
     labelnames=["family"],
 )
 
-WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_DEBOUNCED = Counter(
-    "web_analytics_lazy_precompute_revalidation_debounced_total",
-    "Stale-served reads that skipped enqueueing because a revalidation was already pending.",
-    labelnames=["family"],
-)
-
 
 def is_background_warming_request() -> bool:
     return get_query_tag_value("trigger") in BACKGROUND_WARMING_TRIGGERS
 
 
-def _swr_revalidate_key(team: Team, query: Any) -> str:
-    # The eligibility hash fragments along the same dimensions as the precompute cache
-    # key (filters, date range, breakdown, ...) while ignoring volatile fields
-    # (modifiers, pagination), so one key debounces exactly one job shape.
-    return f"{SWR_REVALIDATE_REDIS_PREFIX}{team.id}:{compute_filters_eligibility_hash(query, team.timezone)}"
-
-
 def enqueue_stale_revalidation(*, team: Team, query: Any, family: str) -> None:
-    """Enqueue a background re-run of `query` so a stale-served read gets fresh data next time.
-
-    Debounced per (team, query shape); fails closed — a Redis error enqueues nothing
-    (the hourly warmer still refreshes warmed shapes, and the next stale hit retries).
-    """
-    try:
-        acquired = redis.get_client().set(
-            _swr_revalidate_key(team, query), "1", nx=True, ex=REVALIDATION_DEBOUNCE_SECONDS
-        )
-    except Exception:
-        logger.warning("web_precompute.swr_debounce_failed", team_id=team.id, family=family, exc_info=True)
-        return
-    if not acquired:
-        WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_DEBOUNCED.labels(family=family).inc()
-        return
-
-    # The task module imports this module (for the trigger + debounce constants), so the
-    # reverse import must stay local to avoid a cycle.
+    """Enqueue a background re-run of `query` so a stale-served read gets fresh data next time."""
+    # The task module imports this module (for the trigger constant), so the reverse
+    # import must stay local to avoid a cycle.
     from products.web_analytics.backend.tasks.lazy_precompute_revalidation import (  # noqa: PLC0415
         revalidate_web_analytics_precompute,
     )
@@ -177,10 +145,16 @@ def handle_stale_served(*, runner: Any, family: str) -> None:
     """Everything a read path does when an ensure came back `stale=True`.
 
     Counts the stale-served read, tags the upcoming read query so query_log can split
-    stale-served vs fresh reads, and enqueues the debounced background revalidation.
+    stale-served vs fresh reads, and enqueues the background revalidation. Enqueues at
+    most once per request: the `precompute_stale` tag it sets doubles as the marker, so
+    a compare-period ensure coming back stale after the current-period one doesn't mint
+    a second task for the same query (one re-run covers both periods).
     """
     WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED.labels(family=family).inc()
+    already_handled = get_query_tag_value("precompute_stale") is True
     tag_queries(precompute_stale=True)
+    if already_handled:
+        return
     enqueue_stale_revalidation(team=runner.team, query=runner.query, family=family)
 
 

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -312,8 +312,8 @@ def execute_lazy_precomputed_read(
                     )
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
                     if prev_result.stale:
-                        # Debounced with the current-period enqueue; one revalidation
-                        # re-runs the whole query, covering both periods.
+                        # handle_stale_served enqueues at most once per request; one
+                        # revalidation re-runs the whole query, covering both periods.
                         handle_stale_served(runner=runner, family=_FAMILY)
 
                     if not prev_result.ready:

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -30,7 +30,10 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     test_account_filter_expr,
     user_filter_expr,
 )
-from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import web_ensure_precomputed
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
+    handle_stale_served,
+    web_ensure_precomputed,
+)
 
 _FAMILY = "web_overview"
 
@@ -260,6 +263,8 @@ def execute_lazy_precomputed_read(
             time_range_end=time_range_end,
         )
         ensure_duration_ms = int((time.perf_counter() - ensure_started) * 1000)
+        if result.stale:
+            handle_stale_served(runner=runner, family=_FAMILY)
 
         logger.info(
             "web_overview_lazy_precompute_ensure_done",
@@ -306,6 +311,10 @@ def execute_lazy_precomputed_read(
                         time_range_end=prev_range_end,
                     )
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
+                    if prev_result.stale:
+                        # Debounced with the current-period enqueue; one revalidation
+                        # re-runs the whole query, covering both periods.
+                        handle_stale_served(runner=runner, family=_FAMILY)
 
                     if not prev_result.ready:
                         WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="previous_not_ready").inc()

--- a/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
@@ -523,8 +523,8 @@ def execute_lazy_precomputed_read(
                     )
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
                     if prev_result.stale:
-                        # Debounced with the current-period enqueue; one revalidation
-                        # re-runs the whole query, covering both periods.
+                        # handle_stale_served enqueues at most once per request; one
+                        # revalidation re-runs the whole query, covering both periods.
                         handle_stale_served(runner=runner, family=_FAMILY)
                     if not prev_result.ready:
                         logger.info(

--- a/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_frustration_lazy_precompute.py
@@ -35,6 +35,7 @@ from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common imp
     ceil_utc_day,
     check_common_eligibility,
     floor_utc_day,
+    handle_stale_served,
     host_filter_expr,
     log_eligibility_outcome,
     test_account_filter_expr,
@@ -45,6 +46,8 @@ if TYPE_CHECKING:
     from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
 
 logger = structlog.get_logger(__name__)
+
+_FAMILY = "web_stats_frustration"
 
 
 # Allowlist of exception class names we expect on the lazy path. Anything
@@ -485,6 +488,8 @@ def execute_lazy_precomputed_read(
             job_count=len(result.job_ids),
             ensure_duration_ms=ensure_duration_ms,
         )
+        if result.stale:
+            handle_stale_served(runner=runner, family=_FAMILY)
 
         if not result.job_ids or not result.ready:
             return None
@@ -517,6 +522,10 @@ def execute_lazy_precomputed_read(
                         time_range_end=prev_range_end,
                     )
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
+                    if prev_result.stale:
+                        # Debounced with the current-period enqueue; one revalidation
+                        # re-runs the whole query, covering both periods.
+                        handle_stale_served(runner=runner, family=_FAMILY)
                     if not prev_result.ready:
                         logger.info(
                             "web_stats_frustration_lazy_precompute_previous_not_ready",

--- a/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
@@ -38,7 +38,10 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     test_account_filter_expr,
     user_filter_expr,
 )
-from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import web_ensure_precomputed
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
+    handle_stale_served,
+    web_ensure_precomputed,
+)
 
 _FAMILY = "web_stats"
 
@@ -617,6 +620,8 @@ def execute_lazy_precomputed_read(
             time_range_start=time_range_start,
             time_range_end=time_range_end,
         )
+        if result.stale:
+            handle_stale_served(runner=runner, family=_FAMILY)
 
         if not result.job_ids:
             WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="no_job_ids").inc()
@@ -665,6 +670,10 @@ def execute_lazy_precomputed_read(
                         time_range_start=prev_range_start,
                         time_range_end=prev_range_end,
                     )
+                    if prev_result.stale:
+                        # Debounced with the current-period enqueue; one revalidation
+                        # re-runs the whole query, covering both periods.
+                        handle_stale_served(runner=runner, family=_FAMILY)
 
                     if not prev_result.ready:
                         WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="previous_not_ready").inc()

--- a/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
@@ -671,8 +671,8 @@ def execute_lazy_precomputed_read(
                         time_range_end=prev_range_end,
                     )
                     if prev_result.stale:
-                        # Debounced with the current-period enqueue; one revalidation
-                        # re-runs the whole query, covering both periods.
+                        # handle_stale_served enqueues at most once per request; one
+                        # revalidation re-runs the whole query, covering both periods.
                         handle_stale_served(runner=runner, family=_FAMILY)
 
                     if not prev_result.ready:

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -792,7 +792,7 @@ def execute_lazy_precomputed_read(
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
 
                     if prev_result.stale:
-                        # The debounce collapses this with the current-period enqueue; one
+                        # handle_stale_served enqueues at most once per request; one
                         # revalidation re-runs the whole query, covering both periods.
                         handle_stale_served(runner=runner, family=_FAMILY)
 

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -28,7 +28,7 @@ from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Feature, Product, get_query_tag_value, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationResult,
@@ -41,7 +41,9 @@ from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common imp
     ceil_utc_day,
     check_common_eligibility,
     floor_utc_day,
+    handle_stale_served,
     host_filter_expr,
+    is_background_warming_request,
     log_eligibility_outcome,
     test_account_filter_expr,
     web_ensure_precomputed,
@@ -51,6 +53,8 @@ if TYPE_CHECKING:
     from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
 
 logger = structlog.get_logger(__name__)
+
+_FAMILY = "web_stats_paths"
 
 
 # Allowlist of exception class names we expect on the lazy path. Anything
@@ -84,11 +88,6 @@ WEB_STATS_PATHS_LAZY_FAILED = Counter(
 WEB_STATS_PATHS_LAZY_EMPTY = Counter(
     "web_stats_paths_lazy_precompute_empty_total",
     "Lazy precompute reads that returned zero rows (potential silent ingestion drop or fresh team).",
-)
-
-WEB_STATS_PATHS_LAZY_STALE_SERVED = Counter(
-    "web_stats_paths_lazy_precompute_stale_served_total",
-    "Reads served from expired-within-grace jobs instead of recomputing inline (serve-stale path).",
 )
 
 WEB_STATS_PATHS_LAZY_ROWS = Histogram(
@@ -405,11 +404,6 @@ def _top_k_ranking_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr | None:
     )
 
 
-# Warming triggers whose ensure calls keep the framework's full wait budget: they run in
-# background Dagster jobs where long synchronous rebuilds are the whole point (rotation
-# recovery depends on a single warmer tick being able to rebuild many windows).
-_BACKGROUND_WARMING_TRIGGERS = frozenset({"webAnalyticsEagerBaselineWarming", "webAnalyticsQueryWarming"})
-
 # Wall-clock budget for a *user-facing* request's whole ensure phase (current period plus
 # the compare period, which shares whatever remains). The executor checks the budget before
 # starting each inline INSERT, so completed windows always persist as READY jobs and later
@@ -419,15 +413,6 @@ _BACKGROUND_WARMING_TRIGGERS = frozenset({"webAnalyticsEagerBaselineWarming", "w
 # case still completes inline; what it bounds is the pile-up case (many stale windows after
 # a hash rotation), which previously held requests for 30s+.
 PATHS_USER_ENSURE_WAIT_SECONDS = 10
-
-# Serve-stale grace for *user-facing* requests: windows that expired within this grace are
-# served from their existing (complete-but-stale) rows instantly instead of recomputing
-# inline. Refresh comes from the hourly eager warmer, which covers every enrolled team, so
-# observed staleness is normally bounded by the warmer cadence — the grace is the ceiling
-# for unwarmed query shapes and warmer outages. Must stay well under the framework's 48h
-# ClickHouse expiry buffer (rows must still exist). Background warmers never get the grace:
-# they are the refresh mechanism and would otherwise serve stale to themselves forever.
-PATHS_USER_STALE_GRACE_SECONDS = 6 * 60 * 60
 
 
 def ensure_web_stats_paths_precomputed(
@@ -459,8 +444,7 @@ def ensure_web_stats_paths_precomputed(
 
     # Warmers keep the framework default; user-facing calls get the 10s budget, or the
     # caller-provided remainder of it when this is the second (compare-period) ensure.
-    is_background = get_query_tag_value("trigger") in _BACKGROUND_WARMING_TRIGGERS
-    if is_background:
+    if is_background_warming_request():
         wait_timeout: float | None = None
     elif wait_budget_seconds is not None:
         wait_timeout = wait_budget_seconds
@@ -477,7 +461,6 @@ def ensure_web_stats_paths_precomputed(
         query_type="web_stats_paths_lazy_insert",
         spill_to_disk=True,  # high-cardinality path breakdown GROUP BY; can build a large hash table
         wait_timeout_seconds=wait_timeout,
-        stale_while_revalidate_seconds=None if is_background else PATHS_USER_STALE_GRACE_SECONDS,
     )
 
 
@@ -747,10 +730,7 @@ def execute_lazy_precomputed_read(
             stale=result.stale,
         )
         if result.stale:
-            WEB_STATS_PATHS_LAZY_STALE_SERVED.inc()
-            # Tag the upcoming read query so query_log can split stale-served vs fresh
-            # reads (the Prometheus counter above can't be joined against query latency).
-            tag_queries(precompute_stale=True)
+            handle_stale_served(runner=runner, family=_FAMILY)
 
         if not result.job_ids:
             return None
@@ -782,7 +762,7 @@ def execute_lazy_precomputed_read(
                     # 2x the intended time. Warmers keep the framework's 180s per call
                     # (their gate is the wider ENSURE_BUDGET_MS); user-facing requests
                     # share the single PATHS_USER_ENSURE_WAIT_SECONDS across both calls.
-                    is_background = get_query_tag_value("trigger") in _BACKGROUND_WARMING_TRIGGERS
+                    is_background = is_background_warming_request()
                     if ensure_duration_ms >= ENSURE_BUDGET_MS:
                         logger.info(
                             "web_stats_paths_lazy_precompute_compare_budget_exceeded",
@@ -810,6 +790,11 @@ def execute_lazy_precomputed_read(
                         wait_budget_seconds=remaining_budget,
                     )
                     ensure_duration_ms += int((time.perf_counter() - prev_ensure_started) * 1000)
+
+                    if prev_result.stale:
+                        # The debounce collapses this with the current-period enqueue; one
+                        # revalidation re-runs the whole query, covering both periods.
+                        handle_stale_served(runner=runner, family=_FAMILY)
 
                     if not prev_result.ready:
                         logger.info(

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -477,7 +477,7 @@ def ensure_web_stats_paths_precomputed(
         query_type="web_stats_paths_lazy_insert",
         spill_to_disk=True,  # high-cardinality path breakdown GROUP BY; can build a large hash table
         wait_timeout_seconds=wait_timeout,
-        serve_stale_grace_seconds=None if is_background else PATHS_USER_STALE_GRACE_SECONDS,
+        stale_while_revalidate_seconds=None if is_background else PATHS_USER_STALE_GRACE_SECONDS,
     )
 
 

--- a/products/web_analytics/backend/hogql_queries/web_vitals_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_vitals_paths_lazy_precompute.py
@@ -42,7 +42,10 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     test_account_filter_expr,
     user_filter_expr,
 )
-from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import web_ensure_precomputed
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
+    handle_stale_served,
+    web_ensure_precomputed,
+)
 
 _FAMILY = "web_vitals_paths"
 
@@ -380,6 +383,8 @@ def execute_lazy_precomputed_read(
             time_range_start=time_range_start,
             time_range_end=time_range_end,
         )
+        if result.stale:
+            handle_stale_served(runner=runner, family=_FAMILY)
 
         if not result.job_ids:
             WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="no_job_ids").inc()

--- a/products/web_analytics/backend/tasks/__init__.py
+++ b/products/web_analytics/backend/tasks/__init__.py
@@ -1,3 +1,3 @@
-from . import heatmap_screenshot
+from . import heatmap_screenshot, lazy_precompute_revalidation
 
-__all__ = ["heatmap_screenshot"]
+__all__ = ["heatmap_screenshot", "lazy_precompute_revalidation"]

--- a/products/web_analytics/backend/tasks/lazy_precompute_revalidation.py
+++ b/products/web_analytics/backend/tasks/lazy_precompute_revalidation.py
@@ -1,0 +1,100 @@
+"""Background revalidation for stale-served lazy precompute reads.
+
+The revalidate half of the stale-while-revalidate semantics (RFC 5861): when a
+user-facing read is served from expired-within-grace jobs, the read path
+enqueues this task (debounced in Redis, see
+`web_lazy_precompute_common.enqueue_stale_revalidation`) to re-run the query in
+the background so the next fetch is fresh instead of waiting for the hourly
+eager warmer — which only covers warmed query shapes.
+"""
+
+import time
+
+import structlog
+from celery import shared_task
+from prometheus_client import Counter
+
+from posthog.hogql.constants import LimitContext
+
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.event_usage import EventSource
+from posthog.hogql_queries.query_runner import ExecutionMode, get_query_runner
+from posthog.models import Team
+from posthog.scoping_audit import skip_team_scope_audit
+from posthog.tasks.utils import CeleryQueue
+
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
+    REVALIDATION_DEBOUNCE_SECONDS,
+    REVALIDATION_TRIGGER,
+)
+
+logger = structlog.get_logger(__name__)
+
+REVALIDATION_RUN = Counter(
+    "web_analytics_lazy_precompute_revalidation_total",
+    "Background stale-while-revalidate re-runs of web analytics queries.",
+    labelnames=["outcome", "query_kind"],
+)
+
+# Worst case is two ensure phases (current + compare period) at the framework's
+# 180s wait budget each, plus the read itself; mirror the heatmap task's limits.
+REVALIDATION_SOFT_TIME_LIMIT = 600
+REVALIDATION_TIME_LIMIT = REVALIDATION_SOFT_TIME_LIMIT + 30
+
+
+@shared_task(
+    ignore_result=True,
+    # Same queue insight cache warming uses — prevents ClickHouse from being overwhelmed.
+    queue=CeleryQueue.ANALYTICS_LIMITED.value,
+    # A task that sat in the queue past the debounce window has been superseded:
+    # either a newer stale hit re-enqueued, or the warmer already refreshed.
+    expires=REVALIDATION_DEBOUNCE_SECONDS,
+    # No retries: the next stale hit after the debounce TTL re-enqueues, and the
+    # hourly warmer converges regardless.
+    max_retries=0,
+    soft_time_limit=REVALIDATION_SOFT_TIME_LIMIT,
+    time_limit=REVALIDATION_TIME_LIMIT,
+)
+@skip_team_scope_audit
+def revalidate_web_analytics_precompute(team_id: int, query: dict) -> None:
+    query_kind = str(query.get("kind"))
+    try:
+        team = Team.objects.get(pk=team_id)
+    except Team.DoesNotExist:
+        logger.warning("web_analytics_swr_revalidation_team_missing", team_id=team_id, query_kind=query_kind)
+        REVALIDATION_RUN.labels(outcome="failed", query_kind=query_kind).inc()
+        return
+
+    logger.info("web_analytics_swr_revalidation_started", team_id=team_id, query_kind=query_kind)
+    started = time.monotonic()
+    try:
+        # Tag BEFORE constructing the runner (tags live in a contextvar the runner's
+        # construction-time I/O inherits). The trigger puts this re-run in
+        # BACKGROUND_WARMING_TRIGGERS, so the ensure gets no stale-while-revalidate
+        # grace (it cannot serve stale to itself) and the full framework wait budget.
+        # Celery resets query tags on task_postrun, so this never leaks across tasks.
+        tag_queries(
+            team_id=team_id,
+            trigger=REVALIDATION_TRIGGER,
+            feature=Feature.CACHE_WARMUP,
+            product=Product.WEB_ANALYTICS,
+        )
+        runner = get_query_runner(query=query, team=team, limit_context=LimitContext.QUERY_ASYNC)
+        # Force-refresh: recomputes the expired precompute windows and replaces the
+        # HogQL result cache entry, so the next user fetch is fresh on both layers.
+        runner.run(
+            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+            analytics_props={"source": EventSource.CACHE_WARMING},
+        )
+    except Exception:
+        logger.exception("web_analytics_swr_revalidation_failed", team_id=team_id, query_kind=query_kind)
+        REVALIDATION_RUN.labels(outcome="failed", query_kind=query_kind).inc()
+        return
+
+    REVALIDATION_RUN.labels(outcome="completed", query_kind=query_kind).inc()
+    logger.info(
+        "web_analytics_swr_revalidation_completed",
+        team_id=team_id,
+        query_kind=query_kind,
+        duration_ms=round((time.monotonic() - started) * 1000),
+    )

--- a/products/web_analytics/backend/tasks/lazy_precompute_revalidation.py
+++ b/products/web_analytics/backend/tasks/lazy_precompute_revalidation.py
@@ -2,10 +2,14 @@
 
 The revalidate half of the stale-while-revalidate semantics (RFC 5861): when a
 user-facing read is served from expired-within-grace jobs, the read path
-enqueues this task (debounced in Redis, see
-`web_lazy_precompute_common.enqueue_stale_revalidation`) to re-run the query in
-the background so the next fetch is fresh instead of waiting for the hourly
-eager warmer — which only covers warmed query shapes.
+enqueues this task (see `web_lazy_precompute_common.enqueue_stale_revalidation`)
+to re-run the query in the background so the next fetch is fresh instead of
+waiting for the hourly eager warmer — which only covers warmed query shapes.
+
+Duplicate tasks for the same query shape are tolerated rather than deduped: the
+framework's PENDING-job unique index collapses concurrent recomputes to one
+insert, and once the first task refreshes the jobs the rest are cheap warm
+reads on a queue that paces ClickHouse work anyway.
 """
 
 import time
@@ -23,10 +27,7 @@ from posthog.models import Team
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.tasks.utils import CeleryQueue
 
-from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
-    REVALIDATION_DEBOUNCE_SECONDS,
-    REVALIDATION_TRIGGER,
-)
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import REVALIDATION_TRIGGER
 
 logger = structlog.get_logger(__name__)
 
@@ -41,16 +42,19 @@ REVALIDATION_RUN = Counter(
 REVALIDATION_SOFT_TIME_LIMIT = 600
 REVALIDATION_TIME_LIMIT = REVALIDATION_SOFT_TIME_LIMIT + 30
 
+# Discard tasks that sat in the queue this long: by then either a sibling task
+# already refreshed the jobs, the warmer did, or a newer stale hit re-enqueued.
+# This is the queue's shedding valve against enqueue bursts on a hot stale shape.
+REVALIDATION_EXPIRES_SECONDS = 15 * 60
+
 
 @shared_task(
     ignore_result=True,
     # Same queue insight cache warming uses — prevents ClickHouse from being overwhelmed.
     queue=CeleryQueue.ANALYTICS_LIMITED.value,
-    # A task that sat in the queue past the debounce window has been superseded:
-    # either a newer stale hit re-enqueued, or the warmer already refreshed.
-    expires=REVALIDATION_DEBOUNCE_SECONDS,
-    # No retries: the next stale hit after the debounce TTL re-enqueues, and the
-    # hourly warmer converges regardless.
+    expires=REVALIDATION_EXPIRES_SECONDS,
+    # No retries: the next stale hit re-enqueues, and the hourly warmer converges
+    # regardless.
     max_retries=0,
     soft_time_limit=REVALIDATION_SOFT_TIME_LIMIT,
     time_limit=REVALIDATION_TIME_LIMIT,

--- a/products/web_analytics/backend/tasks/test/test_lazy_precompute_revalidation.py
+++ b/products/web_analytics/backend/tasks/test/test_lazy_precompute_revalidation.py
@@ -1,0 +1,58 @@
+from posthog.test.base import BaseTest
+from unittest import mock
+
+from posthog.schema import DateRange, WebOverviewQuery
+
+from posthog.clickhouse.query_tagging import get_query_tag_value, reset_query_tags
+from posthog.hogql_queries.query_runner import ExecutionMode
+
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import REVALIDATION_TRIGGER
+from products.web_analytics.backend.tasks.lazy_precompute_revalidation import revalidate_web_analytics_precompute
+
+_MOD = "products.web_analytics.backend.tasks.lazy_precompute_revalidation"
+
+
+class TestRevalidateWebAnalyticsPrecompute(BaseTest):
+    def tearDown(self):
+        # In production Celery resets query tags on task_postrun; calling the task
+        # function directly leaves them on the contextvar.
+        reset_query_tags()
+        super().tearDown()
+
+    def test_reruns_query_as_background_trigger_with_forced_recompute(self):
+        payload = WebOverviewQuery(dateRange=DateRange(date_from="-7d"), properties=[]).model_dump(
+            mode="json", exclude_none=True
+        )
+        seen: dict = {}
+
+        def fake_get_query_runner(*, query, team, limit_context):
+            # The trigger tag must be set BEFORE runner construction, or the ensure
+            # inside the run would not see a background trigger and would be served
+            # stale itself instead of recomputing.
+            seen["trigger_at_construction"] = get_query_tag_value("trigger")
+            seen["team"] = team
+            seen["query"] = query
+            seen["runner"] = mock.Mock()
+            return seen["runner"]
+
+        with mock.patch(f"{_MOD}.get_query_runner", side_effect=fake_get_query_runner):
+            revalidate_web_analytics_precompute(team_id=self.team.pk, query=payload)
+
+        assert seen["trigger_at_construction"] == REVALIDATION_TRIGGER
+        assert seen["team"].pk == self.team.pk
+        assert seen["query"] == payload
+        run_kwargs = seen["runner"].run.call_args.kwargs
+        assert run_kwargs["execution_mode"] == ExecutionMode.CALCULATE_BLOCKING_ALWAYS
+
+    def test_missing_team_returns_without_raising(self):
+        with mock.patch(f"{_MOD}.get_query_runner") as get_runner:
+            revalidate_web_analytics_precompute(team_id=0, query={"kind": "WebOverviewQuery"})
+        assert get_runner.call_count == 0
+
+    def test_query_failure_is_swallowed(self):
+        # A failed revalidation must not raise into Celery retry machinery — the next
+        # stale hit after the debounce TTL (or the hourly warmer) converges instead.
+        runner = mock.Mock()
+        runner.run.side_effect = RuntimeError("clickhouse exploded")
+        with mock.patch(f"{_MOD}.get_query_runner", return_value=runner):
+            revalidate_web_analytics_precompute(team_id=self.team.pk, query={"kind": "WebOverviewQuery"})


### PR DESCRIPTION
## Problem

#69695 shipped the *serve* half of stale-while-revalidate for lazy precompute: user-facing requests whose windows expired within a 6h grace get their complete-but-stale rows instantly instead of paying a 2-8s inline recompute or the raw fallback. But the *revalidate* half was missing. A stale hit triggered no recompute, so refresh relied entirely on the hourly eager warmer, which only covers warmed query shapes. An unwarmed shape would serve stale repeatedly for up to 6 hours and then suddenly pay the inline recompute anyway – exactly the cliff `stale-while-revalidate` (RFC 5861) exists to avoid.

The serve-stale wiring also existed only for the paths tile, and the parameter name didn't say what it actually implements.

## Changes

**Before** (shipped in #69695):

```mermaid
flowchart LR
    A[User request] --> B{Windows fresh?}
    B -- yes --> C[Read precompute]
    B -- expired within 6h grace --> D[Serve stale rows]
    D -.->|no refresh triggered| E[Hourly warmer<br/>warmed shapes only]
    class A phYellow;
    class B phBlue;
    class C,D phGray;
    class E phRed;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
```

**After**:

```mermaid
flowchart LR
    A[User request] --> B{Windows fresh?}
    B -- yes --> C[Read precompute]
    B -- expired within 6h grace --> D[Serve stale rows]
    D -->|once per request| G{{Celery revalidation task}}
    G -->|re-runs query, no grace,<br/>CALCULATE_BLOCKING_ALWAYS| C
    class A phYellow;
    class B,G phBlue;
    class C,D phGray;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
```

Five commits, each green on its own:

1. **Rename** `serve_stale_grace_seconds` to `stale_while_revalidate_seconds` on the executor and `ensure_precomputed`, matching the HTTP cache directive it implements. The internal mechanics (`expired_grace_seconds`, `grace_seconds`) keep their names since they describe the mechanism, not the policy.
2. **Background revalidation.** A stale-served read now enqueues `revalidate_web_analytics_precompute` – a fire-and-forget Celery task on the `ANALYTICS_LIMITED` queue (same "don't overwhelm ClickHouse" queue as insight cache warming) that re-runs the serialized query through the query runner with `CALCULATE_BLOCKING_ALWAYS` and a new `webAnalyticsStaleRevalidation` trigger tag. That trigger is part of `BACKGROUND_WARMING_TRIGGERS`, so the re-run gets no grace (it can't be served stale to itself) and the full framework wait budget. No task retries – the next stale hit re-enqueues, and the hourly warmer converges regardless.
3. **All six families.** The grace was paths-only; it now defaults centrally in `web_ensure_precomputed` (user-facing requests get 6h, background triggers get none), and overview, stats, paths, frustration, goals, and vitals-paths all report stale-served reads through a shared `handle_stale_served` helper (counter + `precompute_stale` query tag + revalidation enqueue), including compare-period ensures.
4. **No dedup layer.** An earlier revision debounced enqueues in Redis; we removed it deliberately. Duplicate tasks carry the same load profile the pre-serve-stale inline path already tolerated at user-request concurrency: the HogQL result cache fronts these queries so stale hits are rare per shape, the framework's PENDING-job unique index collapses concurrent recomputes to one insert, `ANALYTICS_LIMITED` paces ClickHouse work, and the task's `expires` sheds queue backlog. The one real duplication source – a compare-period ensure coming back stale right after the current-period one – is handled in-process: `handle_stale_served` enqueues at most once per request, reusing the `precompute_stale` tag it already sets as the marker.
5. **QA hardening (post-review).** A multi-agent QA pass converged on two fixes, applied in the last commit: the enqueue is now best-effort (a broker outage degrades to "serve stale, warmer converges" instead of aborting the read into the live-query fallback), and the background-warmer check now gates primarily on the `CACHE_WARMUP` feature tag so *any* warmer — including the generic insight cache warmer (`warmingV2`), which isn't in the named trigger set — recomputes instead of persisting stale rows into the insight cache under a fresh timestamp.

> [!NOTE]
> The day-old paths-only counter `web_stats_paths_lazy_precompute_stale_served_total` is replaced by the family-labeled `web_analytics_lazy_precompute_stale_served_total`. Any dashboard on the old name needs the new one. New series: `web_analytics_lazy_precompute_revalidation_enqueued_total{family}`, `web_analytics_lazy_precompute_revalidation_enqueue_failed_total{family}` (broker failures — the stale read is still served), and `web_analytics_lazy_precompute_revalidation_total{outcome, query_kind}`. Health invariant: `rate(stale_served)` per shape should be closely tracked by `rate(revalidation enqueued)`, and the executor's `stale_hit` outcome rate should decay toward the warmer-gap baseline once this rolls out.

`stale-if-error` (serving stale when the inline recompute fails, instead of the raw fallback) was considered and explicitly descoped.

## How did you test this code?

Automated only (no manual run against a live stack):

- Framework suite: 134 passed, including the three renamed serve-stale tests.
- `test_web_lazy_precompute_common.py`: new parameterized test that every background trigger (both warmers **and the new revalidation trigger**) gets `stale_while_revalidate_seconds=None` while user requests get 6h – this is the guard against the revalidation task serving stale to itself, which no existing test covered. New test that two stale ensures in one request (current + compare period) tag the read and enqueue exactly one task.
- New task tests: the trigger tag is set *before* runner construction (setting it after would break the no-grace guarantee), the run uses `CALCULATE_BLOCKING_ALWAYS`, a missing team and a failing query return without raising into retry machinery.
- One wiring test per family (5 new): a `stale=True` ensure result enqueues the revalidation task exactly once – catches any family dropping its `result.stale` hook, which would silently disable SWR for that tile. Each wraps in `tags_context()` because production resets query tags per request/task but the test process doesn't.
- Paths suite: 47 passed, 9 pre-existing skips. `hogli ci:preflight --fix`: 0 failures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a – internal query-path behavior, documented inline.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code from Lucas's direction to align the shipped serve-stale option with HTTP `stale-while-revalidate` semantics. Scope decisions made together up front: background revalidation via a Celery task re-running the query (over an executor-level hook or a warmer wanted-queue, to keep refresh logic on the one path the warmer already uses), rename to the HTTP directive term, all families rather than paths only, and no `stale-if-error`. Skills invoked: `/writing-tests`. The paths module's local `_BACKGROUND_WARMING_TRIGGERS` and grace constant were hoisted into `web_lazy_precompute_common` in the middle commit rather than the last one so every commit is standalone-correct (otherwise the revalidation task's re-run of a paths query would not have counted as background). The Redis debounce was in the original design; Lucas challenged it as redundant with the pre-existing job-level dedup and queue throttling, and the final commit removes it in favor of the in-request marker described above.
