### PR TITLE
feat(autoresearch): lazy-load code off the dashboard eager bundle

### DIFF
--- a/frontend/bin/measure-dashboard-eager.mjs
+++ b/frontend/bin/measure-dashboard-eager.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Measures the dashboard scene's "eager graph": the JS + CSS bytes a browser must download and
+// parse before the dashboard surface is interactive. Same methodology as check-eager-graph.mjs
+// (measured from the esbuild OUTPUT metafile, so tree-shaking is already accounted for), but
+// rooted at the dashboard scene entry chunk instead of the app shell.
+//
+// Reports two numbers:
+//   - total:    every chunk in the dashboard entry's eager closure (cold-load cost).
+//   - marginal: the subset NOT already shipped by the authenticated shell — i.e. the extra
+//               download when a logged-in user navigates into a dashboard. This is the honest
+//               "dashboard loading time" proxy and the number the optimization loop minimizes.
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const frontendDir = path.resolve(__dirname, '..')
+const metaPath = path.join(frontendDir, 'posthog-app-esbuild-meta.json')
+
+const DASHBOARD_ROOT = 'src/scenes/dashboard/Dashboard.tsx'
+const SHELL_ROOT = 'src/scenes/AuthenticatedShell.tsx'
+
+if (!fs.existsSync(metaPath)) {
+    console.error(`Metafile not found at ${metaPath} — run \`pnpm --filter=@posthog/frontend build\` first.`)
+    process.exit(1)
+}
+
+const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
+const outputs = meta.outputs
+if (!outputs) {
+    console.error(`Metafile has no "outputs" — rebuild with metafile output enabled.`)
+    process.exit(1)
+}
+
+function entryChunk(root) {
+    for (const [name, chunk] of Object.entries(outputs)) {
+        if (chunk.entryPoint === root) {
+            return name
+        }
+    }
+    return null
+}
+
+// Eager closure: entry chunk + every chunk reachable through static (import-statement) chunk
+// edges, plus each visited chunk's attached stylesheet (cssBundle, downloaded before render).
+// dynamic-import edges are the lazy boundaries — stop there.
+function eagerChunks(entry) {
+    const seen = new Set([entry])
+    const queue = [entry]
+    const css = new Set()
+    while (queue.length) {
+        const chunk = queue.shift()
+        const cssBundle = outputs[chunk].cssBundle
+        if (cssBundle) {
+            css.add(cssBundle)
+        }
+        for (const imp of outputs[chunk].imports || []) {
+            if (imp.kind !== 'import-statement' || seen.has(imp.path) || !outputs[imp.path]) {
+                continue
+            }
+            seen.add(imp.path)
+            queue.push(imp.path)
+        }
+    }
+    return { js: seen, css }
+}
+
+function sumBytes(chunkSet) {
+    let total = 0
+    for (const c of chunkSet) {
+        total += outputs[c]?.bytes || 0
+    }
+    return total
+}
+
+const dashEntry = entryChunk(DASHBOARD_ROOT)
+if (!dashEntry) {
+    console.error(`Dashboard root '${DASHBOARD_ROOT}' is not an entry chunk — is it still a code-split boundary?`)
+    process.exit(1)
+}
+const shellEntry = entryChunk(SHELL_ROOT)
+
+const dash = eagerChunks(dashEntry)
+const shell = shellEntry ? eagerChunks(shellEntry) : { js: new Set(), css: new Set() }
+
+const totalJs = sumBytes(dash.js)
+const totalCss = sumBytes(dash.css)
+const total = totalJs + totalCss
+
+// Marginal = dashboard eager chunks not already in the shell's eager closure.
+const marginalJsChunks = [...dash.js].filter((c) => !shell.js.has(c))
+const marginalCssChunks = [...dash.css].filter((c) => !shell.css.has(c))
+const marginalJs = sumBytes(marginalJsChunks)
+const marginalCss = sumBytes(marginalCssChunks)
+const marginal = marginalJs + marginalCss
+
+const kib = (b) => (b / 1024).toFixed(1)
+
+// Largest marginal contributors, by the input modules that ship into the marginal chunks.
+const marginalBytesByFile = new Map()
+for (const c of [...marginalJsChunks, ...marginalCssChunks]) {
+    for (const [file, info] of Object.entries(outputs[c].inputs || {})) {
+        if (info.bytesInOutput > 0) {
+            marginalBytesByFile.set(file, (marginalBytesByFile.get(file) || 0) + info.bytesInOutput)
+        }
+    }
+}
+const largest = [...marginalBytesByFile.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20)
+
+console.info(`Dashboard eager graph (root ${DASHBOARD_ROOT}):`)
+console.info(`  entry chunk:        ${dashEntry}`)
+console.info(
+    `  total eager:        ${kib(total)} KiB  (${kib(totalJs)} JS + ${kib(totalCss)} CSS, ${dash.js.size} JS chunks)`
+)
+console.info(
+    `  marginal vs shell:  ${kib(marginal)} KiB  (${kib(marginalJs)} JS + ${kib(marginalCss)} CSS, ${marginalJsChunks.length} JS chunks)`
+)
+console.info(`\n  Largest marginal input modules:`)
+for (const [file, bytes] of largest) {
+    console.info(`    ${kib(bytes).padStart(9)} KiB  ${file}`)
+}
+
+// Machine-readable line for the loop harness.
+console.info(
+    `\nMETRIC total_kib=${kib(total)} marginal_kib=${kib(marginal)} total_bytes=${total} marginal_bytes=${marginal}`
+)

--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -2,7 +2,7 @@ import './DataTable.scss'
 
 import clsx from 'clsx'
 import { BindLogic, BuiltLogic, LogicWrapper, useActions, useValues } from 'kea'
-import { useCallback, useMemo, useState } from 'react'
+import { Suspense, useCallback, useMemo, useState } from 'react'
 
 import { PreAggregatedBadge } from 'lib/components/PreAggregatedBadge'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -13,8 +13,9 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
-import { EventDetails } from 'scenes/activity/explore/EventDetails'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { ViewLinkButton } from 'scenes/data-warehouse/ViewLinkModal'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
 import { PersonDeleteModal } from 'scenes/persons/PersonDeleteModal'
@@ -100,6 +101,12 @@ import { GroupsSearch } from '../GroupsQuery/GroupsSearch'
 import { DataTableOpenEditor } from './DataTableOpenEditor'
 import { DataTableViewReplays } from './DataTableViewReplays'
 import { TableViewSupportedQueryType } from './TableView/tableViewLogic'
+
+// EventDetails only renders inside an expanded table row (a user action) and pulls in heavy
+// event-property renderers (survey responses, AI conversation display) — keep it off the eager path.
+const EventDetails = lazyWithRetry(() =>
+    import('scenes/activity/explore/EventDetails').then((module) => ({ default: module.EventDetails }))
+)
 
 export enum ColumnFeature {
     canSort = 'canSort',
@@ -746,15 +753,23 @@ export function DataTable({
                         onRowExpand: (_: DataTableRow, rowIndex: number) => toggleRowExpanded(rowIndex),
                         onRowCollapse: (_: DataTableRow, rowIndex: number) => toggleRowExpanded(rowIndex),
                         expandedRowRender: function renderExpand({ result }: DataTableRow) {
+                            let event: EventType | Record<string, any> | null = null
                             if (
                                 (isEventsQuery(query.source) || isRevenueExampleEventsQuery(query.source)) &&
                                 Array.isArray(result)
                             ) {
-                                return <EventDetails event={result[columnsInResponse.indexOf('*')] ?? {}} />
+                                event = result[columnsInResponse.indexOf('*')] ?? {}
+                            } else if (result && !Array.isArray(result)) {
+                                event = result as EventType
                             }
-                            if (result && !Array.isArray(result)) {
-                                return <EventDetails event={result as EventType} />
+                            if (event === null) {
+                                return undefined
                             }
+                            return (
+                                <Suspense fallback={<Spinner />}>
+                                    <EventDetails event={event as EventType} />
+                                </Suspense>
+                            )
                         },
                         rowExpandable: ({ result }: DataTableRow) => !!result,
                         noIndent: true,

--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 
 import { IconLlmAnalytics, IconWarning } from '@posthog/icons'
 
@@ -8,13 +8,21 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { insightUrlForEvent } from 'scenes/insights/utils'
-import { ArchiveSurveyButton } from 'scenes/surveys/components/ArchiveSurveyButton'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { saveActionFromEvent } from '~/models/saveAsActionDialog'
 import { EventType, SurveyEventName } from '~/types'
+
+// Only rendered for survey-response rows, inside the row-actions dropdown — keep surveyLogic
+// (a heavy kea logic) off the eager path of every DataTable.
+const ArchiveSurveyButton = lazyWithRetry(() =>
+    import('scenes/surveys/components/ArchiveSurveyButton').then((module) => ({
+        default: module.ArchiveSurveyButton,
+    }))
+)
 
 export function EventRowActions({
     event,
@@ -60,7 +68,9 @@ function EventRowActionsDropdown({ event }: { event: EventType }): JSX.Element {
                 </LemonButton>
             )}
             {event.event === SurveyEventName.SENT && event.uuid && event.properties.$survey_id ? (
-                <ArchiveSurveyButton surveyId={event.properties.$survey_id} responseUuid={event.uuid} />
+                <Suspense fallback={null}>
+                    <ArchiveSurveyButton surveyId={event.properties.$survey_id} responseUuid={event.uuid} />
+                </Suspense>
             ) : null}
             {event.uuid && event.timestamp && <EventCopyLinkButton event={event} />}
             {event.event === '$exception' && '$exception_issue_id' in event.properties ? (

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -1,9 +1,12 @@
 import { useValues } from 'kea'
+import { Suspense } from 'react'
 
 import { IconInfo } from '@posthog/icons'
 import { Link, Tooltip } from '@posthog/lemon-ui'
 
 import { NON_BREAKDOWN_DISPLAY_TYPES } from 'lib/constants'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { pluralize } from 'lib/utils/strings'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { Attribution } from 'scenes/insights/EditorFilters/AttributionFilter'
@@ -21,7 +24,6 @@ import { PoeFilter } from 'scenes/insights/EditorFilters/PoeFilter'
 import { RetentionCondition } from 'scenes/insights/EditorFilters/RetentionCondition'
 import { RetentionOptions } from 'scenes/insights/EditorFilters/RetentionOptions'
 import { SamplingDeprecationNotice } from 'scenes/insights/EditorFilters/SamplingDeprecationNotice'
-import { WebAnalyticsEditorFilters } from 'scenes/insights/EditorFilters/WebAnalyticsEditorFilters'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { FunnelVizType } from 'scenes/insights/views/Funnels/FunnelVizType'
@@ -54,6 +56,14 @@ export interface EditorFiltersProps {
     embedded: boolean
 }
 
+// Web-analytics insights use a bespoke filter UI (and pull in webAnalyticsLogic) — only load it
+// when actually editing a web-analytics insight, not for every insight/dashboard tile.
+const WebAnalyticsEditorFilters = lazyWithRetry(() =>
+    import('scenes/insights/EditorFilters/WebAnalyticsEditorFilters').then((module) => ({
+        default: module.WebAnalyticsEditorFilters,
+    }))
+)
+
 export function EditorFilters({ query, showing, embedded }: EditorFiltersProps): JSX.Element | null {
     const { hasAvailableFeature } = useValues(userLogic)
 
@@ -83,11 +93,13 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
     // Web Analytics insights use their custom filter UI
     if (isWebAnalyticsInsightQuery(query)) {
         return (
-            <WebAnalyticsEditorFilters
-                query={query as WebOverviewQuery | WebStatsTableQuery}
-                showing={showing}
-                embedded={embedded}
-            />
+            <Suspense fallback={<Spinner />}>
+                <WebAnalyticsEditorFilters
+                    query={query as WebOverviewQuery | WebStatsTableQuery}
+                    showing={showing}
+                    embedded={embedded}
+                />
+            </Suspense>
         )
     }
 

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -2,12 +2,13 @@ import './InsightViz.scss'
 
 import clsx from 'clsx'
 import { BindLogic, BuiltLogic, LogicWrapper } from 'kea'
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 
 // InsightViz renders the .InsightCard__viz wrapper whose styles live in InsightCard.scss.
 // Import it here so the viz is sized correctly wherever it renders, not only inside an InsightCard.
 import 'lib/components/Cards/InsightCard/InsightCard.scss'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -18,12 +19,18 @@ import { QueryContext } from '~/queries/types'
 import { InsightLogicProps } from '~/types'
 
 import { DataNodeLogicProps, dataNodeLogic } from '../DataNode/dataNodeLogic'
-import { EditorFilters } from './EditorFilters'
 import { InsightVizDisplay } from './InsightVizDisplay'
 import { insightVizDataCollectionId, insightVizDataNodeKey } from './insightVizKeys'
 import { getCachedResults } from './utils'
 
 export { insightVizDataCollectionId, insightVizDataNodeKey } from './insightVizKeys'
+
+// The insight editor filter panel is only shown while actively editing an insight (never on
+// read-only dashboard tiles, shared views, or exports), and it pulls in the full per-insight-type
+// editor UI — keep it off the eager path and mount it only when the panel is actually showing.
+const EditorFilters = lazyWithRetry(() =>
+    import('./EditorFilters').then((module) => ({ default: module.EditorFilters }))
+)
 
 type InsightVizProps = {
     uniqueKey?: string | number
@@ -134,11 +141,11 @@ export function InsightViz({
                                         : 'InsightCard__viz'
                                 }
                             >
-                                <EditorFilters
-                                    query={query.source}
-                                    showing={!readOnly && showingFilters}
-                                    embedded={isEmbedded}
-                                />
+                                {!readOnly && showingFilters && (
+                                    <Suspense fallback={null}>
+                                        <EditorFilters query={query.source} showing embedded={isEmbedded} />
+                                    </Suspense>
+                                )}
                                 {!isEmbedded ? (
                                     <div className="flex-1 max-h-full overflow-auto">{display}</div>
                                 ) : (

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -1,11 +1,14 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { Suspense } from 'react'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { Funnel } from 'scenes/funnels/Funnel'
 import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
@@ -44,7 +47,6 @@ import { Paths } from 'scenes/paths/Paths'
 import { PathCanvasLabel } from 'scenes/paths/PathsLabel'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { TrendInsight } from 'scenes/trends/Trends'
-import { WebAnalyticsInsight } from 'scenes/web-analytics/WebAnalyticsInsight'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { InsightVizNode, TrendsQuery } from '~/queries/schema/schema-general'
@@ -64,6 +66,12 @@ import { InsightResultMetadata } from './InsightResultMetadata'
 import { ResultCustomizationsModal } from './ResultCustomizationsModal'
 
 /** When the dashboard is still streaming/refreshing tiles, prefer loading UX over "Chart data didn't load". */
+// Web-analytics insights are a specific insight type — keep their bespoke rendering (and the
+// web-analytics tiles it pulls in) off the eager path of every other insight and dashboard tile.
+const WebAnalyticsInsight = lazyWithRetry(() =>
+    import('scenes/web-analytics/WebAnalyticsInsight').then((module) => ({ default: module.WebAnalyticsInsight }))
+)
+
 function DashboardInsightRefreshHintOrLoading({
     dashboardId,
     dashboardItemId,
@@ -382,7 +390,11 @@ export function InsightVizDisplay({
             case InsightType.PATHS:
                 return isUsingPathsV2 ? <PathsV2 /> : <Paths />
             case InsightType.WEB_ANALYTICS:
-                return <WebAnalyticsInsight context={context} editMode={editMode} />
+                return (
+                    <Suspense fallback={<Spinner />}>
+                        <WebAnalyticsInsight context={context} editMode={editMode} />
+                    </Suspense>
+                )
             default:
                 return null
         }

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -1,12 +1,14 @@
 import './Dashboard.scss'
 
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
+import { Suspense } from 'react'
 
 import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
 import { useFileSystemLogView } from 'lib/hooks/useFileSystemLogView'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { cn } from 'lib/utils/css-classes'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { DashboardFilterBar } from 'scenes/dashboard/DashboardFilters'
 import { DashboardItems } from 'scenes/dashboard/DashboardItems'
 import { DashboardLogicProps, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -20,13 +22,20 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { DashboardPlacement, DashboardType, DataColorThemeModel, QueryBasedInsightModel } from '~/types'
 
 import { teamLogic } from '../teamLogic'
-import { AddInsightToDashboardModal } from './addInsightToDashboardModal/AddInsightToDashboardModal'
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 import { DashboardHeader } from './DashboardHeader'
 import { DashboardOverridesBanner } from './DashboardOverridesBanner'
 import { DashboardPublicAccessBanner } from './DashboardPublicAccessBanner'
 import { DashboardZoomControl } from './DashboardZoomControl'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
+
+// Only shown after a user opens the "add insight" modal — keep its saved-insights picker off
+// the dashboard's eager load path.
+const AddInsightToDashboardModal = lazyWithRetry(() =>
+    import('./addInsightToDashboardModal/AddInsightToDashboardModal').then((module) => ({
+        default: module.AddInsightToDashboardModal,
+    }))
+)
 
 interface DashboardProps {
     id?: string
@@ -116,7 +125,11 @@ function DashboardScene({
     return (
         <SceneContent className={cn('dashboard')}>
             {placement == DashboardPlacement.Dashboard && <DashboardHeader />}
-            {canEditDashboard && addInsightToDashboardModalVisible && <AddInsightToDashboardModal />}
+            {canEditDashboard && addInsightToDashboardModalVisible && (
+                <Suspense fallback={null}>
+                    <AddInsightToDashboardModal />
+                </Suspense>
+            )}
             <DashboardPublicAccessBanner dashboard={dashboard} placement={placement} />
 
             {dashboardFailedToLoad ? (

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -1,7 +1,9 @@
 import { useActions, useValues } from 'kea'
+import { Suspense } from 'react'
 
 import { FullScreen } from 'lib/components/FullScreen'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 
@@ -12,9 +14,15 @@ import { DashboardMode } from '~/types'
 
 import { EditModeActions, FullscreenModeActions, ViewModeActions } from './DashboardHeaderActions'
 import { DashboardLoadAction, dashboardLogic } from './dashboardLogic'
-import { DashboardModals } from './DashboardModals'
 import { DashboardSceneMenuBar } from './DashboardSceneMenuBar'
 import { DashboardScenePanel } from './DashboardScenePanel'
+
+// The dashboard modals (sharing, subscriptions, terraform export, add-widget, template editor,
+// delete/duplicate, text/button tile, insight colors) render nothing until a user opens one, so
+// keep them off the dashboard's eager load path behind a lazy boundary.
+const DashboardModals = lazyWithRetry(() =>
+    import('./DashboardModals').then((module) => ({ default: module.DashboardModals }))
+)
 
 export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
@@ -34,7 +42,11 @@ export function DashboardHeader(): JSX.Element | null {
                 <FullScreen onExit={() => setDashboardMode(null, DashboardEventSource.Browser)} />
             )}
 
-            {dashboard && <DashboardModals dashboard={dashboard} />}
+            {dashboard && (
+                <Suspense fallback={null}>
+                    <DashboardModals dashboard={dashboard} />
+                </Suspense>
+            )}
 
             <DashboardScenePanel />
             <DashboardSceneMenuBar />

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -1,7 +1,7 @@
 import './SavedInsights.scss'
 
 import { useActions, useValues } from 'kea'
-import { ComponentType } from 'react'
+import { ComponentType, Suspense } from 'react'
 
 import {
     IconAI,
@@ -54,6 +54,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
@@ -61,6 +62,7 @@ import { cn } from 'lib/utils/css-classes'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { isNonEmptyObject } from 'lib/utils/guards'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { INSIGHT_TYPE_URLS } from 'scenes/insights/utils'
@@ -84,10 +86,15 @@ import {
     SavedInsightsTabs,
 } from '~/types'
 
-import { Alerts } from 'products/alerts/frontend/views/Alerts'
-
 import { ReloadInsight } from './ReloadInsight'
 import { SavedInsightListItem, savedInsightsLogic } from './savedInsightsLogic'
+
+// The alerts view (and its edit modal / detector selector) only renders on the Alerts tab, but is
+// pulled onto the eager path of anything that reads insight-type metadata from this module (e.g.
+// every insight card's heading). Load it lazily so it stays off that path.
+const Alerts = lazyWithRetry(() =>
+    import('products/alerts/frontend/views/Alerts').then((module) => ({ default: module.Alerts }))
+)
 
 export interface InsightTypeMetadata {
     name: string
@@ -1088,7 +1095,9 @@ export function SavedInsights(): JSX.Element {
             {tab === SavedInsightsTabs.History ? (
                 <ActivityLog scope={ActivityScope.INSIGHT} />
             ) : tab === SavedInsightsTabs.Alerts ? (
-                <Alerts alertId={alertModalId} />
+                <Suspense fallback={<Spinner />}>
+                    <Alerts alertId={alertModalId} />
+                </Suspense>
             ) : (
                 <>
                     <SavedInsightsFilters

--- a/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyOpportunityButton.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 
 import { IconMessage } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
@@ -10,6 +10,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { formatPercentage } from 'lib/utils/numbers'
 import { addProductIntent, addProductIntentForCrossSell } from 'lib/utils/product-intents'
+import { lazyWithRetry } from 'lib/utils/retryImport'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { urls } from 'scenes/urls'
 
@@ -27,9 +28,14 @@ import { InsightLogicProps } from '~/types'
 
 import { SURVEY_CREATED_SOURCE } from '../constants'
 import { QuickSurveyType } from '../quick-create/types'
-import { QuickSurveyModal } from '../QuickSurveyModal'
 import { captureMaxAISurveyCreationException } from '../utils'
 import { SurveyableFunnelInsight, extractFunnelContext } from '../utils/opportunityDetection'
+
+// The quick-survey modal pulls in the survey appearance preview (posthog-js/surveys-preview),
+// which is only needed once a user opens it — keep it off the eager path of every insight card.
+const QuickSurveyModal = lazyWithRetry(() =>
+    import('../QuickSurveyModal').then((module) => ({ default: module.QuickSurveyModal }))
+)
 
 export interface SurveyOpportunityButtonProps {
     insight: SurveyableFunnelInsight
@@ -131,12 +137,14 @@ export function SurveyOpportunityButton({
     return (
         <>
             {tooltip ? <Tooltip title={tooltip}>{askUsersButton}</Tooltip> : askUsersButton}
-            {shouldUseQuickCreate && (
-                <QuickSurveyModal
-                    context={{ type: QuickSurveyType.FUNNEL, funnel: funnelContext }}
-                    isOpen={modalOpen}
-                    onCancel={() => setModalOpen(false)}
-                />
+            {shouldUseQuickCreate && modalOpen && (
+                <Suspense fallback={null}>
+                    <QuickSurveyModal
+                        context={{ type: QuickSurveyType.FUNNEL, funnel: funnelContext }}
+                        isOpen={modalOpen}
+                        onCancel={() => setModalOpen(false)}
+                    />
+                </Suspense>
             )}
         </>
     )


### PR DESCRIPTION
## Problem

Opening a dashboard downloads and parses a lot of JavaScript before the page is interactive. Much of that code is for things you rarely do from a dashboard: opening the share or subscriptions modal, expanding an event row, editing an insight's filters, viewing alerts, or creating a survey from a funnel. All of it sat on the dashboard's eager load path, so every dashboard open paid for code most views never use.

## Changes

Converted a series of user-action-gated or rarely-used components to lazy imports (`React.lazy` via the repo's `lazyWithRetry` helper), so they load on demand instead of before first dashboard render. Each was already conditionally rendered, so only the *loading* moment changes.

| Lazily loaded now | Only needed when |
| --- | --- |
| `DashboardModals` (share, subscriptions, terraform export, template editor, delete/duplicate, text/button tile, insight colors) | a user opens one of those modals |
| `AddInsightToDashboardModal` | adding an insight to a dashboard |
| `QuickSurveyModal` (+ `SurveyAppearancePreview` → `posthog-js/surveys-preview`) | opening the "ask users why" survey modal |
| `EventDetails` | expanding an event row in a table |
| `ArchiveSurveyButton` (`surveyLogic`) | a survey-response event row's actions |
| `WebAnalyticsInsight` | rendering a web-analytics insight |
| `WebAnalyticsEditorFilters` (`webAnalyticsLogic`) | editing a web-analytics insight |
| `EditorFilters` (the insight edit panel) | actively editing an insight (never on read-only tiles) |
| `Alerts` view (edit modal, detector selector) | the saved-insights "Alerts" tab |

Measured with a small script added here, `frontend/bin/measure-dashboard-eager.mjs`, which uses the same output-metafile methodology as `check-eager-graph.mjs` but rooted at the dashboard scene. The metric is the dashboard's **marginal** eager download: JS + CSS the dashboard needs that the authenticated app shell hasn't already loaded, i.e. the extra bytes fetched when you navigate into a dashboard.

Result: **3850.7 KiB → 2898.4 KiB, about 25% less** (952 KiB). Step by step:

| After lazy-loading | Marginal eager (KiB) | Δ |
| --- | --- | --- |
| _baseline_ | 3850.7 | – |
| DashboardModals | 3700.5 | −150.2 |
| QuickSurveyModal | 3577.0 | −123.5 |
| EventDetails | 3401.7 | −175.3 |
| ArchiveSurveyButton | 3327.6 | −74.1 |
| AddInsightToDashboardModal | 3315.8 | −11.8 |
| WebAnalyticsInsight | 3236.0 | −79.8 |
| WebAnalyticsEditorFilters | 3144.9 | −91.1 |
| EditorFilters | 3052.2 | −92.7 |
| Alerts view | 2898.4 | −153.8 |

Chart rendering (`chart.js` and friends) was deliberately left eager — it is the dashboard's primary content, so deferring it would hurt perceived load, not help.

> [!NOTE]
> One behavior change worth a look: `EditorFilters` now mounts only when the filter panel is actually shown (i.e. while editing an insight), instead of always mounting hidden. On read-only surfaces (dashboards, shared views, exports) it rendered nothing anyway, so those are unaffected. On the insight editor the only user-visible difference is that toggling the filter panel no longer animates its width.

## How did you test this code?

- Ran the production esbuild build after every change — all pass.
- After each change, confirmed via the esbuild metafile that the lazily-loaded module is no longer reachable on the dashboard's static (eager) import graph.
- Ran `oxlint` and `oxfmt` on the changed files, and the full TypeScript check (`tsgo --noEmit`) — no errors in any file touched here.
- I (Claude) did **not** run the app or click through the UI. Reviewers should sanity-check that each lazily-loaded surface still opens: the share/subscriptions modals, add-insight modal, expanding an event row, the survey "ask users why" modal, editing an insight (and a web-analytics insight), and the saved-insights Alerts tab.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change beyond the editor-panel animation note above, so no docs update needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Created with Autoresearch. This PR was produced by an autonomous optimization loop (Claude Code) with the goal of reducing dashboard loading time. Each iteration made one focused change, rebuilt the production bundle, and re-measured the dashboard's marginal eager output bytes; changes that didn't help would have been reverted.

No repo-mandated skills applied — this is a pure frontend bundle change with no DRF/serializer, migration, taxonomic-filter, API-type, or test changes.

Decisions along the way: I chose the dashboard's marginal eager output (vs the app shell) as the metric because it is the honest proxy for time-to-interactive when navigating into a dashboard from within the app. I traced each surprising module back to its static import chain and only lazy-loaded code that was already conditionally rendered, keeping every change small and behavior-preserving. Two tempting targets were left alone on purpose: `chart.js` (core dashboard content) and the node-`crypto` polyfill pulled in by `lib/hog.ts` (~136 KiB of `bn.js`/`elliptic`/`buffer`) — HogVM consumes that crypto synchronously and cutting it safely needs a dependency/lockfile change out of scope here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
