### PR TITLE
feat(navigation): simplify sidebar tools list for small selections

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -13,7 +13,6 @@ import {
     IconStar,
 } from '@posthog/icons'
 
-import { commandLogic } from 'lib/components/Command/commandLogic'
 import { itemSelectModalLogic } from 'lib/components/FileSystem/ItemSelectModal/itemSelectModalLogic'
 import { KeyboardShortcut } from 'lib/components/KeyboardShortcut/KeyboardShortcut'
 import { dayjs } from 'lib/dayjs'
@@ -33,7 +32,6 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ContextMenuGroup, ContextMenuItem } from 'lib/ui/ContextMenu/ContextMenu'
 import { DropdownMenuGroup } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { cn } from 'lib/utils/css-classes'
-import { isMobile } from 'lib/utils/dom'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { removeProjectIdIfPresent } from 'lib/utils/kea-router'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -74,8 +72,6 @@ export const PROJECT_TREE_KEY = 'project-tree'
 let counter = 0
 
 const SHORTCUT_DISMISSAL_LOCAL_STORAGE_KEY = 'shortcut-dismissal'
-const CUSTOM_PRODUCT_DISMISSAL_LOCAL_STORAGE_KEY = 'custom-product-dismissal-v2'
-const CMD_K_HELPER_DISMISSAL_LOCAL_STORAGE_KEY = 'cmd-k-helper-dismissal'
 const SEEN_CUSTOM_PRODUCTS_LOCAL_STORAGE_KEY = 'seen-custom-products'
 
 const USER_PRODUCT_LIST_REASON_DEFAULTS: { [key in UserProductListReason]?: string } = {
@@ -176,25 +172,13 @@ export function ProjectTree({
     const treeRef = useRef<LemonTreeRef>(null)
     const { openItemSelectModal } = useActions(itemSelectModalLogic)
 
-    const { customProducts, customProductsLoading } = useValues(customProductsLogic)
+    const { customProductsLoading } = useValues(customProductsLogic)
     const { seed } = useActions(customProductsLogic)
-    const { toggleCommand } = useActions(commandLogic)
 
     const [shortcutHelperDismissed, setShortcutHelperDismissed] = useLocalStorage<boolean>(
         SHORTCUT_DISMISSAL_LOCAL_STORAGE_KEY,
         false
     )
-    const [customProductHelperDismissed, setCustomProductHelperDismissed] = useLocalStorage<boolean>(
-        CUSTOM_PRODUCT_DISMISSAL_LOCAL_STORAGE_KEY,
-        false
-    )
-    const [cmdKHelperDismissed, setCmdKHelperDismissed] = useLocalStorage<boolean>(
-        CMD_K_HELPER_DISMISSAL_LOCAL_STORAGE_KEY,
-        false
-    )
-    // Capture the original-banner dismissal state once on mount so the Cmd+K hint only appears
-    // on subsequent sessions — dismissing the first banner shouldn't swap in the second immediately.
-    const [originalDismissedOnMount] = useState<boolean>(() => customProductHelperDismissed === true)
 
     const [seenCustomProducts, setSeenCustomProducts] = useLocalStorage<string[]>(
         `${currentTeamId ?? '*'}-${SEEN_CUSTOM_PRODUCTS_LOCAL_STORAGE_KEY}`,
@@ -244,70 +228,26 @@ export function ProjectTree({
             })
         }
 
-        if (root === 'custom-products://') {
-            const hasRecommendedTools = customProducts.some(
-                (item) =>
-                    item.reason === UserProductListReason.USED_BY_COLLEAGUES ||
-                    item.reason === UserProductListReason.USED_ON_SEPARATE_TEAM
-            )
-
-            const showOriginalBanner = fullFileSystemFiltered.length === 0 || !customProductHelperDismissed
-            const showCmdKBanner =
-                !showOriginalBanner && originalDismissedOnMount && !cmdKHelperDismissed && !isMobile()
-
-            if (showOriginalBanner) {
-                treeData.push({
-                    id: 'products/custom-products-helper-category',
-                    name: 'Example custom products',
-                    type: 'category',
-                    displayName: (
-                        <div className={cn('border border-primary text-xs mb-2 font-normal rounded-xs p-2 -mx-1')}>
-                            You can display your preferred tools here. You can configure what items show up in here by
-                            clicking on the{' '}
-                            <IconPencil className="size-3 border border-[var(--color-neutral-500)] rounded-xs" /> icon
-                            above. We'll automatically suggest new tools to this list as you use them.{' '}
-                            {fullFileSystemFiltered.length > 0 && (
-                                <span
-                                    className="cursor-pointer underline"
-                                    onClick={() => setCustomProductHelperDismissed(true)}
-                                >
-                                    Dismiss.
-                                </span>
-                            )}
-                            {!hasRecommendedTools && fullFileSystemFiltered.length <= 3 && (
-                                <>
-                                    <br />
-                                    <br />
-                                    <span className="cursor-pointer underline" onClick={seed}>
-                                        {customProductsLoading ? 'Adding...' : 'Add recommended tools?'}
-                                    </span>
-                                </>
-                            )}
-                        </div>
-                    ),
-                })
-            } else if (showCmdKBanner) {
-                treeData.push({
-                    id: 'products/cmd-k-helper-category',
-                    name: 'Quick search tip',
-                    type: 'category',
-                    displayName: (
-                        <div className="border border-primary text-xs mb-2 font-normal rounded-xs p-2 -mx-1">
-                            Want to browse all tools or jump back into something recent? Press{' '}
-                            <span
-                                className="cursor-pointer inline-flex items-center gap-1"
-                                onClick={() => toggleCommand()}
-                            >
-                                <KeyboardShortcut command k />
-                            </span>{' '}
-                            to open search. It's faster than hunting through the sidebar.{' '}
-                            <span className="cursor-pointer underline" onClick={() => setCmdKHelperDismissed(true)}>
-                                Dismiss.
-                            </span>
-                        </div>
-                    ),
-                })
-            }
+        // Only nudge users to add tools when they have none. Once the list has anything in it, keep it clean.
+        if (root === 'custom-products://' && fullFileSystemFiltered.length === 0) {
+            treeData.push({
+                id: 'products/custom-products-helper-category',
+                name: 'Example custom products',
+                type: 'category',
+                displayName: (
+                    <div className={cn('border border-primary text-xs mb-2 font-normal rounded-xs p-2 -mx-1')}>
+                        You can display your preferred tools here. You can configure what items show up in here by
+                        clicking on the{' '}
+                        <IconPencil className="size-3 border border-[var(--color-neutral-500)] rounded-xs" /> icon above.
+                        We'll automatically suggest new tools to this list as you use them.
+                        <br />
+                        <br />
+                        <span className="cursor-pointer underline" onClick={seed}>
+                            {customProductsLoading ? 'Adding...' : 'Add recommended tools?'}
+                        </span>
+                    </div>
+                ),
+            })
         }
     }
 

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -238,8 +238,8 @@ export function ProjectTree({
                     <div className={cn('border border-primary text-xs mb-2 font-normal rounded-xs p-2 -mx-1')}>
                         You can display your preferred tools here. You can configure what items show up in here by
                         clicking on the{' '}
-                        <IconPencil className="size-3 border border-[var(--color-neutral-500)] rounded-xs" /> icon above.
-                        We'll automatically suggest new tools to this list as you use them.
+                        <IconPencil className="size-3 border border-[var(--color-neutral-500)] rounded-xs" /> icon
+                        above. We'll automatically suggest new tools to this list as you use them.
                         <br />
                         <br />
                         <span className="cursor-pointer underline" onClick={seed}>

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -14,7 +14,6 @@ import {
 } from '@posthog/icons'
 
 import { itemSelectModalLogic } from 'lib/components/FileSystem/ItemSelectModal/itemSelectModalLogic'
-import { KeyboardShortcut } from 'lib/components/KeyboardShortcut/KeyboardShortcut'
 import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useLocalStorage } from 'lib/hooks/useLocalStorage'

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -1190,19 +1190,24 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                         }
                     }
 
+                    const imports = selectedProducts
+                        .filter((f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag])
+                        .map((i) => ({
+                            ...i,
+                            protocol: 'custom-products://',
+                        }))
+
                     return convertFileSystemEntryToTreeDataItem({
                         root: 'custom-products://',
-                        imports: selectedProducts
-                            .filter((f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag])
-                            .map((i) => ({
-                                ...i,
-                                protocol: 'custom-products://',
-                            })),
+                        imports,
                         checkedItems: {},
                         folderStates,
                         users,
                         foldersFirst: false,
                         searchTerm,
+                        // With only a few tools pinned, category headers add more noise than structure —
+                        // list them in sequence instead.
+                        disableCategories: imports.length < 5,
                         disabledReason: (item) => getProductAccessDisabledReason(item as FileSystemImport),
                     })
                 }

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -52,6 +52,8 @@ export interface ConvertProps {
     users?: Record<string, UserBasicType>
     foldersFirst?: boolean
     allShortcuts?: boolean
+    /** Skip injecting category header rows, listing all items in sequence instead. */
+    disableCategories?: boolean
 }
 
 export function getItemId(item: FileSystemImport | FileSystemEntry, protocol = 'project://'): string {
@@ -122,6 +124,7 @@ export function convertFileSystemEntryToTreeDataItem({
     users,
     foldersFirst = true,
     allShortcuts = false,
+    disableCategories = false,
 }: ConvertProps): TreeDataItem[] {
     function itemToTreeDataItem(item: FileSystemImport | FileSystemEntry): TreeDataItem {
         const pathSplit = splitPath(item.path)
@@ -372,7 +375,7 @@ export function convertFileSystemEntryToTreeDataItem({
         }
     }
 
-    if (rootNodes.find((node) => node.record?.category)) {
+    if (!disableCategories && rootNodes.find((node) => node.record?.category)) {
         const newRootNodes: TreeDataItem[] = []
         let lastCategory: string | null = null
         for (const node of rootNodes) {


### PR DESCRIPTION
## Problem

The "My Tools" list in the main sidebar shows category headers (Analytics, Behavior, App monitoring, and so on) even when someone has only pinned a handful of tools. With a short list those headers add more visual noise than structure. We also stacked up a couple of nudges pushing people to customize the list, including a Cmd+K search tip and a dismissible banner, which showed even once the list had content.

## Changes

- Hide the category headers for the custom products (My Tools) list when fewer than 5 tools are pinned. Below that threshold the tools just list in sequence. At 5+ the category grouping comes back.
- Only show the "add tools" nudge when the list is empty. Once there's anything pinned, the sidebar stays clean.
- Remove the Cmd+K "quick search tip" banner and the dismissal state that backed both banners (localStorage keys, mount-time capture). Also dropped the now-unused imports that came with it.

This is scoped to the `custom-products://` root only. The edit-mode picker (the full products list you get when clicking the pencil) still shows categories, since that's where grouping helps.

## How did you test this code?

No manual testing yet. This checkout has no `node_modules`, so I (Claude) couldn't run `format` or `typescript:check` here. I verified by hand that no removed symbols are still referenced and that all remaining imports are in use, and confirmed no tests reference the removed banners. Please run `pnpm --filter=@posthog/frontend format` and `pnpm --filter=@posthog/frontend typescript:check` before marking ready.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafael directed this work; I (Claude, via PostHog Code) made the changes. The threshold change lives in `getCustomProductTreeItems`, which computes the filtered import list up front and passes a new `disableCategories` flag into `convertFileSystemEntryToTreeDataItem` when the count is below 5. I chose to gate at the conversion layer rather than filtering category rows out afterward, so the flag stays scoped to the one root and edit mode keeps its grouping. The banner cleanup removed the second Cmd+K banner and all the dismissal bookkeeping, since once the nudge only fires on an empty list there's nothing left to dismiss.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
