### PR TITLE
feat(growth): route onboarding on enrichment company-type fallback

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -52,6 +52,8 @@ from posthog.tasks.email import send_posthog_ai_access_request
 from posthog.user_permissions import UserPermissions, UserPermissionsSerializerMixin
 from posthog.utils import get_safe_cache, safe_cache_set
 
+from products.growth.backend.enrichment.routing import resolve_company_type
+
 
 class PremiumMultiorganizationPermission(permissions.BasePermission):
     """Require user to have all necessary premium features on their plan for create access to the endpoint."""
@@ -354,7 +356,10 @@ class OrganizationSerializer(
     @extend_schema_field(serializers.DictField())
     def get_enrichment(self, organization: Organization) -> dict:
         record = getattr(organization, "enrichment_record", None)
-        return record.data if record else {}
+        data = dict(record.data) if record else {}
+        # Single value for onboarding to route on: deterministic unless unknown, then enrichment.
+        data["company_type_resolved"] = resolve_company_type(data)
+        return data
 
     @tracer.start_as_current_span("organization_serializer.to_representation")
     def to_representation(self, instance):

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -147,7 +147,10 @@ class TestSignupAPI(APIBaseTest):
         self.assertEqual(enrichment.data, {"company_type_deterministic": "yc"})
 
         me = self.client.get("/api/users/@me/")
-        self.assertEqual(me.json()["organization"]["enrichment"], {"company_type_deterministic": "yc"})
+        self.assertEqual(
+            me.json()["organization"]["enrichment"],
+            {"company_type_deterministic": "yc", "company_type_resolved": "yc"},
+        )
 
     @pytest.mark.skip_on_multitenancy
     @patch("posthoganalytics.capture")

--- a/products/growth/backend/enrichment/routing.py
+++ b/products/growth/backend/enrichment/routing.py
@@ -1,0 +1,27 @@
+"""Company-type resolution for onboarding routing.
+
+The deterministic classifier runs synchronously at signup and is always present, but it
+returns `unknown` for domains it can't place. Enrichment (Harmonic, async) fills in a
+company type shortly after — often after onboarding's first read — so it's a best-effort
+fallback, not a guarantee. This resolver encodes the precedence and degrades to a safe
+`unknown` default when neither signal is set.
+"""
+
+from products.growth.backend.enrichment.classifier import CompanyType
+
+DETERMINISTIC_KEY = "company_type_deterministic"
+ENRICHED_KEY = "company_type"
+
+
+def resolve_company_type(enrichment_data: dict) -> str:
+    """Return the company type to route on: the deterministic value unless it's unknown or
+    missing, then the enrichment record's value, then `unknown`."""
+    deterministic = enrichment_data.get(DETERMINISTIC_KEY)
+    if deterministic and deterministic != CompanyType.UNKNOWN.value:
+        return deterministic
+
+    enriched = enrichment_data.get(ENRICHED_KEY)
+    if enriched:
+        return enriched
+
+    return CompanyType.UNKNOWN.value

--- a/products/growth/backend/tests/test_enrichment_routing.py
+++ b/products/growth/backend/tests/test_enrichment_routing.py
@@ -1,0 +1,24 @@
+from products.growth.backend.enrichment.classifier import CompanyType
+from products.growth.backend.enrichment.routing import resolve_company_type
+
+
+def test_prefers_known_deterministic_value():
+    assert resolve_company_type({"company_type_deterministic": "yc", "company_type": "STARTUP"}) == "yc"
+
+
+def test_falls_back_to_enrichment_when_deterministic_unknown():
+    data = {"company_type_deterministic": CompanyType.UNKNOWN.value, "company_type": "STARTUP"}
+    assert resolve_company_type(data) == "STARTUP"
+
+
+def test_falls_back_to_enrichment_when_deterministic_missing():
+    assert resolve_company_type({"company_type": "STARTUP"}) == "STARTUP"
+
+
+def test_safe_default_when_nothing_set():
+    assert resolve_company_type({}) == CompanyType.UNKNOWN.value
+
+
+def test_safe_default_when_unknown_and_no_enrichment_yet():
+    # Enrichment hasn't landed by onboarding's first read: degrade to unknown, don't raise.
+    assert resolve_company_type({"company_type_deterministic": "unknown"}) == CompanyType.UNKNOWN.value


### PR DESCRIPTION
## Problem

Onboarding routes on company type. The deterministic classifier (#69423) runs synchronously at signup and is always present, but returns `unknown` for domains it can't place. This PR makes routing fall back to the enrichment record's company type when the deterministic value is unknown, degrading to a safe default when neither is set.

## Changes

- **`products/growth/backend/enrichment/routing.py`** — `resolve_company_type(enrichment_data)`: deterministic value unless it's unknown or missing, then the enrichment record's `company_type`, then `unknown`.
- **`posthog/api/organization.py`** — `get_enrichment` now includes a single `company_type_resolved` key so onboarding routes on one value with the fallback baked in. The raw keys stay in the payload.

Because enrichment is async and often lands after onboarding's first read, the resolver never assumes it's present.

## How did you test this code?

Automated tests I (Claude, via PostHog Code) actually ran locally, 5 passing:

- `test_enrichment_routing.py` — prefers a known deterministic value; falls back to enrichment when deterministic is unknown or missing; safe `unknown` default when nothing is set or enrichment hasn't landed.
- Updated the existing signup enrichment assertion in `test_signup.py` to expect the new `company_type_resolved` key (DB-backed, runs in CI).

`ruff` and `tach check` pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code, driven by @MattBro from a Slack thread. Invoked `/improving-drf-endpoints` before the serializer change: `get_enrichment` is already a `DictField`-typed `SerializerMethodField`, so adding a key doesn't change the schema shape.

> [!NOTE]
> **Stacking.** Based on **#69423** (the `CompanyType` enum + the `enrichment` serializer field). Independent of PRs A and B — it only reads dict keys, one of which (`company_type`) the PR A writer populates.
>
> **Merge order:** (#69423, #69411) → PR A → PR B → **PR C (this)**. Rebases onto master cleanly once #69423 merges.

FYI @abhischekt.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AKRM9P6VD/p1783705019079249?thread_ts=1783705019.079249&cid=C0AKRM9P6VD)*
