### PR TITLE
feat(phrocs): add explicit input mode for sending keystrokes

### DIFF
--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -79,6 +79,8 @@ You typically run phrocs via `hogli start` rather than directly.
 | `g`    | Cycle process grouping (from config `groups` field)     |
 | `a`    | Toggle show all registry processes                      |
 | `/`    | Enter search mode (then `tab` to switch to filter mode) |
+| `↵`    | Send keystrokes to the process (output pane)            |
+| `^g`   | Leave input mode                                         |
 | `esc`  | Exit copy, search, and filter modes                     |
 | `?`    | Toggle full help                                        |
 | `q`    | Quit                                                    |
@@ -90,6 +92,18 @@ Mouse clicks switch focus; mouse wheel scrolls the output pane.
 Press `c` to enter copy mode in the output pane.
 Navigate with `↑`/`↓`, press `c` again to mark the selection start, then extend with `↑`/`↓` and press `c` to copy to clipboard.
 Press `esc` to exit without copying.
+
+### Sending input to a process
+
+Some processes wait for input on stdin — a `(y/n)` confirmation, a REPL, an interactive CLI.
+Focus the output pane (`tab`), then type to send keystrokes to the process's PTY.
+
+phrocs auto-detects a prompt when the last output didn't end in a newline, and starts forwarding
+keystrokes right away. That heuristic misses prompts that print a trailing newline, so you can also
+press `↵` to enter **input mode** explicitly: every key then goes to the process until you press
+`^g` to leave. A cursor after the last output line and an `-- INPUT --` footer show when input is
+being forwarded. `↵` sends the current line, `⌫` deletes a character, and the arrow keys are passed
+through. Pane switching (`tab`) and scrolling (`pgup`/`pgdn`/`home`/`end`) still work while forwarding.
 
 ### Search and filter modes
 

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -80,8 +80,7 @@ You typically run phrocs via `hogli start` rather than directly.
 | `a`    | Toggle show all registry processes                      |
 | `/`    | Enter search mode (then `tab` to switch to filter mode) |
 | `↵`    | Send keystrokes to the process (output pane)            |
-| `^g`   | Leave input mode                                         |
-| `esc`  | Exit copy, search, and filter modes                     |
+| `esc`  | Exit input, copy, search, and filter modes              |
 | `?`    | Toggle full help                                        |
 | `q`    | Quit                                                    |
 
@@ -101,7 +100,7 @@ Focus the output pane (`tab`), then type to send keystrokes to the process's PTY
 phrocs auto-detects a prompt when the last output didn't end in a newline, and starts forwarding
 keystrokes right away. That heuristic misses prompts that print a trailing newline, so you can also
 press `↵` to enter **input mode** explicitly: every key then goes to the process until you press
-`^g` to leave. A cursor after the last output line and an `-- INPUT --` footer show when input is
+`esc` to leave. A cursor after the last output line and an `-- INPUT --` footer show when input is
 being forwarded. `↵` sends the current line, `⌫` deletes a character, and the arrow keys are passed
 through. Pane switching (`tab`) and scrolling (`pgup`/`pgdn`/`home`/`end`) still work while forwarding.
 

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -70,14 +70,17 @@ You typically run phrocs via `hogli start` rather than directly.
 | `pgup` | Scroll output up                                        |
 | `home` | Jump to top of output                                   |
 | `end`  | Jump to bottom of output                                |
+| `s`    | Start selected process                                  |
+| `x`    | Stop selected process                                   |
 | `r`    | Restart selected process                                |
 | `R`    | Restart all failed processes                            |
-| `s`    | Stop selected process                                   |
+| `l`    | Clear logs of selected process                          |
 | `c`    | Enter copy mode                                         |
 | `i`    | Show process info in pager                              |
 | `o`    | Sort processes by <name/CPU/RAM/status>                 |
 | `g`    | Cycle process grouping (from config `groups` field)     |
 | `a`    | Toggle show all registry processes                      |
+| `t`    | Enter setup mode (choose which services to run)         |
 | `/`    | Enter search mode (then `tab` to switch to filter mode) |
 | `esc`  | Exit copy, search, and filter modes                     |
 | `↵`    | Send keystrokes to the process (output pane)            |

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -80,7 +80,6 @@ You typically run phrocs via `hogli start` rather than directly.
 | `a`    | Toggle show all registry processes                      |
 | `/`    | Enter search mode (then `tab` to switch to filter mode) |
 | `↵`    | Send keystrokes to the process (output pane)            |
-| `esc`  | Exit input, copy, search, and filter modes              |
 | `?`    | Toggle full help                                        |
 | `q`    | Quit                                                    |
 
@@ -94,15 +93,9 @@ Press `esc` to exit without copying.
 
 ### Sending input to a process
 
-Some processes wait for input on stdin — a `(y/n)` confirmation, a REPL, an interactive CLI.
-Focus the output pane (`tab`), then type to send keystrokes to the process's PTY.
+Some processes wait for input on stdin, like a `(y/n)` confirmation, a REPL, an interactive CLI. Focus the output pane (`tab`), then type to send keystrokes to the process's PTY.
 
-phrocs auto-detects a prompt when the last output didn't end in a newline, and starts forwarding
-keystrokes right away. That heuristic misses prompts that print a trailing newline, so you can also
-press `↵` to enter **input mode** explicitly: every key then goes to the process until you press
-`esc` to leave. A cursor after the last output line and an `-- INPUT --` footer show when input is
-being forwarded. `↵` sends the current line, `⌫` deletes a character, and the arrow keys are passed
-through. Pane switching (`tab`) and scrolling (`pgup`/`pgdn`/`home`/`end`) still work while forwarding.
+phrocs auto-detects a prompt when the last output didn't end in a newline, and starts forwarding keystrokes right away. That heuristic misses prompts that print a trailing newline, so you can also press `↵` to enter **input mode** explicitly: every key then goes to the process until you press `esc` to leave.
 
 ### Search and filter modes
 

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -79,6 +79,7 @@ You typically run phrocs via `hogli start` rather than directly.
 | `g`    | Cycle process grouping (from config `groups` field)     |
 | `a`    | Toggle show all registry processes                      |
 | `/`    | Enter search mode (then `tab` to switch to filter mode) |
+| `esc`  | Exit copy, search, and filter modes                     |
 | `↵`    | Send keystrokes to the process (output pane)            |
 | `?`    | Toggle full help                                        |
 | `q`    | Quit                                                    |

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -93,7 +93,7 @@ type Model struct {
 	// Buffered text for PTY input when the output pane is focused
 	inputBuffer string
 	// Explicit input mode: forward keystrokes to the proc's PTY regardless of
-	// the HasPrompt() heuristic. Toggled on with enter, off with ctrl+g.
+	// the HasPrompt() heuristic. Toggled on with enter, off with esc.
 	inputMode bool
 
 	// Show-all mode: display registry processes not in the current intent config

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -92,6 +92,9 @@ type Model struct {
 
 	// Buffered text for PTY input when the output pane is focused
 	inputBuffer string
+	// Explicit input mode: forward keystrokes to the proc's PTY regardless of
+	// the HasPrompt() heuristic. Toggled on with enter, off with ctrl+g.
+	inputMode bool
 
 	// Show-all mode: display registry processes not in the current intent config
 	showAllRegProcs bool
@@ -505,6 +508,7 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 	m.copyMode = false
 	m.searchMode = false
 	m.filterMode = false
+	m.inputMode = false
 	m.inputBuffer = ""
 	m.viewport.StyleLineFunc = nil
 

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -198,6 +198,75 @@ func TestFocus_mouseClickOutput(t *testing.T) {
 	}
 }
 
+// ── Input mode ──────────────────────────────────────────────────────────────
+
+// startedModel returns a ready model with a single running process, skipping
+// the test if the subprocess can't be spawned in this environment.
+func startedModel(t *testing.T, shell string) (Model, *process.Process) {
+	t.Helper()
+	f := false
+	cfg := &config.Config{
+		Procs:            map[string]config.ProcConfig{"proc": {Shell: shell, Autostart: &f}},
+		MouseScrollSpeed: 3,
+		Scrollback:       1000,
+	}
+	mgr := process.NewManager(cfg)
+	mgr.SetSend(func(tea.Msg) {}) // drain status/output so Start doesn't block
+	m := New(mgr, cfg, "", nil)
+	m = update(m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	p := m.activeProc()
+	if err := p.Start(mgr.Send()); err != nil {
+		t.Skipf("cannot spawn subprocess: %v", err)
+	}
+	if !p.IsRunning() {
+		t.Skip("proc did not reach running state")
+	}
+	return m, p
+}
+
+func TestInputMode_enterAndExit(t *testing.T) {
+	m, p := startedModel(t, "sleep 30")
+	defer p.Stop()
+
+	m = update(m, specialKey(tea.KeyTab)) // focus output pane
+	if m.focusedPane != focusOutput {
+		t.Fatal("expected output focus after tab")
+	}
+	m = update(m, specialKey(tea.KeyEnter))
+	if !m.inputMode {
+		t.Error("enter should activate input mode on a running proc")
+	}
+	m = update(m, tea.KeyPressMsg{Code: 'g', Mod: tea.ModCtrl})
+	if m.inputMode {
+		t.Error("ctrl+g should leave input mode")
+	}
+}
+
+func TestInputMode_ignoredWhenProcNotRunning(t *testing.T) {
+	m := readyModel(t, "backend")
+	m = update(m, specialKey(tea.KeyTab))
+	if m.focusedPane != focusOutput {
+		t.Fatal("expected output focus after tab")
+	}
+	m = update(m, specialKey(tea.KeyEnter))
+	if m.inputMode {
+		t.Error("enter should not activate input mode when the proc is not running")
+	}
+}
+
+func TestInputMode_resetWhenLeavingOutputPane(t *testing.T) {
+	m := readyModel(t, "backend")
+	m.focusedPane = focusOutput
+	m.inputMode = true
+	m = update(m, specialKey(tea.KeyTab)) // back to sidebar
+	if m.focusedPane != focusServices {
+		t.Fatal("expected sidebar focus after tab")
+	}
+	if m.inputMode {
+		t.Error("leaving the output pane should reset input mode")
+	}
+}
+
 // ── Help ──────────────────────────────────────────────────────────────────────
 
 func TestHelp_toggle(t *testing.T) {

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -236,9 +236,9 @@ func TestInputMode_enterAndExit(t *testing.T) {
 	if !m.inputMode {
 		t.Error("enter should activate input mode on a running proc")
 	}
-	m = update(m, tea.KeyPressMsg{Code: 'g', Mod: tea.ModCtrl})
+	m = update(m, specialKey(tea.KeyEscape))
 	if m.inputMode {
-		t.Error("ctrl+g should leave input mode")
+		t.Error("esc should leave input mode")
 	}
 }
 

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -132,11 +132,11 @@ func defaultKeyMap() keyMap {
 		),
 		InputMode: key.NewBinding(
 			key.WithKeys("enter"),
-			key.WithHelp("↵:", "input"),
+			key.WithHelp("↵:", "input (esc to leave)"),
 		),
 		ExitInput: key.NewBinding(
-			key.WithKeys("ctrl+g"),
-			key.WithHelp("^g:", "leave input"),
+			key.WithKeys("esc"),
+			key.WithHelp("esc:", "leave input"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -25,6 +25,8 @@ type keyMap struct {
 	SearchPrev       key.Binding
 	CommitFilter     key.Binding
 	ToggleFilter     key.Binding
+	InputMode        key.Binding
+	ExitInput        key.Binding
 	Quit             key.Binding
 	Help             key.Binding
 	Backspace        key.Binding
@@ -128,6 +130,14 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("tab"),
 			key.WithHelp("↹:", "back to search"),
 		),
+		InputMode: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("↵:", "input"),
+		),
+		ExitInput: key.NewBinding(
+			key.WithKeys("ctrl+g"),
+			key.WithHelp("^g:", "leave input"),
+		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
 			key.WithHelp("q:", "quit"),
@@ -178,7 +188,7 @@ func defaultKeyMap() keyMap {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
+	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.InputMode, k.SetupMode, k.Quit, k.Help}
 }
 
 func (k keyMap) SearchModeHelp() []key.Binding {
@@ -196,7 +206,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.GotoTop, k.GotoBottom, k.ClearLogs},
 		{k.NextPane, k.PrevPane, k.LazyDocker, k.ProcViewer},
 		{k.Start, k.Stop, k.Restart, k.InfoMode},
-		{k.SearchMode, k.CopyMode, k.SetupMode},
+		{k.SearchMode, k.CopyMode, k.SetupMode, k.InputMode},
 		{k.Quit, k.Help, k.ShowAll},
 	}
 }

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -26,7 +26,6 @@ type keyMap struct {
 	CommitFilter     key.Binding
 	ToggleFilter     key.Binding
 	InputMode        key.Binding
-	ExitInput        key.Binding
 	Quit             key.Binding
 	Help             key.Binding
 	Backspace        key.Binding
@@ -132,11 +131,7 @@ func defaultKeyMap() keyMap {
 		),
 		InputMode: key.NewBinding(
 			key.WithKeys("enter"),
-			key.WithHelp("↵:", "input (esc to leave)"),
-		),
-		ExitInput: key.NewBinding(
-			key.WithKeys("esc"),
-			key.WithHelp("esc:", "leave input"),
+			key.WithHelp("↵:", "input"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
@@ -188,7 +183,7 @@ func defaultKeyMap() keyMap {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.InputMode, k.SetupMode, k.Quit, k.Help}
+	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
 }
 
 func (k keyMap) SearchModeHelp() []key.Binding {
@@ -206,7 +201,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.GotoTop, k.GotoBottom, k.ClearLogs},
 		{k.NextPane, k.PrevPane, k.LazyDocker, k.ProcViewer},
 		{k.Start, k.Stop, k.Restart, k.InfoMode},
-		{k.SearchMode, k.CopyMode, k.SetupMode, k.InputMode},
+		{k.SearchMode, k.CopyMode, k.SetupMode},
 		{k.Quit, k.Help, k.ShowAll},
 	}
 }

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -389,7 +389,7 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		key.Matches(msg, m.keys.ScrollUp)
 
 	if m.isForwardingInput() && !isControlKey {
-		// ctrl+g always leaves explicit input mode without touching the proc.
+		// esc always leaves explicit input mode without touching the proc.
 		if m.inputMode && key.Matches(msg, m.keys.ExitInput) {
 			m.inputMode = false
 			m.inputBuffer = ""

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -87,6 +87,11 @@ func (m *Model) cyclePane(dir int) {
 	for i, p := range panes {
 		if p == m.focusedPane {
 			m.focusedPane = panes[(i+dir+len(panes))%len(panes)]
+			// Leaving the output pane drops explicit input mode.
+			if m.focusedPane != focusOutput {
+				m.inputMode = false
+				m.inputBuffer = ""
+			}
 			m.dbg("focus: → %d", m.focusedPane)
 			return
 		}
@@ -361,11 +366,21 @@ func (m *Model) restartAllFailed() int {
 	return count
 }
 
+// isForwardingInput reports whether keystrokes should go to the active proc's
+// PTY rather than the TUI. True when the output pane is focused, the proc is
+// running, and either the user explicitly entered input mode or the proc looks
+// like it's waiting for input (HasPrompt heuristic).
+func (m Model) isForwardingInput() bool {
+	p := m.activeProc()
+	return p != nil && m.focusedPane == focusOutput && p.IsRunning() &&
+		(m.inputMode || p.HasPrompt())
+}
+
 func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	// When the active process is waiting for input, buffer keystrokes and send them on Enter.
 	p := m.activeProc()
-	procHasPrompt := p != nil && m.focusedPane == focusOutput && p.HasPrompt()
-	// Control keys are excluded so navigation still works.
+	// Control keys are excluded so navigation (pane switching, scrolling) still
+	// works even while keystrokes are being forwarded to the proc.
 	isControlKey := key.Matches(msg, m.keys.NextPane) ||
 		key.Matches(msg, m.keys.PrevPane) ||
 		key.Matches(msg, m.keys.GotoTop) ||
@@ -373,7 +388,15 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		key.Matches(msg, m.keys.ScrollDown) ||
 		key.Matches(msg, m.keys.ScrollUp)
 
-	if procHasPrompt && !isControlKey {
+	if m.isForwardingInput() && !isControlKey {
+		// ctrl+g always leaves explicit input mode without touching the proc.
+		if m.inputMode && key.Matches(msg, m.keys.ExitInput) {
+			m.inputMode = false
+			m.inputBuffer = ""
+			m.dbg("input mode: exit")
+			return m, tea.Batch(cmds...)
+		}
+
 		var input []byte
 
 		switch msg.Code {
@@ -585,6 +608,15 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		m.refreshInfoContent()
 		m.viewport.GotoTop()
 		m.dbg("info mode: enter")
+
+	case key.Matches(msg, m.keys.InputMode):
+		// Enter explicit input mode so keystrokes reach a proc that's waiting on
+		// stdin even when the HasPrompt heuristic didn't catch it.
+		if p != nil && m.focusedPane == focusOutput && p.IsRunning() {
+			m.inputMode = true
+			m.inputBuffer = ""
+			m.dbg("input mode: enter")
+		}
 
 	case key.Matches(msg, m.keys.SetupMode):
 		m = m.enterSetupMode()

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -611,8 +611,10 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 
 	case key.Matches(msg, m.keys.InputMode):
 		// Enter explicit input mode so keystrokes reach a proc that's waiting on
-		// stdin even when the HasPrompt heuristic didn't catch it.
-		if p != nil && m.focusedPane == focusOutput && p.IsRunning() {
+		// stdin even when the HasPrompt heuristic didn't catch it. Skipped while
+		// a committed search (query survives a proc switch) is pending, so the
+		// footer's "enter: navigate" hint doesn't get hijacked into input mode.
+		if p != nil && m.focusedPane == focusOutput && p.IsRunning() && m.searchQuery == "" {
 			m.inputMode = true
 			m.inputBuffer = ""
 			m.dbg("input mode: enter")

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -390,7 +390,7 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 
 	if m.isForwardingInput() && !isControlKey {
 		// esc always leaves explicit input mode without touching the proc.
-		if m.inputMode && key.Matches(msg, m.keys.ExitInput) {
+		if m.inputMode && msg.Code == tea.KeyEscape {
 			m.inputMode = false
 			m.inputBuffer = ""
 			m.dbg("input mode: exit")

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -355,7 +355,7 @@ func (m Model) renderFooter() string {
 			lipgloss.NewStyle().Foreground(colorBlue).Render(hint),
 		)
 	} else if p := m.activeProc(); m.inputMode && m.focusedPane == focusOutput && p != nil && p.IsRunning() {
-		hint := "-- INPUT --  type to send to the process  ↵: send  ⌫: delete  ^g: leave"
+		hint := "-- INPUT --  type to send to the process  ↵: send  ⌫: delete  esc: leave"
 		return footerStyle.Width(m.width - 2).Render(
 			lipgloss.NewStyle().Foreground(colorGreen).Render(hint),
 		)

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -316,9 +316,10 @@ func (m Model) viewportWithIndicator() string {
 
 	lines := strings.Split(view, "\n")
 
-	// Show a cursor after the last line when the process is waiting for input.
+	// Show a cursor after the last line when keystrokes are being forwarded to
+	// the process (auto-detected prompt or explicit input mode).
 	if p := m.activeProc(); p != nil {
-		showCursor := m.focusedPane == focusOutput && p.HasPrompt()
+		showCursor := m.isForwardingInput()
 		if showCursor {
 			lastLine := len(lines) - 1
 			lines[lastLine] = strings.TrimRight(lines[lastLine], " ") + " " + m.inputBuffer + "▌"
@@ -352,6 +353,11 @@ func (m Model) renderFooter() string {
 		}
 		return footerStyle.Width(m.width - 2).Render(
 			lipgloss.NewStyle().Foreground(colorBlue).Render(hint),
+		)
+	} else if p := m.activeProc(); m.inputMode && m.focusedPane == focusOutput && p != nil && p.IsRunning() {
+		hint := "-- INPUT --  type to send to the process  ↵: send  ⌫: delete  ^g: leave"
+		return footerStyle.Width(m.width - 2).Render(
+			lipgloss.NewStyle().Foreground(colorGreen).Render(hint),
 		)
 	} else if m.infoMode {
 		hint := "-- INFO --  i/esc: close"

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -355,7 +355,7 @@ func (m Model) renderFooter() string {
 			lipgloss.NewStyle().Foreground(colorBlue).Render(hint),
 		)
 	} else if p := m.activeProc(); m.inputMode && m.focusedPane == focusOutput && p != nil && p.IsRunning() {
-		hint := "-- INPUT --  type to send to the process  ↵: send  ⌫: delete  esc: leave"
+		hint := "-- INPUT --  send text to the process  ↵: send  ⌫: delete  esc: cancel"
 		return footerStyle.Width(m.width - 2).Render(
 			lipgloss.NewStyle().Foreground(colorGreen).Render(hint),
 		)
@@ -407,9 +407,9 @@ func (m Model) renderFooter() string {
 	if m.searchQuery != "" {
 		var matchInfo string
 		if len(m.searchMatches) == 0 {
-			matchInfo = fmt.Sprintf("search: %q  [no matches]  esc: leave", m.searchQuery)
+			matchInfo = fmt.Sprintf("search: %q  [no matches]  esc: cancel", m.searchQuery)
 		} else {
-			matchInfo = fmt.Sprintf("search: %q  [%d/%d]  ↵/⇧↵: navigate  esc: leave", m.searchQuery, m.searchCursor+1, len(m.searchMatches))
+			matchInfo = fmt.Sprintf("search: %q  [%d/%d]  ↵/⇧↵: navigate  esc: cancel", m.searchQuery, m.searchCursor+1, len(m.searchMatches))
 		}
 		return footerStyle.Width(m.width - 2).Render(
 			lipgloss.NewStyle().Foreground(colorYellow).Render(matchInfo),


### PR DESCRIPTION
## Problem

phrocs only forwarded keystrokes to a process when its prompt-detection heuristic fired — the last chunk of PTY output not ending in a newline. Plenty of processes print a prompt terminated by a newline (anything via `console.log`/`println`, a `(y/n)` confirm on its own line, an Ink/TUI frame, or a normal log line while blocked on stdin), so the heuristic missed them and there was no way to type into the process at all. Reported in the [originating Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1783709209721979?thread_ts=1783709209.721979&cid=C09G8QA6740).

## Changes

- Added an explicit **input mode**: with the output pane focused on a running process, press `↵` to forward every keystroke to the process's PTY, and `esc` to leave.
- The existing HasPrompt heuristic still auto-forwards when it fires — this is an always-available fallback, not a replacement.
- A cursor after the last output line and an `-- INPUT --` footer show when input is being forwarded; pane switching and scrolling still work while forwarding.
- Input mode resets when focus leaves the output pane or the selected process changes.
- Audited the rest of phrocs' keybindings while I was in there and fixed what I found:
  - The README's keybindings table had `s` labeled "Stop selected process" — the code has always bound `s` to start and `x` to stop. Fixed the label and added the missing `x`, `l` (clear logs), and `t` (setup mode) rows.
  - Enter entering input mode is now skipped while a *committed* search (a query that survives a process switch) is pending, so the footer's "navigate matches" hint on that search no longer gets hijacked into forwarding keystrokes to the process.
- Updated the phrocs README keybindings table and added a "Sending input to a process" section.

## How did you test this code?

Added unit tests in `internal/tui/app_test.go`:
- `TestInputMode_enterAndExit` — enter activates input mode on a running proc, esc leaves it (catches the toggle wiring / keybinding regression).
- `TestInputMode_ignoredWhenProcNotRunning` — enter is a no-op when the proc isn't running (guards the entry condition).
- `TestInputMode_resetWhenLeavingOutputPane` — tabbing away from the output pane clears input mode.

Ran `go build ./...` and `go test ./internal/tui/...` locally — both pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app after a user reported being unable to interact with a process in phrocs. Traced the input path: forwarding in `handleNormalKey` was gated solely on `Process.HasPrompt()`, a fragile heuristic with no manual override. Chose to keep the heuristic as an auto-hint and layer an explicit, tmux-style input mode on top rather than unconditionally forwarding keys — that would have broken navigation/scroll/search in the output pane while a process runs. Input mode is reset on pane/proc changes to avoid a stuck state. The leave-key was switched from ctrl+g to esc during review to match the convention used everywhere else in phrocs (copy/search/filter/info modes all leave on esc).

Later asked Claude Code to audit phrocs' full keybinding table for correctness. It traced the README against `internal/tui/keymap.go` and `keys.go` and found the pre-existing `s`/`x` doc mislabel plus a regression the input-mode change introduced: pressing enter over a committed search (one preserved across a process switch) now silently entered input mode instead of doing nothing, contradicting the footer's own navigation hint. Fixed both.