### PR TITLE
chore(insights): remove funnels-compare feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -422,7 +422,6 @@ export const FEATURE_FLAGS = {
     POSTHOG_CODE_BILLING: 'posthog-code-billing', // owner: #team-posthog-code
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics
-    PRODUCT_ANALYTICS_FUNNELS_COMPARE: 'product-analytics-funnels-compare', // owner: @thmsobrmlr #team-product-analytics, gates "Compare to previous" toggle on funnel insights
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS: 'product-analytics-insights-tooltips', // owner: #team-product-analytics, gates the unified quill DefaultTooltip for trends/retention/stickiness insight charts

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -7,9 +7,8 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
-import { FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
+import { NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { alignResolvedDateRangeToInterval, formatResolvedDateRange } from 'lib/utils/datetime'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { InsightDateFilter } from 'scenes/insights/filters/InsightDateFilter'
@@ -50,9 +49,6 @@ export function InsightDisplayConfig(): JSX.Element {
     const { isTrendsFunnel, isStepsFunnel, isTimeToConvertFunnel, isEmptyFunnel } = useValues(
         funnelDataLogic(insightProps)
     )
-    const { featureFlags } = useValues(featureFlagLogic)
-    const funnelsCompareEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE]
-
     const isMetric = display === ChartDisplayType.Metric
     // The slope graph shows the first vs last interval, so it drops the options that need the points
     // between them (compare, smoothing, multiple axes, alert/annotation overlays, statistical analysis).
@@ -66,7 +62,7 @@ export function InsightDisplayConfig(): JSX.Element {
             !isSlopeGraph) ||
         isStickiness ||
         isWebAnalyticsInsightQuery(querySource) ||
-        (funnelsCompareEnabled && isFunnels)
+        isFunnels
     const showInterval =
         isTrendsFunnel ||
         isLifecycle ||

--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -1139,22 +1139,10 @@ describe('insightVizDataLogic', () => {
             [FunnelVizType.TimeToConvert, true],
             // FLOW is excluded — the backend ignores compare for it.
             [FunnelVizType.Flow, false],
-        ] as [FunnelVizType, boolean][])('flag on, %s viz → %s', (funnelVizType, expected) => {
-            featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE]: true,
-            })
+        ] as [FunnelVizType, boolean][])('%s viz → %s', (funnelVizType, expected) => {
             setFunnelVizType(funnelVizType)
 
             expect(builtInsightVizDataLogic.values.supportsCompare).toBe(expected)
-        })
-
-        it('flag off → compare unsupported even for steps viz', () => {
-            featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE]: false,
-            })
-            setFunnelVizType(FunnelVizType.Steps)
-
-            expect(builtInsightVizDataLogic.values.supportsCompare).toBe(false)
         })
     })
 })

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -237,17 +237,17 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         isTrendsLike: [(s) => [s.querySource], (q) => isTrendsQuery(q) || isLifecycleQuery(q) || isStickinessQuery(q)], // this is for filtering out world map
         supportsDisplay: [(s) => [s.querySource], (q) => isTrendsQuery(q) || isStickinessQuery(q)],
         supportsCompare: [
-            (s) => [s.querySource, s.display, s.dateRange, s.featureFlags],
-            (q, display, dateRange, featureFlags) => {
+            (s) => [s.querySource, s.display, s.dateRange],
+            (q, display, dateRange) => {
                 if (dateRange?.date_from === 'all') {
                     return false
                 }
                 if (isTrendsQuery(q) || isStickinessQuery(q) || isWebAnalyticsInsightQuery(q)) {
                     return display !== ChartDisplayType.WorldMap && display !== ChartDisplayType.CalendarHeatmap
                 }
-                // Funnel compare ships behind a flag, for the STEPS, TRENDS and TIME_TO_CONVERT viz
-                // modes. FLOW is excluded — the backend ignores compare for it (mirrors `_is_compare_active`).
-                if (isFunnelsQuery(q) && !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE]) {
+                // Funnel compare is supported for the STEPS, TRENDS and TIME_TO_CONVERT viz modes.
+                // FLOW is excluded — the backend ignores compare for it (mirrors `_is_compare_active`).
+                if (isFunnelsQuery(q)) {
                     return (q.funnelsFilter?.funnelVizType ?? FunnelVizType.Steps) !== FunnelVizType.Flow
                 }
                 return false

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -65,7 +65,6 @@ from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.user import User
-from posthog.ph_client import feature_enabled_or_false
 
 from products.cohorts.backend.models.cohort import Cohort
 
@@ -628,28 +627,10 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         if compare_filter is None or not compare_filter.compare:
             return False
         # Compare is supported for the STEPS, TRENDS and TIME_TO_CONVERT viz modes. FLOW is excluded.
-        if self.context.funnelsFilter.funnelVizType not in (
+        return self.context.funnelsFilter.funnelVizType in (
             FunnelVizType.STEPS,
             FunnelVizType.TRENDS,
             FunnelVizType.TIME_TO_CONVERT,
-        ):
-            return False
-        return self._team_flag_funnels_compare()
-
-    def _team_flag_funnels_compare(self) -> bool:
-        return feature_enabled_or_false(
-            "product-analytics-funnels-compare",
-            str(self.team.uuid),
-            groups={
-                "organization": str(self.team.organization_id),
-                "project": str(self.team.id),
-            },
-            group_properties={
-                "organization": {"id": str(self.team.organization_id)},
-                "project": {"id": str(self.team.id)},
-            },
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
         )
 
     @cached_property

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -13,7 +13,6 @@ from posthog.test.base import (
     create_person_id_override_by_distinct_id,
     snapshot_clickhouse_queries,
 )
-from unittest.mock import patch
 
 from django.test import override_settings
 
@@ -6094,8 +6093,7 @@ class TestFunnelStepsCompareUDF(ClickhouseTestMixin, APIBaseTest):
             compareFilter=CompareFilter(compare=compare, compare_to=compare_to),
         )
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_default_previous_period_tags_steps(self, _feature_enabled):
+    def test_compare_default_previous_period_tags_steps(self):
         # Current window 2021-06-07 .. 2021-06-13; default previous is the prior 7-day window
         # (2021-05-31 .. 2021-06-06). One full conversion lands in each window.
         journeys_for(
@@ -6126,8 +6124,7 @@ class TestFunnelStepsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual([s["count"] for s in current_steps], [1, 1])
         self.assertEqual([s["count"] for s in previous_steps], [1, 1])
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_with_custom_offset_shifts_previous_window(self, _feature_enabled):
+    def test_compare_with_custom_offset_shifts_previous_window(self):
         # Custom offset `-30d` puts the previous window 30 days before the current window's start
         # (2021-05-08 .. 2021-05-14), regardless of window length. Two conversions land there; a
         # third lands in the *default* previous window (2021-05-31 .. 2021-06-06), which `-30d`
@@ -6160,8 +6157,7 @@ class TestFunnelStepsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         previous_steps = [row for row in results if row["compare_label"] == "previous"]
         self.assertEqual([s["count"] for s in previous_steps], [2, 2])
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_with_empty_previous_period(self, _feature_enabled):
+    def test_compare_with_empty_previous_period(self):
         # Only the current period has events. The previous side must still return a tagged step
         # skeleton (zeroed) so the chart can render two bars per step — a missing previous side
         # would leave steps with a single bar and break the grouped-bar layout.
@@ -6268,8 +6264,7 @@ class TestFunnelStepsBreakdownCompareUDF(ClickhouseTestMixin, APIBaseTest):
             ),
         ]
     )
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_breakdown_compare_aligns_inner_funnels_by_value(self, _name, journeys, expected_counts, _feature_enabled):
+    def test_breakdown_compare_aligns_inner_funnels_by_value(self, _name, journeys, expected_counts):
         journeys_for(
             {key: self._conversion(browser, day) for key, (browser, day) in journeys.items()},
             self.team,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_actors_query_options.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_actors_query_options.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Optional
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
-from unittest.mock import patch
 
 from django.test import override_settings
 
@@ -167,8 +166,7 @@ class TestFunnelActorsQueryOptions(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_options_present_and_breakdown_deduped_when_flag_on(self, _feature_enabled):
+    def test_compare_options_present_and_breakdown_deduped(self):
         self._browser_journeys()
 
         runner = FunnelsQueryRunner(
@@ -192,16 +190,6 @@ class TestFunnelActorsQueryOptions(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(values[0], BREAKDOWN_BASELINE_STRING_LABEL)
         self.assertEqual(set(values[1:]), {"Chrome", "Firefox"})
 
-    @patch("posthoganalytics.feature_enabled", return_value=False)
-    def test_compare_options_absent_when_flag_off(self, _feature_enabled):
-        runner = FunnelsQueryRunner(
-            query=self._funnels_query(compare_filter=CompareFilter(compare=True)),
-            team=self.team,
-        )
-        response = runner.to_actors_query_options()
-
-        self.assertIsNone(response.compare)
-
     @parameterized.expand(
         [
             ("whole_float_matches_frontend_number", 1.0, 1),
@@ -218,8 +206,7 @@ class TestFunnelActorsQueryOptions(ClickhouseTestMixin, APIBaseTest):
         # the frontend holds 1, so a stringified whole float breaks dropdown selection matching.
         self.assertEqual(FunnelsQueryRunner._breakdown_option_value(value), expected)
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_trends_viz_breakdown_from_rows_and_compare_suppressed(self, _feature_enabled):
+    def test_trends_viz_breakdown_from_rows_and_compare_suppressed(self):
         self._browser_journeys()
 
         runner = FunnelsQueryRunner(

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_persons.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_persons.py
@@ -12,7 +12,6 @@ from posthog.test.base import (
     flush_persons_and_events,
     snapshot_clickhouse_queries,
 )
-from unittest.mock import patch
 
 from django.test import override_settings
 from django.utils import timezone
@@ -994,8 +993,7 @@ class TestFunnelComparePersons(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(expected_count, len(results))
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_actor_count_matches_bar_count(self, _feature_enabled) -> None:
+    def test_actor_count_matches_bar_count(self) -> None:
         self._seed_converters_and_dropoffs()
         query = self._compare_query()
 

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_time_to_convert.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_time_to_convert.py
@@ -8,7 +8,6 @@ from posthog.test.base import (
     snapshot_clickhouse_queries,
 )
 from unittest.case import skip
-from unittest.mock import patch
 
 from posthog.schema import (
     CompareFilter,
@@ -672,8 +671,7 @@ class TestFunnelTimeToConvertCompare(ClickhouseTestMixin, APIBaseTest):
             compareFilter=CompareFilter(compare=compare, compare_to=compare_to),
         )
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_returns_two_histograms_on_shared_bins(self, _feature_enabled):
+    def test_compare_returns_two_histograms_on_shared_bins(self):
         # Current window 2021-06-07..06-13: one 600 s conversion.
         # Default previous window 2021-05-31..06-06: one 3600 s conversion.
         journeys_for(

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -10,7 +10,6 @@ from posthog.test.base import (
     _create_person,
     snapshot_clickhouse_queries,
 )
-from unittest.mock import patch
 
 from django.test import override_settings
 
@@ -3476,8 +3475,7 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
             compareFilter=CompareFilter(compare=compare, compare_to=compare_to),
         )
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_default_previous_period_tags_rows(self, _feature_enabled):
+    def test_compare_default_previous_period_tags_rows(self):
         # Current period 2021-06-07 .. 2021-06-13. Default previous is the prior 7-day window
         # (2021-05-31 .. 2021-06-06). One conversion lands in each window.
         journeys_for(
@@ -3515,8 +3513,7 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(current_series["days"][0], "2021-06-07")
         self.assertEqual(previous_series["days"][0], "2021-05-31")
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_with_custom_offset_shifts_previous_window(self, _feature_enabled):
+    def test_compare_with_custom_offset_shifts_previous_window(self):
         # Custom offset `-30d` puts the previous window 30 days before the current window's start
         # regardless of the current window's length.
         journeys_for(
@@ -3549,8 +3546,7 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         # The 2021-06-01 conversion (default-previous window) does NOT contribute here.
         self.assertEqual(previous_series["data"].count(100.0), 1)
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_with_empty_previous_period(self, _feature_enabled):
+    def test_compare_with_empty_previous_period(self):
         # Only the current period has events; previous-period series must still be returned (zeroed).
         journeys_for(
             {
@@ -3573,8 +3569,7 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(previous_series["days"]), 7)
         self.assertEqual(set(previous_series["data"]), {0.0})
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_holds_funnel_window_constant(self, _feature_enabled):
+    def test_compare_holds_funnel_window_constant(self):
         # The previous-period sub-runner must use the same funnel window as the current-period one.
         # Only the date range shifts when compare is on; funnelWindowInterval / funnelWindowIntervalUnit
         # stay put. This is what keeps current and previous comparable.
@@ -3588,28 +3583,7 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         # Sanity: previous query's dateRange differs from current.
         self.assertNotEqual(previous_funnel.context.query.dateRange, runner.query.dateRange)
 
-    @patch("posthoganalytics.feature_enabled", return_value=False)
-    def test_compare_feature_flag_off_returns_single_period(self, _feature_enabled):
-        # When the `funnels-compare` flag is off, the runner ignores compareFilter and behaves
-        # as if compare=False — saved-funnel safety.
-        journeys_for(
-            {
-                "u": [
-                    {"event": "step one", "timestamp": datetime(2021, 6, 8, 10)},
-                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 11)},
-                ],
-            },
-            self.team,
-        )
-
-        results = FunnelsQueryRunner(query=self._build_query(), team=self.team).calculate().results
-
-        # Single-period response: one summarized series, no compare_label tagging.
-        self.assertEqual(len(results), 1)
-        self.assertNotIn("compare_label", results[0])
-
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_compare_with_all_time_date_range(self, _feature_enabled):
+    def test_compare_with_all_time_date_range(self):
         # When date_from='all', mirror trends' behavior: the runner does not reject the query;
         # the previous period is whatever QueryPreviousPeriodDateRange resolves to and rows are
         # tagged accordingly. The frontend toggle hides "compare" when date_from='all', but the

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
 import { useState } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import funnelTopToBottomFixture from '~/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottom.json'
@@ -73,18 +72,12 @@ export const Breakdown: Story = {
 // below), each scaled to the shared baseline — not two periods crammed into one bar.
 export const FunnelTopToBottomCompare: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomCompareFixture} width={720} />,
-    parameters: {
-        featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE],
-    },
 }
 
 // Breakdown + compare: each step stacks a bar per (breakdown value, period), paired by value with
 // the previous-period bar desaturated under its current-period sibling.
 export const FunnelTopToBottomBreakdownCompare: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomBreakdownCompareFixture} width={720} />,
-    parameters: {
-        featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE],
-    },
 }
 
 // Narrow widths force the step footers to wrap — each row should grow to fit its own text

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
 import { useState } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import {
     createInsightStory,
     insightSceneMswDecorator,
@@ -134,10 +133,8 @@ export const GoalLine: Story = {
 }
 
 // Compare to previous: current and previous period conversion rates render as separate series
-// (the funnels-compare flag gates this — without it the data degrades to single-period rendering)
 export const Compare: Story = {
     render: () => renderFunnelLineChart(funnelHistoricalTrendsCompareFixture),
-    parameters: { featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE] },
 }
 
 // Full insight scene in edit mode — the funnel trends editor

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
 import { useState } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import {
     createInsightStory,
     expandFirstPropertyFilter,
@@ -84,7 +83,6 @@ export const Breakdown: Story = {
 // each capped at its period's entry level so a shorter period leaves a blank volume gap above its track.
 export const Compare: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomCompareFixture} />,
-    parameters: { featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE] },
 }
 
 // Breakdown + compare: each breakdown value shows its own conversion within its period, and the two
@@ -92,7 +90,6 @@ export const Compare: Story = {
 // larger period filling the column and the smaller one proportionally short, leaving a blank gap above.
 export const BreakdownAndCompare: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomBreakdownCompareFixture} />,
-    parameters: { featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE] },
 }
 
 // Full insight scene in edit mode — the steps funnel editor, and the funnels query kind's full data pipeline


### PR DESCRIPTION
## TL;DR

The "Compare to previous" toggle on funnel insights used to be hidden behind a feature flag. It's now rolled out to everyone, so I'm removing the flag and turning the feature on for all.

## Problem

`product-analytics-funnels-compare` gated the funnel compare-to-previous feature during rollout. The feature has fully shipped, so the flag is now dead weight and adds a per-query flag check plus flag plumbing across the frontend, backend, tests, and stories.

**Why:** clean up the flag now that funnel compare is generally available.

## Changes

- Remove the `PRODUCT_ANALYTICS_FUNNELS_COMPARE` constant.
- Frontend: `showCompare` in `InsightDisplayConfig` and `supportsCompare` in `insightVizDataLogic` no longer check the flag — funnel compare is always on (FLOW viz still excluded, mirroring the backend).
- Backend: `_is_compare_active` in the funnels query runner drops the team-flag lookup.
- Drop the now-obsolete flag-off tests and the flag toggling in the remaining compare tests and stories.

## How did you test this code?

Ran `ruff check` and `ruff format` on the backend funnels package (clean). Frontend lint/typecheck couldn't run in this environment (`node_modules` not installed). The compare test suites keep their assertions; only the flag-gating cases were removed since that branch no longer exists.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) at Thomas's direction to remove the flag. Invoked the `/writing-tests` skill before pruning the flag-gated tests. Chose to make funnel compare unconditionally available (matching the fully-rolled-out state) rather than adjust the flag default, and removed the flag-off test cases because the branch they covered no longer exists.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
