### PR TITLE
feat(lemon-ui): add opt-in showErrorsOnTouch to LemonFormDialog

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -186,9 +186,10 @@ export const LemonFormDialog = ({
     content,
     primaryButtonProps,
     dialogKey,
+    showErrorsOnTouch,
     ...props
 }: LemonFormDialogProps): JSX.Element => {
-    const logicProps = { errors, dialogKey }
+    const logicProps = { errors, dialogKey, showErrorsOnTouch }
     const logic = lemonDialogLogic(logicProps)
     const { form, isFormValid, formValidationErrors } = useValues(logic)
     const { setFormValues } = useActions(logic)

--- a/frontend/src/lib/lemon-ui/LemonDialog/lemonDialogLogic.test.ts
+++ b/frontend/src/lib/lemon-ui/LemonDialog/lemonDialogLogic.test.ts
@@ -32,6 +32,44 @@ describe('lemonDialogLogic', () => {
         saveView.unmount()
     })
 
+    it('with showErrorsOnTouch, exposes field errors only after the field is touched, and clears once fixed', () => {
+        const logic = lemonDialogLogic({
+            dialogKey: 'touch-gated',
+            showErrorsOnTouch: true,
+            errors: { name: (value: string) => (!value ? 'Name is required' : undefined) },
+        })
+        logic.mount()
+        logic.actions.setFormValues({ name: '' })
+
+        // The form knows it's invalid, but the inline error stays hidden until interaction.
+        expect(logic.values.isFormValid).toBe(false)
+        expect(logic.values.formErrors).toEqual({})
+
+        logic.actions.touchFormField('name')
+        expect(logic.values.formErrors).toEqual({ name: 'Name is required' })
+
+        logic.actions.setFormValues({ name: 'valid' })
+        expect(logic.values.formErrors).toEqual({})
+
+        logic.unmount()
+    })
+
+    it('without showErrorsOnTouch, keeps inline field errors hidden even after a field is touched', () => {
+        const logic = lemonDialogLogic({
+            dialogKey: 'not-touch-gated',
+            errors: { name: (value: string) => (!value ? 'Name is required' : undefined) },
+        })
+        logic.mount()
+        logic.actions.setFormValues({ name: '' })
+        logic.actions.touchFormField('name')
+
+        // Default behavior for every other openForm caller: no inline errors, only the disabled submit.
+        expect(logic.values.isFormValid).toBe(false)
+        expect(logic.values.formErrors).toEqual({})
+
+        logic.unmount()
+    })
+
     it('shares state when no key is provided, falling back to a single default instance', () => {
         const first = lemonDialogLogic({ errors: {} })
         first.mount()

--- a/frontend/src/lib/lemon-ui/LemonDialog/lemonDialogLogic.ts
+++ b/frontend/src/lib/lemon-ui/LemonDialog/lemonDialogLogic.ts
@@ -7,6 +7,8 @@ export type LemonDialogFormPropsType = {
     errors?: Record<string, (value: string) => string | undefined>
     /** Unique key that isolates this dialog's form state from other open dialogs. */
     dialogKey?: string
+    /** Surface field errors inline once a field is touched, instead of only via the submit button tooltip. */
+    showErrorsOnTouch?: boolean
 }
 
 export const lemonDialogLogic = kea<lemonDialogLogicType>([
@@ -15,6 +17,7 @@ export const lemonDialogLogic = kea<lemonDialogLogicType>([
     path((k) => ['components', 'lemon-dialog', 'lemonDialogLogic', k]),
     forms(({ props }) => ({
         form: {
+            options: { showErrorsOnTouch: props.showErrorsOnTouch ?? false },
             defaults: {} as Record<string, string>,
             errors: (values: Record<string, string>) => {
                 const entries = Object.entries(props.errors || []).map(([key, valueOf]) => {


### PR DESCRIPTION
## Problem

`LemonFormDialog` only surfaces form validation errors through the submit button's disabled tooltip. There is no way for a dialog to show the precise, field-level error inline, because the dialog's kea form never opts into kea-forms' touch-gated `formErrors` selector. Callers that want "type an invalid value, see why it's invalid right under the input" cannot get that today.

## Changes

Add an opt-in `showErrorsOnTouch?: boolean` prop to `LemonFormDialog` (and `LemonDialogFormPropsType`). When set, it threads into the dialog form's kea-forms `options`, so `LemonField` renders the field error inline once the field is touched. Default is off, so behavior is unchanged for every existing `openForm` caller. The submit button's disabled state and tooltip are untouched (they read the raw `formValidationErrors` / `isFormValid`, which are independent of touch state).

First consumer is the SQL editor "Save as view" dialog, in the stacked PR on top of this one.

## How did you test this code?

Automated (what I actually ran): added two cases to `lemonDialogLogic.test.ts` and ran `hogli test frontend/src/lib/lemon-ui/LemonDialog/` (10 passing):
- with `showErrorsOnTouch`, `formErrors` is empty before interaction, populates after the field is touched, and clears once corrected;
- without it, `formErrors` stays empty even after touch (guards the default for all other dialogs).

These live at the kea-logic level (the cheapest rung that catches the regression: someone dropping the `options` wiring, or the default flipping to always-on for every dialog). I did not manually exercise this component in a browser in isolation; the consumer PR covers the rendered surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: `/writing-tests` (gated the test down to a logic-level test rather than a flaky jsdom focus/blur render test). I first wrote a render test that exercised focus+blur, but jsdom's tab/blur handling was unreliable; the logic test targets the actual change (the `options` wiring) more precisely and deterministically, so I kept that instead.
