### PR TITLE
feat(autoresearch): code-split homepage AI chat components from initial load

### DIFF
--- a/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
+++ b/frontend/src/scenes/max/components/AiFirstMaxInstance.tsx
@@ -1,14 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
-import { IconOpenSidebar, IconShare } from '@posthog/icons'
 import { LemonBanner } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { cn } from 'lib/utils/css-classes'
-import { urls } from 'scenes/urls'
-
-import { SceneName } from '~/layout/scenes/components/SceneTitleSection'
 
 import { EmbeddedRunner } from 'products/posthog_ai/frontend/api/runner'
 
@@ -17,77 +11,11 @@ import { maxGlobalLogic } from '../maxGlobalLogic'
 import { maxLogic } from '../maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from '../maxThreadLogic'
 import { Thread } from '../Thread'
+import { ChatHeader } from './ChatHeader'
 import { MaxNotConfigured } from './MaxNotConfigured'
 import { PhaiViewToggle } from './PhaiViewToggle'
 import { SidebarQuestionInputWithSuggestions } from './SidebarQuestionInputWithSuggestions'
 import { ThreadAutoScroller } from './ThreadAutoScroller'
-
-/* Sits above the chat area */
-export function ChatHeader({
-    conversationId,
-    tabId,
-    children,
-    hideBorder,
-}: {
-    conversationId: string | null
-    tabId?: string
-    children?: React.ReactNode
-    hideBorder?: boolean
-}): JSX.Element {
-    const { openSidePanelMax } = useActions(maxGlobalLogic)
-    const { chatTitle } = useValues(maxLogic)
-    const isTitleLoading = chatTitle === 'New chat'
-
-    return (
-        <div
-            className={cn(
-                'flex w-full gap-2 py-2 border-b border-primary items-center justify-between px-2',
-                hideBorder && 'border-b-0'
-            )}
-        >
-            <div className="flex items-center gap-2 pl-2 text-sm font-medium truncate min-w-0 flex-1">
-                {children}
-                {chatTitle === null ? null : isTitleLoading ? (
-                    <div className="w-100">
-                        <SceneName name="New chat" isLoading />
-                    </div>
-                ) : (
-                    <SceneName name={chatTitle} />
-                )}
-            </div>
-            <div className="flex items-center gap-2">
-                <PhaiViewToggle variant="lemon" />
-                {conversationId ? (
-                    <LemonButton
-                        size="small"
-                        type="secondary"
-                        sideIcon={<IconShare />}
-                        onClick={() => {
-                            copyToClipboard(
-                                urls.absolute(urls.currentProject(urls.ai(conversationId ?? undefined))),
-                                'conversation sharing link'
-                            )
-                        }}
-                    >
-                        Copy link
-                    </LemonButton>
-                ) : undefined}
-                {tabId ? (
-                    <LemonButton
-                        size="small"
-                        type="secondary"
-                        sideIcon={<IconOpenSidebar />}
-                        onClick={() => {
-                            openSidePanelMax(conversationId ?? undefined)
-                        }}
-                    >
-                        Open in context panel
-                    </LemonButton>
-                ) : undefined}
-            </div>
-        </div>
-    )
-}
 
 interface AiFirstMaxInstanceProps {
     tabId: string

--- a/frontend/src/scenes/max/components/ChatHeader.tsx
+++ b/frontend/src/scenes/max/components/ChatHeader.tsx
@@ -1,0 +1,81 @@
+import { useActions, useValues } from 'kea'
+
+import { IconOpenSidebar, IconShare } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { cn } from 'lib/utils/css-classes'
+import { urls } from 'scenes/urls'
+
+import { SceneName } from '~/layout/scenes/components/SceneTitleSection'
+
+import { maxGlobalLogic } from '../maxGlobalLogic'
+import { maxLogic } from '../maxLogic'
+import { PhaiViewToggle } from './PhaiViewToggle'
+
+/* Sits above the chat area */
+export function ChatHeader({
+    conversationId,
+    tabId,
+    children,
+    hideBorder,
+}: {
+    conversationId: string | null
+    tabId?: string
+    children?: React.ReactNode
+    hideBorder?: boolean
+}): JSX.Element {
+    const { openSidePanelMax } = useActions(maxGlobalLogic)
+    const { chatTitle } = useValues(maxLogic)
+    const isTitleLoading = chatTitle === 'New chat'
+
+    return (
+        <div
+            className={cn(
+                'flex w-full gap-2 py-2 border-b border-primary items-center justify-between px-2',
+                hideBorder && 'border-b-0'
+            )}
+        >
+            <div className="flex items-center gap-2 pl-2 text-sm font-medium truncate min-w-0 flex-1">
+                {children}
+                {chatTitle === null ? null : isTitleLoading ? (
+                    <div className="w-100">
+                        <SceneName name="New chat" isLoading />
+                    </div>
+                ) : (
+                    <SceneName name={chatTitle} />
+                )}
+            </div>
+            <div className="flex items-center gap-2">
+                <PhaiViewToggle variant="lemon" />
+                {conversationId ? (
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        sideIcon={<IconShare />}
+                        onClick={() => {
+                            copyToClipboard(
+                                urls.absolute(urls.currentProject(urls.ai(conversationId ?? undefined))),
+                                'conversation sharing link'
+                            )
+                        }}
+                    >
+                        Copy link
+                    </LemonButton>
+                ) : undefined}
+                {tabId ? (
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        sideIcon={<IconOpenSidebar />}
+                        onClick={() => {
+                            openSidePanelMax(conversationId ?? undefined)
+                        }}
+                    >
+                        Open in context panel
+                    </LemonButton>
+                ) : undefined}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/project-homepage/ai-first/AiFirstHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/AiFirstHomepage.tsx
@@ -1,8 +1,9 @@
 import { BindLogic, useValues } from 'kea'
+import { lazy, Suspense } from 'react'
 
 import { Search } from 'lib/components/Search/Search'
 import { cn } from 'lib/utils/css-classes'
-import { ChatHeader } from 'scenes/max/components/AiFirstMaxInstance'
+import { ChatHeader } from 'scenes/max/components/ChatHeader'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { urls } from 'scenes/urls'
 
@@ -12,7 +13,8 @@ import { aiFirstHomepageLogic } from './aiFirstHomepageLogic'
 import { HOMEPAGE_TAB_ID } from './constants'
 import { HomepageInput } from './HomepageInput'
 import { HomepageSearchResults } from './HomepageSearchResults'
-import { HomepageThread } from './HomepageThread'
+
+const HomepageThread = lazy(() => import('./HomepageThread').then((m) => ({ default: m.HomepageThread })))
 
 const PHASE_ORDER = ['idle', 'moving', 'separator', 'content'] as const
 
@@ -79,7 +81,11 @@ export function AiFirstHomepage(): JSX.Element {
                             isAi && isContent ? 'grow opacity-100 pt-12' : 'grow-0 opacity-0'
                         )}
                     >
-                        {isAi && threadStarted && <HomepageThread />}
+                        {isAi && threadStarted && (
+                            <Suspense fallback={null}>
+                                <HomepageThread />
+                            </Suspense>
+                        )}
                     </div>
 
                     {/* Top separator — hidden in search (flush to top edge) */}

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageAiInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageAiInput.tsx
@@ -1,0 +1,59 @@
+import { BindLogic, useAsyncActions, useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { IconArrowRight, IconLock } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { uuid } from 'lib/utils/dom'
+import { SidebarQuestionInput } from 'scenes/max/components/SidebarQuestionInput'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { maxLogic } from 'scenes/max/maxLogic'
+import { MaxThreadLogicProps, maxThreadLogic } from 'scenes/max/maxThreadLogic'
+
+import { HOMEPAGE_TAB_ID } from './constants'
+
+export function HomepageAiInput(): JSX.Element {
+    const { threadLogicKey, conversation } = useValues(maxLogic)
+    const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(maxGlobalLogic)
+    const { acceptDataProcessing } = useAsyncActions(maxGlobalLogic)
+
+    const fallbackConversationId = useMemo(() => uuid(), [])
+    const threadProps: MaxThreadLogicProps = {
+        panelId: HOMEPAGE_TAB_ID,
+        conversationId: threadLogicKey || fallbackConversationId,
+        conversation,
+    }
+
+    if (!dataProcessingAccepted) {
+        const isAdmin = !dataProcessingApprovalDisabledReason
+        return (
+            <div className="border border-primary rounded-lg bg-surface-primary p-4 flex flex-col gap-2">
+                <p className="font-medium text-pretty m-0">
+                    PostHog AI needs your approval to potentially process identifying user data with external AI
+                    providers.
+                </p>
+                <p className="text-muted text-xs m-0">Your data won't be used for training third-party models.</p>
+                {isAdmin ? (
+                    <LemonButton
+                        type="primary"
+                        size="small"
+                        onClick={() => void acceptDataProcessing().catch(console.error)}
+                        sideIcon={<IconArrowRight />}
+                    >
+                        I allow AI analysis in this organization
+                    </LemonButton>
+                ) : (
+                    <LemonButton type="secondary" size="small" disabled sideIcon={<IconLock />}>
+                        {dataProcessingApprovalDisabledReason}
+                    </LemonButton>
+                )}
+            </div>
+        )
+    }
+
+    return (
+        <BindLogic logic={maxThreadLogic} props={threadProps}>
+            <SidebarQuestionInput />
+        </BindLogic>
+    )
+}

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -1,10 +1,10 @@
-import { BindLogic, useActions, useAsyncActions, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconArrowRight, IconClock, IconInfo, IconLock, IconMicrophone, IconPin, IconStar } from '@posthog/icons'
-import { LemonButton, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
+import { IconArrowRight, IconClock, IconInfo, IconMicrophone, IconPin, IconStar } from '@posthog/icons'
+import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
 import { Search } from 'lib/components/Search/Search'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -15,19 +15,15 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { Label } from 'lib/ui/Label/Label'
 import { TextareaPrimitive } from 'lib/ui/TextareaPrimitive/TextareaPrimitive'
 import { cn } from 'lib/utils/css-classes'
-import { uuid } from 'lib/utils/dom'
 import {
     CAPABILITY_CARDS_HEIGHT_PX,
     CapabilityBadges,
     CapabilitySuggestions,
 } from 'scenes/max/components/CapabilityBadges'
 import { FillInHint } from 'scenes/max/components/FillInHint'
-import { SidebarQuestionInput } from 'scenes/max/components/SidebarQuestionInput'
 import { handsFreeLogic } from 'scenes/max/handsFreeLogic'
 import { Intro } from 'scenes/max/Intro'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
-import { maxLogic } from 'scenes/max/maxLogic'
-import { MaxThreadLogicProps, maxThreadLogic } from 'scenes/max/maxThreadLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { ProductIconWrapper, iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
@@ -35,6 +31,8 @@ import { FileSystemIconType } from '~/queries/schema/schema-general'
 
 import { HomepageGridItem, HomepageGridItemKind, aiFirstHomepageLogic } from './aiFirstHomepageLogic'
 import { HOMEPAGE_TAB_ID } from './constants'
+
+const HomepageAiInput = lazy(() => import('./HomepageAiInput').then((m) => ({ default: m.HomepageAiInput })))
 
 function IdleInput(): JSX.Element {
     const { query, fillInHint } = useValues(aiFirstHomepageLogic)
@@ -187,52 +185,6 @@ function IdleInput(): JSX.Element {
                 </div>
             </label>
         </form>
-    )
-}
-
-function HomepageAiInput(): JSX.Element {
-    const { threadLogicKey, conversation } = useValues(maxLogic)
-    const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(maxGlobalLogic)
-    const { acceptDataProcessing } = useAsyncActions(maxGlobalLogic)
-
-    const fallbackConversationId = useMemo(() => uuid(), [])
-    const threadProps: MaxThreadLogicProps = {
-        panelId: HOMEPAGE_TAB_ID,
-        conversationId: threadLogicKey || fallbackConversationId,
-        conversation,
-    }
-
-    if (!dataProcessingAccepted) {
-        const isAdmin = !dataProcessingApprovalDisabledReason
-        return (
-            <div className="border border-primary rounded-lg bg-surface-primary p-4 flex flex-col gap-2">
-                <p className="font-medium text-pretty m-0">
-                    PostHog AI needs your approval to potentially process identifying user data with external AI
-                    providers.
-                </p>
-                <p className="text-muted text-xs m-0">Your data won't be used for training third-party models.</p>
-                {isAdmin ? (
-                    <LemonButton
-                        type="primary"
-                        size="small"
-                        onClick={() => void acceptDataProcessing().catch(console.error)}
-                        sideIcon={<IconArrowRight />}
-                    >
-                        I allow AI analysis in this organization
-                    </LemonButton>
-                ) : (
-                    <LemonButton type="secondary" size="small" disabled sideIcon={<IconLock />}>
-                        {dataProcessingApprovalDisabledReason}
-                    </LemonButton>
-                )}
-            </div>
-        )
-    }
-
-    return (
-        <BindLogic logic={maxThreadLogic} props={threadProps}>
-            <SidebarQuestionInput />
-        </BindLogic>
     )
 }
 
@@ -589,7 +541,11 @@ export function HomepageInput(): JSX.Element {
                     </div>
                 </div>
             )}
-            {mode === 'ai' && <HomepageAiInput />}
+            {mode === 'ai' && (
+                <Suspense fallback={null}>
+                    <HomepageAiInput />
+                </Suspense>
+            )}
             {mode === 'search' && <Search.Input autoFocus />}
         </div>
     )


### PR DESCRIPTION
## Summary
- Extracted `ChatHeader` out of `AiFirstMaxInstance.tsx` so the homepage no longer transitively pulls in the full chat runtime (`EmbeddedRunner`, `Thread`, `Intro`) just to render the header.
- Lazy-loaded `HomepageThread` (only rendered once a chat has started) via `React.lazy` + `Suspense`.
- Extracted and lazy-loaded `HomepageAiInput` (only rendered in AI mode) via `React.lazy` + `Suspense`.

Created with Autoresearch.

## Why
The project homepage always renders in idle mode first, but was eagerly bundling the full AI chat thread/input UI (Thread, QuestionInput, InputFormArea, Context, message renderers) even though those only render once a user starts an AI chat. Deferring them to their own chunks shrinks the code that has to be downloaded and parsed for first paint of the homepage.

## Test plan
- [x] `oxlint` clean on all touched/added files
- [ ] Manual check: homepage idle mode renders, switching to AI mode still loads chat input, starting a chat still loads the thread