### PR TITLE
chore(ci): add hogland admin link to hogbox preview comment

### DIFF
--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -488,6 +488,7 @@ jobs:
                   {
                     echo "url=$(echo "$out" | sed -n 's/^url=//p')"
                     echo "box_id=$(echo "$out" | sed -n 's/^box_id=//p')"
+                    echo "pen_id=$(echo "$out" | sed -n 's/^pen_id=//p')"
                   } >> "$GITHUB_OUTPUT"
               working-directory: tools/hogbox-preview
 
@@ -564,7 +565,10 @@ jobs:
               env:
                   URL: ${{ steps.build.outputs.url }}
                   BOX: ${{ steps.build.outputs.box_id }}
+                  PEN: ${{ steps.build.outputs.pen_id }}
                   SWAP: ${{ steps.fe.outputs.swap }}
+                  # The hogland admin/console host (same value as the OIDC audience).
+                  CONSOLE_HOST: ${{ env.HOG_OIDC_AUDIENCE }}
               with:
                   script: |
                       const pr = Number(process.env.PR);
@@ -589,6 +593,14 @@ jobs:
                       const running = process.env.SWAP === 'true'
                           ? "this PR's backend **and** frontend, on the PostHog `:master` base"
                           : "this PR's backend on the PostHog `:master` base (frontend unchanged by this PR)";
+                      // Admin/console link for the pen — lets folks inspect and
+                      // debug box state in hogland. Only when both the host and pen
+                      // id are known.
+                      const pen = process.env.PEN;
+                      const consoleHost = process.env.CONSOLE_HOST;
+                      const adminUrl = (consoleHost && pen)
+                          ? `https://${consoleHost}/console/fleet/pens/${pen}`
+                          : null;
                       const marker = '<!-- hogbox-preview-comment -->';
                       const body =
                           `${marker}\n### 🦔 Hogbox preview &middot; ✅ ready\n\n` +
@@ -598,6 +610,7 @@ jobs:
                           `| 🧩 **Running** | ${running} |\n` +
                           `| 🔗 **Link** | **stable across rebuilds** — a re-push swaps the box underneath, the URL stays |\n` +
                           `| 🔒 **Access** | tailnet only (PostHog VPN) |\n` +
+                          (adminUrl ? `| 🛠️ **Admin** | [inspect & debug state in hogland](${adminUrl}) |\n` : ``) +
                           `| 💤 **Idle** | sleeps after ~30 min idle (snapshot to S3, zero node cost) and wakes on your next visit in ~30s, behind a brief "waking up" screen |\n\n` +
                           `<sub>commit \`${(process.env.SHA || '').slice(0, 7)}\` &middot; box \`${process.env.BOX}\` &middot; ready in ${secs}s (push → usable) &middot; ` +
                           `<a href="${runUrl}">build log</a> &middot; rebuilds on every push, torn down on close</sub>`;

--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -475,7 +475,7 @@ jobs:
                   # frontend is swapped in afterwards (once build-frontend finishes,
                   # below) so this step runs in parallel with the FE build. The tool
                   # streams `[hogbox-preview +NNNs] <stage>` lines to STDERR for
-                  # per-stage visibility; stdout stays the url=/box_id= contract.
+                  # per-stage visibility; stdout stays the url=/box_id=/pen_id= contract.
                   out=$(uv run --no-project --with posthog-hogland==0.3.0 --python 3.12 \
                     python -m hogbox_preview \
                     --host "$HOG_HOST" \
@@ -596,9 +596,11 @@ jobs:
                       // Admin/console link for the pen — lets folks inspect and
                       // debug box state in hogland. Only when both the host and pen
                       // id are known.
+                      // Guard the literal 'None' too — the CLI parser can surface
+                      // it as a string, and it would otherwise be truthy here.
                       const pen = process.env.PEN;
                       const consoleHost = process.env.CONSOLE_HOST;
-                      const adminUrl = (consoleHost && pen)
+                      const adminUrl = (consoleHost && pen && pen !== 'None')
                           ? `https://${consoleHost}/console/fleet/pens/${pen}`
                           : null;
                       const marker = '<!-- hogbox-preview-comment -->';

--- a/tools/hogbox-preview/hogbox_preview/__main__.py
+++ b/tools/hogbox-preview/hogbox_preview/__main__.py
@@ -63,7 +63,9 @@ def cmd_up(args: argparse.Namespace) -> int:
     stack = build_stack(backend, args)
     url = stack.bring_up()
     print(f"box_id={backend.box_id}")
-    print(f"pen_id={backend.pen_id}")
+    # Empty (not the literal "None") when there's no pen, so the CI parser treats
+    # it as absent rather than rendering an admin link to /pens/None.
+    print(f"pen_id={backend.pen_id or ''}")
     print(f"url={url}")
     if args.destroy:
         backend.destroy()

--- a/tools/hogbox-preview/hogbox_preview/__main__.py
+++ b/tools/hogbox-preview/hogbox_preview/__main__.py
@@ -63,6 +63,7 @@ def cmd_up(args: argparse.Namespace) -> int:
     stack = build_stack(backend, args)
     url = stack.bring_up()
     print(f"box_id={backend.box_id}")
+    print(f"pen_id={backend.pen_id}")
     print(f"url={url}")
     if args.destroy:
         backend.destroy()

--- a/tools/hogbox-preview/hogbox_preview/hogland_backend.py
+++ b/tools/hogbox-preview/hogbox_preview/hogland_backend.py
@@ -336,6 +336,12 @@ class HoglandBackend(PreviewBackend):
     def box_id(self) -> str | None:
         return self._box_id
 
+    @property
+    def pen_id(self) -> str | None:
+        # The pen's stable id (e.g. pen-aa47b706211f) once the pen is ensured.
+        # Used to build the hogland admin/console link for the preview.
+        return self._pen.id if self._pen is not None else None
+
     def destroy(self) -> None:
         # PR-close teardown: drop the live box, then release the stable identity.
         # delete_pen does NOT cascade, so the box must go first. Each step is

--- a/tools/hogbox-preview/hogbox_preview/hogland_backend.py
+++ b/tools/hogbox-preview/hogbox_preview/hogland_backend.py
@@ -339,8 +339,9 @@ class HoglandBackend(PreviewBackend):
     @property
     def pen_id(self) -> str | None:
         # The pen's stable id (e.g. pen-aa47b706211f) once the pen is ensured.
-        # Used to build the hogland admin/console link for the preview.
-        return self._pen.id if self._pen is not None else None
+        # Used to build the hogland admin/console link for the preview. Mirrors
+        # web_url's guard so an ensured-but-idless pen returns None, never "".
+        return self._pen.id if (self._pen is not None and self._pen.id) else None
 
     def destroy(self) -> None:
         # PR-close teardown: drop the live box, then release the stable identity.


### PR DESCRIPTION
## Problem

The hogbox preview comment on a PR links the preview app, but there's no quick way to jump into the hogland fleet console to inspect or debug the underlying box/pen state.

## Changes

- Expose the pen id from the hogland backend and print it from the `up` command.
- Capture `pen_id` as a build-step output in the preview workflow.
- Render an **Admin** row in the ready preview comment linking to `https://<console-host>/console/fleet/pens/<pen-id>` (the console host is the OIDC audience, e.g. `hogland.prod-us.posthog.dev`). Only shown when both the console host and pen id are known.

**Why:** so folks can open the hogland console straight from the PR to check and debug preview box state.

## How did you test this code?

`python -m py_compile` on the changed Python. No test added for the new `pen_id` accessor — it's a trivial getter (per the repo's testing conventions, getters aren't worth a dedicated test). The existing hogland-backend unit tests already stand up a fake pen exposing `.id`, which the new property reads.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code). Invoked the `/writing-tests` skill to decide against adding a test for the trivial `pen_id` getter. The console host is derived from the workflow's existing `HOG_OIDC_AUDIENCE` env rather than hardcoded, keeping the value in one place.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
