### PR TITLE
feat(data-warehouse): searchable folder picker and inline name errors

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1374,7 +1374,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                                                         labelInMenu: () => (
                                                             <button
                                                                 type="button"
-                                                                className="w-full text-left text-primary px-2 py-1.5"
+                                                                className="w-full text-left text-primary px-2 py-1.5 cursor-pointer"
                                                                 onClick={() => createFolderAndSelect(onChange)}
                                                             >
                                                                 + Add new folder

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -21,7 +21,15 @@ import { type IRange, Uri, editor } from 'monaco-editor'
 import posthog from 'posthog-js'
 import { Suspense } from 'react'
 
-import { LemonCheckbox, LemonDialog, LemonInput, LemonSelect, Spinner, lemonToast, Tooltip } from '@posthog/lemon-ui'
+import {
+    LemonCheckbox,
+    LemonDialog,
+    LemonInput,
+    LemonSearchableSelect,
+    Spinner,
+    lemonToast,
+    Tooltip,
+} from '@posthog/lemon-ui'
 
 import api, { ApiError } from 'lib/api'
 import { tryShowMCPHint } from 'lib/components/MCPHint/mcpHintLogic'
@@ -1325,6 +1333,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                 LemonDialog.openForm({
                     title: 'Save as view',
+                    showErrorsOnTouch: true,
                     initialValues: {
                         viewName: values.activeTab?.name || '',
                         folderId: null,
@@ -1334,7 +1343,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                             ? (values.dags.find((d) => d.id === values.selectedDagId)?.id ?? values.dags[0]?.id ?? null)
                             : undefined,
                     },
-                    description: `View names can only contain letters, numbers, '_', or '$'. Spaces are not allowed.`,
+                    description: `View names must start with a letter, '_', or '$' and can only contain letters, numbers, '_', '.', or '$'. Spaces are not allowed.`,
                     content: (isLoading) =>
                         isLoading ? (
                             <div className="h-[37px] flex items-center">
@@ -1342,7 +1351,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                             </div>
                         ) : (
                             <>
-                                <LemonField name="viewName">
+                                <LemonField name="viewName" label="Name">
                                     <LemonInput
                                         data-attr="sql-editor-input-save-view-name"
                                         disabled={isLoading}
@@ -1353,9 +1362,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                                 <div className="flex gap-2 mt-2">
                                     <LemonField name="folderId" label="Add to folder" className="flex-1">
                                         {({ value, onChange }) => (
-                                            <LemonSelect<string | null>
+                                            <LemonSearchableSelect<string | null>
                                                 value={value}
                                                 onChange={onChange}
+                                                searchPlaceholder="Search folders"
                                                 options={[
                                                     ...folderOptions,
                                                     {


### PR DESCRIPTION
## Problem

The SQL editor "Save as view" dialog validates the view name with `validateSavedQueryName`, but the precise rule violation never reaches the user inline: they see a disabled Submit button and, only on hover, the reason. The dialog's description copy was also stale (it omitted the leading-character rule and the allowed `.`). Separately, the "Add to folder" picker is a plain `LemonSelect`, so with many folders you scroll a long unsearchable list.

Stacked on top of the `LemonFormDialog` `showErrorsOnTouch` opt-in.

## Changes

- Turn on `showErrorsOnTouch` for the "Save as view" dialog, so the exact `validateSavedQueryName` message shows inline once the name field is touched. Submit stays disabled with its existing tooltip as secondary feedback.
- Label the name field `Name`.
- Fix the description copy to match the real rule: names must start with a letter, `_`, or `$`, and may contain letters, numbers, `_`, `.`, or `$` (no spaces).
- Swap the folder `LemonSelect` for the existing `LemonSearchableSelect` with a "Search folders" box, so a long folder list can be filtered by name. "No folder", "+ Add new folder", newly created folder selection, and submit behavior are unchanged.

No backend, API, generated-type, or docs changes.

## How did you test this code?

Automated (what I actually ran): `hogli ci:preflight` (0 failures) and `hogli test frontend/src/lib/lemon-ui/LemonDialog/` (the `showErrorsOnTouch` wiring this PR relies on is covered by the base PR's logic tests). No new test in this PR: the changes are a config flag, static copy, a field label, and a swap to an already-tested shared component, so there's no new regression a test would catch that existing coverage doesn't.

I drove the live "Save as view" modal via a headless browser to confirm the flow, but the running local dev server is built from a different worktree, so it renders the pre-change UI. I could not render this branch's AFTER state live without restarting that server. Screenshots to follow once verified in a build of this branch.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Decisions: kept the folder-search change a straight drop-in to `LemonSearchableSelect` (the "+ Add new folder" action is allowed to filter out while searching and reappears when the query clears) rather than adding custom always-visible handling, per the requester's preference for the simplest swap. Shipped as a 2-PR Graphite stack so the reusable `LemonFormDialog` change is reviewable on its own.
