### PR TITLE
feat(notebooks): link to insight from markdown notebook blocks

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
@@ -275,6 +275,9 @@ export type MarkdownNotebookProps = {
     /** In view mode, keep the filters toggle for definitions with `viewModeFilters` — for
      * read-only canvases where the filters panel is the only way to configure a node. */
     allowViewModeFilters?: boolean
+    /** Public/shared read-only renders: hide per-block resource links whose relative URLs would
+     * resolve against the viewer's project rather than the author's. */
+    hideResourceLinks?: boolean
     placeholder?: string
     className?: string
     autoFocus?: boolean
@@ -584,6 +587,7 @@ function MarkdownNotebookEditor({
     focusAIPromptRequest,
     aiWritingNodeIndexes,
     allowViewModeFilters = false,
+    hideResourceLinks = false,
     placeholder = 'Start writing...',
     className,
     autoFocus = false,
@@ -5846,6 +5850,7 @@ function MarkdownNotebookEditor({
                     rememberedComponentPanels: componentPanelCacheEntry?.remembered,
                     persistComponentPanelVisibility,
                     allowViewModeFilters,
+                    hideResourceLinks,
                     isSelected: selectedComponentNodeIds.has(node.id),
                     toggleComponentPanel: (panel) => {
                         const nextPanels = {

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -12,11 +12,11 @@ import {
 
 import {
     IconDatabase,
+    IconExternal,
     IconEye,
     IconGraph,
     IconHide,
     IconList,
-    IconOpenInNew,
     IconPencil,
     IconPeople,
     IconTrash,
@@ -342,7 +342,7 @@ export function NotebookComponentShell({
                             <LemonButton
                                 aria-label="Open in new tab"
                                 size="xsmall"
-                                icon={<IconOpenInNew />}
+                                icon={<IconExternal />}
                                 tooltip="Open in new tab"
                                 to={href}
                                 targetBlank

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -10,7 +10,17 @@ import {
     useState,
 } from 'react'
 
-import { IconDatabase, IconEye, IconGraph, IconHide, IconList, IconPencil, IconPeople, IconTrash } from '@posthog/icons'
+import {
+    IconDatabase,
+    IconEye,
+    IconGraph,
+    IconHide,
+    IconList,
+    IconOpenInNew,
+    IconPencil,
+    IconPeople,
+    IconTrash,
+} from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 import { PostHogErrorBoundary } from '@posthog/react'
 
@@ -91,6 +101,7 @@ export function NotebookComponentShell({
     const hasOpenComponentPanel = componentPanels.filters || componentPanels.results
     const titleDisplay = getComponentTitleDisplay(node, definition)
     const toolbarTitle = getComponentToolbarTitle(node, definition, titleDisplay.label)
+    const href = definition?.getHref?.(node) ?? null
     // The user-set title (props.title) wins; the computed contextual title is the watermark/fallback.
     // A title equal to the component's own label (e.g. code blocks default to "Python") is treated
     // as "no user title" so the field reads as empty by default.
@@ -325,16 +336,28 @@ export function NotebookComponentShell({
                         {resolvedTitle}
                     </div>
                 ) : null}
-                {mode === 'edit' ? (
+                {href || mode === 'edit' ? (
                     <div className="MarkdownNotebook__component-actions">
-                        <LemonButton
-                            aria-label="Delete component"
-                            size="xsmall"
-                            icon={<IconTrash />}
-                            tooltip="Delete"
-                            status="danger"
-                            onClick={deleteNode}
-                        />
+                        {href ? (
+                            <LemonButton
+                                aria-label="Open in new tab"
+                                size="xsmall"
+                                icon={<IconOpenInNew />}
+                                tooltip="Open in new tab"
+                                to={href}
+                                targetBlank
+                            />
+                        ) : null}
+                        {mode === 'edit' ? (
+                            <LemonButton
+                                aria-label="Delete component"
+                                size="xsmall"
+                                icon={<IconTrash />}
+                                tooltip="Delete"
+                                status="danger"
+                                onClick={deleteNode}
+                            />
+                        ) : null}
                     </div>
                 ) : null}
             </div>

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -67,6 +67,10 @@ export type NotebookComponentShellProps = {
     persistComponentPanelVisibility: boolean
     /** Surface-level opt-in for definitions with `viewModeFilters` (read-only canvases). */
     allowViewModeFilters?: boolean
+    /** Public/shared read-only renders: hide the resource link, whose relative URL resolves
+     * against the viewer's project (wrong project or 404 for logged-in viewers, unusable for
+     * anonymous ones). Mirrors the legacy notebook's `!isShared` gate. */
+    hideResourceLinks?: boolean
     isSelected: boolean
     registry: NotebookComponentRegistry
     toggleComponentPanel: (panel: ComponentPanel) => void
@@ -87,6 +91,7 @@ export function NotebookComponentShell({
     rememberedComponentPanels,
     persistComponentPanelVisibility,
     allowViewModeFilters,
+    hideResourceLinks,
     isSelected,
     registry,
     toggleComponentPanel,
@@ -122,6 +127,9 @@ export function NotebookComponentShell({
     const titleDisplay = getComponentTitleDisplay(node, definition)
     const toolbarTitle = getComponentToolbarTitle(node, definition, titleDisplay.label)
     const href = definition?.getHref?.(node) ?? null
+    // Suppress the link on public/shared renders (see hideResourceLinks): its relative URL would
+    // resolve against the viewer's own project rather than the notebook author's.
+    const showResourceLink = !!href && !hideResourceLinks
     // The user-set title (props.title) wins; the computed contextual title is the watermark/fallback.
     // A title equal to the component's own label (e.g. code blocks default to "Python") is treated
     // as "no user title" so the field reads as empty by default.
@@ -418,7 +426,7 @@ export function NotebookComponentShell({
                         {resolvedTitle}
                     </div>
                 ) : null}
-                {href || mode === 'edit' || toolbarMenuItems || showCollapseToggle ? (
+                {showResourceLink || mode === 'edit' || toolbarMenuItems || showCollapseToggle ? (
                     <div className="MarkdownNotebook__component-actions">
                         {showCollapseToggle ? (
                             <LemonButton
@@ -439,13 +447,13 @@ export function NotebookComponentShell({
                                 />
                             </LemonMenu>
                         ) : null}
-                        {href ? (
+                        {showResourceLink ? (
                             <LemonButton
                                 aria-label="Open in new tab"
                                 size="xsmall"
                                 icon={<IconExternal />}
                                 tooltip="Open in new tab"
-                                to={href}
+                                to={href ?? undefined}
                                 targetBlank
                             />
                         ) : null}

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -16,6 +16,7 @@ import {
     IconDatabase,
     IconEllipsis,
     IconExpand,
+    IconExternal,
     IconEye,
     IconPencil,
     IconGraph,
@@ -120,6 +121,7 @@ export function NotebookComponentShell({
     const hasOpenComponentPanel = componentPanels.filters || componentPanels.results
     const titleDisplay = getComponentTitleDisplay(node, definition)
     const toolbarTitle = getComponentToolbarTitle(node, definition, titleDisplay.label)
+    const href = definition?.getHref?.(node) ?? null
     // The user-set title (props.title) wins; the computed contextual title is the watermark/fallback.
     // A title equal to the component's own label (e.g. code blocks default to "Python") is treated
     // as "no user title" so the field reads as empty by default.
@@ -416,7 +418,7 @@ export function NotebookComponentShell({
                         {resolvedTitle}
                     </div>
                 ) : null}
-                {mode === 'edit' || toolbarMenuItems || showCollapseToggle ? (
+                {href || mode === 'edit' || toolbarMenuItems || showCollapseToggle ? (
                     <div className="MarkdownNotebook__component-actions">
                         {showCollapseToggle ? (
                             <LemonButton
@@ -436,6 +438,16 @@ export function NotebookComponentShell({
                                     tooltip="More actions"
                                 />
                             </LemonMenu>
+                        ) : null}
+                        {href ? (
+                            <LemonButton
+                                aria-label="Open in new tab"
+                                size="xsmall"
+                                icon={<IconExternal />}
+                                tooltip="Open in new tab"
+                                to={href}
+                                targetBlank
+                            />
                         ) : null}
                         {mode === 'edit' ? (
                             <LemonButton

--- a/frontend/src/lib/components/MarkdownNotebook/renderNode.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/renderNode.tsx
@@ -35,6 +35,7 @@ export function renderNode({
     rememberedComponentPanels,
     persistComponentPanelVisibility,
     allowViewModeFilters,
+    hideResourceLinks,
     isSelected,
     toggleComponentPanel,
     setLocalComponentPanels,
@@ -83,6 +84,7 @@ export function renderNode({
     rememberedComponentPanels?: ComponentPanelVisibility
     persistComponentPanelVisibility: boolean
     allowViewModeFilters?: boolean
+    hideResourceLinks?: boolean
     isSelected: boolean
     toggleComponentPanel: (panel: ComponentPanel) => void
     setLocalComponentPanels: (nodeId: string, panels: ComponentPanelVisibility) => void
@@ -185,6 +187,7 @@ export function renderNode({
                 rememberedComponentPanels={rememberedComponentPanels}
                 persistComponentPanelVisibility={persistComponentPanelVisibility}
                 allowViewModeFilters={allowViewModeFilters}
+                hideResourceLinks={hideResourceLinks}
                 setLocalComponentPanels={setLocalComponentPanels}
                 rememberComponentPanels={rememberComponentPanels}
                 setBlockRef={setBlockRef}

--- a/frontend/src/lib/components/MarkdownNotebook/types.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/types.ts
@@ -157,6 +157,8 @@ export type NotebookComponentDefinition = {
     defaultProps?: NotebookComponentProps | (() => NotebookComponentProps)
     validateProps?: (props: NotebookComponentProps) => string[]
     getTitle?: (node: NotebookComponentBlockNode) => string | null | undefined
+    /** Canonical PostHog URL the block points at (e.g. the insight, recording, or person it renders), opened in a new tab from the toolbar. */
+    getHref?: (node: NotebookComponentBlockNode) => string | null | undefined
     ViewComponent: (props: NotebookComponentRenderProps) => JSX.Element
     EditComponent?: (props: NotebookComponentRenderProps) => JSX.Element
     exclusiveEditPanel?: boolean

--- a/frontend/src/lib/components/MarkdownNotebook/types.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/types.ts
@@ -163,6 +163,8 @@ export type NotebookComponentDefinition = {
     defaultProps?: NotebookComponentProps | (() => NotebookComponentProps)
     validateProps?: (props: NotebookComponentProps) => string[]
     getTitle?: (node: NotebookComponentBlockNode) => string | null | undefined
+    /** Canonical PostHog URL the block points at (e.g. the insight, recording, or person it renders), opened in a new tab from the toolbar. */
+    getHref?: (node: NotebookComponentBlockNode) => string | null | undefined
     ViewComponent: (props: NotebookComponentRenderProps) => JSX.Element
     EditComponent?: (props: NotebookComponentRenderProps) => JSX.Element
     exclusiveEditPanel?: boolean

--- a/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
@@ -89,8 +89,14 @@ type MarkdownNotebookEntityPickerKind =
 
 export function MarkdownNotebookV2({ debugOpen, onDebugOpenChange }: MarkdownNotebookV2Props): JSX.Element {
     const mountedNotebookLogic = useMountedLogic(notebookLogic)
-    const { isEditable, notebook, markdownEditorValue, markdownEditorInteractionActive, markdownRemoteCarets } =
-        useValues(notebookLogic)
+    const {
+        isEditable,
+        isShared,
+        notebook,
+        markdownEditorValue,
+        markdownEditorInteractionActive,
+        markdownRemoteCarets,
+    } = useValues(notebookLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const markdownRegistry = useMemo(() => getMarkdownRegistryForFeatureFlags(featureFlags), [featureFlags])
     const hiddenInsertCommandKeys = useMemo(
@@ -749,6 +755,7 @@ export function MarkdownNotebookV2({ debugOpen, onDebugOpenChange }: MarkdownNot
                     remoteValue={remoteMarkdown}
                     remoteVersion={notebook?.version}
                     mode={isEditable ? 'edit' : 'view'}
+                    hideResourceLinks={isShared}
                     registry={markdownRegistry}
                     extraInsertCommands={isEditable ? buildExtraInsertCommands : undefined}
                     hiddenInsertCommandKeys={hiddenInsertCommandKeys}

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -220,6 +220,7 @@ export const NOTEBOOK_MARKDOWN_REGISTRY: NotebookComponentRegistry = createMarkd
             insertCommand: definition.insertCommand,
             getTitle: (node: NotebookComponentBlockNode) =>
                 getMarkdownNotebookNodeTitle(node, nodeType, options, label),
+            getHref: (node: NotebookComponentBlockNode) => getMarkdownNotebookNodeHref(node, nodeType, options),
         }
     }),
     {
@@ -313,6 +314,21 @@ export function getMarkdownNotebookNodeTitle(
         getUnknownStringProp(attributes.id) ??
         fallback
     )
+}
+
+export function getMarkdownNotebookNodeHref(
+    node: NotebookComponentBlockNode,
+    nodeType: NotebookNodeType | undefined,
+    options: CreatePostHogWidgetNodeOptions<any> | null
+): string | null {
+    // Reuse the legacy node's `href` (e.g. Query → urls.insightView/urls.insightNew) so saved and
+    // ad-hoc insights, recordings, persons, etc. all expose a link to the underlying resource.
+    if (!options?.href) {
+        return null
+    }
+    const attributes = getNodeAttributes(node.props, node.id, options, nodeType, false)
+    const href = typeof options.href === 'function' ? options.href(attributes) : options.href
+    return href ?? null
 }
 
 export function getNotebookStringProp(value: NotebookPropValue | undefined): string | null {

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -255,6 +255,7 @@ export const NOTEBOOK_MARKDOWN_REGISTRY: NotebookComponentRegistry = createMarkd
             insertCommand: definition.insertCommand,
             getTitle: (node: NotebookComponentBlockNode) =>
                 getMarkdownNotebookNodeTitle(node, nodeType, options, label),
+            getHref: (node: NotebookComponentBlockNode) => getMarkdownNotebookNodeHref(node, nodeType, options),
         }
     }),
     {
@@ -359,6 +360,21 @@ export function getMarkdownNotebookNodeTitle(
         getUnknownStringProp(attributes.id) ??
         fallback
     )
+}
+
+export function getMarkdownNotebookNodeHref(
+    node: NotebookComponentBlockNode,
+    nodeType: NotebookNodeType | undefined,
+    options: CreatePostHogWidgetNodeOptions<any> | null
+): string | null {
+    // Reuse the legacy node's `href` (e.g. Query → urls.insightView/urls.insightNew) so saved and
+    // ad-hoc insights, recordings, persons, etc. all expose a link to the underlying resource.
+    if (!options?.href) {
+        return null
+    }
+    const attributes = getNodeAttributes(node.props, node.id, options, nodeType, false)
+    const href = typeof options.href === 'function' ? options.href(attributes) : options.href
+    return href ?? null
 }
 
 export function getNotebookStringProp(value: NotebookPropValue | undefined): string | null {


### PR DESCRIPTION
## Problem

In the new markdown notebook experience, an embedded insight has no clickable way to jump to the insight itself — you can't open it in a new tab from the notebook. Raised in a Slack thread.

## Changes

Adds an "Open in new tab" button to the markdown notebook component toolbar that links to the underlying resource, shown in both view and edit modes.

- For Query blocks it links to the insight: `urls.insightView` for saved insights and `urls.insightNew` for ad-hoc ones.
- It reuses each legacy node's existing `href` option, so recordings, persons, flags, etc. get the same affordance for free.
- Wiring: a new optional `getHref` on the markdown component definition, populated in the registry from `options.href`, rendered via a `LemonButton` with `targetBlank`.

## How did you test this code?

Not able to run the frontend typecheck/lint locally in this environment (no `node_modules` in the checkout) — relying on CI. No automated tests were added; this is a small UI affordance and the URL construction reuses the existing, already-tested `href` option from the legacy notebook node. Manual verification of the rendered button is left to review.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a Slack thread. No repo skills were required for this change. Explored the two coexisting notebook implementations (legacy TipTap and the new markdown engine) and chose to surface the link generically by reusing the legacy nodes' existing `href` option rather than hardcoding insight-URL logic in the toolbar — this covers saved and ad-hoc insights plus every other node type that already defines an `href`. Left the saved-insight title suppression untouched to keep the change focused on the link.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1783510356208459?thread_ts=1783510356.208459&cid=C0ACRAMJUAG)*
