### PR TITLE
refactor(flags): holdout attachment capability and experiment rule accessor

### DIFF
--- a/ee/clickhouse/views/experiment_holdouts.py
+++ b/ee/clickhouse/views/experiment_holdouts.py
@@ -13,8 +13,9 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
-from products.experiments.backend.models.experiment import ExperimentHoldout, holdout_filters_for_flag
+from products.experiments.backend.models.experiment import ExperimentHoldout
 from products.feature_flags.backend.api.feature_flag import FeatureFlagSerializer
+from products.feature_flags.backend.facade.filters import set_holdout
 
 
 @extend_schema_field(FeatureFlagConditionGroupSchemaSerializer(many=True))
@@ -122,10 +123,12 @@ class ExperimentHoldoutSerializer(UserAccessControlSerializerMixin, serializers.
                     existing_flag_serializer = FeatureFlagSerializer(
                         flag,
                         data={
-                            "filters": {
-                                **flag.filters,
-                                **holdout_filters_for_flag(instance.id, validated_data["filters"]),
-                            },
+                            "filters": set_holdout(
+                                flag.filters,
+                                holdout_id=instance.id,
+                                # validate_filters guarantees a non-empty list with rollout_percentage present.
+                                exclusion_percentage=new_filters[0]["rollout_percentage"],
+                            ),
                         },
                         partial=True,
                         context=self.context,
@@ -156,10 +159,7 @@ class ExperimentHoldoutViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 existing_flag_serializer = FeatureFlagSerializer(
                     flag,
                     data={
-                        "filters": {
-                            **flag.filters,
-                            **holdout_filters_for_flag(None, None),
-                        }
+                        "filters": set_holdout(flag.filters, holdout_id=None, exclusion_percentage=None),
                     },
                     partial=True,
                     context={"request": request, "team": self.team, "team_id": self.team_id},

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -739,6 +739,7 @@
     '_meta',
     'created_at',
     'created_by_id',
+    'exclusion_percentage',
     'experiment_set',
     'get_next_by_created_at',
     'get_next_by_updated_at',

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -77,7 +77,6 @@ from products.experiments.backend.models.experiment import (
     ExperimentToSavedMetric,
     ExposureFreezeBlocker,
     experiment_has_legacy_metrics,
-    holdout_filters_for_flag,
 )
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 from products.experiments.backend.result_serialization import strip_step_sessions
@@ -93,7 +92,12 @@ from products.feature_flags.backend.facade.api import (
     update_flag,
     user_can_edit_flag,
 )
-from products.feature_flags.backend.facade.filters import restrict_groups_to_cohort, strip_group_cohort_restriction
+from products.feature_flags.backend.facade.filters import (
+    restrict_groups_to_cohort,
+    set_holdout,
+    strip_group_cohort_restriction,
+)
+from products.feature_flags.backend.facade.rules import experiment_rule_from_filters
 from products.feature_flags.backend.models.evaluation_context import FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag, experiment_eligibility_error
 from products.notifications.backend.facade.api import (
@@ -1231,7 +1235,7 @@ class ExperimentService:
 
         if existing_flag:
             self._validate_existing_flag(existing_flag)
-            variants = existing_flag.filters.get("multivariate", {}).get("variants", list(DEFAULT_VARIANTS))
+            variants = experiment_rule_from_filters(existing_flag.filters or {}).variants or list(DEFAULT_VARIANTS)
             return existing_flag, variants
 
         config = feature_flag_config or {}
@@ -1251,13 +1255,16 @@ class ExperimentService:
         # prompt experiments map each variant to {"prompt_name": ..., "prompt_version": ...})
         # and any future key — is applied as-is so nothing the serializer accepted is
         # silently dropped.
-        feature_flag_filters = {
-            "aggregation_group_type_index": None,
-            **{k: v for k, v in config_filters.items() if k not in ("groups", "multivariate")},
-            "groups": [{"properties": [], "rollout_percentage": experiment_rollout_percentage}],
-            "multivariate": {"variants": variants or list(DEFAULT_VARIANTS)},
-            **holdout_filters_for_flag(holdout.id if holdout else None, holdout.filters if holdout else None),
-        }
+        feature_flag_filters = set_holdout(
+            {
+                "aggregation_group_type_index": None,
+                **{k: v for k, v in config_filters.items() if k not in ("groups", "multivariate")},
+                "groups": [{"properties": [], "rollout_percentage": experiment_rollout_percentage}],
+                "multivariate": {"variants": variants or list(DEFAULT_VARIANTS)},
+            },
+            holdout_id=holdout.id if holdout else None,
+            exclusion_percentage=holdout.exclusion_percentage if holdout else None,
+        )
 
         feature_flag_data: dict[str, Any] = {
             "key": feature_flag_key,
@@ -3075,13 +3082,16 @@ class ExperimentService:
             # merged, and variants always resolve against the flag); every other validated filters
             # key is merged as-is over the flag's current filters, so nothing the serializer
             # accepted is silently dropped.
-            new_filters = {
-                **existing_filters,
-                **{k: v for k, v in config_filters.items() if k not in ("groups", "multivariate")},
-                "groups": new_groups,
-                "multivariate": {"variants": variants or list(DEFAULT_VARIANTS)},
-                **holdout_filters_for_flag(holdout.id if holdout else None, holdout.filters if holdout else None),
-            }
+            new_filters = set_holdout(
+                {
+                    **existing_filters,
+                    **{k: v for k, v in config_filters.items() if k not in ("groups", "multivariate")},
+                    "groups": new_groups,
+                    "multivariate": {"variants": variants or list(DEFAULT_VARIANTS)},
+                },
+                holdout_id=holdout.id if holdout else None,
+                exclusion_percentage=holdout.exclusion_percentage if holdout else None,
+            )
 
             flag_update_data: dict[str, Any] = {"filters": new_filters}
             if "ensure_experience_continuity" in feature_flag_config:
@@ -3092,12 +3102,11 @@ class ExperimentService:
             update_flag(
                 feature_flag,
                 {
-                    "filters": {
-                        **feature_flag.filters,
-                        **holdout_filters_for_flag(
-                            holdout.id if holdout else None, holdout.filters if holdout else None
-                        ),
-                    }
+                    "filters": set_holdout(
+                        feature_flag.filters,
+                        holdout_id=holdout.id if holdout else None,
+                        exclusion_percentage=holdout.exclusion_percentage if holdout else None,
+                    )
                 },
                 team=self.team,
                 user=self.user,

--- a/products/experiments/backend/experiment_summary_data_service.py
+++ b/products/experiments/backend/experiment_summary_data_service.py
@@ -37,7 +37,7 @@ from products.experiments.backend.hogql_queries.experiment_exposures_query_runne
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
 from products.experiments.backend.hogql_queries.utils import get_experiment_stats_method
 from products.experiments.backend.metric_utils import get_default_metric_title
-from products.experiments.backend.models.experiment import Experiment
+from products.experiments.backend.models.experiment import Experiment, get_experiment_rule
 
 
 @dataclass
@@ -173,8 +173,7 @@ class ExperimentSummaryDataService:
         if not feature_flag:
             raise ValueError(f"Experiment {experiment_id} has no feature flag")
 
-        multivariate = feature_flag.filters.get("multivariate", {})
-        variants = [v.get("key") for v in multivariate.get("variants", []) if v.get("key")]
+        variants = [v.get("key") for v in get_experiment_rule(experiment).variants if v.get("key")]
         stats_method = get_experiment_stats_method(experiment)
         # PostHog AI gets one shot at the data — unlike the frontend it can't poll, so a
         # stale metric returned as "pending" is silently dropped from the summary. Always

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -17,6 +17,7 @@ from products.feature_flags.backend.facade.filters import (
     group_cohort_restriction_blocker,
     groups_carry_restriction_marker,
 )
+from products.feature_flags.backend.facade.rules import ExperimentRuleConfig, experiment_rule_from_filters
 
 if TYPE_CHECKING:
     from posthog.models.team import Team
@@ -312,13 +313,15 @@ def flag_has_live_experiment(feature_flag_id: int) -> bool:
     return _live_experiments_for_flag(feature_flag_id).exists()
 
 
-def holdout_filters_for_flag(holdout_id: int | None, filters: list | None) -> dict:
-    """Return the `holdout` field for a feature flag's filters."""
-    if not holdout_id or not filters:
-        return {"holdout": None}
-    return {
-        "holdout": {"id": holdout_id, "exclusion_percentage": filters[0]["rollout_percentage"]},
-    }
+def get_experiment_rule(experiment: Experiment) -> ExperimentRuleConfig:
+    """The experiment's normalized rule config — the single home for experiment-to-rule resolution.
+
+    A v1 flag hosting an experiment is one implicit experiment rule, so this reads the
+    whole linked flag through the flag-side derivation. When the rule-level flag model
+    lands, this resolves the flag rule carrying this experiment's id instead — consumers
+    are untouched.
+    """
+    return experiment_rule_from_filters(experiment.feature_flag.filters or {})
 
 
 LEGACY_METRIC_KINDS: frozenset[str] = frozenset({"ExperimentTrendsQuery", "ExperimentFunnelsQuery"})
@@ -365,6 +368,12 @@ class ExperimentHoldout(ModelActivityMixin, RootTeamMixin, models.Model):
             super(ModelActivityMixin, self).save(*args, **kwargs)
         else:
             super().save(*args, **kwargs)
+
+    @property
+    def exclusion_percentage(self) -> float | None:
+        # Only the first release-condition group's rollout_percentage is denormalized onto
+        # linked flags as the holdout's exclusion percentage (see the holdout API help text).
+        return self.filters[0]["rollout_percentage"] if self.filters else None
 
 
 class ExperimentSavedMetric(ModelActivityMixin, RootTeamMixin, models.Model):

--- a/products/feature_flags/backend/facade/filters.py
+++ b/products/feature_flags/backend/facade/filters.py
@@ -113,6 +113,19 @@ def groups_carry_restriction_marker(current_filters: dict, *, marker_key: str) -
     return bool(groups) and all(group.get(marker_key) is True for group in groups)
 
 
+def set_holdout(current_filters: dict, *, holdout_id: int | None, exclusion_percentage: float | None) -> dict:
+    """Set (or clear) the flag-level ``holdout`` object on the filters.
+
+    Takes plain values — the caller resolves them from its own holdout concept, so the
+    flag product learns none. Without a holdout id or a usable exclusion percentage the
+    ``holdout`` key is written as None (not removed), so a previously attached holdout
+    is detached by the same write.
+    """
+    if not holdout_id or exclusion_percentage is None:
+        return {**current_filters, "holdout": None}
+    return {**current_filters, "holdout": {"id": holdout_id, "exclusion_percentage": exclusion_percentage}}
+
+
 def group_cohort_restriction_blocker(current_filters: dict) -> CohortRestrictionBlocker | None:
     """Why the flag's release groups can't be reversibly narrowed to a person cohort, or None.
 

--- a/products/feature_flags/backend/facade/rules.py
+++ b/products/feature_flags/backend/facade/rules.py
@@ -33,15 +33,20 @@ class ExperimentRuleConfig:
 
 
 def experiment_rule_from_filters(current_filters: dict) -> ExperimentRuleConfig:
-    """Derive the implicit experiment rule from a v1 flag's ``filters`` dict."""
+    """Derive the implicit experiment rule from a v1 flag's ``filters`` dict.
+
+    Tolerant of legacy null/partial shapes: an explicit null ``multivariate`` reads as no
+    variants, and a holdout without an ``id`` reads as no holdout.
+    """
     groups = current_filters.get("groups") or []
-    holdout = current_filters.get("holdout") or None
+    holdout = current_filters.get("holdout") or {}
+    holdout_id = holdout.get("id")
     return ExperimentRuleConfig(
         # Explicit nulls occur in real flag data (see FeatureFlag.variants) — coalesce them too.
         variants=(current_filters.get("multivariate") or {}).get("variants") or [],
         rollout_percentage=groups[0].get("rollout_percentage") if groups else None,
         assign_variant_by=current_filters.get("aggregation_group_type_index"),
-        holdout=HoldoutRef(id=holdout["id"], exclusion_percentage=holdout.get("exclusion_percentage"))
-        if holdout
+        holdout=HoldoutRef(id=holdout_id, exclusion_percentage=holdout.get("exclusion_percentage"))
+        if holdout_id
         else None,
     )

--- a/products/feature_flags/backend/facade/rules.py
+++ b/products/feature_flags/backend/facade/rules.py
@@ -1,0 +1,46 @@
+"""The experiment-rule view of a feature flag's config.
+
+A v1 flag hosting an experiment is a single implicit experiment rule: the flag-wide
+``multivariate`` variants, the first release group's rollout percentage, and the
+flag-level holdout/aggregation settings. This module derives that normalized rule
+config from today's ``filters`` format; when the rule-level flag model lands, the
+derivation becomes a read off the rule itself and consumers are untouched.
+
+The DTO stays deliberately minimal while the rule-level model is being designed:
+no seed handling, no reason mapping. It is the seam for the format swap — do not
+grow it into a general flag-read layer (``flag.variants`` and friends remain the
+right interface for plain reads).
+
+Deliberately free of Django/DRF imports (same reason as ``facade.filters``):
+consumer model modules import this at module level.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HoldoutRef:
+    id: int
+    exclusion_percentage: float | None
+
+
+@dataclass(frozen=True)
+class ExperimentRuleConfig:
+    variants: list[dict]  # v1 variant dicts: {key, rollout_percentage, name?}
+    rollout_percentage: float | None
+    assign_variant_by: int | None  # v1: the flag's aggregation_group_type_index (None = persons)
+    holdout: HoldoutRef | None
+
+
+def experiment_rule_from_filters(current_filters: dict) -> ExperimentRuleConfig:
+    """Derive the implicit experiment rule from a v1 flag's ``filters`` dict."""
+    groups = current_filters.get("groups") or []
+    holdout = current_filters.get("holdout") or None
+    return ExperimentRuleConfig(
+        variants=current_filters.get("multivariate", {}).get("variants", []),
+        rollout_percentage=groups[0].get("rollout_percentage") if groups else None,
+        assign_variant_by=current_filters.get("aggregation_group_type_index"),
+        holdout=HoldoutRef(id=holdout["id"], exclusion_percentage=holdout.get("exclusion_percentage"))
+        if holdout
+        else None,
+    )

--- a/products/feature_flags/backend/facade/rules.py
+++ b/products/feature_flags/backend/facade/rules.py
@@ -37,7 +37,8 @@ def experiment_rule_from_filters(current_filters: dict) -> ExperimentRuleConfig:
     groups = current_filters.get("groups") or []
     holdout = current_filters.get("holdout") or None
     return ExperimentRuleConfig(
-        variants=current_filters.get("multivariate", {}).get("variants", []),
+        # Explicit nulls occur in real flag data (see FeatureFlag.variants) — coalesce them too.
+        variants=(current_filters.get("multivariate") or {}).get("variants") or [],
         rollout_percentage=groups[0].get("rollout_percentage") if groups else None,
         assign_variant_by=current_filters.get("aggregation_group_type_index"),
         holdout=HoldoutRef(id=holdout["id"], exclusion_percentage=holdout.get("exclusion_percentage"))

--- a/products/feature_flags/backend/test/test_facade.py
+++ b/products/feature_flags/backend/test/test_facade.py
@@ -20,6 +20,7 @@ from products.feature_flags.backend.facade.filters import (
     group_cohort_restriction_blocker,
     groups_carry_restriction_marker,
     restrict_groups_to_cohort,
+    set_holdout,
     strip_group_cohort_restriction,
 )
 from products.feature_flags.backend.facade.rules import ExperimentRuleConfig, HoldoutRef, experiment_rule_from_filters
@@ -301,6 +302,24 @@ class TestFilterTransforms:
     def test_group_cohort_restriction_blocker(self, _name: str, filters: dict, expected: str | None):
         assert group_cohort_restriction_blocker(filters) == expected
 
+    @parameterized.expand(
+        [
+            ("write", 7, 10, {"id": 7, "exclusion_percentage": 10}),
+            ("clear_both_missing", None, None, None),
+            ("clear_missing_id", None, 10, None),
+            ("clear_missing_exclusion", 7, None, None),
+        ]
+    )
+    def test_set_holdout(
+        self, _name: str, holdout_id: int | None, exclusion_percentage: float | None, expected: dict | None
+    ):
+        filters = {"groups": [{"properties": []}], "holdout": {"id": 1, "exclusion_percentage": 5}}
+
+        result = set_holdout(filters, holdout_id=holdout_id, exclusion_percentage=exclusion_percentage)
+
+        assert result == {"groups": [{"properties": []}], "holdout": expected}
+        assert filters["holdout"] == {"id": 1, "exclusion_percentage": 5}
+
 
 class TestExperimentRuleFromFilters:
     @parameterized.expand(
@@ -340,6 +359,21 @@ class TestExperimentRuleFromFilters:
                 "group_without_rollout_and_null_holdout",
                 {"groups": [{"properties": []}], "holdout": None, "multivariate": {"variants": []}},
                 ExperimentRuleConfig(variants=[], rollout_percentage=None, assign_variant_by=None, holdout=None),
+            ),
+            (
+                "holdout_without_id_reads_as_no_holdout",
+                {"holdout": {"exclusion_percentage": 10}},
+                ExperimentRuleConfig(variants=[], rollout_percentage=None, assign_variant_by=None, holdout=None),
+            ),
+            (
+                "holdout_without_exclusion_percentage",
+                {"holdout": {"id": 7}},
+                ExperimentRuleConfig(
+                    variants=[],
+                    rollout_percentage=None,
+                    assign_variant_by=None,
+                    holdout=HoldoutRef(id=7, exclusion_percentage=None),
+                ),
             ),
             (
                 "null_multivariate",

--- a/products/feature_flags/backend/test/test_facade.py
+++ b/products/feature_flags/backend/test/test_facade.py
@@ -22,6 +22,7 @@ from products.feature_flags.backend.facade.filters import (
     restrict_groups_to_cohort,
     strip_group_cohort_restriction,
 )
+from products.feature_flags.backend.facade.rules import ExperimentRuleConfig, HoldoutRef, experiment_rule_from_filters
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 
@@ -299,3 +300,48 @@ class TestFilterTransforms:
     )
     def test_group_cohort_restriction_blocker(self, _name: str, filters: dict, expected: str | None):
         assert group_cohort_restriction_blocker(filters) == expected
+
+
+class TestExperimentRuleFromFilters:
+    @parameterized.expand(
+        [
+            (
+                "full_v1_filters",
+                {
+                    "groups": [
+                        {"properties": [], "rollout_percentage": 40},
+                        {"properties": [], "rollout_percentage": 100},
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 50},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                    "aggregation_group_type_index": 2,
+                    "holdout": {"id": 7, "exclusion_percentage": 10},
+                },
+                ExperimentRuleConfig(
+                    variants=[
+                        {"key": "control", "rollout_percentage": 50},
+                        {"key": "test", "rollout_percentage": 50},
+                    ],
+                    rollout_percentage=40,
+                    assign_variant_by=2,
+                    holdout=HoldoutRef(id=7, exclusion_percentage=10),
+                ),
+            ),
+            (
+                "empty_filters",
+                {},
+                ExperimentRuleConfig(variants=[], rollout_percentage=None, assign_variant_by=None, holdout=None),
+            ),
+            (
+                "group_without_rollout_and_null_holdout",
+                {"groups": [{"properties": []}], "holdout": None, "multivariate": {"variants": []}},
+                ExperimentRuleConfig(variants=[], rollout_percentage=None, assign_variant_by=None, holdout=None),
+            ),
+        ]
+    )
+    def test_derivation(self, _name, filters, expected):
+        assert experiment_rule_from_filters(filters) == expected

--- a/products/feature_flags/backend/test/test_facade.py
+++ b/products/feature_flags/backend/test/test_facade.py
@@ -341,6 +341,16 @@ class TestExperimentRuleFromFilters:
                 {"groups": [{"properties": []}], "holdout": None, "multivariate": {"variants": []}},
                 ExperimentRuleConfig(variants=[], rollout_percentage=None, assign_variant_by=None, holdout=None),
             ),
+            (
+                "null_multivariate",
+                {"multivariate": None},
+                ExperimentRuleConfig(variants=[], rollout_percentage=None, assign_variant_by=None, holdout=None),
+            ),
+            (
+                "null_variants",
+                {"multivariate": {"variants": None}},
+                ExperimentRuleConfig(variants=[], rollout_percentage=None, assign_variant_by=None, holdout=None),
+            ),
         ]
     )
     def test_derivation(self, _name, filters, expected):


### PR DESCRIPTION
## Problem

Two remaining leaks in the flag facade boundary series (prep for PostHog/requests-for-comments-internal#1097):

1. `holdout_filters_for_flag` in the experiment model hand-built the flag's `holdout` filters field.
2. "What is this experiment's flag config" had no single home: call sites dug into `filters.multivariate` / `groups[0]` independently. Under the upcoming rule-level model, an experiment's config becomes a rule on the flag, so resolution needs exactly one place to swap the v2 arm in.

**Stacked on #70123** (review only the last commit).

## Changes

Pure move and consolidation, no behavior change:

- `set_holdout(current_filters, *, holdout_id, exclusion_percentage)` joins the facade's pure filters transforms. It takes plain values, so flags learns no experiment concepts; the experiment-holdout shape knowledge (first release group's rollout percentage) stays experiments-side as an `ExperimentHoldout.exclusion_percentage` property. The holdout viewset propagation in `ee/clickhouse/views/experiment_holdouts.py` uses it too and stops importing an experiments-model internal.
- New `products/feature_flags/backend/facade/rules.py`: minimal frozen dataclasses `ExperimentRuleConfig` (variants, rollout percentage, assignment unit, holdout ref) and `HoldoutRef`, plus `experiment_rule_from_filters(filters)`, the v1 derivation (flag-wide `multivariate` + `groups[0]` + flag-level holdout/aggregation). Deliberately excludes seed handling and reason mapping, which are open design items. The module is Django-free so model modules can import it without cycles.
- `get_experiment_rule(experiment)` next to the Experiment model is now the one home for experiment-to-rule resolution. The mechanical deep reads route through it (`_ensure_feature_flag`'s existing-flag variants dig, the summary data service). Analysis and query-runner reads are deliberately untouched: the holdout marker representation under the new model is an open decision.

## How did you test this code?

Automated tests only, no manual testing.

- `test_facade.py`: 9 passed (6 base + a 3-case parameterized test for the rule-config derivation: full v1 filters, empty filters, group-without-rollout with null holdout — the derivation had no direct coverage before)
- `test_experiment_service.py`: 455 passed; experiments holdout subset 10 passed
- `ee/clickhouse/views/test/test_experiment_holdouts.py`: 7 passed (attach/update/detach end to end, unchanged)
- summary tool + `test_feature_flag_bypass_matrix.py`: 47 passed; `tach check --dependencies --interfaces` clean

One unreachable edge diverges: a holdout with `filters=[{"rollout_percentage": None}]` previously wrote `exclusion_percentage: None` into the flag and now clears the holdout. `validate_filters` rejects that input on every write path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed: internal refactor, no API surface changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) executing a reviewed execution plan, as one of several subagents working in parallel git worktrees on this PR series. Skills invoked: `/writing-tests`. The minimal-DTO shape is a deliberate plan decision (it is the future adapter seam), while other plain flag reads intentionally stay as model accessors rather than DTO-wrapped.
