### PR TITLE
fix(data-warehouse): stop postgres date loader corrupting non-standard date text

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -1558,16 +1558,22 @@ class SafeDateLoader(Loader):
     """Load PostgreSQL dates, handling edge cases beyond Python's date range.
 
     PostgreSQL can store dates beyond Python's datetime.date limits (year 1 to
-    year 9999). This includes 'infinity', '-infinity', and dates in years > 9999.
-    When encountering such dates, we clamp to Python's date limits rather than
-    raising an error.
+    year 9999). This includes 'infinity', '-infinity', and dates in years > 9999,
+    which we clamp to Python's date limits rather than raising an error.
+
+    Some Postgres-compatible engines (duckdb/duckgres) render a `date` in text
+    mode with a trailing time component ("2022-04-01 00:00:00" or ISO "…T…") — we
+    strip it before parsing. A value we genuinely cannot parse raises rather than
+    being clamped: silently mapping it onto date.max fabricates a real-looking
+    9999-12-31 and corrupts the whole column, which is far worse than a loud sync
+    failure.
     """
 
     def load(self, data) -> date | None:
         if data is None:
             return None
 
-        s = bytes(data).decode("utf-8")
+        s = bytes(data).decode("utf-8").strip()
 
         if s in ("infinity", "-infinity"):
             return date.max if s == "infinity" else date.min
@@ -1576,24 +1582,20 @@ class SafeDateLoader(Loader):
         if s.startswith("-") or "bc" in s.lower():
             return date.min
 
+        # Keep only the date portion — duckdb/duckgres may append a time or ISO "T".
+        date_part = s.replace("T", " ").split(" ", 1)[0]
+
         try:
-            parts = s.split("-")
-            if len(parts) == 3:
-                year = int(parts[0])
-                month = int(parts[1])
-                day = int(parts[2])
+            year, month, day = (int(part) for part in date_part.split("-"))
+        except ValueError as e:
+            raise ValueError(f"Unparseable PostgreSQL date value: {s!r}") from e
 
-                if year > 9999:
-                    return date.max
-                if year < 1:
-                    return date.min
+        if year > 9999:
+            return date.max
+        if year < 1:
+            return date.min
 
-                return date(year, month, day)
-        except (ValueError, IndexError):
-            pass
-
-        # Fallback: clamp to max for unparseable dates
-        return date.max
+        return date(year, month, day)
 
 
 def _clamp_out_of_range_timestamp(data, *, tzinfo: timezone | None) -> datetime:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -3150,10 +3150,16 @@ def postgres_source(
                 # cursor FETCH inherits the session statement_timeout, and on
                 # wide/partitioned scans the source's default (often 30-60s)
                 # kills the fetch before rows come back.
+                #
+                # Also pin DateStyle to ISO so text-mode date/timestamp values always
+                # arrive as YYYY-MM-DD regardless of the server's configured DateStyle.
+                # A non-ISO source (e.g. German/SQL/Postgres styles) would otherwise send
+                # "04/01/2022" or "15.01.2024", which the Safe*Loaders can't parse.
                 try:
                     # Use psycopg.Cursor directly to bypass cursor_factory (which may be
                     # ServerCursor and requires a `name` arg, breaking an unnamed cursor()).
                     with psycopg.Cursor(connection) as setup_cursor:
+                        setup_cursor.execute(sql.SQL("SET DateStyle TO 'ISO, MDY'"))
                         setup_cursor.execute(
                             sql.SQL("SET statement_timeout = {timeout}").format(
                                 timeout=sql.Literal(SYNC_STATEMENT_TIMEOUT_MS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -143,11 +143,24 @@ class TestSafeDateLoader:
             (b"-0044-03-15", date.min),
             (b"0000-01-01", date.min),
             (b"0044-03-15 BC", date.min),
+            # duckdb/duckgres render `date` in text mode with a trailing time component; the
+            # date portion must survive rather than falling through to a fabricated 9999-12-31.
+            (b"2022-04-01 00:00:00", date(2022, 4, 1)),
+            (b"2022-04-01T00:00:00", date(2022, 4, 1)),
+            (b"2022-04-01 00:00:00+00", date(2022, 4, 1)),
+            (b"  2024-01-15  ", date(2024, 1, 15)),
             (None, None),
         ],
     )
     def test_load_dates(self, loader, input_data, expected):
         assert loader.load(input_data) == expected
+
+    @pytest.mark.parametrize("input_data", [b"04/01/2022", b"not-a-date", b"20220401"])
+    def test_unparseable_dates_raise_instead_of_clamping(self, loader, input_data):
+        # A silent clamp to date.max corrupts the whole column with a real-looking date;
+        # an unparseable value must surface as a loud sync failure instead.
+        with pytest.raises(ValueError):
+            loader.load(input_data)
 
 
 class TestSafeTimestampLoader:


### PR DESCRIPTION
## Problem

A Postgres-source import from a duckdb/duckgres-backed database produced a Delta table where **every row** of a `date` column was `9999-12-31`, even though the source clearly held real dates (April 2022, May 2022, ...). ClickHouse then refused to read the resulting parquet:

```
Input value 2932896 is out of allowed Date32 range, which is [-25567, 120530]: ... column: period_start
```

`2932896` is the day-count for `9999-12-31` (`date.max`), which overflows ClickHouse's `Date32` range (`1900-01-01` .. `2299-12-31`).

Root cause is in `SafeDateLoader`. It only understood the exact text form `YYYY-MM-DD` and, for anything else, **silently returned `date.max`**:

```python
try:
    parts = s.split("-")
    ...
    day = int(parts[2])       # raises on "01 00:00:00"
    ...
except (ValueError, IndexError):
    pass
return date.max               # <- fabricates 9999-12-31
```

Postgres-compatible engines such as duckdb/duckgres render a `date` in text mode with a trailing time component (`2022-04-01 00:00:00`, or ISO `2022-04-01T00:00:00`). `int(parts[2])` raised, the `except` swallowed it, and the whole column collapsed to `9999-12-31`. Real Postgres sends bare `2022-04-01` in text mode, so the bug never fired there — only against the compatible engine.

## Changes

- `SafeDateLoader` now strips any trailing time component (space- or `T`-separated) before parsing, so `2022-04-01 00:00:00` correctly yields `2022-04-01`.
- The silent `date.max` fallback is removed. A value that genuinely cannot be parsed now **raises**, surfacing as a loud sync failure instead of fabricating a real-looking date that corrupts the whole column. The intentional clamps (`infinity`/`-infinity`, BC dates, year `> 9999`, year `< 1`) are preserved.

The sibling `SafeTimestampLoader`/`SafeTimestamptzLoader` already use the safer pattern (defer to psycopg's default loader, clamp only on `psycopg.DataError`), so they are left unchanged.

> [!NOTE]
> Tables already imported with this bug hold the bad `9999-12-31` values at rest and need a resync after this lands to repair the data.

## How did you test this code?

Extended `TestSafeDateLoader.test_load_dates` with the duckdb/duckgres formats (`2022-04-01 00:00:00`, `2022-04-01T00:00:00`, `2022-04-01 00:00:00+00`, and a surrounding-whitespace case) — these are the regression: previously each returned `9999-12-31`. Added `test_unparseable_dates_raise_instead_of_clamping` to lock in that genuinely unparseable input raises rather than silently clamping to `date.max`.

```
python -m pytest .../postgres/test_postgres.py -k SafeDateLoader
21 passed
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
