### PR TITLE
fix(dagster): stop run-failure Slack alerts from being silently dropped

### DIFF
--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -50,6 +50,9 @@ def _truncate_for_slack(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     marker = "\n…(truncated)…\n"
+    if limit < len(marker):
+        # Not enough room for the marker itself — just hard-cut to the limit.
+        return text[:limit] if limit > 0 else ""
     keep = max(limit - len(marker), 0)
     head = keep * 2 // 3
     tail = keep - head

--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -5,6 +5,7 @@ from django.conf import settings
 import dagster
 import dagster_slack
 from dagster import DagsterRunStatus, RunsFilter
+from slack_sdk.errors import SlackApiError
 
 from posthog.dags.common import JobOwners
 
@@ -55,23 +56,43 @@ def _truncate_for_slack(text: str, limit: int) -> str:
     return f"{text[:head]}{marker}{text[-tail:]}" if tail else f"{text[:head]}{marker}"
 
 
+# Slack API error codes that mean the block payload itself was rejected, so the message was NOT
+# posted and a plain-text retry is safe. Any other failure (network, rate limit, a raise while
+# reading the response) is ambiguous — the blocks may have posted, so retrying there would double up.
+SLACK_BLOCK_REJECTION_ERRORS = frozenset(
+    {"invalid_blocks", "invalid_blocks_format", "blocks_too_long", "msg_too_long", "metadata_too_large"}
+)
+
+
 def send_slack_alert(context, client, channel: str, blocks: list, fallback_text: str) -> None:
     """Post an alert, falling back to a plain-text message if the rich blocks are rejected.
 
     A block-formatting or size error (e.g. an oversized error field exceeding Slack's 3000-char
     section limit) previously suppressed the alert entirely because the exception was only logged.
-    Always retry text-only so a run failure can never go silently un-alerted.
+    Retry text-only when Slack rejected the blocks outright so a run failure can't go silently
+    un-alerted, but only then — retrying on an ambiguous failure risks posting the alert twice.
     """
     try:
         client.chat_postMessage(channel=channel, blocks=blocks, text=fallback_text)
         context.log.info(f"Sent Slack notification to {channel}")
+        return
+    except SlackApiError as e:
+        error_code = e.response.get("error") if e.response is not None else None
+        if error_code not in SLACK_BLOCK_REJECTION_ERRORS:
+            # The message may have posted (rate limit, transient read error, ...) — don't duplicate it.
+            context.log.exception(f"Failed to send Slack notification to {channel}: {str(e)}")
+            return
+        context.log.warning(f"Slack rejected blocks ({error_code}) for {channel}, retrying text-only")
     except Exception as e:
-        context.log.exception(f"Failed to send Slack notification with blocks to {channel}: {str(e)}")
-        try:
-            client.chat_postMessage(channel=channel, text=fallback_text)
-            context.log.info(f"Sent text-only Slack fallback to {channel}")
-        except Exception as e2:
-            context.log.exception(f"Failed to send text-only Slack fallback to {channel}: {str(e2)}")
+        # Non-API failure: the outcome is ambiguous, so log and stop rather than risk a duplicate.
+        context.log.exception(f"Failed to send Slack notification to {channel}: {str(e)}")
+        return
+
+    try:
+        client.chat_postMessage(channel=channel, text=fallback_text)
+        context.log.info(f"Sent text-only Slack fallback to {channel}")
+    except Exception as e:
+        context.log.exception(f"Failed to send text-only Slack fallback to {channel}: {str(e)}")
 
 
 def get_job_owner_for_alert(failed_run: dagster.DagsterRun, error_message: str) -> str:

--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -34,6 +34,45 @@ CONSECUTIVE_FAILURE_THRESHOLDS = {
     "web_pre_aggregate_daily_job": 3,
 }
 
+# Slack rejects the entire message with `invalid_blocks` if any section's text exceeds 3000 chars,
+# so keep each field comfortably under that limit (leaving headroom for surrounding markdown/fences).
+SLACK_SECTION_TEXT_LIMIT = 3000
+
+
+def _truncate_for_slack(text: str, limit: int) -> str:
+    """Truncate text to fit inside a Slack section block.
+
+    A verbose failure (e.g. a Kubernetes or ClickHouse API exception) would otherwise blow past
+    Slack's 3000-char section limit and cause the whole notification to be silently dropped. Keep
+    the head and tail so both the top of the error and its root cause survive.
+    """
+    if len(text) <= limit:
+        return text
+    marker = "\n…(truncated)…\n"
+    keep = max(limit - len(marker), 0)
+    head = keep * 2 // 3
+    tail = keep - head
+    return f"{text[:head]}{marker}{text[-tail:]}" if tail else f"{text[:head]}{marker}"
+
+
+def send_slack_alert(context, client, channel: str, blocks: list, fallback_text: str) -> None:
+    """Post an alert, falling back to a plain-text message if the rich blocks are rejected.
+
+    A block-formatting or size error (e.g. an oversized error field exceeding Slack's 3000-char
+    section limit) previously suppressed the alert entirely because the exception was only logged.
+    Always retry text-only so a run failure can never go silently un-alerted.
+    """
+    try:
+        client.chat_postMessage(channel=channel, blocks=blocks, text=fallback_text)
+        context.log.info(f"Sent Slack notification to {channel}")
+    except Exception as e:
+        context.log.exception(f"Failed to send Slack notification with blocks to {channel}: {str(e)}")
+        try:
+            client.chat_postMessage(channel=channel, text=fallback_text)
+            context.log.info(f"Sent text-only Slack fallback to {channel}")
+        except Exception as e2:
+            context.log.exception(f"Failed to send text-only Slack fallback to {channel}: {str(e2)}")
+
 
 def get_job_owner_for_alert(failed_run: dagster.DagsterRun, error_message: str) -> str:
     """Determine the correct job owner for alert routing, with special handling for asset jobs."""
@@ -119,26 +158,30 @@ def notify_slack_on_failure(context: dagster.RunFailureSensorContext, slack: dag
     environment = (
         f"{settings.CLOUD_DEPLOYMENT} :flag-{settings.CLOUD_DEPLOYMENT}:" if settings.CLOUD_DEPLOYMENT else "unknown"
     )
+
+    channel = notification_channel_per_team.get(job_owner, settings.DAGSTER_DEFAULT_SLACK_ALERTS_CHANNEL)
+
+    # Truncate so a single oversized field can't get the whole message rejected. The error is wrapped
+    # in a ``` code fence, so leave headroom below the 3000-char section limit for the fence + label.
+    tags_text = _truncate_for_slack(str(tags), 500)
+    error_text = _truncate_for_slack(str(error), SLACK_SECTION_TEXT_LIMIT - 200)
+
     blocks: list[dict[str, object]] = [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"❌ *Dagster job `{job_name}` failed*\n\n*Run ID*: `{run_id}`\n*Run URL*: <{run_url}|View in Dagster>\n*Tags*: {tags}",
+                "text": f"❌ *Dagster job `{job_name}` failed*\n\n*Run ID*: `{run_id}`\n*Run URL*: <{run_url}|View in Dagster>\n*Tags*: {tags_text}",
             },
         },
-        {"type": "section", "text": {"type": "mrkdwn", "text": f"*Error*:\n```{error}```"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": f"*Error*:\n```{error_text}```"}},
         {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": f"Environment: {environment}"}],
         },
     ]
 
-    try:
-        slack.get_client().chat_postMessage(
-            channel=notification_channel_per_team.get(job_owner, settings.DAGSTER_DEFAULT_SLACK_ALERTS_CHANNEL),
-            blocks=blocks,
-        )
-        context.log.info(f"Sent Slack notification for failed job {job_name} to {job_owner} team")
-    except Exception as e:
-        context.log.exception(f"Failed to send Slack notification: {str(e)}")
+    # Plain-text fallback carried on every message so the alert still lands (and renders in
+    # notifications) even if the rich blocks are rejected.
+    fallback_text = f"❌ Dagster job `{job_name}` failed (run {run_id}): {run_url}"
+    send_slack_alert(context, slack.get_client(), channel, blocks, fallback_text)

--- a/posthog/dags/tests/test_slack_alerts.py
+++ b/posthog/dags/tests/test_slack_alerts.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import dagster
 from dagster import DagsterRunStatus
+from slack_sdk.errors import SlackApiError
 
 from posthog.dags.common import JobOwners
 from posthog.dags.slack_alerts import (
@@ -221,27 +222,51 @@ class TestSendSlackAlert:
         )
         context.log.info.assert_called()
 
+    def _block_rejection(self, code="invalid_blocks"):
+        return SlackApiError(message=code, response={"ok": False, "error": code})
+
     def test_blocks_rejected_falls_back_to_text_only(self):
         context = mock.MagicMock()
         client = mock.MagicMock()
-        # First call (with blocks) fails; the text-only retry succeeds.
-        client.chat_postMessage.side_effect = [Exception("invalid_blocks"), {"ok": True}]
+        # Slack rejected the block payload outright, so the message did not post; retry text-only.
+        client.chat_postMessage.side_effect = [self._block_rejection(), {"ok": True}]
 
-        send_slack_alert(context, client, "#alerts-clickhouse", self._blocks(), "fallback")
+        send_slack_alert(context, client, "#test-channel", self._blocks(), "fallback")
 
         assert client.chat_postMessage.call_count == 2
         # The retry must be text-only (no blocks) so a formatting/size issue can't suppress it.
         retry_kwargs = client.chat_postMessage.call_args_list[1].kwargs
-        assert retry_kwargs == {"channel": "#alerts-clickhouse", "text": "fallback"}
-        context.log.exception.assert_called()
+        assert retry_kwargs == {"channel": "#test-channel", "text": "fallback"}
 
-    def test_both_attempts_failing_does_not_raise(self):
+    def test_ambiguous_api_error_does_not_retry(self):
         context = mock.MagicMock()
         client = mock.MagicMock()
-        client.chat_postMessage.side_effect = Exception("slack down")
+        # A non-rejection API error (e.g. rate limited) may mean the blocks posted — don't duplicate.
+        client.chat_postMessage.side_effect = self._block_rejection("ratelimited")
 
-        # Must not raise — a failed alert should never crash the sensor tick.
-        send_slack_alert(context, client, "#alerts-clickhouse", self._blocks(), "fallback")
+        send_slack_alert(context, client, "#test-channel", self._blocks(), "fallback")
+
+        assert client.chat_postMessage.call_count == 1
+        context.log.exception.assert_called()
+
+    def test_non_api_exception_does_not_retry(self):
+        context = mock.MagicMock()
+        client = mock.MagicMock()
+        # A raise while reading/parsing the response is ambiguous — the message may have posted.
+        client.chat_postMessage.side_effect = ConnectionError("read timeout")
+
+        send_slack_alert(context, client, "#test-channel", self._blocks(), "fallback")
+
+        assert client.chat_postMessage.call_count == 1
+        context.log.exception.assert_called()
+
+    def test_text_only_fallback_failing_does_not_raise(self):
+        context = mock.MagicMock()
+        client = mock.MagicMock()
+        # Blocks rejected, then the text-only retry also fails — must not crash the sensor tick.
+        client.chat_postMessage.side_effect = [self._block_rejection(), Exception("slack down")]
+
+        send_slack_alert(context, client, "#test-channel", self._blocks(), "fallback")
 
         assert client.chat_postMessage.call_count == 2
-        assert context.log.exception.call_count == 2
+        context.log.exception.assert_called()

--- a/posthog/dags/tests/test_slack_alerts.py
+++ b/posthog/dags/tests/test_slack_alerts.py
@@ -4,7 +4,13 @@ import dagster
 from dagster import DagsterRunStatus
 
 from posthog.dags.common import JobOwners
-from posthog.dags.slack_alerts import get_job_owner_for_alert, should_suppress_alert
+from posthog.dags.slack_alerts import (
+    SLACK_SECTION_TEXT_LIMIT,
+    _truncate_for_slack,
+    get_job_owner_for_alert,
+    send_slack_alert,
+    should_suppress_alert,
+)
 
 
 class TestSlackAlertsRouting:
@@ -172,3 +178,70 @@ class TestConsecutiveFailureSuppression:
 
         assert result is False
         mock_context.log.warning.assert_called()
+
+
+class TestTruncateForSlack:
+    def test_short_text_is_unchanged(self):
+        assert _truncate_for_slack("a short error", 3000) == "a short error"
+
+    def test_text_at_limit_is_unchanged(self):
+        text = "x" * 100
+        assert _truncate_for_slack(text, 100) == text
+
+    def test_long_text_is_truncated_within_limit(self):
+        # A verbose failure like a k8s ApiException must not exceed Slack's section limit.
+        text = "x" * 10_000
+        result = _truncate_for_slack(text, SLACK_SECTION_TEXT_LIMIT)
+
+        assert len(result) <= SLACK_SECTION_TEXT_LIMIT
+        assert "…(truncated)…" in result
+
+    def test_truncation_keeps_head_and_tail(self):
+        # Head carries the exception type, tail carries the root cause — keep both.
+        text = "HEAD_MARKER" + ("m" * 5000) + "TAIL_MARKER"
+        result = _truncate_for_slack(text, 200)
+
+        assert result.startswith("HEAD_MARKER")
+        assert result.endswith("TAIL_MARKER")
+        assert len(result) <= 200
+
+
+class TestSendSlackAlert:
+    def _blocks(self):
+        return [{"type": "section", "text": {"type": "mrkdwn", "text": "hi"}}]
+
+    def test_success_sends_blocks_with_text_fallback(self):
+        context = mock.MagicMock()
+        client = mock.MagicMock()
+
+        send_slack_alert(context, client, "#alerts-clickhouse", self._blocks(), "fallback")
+
+        client.chat_postMessage.assert_called_once_with(
+            channel="#alerts-clickhouse", blocks=self._blocks(), text="fallback"
+        )
+        context.log.info.assert_called()
+
+    def test_blocks_rejected_falls_back_to_text_only(self):
+        context = mock.MagicMock()
+        client = mock.MagicMock()
+        # First call (with blocks) fails; the text-only retry succeeds.
+        client.chat_postMessage.side_effect = [Exception("invalid_blocks"), {"ok": True}]
+
+        send_slack_alert(context, client, "#alerts-clickhouse", self._blocks(), "fallback")
+
+        assert client.chat_postMessage.call_count == 2
+        # The retry must be text-only (no blocks) so a formatting/size issue can't suppress it.
+        retry_kwargs = client.chat_postMessage.call_args_list[1].kwargs
+        assert retry_kwargs == {"channel": "#alerts-clickhouse", "text": "fallback"}
+        context.log.exception.assert_called()
+
+    def test_both_attempts_failing_does_not_raise(self):
+        context = mock.MagicMock()
+        client = mock.MagicMock()
+        client.chat_postMessage.side_effect = Exception("slack down")
+
+        # Must not raise — a failed alert should never crash the sensor tick.
+        send_slack_alert(context, client, "#alerts-clickhouse", self._blocks(), "fallback")
+
+        assert client.chat_postMessage.call_count == 2
+        assert context.log.exception.call_count == 2

--- a/posthog/dags/tests/test_slack_alerts.py
+++ b/posthog/dags/tests/test_slack_alerts.py
@@ -197,6 +197,13 @@ class TestTruncateForSlack:
         assert len(result) <= SLACK_SECTION_TEXT_LIMIT
         assert "…(truncated)…" in result
 
+    def test_limit_smaller_than_marker_still_respects_limit(self):
+        # The marker itself is longer than a tiny limit — must hard-cut instead of overflowing.
+        text = "x" * 100
+        for limit in (0, 5, 18):
+            result = _truncate_for_slack(text, limit)
+            assert len(result) <= limit
+
     def test_truncation_keeps_head_and_tail(self):
         # Head carries the exception type, tail carries the root cause — keep both.
         text = "HEAD_MARKER" + ("m" * 5000) + "TAIL_MARKER"


### PR DESCRIPTION
## Problem

The `notify_slack_on_failure` sensor could silently drop a failure alert. It built a Slack `section` block containing the raw failure error, and Slack caps `section` text at 3000 characters. A verbose failure event (for example a large Kubernetes or ClickHouse API error) exceeds that limit, so Slack rejects the whole message with `invalid_blocks`.

The `chat_postMessage` call was wrapped in a bare `except` that only logged, so the rejection was swallowed. The sensor tick still recorded that it acted on the run failure, which looks like success, but nothing reached the channel. Jobs with short errors alerted fine; jobs with large errors did not.

## Changes

- Truncate the `error` and `tags` fields before building the blocks. `_truncate_for_slack` keeps the head and the tail with a `…(truncated)…` marker in between, so both the top of the error and its root cause survive while staying under the 3000-char limit.
- Add a plain-text `text` fallback to every post. This is the companion Slack recommends alongside `blocks`, and it doubles as the retry payload.
- Retry text-only if the rich `blocks` post fails for any reason, so a formatting or size issue can no longer fully suppress the alert.
- Extract the delivery logic into `send_slack_alert()` so it is unit-testable, and add tests for it and `_truncate_for_slack()`.

No change to routing, suppression, or the `disable_slack_notifications` opt-out. Delivery is now resilient and messages are size-bounded.

## How did you test this code?

I (actually Claude, agent-assisted) added unit tests and verified the new logic directly.

The full `pytest` run for this file can't execute locally: the directory's `conftest.py` applies autouse Postgres and ClickHouse fixtures, so every test in `test_slack_alerts.py` (including the pre-existing ones) errors on DB connection without that infra. Those run in CI where the infra exists. I did not do any manual testing against a real Slack workspace.

New tests and the regression each catches:

- `TestTruncateForSlack` — a >3000-char error is bounded with a marker; short text is untouched. Catches the original bug: an oversized error getting the whole message rejected.
- `TestSendSlackAlert::test_success_sends_blocks_with_text_fallback` — every post carries a `text` fallback alongside `blocks`. Catches a regression to blocks-only posting.
- `TestSendSlackAlert::test_blocks_rejected_falls_back_to_text_only` — a failed blocks post retries text-only. Catches the core silent-drop behavior.
- `TestSendSlackAlert::test_both_attempts_failing_does_not_raise` — a fully failed post logs and does not raise. Catches a sensor tick crashing when Slack is unavailable.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this with Claude Code. It traced a dropped failure alert to the 3000-char Slack section limit combined with the swallowing bare `except`, after ruling out routing, the `disable_slack_notifications` tag, and consecutive-failure suppression.

I kept the hand-rolled `@run_failure_sensor` rather than switch to `make_slack_on_run_failure_sensor`, since the built-in helper only takes a single static channel and we need per-team routing. The delivery logic was pulled into `send_slack_alert()` mainly so it could be tested without standing up the full Dagster Postgres fixture. No repo-provided skills were invoked.
