### PR TITLE
fix(exports): record terminal export failures so downloads never 404 silently

### DIFF
--- a/posthog/temporal/exports/__init__.py
+++ b/posthog/temporal/exports/__init__.py
@@ -1,16 +1,18 @@
-from posthog.temporal.exports.activities import export_asset_activity
+from posthog.temporal.exports.activities import export_asset_activity, record_export_failure_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
+from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult, RecordExportFailureInputs
 from posthog.temporal.exports.workflows import ExportAssetWorkflow
 
 __all__ = [
     "export_asset_activity",
+    "record_export_failure_activity",
     "ExportAssetWorkflow",
     "EXPORT_RETRY_POLICY",
     "ExportAssetActivityInputs",
     "ExportAssetResult",
+    "RecordExportFailureInputs",
 ]
 
 WORKFLOWS = [ExportAssetWorkflow]
 
-ACTIVITIES = [export_asset_activity]
+ACTIVITIES = [export_asset_activity, record_export_failure_activity]

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -9,10 +9,15 @@ from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
 from posthog.temporal.common.errors import MAX_ERROR_MESSAGE_CHARS, MAX_ERROR_TRACE_CHARS, truncate_for_temporal_payload
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
+from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult, RecordExportFailureInputs
 
 from products.exports.backend.models.exported_asset import ExportedAsset
-from products.exports.backend.tasks.failure_handler import SYSTEM_ERROR_NAMES, TIMEOUT_ERROR_NAMES, ExportCancelled
+from products.exports.backend.tasks.failure_handler import (
+    SYSTEM_ERROR_NAMES,
+    TIMEOUT_ERROR_NAMES,
+    ExportCancelled,
+    classify_failure_type,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -72,3 +77,27 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
             exported_asset_id=asset.id,
             success=asset.has_content,
         )
+
+
+@temporalio.activity.defn
+async def record_export_failure_activity(inputs: RecordExportFailureInputs) -> None:
+    """Persist a terminal export failure onto the asset as a safety net.
+
+    ``export_asset_direct`` records failures in-process, but a worker that is hard-killed
+    (OOM, activity timeout, pod eviction) never reaches that handler, leaving the asset
+    empty with no exception. The download endpoint can then only surface that silent
+    failure as a bare 404. Once the workflow has exhausted its retries the export is
+    terminally failed, so we record that here. Idempotent: never overwrites content or a
+    more specific exception already recorded in-process.
+    """
+
+    def _record() -> None:
+        asset = ExportedAsset.objects_including_ttl_deleted.get(pk=inputs.exported_asset_id)
+        if asset.has_content or asset.exception:
+            return
+        asset.exception = inputs.message
+        asset.exception_type = inputs.exception_type
+        asset.failure_type = classify_failure_type(inputs.exception_type)
+        asset.save(update_fields=["exception", "exception_type", "failure_type"])
+
+    await database_sync_to_async(_record, thread_sensitive=False)()

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -11,6 +11,13 @@ class ExportAssetActivityInputs:
 
 
 @dataclasses.dataclass
+class RecordExportFailureInputs:
+    exported_asset_id: int
+    message: str
+    exception_type: str
+
+
+@dataclasses.dataclass
 class ExportError:
     exception_class: str
     error_trace: str = ""

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -3,16 +3,24 @@ import dataclasses
 from datetime import timedelta
 
 import temporalio.workflow as wf
+from temporalio.common import RetryPolicy
 
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloConfig, SloOutcome
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.common.errors import resolve_exception_class
-from posthog.temporal.exports.activities import export_asset_activity
+from posthog.temporal.common.errors import resolve_exception_class, unwrap_temporal_cause
+from posthog.temporal.exports.activities import export_asset_activity, record_export_failure_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import ExportAssetActivityInputs
+from posthog.temporal.exports.types import ExportAssetActivityInputs, RecordExportFailureInputs
 
 from products.exports.backend.tasks.failure_handler import is_user_query_error_type
+
+# Shown to the user when the export failed but no in-process exception was recorded — i.e. the
+# worker timed out or was killed before it could persist a specific error.
+DEFAULT_EXPORT_FAILURE_MESSAGE = (
+    "Export failed to complete. The query may have timed out, or the worker was interrupted "
+    "before finishing. Please try running the export again."
+)
 
 
 @dataclasses.dataclass
@@ -46,7 +54,30 @@ class ExportAssetWorkflow(PostHogWorkflow):
                 retry_policy=EXPORT_RETRY_POLICY,
             )
         except Exception as e:
+            exception_type = resolve_exception_class(e)
+
+            # The activity has exhausted its retries, so the export is terminally failed. Persist
+            # that onto the asset (idempotently) so it's never left silently empty — a worker that
+            # was killed before its in-process handler ran would otherwise leave no exception, and
+            # the download endpoint could only surface that as a bare 404. Uses its own retry policy;
+            # a failure to record must not mask the original error.
+            cause = unwrap_temporal_cause(e)
+            message = cause.message if cause is not None and cause.message else DEFAULT_EXPORT_FAILURE_MESSAGE
+            try:
+                await wf.execute_activity(
+                    record_export_failure_activity,
+                    RecordExportFailureInputs(
+                        exported_asset_id=inputs.exported_asset_id,
+                        message=message,
+                        exception_type=exception_type,
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+            except Exception:
+                wf.logger.warning("Failed to record terminal export failure", exc_info=True)
+
             # User-query failures aren't an SLO breach -> reclassify as SUCCESS
-            if inputs.slo and is_user_query_error_type(resolve_exception_class(e)):
+            if inputs.slo and is_user_query_error_type(exception_type):
                 inputs.slo.outcome = SloOutcome.SUCCESS
             raise

--- a/posthog/temporal/tests/test_export_activities.py
+++ b/posthog/temporal/tests/test_export_activities.py
@@ -17,9 +17,9 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.exports.activities import export_asset_activity
+from posthog.temporal.exports.activities import export_asset_activity, record_export_failure_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
+from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult, RecordExportFailureInputs
 
 from products.exports.backend.models.exported_asset import ExportedAsset
 from products.exports.backend.tasks.failure_handler import ExcelColumnLimitExceeded, ExportCancelled
@@ -145,3 +145,53 @@ async def test_export_asset_activity_timeout_errors_are_retryable(
         await activity_environment.run(export_asset_activity, ExportAssetActivityInputs(exported_asset_id=asset.id))
 
     assert exc_info.value.non_retryable is expected_non_retryable
+
+
+async def test_record_export_failure_activity_records_on_empty_asset(activity_environment, team):
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        export_format=ExportedAsset.ExportFormat.CSV,
+    )
+
+    await activity_environment.run(
+        record_export_failure_activity,
+        RecordExportFailureInputs(
+            exported_asset_id=asset.id,
+            message="Export failed to complete",
+            exception_type="TimeoutError",
+        ),
+    )
+
+    await sync_to_async(asset.refresh_from_db)()
+    assert asset.exception == "Export failed to complete"
+    assert asset.exception_type == "TimeoutError"
+    # TimeoutError classifies as a generation timeout via failure_handler
+    assert asset.failure_type == "timeout_generation"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"exception": "the real error", "exception_type": "QueryError"},
+        {"content": b"already-has-bytes"},
+    ],
+    ids=["existing_exception", "has_content"],
+)
+async def test_record_export_failure_activity_does_not_clobber_terminal_state(activity_environment, team, kwargs):
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        export_format=ExportedAsset.ExportFormat.CSV,
+        **kwargs,
+    )
+
+    await activity_environment.run(
+        record_export_failure_activity,
+        RecordExportFailureInputs(
+            exported_asset_id=asset.id,
+            message="should not overwrite",
+            exception_type="TimeoutError",
+        ),
+    )
+
+    await sync_to_async(asset.refresh_from_db)()
+    assert asset.exception == kwargs.get("exception")

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -14,7 +14,7 @@ from posthog.hogql.errors import QueryError
 from posthog.errors import CHQueryErrorS3Error
 from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.temporal.common.slo_interceptor import SloInterceptor
-from posthog.temporal.exports.activities import export_asset_activity
+from posthog.temporal.exports.activities import export_asset_activity, record_export_failure_activity
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 
 from products.exports.backend.models.exported_asset import ExportedAsset
@@ -31,7 +31,7 @@ async def _run_export_workflow(env, asset, team, mock_exporter, fake_export):
         env.client,
         task_queue=settings.TEMPORAL_TASK_QUEUE,
         workflows=[ExportAssetWorkflow],
-        activities=[export_asset_activity],
+        activities=[export_asset_activity, record_export_failure_activity],
         interceptors=[SloInterceptor()],
         workflow_runner=UnsandboxedWorkflowRunner(),
         activity_executor=ThreadPoolExecutor(max_workers=5),
@@ -203,3 +203,29 @@ async def test_export_failure_emits_slo_outcome(
     assert props["error_type"] == expected_exception_class
     assert props["error_message"] == expected_error_msg
     assert "Traceback" in props["error_trace"]
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_terminal_failure_is_recorded_on_asset(
+    mock_exporter: MagicMock,
+    mock_analytics: MagicMock,
+    team,
+):
+    # Simulate a worker that dies before its in-process handler can persist an exception:
+    # the export raises but leaves the asset empty with no exception recorded.
+    asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
+
+    def silent_failing_export(asset_obj, **kwargs):
+        raise QueryError("Invalid HogQL query")
+
+    with pytest.raises(Exception):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            await _run_export_workflow(env, asset, team, mock_exporter, silent_failing_export)
+
+    # The workflow must record the terminal failure so the asset is never left silently empty.
+    await sync_to_async(asset.refresh_from_db)()
+    assert not asset.has_content
+    assert asset.exception is not None
+    assert "Invalid HogQL query" in asset.exception
+    assert asset.exception_type == "QueryError"

--- a/products/exports/backend/api/exports.py
+++ b/products/exports/backend/api/exports.py
@@ -25,7 +25,6 @@ from posthog.models.organization import Organization
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.security.url_validation import is_url_allowed
-from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
 from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.common.client import async_connect
@@ -33,7 +32,12 @@ from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 from posthog.temporal.session_replay.rasterize_recording.types import RasterizeRecordingInputs
 
-from products.exports.backend.models.exported_asset import ExportedAsset, get_content_response
+from products.exports.backend.models.exported_asset import (
+    STUCK_EXPORT_MESSAGE,
+    ExportedAsset,
+    get_content_response,
+    is_export_stuck,
+)
 from products.product_analytics.backend.models.insight import Insight
 
 # Full video exports per team per calendar month, tiered by plan.
@@ -80,17 +84,11 @@ class ExportedAssetSerializer(UserAccessControlSerializerMixin, serializers.Mode
         """Override to show stuck exports as having an exception."""
         data = super().to_representation(instance)
 
-        # Check if this export is stuck (created over HOGQL_INCREASED_MAX_EXECUTION_TIME seconds ago,
-        # has no content, and has no recorded exception)
-        timeout_threshold = now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + 30)
-        if (
-            timeout_threshold
-            and instance.created_at < timeout_threshold
-            and not instance.has_content
-            and not instance.exception
-        ):
-            timeout_message = f"Export failed without throwing an exception. Please try to rerun this export and contact support if it fails to complete multiple times."
-            data["exception"] = timeout_message
+        # A stuck export (empty well past its timeout budget, no recorded exception) is a silent
+        # failure the workflow never got to record — surface it as an exception so the UI shows a
+        # real error instead of a spinner.
+        if is_export_stuck(instance):
+            data["exception"] = STUCK_EXPORT_MESSAGE
 
             distinct_id = (
                 self.context["request"].user.distinct_id
@@ -102,7 +100,7 @@ class ExportedAssetSerializer(UserAccessControlSerializerMixin, serializers.Mode
                 event="export timeout error returned",
                 properties={
                     **instance.get_analytics_metadata(),
-                    "timeout_message": timeout_message,
+                    "timeout_message": STUCK_EXPORT_MESSAGE,
                     "stuck_duration_seconds": (now() - instance.created_at).total_seconds(),
                 },
                 groups=groups(instance.team.organization, instance.team),

--- a/products/exports/backend/api/test/test_exports.py
+++ b/products/exports/backend/api/test/test_exports.py
@@ -683,6 +683,58 @@ class TestExports(APIBaseTest):
         stuck_export.refresh_from_db()
         self.assertIsNone(stuck_export.exception)
 
+    def test_content_download_of_failed_export_surfaces_error_not_bare_404(self) -> None:
+        export = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard_id=self.dashboard.id,
+            export_format="text/csv",
+            created_by=self.user,
+            content=None,
+            content_location=None,
+            exception="Query exceeded memory limit",
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/exports/{export.id}/content")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        body = response.json()
+        self.assertEqual(body["code"], "export_failed")
+        self.assertIn("Query exceeded memory limit", body["detail"])
+
+    def test_content_download_of_silently_stuck_export_surfaces_error_not_bare_404(self) -> None:
+        with freeze_time(now() - timedelta(seconds=2 * HOGQL_INCREASED_MAX_EXECUTION_TIME)):
+            export = ExportedAsset.objects.create(
+                team=self.team,
+                dashboard_id=self.dashboard.id,
+                export_format="text/csv",
+                created_by=self.user,
+                created_at=now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + 100),
+                content=None,
+                content_location=None,
+                exception=None,
+            )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/exports/{export.id}/content")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "export_failed")
+
+    def test_content_download_of_in_progress_export_is_not_ready_not_404(self) -> None:
+        export = ExportedAsset.objects.create(
+            team=self.team,
+            dashboard_id=self.dashboard.id,
+            export_format="text/csv",
+            created_by=self.user,
+            content=None,
+            content_location=None,
+            exception=None,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/exports/{export.id}/content")
+
+        self.assertEqual(response.status_code, status.HTTP_425_TOO_EARLY)
+        self.assertEqual(response.json()["code"], "export_not_ready")
+
     @parameterized.expand(
         [
             ("retrieve", "/api/projects/{team_id}/exports/{export_id}"),

--- a/products/exports/backend/models/exported_asset.py
+++ b/products/exports/backend/models/exported_asset.py
@@ -10,12 +10,13 @@ from django.utils.text import slugify
 from django.utils.timezone import now
 
 import structlog
-from rest_framework.exceptions import NotFound
+from rest_framework import status
+from rest_framework.exceptions import APIException
 
 from posthog.exceptions_capture import capture_exception
 from posthog.jwt import PosthogJwtAudience, decode_jwt, encode_jwt
 from posthog.models.utils import UUIDT
-from posthog.settings import DEBUG
+from posthog.settings import DEBUG, HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.storage import object_storage
 from posthog.storage.object_storage import ObjectStorageError
 from posthog.utils import absolute_uri
@@ -26,6 +27,34 @@ PUBLIC_ACCESS_TOKEN_EXP_DAYS = 365
 MAX_AGE_CONTENT = 86400  # 1 day
 EXPORTED_ASSET_PURPOSE_RENDER = "render"
 EXPORTED_ASSET_PURPOSE_SUBSCRIPTION_DELIVERY = "subscription_delivery"
+
+# Backstop for an export left empty with no recorded exception this many seconds past its
+# query-timeout budget. The workflow now records terminal failures onto the asset directly,
+# so this only catches the pathological case where the workflow itself never got to record
+# (e.g. it was terminated). Treated as a silent failure rather than "still processing".
+STUCK_EXPORT_GRACE_SECONDS = 30
+
+STUCK_EXPORT_MESSAGE = (
+    "Export failed without throwing an exception. Please try to rerun this export and "
+    "contact support if it fails to complete multiple times."
+)
+
+
+class ExportFailedError(APIException):
+    """The export ran but failed to produce content."""
+
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "This export failed to generate. Please try running it again."
+    default_code = "export_failed"
+
+
+class ExportNotReadyError(APIException):
+    """The export is still being generated and has no content yet."""
+
+    status_code = status.HTTP_425_TOO_EARLY
+    default_detail = "This export is still being generated. Please try again shortly."
+    default_code = "export_not_ready"
+
 
 SEVEN_DAYS = timedelta(days=7)
 SIX_MONTHS = timedelta(days=180)
@@ -240,6 +269,31 @@ def asset_for_token(token: str) -> tuple[ExportedAsset, str | None]:
     return asset, info.get("purpose")
 
 
+def is_export_stuck(asset: ExportedAsset) -> bool:
+    """True if the export produced no content and recorded no exception well past its
+    query-timeout budget — the workflow neither succeeded nor recorded a failure."""
+    if asset.has_content or asset.exception:
+        return False
+    if not asset.created_at:
+        return False
+    timeout_threshold = now() - timedelta(seconds=HOGQL_INCREASED_MAX_EXECUTION_TIME + STUCK_EXPORT_GRACE_SECONDS)
+    return asset.created_at < timeout_threshold
+
+
+def get_export_error(asset: ExportedAsset) -> Optional[str]:
+    """User-facing failure message for an export, or None if it hasn't failed.
+
+    A recorded ``exception`` always wins — the export workflow persists one for every terminal
+    failure. The stuck check is only a backstop for the pathological case where the workflow
+    never got to record, so callers surface a real error instead of pretending the asset is
+    missing."""
+    if asset.exception:
+        return asset.exception
+    if is_export_stuck(asset):
+        return STUCK_EXPORT_MESSAGE
+    return None
+
+
 def get_content_response(asset: ExportedAsset, download: bool = False):
     if asset.content_location:
         content_disposition = f'attachment; filename="{asset.filename}"' if download else None
@@ -253,7 +307,12 @@ def get_content_response(asset: ExportedAsset, download: bool = False):
 
     content = asset.content
     if not content:
-        raise NotFound()
+        # The row exists but has no bytes. Distinguish a genuine failure (surface the real error
+        # instead of a bare 404) from an export that is simply still being generated.
+        error = get_export_error(asset)
+        if error is not None:
+            raise ExportFailedError(error)
+        raise ExportNotReadyError()
 
     res = HttpResponse(content, content_type=asset.export_format)
     if download:


### PR DESCRIPTION
## Problem

Downloading an insight / dashboard / SQL / cohort / logs export via
`/api/environments/:team/exports/:id/content` could return a bare
`{"code":"not_found","detail":"Not found."}` whenever the asset had no bytes —
making a *failed* or *timed-out* export indistinguishable from a genuinely
missing one. Because every export type funnels through the same `get_content_response`,
they all presented identically.

The underlying root cause is deeper than the response shaping: a terminally-failed
export could be left with **no recorded exception at all**. Failures are only
persisted by the in-process handler in `export_asset_direct`. A worker that is
hard-killed before that handler runs — an activity timeout, OOM, or pod eviction,
which is especially easy to hit on heavy SQL / warehouse queries — leaves the
asset empty with `exception = NULL`. The workflow observed the terminal failure
but never wrote it back, so the only signal left was "no content", which the
download endpoint could only surface as a 404.

## Changes

Foundational fix — make the asset's failed state authoritative instead of guessed:

- The export workflow now records the terminal failure onto the asset once its
  retries are exhausted, via a new idempotent safety-net activity
  (`record_export_failure_activity`). It never overwrites content or a more
  specific exception already recorded in-process, so an export can no longer end
  up silently empty regardless of how the worker died.
- With that state now reliable, `get_content_response` distinguishes a real
  failure (`400 export_failed`, carrying the actual message) from an export still
  being generated (`425 export_not_ready`) instead of a blanket 404. The
  time-based "stuck" heuristic is kept only as a last-resort backstop for the
  pathological case where the workflow itself never got to record.
- The list/detail serializer and the raw download now share the same helpers, so
  they agree on an export's state.

**Why:** raised from a support escalation where export downloads across several
orgs (US + EU) were returning `not_found` with no explanation. This addresses the
root cause — unrecorded terminal failures — rather than only the download-response
seam. Complements / supersedes the seam-only #69963.

## How did you test this code?

Added backend tests:

- `test_export_activities.py` — `record_export_failure_activity` records a failure
  on an empty asset and is idempotent (never clobbers an existing exception or
  content). Catches a regression where a killed worker's export is left silently
  empty.
- `test_export_workflow.py::test_terminal_failure_is_recorded_on_asset` — a
  terminal failure where the in-process handler did *not* record an exception
  still leaves the asset with a recorded exception after the workflow fails.
- `test_exports.py` — the content endpoint returns `400 export_failed` (with the
  message) for a failed/stuck export and `425 export_not_ready` for an in-progress
  one, instead of a bare 404. No existing test exercised the owner-accessible
  empty-content path (the existing 404 cases are all RBAC denials).

I (the agent) was not able to run the Django / Temporal suites in this
environment (no local stack); `ruff check` passes on all changed files and they
compile clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc impact — internal export lifecycle behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack investigation thread. The
investigation ruled out the recent exports RBAC change (#64621 only added the
access-control mixin; the `created_by`/resource gate predated it and skips
SQL/cohort/logs) and the generation pipeline (unchanged since June), then traced
the 404 to unrecorded terminal failures. Chose to persist failures at the
workflow level (root cause) rather than only reshape the download response (the
seam). No skills mutated code; `/writing-tests` was consulted before adding tests.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ALCCKESZ/p1783693615835409?thread_ts=1783693615.835409&cid=C09ALCCKESZ)*
