### PR TITLE
chore(warehouse-sources): note egress path for posthog-owned budgets

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -453,6 +453,16 @@ If undocumented, keep parsing/merge logic conservative and add a short code comm
 - Bound and make deterministic (`stop_after_attempt`). Preserve clear terminal behavior.
 - Keep timeout/retry settings near the top of the module for easy tuning.
 
+The backoff above is the right control when the **customer owns the credential** — their own PAT / API key / OAuth token on their own third-party account, which is nearly every source.
+PostHog can't overspend a budget it doesn't own, so honoring `429` / `Retry-After` at the source is enough.
+
+**The exception is a credential PostHog owns and shares across processes** — today that's the PostHog GitHub App installation token (many PostHog subsystems draw from one per-installation budget at once).
+There, reactive backoff isn't enough: without coordination, concurrent PostHog callers collectively blow past the shared limit before any `429` comes back.
+Those calls must route through [`posthog/egress/`](../../../posthog/egress/README.md) — a Redis-backed shared budget plus telemetry, gated by construction — never hand-rolled `requests`.
+The GitHub source (`sources/github/github.py`) is the reference: it keys the limiter on the **GitHub App installation id** (the budget owner in GitHub's own id space, not a PostHog DB row), and the customer-PAT path skips the limiter token-blind.
+Raw calls to `api.github.com` are blocked by the `github-api-calls-go-through-egress` semgrep rule, so a GitHub-shaped source lands on the egress path by construction.
+Deciding question is never "is this a warehouse source?" — it's **"who owns the token, and could concurrent PostHog processes trample each other on it?"**
+
 ## Fan-out endpoints
 
 Fan-out = iterate a parent resource, then query child endpoints per parent.

--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -459,7 +459,7 @@ PostHog can't overspend a budget it doesn't own, so honoring `429` / `Retry-Afte
 **The exception is a credential PostHog owns and shares across processes** — today that's the PostHog GitHub App installation token (many PostHog subsystems draw from one per-installation budget at once).
 There, reactive backoff isn't enough: without coordination, concurrent PostHog callers collectively blow past the shared limit before any `429` comes back.
 Those calls must route through [`posthog/egress/`](../../../posthog/egress/README.md) — a Redis-backed shared budget plus telemetry, gated by construction — never hand-rolled `requests`.
-The GitHub source (`sources/github/github.py`) is the reference: it keys the limiter on the **GitHub App installation id** (the budget owner in GitHub's own id space, not a PostHog DB row), and the customer-PAT path skips the limiter token-blind.
+The [GitHub source](../../../products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py) is the reference: it keys the limiter on the **GitHub App installation id** (the budget owner in GitHub's own id space, not a PostHog DB row), and the customer-PAT path skips the limiter token-blind.
 Raw calls to `api.github.com` are blocked by the `github-api-calls-go-through-egress` semgrep rule, so a GitHub-shaped source lands on the egress path by construction.
 Deciding question is never "is this a warehouse source?" — it's **"who owns the token, and could concurrent PostHog processes trample each other on it?"**
 


### PR DESCRIPTION
## Problem

The `implementing-warehouse-sources` skill's retry/throttling section only taught reactive backoff. That's the correct control for the common case, where the customer owns the credential (their own PAT or API key on their own third-party account) and PostHog can't overspend a budget it doesn't own.

It said nothing about the exception, and that's the case where not knowing is expensive: a call that spends a budget PostHog owns and shares across processes. Today that's the PostHog GitHub App installation token. Many PostHog subsystems draw from one per-installation budget at once, so concurrent callers overshoot the shared limit before any 429 comes back. Those calls have to go through `posthog/egress/`, and a raw call to `api.github.com` is already blocked by the `github-api-calls-go-through-egress` semgrep rule.

With Gilbert09 adding a lot of API-based warehouse sources, a GitHub-shaped source authored from the skill alone would either add an unpoliced caller to a shared budget or hit the semgrep wall with no idea why.

## Changes

Adds a short note to the "Retry and throttling strategy" section that draws the line by credential ownership, not by "is this a warehouse source":

- Frames the existing backoff guidance as correct for customer-owned credentials.
- Calls out the exception (a budget PostHog owns and shares) and points at `posthog/egress/` with the GitHub source as the reference.
- Notes the identity rule (key on the GitHub App installation id, not a PostHog DB row) and that the customer-PAT path skips the limiter token-blind.
- Ends on the deciding question so nobody reads it as "DWH is exempt."

Docs/skill only, no code or behavior change.

## How did you test this code?

Nothing to run, it's a markdown-only skill change. `hogli ci:preflight --strict` passed (markdown formatting via oxfmt, one file). No product or manual testing applies.

## Docs update

Add `skip-inkeep-docs` if desired — this is an internal agent skill, not user-facing product docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Julian) asked Claude to check whether the egress package I built should be surfaced to the warehouse-source authors, since Gilbert09 is landing many API sources. We talked through the boundary: egress isn't "PostHog's own traffic," it's calls that spend a budget PostHog owns and shares. Almost all DWH sources use customer-owned credentials, so they legitimately sit outside egress and reactive backoff is enough. The one that doesn't is a GitHub-shaped source on the App installation token.

Claude confirmed the `github/github.py` warehouse source already routes through `posthog/egress` (installation-id path hits the limiter, PAT path skips it token-blind), verified the semgrep rule exists, and found the skill had zero pointer to egress. We chose to land the note only in `implementing-warehouse-sources` (the authoring side) since the egress README already documents the warehouse/PAT case from its own side, and to skip the two user-facing MCP source skills since those cover connecting a source through the UI, not writing source code.

No skills were invoked to produce the change beyond editing the skill file itself.
