### PR TITLE
fix(mcp-analytics): source tool failures from $mcp_is_error not $exception

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -28434,10 +28434,10 @@
         },
         "MCPToolFailureItem": {
             "additionalProperties": false,
-            "description": "One row of the per-tool \"Failures\" table: an exception message paired with a tool.",
+            "description": "One row of the per-tool \"Failures\" table: a failure bucket (error type/status) for a tool.",
             "properties": {
                 "harnesses": {
-                    "description": "Resolved harness labels seen for this exception, deduped and sorted.",
+                    "description": "Resolved harness labels seen for this failure, deduped and sorted.",
                     "items": {
                         "type": "string"
                     },
@@ -28447,6 +28447,7 @@
                     "type": "string"
                 },
                 "message": {
+                    "description": "Failure label composed from $mcp_error_type and, when present, $mcp_error_status (e.g. \"api_5xx (HTTP 500)\").",
                     "type": "string"
                 },
                 "occurrences": {
@@ -28458,7 +28459,7 @@
         },
         "MCPToolFailuresQuery": {
             "additionalProperties": false,
-            "description": "Top exception messages paired with a single MCP tool, with server-resolved harness labels.",
+            "description": "Errored calls of a single MCP tool grouped by error type/status, with server-resolved harness labels.",
             "properties": {
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
@@ -28478,7 +28479,7 @@
                     "$ref": "#/definitions/QueryLogTags"
                 },
                 "toolName": {
-                    "description": "The raw $mcp_tool_name to scope $exception events to.",
+                    "description": "The effective tool name to scope to (matched against the single-exec-resolved tool name).",
                     "type": "string"
                 },
                 "version": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2655,12 +2655,13 @@ export interface MCPToolTopUsersQuery extends DataNode<MCPToolTopUsersQueryRespo
 
 export type CachedMCPToolTopUsersQueryResponse = CachedQueryResponse<MCPToolTopUsersQueryResponse>
 
-/** One row of the per-tool "Failures" table: an exception message paired with a tool. */
+/** One row of the per-tool "Failures" table: a failure bucket (error type/status) for a tool. */
 export interface MCPToolFailureItem {
+    /** Failure label composed from $mcp_error_type and, when present, $mcp_error_status (e.g. "api_5xx (HTTP 500)"). */
     message: string
     occurrences: integer
     last_seen: string
-    /** Resolved harness labels seen for this exception, deduped and sorted. */
+    /** Resolved harness labels seen for this failure, deduped and sorted. */
     harnesses: string[]
 }
 
@@ -2668,10 +2669,10 @@ export interface MCPToolFailuresQueryResponse extends AnalyticsQueryResponseBase
     results: MCPToolFailureItem[]
 }
 
-/** Top exception messages paired with a single MCP tool, with server-resolved harness labels. */
+/** Errored calls of a single MCP tool grouped by error type/status, with server-resolved harness labels. */
 export interface MCPToolFailuresQuery extends DataNode<MCPToolFailuresQueryResponse> {
     kind: NodeKind.MCPToolFailuresQuery
-    /** The raw $mcp_tool_name to scope $exception events to. */
+    /** The effective tool name to scope to (matched against the single-exec-resolved tool name). */
     toolName: string
     dateRange?: DateRange
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5267,10 +5267,16 @@ class MCPToolFailureItem(BaseModel):
     )
     harnesses: list[str] = Field(
         ...,
-        description=("Resolved harness labels seen for this exception, deduped and sorted."),
+        description=("Resolved harness labels seen for this failure, deduped and sorted."),
     )
     last_seen: str
-    message: str
+    message: str = Field(
+        ...,
+        description=(
+            'Failure label composed from $mcp_error_type and, when present, $mcp_error_status (e.g. "api_5xx (HTTP '
+            '500)").'
+        ),
+    )
     occurrences: int
 
 
@@ -24177,7 +24183,10 @@ class MCPToolFailuresQuery(BaseModel):
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     response: MCPToolFailuresQueryResponse | None = None
     tags: QueryLogTags | None = None
-    toolName: str = Field(..., description="The raw $mcp_tool_name to scope $exception events to.")
+    toolName: str = Field(
+        ...,
+        description="The effective tool name to scope to (matched against the single-exec-resolved tool name).",
+    )
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5273,8 +5273,8 @@ class MCPToolFailureItem(BaseModel):
     message: str = Field(
         ...,
         description=(
-            'Failure label composed from $mcp_error_type and, when present, $mcp_error_status (e.g. "api_5xx (HTTP '
-            '500)").'
+            "Failure label composed from $mcp_error_type and, when present,"
+            ' $mcp_error_status (e.g. "api_5xx (HTTP 500)").'
         ),
     )
     occurrences: int
@@ -24185,7 +24185,7 @@ class MCPToolFailuresQuery(BaseModel):
     tags: QueryLogTags | None = None
     toolName: str = Field(
         ...,
-        description="The effective tool name to scope to (matched against the single-exec-resolved tool name).",
+        description=("The effective tool name to scope to (matched against the single-exec-resolved tool name)."),
     )
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 

--- a/products/mcp_analytics/backend/hogql_queries/tool_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_tables.py
@@ -76,6 +76,19 @@ _EFFECTIVE_DESCRIPTION = (
 # token only has to be materialized once as `h`.
 _HARNESS_LABELS_AGG = f"arraySort(arrayDistinct(groupArray({mcp_harness.harness_label_sql('h')})))"
 
+# Human-readable failure label for an errored $mcp_tool_call. There is no free-text error
+# message on tool-call events — the SDK stamps a semantic bucket ($mcp_error_type: internal,
+# validation, api_4xx, api_5xx, permission, timeout, rate_limited, missing_context) plus an
+# optional HTTP status ($mcp_error_status). We compose the two into one label, falling back to
+# "unknown" when neither is present (older SDKs / server paths that only set $mcp_is_error).
+_FAILURE_LABEL = (
+    "concat("
+    "coalesce(nullIf(toString(properties.$mcp_error_type), ''), 'unknown'), "
+    "if(empty(coalesce(toString(properties.$mcp_error_status), '')), '', "
+    "concat(' (HTTP ', toString(properties.$mcp_error_status), ')'))"
+    ")"
+)
+
 
 def _display_properties(*, email: str, name: str) -> str:
     """JSON of only the person fields the Top-users cell renders, omitting blanks."""
@@ -197,23 +210,14 @@ class MCPToolFailuresQueryRunner(AnalyticsQueryRunner[MCPToolFailuresQueryRespon
         return mcp_query_date_range(self.team, self.query.dateRange)
 
     def _where(self) -> ast.Expr:
-        # $exception events don't carry the new-SDK markers ($mcp_source / $mcp_exec_tool_call_name),
-        # so this matches the raw $mcp_tool_name rather than the effective tool name.
-        return ast.And(
-            exprs=[
-                parse_expr("event = {event}", placeholders={"event": ast.Constant(value="$exception")}),
-                parse_expr(
-                    "timestamp >= {date_from}", placeholders={"date_from": self.query_date_range.date_from_as_hogql()}
-                ),
-                parse_expr(
-                    "timestamp <= {date_to}", placeholders={"date_to": self.query_date_range.date_to_as_hogql()}
-                ),
-                parse_expr(
-                    "toString(properties.$mcp_tool_name) = {tool}",
-                    placeholders={"tool": ast.Constant(value=self.query.toolName)},
-                ),
-                parse_expr("notEmpty(toString(properties.$exception_message))"),
-            ]
+        # Failures share the tool-call source with every other tool-detail table, so they use the
+        # effective tool name and the same $mcp_source scoping as the stats/error-rate query — the
+        # two can never disagree. (Previously this read $exception events, which don't carry MCP
+        # tool markers, so the table was always empty while the error rate showed failures.)
+        return _tool_call_where(
+            self.query.toolName,
+            self.query_date_range,
+            extra=[parse_expr("toBool(properties.$mcp_is_error)")],
         )
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
@@ -226,7 +230,7 @@ class MCPToolFailuresQueryRunner(AnalyticsQueryRunner[MCPToolFailuresQueryRespon
                 {_HARNESS_LABELS_AGG} AS harnesses
             FROM (
                 SELECT
-                    substring(toString(properties.$exception_message), 1, 200) AS message,
+                    {_FAILURE_LABEL} AS message,
                     timestamp,
                     {token} AS h
                 FROM events
@@ -238,6 +242,7 @@ class MCPToolFailuresQueryRunner(AnalyticsQueryRunner[MCPToolFailuresQueryRespon
             """,
             placeholders={
                 "_HARNESS_LABELS_AGG": parse_expr(_HARNESS_LABELS_AGG),
+                "_FAILURE_LABEL": parse_expr(_FAILURE_LABEL),
                 "token": parse_expr(mcp_harness.HARNESS_TOKEN_SQL),
                 "where": self._where(),
             },

--- a/products/mcp_analytics/backend/hogql_queries/tool_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_tables.py
@@ -81,6 +81,8 @@ _HARNESS_LABELS_AGG = f"arraySort(arrayDistinct(groupArray({mcp_harness.harness_
 # validation, api_4xx, api_5xx, permission, timeout, rate_limited, missing_context) plus an
 # optional HTTP status ($mcp_error_status). We compose the two into one label, falling back to
 # "unknown" when neither is present (older SDKs / server paths that only set $mcp_is_error).
+# Both properties are event-supplied and unbounded, so the query caps the label at 200 chars
+# before grouping on it.
 _FAILURE_LABEL = (
     "concat("
     "coalesce(nullIf(toString(properties.$mcp_error_type), ''), 'unknown'), "
@@ -230,7 +232,7 @@ class MCPToolFailuresQueryRunner(AnalyticsQueryRunner[MCPToolFailuresQueryRespon
                 {_HARNESS_LABELS_AGG} AS harnesses
             FROM (
                 SELECT
-                    {_FAILURE_LABEL} AS message,
+                    substring({_FAILURE_LABEL}, 1, 200) AS message,
                     timestamp,
                     {token} AS h
                 FROM events

--- a/products/mcp_analytics/backend/hogql_queries/tool_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_tables.py
@@ -85,7 +85,7 @@ _FAILURE_LABEL = (
     "concat("
     "coalesce(nullIf(toString(properties.$mcp_error_type), ''), 'unknown'), "
     "if(empty(coalesce(toString(properties.$mcp_error_status), '')), '', "
-    "concat(' (HTTP ', toString(properties.$mcp_error_status), ')'))"
+    "concat(' (HTTP ', coalesce(toString(properties.$mcp_error_status), ''), ')'))"
     ")"
 )
 

--- a/products/mcp_analytics/backend/tests/test_tool_tables.py
+++ b/products/mcp_analytics/backend/tests/test_tool_tables.py
@@ -130,21 +130,34 @@ class TestMCPToolTopUsersQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Clickhous
 
 
 class TestMCPToolFailuresQueryRunner(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin, APIBaseTest):
-    def _emit_exception(
+    def _emit(
         self,
         *,
         tool_name: str = "query_run",
-        message: str = "boom",
+        distinct_id: str = "d1",
         client_name: str | None = None,
+        source: str | None = NEW_SDK_SOURCE,
+        is_error: bool = True,
+        error_type: str | None = None,
+        error_status: str | None = None,
+        exec_tool: str | None = None,
         timestamp: datetime | None = None,
     ) -> None:
-        properties: dict[str, Any] = {"$mcp_tool_name": tool_name, "$exception_message": message}
+        properties: dict[str, Any] = {"$mcp_tool_name": tool_name, "$mcp_is_error": is_error}
+        if source is not None:
+            properties["$mcp_source"] = source
         if client_name is not None:
             properties["$mcp_client_name"] = client_name
+        if error_type is not None:
+            properties["$mcp_error_type"] = error_type
+        if error_status is not None:
+            properties["$mcp_error_status"] = error_status
+        if exec_tool is not None:
+            properties["$mcp_exec_tool_call_name"] = exec_tool
         _create_event(
             team=self.team,
-            event="$exception",
-            distinct_id="d1",
+            event="$mcp_tool_call",
+            distinct_id=distinct_id,
             timestamp=timestamp or datetime.now(tz=UTC),
             properties=properties,
         )
@@ -158,48 +171,64 @@ class TestMCPToolFailuresQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Clickhous
 
     @parameterized.expand(
         [
-            ("sdk_claudeai", "claude-ai", ["Claude.ai"]),
-            ("sdk_mcp_remote_stripped", "claude-ai (via mcp-remote 0.1.37)", ["Claude.ai"]),
-            ("sdk_unknown_to_other", "weird-client", ["Other"]),
+            ("type_and_status", "api_5xx", "500", "api_5xx (HTTP 500)"),
+            ("type_only", "validation", None, "validation"),
+            ("neither_falls_back_to_unknown", None, None, "unknown"),
         ]
     )
-    def test_resolves_harness_labels(self, _name: str, client_name: str, expected: list[str]) -> None:
-        self._emit_exception(client_name=client_name)
+    def test_composes_failure_label(
+        self, _name: str, error_type: str | None, error_status: str | None, expected: str
+    ) -> None:
+        self._emit(error_type=error_type, error_status=error_status, client_name="claude-ai")
         flush_persons_and_events()
 
         rows = self._run()
 
         assert len(rows) == 1
-        assert rows[0].harnesses == expected
+        assert rows[0].message == expected
 
-    def test_groups_by_message_and_counts_occurrences(self) -> None:
-        self._emit_exception(message="boom", client_name="claude-ai")
-        self._emit_exception(message="boom", client_name="cursor-vscode")
-        self._emit_exception(message="other", client_name="claude-ai")
+    def test_only_counts_errored_calls(self) -> None:
+        # The fix's core behavior: failures are sourced from $mcp_is_error on $mcp_tool_call,
+        # so successful calls must never appear (they did when the table read $exception events).
+        self._emit(is_error=False, error_type="validation", client_name="claude-ai")
+        self._emit(is_error=True, error_type="internal", client_name="claude-ai")
         flush_persons_and_events()
 
-        rows = self._run()
-        by_message = {r.message: r for r in rows}
+        assert [r.message for r in self._run()] == ["internal"]
 
-        assert by_message["boom"].occurrences == 2
-        assert by_message["boom"].harnesses == ["Claude.ai", "Cursor"]
-        assert by_message["other"].occurrences == 1
-
-    def test_excludes_other_tools(self) -> None:
-        self._emit_exception(tool_name="other_tool", message="boom", client_name="claude-ai")
+    def test_groups_by_label_dedupes_harnesses_and_counts(self) -> None:
+        self._emit(error_type="internal", client_name="claude-ai")
+        self._emit(error_type="internal", client_name="cursor-vscode")
+        self._emit(error_type="validation", client_name="claude-ai")
         flush_persons_and_events()
 
-        assert self._run(tool_name="query_run") == []
+        by_label = {r.message: r for r in self._run()}
+
+        assert by_label["internal"].occurrences == 2
+        assert by_label["internal"].harnesses == ["Claude.ai", "Cursor"]
+        assert by_label["validation"].occurrences == 1
+
+    def test_excludes_other_tools_and_resolves_effective_tool_name(self) -> None:
+        self._emit(tool_name="other_tool", error_type="internal", client_name="claude-ai")
+        # Single-exec wrapper: the effective tool is in $mcp_exec_tool_call_name, not $mcp_tool_name.
+        self._emit(tool_name="exec", exec_tool="query_run", error_type="validation", client_name="cursor-vscode")
+        flush_persons_and_events()
+
+        assert [r.message for r in self._run(tool_name="query_run")] == ["validation"]
+
+    def test_excludes_events_without_new_sdk_source(self) -> None:
+        self._emit(source=None, error_type="internal", client_name="claude-ai")
+        flush_persons_and_events()
+
+        assert self._run() == []
 
     def test_date_range_excludes_older_events(self) -> None:
         now = datetime.now(tz=UTC)
-        self._emit_exception(message="old", client_name="claude-ai", timestamp=now - timedelta(days=30))
-        self._emit_exception(message="recent", client_name="claude-ai", timestamp=now)
+        self._emit(error_type="internal", timestamp=now - timedelta(days=30))
+        self._emit(error_type="validation", timestamp=now)
         flush_persons_and_events()
 
-        rows = self._run()
-
-        assert {r.message for r in rows} == {"recent"}
+        assert {r.message for r in self._run()} == {"validation"}
 
 
 def _emit_tool_call(

--- a/products/mcp_analytics/backend/tests/test_tool_tables.py
+++ b/products/mcp_analytics/backend/tests/test_tool_tables.py
@@ -174,6 +174,9 @@ class TestMCPToolFailuresQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Clickhous
             ("type_and_status", "api_5xx", "500", "api_5xx (HTTP 500)"),
             ("type_only", "validation", None, "validation"),
             ("neither_falls_back_to_unknown", None, None, "unknown"),
+            # Event-supplied fields are unbounded; the label must be capped so an attacker
+            # emitting huge unique values can't inflate the grouping key and response size.
+            ("long_type_truncated_to_200_chars", "x" * 300, None, "x" * 200),
         ]
     )
     def test_composes_failure_label(

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -677,13 +677,13 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
             <div className="flex flex-col gap-3 px-4 pb-4">
                 <ResultTable
                     title="Failures"
-                    description="Top exception messages paired with this tool. Sourced from $exception events."
+                    description="Errored calls of this tool grouped by error type and HTTP status. Sourced from the $mcp_is_error flag on $mcp_tool_call events, the same source as the error rate above."
                     rows={failureRows}
                     loading={failureRowsLoading}
-                    emptyMessage="No exceptions recorded for this tool in the last 7 days."
+                    emptyMessage="No errored calls recorded for this tool in the last 7 days."
                     columns={[
                         {
-                            header: 'Message',
+                            header: 'Error type',
                             expand: true,
                             render: (r) => <span className="font-mono text-xs">{String(r[0] ?? '')}</span>,
                         },

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -233,12 +233,12 @@ wrappers:
             idempotent: true
         title: Top errors for one MCP tool
         description: >
-            Return the most common error messages for a single MCP tool, each with the resolved client harness it came
-            from. Pass toolName as the raw $mcp_tool_name (the registered tool name) — failures are matched on
-            $exception events, which don't carry the new-SDK effective-tool markers, so unlike the other tool-detail
-            tools this one does NOT resolve the inner tool of a single-exec wrapper call. Also pass a dateRange. Use to
-            answer "why is tool X failing?" or "what errors does tool X throw, and on which clients?".
-        system_prompt_hint: One MCP tool's top error messages, by harness (scoped by raw tool name)
+            Return the most common failure buckets for a single MCP tool, each with the resolved client harness it came
+            from. Failures are the errored $mcp_tool_call events ($mcp_is_error = true) — the same source as the error
+            rate — grouped by $mcp_error_type and HTTP $mcp_error_status (there is no free-text error message on tool
+            calls). Pass toolName (effective tool name, resolved server-side, matching the other tool-detail tools) and a
+            dateRange. Use to answer "why is tool X failing?" or "what errors does tool X throw, and on which clients?".
+        system_prompt_hint: One MCP tool's top failure buckets, by harness (error type + HTTP status)
         exclude_properties:
             - response
             - modifiers

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -236,8 +236,9 @@ wrappers:
             Return the most common failure buckets for a single MCP tool, each with the resolved client harness it came
             from. Failures are the errored $mcp_tool_call events ($mcp_is_error = true) — the same source as the error
             rate — grouped by $mcp_error_type and HTTP $mcp_error_status (there is no free-text error message on tool
-            calls). Pass toolName (effective tool name, resolved server-side, matching the other tool-detail tools) and a
-            dateRange. Use to answer "why is tool X failing?" or "what errors does tool X throw, and on which clients?".
+            calls). Pass toolName (effective tool name, resolved server-side, matching the other tool-detail tools) and
+            a dateRange. Use to answer "why is tool X failing?" or "what errors does tool X throw, and on which
+            clients?".
         system_prompt_hint: One MCP tool's top failure buckets, by harness (error type + HTTP status)
         exclude_properties:
             - response

--- a/products/mcp_analytics/skills/exploring-mcp-tool-quality/SKILL.md
+++ b/products/mcp_analytics/skills/exploring-mcp-tool-quality/SKILL.md
@@ -100,7 +100,7 @@ SELECT
     concat(
         coalesce(nullIf(toString(properties.$mcp_error_type), ''), 'unknown'),
         if(empty(coalesce(toString(properties.$mcp_error_status), '')), '',
-           concat(' (HTTP ', toString(properties.$mcp_error_status), ')'))
+           concat(' (HTTP ', coalesce(toString(properties.$mcp_error_status), ''), ')'))
     ) AS failure,
     count() AS n
 FROM events

--- a/products/mcp_analytics/skills/exploring-mcp-tool-quality/SKILL.md
+++ b/products/mcp_analytics/skills/exploring-mcp-tool-quality/SKILL.md
@@ -86,26 +86,33 @@ under "Tool-quality matrix".
 
 ## Workflow: why is a tool failing
 
-For one tool's top error messages (grouped by harness), call
+For one tool's top failure buckets (grouped by harness), call
 `posthog:query-mcp-tool-failures` with the `toolName` — it's the typed equivalent of the
-query below. Pass the **raw** `$mcp_tool_name` (the registered tool name), not
-the effective inner tool: failures match `$exception` events, which don't carry
-the new-SDK effective-tool markers. Drop to SQL only to correlate to richer
-exception detail (`$exception` events carry `$exception_message`, joined by
-`$session_id` and timestamp) — that session join is approximate: it surfaces
-every exception in the session, not only this tool's, so treat it as a lead, not
-exact attribution:
+query below. Failures come from the **same source as the error rate**: errored
+`$mcp_tool_call` events (`$mcp_is_error`), scoped by the effective tool name. There is no
+free-text error message on tool calls, so failures are grouped by `$mcp_error_type` (a
+semantic bucket: `internal`, `validation`, `api_4xx`, `api_5xx`, `permission`, `timeout`,
+`rate_limited`, `missing_context`) and the HTTP `$mcp_error_status` when present:
 
 ```sql
 posthog:execute-sql
-SELECT toString(properties.$mcp_error_message) AS error, count() AS n
+SELECT
+    concat(
+        coalesce(nullIf(toString(properties.$mcp_error_type), ''), 'unknown'),
+        if(empty(coalesce(toString(properties.$mcp_error_status), '')), '',
+           concat(' (HTTP ', toString(properties.$mcp_error_status), ')'))
+    ) AS failure,
+    count() AS n
 FROM events
 WHERE event = '$mcp_tool_call'
     AND toBool(properties.$mcp_is_error)
     AND coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name)) = '<tool>'
     AND timestamp >= now() - INTERVAL 30 DAY
-GROUP BY error ORDER BY n DESC LIMIT 10
+GROUP BY failure ORDER BY n DESC LIMIT 10
 ```
+
+`$mcp_error_type` is only populated on newer SDK/server paths — a chunk of errored calls
+carry neither type nor status and fall into the `unknown` bucket.
 
 ## Workflow: slowest tools
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
@@ -4,13 +4,13 @@ Any MCP server instrumented with the `@posthog/mcp` SDK — and PostHog's own MC
 
 Query the canonical `$`-prefixed event name. Servers instrumented with the `@posthog/mcp` SDK emit only `$mcp_tool_call` / `$mcp_initialize`; PostHog's own hosted server additionally dual-emits legacy un-prefixed `mcp_tool_call` / `mcp_initialize` aliases through a transition shim. Match the canonical name only — an `event IN ('mcp_tool_call', '$mcp_tool_call')` would double-count PostHog's own server.
 
-**For a single tool, prefer the typed tools.** Each takes a `toolName` plus a `dateRange`, runs the same query runner the tool-detail UI uses, and is gated behind the `mcp-analytics` flag, so results match the UI exactly and you don't re-derive the SQL below. For all of them **except `posthog:query-mcp-tool-failures`**, `toolName` is the effective name (resolved server-side — the inner tool of a single-exec wrapper call). `posthog:query-mcp-tool-failures` is the exception: it matches `$exception` events, which don't carry the new-SDK effective-tool markers, so it takes the **raw** `$mcp_tool_name` (the registered tool name):
+**For a single tool, prefer the typed tools.** Each takes a `toolName` plus a `dateRange`, runs the same query runner the tool-detail UI uses, and is gated behind the `mcp-analytics` flag, so results match the UI exactly and you don't re-derive the SQL below. `toolName` is the effective name (resolved server-side — the inner tool of a single-exec wrapper call) for all of them, including `posthog:query-mcp-tool-failures`:
 
 | question about one tool                                             | tool                                                     |
 | ------------------------------------------------------------------- | -------------------------------------------------------- |
 | headline numbers (calls, errors, p50/p95, users, sessions, intents) | `posthog:query-mcp-tool-stats`                           |
 | day-by-day trend                                                    | `posthog:query-mcp-tool-daily-stats`                     |
-| top error messages, by harness                                      | `posthog:query-mcp-tool-failures` (raw `$mcp_tool_name`) |
+| top failure buckets, by harness                                     | `posthog:query-mcp-tool-failures`                        |
 | top callers (incl. person email/name)                               | `posthog:query-mcp-tool-top-users`                       |
 | tools called before/after it (`neighborDirection: before`/`after`)  | `posthog:query-mcp-tool-neighbors`                       |
 | recent agent intents                                                | `posthog:query-mcp-tool-sample-intents`                  |
@@ -27,7 +27,8 @@ And `posthog:query-mcp-harness-breakdown` for the cross-tool harness cut (see be
 | `$mcp_tool_name`           | Registered tool name.                                                                                                                    |
 | `$mcp_exec_tool_call_name` | Inner tool name when the call went through the new-SDK single-exec wrapper. See effective-tool-name note below.                          |
 | `$mcp_is_error`            | Whether the call failed. Always read via `toBool(properties.$mcp_is_error)`.                                                             |
-| `$mcp_error_message`       | Error text when `$mcp_is_error` is true.                                                                                                 |
+| `$mcp_error_type`          | Semantic failure bucket when `$mcp_is_error` is true (`internal`, `validation`, `api_4xx`, `api_5xx`, `permission`, `timeout`, `rate_limited`, `missing_context`). Only newer SDK/server paths set it. |
+| `$mcp_error_status`        | HTTP status code for an errored call, when the failure came from an HTTP call.                                                           |
 | `$mcp_duration_ms`         | Wall-clock duration; cast with `toFloat(...)`.                                                                                           |
 | `$session_id`              | Session/conversation id — the grouping key for a single agent run. Use the bare `$session_id` field, not `properties.$session_id`.       |
 | `$mcp_intent`              | The agent's stated intent for the call, when supplied.                                                                                   |
@@ -41,7 +42,7 @@ And `posthog:query-mcp-harness-breakdown` for the cross-tool harness cut (see be
 coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))
 ```
 
-**Failures with detail.** `$mcp_tool_call` carries `$mcp_is_error` + `$mcp_error_message`; richer stack/exception data is on `$exception` events (`$exception_message`), correlated by `$mcp_session_id` / `$session_id` and timestamp.
+**Failures with detail.** `$mcp_tool_call` carries `$mcp_is_error` plus a semantic `$mcp_error_type` and, for HTTP failures, `$mcp_error_status`. `posthog:query-mcp-tool-failures` groups errored tool calls by these two fields. A free-text `$mcp_error_message` / `$mcp_response` exists in the SDK schema but PostHog's hosted server leaves both empty, so don't rely on them for tool-failure detail. PostHog's own tool calls also don't emit `$exception` events — those only exist for separately-instrumented MCP servers.
 
 ## Example queries
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
@@ -6,15 +6,15 @@ Query the canonical `$`-prefixed event name. Servers instrumented with the `@pos
 
 **For a single tool, prefer the typed tools.** Each takes a `toolName` plus a `dateRange`, runs the same query runner the tool-detail UI uses, and is gated behind the `mcp-analytics` flag, so results match the UI exactly and you don't re-derive the SQL below. `toolName` is the effective name (resolved server-side — the inner tool of a single-exec wrapper call) for all of them, including `posthog:query-mcp-tool-failures`:
 
-| question about one tool                                             | tool                                                     |
-| ------------------------------------------------------------------- | -------------------------------------------------------- |
-| headline numbers (calls, errors, p50/p95, users, sessions, intents) | `posthog:query-mcp-tool-stats`                           |
-| day-by-day trend                                                    | `posthog:query-mcp-tool-daily-stats`                     |
-| top failure buckets, by harness                                     | `posthog:query-mcp-tool-failures`                        |
-| top callers (incl. person email/name)                               | `posthog:query-mcp-tool-top-users`                       |
-| tools called before/after it (`neighborDirection: before`/`after`)  | `posthog:query-mcp-tool-neighbors`                       |
-| recent agent intents                                                | `posthog:query-mcp-tool-sample-intents`                  |
-| distinct descriptions seen                                          | `posthog:query-mcp-tool-descriptions`                    |
+| question about one tool                                             | tool                                    |
+| ------------------------------------------------------------------- | --------------------------------------- |
+| headline numbers (calls, errors, p50/p95, users, sessions, intents) | `posthog:query-mcp-tool-stats`          |
+| day-by-day trend                                                    | `posthog:query-mcp-tool-daily-stats`    |
+| top failure buckets, by harness                                     | `posthog:query-mcp-tool-failures`       |
+| top callers (incl. person email/name)                               | `posthog:query-mcp-tool-top-users`      |
+| tools called before/after it (`neighborDirection: before`/`after`)  | `posthog:query-mcp-tool-neighbors`      |
+| recent agent intents                                                | `posthog:query-mcp-tool-sample-intents` |
+| distinct descriptions seen                                          | `posthog:query-mcp-tool-descriptions`   |
 
 And `posthog:query-mcp-harness-breakdown` for the cross-tool harness cut (see below).
 
@@ -22,19 +22,19 @@ And `posthog:query-mcp-harness-breakdown` for the cross-tool harness cut (see be
 
 ## Key properties
 
-| Property                   | Meaning                                                                                                                                  |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `$mcp_tool_name`           | Registered tool name.                                                                                                                    |
-| `$mcp_exec_tool_call_name` | Inner tool name when the call went through the new-SDK single-exec wrapper. See effective-tool-name note below.                          |
-| `$mcp_is_error`            | Whether the call failed. Always read via `toBool(properties.$mcp_is_error)`.                                                             |
+| Property                   | Meaning                                                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `$mcp_tool_name`           | Registered tool name.                                                                                                                                                                                  |
+| `$mcp_exec_tool_call_name` | Inner tool name when the call went through the new-SDK single-exec wrapper. See effective-tool-name note below.                                                                                        |
+| `$mcp_is_error`            | Whether the call failed. Always read via `toBool(properties.$mcp_is_error)`.                                                                                                                           |
 | `$mcp_error_type`          | Semantic failure bucket when `$mcp_is_error` is true (`internal`, `validation`, `api_4xx`, `api_5xx`, `permission`, `timeout`, `rate_limited`, `missing_context`). Only newer SDK/server paths set it. |
-| `$mcp_error_status`        | HTTP status code for an errored call, when the failure came from an HTTP call.                                                           |
-| `$mcp_duration_ms`         | Wall-clock duration; cast with `toFloat(...)`.                                                                                           |
-| `$session_id`              | Session/conversation id — the grouping key for a single agent run. Use the bare `$session_id` field, not `properties.$session_id`.       |
-| `$mcp_intent`              | The agent's stated intent for the call, when supplied.                                                                                   |
-| `$mcp_client_name`         | Raw client string (e.g. `claude-code/1.2.3`). The dashboard buckets these into harnesses in the frontend; there is no `category` column. |
-| `$mcp_tool_category`       | Tool category, when tagged.                                                                                                              |
-| `$mcp_tool_description`    | Tool description as seen by the agent (revisions over time).                                                                             |
+| `$mcp_error_status`        | HTTP status code for an errored call, when the failure came from an HTTP call.                                                                                                                         |
+| `$mcp_duration_ms`         | Wall-clock duration; cast with `toFloat(...)`.                                                                                                                                                         |
+| `$session_id`              | Session/conversation id — the grouping key for a single agent run. Use the bare `$session_id` field, not `properties.$session_id`.                                                                     |
+| `$mcp_intent`              | The agent's stated intent for the call, when supplied.                                                                                                                                                 |
+| `$mcp_client_name`         | Raw client string (e.g. `claude-code/1.2.3`). The dashboard buckets these into harnesses in the frontend; there is no `category` column.                                                               |
+| `$mcp_tool_category`       | Tool category, when tagged.                                                                                                                                                                            |
+| `$mcp_tool_description`    | Tool description as seen by the agent (revisions over time).                                                                                                                                           |
 
 **Effective tool name.** New-SDK events wrap the real tool in a single-exec call, so to filter/group by the tool the agent actually invoked, use:
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6498,7 +6498,7 @@
         "system_prompt_hint": "Distinct effective descriptions seen for one MCP tool"
     },
     "query-mcp-tool-failures": {
-        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName as the raw $mcp_tool_name (the registered tool name) — failures are matched on $exception events, which don't carry the new-SDK effective-tool markers, so unlike the other tool-detail tools this one does NOT resolve the inner tool of a single-exec wrapper call. Also pass a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
+        "description": "Return the most common failure buckets for a single MCP tool, each with the resolved client harness it came from. Failures are the errored $mcp_tool_call events ($mcp_is_error = true) — the same source as the error rate — grouped by $mcp_error_type and HTTP $mcp_error_status (there is no free-text error message on tool calls). Pass toolName (effective tool name, resolved server-side, matching the other tool-detail tools) and a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
         "category": "MCP analytics",
         "feature": "mcp_analytics",
         "summary": "Top errors for one MCP tool",
@@ -6511,7 +6511,7 @@
             "readOnlyHint": true
         },
         "feature_flag": "mcp-analytics",
-        "system_prompt_hint": "One MCP tool's top error messages, by harness (scoped by raw tool name)"
+        "system_prompt_hint": "One MCP tool's top failure buckets, by harness (error type + HTTP status)"
     },
     "query-mcp-tool-neighbors": {
         "description": "Return the tools most often called immediately before or after a single MCP tool within the same conversation. Pass toolName (effective tool name, resolved server-side), a dateRange, and neighborDirection ('before' or 'after'). Use to answer \"what does an agent call around tool X?\" — revealing common tool sequences and which tools pair up.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6963,7 +6963,7 @@
         "system_prompt_hint": "Distinct effective descriptions seen for one MCP tool"
     },
     "query-mcp-tool-failures": {
-        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName as the raw $mcp_tool_name (the registered tool name) — failures are matched on $exception events, which don't carry the new-SDK effective-tool markers, so unlike the other tool-detail tools this one does NOT resolve the inner tool of a single-exec wrapper call. Also pass a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
+        "description": "Return the most common failure buckets for a single MCP tool, each with the resolved client harness it came from. Failures are the errored $mcp_tool_call events ($mcp_is_error = true) — the same source as the error rate — grouped by $mcp_error_type and HTTP $mcp_error_status (there is no free-text error message on tool calls). Pass toolName (effective tool name, resolved server-side, matching the other tool-detail tools) and a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
         "category": "MCP analytics",
         "feature": "mcp_analytics",
         "summary": "Top errors for one MCP tool",
@@ -6976,7 +6976,7 @@
             "readOnlyHint": true
         },
         "feature_flag": "mcp-analytics",
-        "system_prompt_hint": "One MCP tool's top error messages, by harness (scoped by raw tool name)"
+        "system_prompt_hint": "One MCP tool's top failure buckets, by harness (error type + HTTP status)"
     },
     "query-mcp-tool-neighbors": {
         "description": "Return the tools most often called immediately before or after a single MCP tool within the same conversation. Pass toolName (effective tool name, resolved server-side), a dateRange, and neighborDirection ('before' or 'after'). Use to answer \"what does an agent call around tool X?\" — revealing common tool sequences and which tools pair up.",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -28694,9 +28694,10 @@ export namespace Schemas {
     }
 
     export interface MCPToolFailureItem {
-      /** Resolved harness labels seen for this exception, deduped and sorted. */
+      /** Resolved harness labels seen for this failure, deduped and sorted. */
       harnesses: string[];
       last_seen: string;
+      /** Failure label composed from $mcp_error_type and, when present, $mcp_error_status (e.g. "api_5xx (HTTP 500)"). */
       message: string;
       occurrences: number;
     }
@@ -28728,7 +28729,7 @@ export namespace Schemas {
       modifiers?: HogQLQueryModifiers | null;
       response?: MCPToolFailuresQueryResponse | null;
       tags?: QueryLogTags | null;
-      /** The raw $mcp_tool_name to scope $exception events to. */
+      /** The effective tool name to scope to (matched against the single-exec-resolved tool name). */
       toolName: string;
       /** version of the node, used for schema migrations */
       version?: number | null;

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -544,7 +544,9 @@ const MCPToolDailyStatsQuery = z.object({
 const MCPToolFailuresQuery = z.object({
     dateRange: DateRange.optional(),
     kind: z.literal('MCPToolFailuresQuery').default('MCPToolFailuresQuery'),
-    toolName: z.string().describe('The raw $mcp_tool_name to scope $exception events to.'),
+    toolName: z
+        .string()
+        .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
 })
 
 const MCPToolTopUsersQuery = z.object({


### PR DESCRIPTION
## Problem

On the MCP analytics tool-detail page, a tool can show a non-zero error rate while the "Failures" table right below it stays empty. Raised in a Slack thread after someone hit exactly this on a tool showing ~2.3% errors with nothing in the failures list.

The two surfaces read different events:

- **Error rate** counts the `$mcp_is_error` flag on `$mcp_tool_call` events.
- **Failures table** queried `$exception` events scoped by `$mcp_tool_name`.

MCP tool failures aren't emitted as `$exception` events - the failure signal lives entirely on the tool-call event. So the failures query matched essentially nothing, and the table was always empty in prod even when the error rate was real.

## Changes

Repoint `MCPToolFailuresQueryRunner` at errored `$mcp_tool_call` events (`$mcp_is_error`), scoped by the effective tool name and `$mcp_source` like every other tool-detail table. Same source as the error rate, so the two can't disagree again.

There's no free-text error message on tool calls, so failures are grouped into a label built from `$mcp_error_type` (semantic bucket: `internal`, `validation`, `api_4xx`, `api_5xx`, `permission`, `timeout`, `rate_limited`, `missing_context`) plus the HTTP `$mcp_error_status` when present, e.g. `api_5xx (HTTP 500)`. Calls with neither fall back to `unknown`.

> [!NOTE]
> `$mcp_error_type` is only populated on newer SDK/server paths, so a meaningful share of errored calls land in the `unknown` bucket today. Populating it (and optionally a real error message) more reliably is a server/SDK follow-up, not part of this change.

Also updated so nothing still points at the old path:

- `MCPToolFailuresQuery` schema + generated artifacts (`schema.py`, `schema.json`, generated tool definitions) - `toolName` is now the effective name.
- The MCP tool description for `query-mcp-tool-failures`.
- Frontend copy on the Failures table (title description, empty state, column header `Error type`).
- The `exploring-mcp-tool-quality` skill and the `models-mcp.md` reference, which documented the `$exception` path and a `$mcp_error_message` property that isn't actually populated.

```diff
- WHERE event = '$exception' AND properties.$mcp_tool_name = <tool>
-       AND notEmpty($exception_message)
+ WHERE event = '$mcp_tool_call' AND <effective tool name> = <tool>
+       AND $mcp_source = 'posthog_mcp_analytics' AND toBool($mcp_is_error)
```

## How did you test this code?

Rewrote `TestMCPToolFailuresQueryRunner` to emit errored `$mcp_tool_call` events. The new cases each lock in a distinct regression:

- `test_only_counts_errored_calls` - successful calls must never appear (the core bug: reading the wrong event let non-failures through / matched nothing).
- `test_composes_failure_label` - type+status, type-only, and the `unknown` fallback.
- `test_groups_by_label_dedupes_harnesses_and_counts` - grouping, occurrence counts, harness dedup.
- `test_excludes_other_tools_and_resolves_effective_tool_name` - single-exec wrapper resolution.
- `test_excludes_events_without_new_sdk_source` - `$mcp_source` scoping.

I (the agent) could not run the ClickHouse-backed test suite in this environment - no local Python/stack. I ran `ruff check` and `ruff format --check` on the changed Python (both pass). CI will run the tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and authored by the PostHog Slack app (Claude) from a Slack thread, driven by @DanielVisca. Confirmed the root cause against prod data before writing code: for the flagged tool the error rate came from 27 errored `$mcp_tool_call` events while the `$exception`-sourced failures query returned zero rows, and project-wide `$mcp_error_message` / `$mcp_response` are never populated on errored calls (so grouping by `$mcp_error_type` + `$mcp_error_status` is the right detail to surface).

Considered grouping by a real error message (to match the sessions view's `_extract_error_message`) but rejected it - both underlying fields are empty for the hosted server, so it would produce one empty bucket. Invoked the `writing-tests` skill before reworking the test class.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1783709354686999?thread_ts=1783709354.686999&cid=C0B3E1Y576X)*
