### PR TITLE
feat(data-warehouse): promote revenuecat source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/source.py
@@ -163,8 +163,7 @@ class RevenueCatSource(
                     ),
                 ],
             ),
-            releaseStatus=ReleaseStatus.BETA,
-            featureFlag="dwh-revenuecat",
+            releaseStatus=ReleaseStatus.GA,
             webhookSetupCaption=(
                 "PostHog tries to register a webhook integration in RevenueCat using your "
                 "secret API key. RevenueCat does not HMAC-sign deliveries — instead, the "


### PR DESCRIPTION
## Problem

RevenueCat has been shipping as a beta data warehouse source. It now clears the bar we use to promote a source to GA, so it should graduate to general availability and drop its rollout gate.

## Changes

Status promotion only. No changes to connector behavior, schemas, or sync logic.

- `releaseStatus`: `beta` -> `ga`
- Removed the `dwh-revenuecat` feature flag gate. None of our GA sources carry a `featureFlag` (it's a controlled-rollout gate that contradicts general availability), so promoting to GA means the source becomes visible and connectable for everyone.

Qualification metrics (7-day window):

| Gate | Requirement | Current |
| --- | --- | --- |
| Adoption | 100+ teams or live 3+ months | 136 teams |
| Import error rate | < 2.5% | 2.5% |

> [!NOTE]
> The reported import error rate rounds to 2.5%, right at the bar rather than comfortably below it. Worth a glance before merge, though adoption clears the threshold with room to spare.

## How did you test this code?

No manual testing. This is a metadata-only change (an enum value plus removing a gating flag). I confirmed `ReleaseStatus.GA` is a valid enum member, that nothing else in the codebase references the removed `dwh-revenuecat` flag, and that `ruff check` passes on the changed file. The repo's Python test runner wasn't provisioned in this environment, so I did not run the RevenueCat source test suite locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code. I invoked the `/implementing-warehouse-sources` skill for the repo's release-status conventions, located the source definition at `products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/source.py`, and flipped `releaseStatus` to GA. I checked how the 23 existing GA sources handle gating and found none carry a `featureFlag`, which is what made removing `dwh-revenuecat` the clear convention rather than a judgment call. I also searched open PRs (including the maintainer's own) to rule out a duplicate promotion before opening this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
