### PR TITLE
fix(dashboards): match tile header date display to backend override semantics

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.test.tsx
@@ -2,9 +2,43 @@ import '@testing-library/jest-dom'
 
 import { render } from '@testing-library/react'
 
-import { InsightMetaContent } from './InsightMeta'
+import { getEffectiveDateOverride, InsightMetaContent } from './InsightMeta'
 
-describe('InsightMetaContent', () => {
+describe('InsightMeta', () => {
+    // A non-empty tile override replaces the dashboard override wholesale on the backend
+    // (apply_dashboard_filters), so the header must not fall back to the dashboard's dates
+    // when the tile override sets none — regression coverage for that all-or-nothing rule.
+    describe('getEffectiveDateOverride', () => {
+        it.each([
+            {
+                label: 'tile override with dates → uses tile dates, ignores dashboard',
+                filtersOverride: { date_from: '-30d' },
+                tileFiltersOverride: { date_from: '-7d' },
+                expected: { dateFromOverride: '-7d', dateToOverride: undefined },
+            },
+            {
+                label: 'tile override without dates (properties-only) → falls back to insight, not dashboard',
+                filtersOverride: { date_from: '-30d' },
+                tileFiltersOverride: { properties: [] },
+                expected: { dateFromOverride: undefined, dateToOverride: undefined },
+            },
+            {
+                label: 'no tile override → uses dashboard override dates',
+                filtersOverride: { date_from: '-30d' },
+                tileFiltersOverride: null,
+                expected: { dateFromOverride: '-30d', dateToOverride: undefined },
+            },
+            {
+                label: 'no overrides at all → no date override',
+                filtersOverride: null,
+                tileFiltersOverride: null,
+                expected: { dateFromOverride: undefined, dateToOverride: undefined },
+            },
+        ])('$label', ({ filtersOverride, tileFiltersOverride, expected }) => {
+            expect(getEffectiveDateOverride(filtersOverride as any, tileFiltersOverride as any)).toEqual(expected)
+        })
+    })
+
     const description = 'Test description content'
 
     // The caller (InsightMeta) computes showDescription from tile.show_description:

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -185,13 +185,17 @@ export function InsightMeta({
     const isSqlInsight = isDataVisualizationNode(insight.query)
     const showCompactHeading = !showCompactTile || !isSqlInsight
 
+    const hasTileOverrides = Object.keys(tileFiltersOverride ?? {}).length > 0
+    // A non-empty tile override replaces the dashboard override wholesale (see apply_dashboard_filters
+    // on the backend), so don't fall back to the dashboard's dates when the tile override has none —
+    // the insight's own date range is what actually applies then.
     const topHeadingProps = {
         query: insight.query,
         lastRefresh: insight.last_refresh,
-        hasTileOverrides: Object.keys(tileFiltersOverride ?? {}).length > 0,
+        hasTileOverrides,
         resolvedDateRange: insightData?.resolved_date_range,
-        dateFromOverride: tileFiltersOverride?.date_from ?? filtersOverride?.date_from,
-        dateToOverride: tileFiltersOverride?.date_to ?? filtersOverride?.date_to,
+        dateFromOverride: hasTileOverrides ? tileFiltersOverride?.date_from : filtersOverride?.date_from,
+        dateToOverride: hasTileOverrides ? tileFiltersOverride?.date_to : filtersOverride?.date_to,
     }
 
     const summary = useSummarizeInsight()(insight.query)

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -40,7 +40,7 @@ import { urls } from 'scenes/urls'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { useInsightDisplayOptions } from '~/queries/nodes/InsightViz/insightDisplayOptions'
-import { Node, ProductKey } from '~/queries/schema/schema-general'
+import { DashboardFilter, Node, ProductKey, TileFilters } from '~/queries/schema/schema-general'
 import { isDataVisualizationNode } from '~/queries/utils'
 import {
     AccessControlLevel,
@@ -103,6 +103,19 @@ interface InsightMetaProps extends Pick<
     onCreateAlert?: () => void
     onEditAlert?: (alertId: AlertType['id']) => void
     onCreateAnomalyAlert?: () => void
+}
+
+// A non-empty tile override replaces the dashboard override wholesale (see apply_dashboard_filters
+// on the backend), so don't fall back to the dashboard's dates when the tile override has none —
+// the insight's own date range is what actually applies then.
+export function getEffectiveDateOverride(
+    filtersOverride: DashboardFilter | null | undefined,
+    tileFiltersOverride: TileFilters | null | undefined
+): { dateFromOverride: string | null | undefined; dateToOverride: string | null | undefined } {
+    const hasTileOverrides = Object.keys(tileFiltersOverride ?? {}).length > 0
+    return hasTileOverrides
+        ? { dateFromOverride: tileFiltersOverride?.date_from, dateToOverride: tileFiltersOverride?.date_to }
+        : { dateFromOverride: filtersOverride?.date_from, dateToOverride: filtersOverride?.date_to }
 }
 
 export function InsightMeta({
@@ -186,16 +199,13 @@ export function InsightMeta({
     const showCompactHeading = !showCompactTile || !isSqlInsight
 
     const hasTileOverrides = Object.keys(tileFiltersOverride ?? {}).length > 0
-    // A non-empty tile override replaces the dashboard override wholesale (see apply_dashboard_filters
-    // on the backend), so don't fall back to the dashboard's dates when the tile override has none —
-    // the insight's own date range is what actually applies then.
+    const dateOverride = getEffectiveDateOverride(filtersOverride, tileFiltersOverride)
     const topHeadingProps = {
         query: insight.query,
         lastRefresh: insight.last_refresh,
         hasTileOverrides,
         resolvedDateRange: insightData?.resolved_date_range,
-        dateFromOverride: hasTileOverrides ? tileFiltersOverride?.date_from : filtersOverride?.date_from,
-        dateToOverride: hasTileOverrides ? tileFiltersOverride?.date_to : filtersOverride?.date_to,
+        ...dateOverride,
     }
 
     const summary = useSummarizeInsight()(insight.query)


### PR DESCRIPTION
## Problem

On the backend, a non-empty tile filter override replaces the dashboard filter override wholesale (`apply_dashboard_filters` via `calculate_results.py`). The insight card header disagreed: it displayed the date as `tileOverride.date_from ?? dashboardOverride.date_from`, a per-field fallback. So a tile with an override that sets only properties would show the dashboard's date range in its header while the backend computed with the insight's own date range. The header could label a chart with a date that was never applied.

## Changes

- When a tile override is active, the header uses only the tile override's dates (falling through to the insight's own date range when the tile sets none), never the dashboard's
- No change when no tile override is present

## How did you test this code?

- Ran oxlint and the frontend TypeScript check on the changed file
- No new tests: this is a two-line display-logic fix, the incorrect and correct values differ only with a specific combination of overrides that Storybook fixtures don't model, and the change mirrors documented backend semantics

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Inconsistency found while mapping backend override precedence (`calculate_results.py`, `products/product_analytics/backend/api/insight.py`) against the frontend display for [#70110](https://github.com/PostHog/posthog/pull/70110); split out into this separate PR at Matt's request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*