### PR TITLE
fix(ci): align Trunk flaky-test setup with trunk.io guidance

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1571,9 +1571,9 @@ jobs:
                   fi
                   if [[ "$MODE" == "selected" ]]; then
                       # Selected mode: run only the test files chosen by the snob shadow selector.
-                      # No --splits/--group (no sharding), and no --reruns in selected mode. The full
-                      # run keeps a reduced --reruns 1 cold-start net, mirroring canonical (which runs
-                      # it until Trunk's quarantine list matures; the shadow strips the gate itself).
+                      # No --splits/--group (no sharding), and no --reruns anywhere, mirroring
+                      # canonical: retries mask the raw flake signal Trunk needs (the shadow
+                      # strips the quarantine gate itself).
                       if [[ "${{ matrix.person-on-events }}" == "true" ]]; then
                           targets="$POE_FILES"
                       else
@@ -1604,7 +1604,6 @@ jobs:
                         --pytest-durations=100 \
                         --splitting-algorithm="$SPLITTING_ALGORITHM" \
                         "${SPLIT_GRANULARITY[@]}" \
-                        --reruns 1 --reruns-delay 1 \
                         -r fEsxX \
                         --junitxml=junit-core.xml \
                         $PYTEST_ARGS
@@ -1673,7 +1672,7 @@ jobs:
                   # The --deselect guards stay on both branches so a selected run can't re-enable them.
                   if [[ "$MODE" == "selected" ]]; then
                       # Selected mode: no sharding, no --reruns — see the core selected branch;
-                      # the full run keeps a reduced --reruns 1 cold-start net mirroring canonical.
+                      # the full run also skips --reruns, mirroring canonical.
                       # shellcheck disable=SC2086
                       pytest -v --tb=short --reuse-db -o junit_duration_report=call $TEMPORAL_FILES -m "not async_migrations" \
                           --deselect "posthog/temporal/tests/data_modeling/test_run_workflow.py::test_run_workflow_with_minio_bucket" \
@@ -1695,7 +1694,6 @@ jobs:
                           --pytest-durations=100 \
                           --splitting-algorithm="$SPLITTING_ALGORITHM" \
                           "${SPLIT_GRANULARITY[@]}" \
-                          --reruns 1 --reruns-delay 1 \
                           -r fEsxX \
                           --junitxml=junit-temporal.xml \
                           $PYTEST_ARGS

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -772,6 +772,10 @@ jobs:
                       posthog-test-durations-
 
             - name: Run product tests
+              id: run-product-tests
+              # continue-on-error so the quarantine gate below is the verdict — it passes when
+              # every failure is an already-quarantined flake, fails otherwise.
+              continue-on-error: true
               # --force: discover already decided this product needs testing, skip turbo cache
               # --log-order=stream: stream pytest output live instead of buffering until completion
               # pytest_args: optional pytest-split flags for sharded products (e.g. "-- --splits 3 --group 1")
@@ -801,17 +805,29 @@ jobs:
                       exit $exit_code
                   fi
 
-            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
-            - name: Upload test results to Trunk
-              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+            # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
+            # the verdict, so a Trunk outage can't red a passing shard. Internal PRs only (needs the
+            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            - name: Quarantine gate
+              id: quarantine_gate
               continue-on-error: true
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: products/*/junit-product.xml
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
+                  quarantine: true
+                  previous-step-outcome: ${{ steps.run-product-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
+
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot. Sits before the timing-data upload so
+            # a real failure still skips it, as it did before the test step got continue-on-error.
+            - name: Fail on test failure
+              if: ${{ !cancelled() && steps.run-product-tests.outcome == 'failure' && steps.quarantine_gate.outcome != 'success' }}
+              shell: bash
+              run: exit 1
 
             - name: Upload timing data
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2479,8 +2479,8 @@ jobs:
                       # Selected mode: run only the test files chosen by the snob shadow selector.
                       # No --splits/--group (no sharding), no --store-durations (don't pollute timing
                       # data with a partial run), and no --reruns (fail loud on the narrow subset).
-                      # The full run below keeps a reduced --reruns 1 as a cold-start net while Trunk's
-                      # quarantine list matures; drop it back to 0 once quarantine reliably catches flakes.
+                      # The full run below also runs without --reruns: retries mask the raw flake
+                      # signal Trunk needs, and the quarantine gate is the flake net instead.
                       if [[ "${{ matrix.person-on-events }}" == "true" ]]; then
                           targets="$POE_FILES"
                       else
@@ -2511,7 +2511,6 @@ jobs:
                         --pytest-durations=100 \
                         --splitting-algorithm="$SPLITTING_ALGORITHM" \
                         "${SPLIT_GRANULARITY[@]}" \
-                        --reruns 1 --reruns-delay 1 \
                         -r fEsxX \
                         --junitxml=junit-core.xml \
                         $PYTEST_ARGS
@@ -2590,7 +2589,7 @@ jobs:
                   if [[ "$MODE" == "selected" ]]; then
                       # Selected mode: no sharding, no --store-durations (don't pollute
                       # timing data with a partial run), no --reruns. See the core selected branch;
-                      # the full run keeps a reduced --reruns 1 cold-start net until quarantine matures.
+                      # the full run also skips --reruns so raw flake signal reaches Trunk.
                       # shellcheck disable=SC2086
                       pytest -v --tb=short --reuse-db -o junit_duration_report=call $TEMPORAL_FILES -m "not async_migrations" \
                           -r fEsxX \
@@ -2609,7 +2608,6 @@ jobs:
                           --pytest-durations=100 \
                           --splitting-algorithm="$SPLITTING_ALGORITHM" \
                           "${SPLIT_GRANULARITY[@]}" \
-                          --reruns 1 --reruns-delay 1 \
                           -r fEsxX \
                           --junitxml=junit-temporal.xml \
                           $PYTEST_ARGS

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -14,7 +14,7 @@ on:
     workflow_dispatch:
         inputs:
             playwright_retries:
-                description: 'Override Playwright retries (leave empty for default of 1 on CI — a cold-start net while Trunk quarantine matures). Set to 0 to surface true per-test failure rate.'
+                description: 'Override Playwright retries (leave empty for default of 0 on CI so raw per-test signal reaches Trunk). Set to 1+ to add a retry net for a one-off run.'
                 required: false
                 type: string
                 default: ''
@@ -619,11 +619,10 @@ jobs:
               continue-on-error: true
               shell: bash
               env:
-                  # Retries default to 1 as a cold-start net while Trunk's quarantine list
-                  # matures — a not-yet-classified flake gets one retry instead of reding the PR.
-                  # Drop back to 0 once quarantine reliably catches flakes so raw signal reaches
-                  # Trunk. The flake-audit workflow still forces 0; workflow_dispatch can override.
-                  PLAYWRIGHT_RETRIES: ${{ inputs.playwright_retries || '1' }}
+                  # Retries default to 0 so raw per-test signal reaches Trunk — retries mask
+                  # the flake signal quarantining relies on; the quarantine gate below is the
+                  # flake net instead. workflow_dispatch can override for a one-off run.
+                  PLAYWRIGHT_RETRIES: ${{ inputs.playwright_retries || '0' }}
               # WARNING: Worker count is tuned to avoid CPU scheduling contention. Talk to #team-devex before changing.
               # Reduced from 6+4 to 4+2 to minimize CPU scheduling contention (see PR #46853)
               # Capture-only: VR is the gate for visual changes, Playwright just captures screenshots

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -80,6 +80,10 @@ jobs:
               run: uv sync --frozen --dev
 
             - name: Run tests
+              id: run-tests
+              # continue-on-error so the quarantine gate below is the verdict — it passes when
+              # every failure is an already-quarantined flake, fails otherwise.
+              continue-on-error: true
               env:
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -97,17 +101,28 @@ jobs:
                   name: junit-results-llm-gateway
                   path: services/llm-gateway/junit.xml
 
-            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
-            - name: Upload test results to Trunk
-              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+            # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
+            # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
+            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            - name: Quarantine gate
+              id: quarantine_gate
               continue-on-error: true
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: services/llm-gateway/junit.xml
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
+                  quarantine: true
+                  previous-step-outcome: ${{ steps.run-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
+
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot.
+            - name: Fail on test failure
+              if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' && steps.quarantine_gate.outcome != 'success' }}
+              shell: bash
+              run: exit 1
 
     # Single required status check for branch protection. Add future LLM
     # services test jobs to `needs` here rather than reconfiguring GitHub.

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -553,6 +553,10 @@ jobs:
                   verbose: true
 
             - name: Run integration tests
+              id: run-integration-tests
+              # continue-on-error so the quarantine gate below is the verdict — it passes when
+              # every failure is an already-quarantined flake, fails otherwise.
+              continue-on-error: true
               # The junit reporter (alongside the default console one) feeds the Trunk upload below.
               run: cd services/mcp && pnpm run test:integration -- --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
               env:
@@ -561,17 +565,29 @@ jobs:
                   TEST_ORG_ID: ${{ env.TEST_ORG_ID }}
                   TEST_PROJECT_ID: ${{ env.TEST_PROJECT_ID }}
 
-            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
-            - name: Upload test results to Trunk
-              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+            # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
+            # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
+            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            - name: Quarantine gate
+              id: quarantine_gate
               continue-on-error: true
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: services/mcp/junit-integration.xml
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
+                  quarantine: true
+                  previous-step-outcome: ${{ steps.run-integration-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
+
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot. Sits before the logs-on-failure steps
+            # so a real failure still triggers them via failure().
+            - name: Fail on test failure
+              if: ${{ !cancelled() && steps.run-integration-tests.outcome == 'failure' && steps.quarantine_gate.outcome != 'success' }}
+              shell: bash
+              run: exit 1
 
             - name: Show server logs on failure
               if: failure()

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -354,6 +354,10 @@ jobs:
                   cd nodejs && pnpm run setup:test:persons-parity
 
             - name: Test with Jest
+              id: run-jest
+              # continue-on-error so the quarantine gate below is the verdict — it passes when
+              # every failure is an already-quarantined flake, fails otherwise.
+              continue-on-error: true
               env:
                   # Below DB name has `test_` prepended, as that's how Django (ran above) creates the test DB
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_posthog'
@@ -377,6 +381,8 @@ jobs:
               run: bin/turbo run test --filter=@posthog/nodejs
 
             - name: Test postgres-parity (isolated DB)
+              id: run-parity
+              continue-on-error: true
               if: (success() || failure()) && matrix.shard == 1
               env:
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_posthog'
@@ -392,17 +398,31 @@ jobs:
                   JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
               run: cd nodejs && pnpm run test:postgres-parity
 
-            # Upload results to Trunk for flaky-test detection. Non-gating (continue-on-error),
-            # so a Trunk outage never fails the job. Runs the token only on internal PRs,
-            # master, and the merge queue — never on fork PRs or Dependabot, which have no secret.
-            - name: Upload test results to Trunk
-              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
+            # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
+            # the verdict, so a Trunk outage can't red a passing shard. Internal PRs only (needs the
+            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            - name: Quarantine gate
+              id: quarantine_gate
               continue-on-error: true
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: junit-results/junit-*.xml
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
+                  quarantine: true
+                  # Worst of the two test steps: the gate must know the run failed even when
+                  # only the parity step (shard 1) did. A skipped parity step counts as success.
+                  previous-step-outcome: ${{ (steps.run-jest.outcome == 'failure' || steps.run-parity.outcome == 'failure') && 'failure' || 'success' }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
+
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot. Sits before the logs-on-failure step
+            # so a real failure still triggers it via failure().
+            - name: Fail on test failure
+              if: ${{ !cancelled() && (steps.run-jest.outcome == 'failure' || steps.run-parity.outcome == 'failure') && steps.quarantine_gate.outcome != 'success' }}
+              shell: bash
+              run: exit 1
 
             - name: Output logs on failure
               if: failure()

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -37,10 +37,11 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /*
-        Retries are 3 on CI by default. The nightly flake-audit workflow sets
-        PLAYWRIGHT_RETRIES=0 to surface the true per-test failure rate, which the
-        default retry budget otherwise hides (50%-flaky tests pass 93.75% of the time
-        with 4 attempts).
+        Retries are 3 on CI by default (when PLAYWRIGHT_RETRIES is unset). The CI
+        Playwright workflow and the nightly flake-audit both set PLAYWRIGHT_RETRIES=0
+        to surface the true per-test failure rate for Trunk quarantining, which a
+        retry budget otherwise hides (50%-flaky tests pass 93.75% of the time with
+        4 attempts).
      */
     retries: process.env.PLAYWRIGHT_RETRIES ? Number(process.env.PLAYWRIGHT_RETRIES) : process.env.CI ? 3 : 2,
     /*

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -23,6 +23,7 @@ from posthog.test.base import (
 from unittest.mock import MagicMock, Mock, patch
 
 from django.apps import apps
+from django.db import connection
 from django.test import TestCase
 from django.utils.timezone import now
 
@@ -5113,12 +5114,18 @@ class TestQuerySplitting(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, Test
         Team.objects.all().delete()
         Organization.objects.all().delete()
 
-        # Create a fresh team for testing
-        self.team = Team.objects.create(organization=Organization.objects.create(name="test"))
-
-        # Create analytics team for AI credits tests (team 2 for US region)
+        # Create analytics team for AI credits tests (team 2 for US region). The explicit
+        # pk doesn't advance the id sequence, so bump it past the max to keep the auto-pk
+        # team below from being handed id 2 and colliding.
         analytics_org = Organization.objects.create(name="PostHog Analytics")
         self.analytics_team = Team.objects.create(pk=2, organization=analytics_org, name="Analytics")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT setval(pg_get_serial_sequence('posthog_team', 'id'), (SELECT MAX(id) FROM posthog_team))"
+            )
+
+        # Create a fresh team for testing
+        self.team = Team.objects.create(organization=Organization.objects.create(name="test"))
 
         # Create test events across a time period
         self.begin = datetime(2023, 1, 1, 0, 0)

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,9 @@ env =
     DEBUG=1
     TEST=1
 DJANGO_SETTINGS_MODULE = posthog.settings
+# Trunk flaky-test detection wants per-test file paths in junit XML; the default
+# xunit2 family strips the file/line testcase attributes.
+junit_family = xunit1
 # --pytest-durations=0 disables the pytest-durations plugin by default; CI shard steps re-enable it explicitly
 # -p no:tach disables tach's pytest plugin: without --tach it builds the full import graph (~5-10s
 # per invocation) only to print a "could be skipped" hint. Opt back in with: pytest -p tach --tach

--- a/services/llm-gateway/pyproject.toml
+++ b/services/llm-gateway/pyproject.toml
@@ -97,7 +97,9 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 pythonpath = ["src"]
-addopts = ["--junitxml=junit.xml", "--reruns=2", "--reruns-delay=5"]
+# No --reruns: retries mask the raw flake signal Trunk quarantining relies on.
+# xunit1 keeps per-test file paths in the junit XML for Trunk flake attribution.
+addopts = ["--junitxml=junit.xml", "-o", "junit_family=xunit1"]
 
 [tool.mypy]
 python_version = "3.13"


### PR DESCRIPTION
## Problem

Our Trunk flaky-test setup deviated from trunk.io's guidance in a few places:

- The backend **products** shard (and the mcp, nodejs, and llm-gateway suites) uploaded results as a fire-and-forget step (`continue-on-error: true`, no gating), so Trunk quarantining could never clear an already-quarantined flake there — a quarantined flake still redded the job. The Core/Temporal shards, jest, and playwright already gate.
- Backend pytest ran with `--reruns 1` and the CI Playwright suite defaulted to 1 retry. Trunk's docs say retries compromise flaky-test detection — a 50%-flaky test passes most runs with a retry budget, so the raw signal never reaches Trunk.
- pytest emitted junit in the default `xunit2` family, which strips the per-test `file`/`line` attributes Trunk's pytest guide asks for (`junit_family=xunit1`) for flake attribution.

## Changes

- Convert the products, mcp, nodejs, and llm-gateway Trunk uploads to the house quarantine-gate pattern: test step gets `continue-on-error` + an `id`, the uploader runs with `quarantine: true`, `previous-step-outcome`, and a pinned `cli-version`, and an explicit "Fail on test failure" verdict step reds the job on real (unquarantined) failures. This keeps `continue-on-error` on the gate itself — paired with the verdict step it is strictly more outage-tolerant than the docs' plain setup: a Trunk outage on a passing run stays green, real failures still red. Verdict steps sit before `if: failure()` log-dump steps so those still fire.
- Drop `--reruns 1 --reruns-delay 1` from the backend Core/Temporal shards and default `PLAYWRIGHT_RETRIES` to 0 in CI, per the "drop once quarantine is the net" comments already in the file — the gates are the flake net now.
- Add `junit_family = xunit1` to `pytest.ini`.

The ci-ai and ci-storybook uploads stay plain (matching the docs' basic non-quarantine example): both run in aggregation jobs downstream of the test jobs, so gating there can't clear the shards that actually red. ci-dagster doesn't feed Trunk, so its retries are untouched.

## How did you test this code?

Automated only: verified every modified workflow still parses as YAML and the new steps' `id`/`if`/`continue-on-error`/`previous-step-outcome` wiring matches the existing Core/Temporal gates. `bin/hogli lint:workflows` and `actionlint` weren't runnable in this environment (no flox/node_modules); CI runs them on this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — CI-internal change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code; skills invoked: `/authoring-ci-workflows`.
- Reviewed every `trunk-io/analytics-uploader` use in the repo against Trunk's flaky-tests docs (GitHub Actions + pytest guides). First commit fixed the products shard; on request, the second commit fixed all remaining deviations.
- Considered simply removing `continue-on-error` from upload steps as originally advised; rejected because without a verdict step that reds every shard on a Trunk outage, and the docs' own basic example keeps `continue-on-error` on ungated uploads. The gate + verdict pattern used here is the repo's established, more outage-tolerant equivalent.
- For the nodejs job, which has two test steps (jest + postgres-parity on shard 1), the gate takes the worst of both outcomes and the verdict checks either.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
