### PR TITLE
fix(marketing-analytics): match default utm sources in utm audit

### DIFF
--- a/products/marketing_analytics/backend/services/test_utm_audit.py
+++ b/products/marketing_analytics/backend/services/test_utm_audit.py
@@ -52,7 +52,7 @@ class TestCrossReference:
 
     def test_campaign_with_source_mismatch(self):
         campaigns = [Campaign("Brand Campaign", "789", "google", 200.0, 80, 2000)]
-        utm_events = {("brand campaign", "adwords"): 30}
+        utm_events = {("brand campaign", "partner_newsletter"): 30}
 
         results = _cross_reference(campaigns, utm_events, NO_MAPPINGS, DEFAULT_KNOWN_SOURCES)
 
@@ -418,7 +418,7 @@ class TestBuildAllUtmEvents:
 
     def test_campaign_auto_source_none(self):
         campaigns = [Campaign("brand", "1", "google", 0, 0, 0)]
-        utm_events = {("brand", "adwords"): 30}
+        utm_events = {("brand", "partner_newsletter"): 30}
 
         result = _build_all_utm_events(campaigns, utm_events, NO_MAPPINGS)
 
@@ -426,6 +426,27 @@ class TestBuildAllUtmEvents:
         assert result[0].campaign_match == "auto"
         assert result[0].source_match == "none"
         assert result[0].matched_campaign == "brand"
+
+    @pytest.mark.parametrize(
+        "utm_source,expected_source_match",
+        [
+            ("adwords", "auto"),  # default source of the google integration
+            ("partner_blog", "mapped"),  # custom team mapping
+        ],
+    )
+    def test_default_source_is_auto_and_custom_source_is_mapped(self, utm_source, expected_source_match):
+        campaigns = [Campaign("brand", "1", "google", 0, 0, 0)]
+        utm_events = {("brand", utm_source): 30}
+        mappings = TeamMappings(
+            source_to_integration={"adwords": "google", "partner_blog": "google"},
+            campaign_aliases={},
+            field_preferences={},
+        )
+
+        result = _build_all_utm_events(campaigns, utm_events, mappings)
+
+        assert len(result) == 1
+        assert result[0].source_match == expected_source_match
 
     def test_source_auto_campaign_none(self):
         campaigns = [Campaign("brand", "1", "google", 0, 0, 0)]
@@ -492,17 +513,20 @@ class TestBuildAllUtmEvents:
 
 
 class TestLoadTeamMappings(BaseTest):
-    def test_returns_empty_mappings_when_config_is_none(self):
+    def test_seeds_default_sources_when_config_is_none(self):
         team = MagicMock()
         team.marketing_analytics_config = None
 
         result = _load_team_mappings(team)
 
-        assert result.source_to_integration == {}
+        # Default utm_source values must resolve even without any custom config,
+        # mirroring the adapter defaults attribution uses.
+        assert result.source_to_integration["facebook"] == "meta"
+        assert result.source_to_integration["adwords"] == "google"
         assert result.campaign_aliases == {}
         assert result.field_preferences == {}
 
-    def test_returns_empty_mappings_when_all_config_dicts_are_empty(self):
+    def test_seeds_default_sources_when_all_config_dicts_are_empty(self):
         self.team.marketing_analytics_config.custom_source_mappings = {}
         self.team.marketing_analytics_config.campaign_name_mappings = {}
         self.team.marketing_analytics_config.campaign_field_preferences = {}
@@ -510,9 +534,21 @@ class TestLoadTeamMappings(BaseTest):
 
         result = _load_team_mappings(self.team)
 
-        assert result.source_to_integration == {}
+        assert result.source_to_integration["facebook"] == "meta"
+        assert result.source_to_integration["adwords"] == "google"
         assert result.campaign_aliases == {}
         assert result.field_preferences == {}
+
+    def test_custom_mapping_overrides_default_source(self):
+        # "facebook" is a Meta default, but the team explicitly maps it to GoogleAds.
+        self.team.marketing_analytics_config.custom_source_mappings = {
+            "GoogleAds": ["facebook"],
+        }
+        self.team.marketing_analytics_config.save()
+
+        result = _load_team_mappings(self.team)
+
+        assert result.source_to_integration["facebook"] == "google"
 
     def test_builds_source_to_integration_from_custom_source_mappings(self):
         self.team.marketing_analytics_config.custom_source_mappings = {
@@ -751,6 +787,20 @@ class TestRunUtmAudit(BaseTest):
 
         assert result.campaigns_with_issues == 0
         assert result.results[0].has_utm_events is True
+
+    @patch("products.marketing_analytics.backend.services.utm_audit._get_utm_events")
+    @patch("products.marketing_analytics.backend.services.utm_audit._get_campaigns_with_spend")
+    def test_default_source_counts_as_matched(self, mock_campaigns, mock_utm):
+        # utm_source=facebook is in Meta's default source list: the audit must count
+        # these events as matched (like attribution does), not report a source mismatch.
+        mock_campaigns.return_value = [self._make_campaign("spring sale", "123", "meta", spend=500.0)]
+        mock_utm.return_value = {("spring sale", "facebook"): 75}
+
+        result = run_utm_audit(self.team)
+
+        assert result.campaigns_with_issues == 0
+        assert result.results[0].has_utm_events is True
+        assert result.results[0].event_count == 75
 
     @patch("products.marketing_analytics.backend.services.utm_audit._get_utm_events")
     @patch("products.marketing_analytics.backend.services.utm_audit._get_campaigns_with_spend")

--- a/products/marketing_analytics/backend/services/utm_audit.py
+++ b/products/marketing_analytics/backend/services/utm_audit.py
@@ -38,11 +38,40 @@ from products.marketing_analytics.backend.services.types import (
 logger = structlog.get_logger(__name__)
 
 
+def _default_source_to_integration() -> dict[str, str]:
+    """Map each integration's default utm_source values to its primary source.
+
+    Mirrors the adapter defaults attribution uses: every adapter's
+    `get_source_identifier_mapping` returns `{INTEGRATION_PRIMARY_SOURCE:
+    INTEGRATION_DEFAULT_SOURCES}`, which `MarketingSourceFactory.
+    get_all_source_identifier_mappings` merges with custom mappings. The audit
+    must recognize the same utm_source values attribution does, or it reports
+    "source mismatch" for events attribution happily counts.
+    """
+    result: dict[str, str] = {}
+    for native_source, sources in INTEGRATION_DEFAULT_SOURCES.items():
+        primary = INTEGRATION_PRIMARY_SOURCE.get(native_source)
+        if not primary:
+            continue
+        primary_lower = str(primary).lower().strip()
+        for source in sources:
+            result[source.lower().strip()] = primary_lower
+    return result
+
+
+_DEFAULT_SOURCE_TO_INTEGRATION: dict[str, str] = _default_source_to_integration()
+
+
 def _load_team_mappings(team: Team) -> TeamMappings:
-    """Load custom source mappings and campaign name mappings from team config."""
+    """Load custom source mappings and campaign name mappings from team config.
+
+    `source_to_integration` is seeded with every integration's default utm_source
+    values; custom mappings are layered on top and win on conflict.
+    """
     config = team.marketing_analytics_config
+    source_to_integration: dict[str, str] = dict(_DEFAULT_SOURCE_TO_INTEGRATION)
     if config is None:
-        return TeamMappings(source_to_integration={}, campaign_aliases={}, field_preferences={})
+        return TeamMappings(source_to_integration=source_to_integration, campaign_aliases={}, field_preferences={})
 
     # Build source mapping: custom utm_source values -> the integration's primary source.
     # e.g. custom_source_mappings = {"GoogleAds": ["partner_blog", "affiliate"]} →
@@ -50,7 +79,6 @@ def _load_team_mappings(team: Team) -> TeamMappings:
     # uses "google" as `source_name`. The (target_key, raw_value) pairs come from
     # `iter_custom_source_mappings` so the enum-resolution rules stay shared with
     # `native_integrations.build_combined_alias_map`.
-    source_to_integration: dict[str, str] = {}
     for target_key, raw_value in iter_custom_source_mappings(config.custom_source_mappings):
         native = KEY_TO_NATIVE[target_key]
         primary = INTEGRATION_PRIMARY_SOURCE.get(native)
@@ -281,7 +309,7 @@ def _get_utm_events(team: Team, date_range: QueryDateRange, *, user: User | None
 
 
 def _resolve_source(utm_source: str, mappings: TeamMappings) -> str:
-    """Resolve a utm_source to its integration source using custom mappings."""
+    """Resolve a utm_source to its integration source using default + custom mappings."""
     return mappings.source_to_integration.get(utm_source, utm_source)
 
 
@@ -315,15 +343,17 @@ def _build_all_utm_events(
             if alias not in campaign_lookup:
                 campaign_lookup[alias] = (campaign.campaign_name, MatchType.MAPPED)
 
-    # Pre-compute source lookup: source_name -> match_type
+    # Pre-compute source lookup: source_name -> match_type. Default sources count as
+    # AUTO (recognized without user config); custom mappings count as MAPPED.
     source_lookup: dict[str, str] = {}
     for campaign in campaigns:
         source_name_lower = campaign.source_name.lower().strip()
         if source_name_lower not in source_lookup:
             source_lookup[source_name_lower] = MatchType.AUTO
-    for custom_source, primary_source in mappings.source_to_integration.items():
-        if primary_source in source_lookup and custom_source not in source_lookup:
-            source_lookup[custom_source] = MatchType.MAPPED
+    for source, primary_source in mappings.source_to_integration.items():
+        if primary_source in source_lookup and source not in source_lookup:
+            is_default = _DEFAULT_SOURCE_TO_INTEGRATION.get(source) == primary_source
+            source_lookup[source] = MatchType.AUTO if is_default else MatchType.MAPPED
 
     result: list[UtmEvent] = []
     for (utm_campaign, utm_source), count in utm_events.items():
@@ -332,10 +362,6 @@ def _build_all_utm_events(
         matched_campaign_name = campaign_entry[0] if campaign_entry else None
 
         source_match = source_lookup.get(utm_source, MatchType.NONE)
-        if source_match == MatchType.NONE:
-            resolved = _resolve_source(utm_source, mappings)
-            if resolved in source_lookup:
-                source_match = MatchType.MAPPED if utm_source in mappings.source_to_integration else MatchType.AUTO
 
         result.append(
             UtmEvent(


### PR DESCRIPTION
## Problem

The marketing analytics UTM audit and attribution disagree on default UTM source lists.
Attribution resolves utm_source via `MarketingSourceFactory.get_all_source_identifier_mappings`, which merges each adapter's default sources (e.g. facebook/instagram/fb → meta, adwords/youtube → google) with the team's custom mappings.
The audit's `_load_team_mappings` only consulted custom mappings, so events whose utm_source is in an integration's default list (e.g. `utm_source=facebook` for a Meta campaign) were reported as "source mismatch" / "no tagged events" even though attribution counts them fine.

## Changes

- `utm_audit.py`: build a module-level default map from `INTEGRATION_DEFAULT_SOURCES` + `INTEGRATION_PRIMARY_SOURCE` (the exact constants every adapter's `get_source_identifier_mapping` returns, so the audit stays consistent with attribution) and seed `_load_team_mappings`' `source_to_integration` with it, including when the team has no marketing config. Custom mappings are layered on top and win on conflict.
- `_build_all_utm_events`: default-source matches are labeled `auto` (recognized without user config), custom mappings stay `mapped`. The now-unreachable resolve fallback was removed since the seeded map covers it.

## How did you test this code?

Ran `hogli test products/marketing_analytics/backend/services/test_utm_audit.py` – 68 passed.

New tests and the regression each catches:

- `test_seeds_default_sources_when_config_is_none` / `test_seeds_default_sources_when_all_config_dicts_are_empty` (updated from asserting empty mappings) – fail if `_load_team_mappings` stops seeding defaults, which is exactly the bug being fixed.
- `test_custom_mapping_overrides_default_source` – catches a flip in the layering order (default winning over an explicit custom mapping).
- `test_default_source_counts_as_matched` – end-to-end through `run_utm_audit`: a Meta campaign with `utm_source=facebook` events must produce zero issues.
- `test_default_source_is_auto_and_custom_source_is_mapped` – guards the auto vs mapped labeling in the all-events view.

Two existing tests embodied the old (buggy) expectation and were updated:

- `test_campaign_with_source_mismatch` used `utm_source=adwords` against a Google campaign as its "mismatch" fixture, but adwords is a Google default and now correctly matches. Swapped to an unclaimed source so the test still covers the genuine mismatch path.
- `TestBuildAllUtmEvents.test_campaign_auto_source_none` had the same adwords-vs-google fixture, swapped the same way.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal audit behavior fix with no documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code from a human-confirmed bug report. Skills invoked: /writing-tests.
Chose seeding from `INTEGRATION_DEFAULT_SOURCES`/`INTEGRATION_PRIMARY_SOURCE` over calling `MarketingSourceFactory.get_all_source_identifier_mappings` directly, since the adapters derive their mappings from those same constants and the existing custom-mapping loop (with its shared enum-resolution rules and warning logging) could stay untouched.
