### PR TITLE
feat(lemon-ui): no-results message and keyboard nav in LemonSearchableSelect

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSearchableSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSearchableSelect.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { useMemo, useState } from 'react'
 
 import { LemonInput } from '@posthog/lemon-ui'
@@ -20,6 +21,8 @@ export interface LemonSearchableSelectPropsBase<T> extends LemonSelectPropsBase<
     searchKeys?: string[]
     /** `data-attr` for the search input, so its usage can be tracked per call site. */
     searchInputDataAttr?: string
+    /** Message shown when a search term matches no options. */
+    noResultsMessage?: string
 }
 
 export interface LemonSearchableSelectPropsClearable<T>
@@ -88,19 +91,94 @@ function filterOptions<T>(
     return options.map((item) => filterStructure(item, matchedOptions)).filter(Boolean) as LemonSelectOptions<T>
 }
 
+// A searchable option is a selectable leaf rendered as a plain menu-item button — not a custom
+// control (e.g. a labelInMenu render function) and not a hidden option.
+function getSearchableLeaves<T>(options: LemonSelectOptions<T>): LemonSelectOption<T>[] {
+    return flattenOptions(options).filter(
+        (option) => 'value' in option && typeof option.labelInMenu !== 'function' && !option.hidden
+    )
+}
+
+// Rebuild the option tree with the active option carrying the standard LemonButton highlight class,
+// so keyboard navigation highlights it the same way hovering does.
+function highlightActiveOption<T>(
+    options: LemonSelectOptions<T>,
+    activeOption: LemonSelectOption<T> | null
+): LemonSelectOptions<T> {
+    if (!activeOption) {
+        return options
+    }
+    const mark = (item: LemonSelectOption<T> | LemonSelectSection<T>): typeof item => {
+        if ('options' in item) {
+            return { ...item, options: item.options.map(mark) } as typeof item
+        }
+        return item === activeOption ? { ...item, className: clsx(item.className, 'LemonButton--active') } : item
+    }
+    return options.map(mark) as LemonSelectOptions<T>
+}
+
+const POPOVER_BOX_SELECTOR = '.Popover__box'
+const MENU_ITEM_SELECTOR = 'button[role="menuitem"]'
+
 export function LemonSearchableSelect<T extends string | number | boolean | null>({
     searchPlaceholder,
     searchKeys = ['label'],
     searchInputDataAttr = 'lemon-searchable-select-search',
+    noResultsMessage = 'No results',
     onChange,
     onSelect,
     ...selectProps
 }: LemonSearchableSelectProps<T>): JSX.Element {
     const [searchTerm, setSearchTerm] = useState('')
+    // Index into `navigableOptions` of the row highlighted via arrow keys, or -1 for the search box.
+    const [activeIndex, setActiveIndex] = useState(-1)
 
     const filteredOptions = useMemo(() => {
         return filterOptions(selectProps.options, searchTerm, searchKeys)
     }, [selectProps.options, searchTerm, searchKeys])
+
+    const navigableOptions = useMemo(() => getSearchableLeaves(filteredOptions), [filteredOptions])
+    const activeOption =
+        activeIndex >= 0 && activeIndex < navigableOptions.length ? navigableOptions[activeIndex] : null
+
+    const handleSearchChange = (newSearchTerm: string): void => {
+        setSearchTerm(newSearchTerm)
+        setActiveIndex(-1)
+    }
+
+    const scrollMenuItemIntoView = (fromElement: HTMLElement, index: number): void => {
+        const menuItems = fromElement.closest(POPOVER_BOX_SELECTOR)?.querySelectorAll(MENU_ITEM_SELECTOR)
+        menuItems?.[index]?.scrollIntoView({ block: 'nearest' })
+    }
+
+    const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+        if (e.key === 'ArrowDown') {
+            // Stop propagation so an enclosing form (e.g. LemonFormDialog) doesn't also act on the key.
+            e.preventDefault()
+            e.stopPropagation()
+            const nextIndex = Math.min(activeIndex + 1, navigableOptions.length - 1)
+            setActiveIndex(nextIndex)
+            scrollMenuItemIntoView(e.currentTarget, nextIndex)
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault()
+            e.stopPropagation()
+            const nextIndex = Math.max(activeIndex - 1, -1)
+            setActiveIndex(nextIndex)
+            if (nextIndex >= 0) {
+                scrollMenuItemIntoView(e.currentTarget, nextIndex)
+            }
+        } else if (e.key === 'Enter') {
+            // Keep Enter scoped to the dropdown so it never submits an enclosing form (e.g. LemonFormDialog),
+            // even when no result is highlighted yet.
+            e.preventDefault()
+            e.stopPropagation()
+            if (activeOption) {
+                // Click the highlighted menu item so it goes through the same select-and-close path as a mouse click.
+                const menuItems = e.currentTarget.closest(POPOVER_BOX_SELECTOR)?.querySelectorAll(MENU_ITEM_SELECTOR)
+                ;(menuItems?.[activeIndex] as HTMLElement | undefined)?.click()
+            }
+        }
+    }
 
     // Add search input as first menu item
     const optionsWithSearch = useMemo(() => {
@@ -111,7 +189,8 @@ export function LemonSearchableSelect<T extends string | number | boolean | null
                     placeholder={searchPlaceholder || 'Search'}
                     autoFocus
                     value={searchTerm}
-                    onChange={setSearchTerm}
+                    onChange={handleSearchChange}
+                    onKeyDown={handleSearchKeyDown}
                     fullWidth
                     onClick={(e) => e.stopPropagation()}
                     className="mb-1"
@@ -121,13 +200,22 @@ export function LemonSearchableSelect<T extends string | number | boolean | null
             custom: true,
         } as any
 
-        return [searchMenuItem, ...filteredOptions] as LemonSelectOptions<T>
-    }, [searchPlaceholder, searchTerm, filteredOptions, searchInputDataAttr])
+        const hasNoResults = searchTerm.length > 0 && filteredOptions.length === 0
+        const emptyMenuItem: LemonSelectOption<T> = {
+            label: () => <div className="px-2 py-1.5 text-secondary">{noResultsMessage}</div>,
+            custom: true,
+        } as any
+
+        const listOptions = hasNoResults ? [emptyMenuItem] : highlightActiveOption(filteredOptions, activeOption)
+        return [searchMenuItem, ...listOptions] as LemonSelectOptions<T>
+        // handleSearchKeyDown/handleSearchChange are stable enough for this memo; activeOption drives the highlight.
+    }, [searchPlaceholder, searchTerm, filteredOptions, noResultsMessage, searchInputDataAttr, activeOption]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleChange = (newValue: T | null): void => {
         // Cast to `any` because `onChange` is a union type (T vs T | null) and TS can't infer it here.
         onChange?.(newValue as any)
         setSearchTerm('')
+        setActiveIndex(-1)
     }
 
     const handleOnSelect = (newValue: T | null): void => {
@@ -149,6 +237,7 @@ export function LemonSearchableSelect<T extends string | number | boolean | null
                     // selected option filtered out and the trigger falls back to rendering the raw value.
                     if (!visible) {
                         setSearchTerm('')
+                        setActiveIndex(-1)
                     }
                 },
             }}

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1374,7 +1374,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                                                         labelInMenu: () => (
                                                             <button
                                                                 type="button"
-                                                                className="w-full text-left text-primary px-2 py-1.5"
+                                                                className="w-full text-left text-primary px-2 py-1.5 cursor-pointer"
                                                                 onClick={() => createFolderAndSelect(onChange)}
                                                             >
                                                                 + Add new folder

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -21,7 +21,15 @@ import { type IRange, Uri, editor } from 'monaco-editor'
 import posthog from 'posthog-js'
 import { Suspense } from 'react'
 
-import { LemonCheckbox, LemonDialog, LemonInput, LemonSelect, Spinner, lemonToast, Tooltip } from '@posthog/lemon-ui'
+import {
+    LemonCheckbox,
+    LemonDialog,
+    LemonInput,
+    LemonSearchableSelect,
+    Spinner,
+    lemonToast,
+    Tooltip,
+} from '@posthog/lemon-ui'
 
 import api, { ApiError } from 'lib/api'
 import { tryShowMCPHint } from 'lib/components/MCPHint/mcpHintLogic'
@@ -1325,6 +1333,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                 LemonDialog.openForm({
                     title: 'Save as view',
+                    showErrorsOnTouch: true,
                     initialValues: {
                         viewName: values.activeTab?.name || '',
                         folderId: null,
@@ -1334,7 +1343,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                             ? (values.dags.find((d) => d.id === values.selectedDagId)?.id ?? values.dags[0]?.id ?? null)
                             : undefined,
                     },
-                    description: `View names can only contain letters, numbers, '_', or '$'. Spaces are not allowed.`,
+                    description: `View names must start with a letter, '_', or '$' and can only contain letters, numbers, '_', '.', or '$'. Spaces are not allowed.`,
                     content: (isLoading) =>
                         isLoading ? (
                             <div className="h-[37px] flex items-center">
@@ -1342,7 +1351,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                             </div>
                         ) : (
                             <>
-                                <LemonField name="viewName">
+                                <LemonField name="viewName" label="Name">
                                     <LemonInput
                                         data-attr="sql-editor-input-save-view-name"
                                         disabled={isLoading}
@@ -1353,9 +1362,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                                 <div className="flex gap-2 mt-2">
                                     <LemonField name="folderId" label="Add to folder" className="flex-1">
                                         {({ value, onChange }) => (
-                                            <LemonSelect<string | null>
+                                            <LemonSearchableSelect<string | null>
                                                 value={value}
                                                 onChange={onChange}
+                                                searchPlaceholder="Search folders"
                                                 options={[
                                                     ...folderOptions,
                                                     {


### PR DESCRIPTION
## Problem

Two rough edges in the shared `LemonSearchableSelect`, surfaced while polishing the SQL editor "Save as view" folder picker (the consumer PR below this in the stack) but fixed in the shared component so every consumer (`ViewLinkModal`, audit-log filters, etc.) benefits:

1. When a search matched nothing, the dropdown showed just the search box over a blank area, with no signal that nothing matched.
2. There was no keyboard navigation: the search box is injected as the first menu item, and `LemonMenu`'s arrow-key nav only wires to real menu-item buttons, so arrows did nothing and results were mouse-only.

## Changes

- **No-results message:** when the search term matches nothing, render a `noResultsMessage` row (default `No results`, overridable per consumer).
- **Keyboard navigation:** ArrowUp/ArrowDown move a highlight through the filtered results while focus stays in the search box, and Enter selects the highlighted option (routing through the same select-and-close path as a mouse click). Handled keys stop propagation so navigating/selecting inside the dropdown doesn't also trigger an enclosing form. This last part fixed a bug I hit while testing: Enter was both selecting the folder *and* submitting the surrounding `LemonFormDialog`.

## How did you test this code?

Automated: `tsgo` on the changed file (clean).

Manual (browser, against a local build of this branch): opened the SQL editor "Save as view" folder picker and confirmed:
- searching a non-existent name shows "No results";
- ArrowDown/ArrowUp move the highlight across "No folder" / folders and scroll it into view;
- Enter on a highlighted folder selects it and closes the dropdown, and the dialog stays open (does not submit / create a view).

No unit test added: the empty-state is a trivial render branch, and the keyboard behavior is DOM-interaction-heavy (focus, menu-item clicking) where a jsdom test would be flaky and low-value; verified in a real browser instead.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in response to review feedback on the stacked "Save as view" PR. Chose a combobox-style approach (focus stays in the search input, arrows move a highlighted index, Enter clicks the active menu item) rather than reworking `LemonMenu`'s focus-based navigation, which the injected search box desyncs. Live browser testing caught the enclosing-form submit bug, which the stop-propagation fix resolves. Kept the no-results copy configurable so the shared component stays generic. Also considered switching to strict prefix matching per review, but kept the existing fuzzy match at the requester's direction.
