### PR TITLE
feat(metrics): pin the OTel metric type in saved MetricsQuery insights

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -31660,6 +31660,11 @@
             "enum": ["eq", "neq", "regex", "not_regex"],
             "type": "string"
         },
+        "MetricsOtelType": {
+            "description": "OTel metric type; matches what ingest writes to `metric_type`",
+            "enum": ["gauge", "sum", "histogram", "exponential_histogram", "summary"],
+            "type": "string"
+        },
         "MetricsQuery": {
             "additionalProperties": false,
             "properties": {
@@ -31723,6 +31728,10 @@
                 },
                 "metricName": {
                     "type": "string"
+                },
+                "metricType": {
+                    "$ref": "#/definitions/MetricsOtelType",
+                    "description": "Series identity includes the OTel type — one name can exist as e.g. both a counter and a gauge — so a clause pins it to avoid blending distinct series."
                 },
                 "name": {
                     "description": "Alias a formula refers to (e.g. \"a\"); must be unique within the query",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3515,6 +3515,9 @@ export type MetricsAttributeScope = 'resource' | 'attribute' | 'auto'
 
 export type MetricsFilterOp = 'eq' | 'neq' | 'regex' | 'not_regex'
 
+/** OTel metric type; matches what ingest writes to `metric_type` */
+export type MetricsOtelType = 'gauge' | 'sum' | 'histogram' | 'exponential_histogram' | 'summary'
+
 export type MetricsAggregation =
     | 'sum'
     | 'avg'
@@ -3543,6 +3546,9 @@ export interface MetricsQueryClause {
     name: string
     metricName: string
     aggregation: MetricsAggregation
+    /** Series identity includes the OTel type — one name can exist as e.g. both a
+     * counter and a gauge — so a clause pins it to avoid blending distinct series. */
+    metricType?: MetricsOtelType
     filters?: MetricsQueryFilter[]
     groupBy?: MetricsQueryGroupBy[]
     /** In (0, 1); required for `quantile` / `histogram_quantile` aggregations */

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -177,6 +177,7 @@ from posthog.schema_enums import (
     MetricsAggregation as MetricsAggregation,
     MetricsAttributeScope as MetricsAttributeScope,
     MetricsFilterOp as MetricsFilterOp,
+    MetricsOtelType as MetricsOtelType,
     MetricSummary as MetricSummary,
     MrrOrGross as MrrOrGross,
     MultipleBreakdownType as MultipleBreakdownType,
@@ -5454,6 +5455,14 @@ class MetricsQueryClause(BaseModel):
     filters: list[MetricsQueryFilter] | None = None
     groupBy: list[MetricsQueryGroupBy] | None = None
     metricName: str
+    metricType: MetricsOtelType | None = Field(
+        default=None,
+        description=(
+            "Series identity includes the OTel type — one name can exist as e.g. both a"
+            " counter and a gauge — so a clause pins it to avoid blending distinct"
+            " series."
+        ),
+    )
     name: str = Field(
         ...,
         description=('Alias a formula refers to (e.g. "a"); must be unique within the query'),

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2570,6 +2570,14 @@ class MetricsFilterOp(StrEnum):
     NOT_REGEX = "not_regex"
 
 
+class MetricsOtelType(StrEnum):
+    GAUGE = "gauge"
+    SUM = "sum"
+    HISTOGRAM = "histogram"
+    EXPONENTIAL_HISTOGRAM = "exponential_histogram"
+    SUMMARY = "summary"
+
+
 class MultiQuestionFormFieldType(StrEnum):
     TEXT = "text"
     NUMBER = "number"

--- a/products/metrics/backend/metrics_query_runner.py
+++ b/products/metrics/backend/metrics_query_runner.py
@@ -28,7 +28,7 @@ from posthog.rbac.user_access_control import UserAccessControl
 
 from products.metrics.backend.facade.api import run_metric_query
 from products.metrics.backend.facade.contracts import MetricFilter, MetricGroupBy, MetricQueryClause, MetricQueryRequest
-from products.metrics.backend.facade.enums import AttributeScope, FilterOp, MetricAggregation
+from products.metrics.backend.facade.enums import AttributeScope, FilterOp, MetricAggregation, MetricType
 
 if TYPE_CHECKING:
     from posthog.models import User
@@ -68,6 +68,7 @@ class MetricsQueryRunner(AnalyticsQueryRunner[MetricsQueryResponse]):
                 name=clause.name,
                 metric_name=clause.metricName,
                 aggregation=MetricAggregation(clause.aggregation.value),
+                metric_type=MetricType(clause.metricType.value) if clause.metricType is not None else None,
                 filters=tuple(
                     MetricFilter(
                         key=f.key,

--- a/products/metrics/backend/tests/test_metrics_query_runner.py
+++ b/products/metrics/backend/tests/test_metrics_query_runner.py
@@ -20,7 +20,7 @@ from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.rbac.user_access_control import UserAccessControlError
 
-from products.metrics.backend.facade.enums import AttributeScope, FilterOp, MetricAggregation
+from products.metrics.backend.facade.enums import AttributeScope, FilterOp, MetricAggregation, MetricType
 from products.metrics.backend.metrics_query_runner import MetricsQueryRunner
 from products.metrics.backend.tests._seeder import seed_metric
 
@@ -38,6 +38,7 @@ class TestMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     name="a",
                     metricName="http_requests_total",
                     aggregation="histogram_quantile",
+                    metricType="histogram",
                     quantile=0.95,
                     filters=[MetricsQueryFilter(key="container", op="eq", value="capture", scope="attribute")],
                     groupBy=[MetricsQueryGroupBy(key="namespace")],
@@ -52,6 +53,7 @@ class TestMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         clause = request.clauses[0]
         assert clause.metric_name == "http_requests_total"
+        assert clause.metric_type is MetricType.HISTOGRAM
         assert clause.aggregation is MetricAggregation.HISTOGRAM_QUANTILE
         assert clause.quantile == 0.95
         assert clause.filters[0].op is FilterOp.EQ

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -99,6 +99,7 @@ describe('metricsViewerLogic', () => {
                     name: 'a',
                     metricName: 'request_duration',
                     aggregation: 'quantile',
+                    metricType: 'histogram',
                     quantile: 0.95,
                     filters: [{ key: 'namespace', op: 'eq', value: 'posthog' }],
                     groupBy: [{ key: 'container' }],
@@ -110,6 +111,13 @@ describe('metricsViewerLogic', () => {
 
     it('produces no MetricsQuery node without a metric name', () => {
         expect(logic.values.metricsQueryNode).toBeNull()
+    })
+
+    // A type outside the API enum (or a metric missing from the picker list) must be
+    // omitted, not persisted — the backend rejects unknown metric types.
+    it('omits metricType from the node when the picked type is unknown', () => {
+        logic.actions.setMetricName('mystery_metric')
+        expect(logic.values.metricsQueryNode?.clauses[0]).not.toHaveProperty('metricType')
     })
 
     // A failed query (bad regex, 500) used to render the same "No data" empty state as a genuinely

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -120,6 +120,23 @@ describe('metricsViewerLogic', () => {
         expect(logic.values.metricsQueryNode?.clauses[0]).not.toHaveProperty('metricType')
     })
 
+    // The picker's items are live search results: typing a new search after picking
+    // a metric replaces them. The picked type must be latched, not derived, or a
+    // save at that moment silently persists an untyped (blendable) query.
+    it('keeps the picked metric type when the picker search results change', () => {
+        logic.actions.setMetricName('queue_depth')
+        metricNamePickerLogic.actions.loadItemsSuccess([{ name: 'http_requests', metric_type: 'sum' }] as any)
+        expect(logic.values.metricsQueryNode?.clauses[0].metricType).toBe('gauge')
+    })
+
+    it('backfills the metric type when the picker loads after the metric was set', () => {
+        metricNamePickerLogic.actions.loadItemsSuccess([])
+        logic.actions.setMetricName('queue_depth')
+        expect(logic.values.metricsQueryNode?.clauses[0]).not.toHaveProperty('metricType')
+        metricNamePickerLogic.actions.loadItemsSuccess(PICKER_ITEMS)
+        expect(logic.values.metricsQueryNode?.clauses[0].metricType).toBe('gauge')
+    })
+
     // A failed query (bad regex, 500) used to render the same "No data" empty state as a genuinely
     // empty result. The failure records the message so the viewer can show a real error instead.
     // kea-loaders dispatches `<key>Failure(error.message, error)`, so the reducer reads the message.

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -380,8 +380,24 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         // persists, so the saved tile re-runs exactly what the viewer shows.
         // The REST viewer's 'p95' shorthand maps to the node's quantile aggregation.
         metricsQueryNode: [
-            (s) => [s.metricName, s.aggregation, s.dateFrom, s.dateTo, s.groupByKeys, s.queryFilters],
-            (metricName, aggregation, dateFrom, dateTo, groupByKeys, queryFilters): MetricsQuery | null => {
+            (s) => [
+                s.metricName,
+                s.aggregation,
+                s.selectedMetricType,
+                s.dateFrom,
+                s.dateTo,
+                s.groupByKeys,
+                s.queryFilters,
+            ],
+            (
+                metricName,
+                aggregation,
+                selectedMetricType,
+                dateFrom,
+                dateTo,
+                groupByKeys,
+                queryFilters
+            ): MetricsQuery | null => {
                 const trimmedName = metricName.trim()
                 if (!trimmedName) {
                     return null
@@ -390,6 +406,9 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                     name: 'a',
                     metricName: trimmedName,
                     aggregation: aggregation === 'p95' ? 'quantile' : aggregation,
+                    // Pins the OTel type so the saved tile can't blend same-named
+                    // series of different types (mirrors the live viewer's query).
+                    ...(selectedMetricType ? { metricType: selectedMetricType } : {}),
                     ...(aggregation === 'p95' ? { quantile: 0.95 } : {}),
                     ...(queryFilters.length
                         ? {

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -142,13 +142,21 @@ export const resolveDate = (value: string | null | undefined): string | null => 
     return dj.isValid() ? dj.toISOString() : null
 }
 
+// The picker reports raw ingest strings; only enum members may reach the API.
+const toKnownMetricType = (metricType: string | undefined): OtelMetricTypeEnumApi | null => {
+    const known = Object.values(OtelMetricTypeEnumApi) as string[]
+    return metricType && known.includes(metricType) ? (metricType as OtelMetricTypeEnumApi) : null
+}
+
 export const metricsViewerLogic = kea<metricsViewerLogicType>([
     path(['products', 'metrics', 'frontend', 'components', 'metricsViewerLogic']),
     connect(() => ({
         values: [teamLogic, ['currentTeamId'], metricNamePickerLogic, ['items']],
+        actions: [metricNamePickerLogic, ['loadItemsSuccess']],
     })),
     actions({
         setMetricName: (metricName: string) => ({ metricName }),
+        setSelectedMetricType: (metricType: OtelMetricTypeEnumApi | null) => ({ metricType }),
         setAggregation: (aggregation: MetricAggregation) => ({ aggregation }),
         // Auto-applied on metric switch — a separate action so usage tracking can
         // tell it apart from the user picking an aggregation themselves.
@@ -168,6 +176,16 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
     }),
     reducers({
         metricName: ['' as string, { setMetricName: (_, { metricName }) => metricName }],
+        // The picked metric's type, latched at pick time (and backfilled if the
+        // picker list arrives later). Not derived from the picker's `items` —
+        // those are live search results, so typing a new search would wipe a
+        // derived value and queries/saves would silently go untyped. Sent with
+        // queries so a name that exists as several types (e.g. a counter and a
+        // gauge) charts only the picked one instead of blending them.
+        selectedMetricType: [
+            null as OtelMetricTypeEnumApi | null,
+            { setSelectedMetricType: (_, { metricType }) => metricType },
+        ],
         aggregation: [
             DEFAULT_AGGREGATION as MetricAggregation,
             {
@@ -206,12 +224,25 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
     }),
     listeners(({ actions, values, cache }) => ({
         setMetricName: ({ metricName }) => {
+            const metricType = values.items.find((item) => item.name === metricName.trim())?.metric_type
+            actions.setSelectedMetricType(toKnownMetricType(metricType))
             // Each metric type has one sensible default; a manual aggregation pick
             // holds only until the next metric switch.
-            const metricType = values.items.find((item) => item.name === metricName)?.metric_type
             const recommended = metricType ? RECOMMENDED_AGGREGATION_BY_TYPE[metricType] : undefined
             if (recommended && recommended !== values.aggregation) {
                 actions.setRecommendedAggregation(recommended)
+            }
+        },
+        // Recovers the type when the metric name was set before the picker's list
+        // arrived (initial load); an already-latched type is left alone.
+        loadItemsSuccess: () => {
+            if (values.selectedMetricType !== null || !values.hasMetricName) {
+                return
+            }
+            const metricType = values.items.find((item) => item.name === values.metricName.trim())?.metric_type
+            const known = toKnownMetricType(metricType)
+            if (known) {
+                actions.setSelectedMetricType(known)
             }
         },
         saveAsInsightFailure: ({ error }) => {
@@ -365,17 +396,6 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
     })),
     selectors({
         hasMetricName: [(s) => [s.metricName], (metricName) => metricName.trim().length > 0],
-        // The picked metric's type (from the names list). Sent with the query so
-        // a name that exists as several types (e.g. a counter and a gauge)
-        // charts only the picked one instead of blending them.
-        selectedMetricType: [
-            (s) => [s.metricName, s.items],
-            (metricName, items): OtelMetricTypeEnumApi | null => {
-                const metricType = items.find((item) => item.name === metricName.trim())?.metric_type
-                const known = Object.values(OtelMetricTypeEnumApi) as string[]
-                return metricType && known.includes(metricType) ? (metricType as OtelMetricTypeEnumApi) : null
-            },
-        ],
         // The viewer state as a `MetricsQuery` schema node — what "Save as insight"
         // persists, so the saved tile re-runs exactly what the viewer shows.
         // The REST viewer's 'p95' shorthand maps to the node's quantile aggregation.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -27966,11 +27966,24 @@ export namespace Schemas {
       scope?: MetricsAttributeScope | null;
     }
 
+    export type MetricsOtelType = typeof MetricsOtelType[keyof typeof MetricsOtelType];
+
+
+    export const MetricsOtelType = {
+      Gauge: 'gauge',
+      Sum: 'sum',
+      Histogram: 'histogram',
+      ExponentialHistogram: 'exponential_histogram',
+      Summary: 'summary',
+    } as const;
+
     export interface MetricsQueryClause {
       aggregation: MetricsAggregation;
       filters?: MetricsQueryFilter[] | null;
       groupBy?: MetricsQueryGroupBy[] | null;
       metricName: string;
+      /** Series identity includes the OTel type — one name can exist as e.g. both a counter and a gauge — so a clause pins it to avoid blending distinct series. */
+      metricType?: MetricsOtelType | null;
       /** Alias a formula refers to (e.g. "a"); must be unique within the query */
       name: string;
       /** In (0, 1); required for `quantile` / `histogram_quantile` aggregations */


### PR DESCRIPTION
## Problem

The live metrics viewer constrains queries to the picked metric's OTel type so same-named series of different types don't blend (#69412).
The saved `MetricsQuery` schema node dropped that constraint, so a saved insight or dashboard tile could re-run a different query than the viewer showed and silently blend a counter with a gauge of the same name.

## Changes

- Adds an optional `metricType` field to `MetricsQueryClause` (schema + regenerated JSON/Python).
- `MetricsQueryRunner._to_request` threads it into the facade's existing per-clause `metric_type`.
- The viewer's `metricsQueryNode` selector now embeds the picked metric's type, so "Save as insight" persists exactly what the viewer charts. Unknown types are omitted, matching the live-query behavior.

## How did you test this code?

- Extended `test_translates_schema_node_to_facade_request` with a `metricType` assertion (red before the runner change, green after) — catches the runner dropping the field again.
- Extended the `metricsQueryNode` jest test to expect `metricType: 'histogram'`, plus a case asserting unknown types are omitted (the backend rejects them).
- `hogli test products/metrics/backend/tests/test_metrics_query_runner.py` (10 passed) and the metrics component jest suites (46 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — schema-internal correctness fix, no user-facing workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) directed by Daniel.
Skills invoked: /writing-tests.
The facade already supported per-clause `metric_type` (used by the REST viewer path), so the change is a thin threading of the existing capability through the schema node; no query-engine changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*