### PR TITLE
feat(tasks): capture repository visibility on pr webhook events

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -83,6 +83,7 @@ class TestGitHubPRWebhook(TestCase):
 
         payload = {
             "action": "closed",
+            "repository": {"full_name": "posthog/posthog", "private": True},
             "pull_request": {
                 "html_url": "https://github.com/posthog/posthog/pull/123",
                 "merged": True,
@@ -100,6 +101,7 @@ class TestGitHubPRWebhook(TestCase):
         self.assertEqual(call_kwargs["properties"]["task_id"], str(self.task.id))
         self.assertEqual(call_kwargs["properties"]["run_id"], str(self.task_run.id))
         self.assertEqual(call_kwargs["properties"]["pr_source"], "task")
+        self.assertIs(call_kwargs["properties"]["pr_repo_private"], True)
 
         self.task_run.refresh_from_db()
         assert self.task_run.output is not None
@@ -621,7 +623,7 @@ class TestExternalPRWebhook(TestCase):
         return {
             "action": action,
             "installation": {"id": 555000},
-            "repository": {"full_name": "acme/widgets"},
+            "repository": {"full_name": "acme/widgets", "private": False},
             "pull_request": {
                 "html_url": "https://github.com/acme/widgets/pull/7",
                 "number": 7,
@@ -663,6 +665,7 @@ class TestExternalPRWebhook(TestCase):
         self.assertEqual(props["pr_source"], "external")
         self.assertEqual(props["team_id"], self.team.id)
         self.assertEqual(props["repository"], "acme/widgets")
+        self.assertIs(props["pr_repo_private"], False)
         self.assertEqual(props["pr_number"], 7)
         self.assertEqual(props["pr_author"], "octocat")
         self.assertEqual(props["pr_base_ref"], "main")

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -261,6 +261,9 @@ def _pr_payload_properties(payload: dict) -> dict:
         "pr_deletions": pull_request.get("deletions"),
         "pr_changed_files": pull_request.get("changed_files"),
         "pr_commits": pull_request.get("commits"),
+        # Read from the top-level payload.repository (not pull_request) so downstream
+        # consumers can distinguish public vs private repos before following the PR link.
+        "pr_repo_private": (payload.get("repository") or {}).get("private"),
     }
 
 

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -261,8 +261,7 @@ def _pr_payload_properties(payload: dict) -> dict:
         "pr_deletions": pull_request.get("deletions"),
         "pr_changed_files": pull_request.get("changed_files"),
         "pr_commits": pull_request.get("commits"),
-        # Read from the top-level payload.repository (not pull_request) so downstream
-        # consumers can distinguish public vs private repos before following the PR link.
+        # Note the top-level payload.repository source, unlike the pull_request keys above.
         "pr_repo_private": (payload.get("repository") or {}).get("private"),
     }
 


### PR DESCRIPTION
## Problem

The "Wizard Cloud Run PR Merged" workflow posts merged wizard PRs to a Slack channel, but readers can't tell whether the linked repo is public or private before clicking. Most are private and 404 on click. Capturing repository visibility on the PR webhook analytics events lets downstream consumers (like that Slack message template) distinguish public vs private repos up front.

## Changes

Add `pr_repo_private` to the properties captured on GitHub `pull_request` webhook events. It reads from the top-level `payload.repository.private` (GitHub always includes this bool), not from `pull_request`. Both the task-run and external capture paths flow through `_pr_payload_properties`, so adding it there covers both in one place.

## How did you test this code?

Extended two existing tests in `products/tasks/backend/tests/test_webhooks.py`:
- The task-run merged-PR test now sets `repository.private = true` and asserts the captured `pr_repo_private` is `True`.
- The external-PR fixture now sets `repository.private = false` and asserts the captured `pr_repo_private` is `False`.

Together these cover both capture paths and both boolean values, and guard against the property being dropped or read from the wrong payload location.

I (an agent) could not run the Python test suite in this environment — no working Django/pytest runtime was available. I verified the files compile (`py_compile`) and pass `ruff check` and `ruff format --check`. The test suite should be run in CI / locally before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread; Matt directed the change. Invoked the `/writing-tests` skill before touching the test file — that steered me to extend the two existing task-run and external-path tests rather than add new near-duplicate test functions.

Design decision: the change reads `repository.private` from the top-level payload, but `_pr_payload_properties` already receives the full `payload`, so I added the key there directly rather than threading `payload` through `_capture_pr_event` separately. One edit, both paths covered.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AKRM9P6VD/p1783705322195109?thread_ts=1783705322.195109&cid=C0AKRM9P6VD)*
