### PR TITLE
chore(rust): bump posthog-rs to 0.19.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7887,9 +7887,9 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bcf2bdf6c269ff65ff9d4f360bc5f42d560afff96a589d873326594d473bd6"
+checksum = "9b19b9f71d36b4f2bd5c6b4db79a1d62c11b7ecf6772294aa5128711ca961f0b"
 dependencies = [
  "backtrace",
  "brotli 7.0.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -200,7 +200,7 @@ aws-smithy-runtime-api = { version = "1.11.5", features = ["client"] }
 aws-smithy-http-client = { version = "1.1.11", features = ["rustls-aws-lc"] }
 mockall = "0.13.0"
 moka = { version = "0.12.15", features = ["sync", "future"] }
-posthog-rs = { version = "0.18.0", features = ["async-client", "capture-v1"] }
+posthog-rs = { version = "0.19.1", features = ["async-client", "capture-v1"] }
 redis = { version = "0.32.7", features = [
   "tokio-comp",
   "cluster",


### PR DESCRIPTION
## Problem

posthog-rs 0.19.1 sends error tracking stack frames in canonical wire order (the first SDK flip of PostHog/sdk-specs#11) and carries the demangler-robust SDK-frame stripping fix. Bumping our own services onto it dogfoods the flip end to end: our rust exceptions arrive canonical, pass the cymbal version gate (cutoff 0.19.0), and keep grouping into their existing issues via the legacy fingerprint versions.

Stacked on #67600 (0.18.0 upgrade + on_error metric) — merge that first; this PR is just the 0.18.0 → 0.19.1 delta on top and retargets to master automatically when it lands.

## Changes

- Workspace pin 0.18.0 → 0.19.1 + lockfile. Nothing else: #67600 already unified the split pins and moved the import worker to `capture_batch_immediate`.

## How did you test this code?

Automated only:

- `cargo build`/`clippy -D warnings` clean for the three consumers (`common-posthog`, `batch-import-worker`, `cymbal`).
- `cargo test`: batch-import-worker + common-posthog 687 passed total across the three consumers on top of the stacked branch, 0 failures — including eli's new on_error hook tests and the import worker's `failure_reason_maps_every_variant` metric-contract test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal dependency bump.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code did the bump under my direction as part of the wire-order flip rollout: unified the split pins, caught the `capture_batch` fire-and-forget semantics change (silent drops would have broken the import worker's loss accounting) and switched that call site to the immediate-delivery API introduced in posthog-rs #175.
