### PR TITLE
fix(aio): keep error row actions visible

### DIFF
--- a/products/ai_observability/frontend/AIObservabilityErrors.tsx
+++ b/products/ai_observability/frontend/AIObservabilityErrors.tsx
@@ -112,11 +112,11 @@ export function AIObservabilityErrors(): JSX.Element {
                                 errorString.length > 80 ? errorString.slice(0, 77) + '...' : errorString
 
                             return (
-                                <div className="flex items-center gap-1">
+                                <div className="flex min-w-0 items-center gap-1">
                                     <Tooltip title={errorString}>
                                         <Link
                                             to={buildErrorTracesUrl(errorString, searchParams, currentPropertyFilters)}
-                                            className="font-mono text-sm"
+                                            className="min-w-0 flex-1 truncate font-mono text-sm"
                                             data-attr="llm-errors-row-click"
                                         >
                                             {displayValue}

--- a/products/ai_observability/frontend/AIObservabilityErrors.tsx
+++ b/products/ai_observability/frontend/AIObservabilityErrors.tsx
@@ -116,7 +116,7 @@ export function AIObservabilityErrors(): JSX.Element {
                                     <Tooltip title={errorString}>
                                         <Link
                                             to={buildErrorTracesUrl(errorString, searchParams, currentPropertyFilters)}
-                                            className="min-w-0 flex-1 truncate font-mono text-sm"
+                                            className="min-w-0 shrink truncate font-mono text-sm"
                                             data-attr="llm-errors-row-click"
                                         >
                                             {displayValue}


### PR DESCRIPTION
## Problem

Long normalized error messages can push the trend and copy actions outside the visible Errors table cell, especially at narrower viewport widths.

## Changes

- Allow the error row content to shrink within the available cell width.
- Truncate long error labels while preserving space for both row actions.
- No screenshot is included because the affected state depends on project error data and was not manually exercised.

## How did you test this code?

- The existing Ai observability Errors test passes.
- File-level lint and CI preflight pass.
- The full frontend typecheck remains blocked by existing master errors in event usage and session recording files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed for this layout-only fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop investigated and implemented this fix. The session link is unavailable from the local runtime. Skills invoked: /react-doctor, /running-ci-preflight, /llma-git-workflow, and /create-pr.

The implementation keeps the action buttons as non-shrinking flex items and constrains the error link to the remaining width. The automated React Doctor scan could not download its package in the restricted environment, so focused source inspection and repository checks were used.