### PR TITLE
feat(taxonomy): hide legacy events from fuzzy search unless exact match

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/hooks/fetchTaxonomicListPage.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/fetchTaxonomicListPage.ts
@@ -10,6 +10,8 @@ import { combineUrl } from 'kea-router'
 import api from 'lib/api'
 import { ListStorage, TaxonomicFilterGroup, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
+import { filterExactSearchOnlyItems } from '~/taxonomy/helpers'
+
 export interface FetchTaxonomicPageParams {
     group: TaxonomicFilterGroup
     searchQuery: string
@@ -83,8 +85,18 @@ export async function fetchTaxonomicListPage({
             : Promise.resolve(null),
     ])
 
-    const results = primary?.results ?? primary ?? []
-    const count = primary?.count ?? (Array.isArray(primary) ? primary.length : results.length)
+    const rawResults = primary?.results ?? primary ?? []
+    const rawCount = primary?.count ?? (Array.isArray(primary) ? primary.length : rawResults.length)
+
+    // Drop legacy/deprecated definitions that only surface on an exact query (mirrors the
+    // legacy infiniteListLogic loader). This fetches a single page, so no offset mapping to keep.
+    const results = filterExactSearchOnlyItems(
+        rawResults,
+        (item: { name?: string }) => group.getName?.(item) ?? item?.name,
+        group.type,
+        searchQuery
+    )
+    const count = Math.max(0, rawCount - (rawResults.length - results.length))
 
     return {
         results,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/fetchTaxonomicListPage.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/fetchTaxonomicListPage.ts
@@ -92,7 +92,7 @@ export async function fetchTaxonomicListPage({
     // legacy infiniteListLogic loader). This fetches a single page, so no offset mapping to keep.
     const results = filterExactSearchOnlyItems(
         rawResults,
-        (item: { name?: string }) => group.getName?.(item) ?? item?.name,
+        (item: any) => group.getName?.(item) ?? item?.name,
         group.type,
         searchQuery
     )

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -50,7 +50,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
 
-import { getCoreFilterDefinition } from '~/taxonomy/helpers'
+import { filterExactSearchOnlyItems, getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { CohortType, EventDefinition, GroupTypeIndex, PropertyType } from '~/types'
 
 import { teamLogic } from '../../../scenes/teamLogic'
@@ -390,21 +390,30 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     const existingResults = values.remoteItems.results
                     cache.abortController = null
 
+                    // Drop legacy/deprecated definitions that only surface on an exact query
+                    // (mirrors the rebuild's fetchTaxonomicListPage). Narrow legacy searches
+                    // return a single page, so filtering here doesn't disturb offset mapping.
+                    const rawResults: any[] = response.results || response
+                    const filteredResults = filterExactSearchOnlyItems(
+                        rawResults,
+                        (item) => values.group?.getName?.(item) ?? (item as { name?: string })?.name,
+                        listGroupType,
+                        searchQuery
+                    )
+                    const removedCount = rawResults.length - filteredResults.length
+                    const rawCount =
+                        response.count ||
+                        (Array.isArray(response) ? response.length : 0) ||
+                        (response.results || []).length
+
                     return {
-                        results: appendAtIndex(
-                            queryChanged ? [] : existingResults,
-                            response.results || response,
-                            offset
-                        ),
+                        results: appendAtIndex(queryChanged ? [] : existingResults, filteredResults, offset),
                         searchQuery,
                         queryChanged,
                         // Only the initial page times the search; "load more" (offset > 0)
                         // would otherwise overwrite it with pagination latency.
                         loadDurationMs: offset === 0 ? Math.floor(performance.now() - start) : undefined,
-                        count:
-                            response.count ||
-                            (Array.isArray(response) ? response.length : 0) ||
-                            (response.results || []).length,
+                        count: Math.max(0, rawCount - removedCount),
                         expandedCount: expandedCountResponse?.count,
                     }
                 },

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4045,7 +4045,8 @@
         "mcp init": {
             "description": "LEGACY \u2014 do not use. MCP initialization event from the retired mcpcat library. Superseded by `$mcp_initialize`. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": true,
-            "label": "MCP init (legacy)"
+            "label": "MCP init (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp organization switched": {
             "description": "Fires when a user switches the active organization in their MCP session.",
@@ -4058,72 +4059,86 @@
         "mcp tool call": {
             "description": "LEGACY \u2014 do not use. Tool-call event from the external mcpcat integration (still trickling in until that integration is switched off). Superseded by `$mcp_tool_call`, which covers all traffic from 2026-06-16 on. Query this only for older historical data.",
             "ignored_in_assistant": true,
-            "label": "MCP tool call \u2014 mcpcat (legacy)"
+            "label": "MCP tool call \u2014 mcpcat (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp tool response": {
             "description": "LEGACY \u2014 do not use. Tool-response event from the external mcpcat integration (still trickling in until that integration is switched off). Responses now ride inline on `$mcp_tool_call` (under `$mcp_response`). Query this only for older historical data.",
             "ignored_in_assistant": true,
-            "label": "MCP tool response \u2014 mcpcat (legacy)"
+            "label": "MCP tool response \u2014 mcpcat (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_custom": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_custom`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP custom event (legacy)"
+            "label": "MCP custom event (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_initialize": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_initialize`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP initialize (legacy)"
+            "label": "MCP initialize (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_mcpcat:identify": {
             "description": "LEGACY \u2014 do not use. Identify event from the retired mcpcat library. Superseded by the canonical `$identify` emitted by @posthog/mcp. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": true,
-            "label": "MCP identify \u2014 mcpcat (legacy)"
+            "label": "MCP identify \u2014 mcpcat (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_posthog:identify": {
             "description": "LEGACY \u2014 do not use. Identify event from PostHog's retired in-tree MCP analytics path. Superseded by the canonical `$identify` emitted by @posthog/mcp. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": true,
-            "label": "MCP identify \u2014 in-tree (legacy)"
+            "label": "MCP identify \u2014 in-tree (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_prompt_get": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_prompt_get`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP prompt fetched (legacy)"
+            "label": "MCP prompt fetched (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_prompts_list": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_prompts_list`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP prompts listed (legacy)"
+            "label": "MCP prompts listed (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_resource_read": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_resource_read`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP resource read (legacy)"
+            "label": "MCP resource read (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_resources_list": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_resources_list`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP resources listed (legacy)"
+            "label": "MCP resources listed (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_tool_call": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_tool_call`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical tool calls before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP tool call (legacy)"
+            "label": "MCP tool call (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_tool_called": {
             "description": "LEGACY \u2014 do not use. Tool-call event from PostHog's retired in-tree MCP analytics path. Superseded by `$mcp_tool_call`. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": true,
-            "label": "MCP tool called \u2014 in-tree (legacy)"
+            "label": "MCP tool called \u2014 in-tree (legacy)",
+            "only_shown_on_exact_search": true
         },
         "mcp_tools_list": {
             "description": "LEGACY \u2014 do not use. Superseded by `$mcp_tools_list`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP tools listed (legacy)"
+            "label": "MCP tools listed (legacy)",
+            "only_shown_on_exact_search": true
         },
         "posthog_identify": {
             "description": "LEGACY \u2014 do not use. Superseded by the canonical `$identify` emitted by @posthog/mcp, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": true,
-            "label": "MCP identify (legacy)"
+            "label": "MCP identify (legacy)",
+            "only_shown_on_exact_search": true
         }
     },
     "groups": {

--- a/frontend/src/taxonomy/helpers.test.ts
+++ b/frontend/src/taxonomy/helpers.test.ts
@@ -1,0 +1,23 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { filterExactSearchOnlyItems } from './helpers'
+
+describe('filterExactSearchOnlyItems', () => {
+    // `mcp init` is flagged `only_shown_on_exact_search` in the taxonomy; the canonical
+    // `$mcp_tool_call` and `$pageview` are not.
+    const items = [{ name: 'mcp init' }, { name: '$mcp_tool_call' }, { name: '$pageview' }]
+    const run = (query: string): string[] =>
+        filterExactSearchOnlyItems(items, (i) => i.name, TaxonomicFilterGroupType.Events, query).map((i) => i.name)
+
+    const cases: [string, string, string[]][] = [
+        ['no query hides the legacy event', '', ['$mcp_tool_call', '$pageview']],
+        ['fuzzy match hides the legacy event', 'mcp', ['$mcp_tool_call', '$pageview']],
+        ['exact name keeps the legacy event', 'mcp init', ['mcp init', '$mcp_tool_call', '$pageview']],
+        ['exact name is case-insensitive', 'MCP INIT', ['mcp init', '$mcp_tool_call', '$pageview']],
+        ['exact label keeps the legacy event', 'MCP init (legacy)', ['mcp init', '$mcp_tool_call', '$pageview']],
+    ]
+
+    it.each(cases)('%s', (_label, query, expected) => {
+        expect(run(query)).toEqual(expected)
+    })
+})

--- a/frontend/src/taxonomy/helpers.ts
+++ b/frontend/src/taxonomy/helpers.ts
@@ -119,6 +119,33 @@ export function getCoreFilterDefinition(
     return null
 }
 
+/**
+ * Drop definitions flagged `only_shown_on_exact_search` (legacy/deprecated events) from a page
+ * of results unless the trimmed query exactly matches the item's name or label. Keeps a fuzzy
+ * search like "mcp" from surfacing every retired MCP variant, while typing the full name still
+ * finds them. Applied at the data-fetch layer of both TaxonomicFilter variants — the legacy
+ * `infiniteListLogic` and the rebuild's `fetchTaxonomicListPage` — so keep the two in sync.
+ */
+export function filterExactSearchOnlyItems<T>(
+    items: T[],
+    getName: (item: T) => string | null | undefined,
+    type: TaxonomicFilterGroupType,
+    searchQuery: string
+): T[] {
+    const query = searchQuery.trim().toLowerCase()
+    return items.filter((item) => {
+        const name = getName(item)
+        const definition = getCoreFilterDefinition(name, type)
+        if (!definition?.only_shown_on_exact_search) {
+            return true
+        }
+        if (!query) {
+            return false
+        }
+        return query === (name ?? '').toString().toLowerCase() || query === definition.label.trim().toLowerCase()
+    })
+}
+
 export function getFirstFilterTypeFor(propertyKey: string): TaxonomicFilterGroupType | null {
     for (const type of Object.keys(CORE_FILTER_DEFINITIONS_BY_GROUP) as CoreFilterDefinitionsGroup[]) {
         if (propertyKey in CORE_FILTER_DEFINITIONS_BY_GROUP[type]) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4971,6 +4971,10 @@ export interface CoreFilterDefinition {
     used_for_debug?: boolean
     /** Name of a single property on events of this name that UIs should display alongside the event. */
     primary_property?: string
+    /** Hide from TaxonomicFilter search results unless the query exactly matches the name or
+     *  label (case-insensitive). Used for legacy/deprecated definitions so they don't clutter
+     *  fuzzy matches, while staying reachable by typing the full name. */
+    only_shown_on_exact_search?: boolean
 }
 
 export interface TileParams {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -15,6 +15,11 @@ class CoreFilterDefinition(TypedDict):
     system: NotRequired[bool]
     type: NotRequired[Literal["String", "Numeric", "DateTime", "Boolean"]]
     ignored_in_assistant: NotRequired[bool]
+    # Hide from TaxonomicFilter search results unless the query exactly matches the
+    # event name or label (case-insensitive). Use for legacy/deprecated definitions
+    # that would otherwise clutter fuzzy matches (e.g. searching "mcp" surfacing every
+    # retired MCP event). They stay reachable by typing the full name.
+    only_shown_on_exact_search: NotRequired[bool]
     virtual: NotRequired[bool]
     used_for_debug: NotRequired[bool]
     primary_property: NotRequired[str]
@@ -338,46 +343,55 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "MCP tool call (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_tool_call`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical tool calls before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_tools_list": {
             "label": "MCP tools listed (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_tools_list`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_initialize": {
             "label": "MCP initialize (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_initialize`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_resources_list": {
             "label": "MCP resources listed (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_resources_list`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_resource_read": {
             "label": "MCP resource read (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_resource_read`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_prompts_list": {
             "label": "MCP prompts listed (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_prompts_list`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_prompt_get": {
             "label": "MCP prompt fetched (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_prompt_get`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_custom": {
             "label": "MCP custom event (legacy)",
             "description": "LEGACY — do not use. Superseded by `$mcp_custom`, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "posthog_identify": {
             "label": "MCP identify (legacy)",
             "description": "LEGACY — do not use. Superseded by the canonical `$identify` emitted by @posthog/mcp, which covers all MCP traffic from 2026-06-16 on. Query this only for historical data before that date.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         # Oldest MCP events — LEGACY, DO NOT USE. Predate the `$mcp_*` SDK. The in-tree names have
         # stopped; the mcpcat `mcp tool call` / `mcp tool response` still trickle in from the
@@ -386,31 +400,37 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "MCP init (legacy)",
             "description": "LEGACY — do not use. MCP initialization event from the retired mcpcat library. Superseded by `$mcp_initialize`. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_mcpcat:identify": {
             "label": "MCP identify — mcpcat (legacy)",
             "description": "LEGACY — do not use. Identify event from the retired mcpcat library. Superseded by the canonical `$identify` emitted by @posthog/mcp. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_posthog:identify": {
             "label": "MCP identify — in-tree (legacy)",
             "description": "LEGACY — do not use. Identify event from PostHog's retired in-tree MCP analytics path. Superseded by the canonical `$identify` emitted by @posthog/mcp. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp_tool_called": {
             "label": "MCP tool called — in-tree (legacy)",
             "description": "LEGACY — do not use. Tool-call event from PostHog's retired in-tree MCP analytics path. Superseded by `$mcp_tool_call`. Query this only for historical data before 2026-06-16.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp tool call": {
             "label": "MCP tool call — mcpcat (legacy)",
             "description": "LEGACY — do not use. Tool-call event from the external mcpcat integration (still trickling in until that integration is switched off). Superseded by `$mcp_tool_call`, which covers all traffic from 2026-06-16 on. Query this only for older historical data.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp tool response": {
             "label": "MCP tool response — mcpcat (legacy)",
             "description": "LEGACY — do not use. Tool-response event from the external mcpcat integration (still trickling in until that integration is switched off). Responses now ride inline on `$mcp_tool_call` (under `$mcp_response`). Query this only for older historical data.",
             "ignored_in_assistant": True,
+            "only_shown_on_exact_search": True,
         },
         "mcp project switched": {
             "label": "MCP project switched",


### PR DESCRIPTION
## Problem

Searching the TaxonomicFilter for a term like `mcp` returns a wall of retired/legacy event variants alongside the canonical ones. These legacy events shouldn't be picked in new insights, but there was no way to keep them out of partial-match results while still leaving them reachable for querying older history.

## Changes

Adds an `only_shown_on_exact_search` flag to core filter definitions (`posthog/taxonomy/taxonomy.py` + the mirrored frontend `CoreFilterDefinition` type). When set, the item is dropped from TaxonomicFilter results unless the trimmed query exactly matches the event's name or label (case-insensitive), so typing the full name still finds it.

- Filtering happens at the data-fetch layer of **both** TaxonomicFilter variants via a shared `filterExactSearchOnlyItems` helper — the legacy `infiniteListLogic` loader and the rebuild's `fetchTaxonomicListPage`.
- Marks the 15 retired MCP events (the `(legacy)` labels) with the flag. The canonical `$mcp_*` events are untouched.

**Why:** the legacy MCP events clutter every `mcp` search and are easy to pick by mistake; this keeps them out of fuzzy results while preserving access for historical queries.

## How did you test this code?

Added `frontend/src/taxonomy/helpers.test.ts` covering `filterExactSearchOnlyItems`: a flagged legacy event is hidden on empty/fuzzy queries and reappears on an exact (case-insensitive) name or label match, while unflagged events are always kept. This guards against legacy items leaking back into partial-match results or the exact-match escape hatch regressing.

Verified the taxonomy regenerates cleanly (only the 15 intended entries change in the generated JSON) and `ruff check`/`ruff format` pass on the Python change. The agent could not run the Jest suite or the TypeScript check locally (frontend `node_modules` not installed in this environment); CI will cover those.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code. Invoked the `/modifying-taxonomic-filter` skill (which flagged the three live filter variants and the legacy/rebuild mirroring requirement) and `/writing-tests` before adding the test. Chose to filter at the data-fetch layer in both arms rather than the render/combine step to avoid disturbing the legacy list's windowed offset mapping; narrow legacy searches return a single page, so per-page filtering is safe. Reused the existing `ignored_in_assistant`-style taxonomy flag pattern for consistency.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
