### PR TITLE
docs: add user-facing copy section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,17 +166,13 @@ See [.agents/security.md](.agents/security.md) for security guidelines — least
 
 ## User-facing copy
 
-Applies to every string a person reads: UI labels, buttons, tooltips, empty states, error and success messages, notifications, docs, and support or customer replies.
-When copy matters and you're unsure whether it reads well, ask a human rather than guessing.
+For any text a person reads (UI labels, tooltips, empty/error states, notifications, docs, support replies). When unsure whether copy reads well, ask a human.
 
-- PostHog writes in sentence case, not Title Case: capitalize only the first word and proper nouns.
-  This covers product names ('Product analytics', not 'Product Analytics'), buttons, tab text, tooltips, titles, and headings ('Save as view', not 'Save As View').
-- Do not use the common signatures of AI-generated text.
-  No em dashes (—); no "it's not just X, it's Y" constructions; no rule-of-three padding; no hedging setups ("Here's the thing:", "A few things to note:"); no tidy parallel-list scaffolding.
-  Write like a person typed it, and when a phrasing feels machine-generated but you can't tell, ask a human.
-- Plain language, no jargon. Never leak internal terminology or code identifiers into user-facing text. Name the actual feature or plan (not "premium PostHog offering"), and use the labels a user sees in the UI, never internal field names (`surveyPopupDelaySeconds` becomes "Delay the survey popup").
-- Be direct and friendly. Get to the point, keep sentences short and each paragraph about one thing, and keep the tone consistent across tooltips, modals, empty states, and error pages. Explain things the way you would to a smart colleague, not in a corporate memo.
-- Error and empty states must guide, not dead-end. An error says what happened and what to do next; a permission error names which permission and how to get it; an empty state points to the next action.
+- Sentence case, not Title Case: capitalize only the first word and proper nouns ('Product analytics', 'Save as view').
+- Avoid the tells of AI-generated text: em dashes (—), "not just X, but Y", rule-of-three padding, hedging preambles. Write like a person typed it; if you can't tell, ask a human.
+- Plain language, no jargon. Use the labels users see, not internal names (`surveyPopupDelaySeconds` becomes "Delay the survey popup").
+- Be direct and friendly: short sentences, consistent tone across surfaces.
+- Errors and empty states guide, don't dead-end: say what happened and the next action.
 
 ## Agent automation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,20 @@ See [.agents/security.md](.agents/security.md) for security guidelines — least
 - Reduce nesting: Use early returns, guard clauses, and helper methods to avoid deeply nested code
 - Markdown: prefer semantic line breaks; no hard wrapping
 - Use American English spelling
-- When mentioning PostHog products, the product names should use Sentence casing, not Title Casing. For example, 'Product analytics', not 'Product Analytics'. Any other buttons, tab text, tooltips, etc should also all use Sentence casing. For example, 'Save as view' instead of 'Save As View'.
+
+## User-facing copy
+
+Applies to every string a person reads: UI labels, buttons, tooltips, empty states, error and success messages, notifications, docs, and support or customer replies.
+When copy matters and you're unsure whether it reads well, ask a human rather than guessing.
+
+- PostHog writes in sentence case, not Title Case: capitalize only the first word and proper nouns.
+  This covers product names ('Product analytics', not 'Product Analytics'), buttons, tab text, tooltips, titles, and headings ('Save as view', not 'Save As View').
+- Do not use the common signatures of AI-generated text.
+  No em dashes (—); no "it's not just X, it's Y" constructions; no rule-of-three padding; no hedging setups ("Here's the thing:", "A few things to note:"); no tidy parallel-list scaffolding.
+  Write like a person typed it, and when a phrasing feels machine-generated but you can't tell, ask a human.
+- Plain language, no jargon. Never leak internal terminology or code identifiers into user-facing text. Name the actual feature or plan (not "premium PostHog offering"), and use the labels a user sees in the UI, never internal field names (`surveyPopupDelaySeconds` becomes "Delay the survey popup").
+- Be direct and friendly. Get to the point, keep sentences short and each paragraph about one thing, and keep the tone consistent across tooltips, modals, empty states, and error pages. Explain things the way you would to a smart colleague, not in a corporate memo.
+- Error and empty states must guide, not dead-end. An error says what happened and what to do next; a permission error names which permission and how to get it; an empty state points to the next action.
 
 ## Agent automation
 


### PR DESCRIPTION
## Problem

The "avoid em-dashes" line that used to sit at the top of AGENTS.md was removed (it was a poor prompt and, ironically, the file itself contained em dashes). But the underlying want is real: AI-generated copy has been surfacing in user-facing UI and reading like slop. Rather than one brittle line, we want a proper section on how PostHog wants copy to read.

## Changes

Adds a **User-facing copy** section to AGENTS.md covering every string a person reads (UI labels, buttons, tooltips, empty/error states, notifications, docs, support replies):

- sentence case, not Title Case (this folds in the existing product-name casing rule, which I moved out of the generic code-style list)
- don't use the common signatures of AI-generated text (em dashes, the "it's not just X, it's Y" tic, rule-of-three padding, hedging setups), and ask a human when you can't tell if a phrasing reads naturally
- plain language, no jargon or internal field names in user-facing text
- a direct and friendly tone, consistent across surfaces
- error and empty states that guide rather than dead-end

I also kept the section itself em-dash-free so it doesn't contradict its own advice.

## How did you test this code?

Docs-only change to AGENTS.md. No code paths affected, so no automated tests were run. I visually checked the rendered markdown and confirmed the diff against master is the single new section plus removal of the now-folded-in casing line.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) from a Slack thread. Paul asked for a new "user-facing copy" section seeded with two rules ("no common AI text signatures like em dashes, ask a human when unsure" and "PostHog writes in sentence case"), and left room to rewrite them and add more.

I sourced the supporting rules from writing guidance already in the repo rather than inventing them: the QA copywriting-specialist persona (`.agents/skills/qa-team/references/personas.md`), the surveys support-reply style (`products/surveys/skills/debugging-surveys/SKILL.md`), and the product-name sentence-casing rule that previously lived in the code-style list. The two seed rules were reworded for clarity and I added rules on jargon, tone, and error/empty states.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1783689133347649?thread_ts=1783689133.347649&cid=C0113360FFV)*
