### PR TITLE
fix(mcp-analytics): sync tool-quality categories to url and fix stale date label

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
@@ -16,7 +16,8 @@ import { ToolQualityCharts } from './tool-quality/ToolQualityCharts'
 import { ToolQualityTable } from './tool-quality/ToolQualityTable'
 
 function FilterBar(): JSX.Element {
-    const { availableCategories, selectedCategories, scopeShare, dateFilter } = useValues(mcpAnalyticsToolQualityLogic)
+    const { availableCategories, selectedCategories, scopeShare, dateFilter, dateRangeLabel } =
+        useValues(mcpAnalyticsToolQualityLogic)
     const { setSelectedCategories, setDateFilter } = useActions(mcpAnalyticsToolQualityLogic)
 
     const hasScope = selectedCategories.length > 0
@@ -42,10 +43,10 @@ function FilterBar(): JSX.Element {
             />
             {hasScope && sharePct !== null ? (
                 <Tooltip
-                    title={`${scopeShare.inScope.toLocaleString()} of ${scopeShare.total.toLocaleString()} MCP tool calls in the last 7 days were in the selected categories`}
+                    title={`${scopeShare.inScope.toLocaleString()} of ${scopeShare.total.toLocaleString()} MCP tool calls were in the selected categories (${dateRangeLabel})`}
                 >
                     <div className="text-sm text-muted">
-                        <span className="font-semibold text-default">{sharePct}%</span> of MCP usage (last 7d)
+                        <span className="font-semibold text-default">{sharePct}%</span> of MCP usage ({dateRangeLabel})
                     </div>
                 </Tooltip>
             ) : null}

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
@@ -84,7 +84,7 @@ describe('mcpAnalyticsToolQualityLogic', () => {
             return mockApi.query.mock.calls.slice(callIndex).map((call) => call[0] as any)
         }
 
-        it('reloads the tool rows and daily stats with the new date range when the date filter changes', async () => {
+        it('reloads the tool rows, daily stats and category counts with the new date range when the date filter changes', async () => {
             const logic = mcpAnalyticsToolQualityLogic()
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
@@ -95,8 +95,10 @@ describe('mcpAnalyticsToolQualityLogic', () => {
             }).toFinishAllListeners()
 
             const newCalls = queryCallsSince(callsBefore)
-            expect(newCalls.length).toBe(2) // tool rows + daily stats
+            expect(newCalls.length).toBe(3) // tool rows + daily stats + category counts
+            // The scope-share headline must track the same window as the rest of the tab.
             expect(newCalls.map((call) => call.filters.dateRange)).toEqual([
+                { date_from: '-30d', date_to: null },
                 { date_from: '-30d', date_to: null },
                 { date_from: '-30d', date_to: null },
             ])

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -4,7 +4,7 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
-import { dateStringToDayJs } from 'lib/utils/dateFilters'
+import { dateFilterToText, dateStringToDayJs } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -30,14 +30,16 @@ WHERE event = '$mcp_tool_call'
 ORDER BY category
 `
 
-// Per-category call counts over a fixed 7-day window powering the "share of MCP
+// Per-category call counts over the selected window, powering the "share of MCP
 // usage" headline. Rows with an empty category count toward the total but not the
-// in-scope numerator, so uncategorized traffic dilutes the share as expected.
-const CATEGORY_COUNTS_QUERY = hogql`
+// in-scope numerator, so uncategorized traffic dilutes the share as expected. The
+// date range rides in via the {filters} placeholder so the headline tracks the
+// same window as the rest of the tab.
+const CATEGORY_COUNTS_QUERY = `
 SELECT toString(properties.$mcp_tool_category) AS category, count() AS calls
 FROM events
 WHERE event = '$mcp_tool_call'
-    AND timestamp >= now() - INTERVAL 7 DAY
+    AND {filters}
 GROUP BY category
 `
 
@@ -221,8 +223,17 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
             [] as CategoryCount[],
             {
                 loadCategoryCounts: async (): Promise<CategoryCount[]> => {
-                    const response = await hogqlQuery(CATEGORY_COUNTS_QUERY)
-                    return ((response?.results as unknown[][]) ?? []).map((r) => ({
+                    const response = (await api.query({
+                        kind: NodeKind.HogQLQuery,
+                        query: CATEGORY_COUNTS_QUERY,
+                        filters: {
+                            dateRange: {
+                                date_from: values.dateFilter.dateFrom,
+                                date_to: values.dateFilter.dateTo,
+                            },
+                        },
+                    })) as HogQLQueryResponse
+                    return ((response.results as unknown[][]) ?? []).map((r) => ({
                         category: String(r[0] ?? ''),
                         calls: Number(r[1] ?? 0),
                     }))
@@ -341,6 +352,14 @@ ORDER BY day
                       ]
                     : [],
         ],
+        // Human-readable label for the active window (e.g. "Last 7 days"), used by
+        // the scope-share headline so it never falls out of sync with the filter.
+        dateRangeLabel: [
+            (s) => [s.dateFilter],
+            (dateFilter: DateFilter): string =>
+                dateFilterToText(dateFilter.dateFrom, dateFilter.dateTo, 'the selected range') ??
+                'the selected range',
+        ],
         scopeShare: [
             (s) => [s.categoryCounts, s.selectedCategories],
             (categoryCounts: CategoryCount[], selectedCategories: string[]): ScopeShare => {
@@ -374,9 +393,12 @@ ORDER BY day
     }),
 
     listeners(({ actions, values }) => ({
-        // Both scope filters refetch the table and the charts
+        // Both scope filters refetch the table and the charts; a date change also
+        // refreshes the category counts so the "share of MCP usage" headline tracks
+        // the same window.
         setDateFilter: () => {
             actions.reloadAll()
+            actions.loadCategoryCounts()
         },
         setSelectedCategories: () => {
             actions.reloadAll()
@@ -406,6 +428,11 @@ ORDER BY day
             } else {
                 delete searchParams.tool
             }
+            if (values.selectedCategories.length > 0) {
+                searchParams.categories = values.selectedCategories
+            } else {
+                delete searchParams.categories
+            }
             if (values.dateFilter.dateFrom) {
                 searchParams.date_from = values.dateFilter.dateFrom
             } else {
@@ -421,6 +448,7 @@ ORDER BY day
         return {
             setSelectedTool: syncUrl,
             setDateFilter: syncUrl,
+            setSelectedCategories: syncUrl,
         }
     }),
 
@@ -429,6 +457,14 @@ ORDER BY day
             const tool = typeof searchParams.tool === 'string' && searchParams.tool ? searchParams.tool : null
             if (tool !== values.selectedTool) {
                 actions.setSelectedTool(tool)
+            }
+            const categories = Array.isArray(searchParams.categories)
+                ? searchParams.categories.map(String)
+                : typeof searchParams.categories === 'string' && searchParams.categories
+                  ? [searchParams.categories]
+                  : []
+            if (JSON.stringify(categories) !== JSON.stringify(values.selectedCategories)) {
+                actions.setSelectedCategories(categories)
             }
             const dateFrom =
                 typeof searchParams.date_from === 'string' ? searchParams.date_from : values.dateFilter.dateFrom

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -357,8 +357,7 @@ ORDER BY day
         dateRangeLabel: [
             (s) => [s.dateFilter],
             (dateFilter: DateFilter): string =>
-                dateFilterToText(dateFilter.dateFrom, dateFilter.dateTo, 'the selected range') ??
-                'the selected range',
+                dateFilterToText(dateFilter.dateFrom, dateFilter.dateTo, 'the selected range') ?? 'the selected range',
         ],
         scopeShare: [
             (s) => [s.categoryCounts, s.selectedCategories],


### PR DESCRIPTION
## Problem

On the MCP analytics **Tool quality** tab:
- The category scope selection wasn't reflected in the URL, so it was lost on reload and couldn't be shared as a link — unlike the tool and date filters, which already sync.
- The "share of MCP usage" headline (and its tooltip) hardcoded "last 7d" and was always computed over a fixed 7-day window, so changing the date range left the label reading "last 7d" and the percentage stuck on the wrong window.

Raised from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1783709137391319).

## Changes

- Persist selected categories as a `categories` search param via `actionToUrl`/`urlToAction`, matching the existing `tool`/`date_from`/`date_to` sync.
- Route the category-counts query through the same date filter as the rest of the tab (via the `{filters}` placeholder) and reload it when the date range changes.
- Add a `dateRangeLabel` selector and render it in the headline and tooltip in place of the hardcoded "last 7d".

## How did you test this code?

Updated the logic unit test to assert that a date-range change also reloads the category counts with the new window. I was not able to run the frontend test suite or typecheck in this environment (no `node_modules`); CI will exercise them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. No repo-provided skills applied cleanly (the `writing-tests` skill referenced by repo rules is not registered in this environment); the existing date-filter test was updated in place rather than adding new tests, keeping to the "does it catch a real regression" bar — the new assertion guards that the scope-share headline tracks the selected window.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1783709137391319)*
