### PR TITLE
chore(rust): bump posthog-rs to 0.19.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
  "moka",
  "natord",
  "object_store",
- "posthog-rs 0.13.3",
+ "posthog-rs",
  "rayon",
  "rdkafka",
  "reqwest 0.12.28",
@@ -2441,7 +2441,7 @@ name = "common-posthog"
 version = "0.1.0"
 dependencies = [
  "httpmock",
- "posthog-rs 0.17.3",
+ "posthog-rs",
  "serde_json",
  "tokio",
  "tracing",
@@ -2882,7 +2882,7 @@ dependencies = [
  "mockall",
  "moka",
  "personhog-common",
- "posthog-rs 0.17.3",
+ "posthog-rs",
  "posthog-symbol-data",
  "proguard",
  "rand 0.8.5",
@@ -7885,33 +7885,9 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.13.3"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2136b5250589588b5b514cd64b286bfb8630f2223e4f56ab1fa3858f1600ab38"
-dependencies = [
- "backtrace",
- "brotli 7.0.0",
- "chrono",
- "derive_builder",
- "flate2",
- "os_info",
- "regex",
- "reqwest 0.13.4",
- "semver",
- "serde",
- "serde_json",
- "sha1",
- "tokio",
- "tracing",
- "uuid",
- "zstd",
-]
-
-[[package]]
-name = "posthog-rs"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f226e5d9495b0b870a88a53bbbd0d80acbcb66321717791a35991fcf4e890f6"
+checksum = "9b19b9f71d36b4f2bd5c6b4db79a1d62c11b7ecf6772294aa5128711ca961f0b"
 dependencies = [
  "backtrace",
  "brotli 7.0.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -200,7 +200,7 @@ aws-smithy-runtime-api = { version = "1.11.5", features = ["client"] }
 aws-smithy-http-client = { version = "1.1.11", features = ["rustls-aws-lc"] }
 mockall = "0.13.0"
 moka = { version = "0.12.15", features = ["sync", "future"] }
-posthog-rs = { version = "0.17.3", features = ["async-client", "capture-v1"] }
+posthog-rs = { version = "0.19.1", features = ["async-client", "capture-v1"] }
 redis = { version = "0.32.7", features = [
   "tokio-comp",
   "cluster",

--- a/rust/batch-import-worker/Cargo.toml
+++ b/rust/batch-import-worker/Cargo.toml
@@ -49,7 +49,7 @@ metrics = { workspace = true }
 url = { workspace = true }
 urlencoding = "2.1"
 moka = { workspace = true }
-posthog-rs = { version = "0.13.3", features = ["async-client", "capture-v1"] }
+posthog-rs = { version = "0.19.1", features = ["async-client", "capture-v1"] }
 
 [dev-dependencies]
 httpmock = { workspace = true }

--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -160,7 +160,7 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
 
         for batch in batches {
             let batch_count = batch.len();
-            if let Err(e) = self.client.capture_batch(batch, true).await {
+            if let Err(e) = self.client.capture_batch_immediate(batch, true).await {
                 // The worker is the only place that sees per-event loss attributed to a
                 // reason: capture counts requests, not events, and a failed import sub-batch
                 // can carry thousands of events. `reason` lets alerting exclude expected


### PR DESCRIPTION
## Problem

posthog-rs 0.19.1 sends error tracking stack frames in canonical wire order (the first SDK flip of PostHog/sdk-specs#11) and carries the demangler-robust SDK-frame stripping fix. Bumping our own services onto it dogfoods the flip end to end: our rust exceptions arrive canonical, pass the cymbal version gate (cutoff 0.19.0), and keep grouping into their existing issues via the legacy fingerprint versions.

The workspace was also carrying two locked copies (0.13.3 for batch-import-worker, 0.17.3 for the workspace) — this unifies them.

## Changes

- Workspace and batch-import-worker pins → 0.19.1, single locked version.
- `capture_batch` became fire-and-forget in 0.19 (enqueue into the bounded transport queue, no delivery result). The import worker depends on per-event loss attribution for its `capture_batch_events_total{reason}` alerting contract, so it moves to `capture_batch_immediate` — same arguments, returns `Result` again, and every error variant `failure_reason` maps still exists unchanged (verified against 0.19.1's `Error` enum; the variant-mapping test still passes).

## How did you test this code?

Automated only:

- `cargo build`/`clippy -D warnings` clean for the three consumers (`common-posthog`, `batch-import-worker`, `cymbal`).
- `cargo test`: batch-import-worker + common-posthog 405 passed, cymbal 281 passed, 0 failures — including the import worker's `failure_reason_maps_every_variant` metric-contract test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal dependency bump.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code did the bump under my direction as part of the wire-order flip rollout: unified the split pins, caught the `capture_batch` fire-and-forget semantics change (silent drops would have broken the import worker's loss accounting) and switched that call site to the immediate-delivery API introduced in posthog-rs #175.
