### PR TITLE
fix(stamphog): single app approval and app token for all actions

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -90,15 +90,11 @@ jobs:
             - name: Post review
               if: always()
               env:
-                  # Approvals are posted twice, on purpose. The Stamphog app
-                  # (GH_TOKEN) posts the review body as an approval so the
-                  # human-facing feedback carries the bot's own identity;
-                  # github-actions[bot] (GH_TOKEN_APPROVE) posts a second,
-                  # bodyless approval. We keep both while we confirm which
-                  # identity's approval actually counts toward branch protection
-                  # — GitHub App bot approvals have shown author_association NONE.
-                  # If the github-actions[bot] one proves redundant, drop it.
-                  GH_TOKEN_APPROVE: ${{ github.token }}
+                  # Everything stamphog does — the approval, the sticky comment,
+                  # the label strip — posts as the Stamphog app (GH_TOKEN) so it
+                  # all carries the bot's own identity. The app approval was
+                  # confirmed to unblock PRs, so the earlier bodyless
+                  # github-actions[bot] fallback approval has been dropped.
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   # Derived from the token step so the sticky-comment author
                   # filter tracks an app rename instead of failing silent.
@@ -122,24 +118,15 @@ jobs:
                   fi
 
                   if [ "$VERDICT" = "APPROVED" ]; then
-                    # Stamphog app approval, carrying the review body. Best-effort:
-                    # the step runs under `set -e`, so a failure here (e.g. the App
-                    # install missing Pull-requests write, or a transient error)
-                    # would otherwise abort before the github-actions[bot] approval
-                    # below — the identity currently known to unblock PRs. Keep it
-                    # non-fatal and surface the failure as a warning instead.
+                    # Single Stamphog app approval, carrying the review body.
+                    # Fatal on failure (the step runs under `set -e`): this is
+                    # now the only approval, so if it doesn't post the PR stays
+                    # blocked and that must surface as a red run, not a warning.
                     gh api \
                       -X POST "repos/$REPO/pulls/$PR/reviews" \
                       "${SHA_ARGS[@]}" \
                       -f event=APPROVE \
-                      -f body="$REASONING" \
-                      || echo "::warning::stamphog app approval failed to post; continuing with the github-actions[bot] approval"
-                    # Bodyless github-actions[bot] approval — kept alongside the
-                    # app approval until we've confirmed which one unblocks PRs.
-                    GH_TOKEN="$GH_TOKEN_APPROVE" gh api \
-                      -X POST "repos/$REPO/pulls/$PR/reviews" \
-                      "${SHA_ARGS[@]}" \
-                      -f event=APPROVE
+                      -f body="$REASONING"
                   else
                     # Non-approve verdicts share ONE sticky comment, updated in
                     # place, instead of a fresh COMMENT review per run. Review
@@ -362,10 +349,20 @@ jobs:
         timeout-minutes: 5
 
         steps:
+            - name: Get app token
+              id: app-token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_PR_APPROVAL_AGENT_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_PR_APPROVAL_AGENT_PRIVATE_KEY }}
+
             - name: Dismiss stale bot approvals
               env:
-                  # github.token can dismiss both bot identities' approvals.
-                  GH_TOKEN: ${{ github.token }}
+                  # Act as the Stamphog app for consistency with every other
+                  # write. pull-requests:write can dismiss any review regardless
+                  # of its author, so the app dismisses both its own approvals
+                  # and any legacy github-actions[bot] ones.
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR: ${{ github.event.pull_request.number }}
                   REPO: ${{ github.repository }}
                   REASON: ${{ needs.decide-delta.outputs.reason || (needs.decide-delta.result == 'skipped' && 'label_absent') || 'decide_delta_failed' }}

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -336,10 +336,16 @@ jobs:
         # is skipped for bots, which routes here via the 'skipped' fail-closed
         # path. This only ever touches github-actions[bot] approvals, so it's a
         # no-op when there's nothing to dismiss.
+        # Same-repo only: forked / Dependabot PRs don't receive the app secrets,
+        # so the app-token step below would fail on every such synchronize. There
+        # is nothing to dismiss there anyway, since stamphog can never have
+        # approved a fork PR (the review job's app-token step is equally starved
+        # of secrets on forks), so gate the whole job to head branches in this repo.
         if: >-
             always()
             && github.event.action == 'synchronize'
             && !github.event.pull_request.draft
+            && github.event.pull_request.head.repo.full_name == github.repository
             && (
               needs.decide-delta.outputs.dismiss_approval == 'true'
               || needs.decide-delta.result == 'failure'

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -139,9 +139,8 @@ Final verdict → GitHub review (approve) or sticky comment (everything else)
 
 The bot never posts request-changes.
 Approvals are posted as real PR reviews (they must count toward branch protection).
-An approval is posted twice on purpose: the Stamphog app (`stamphog[bot]`) posts the review body as an approval, and `github-actions[bot]` posts a second, bodyless approval.
-We keep both while confirming which identity's approval actually satisfies branch protection — GitHub App bot approvals have shown `author_association: NONE`.
-If the `github-actions[bot]` one proves redundant, it can be dropped.
+An approval is posted once, as the Stamphog app (`stamphog[bot]`), carrying the review body.
+This identity was confirmed to satisfy branch protection, so the earlier bodyless `github-actions[bot]` fallback approval has been dropped and every stamphog action now runs under the app token.
 Every other verdict (REFUSED, ESCALATE, WAIT, ERROR) goes into a single sticky comment that is updated in place on each run, with a counter of how many verdicts the comment has carried (failure notes append without bumping it) — repeated refusals don't stack up as separate review comments on the PR.
 
 ## Tiers

--- a/tools/pr-approval-agent/dismiss_check.py
+++ b/tools/pr-approval-agent/dismiss_check.py
@@ -36,9 +36,9 @@ from pathlib import Path
 
 from gates import is_trivial_at_dismiss_time
 
-# Both identities Stamphog approves under: github-actions[bot] posts a
-# bodyless approval, stamphog[bot] (the app) posts the approval carrying the
-# review body. Either counts as a prior bot approval for the delta check.
+# Stamphog now approves only as stamphog[bot] (the app), carrying the review
+# body. github-actions[bot] is kept here so legacy bodyless approvals from
+# before that change still count as a prior bot approval for the delta check.
 BOT_LOGINS = {"github-actions[bot]", "stamphog[bot]"}
 
 

--- a/tools/pr-approval-agent/review_pr.py
+++ b/tools/pr-approval-agent/review_pr.py
@@ -448,11 +448,24 @@ class Pipeline:
         summary of who has actually vouched for the current head.
         """
         pr = self.pr
+        # Exclude the author's own reviews: an author commenting on or replying
+        # within their own PR records a COMMENTED review at head, which would
+        # otherwise surface as "<author> reviewed the current head." Self-review
+        # is never independent assurance, so it must not read as a vouch — to the
+        # human in the review body or to the LLM in the trusted prompt block.
         head_approvals = sorted(
-            {r["user"] for r in pr.reviews if r.get("is_current_head") and r.get("state") == "APPROVED"}
+            {
+                r["user"]
+                for r in pr.reviews
+                if r.get("is_current_head") and r.get("state") == "APPROVED" and r["user"] != pr.author
+            }
         )
         head_commented_users = sorted(
-            {r["user"] for r in pr.reviews if r.get("is_current_head") and r.get("state") == "COMMENTED"}
+            {
+                r["user"]
+                for r in pr.reviews
+                if r.get("is_current_head") and r.get("state") == "COMMENTED" and r["user"] != pr.author
+            }
         )
         # Count unresolved conversations, not flattened comments: replies inherit
         # the thread's resolution state, so a single 4-reply thread must read as

--- a/tools/pr-approval-agent/test_review_pr.py
+++ b/tools/pr-approval-agent/test_review_pr.py
@@ -61,6 +61,22 @@ def test_summarize_assurance_counts_threads_not_flattened_replies() -> None:
     assert pipeline._summarize_assurance()["unresolved_threads"] == 1
 
 
+def test_summarize_assurance_excludes_author_self_review() -> None:
+    # An author replying within their own PR records a COMMENTED review at head.
+    # That self-review must not read as a vouch — otherwise the review body and
+    # the trusted assurance block both claim "<author> reviewed the current head."
+    pipeline = Pipeline(pr_number=1, repo="PostHog/posthog")
+    pr = _fake_pr(head_sha="abc123")  # _fake_pr author is "alice"
+    pr.reviews = [
+        {"user": "alice", "state": "COMMENTED", "is_current_head": True, "commit_id": "abc123"},
+        {"user": "bob", "state": "COMMENTED", "is_current_head": True, "commit_id": "abc123"},
+    ]
+    pipeline.pr = pr
+
+    assurance = pipeline._summarize_assurance()
+    assert assurance["head_commented_users"] == ["bob"]
+
+
 def test_to_dict_includes_head_sha() -> None:
     """The post-review workflow step reads head_sha from the JSON output to
     lock the resulting GitHub review to the sha the LLM actually saw — see


### PR DESCRIPTION
## Problem

Follow-up to [#70069](https://github.com/PostHog/posthog/pull/70069), which posted two approvals (the `stamphog[bot]` app approval carrying the review body, plus a bodyless `github-actions[bot]` one) so we could observe which identity actually unblocks PRs. The app approval works, so the second one is now redundant.

Two things to clean up:

1. The extra `github-actions[bot]` approval can go, and while we're here every stamphog write should run under the app's own identity - the `dismiss` job was still using `github.token`.
2. Stamphog's review body kept saying "<author> reviewed the current head" naming the PR author. When an author comments or replies within their own PR, GitHub records a COMMENTED review at head under their name. We were counting that as assurance, both in the human-facing body and in the trusted block the LLM reads. Self-review is not a vouch.

## Changes

- Drop the bodyless `github-actions[bot]` approval. The single `stamphog[bot]` app approval now carries the review body and is fatal on failure (if it can't post, the PR stays blocked, so that must show as a red run rather than a swallowed warning).
- Route the `dismiss` job through the app token. `pull-requests: write` can dismiss any review regardless of author, so the app dismisses both its own approvals and any legacy `github-actions[bot]` ones. Every `GH_TOKEN` in the workflow is now the app token.
- Exclude the PR author from the head-reviewer derivation in `_summarize_assurance`, so an author's own review never reads as "reviewed the current head".
- `dismiss_check.py` keeps recognizing `github-actions[bot]` as a prior bot approval so legacy approvals on already-open PRs still get handled during the transition.
- README updated to describe the single app approval.

## How did you test this code?

- Added `test_summarize_assurance_excludes_author_self_review` - catches a regression where the PR author's own COMMENTED review at head leaks back into the assurance lists. No existing test covered author exclusion (the neighbor covers thread counting).
- Ran the `tools/pr-approval-agent` pure-function suite: 85 passed. The 20 errored cases are the git-fixture tests in `test_dismiss_check.py`, which fail only because this sandbox blocks `git commit`; they pass in CI.
- `ruff check` / `ruff format --check` clean on the touched Python; workflow YAML parses.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by @webjunkie, implemented by Claude (Claude Code). Follow-up to the observation on [#70069](https://github.com/PostHog/posthog/pull/70069) that the app approval alone unblocks PRs.

Investigated the "<author> reviewed the current head" report and traced it to `_summarize_assurance` counting the author's own COMMENTED review at head (GitHub blocks self-approval, so only the COMMENTED path leaks the author). Fixed by excluding the author. Considered whether to keep dismissing `github-actions[bot]` approvals: kept it for the transition since open PRs may still carry one, but new runs only ever produce a `stamphog[bot]` approval.

Skills invoked: `/writing-tests` (gate for the new assurance test).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
