### PR TITLE
fix(aio): make sentiment input lookup resilient to query failures

### DIFF
--- a/products/ai_observability/frontend/sentimentQueries.test.ts
+++ b/products/ai_observability/frontend/sentimentQueries.test.ts
@@ -149,4 +149,58 @@ describe('sentimentQueries', () => {
             },
         })
     })
+
+    it('still returns generations when the input lookup query fails', async () => {
+        // Input enrichment is best-effort: a failing HogQL input lookup must not
+        // take down the whole sentiment page load. Sentiment is intact; aiInput falls back.
+        jest.spyOn(console, 'warn').mockImplementation(() => {})
+        jest.spyOn(mockApi, 'query').mockResolvedValue({
+            results: [['generation-uuid', 'trace-1', null, 'gpt-4.1', 'distinct-1', '2026-06-23T10:00:00Z']],
+        } as any)
+        jest.spyOn(mockApi, 'queryHogQL')
+            // stored sentiment lookup (ai_events) succeeds
+            .mockResolvedValueOnce({
+                results: [
+                    [
+                        'trace-1',
+                        'generation-uuid',
+                        'positive',
+                        '0.91',
+                        { positive: 0.91, neutral: 0.08, negative: 0.01 },
+                        {
+                            '0': {
+                                label: 'positive',
+                                score: 0.91,
+                                scores: { positive: 0.91, neutral: 0.08, negative: 0.01 },
+                            },
+                        },
+                        1,
+                        '2026-06-23T10:00:01Z',
+                    ],
+                ],
+            } as any)
+            // both input lookups (ai_events then events fallback) fail server-side
+            .mockRejectedValueOnce(new Error('Non-OK response (status 500)'))
+            .mockRejectedValueOnce(new Error('Non-OK response (status 500)'))
+
+        const page = await fetchSentimentGenerationsPage(
+            {
+                dateFilter: { dateFrom: '-7d', dateTo: null },
+                shouldFilterTestAccounts: false,
+                propertyFilters: [],
+            },
+            0
+        )
+
+        expect(page.generations).toHaveLength(1)
+        expect(page.generations[0]).toMatchObject({
+            uuid: 'generation-uuid',
+            traceId: 'trace-1',
+            aiInput: null,
+            sentiment: {
+                label: 'positive',
+                score: 0.91,
+            },
+        })
+    })
 })

--- a/products/ai_observability/frontend/sentimentQueries.ts
+++ b/products/ai_observability/frontend/sentimentQueries.ts
@@ -287,6 +287,18 @@ async function queryGenerationInputs(
     return inputs
 }
 
+async function safeQueryGenerationInputs(
+    generations: SentimentGeneration[],
+    source: GenerationInputQuerySource
+): Promise<Map<string, unknown>> {
+    try {
+        return await queryGenerationInputs(generations, source)
+    } catch (error) {
+        console.warn(`[sentimentQueries] failed to load generation inputs from ${source.from}`, error)
+        return new Map()
+    }
+}
+
 async function fetchGenerationInputs(generations: SentimentGeneration[]): Promise<Record<string, unknown>> {
     const inputsByGenerationKey: Record<string, unknown> = {}
     const missingInputs = generations.filter((generation) => {
@@ -301,7 +313,9 @@ async function fetchGenerationInputs(generations: SentimentGeneration[]): Promis
         return inputsByGenerationKey
     }
 
-    const aiEventsInputs = await queryGenerationInputs(missingInputs, AI_EVENTS_SOURCE)
+    // Input lookup is best-effort enrichment: a failure here must not take down the whole
+    // sentiment page load, since cards render off sentiment and fall back to generation.aiInput.
+    const aiEventsInputs = await safeQueryGenerationInputs(missingInputs, AI_EVENTS_SOURCE)
     for (const [uuid, aiInput] of aiEventsInputs) {
         inputsByGenerationKey[uuid] = aiInput
     }
@@ -311,7 +325,7 @@ async function fetchGenerationInputs(generations: SentimentGeneration[]): Promis
         return inputsByGenerationKey
     }
 
-    const eventsInputs = await queryGenerationInputs(fallbackGenerations, EVENTS_SOURCE)
+    const eventsInputs = await safeQueryGenerationInputs(fallbackGenerations, EVENTS_SOURCE)
     for (const [uuid, aiInput] of eventsInputs) {
         inputsByGenerationKey[uuid] = aiInput
     }


### PR DESCRIPTION
## Problem

An error-tracking alert flagged a `500` from `POST /query/HogQLQuery/` originating in the AI observability **Sentiment** tab (`loadGenerations` → `fetchSentimentGenerationsPage` → `fetchGenerationInputs` → `queryGenerationInputs` → `api.queryHogQL`).

The sentiment tab enriches each generation with its AI input via a best-effort HogQL lookup against `ai_events` (falling back to `events`). That lookup ran unguarded inside a `Promise.all`, so when the query failed server-side the error propagated all the way up through `loadGenerations` and failed the **entire** sentiment page load — even though the input is non-critical enrichment that already falls back to `generation.aiInput`, and cards render off sentiment, not input.

The sibling `aiObservabilityAIDataLogic` already guards the identical `ai_events` → `events` heavy-input lookup with try/catch; `sentimentQueries` was simply missing that guard.

## Changes

- Add `safeQueryGenerationInputs`, wrapping `queryGenerationInputs` in a try/catch that logs a warning and returns an empty result on failure.
- Route both the `ai_events` and `events` lookups in `fetchGenerationInputs` through it, so a failed input lookup degrades gracefully instead of taking down the whole sentiment page.

**Why:** a single input-enrichment query failure shouldn't break the whole Sentiment tab load for the user; generations and sentiments should still render.

## How did you test this code?

Reproduced the generated HogQL query structure against a project with AI observability data to confirm it is syntactically valid (the observed failure is a runtime/server-side `500`, not a malformed query). I was not able to run the frontend typecheck or lint locally (`node_modules` not installed in this environment); the change is small and mirrors the existing typed pattern in `aiObservabilityAIDataLogic`. No automated tests were added — the behavior is a try/catch fallback around an existing best-effort lookup.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated an error-tracking alert with the PostHog Slack app using the `investigating-error-issue` skill: pulled the issue and a sample exception event to locate the failing call stack, then read the relevant frontend code. Confirmed the emitted query was structurally valid, so the root cause is a server-side failure surfacing as an unhandled rejection. Chose a resilience fix scoped to input enrichment (not sentiment fetching, to avoid changing what data the tab shows), matching the pre-existing try/catch pattern in the sibling `aiObservabilityAIDataLogic` loader.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1783684996382999?thread_ts=1783684996.382999&cid=C0A006STKHR)*
