### PR TITLE
feat(onboarding): showcase flagship products in the welcome dialog

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7787,13 +7787,25 @@ snapshots:
     scenes-other-welcome-dialog--default--light:
         hash: v1.k794b7964.94d0889537f8a4a1345a155d78629fa3e090e1e8830323a77f37557c249ff45d.kPlrU8LIQApctwOYT1bNNhPfH3iynBBs41dZv4PqyzI
     scenes-other-welcome-dialog--empty-organization--dark:
-        hash: v1.k794b7964.6bdfd4a2f62c400ee4e1f0cd409cd023795d3f5d1d718f4e16fe9aa6c553ec37.2r3aWkkRHlnER2Dmk-IZb5e6dxVpepgRQvsE04P3wdU
+        hash: v1.k794b7964.9951b983bc53fd0147615d6216e76c8971dafa5fe5f5dcf2f89b076f21d05ac4.xD0q1sDMZaYraoKBg4mlmlnUldBZlVO1PNUkqLXfBuY
     scenes-other-welcome-dialog--empty-organization--light:
-        hash: v1.k794b7964.f78fc4d3e20a89fb63b048b560b09e63aa9b27f98832955fc459b1412dedc7d3.VzMxN3CHqytX43UQGDz6YDbJjAAdbv347XZQylfVroI
+        hash: v1.k794b7964.eb441c3b4223d47e62b1ad8f39138d27b4621e5c059ed4b8bcd90dee3fc7ee8d.CuE1WUVJAOt82qzcXB6UwIyUCLHw5Gu_NYnTrmgYlFk
     scenes-other-welcome-dialog--no-inviter--dark:
         hash: v1.k794b7964.7b34aac52fe0499a37f5971ccf76a25e12cde19e7c3e6f2f779802111fb99cd7.pF2gizxUDboEBZD4sG2K5U7GkIqm-yX_Ch6gtey_Mng
     scenes-other-welcome-dialog--no-inviter--light:
         hash: v1.k794b7964.f766cbd27b7bc11b50ce42602ca2fcab11fa005e795aad0d66e6f67e627570d2.M3CFGWAqq3ebMX5h9Rlb9cCCOBUfhrdc86fQexL6-MA
+    scenes-other-welcome-dialog--provisioned--dark:
+        hash: v1.k794b7964.ca1f1c0c19f2b721c8a57b8ab8527214aa231c3557caedcf392b4f7f531a267b.fd-faV75IyRDiQaarDTPWOAU3fiQYfGTgwg-1kAqZ88
+    scenes-other-welcome-dialog--provisioned--light:
+        hash: v1.k794b7964.4241f0cd5107adba6f5385cad103712e340ab458747b0936107c9a85e0c9f423.L5KqvkCuIdvMTJ4AknHk45IwOt-XgmGYjBmeDA_Bkuc
+    scenes-other-welcome-flagshipproductscard--default--dark:
+        hash: v1.k794b7964.d3a26ab7dedc62599bcc213bc25209189a39ec87e2472821d79dec3d5062d38d.DJtX4EJhBeB0ZjyBmXhQK3F1oZ1BK1Nm7TU4bH0RXnE
+    scenes-other-welcome-flagshipproductscard--default--light:
+        hash: v1.k794b7964.358a8cb872b3bc97b9f8844bb29bf00638879dc17dd20d5e93479d59b4064d36.YYXK42rCO__vp0IfRMrfGQyICVpArFGBiHNY7Ka1JNY
+    scenes-other-welcome-installprogresscard--default--dark:
+        hash: v1.k794b7964.b321aa0af8cd6635d3746c0f22e768f1ef0ed4a56210e219babebd1c38896890.2f7pqD-CII2Cb_5O9oo_SAA4A-hzd2n42nThxggLws8
+    scenes-other-welcome-installprogresscard--default--light:
+        hash: v1.k794b7964.18bf702600c4ca6149a0b4b3e9481b2b1f8d55b54165c4a5768bcf3c7b989db2.xPgy_DM70OW8Q1dMWhXPeOYMPVHC5YuNKwdvBjFEcYQ
     scenes-session-recordings-networkview--default--dark:
         hash: v1.k794b7964.e03dd8a06b90190b999e4dc6e568b018b13e36c6e0b690d14a8e692e6c153ea8.TnB0l_7lTb-n7V9wf8FQPRBP-IL-l7JZJcNPgG8uBvk
     scenes-session-recordings-networkview--default--light:

--- a/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdShared.tsx
+++ b/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdShared.tsx
@@ -97,6 +97,42 @@ function GeometricPattern(): JSX.Element {
     )
 }
 
+/**
+ * Presentational product "hog + text" hero: a Hoggie illustration over the product's brand-tinted
+ * geometric background, with a title and blurb below. Shared by the nav advertisement card and the
+ * welcome dialog's flagship-products showcase so both read as one visual. ``topRight`` is an optional
+ * slot for an overlay control (e.g. a dismiss button); the welcome showcase leaves it empty.
+ */
+export function ProductHogHero({
+    hero,
+    title,
+    text,
+    topRight,
+}: {
+    hero: ProductPushDisplay
+    title: string
+    text: string
+    topRight?: JSX.Element
+}): JSX.Element {
+    return (
+        <>
+            <div
+                className="relative flex h-24 items-center justify-center"
+                style={{ backgroundColor: hero.accentColor }}
+            >
+                <GeometricPattern />
+                <hero.Hoggie className="relative h-20 w-auto" aria-hidden="true" />
+                <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-surface-primary" />
+                {topRight ? <div className="absolute top-1 right-1">{topRight}</div> : null}
+            </div>
+            <div className="flex flex-col gap-1 px-2 pt-0.5 pb-2">
+                <strong className="text-sm leading-tight">{title}</strong>
+                <p className="mb-0 text-secondary">{text}</p>
+            </div>
+        </>
+    )
+}
+
 export function AdvertisementCard({
     emoji,
     emojiLabel,
@@ -136,21 +172,7 @@ export function AdvertisementCard({
     return (
         <div className="overflow-hidden rounded border bg-surface-primary text-xs shadow-sm transition-shadow hover:shadow-md">
             {hero ? (
-                <>
-                    <div
-                        className="relative flex h-24 items-center justify-center"
-                        style={{ backgroundColor: hero.accentColor }}
-                    >
-                        <GeometricPattern />
-                        <hero.Hoggie className="relative h-20 w-auto" aria-hidden="true" />
-                        <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-surface-primary" />
-                        <div className="absolute top-1 right-1">{dismissButton}</div>
-                    </div>
-                    <div className="flex flex-col gap-1 px-2 pt-0.5 pb-2">
-                        <strong className="text-sm leading-tight">{title}</strong>
-                        <p className="mb-0 text-secondary">{text}</p>
-                    </div>
-                </>
+                <ProductHogHero hero={hero} title={title} text={text} topRight={dismissButton} />
             ) : (
                 <div className="flex flex-col gap-1 px-2 py-1.5">
                     <div className="flex items-start justify-between gap-2">

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/activeCloudRunLogic.test.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/activeCloudRunLogic.test.ts
@@ -129,5 +129,22 @@ describe('activeCloudRunLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
             expect(logic.values.activeCloudRun).toMatchObject({ taskId: 'local-task' })
         })
+
+        it('clears a stale local handle when the server reports no active run', async () => {
+            // A returning provisioned user whose run finished/was abandoned still has a handle in
+            // localStorage. Hydration must reconcile it away, or the install card and FAB keep
+            // claiming setup is in flight forever. Mount before the user loads so the seeded handle
+            // is in place before the single hydration runs (no mount-time race to reason about).
+            mockActiveWizardRun.mockResolvedValue(undefined)
+            logic = activeCloudRunLogic()
+            logic.mount()
+            logic.actions.setActiveCloudRun('stale-task', 'stale-run', '2026-01-01T00:00:00Z', MOCK_TEAM_ID)
+            expect(logic.values.activeCloudRun).not.toBeNull()
+
+            setUser(true)
+
+            await expectLogic(logic).toDispatchActions(['hydrateFromServer', 'clearActiveCloudRun'])
+            expect(logic.values.activeCloudRun).toBeNull()
+        })
     })
 })

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/activeCloudRunLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/activeCloudRunLogic.ts
@@ -101,14 +101,25 @@ export const activeCloudRunLogic = kea<activeCloudRunLogicType>([
                 return
             }
             const projectId = values.currentProjectId
-            if (projectId == null || values.activeCloudRun) {
-                // Never clobber a fresher local handle — server hydration is a fallback only.
+            if (projectId == null) {
                 return
             }
             try {
+                // The server owns the "is there an active run" truth (it drops terminal/stale runs),
+                // so we reconcile the persisted handle against it — not just seed when empty. Without
+                // this a finished or abandoned run leaves a stale handle in localStorage that keeps
+                // the install progress card and FAB claiming setup is still in flight forever.
                 const handle = await tasksActiveWizardRunRetrieve(String(projectId))
-                // 204 → void; nothing to surface.
-                if (!handle || values.activeCloudRun) {
+                if (!handle) {
+                    // 204 → no active run. Clear any stale local handle so we stop showing progress.
+                    if (values.activeCloudRun) {
+                        actions.clearActiveCloudRun()
+                    }
+                    return
+                }
+                if (values.activeCloudRun) {
+                    // Server confirms a run and we already hold a handle — keep the local one, it's at
+                    // least as fresh (client kickoff writes it before the server round-trip resolves).
                     return
                 }
                 actions.setActiveCloudRun(

--- a/frontend/src/scenes/welcome/WelcomeDialog.stories.tsx
+++ b/frontend/src/scenes/welcome/WelcomeDialog.stories.tsx
@@ -1,9 +1,10 @@
-import { MOCK_DEFAULT_USER } from 'lib/api.mock'
+import { MOCK_DEFAULT_USER, MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { Meta, StoryFn } from '@storybook/react'
 import { useMountedLogic } from 'kea'
 import { useEffect } from 'react'
 
+import { activeCloudRunLogic } from 'scenes/onboarding/shared/wizard-sync/activeCloudRunLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { mswDecorator } from '~/mocks/browser'
@@ -125,6 +126,14 @@ const INVITED_USER: UserType = {
     is_organization_first_user: false,
 }
 
+// A partner-provisioned account: no inviter (first org user), onboarding skipped as 'provisioned'.
+const PROVISIONED_USER: UserType = {
+    ...MOCK_DEFAULT_USER,
+    first_name: 'Robin',
+    is_organization_first_user: true,
+    onboarding_skipped_reason: 'provisioned',
+}
+
 const meta: Meta = {
     title: 'Scenes-Other/Welcome Dialog',
     component: WelcomeDialog,
@@ -170,5 +179,29 @@ export const NoInviter: StoryFn = () => <Template />
 NoInviter.decorators = [
     mswDecorator({
         get: { '/api/organizations/@current/welcome/current/': { ...FULL_PAYLOAD, inviter: null } },
+    }),
+]
+
+// Partner-provisioned account: the dialog leads with the background-install card and the flagship
+// product tour (a different card order than invited users get).
+function ProvisionedTemplate(): JSX.Element {
+    useMountedLogic(userLogic)
+    useMountedLogic(activeCloudRunLogic)
+    useEffect(() => {
+        welcomeDialogLogic.mount()
+        // Seed an active cloud run so the "we're setting up PostHog in your repo" card shows
+        // (storybook app context sets current_project to MOCK_TEAM_ID).
+        activeCloudRunLogic.actions.setActiveCloudRun('task-1', 'run-1', new Date().toISOString(), MOCK_TEAM_ID)
+    }, [])
+    return <WelcomeDialog />
+}
+
+export const Provisioned: StoryFn = () => <ProvisionedTemplate />
+Provisioned.decorators = [
+    mswDecorator({
+        get: {
+            '/api/users/@me/': PROVISIONED_USER,
+            '/api/organizations/@current/welcome/current/': { ...FULL_PAYLOAD, inviter: null },
+        },
     }),
 ]

--- a/frontend/src/scenes/welcome/WelcomeDialog.tsx
+++ b/frontend/src/scenes/welcome/WelcomeDialog.tsx
@@ -9,6 +9,8 @@ import { Scene } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
 import { AskMaxCard } from './cards/AskMaxCard'
+import { FlagshipProductsCard } from './cards/FlagshipProductsCard'
+import { InstallProgressCard } from './cards/InstallProgressCard'
 import { PopularDashboardsCard } from './cards/PopularDashboardsCard'
 import { ProductsInUseCard } from './cards/ProductsInUseCard'
 import { RecentActivityCard } from './cards/RecentActivityCard'
@@ -28,9 +30,11 @@ const WELCOME_DIALOG_ALLOWED_SCENES = new Set<Scene>([Scene.ProjectHomepage, Sce
  * signup (project home, primary dashboard, etc.). Scene gating ensures the dialog only auto-opens
  * on the home / primary-dashboard scenes, not over deep-linked settings/billing/replay pages. */
 export function MaybeWelcomeDialog(): JSX.Element | null {
-    const { user } = useValues(userLogic)
+    const { user, isProvisionedUser } = useValues(userLogic)
     const { sceneId } = useValues(sceneLogic)
-    if (!user || user.is_organization_first_user !== false || wasWelcomeDismissed(user.uuid, user.organization?.id)) {
+    // Invitees see it as before; partner-provisioned accounts (no inviter) get it too.
+    const eligible = !!user && (user.is_organization_first_user === false || isProvisionedUser)
+    if (!eligible || !user || wasWelcomeDismissed(user.uuid, user.organization?.id)) {
         return null
     }
     if (!sceneId || !WELCOME_DIALOG_ALLOWED_SCENES.has(sceneId as Scene)) {
@@ -51,6 +55,7 @@ export function WelcomeDialog(): JSX.Element | null {
         recentActivity,
         popularDashboards,
         productsInUse,
+        isProvisionedUser,
     } = useValues(welcomeDialogLogic)
     const { dismissWelcome, closeDialog, loadWelcomeData } = useActions(welcomeDialogLogic)
     const { user } = useValues(userLogic)
@@ -115,14 +120,33 @@ export function WelcomeDialog(): JSX.Element | null {
                     ) : (
                         <p className="text-muted text-sm m-0">{introCopy}</p>
                     )}
-                    {/* Quick orientation first: products in use, AI helper, suggested next steps. */}
-                    <ProductsInUseCard />
-                    <AskMaxCard />
-                    <SuggestedNextStepsCard />
-                    {/* Then deeper context about what's been happening. */}
-                    <RecentActivityCard />
-                    <PopularDashboardsCard />
-                    <TeamMembersCard />
+                    {/* Provisioned/new accounts lead with the background install + a tour of what PostHog
+                        offers; invited users get their team's context first and the product tour lower down. */}
+                    {isProvisionedUser ? (
+                        <>
+                            <InstallProgressCard />
+                            <FlagshipProductsCard />
+                            <AskMaxCard />
+                            <SuggestedNextStepsCard />
+                            <ProductsInUseCard />
+                            <RecentActivityCard />
+                            <PopularDashboardsCard />
+                            <TeamMembersCard />
+                        </>
+                    ) : (
+                        <>
+                            {/* Quick orientation first: products in use, AI helper, suggested next steps. */}
+                            <ProductsInUseCard />
+                            <AskMaxCard />
+                            <SuggestedNextStepsCard />
+                            {/* Then deeper context about what's been happening. */}
+                            <RecentActivityCard />
+                            <PopularDashboardsCard />
+                            <TeamMembersCard />
+                            {/* Flagship product tour sits lower for invited users. */}
+                            <FlagshipProductsCard />
+                        </>
+                    )}
                 </div>
             )}
         </LemonModal>

--- a/frontend/src/scenes/welcome/cards/FlagshipProductsCard.stories.tsx
+++ b/frontend/src/scenes/welcome/cards/FlagshipProductsCard.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryFn } from '@storybook/react'
+import { useMountedLogic } from 'kea'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import { welcomeDialogLogic } from '../welcomeDialogLogic'
+import { FlagshipProductsCard } from './FlagshipProductsCard'
+
+const meta: Meta<typeof FlagshipProductsCard> = {
+    title: 'Scenes-Other/Welcome/FlagshipProductsCard',
+    component: FlagshipProductsCard,
+    parameters: {
+        layout: 'padded',
+        testOptions: { include: false },
+    },
+    decorators: [mswDecorator({})],
+}
+export default meta
+
+export const Default: StoryFn<typeof FlagshipProductsCard> = () => {
+    useMountedLogic(welcomeDialogLogic)
+    return (
+        <div className="max-w-[608px]">
+            <FlagshipProductsCard />
+        </div>
+    )
+}

--- a/frontend/src/scenes/welcome/cards/FlagshipProductsCard.tsx
+++ b/frontend/src/scenes/welcome/cards/FlagshipProductsCard.tsx
@@ -1,0 +1,52 @@
+import { useActions } from 'kea'
+
+import { ProductHogHero } from 'lib/components/NavPanelAdvertisement/navPanelAdShared'
+import { getProductPushDisplay } from 'lib/components/NavPanelAdvertisement/navPanelProductPushDisplay'
+import { LemonCard } from 'lib/lemon-ui/LemonCard'
+import { Link } from 'lib/lemon-ui/Link'
+
+import { brandingForProduct } from '../productBranding'
+import { welcomeDialogLogic } from '../welcomeDialogLogic'
+
+// The products we want every new account exploring. Both keys resolve in PRODUCT_BRANDING (label +
+// docs) and PRODUCT_PUSH_DISPLAY (hog illustration + brand accent + tagline), so the showcase reuses
+// the same hog+text visual as the nav advertisement.
+const FLAGSHIP_PRODUCT_KEYS = [
+    'product_analytics',
+    'web_analytics',
+    'session_replay',
+    'error_tracking',
+    'llm_analytics',
+] as const
+
+export function FlagshipProductsCard(): JSX.Element {
+    const { trackCardClick } = useActions(welcomeDialogLogic)
+
+    return (
+        <LemonCard hoverEffect={false} className="p-4">
+            <h2 className="text-lg font-semibold mb-1">What you get with PostHog</h2>
+            <p className="text-xs text-muted mb-3 m-0">
+                One platform, one set of events. Click any product to see how it works.
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+                {FLAGSHIP_PRODUCT_KEYS.map((productKey) => {
+                    const display = getProductPushDisplay(productKey)
+                    const meta = brandingForProduct(productKey)
+                    return (
+                        <Link
+                            key={productKey}
+                            to={meta.docsHref}
+                            target="_blank"
+                            subtle
+                            onClick={() => trackCardClick('products', meta.docsHref)}
+                            className="overflow-hidden rounded border bg-surface-primary text-xs shadow-sm transition-shadow hover:shadow-md"
+                            data-attr={`welcome-flagship-${productKey}`}
+                        >
+                            <ProductHogHero hero={display} title={meta.label} text={display.tagline} />
+                        </Link>
+                    )
+                })}
+            </div>
+        </LemonCard>
+    )
+}

--- a/frontend/src/scenes/welcome/cards/InstallProgressCard.stories.tsx
+++ b/frontend/src/scenes/welcome/cards/InstallProgressCard.stories.tsx
@@ -1,0 +1,36 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
+import { Meta, StoryFn } from '@storybook/react'
+import { useMountedLogic } from 'kea'
+import { useEffect } from 'react'
+
+import { activeCloudRunLogic } from 'scenes/onboarding/shared/wizard-sync/activeCloudRunLogic'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import { InstallProgressCard } from './InstallProgressCard'
+
+const meta: Meta<typeof InstallProgressCard> = {
+    title: 'Scenes-Other/Welcome/InstallProgressCard',
+    component: InstallProgressCard,
+    parameters: {
+        layout: 'padded',
+        testOptions: { include: false },
+    },
+    decorators: [mswDecorator({})],
+}
+export default meta
+
+// The card only renders while there's an active cloud run for the current project, so seed one
+// (the storybook app context sets current_project to MOCK_TEAM_ID).
+export const Default: StoryFn<typeof InstallProgressCard> = () => {
+    useMountedLogic(activeCloudRunLogic)
+    useEffect(() => {
+        activeCloudRunLogic.actions.setActiveCloudRun('task-1', 'run-1', new Date().toISOString(), MOCK_TEAM_ID)
+    }, [])
+    return (
+        <div className="max-w-[608px]">
+            <InstallProgressCard />
+        </div>
+    )
+}

--- a/frontend/src/scenes/welcome/cards/InstallProgressCard.tsx
+++ b/frontend/src/scenes/welcome/cards/InstallProgressCard.tsx
@@ -23,7 +23,7 @@ export function InstallProgressCard(): JSX.Element | null {
                     <h2 className="text-lg font-semibold mb-1">We're setting up PostHog in your repo</h2>
                     <p className="text-sm text-muted m-0">
                         A pull request that wires up PostHog is being prepared in the background. Follow its progress in
-                        the setup panel in the bottom-right corner — it'll link the pull request as soon as it's open.
+                        the setup panel in the bottom-right corner - it'll link the pull request as soon as it's open.
                     </p>
                 </div>
             </div>

--- a/frontend/src/scenes/welcome/cards/InstallProgressCard.tsx
+++ b/frontend/src/scenes/welcome/cards/InstallProgressCard.tsx
@@ -1,0 +1,32 @@
+import { useValues } from 'kea'
+
+import { IconGithub } from '@posthog/icons'
+
+import { LemonCard } from 'lib/lemon-ui/LemonCard'
+import { activeCloudRunLogic } from 'scenes/onboarding/shared/wizard-sync/activeCloudRunLogic'
+
+// Shown to partner-provisioned users while their setup wizard cloud run is in flight. The live
+// progress + PR link live in the setup FAB (bottom-right); this card just makes the background
+// work legible from inside the welcome dialog and points at it.
+export function InstallProgressCard(): JSX.Element | null {
+    const { activeCloudRun } = useValues(activeCloudRunLogic)
+
+    if (!activeCloudRun) {
+        return null
+    }
+
+    return (
+        <LemonCard hoverEffect={false} className="p-4">
+            <div className="flex items-start gap-3">
+                <IconGithub className="text-2xl shrink-0 mt-0.5" />
+                <div>
+                    <h2 className="text-lg font-semibold mb-1">We're setting up PostHog in your repo</h2>
+                    <p className="text-sm text-muted m-0">
+                        A pull request that wires up PostHog is being prepared in the background. Follow its progress in
+                        the setup panel in the bottom-right corner — it'll link the pull request as soon as it's open.
+                    </p>
+                </div>
+            </div>
+        </LemonCard>
+    )
+}

--- a/frontend/src/scenes/welcome/welcomeDialogLogic.test.ts
+++ b/frontend/src/scenes/welcome/welcomeDialogLogic.test.ts
@@ -20,6 +20,14 @@ const ORG_CREATOR_USER: UserType = {
     is_organization_first_user: true,
 }
 
+// A partner-provisioned account: no inviter (so first org user), but onboarding was skipped as
+// 'provisioned'. Should still get the welcome dialog even though it isn't an invitee.
+const PROVISIONED_USER: UserType = {
+    ...MOCK_DEFAULT_USER,
+    is_organization_first_user: true,
+    onboarding_skipped_reason: 'provisioned',
+}
+
 const mockPayload = {
     organization_name: 'Acme Inc',
     inviter: { name: 'Alex', email: 'alex@acme.com' },
@@ -83,6 +91,15 @@ describe('welcomeDialogLogic', () => {
 
         expect(logic.values.shouldShowDialog).toBe(false)
         await expectLogic(logic).toNotHaveDispatchedActions(['loadWelcomeData'])
+    })
+
+    it('opens for a partner-provisioned user even though they are the first org user', async () => {
+        userLogic.actions.loadUserSuccess(PROVISIONED_USER)
+        logic = welcomeDialogLogic()
+        logic.mount()
+
+        await expectLogic(logic).toDispatchActions(['loadWelcomeData', 'loadWelcomeDataSuccess'])
+        expect(logic.values.shouldShowDialog).toBe(true)
     })
 
     it('does not reopen for a user who has already dismissed', async () => {

--- a/frontend/src/scenes/welcome/welcomeDialogLogic.ts
+++ b/frontend/src/scenes/welcome/welcomeDialogLogic.ts
@@ -137,7 +137,7 @@ export const welcomeDialogLogic = kea<welcomeDialogLogicType>([
     path(['scenes', 'welcome', 'welcomeDialogLogic']),
 
     connect(() => ({
-        values: [userLogic, ['user']],
+        values: [userLogic, ['user', 'isProvisionedUser']],
     })),
 
     actions({
@@ -238,12 +238,13 @@ export const welcomeDialogLogic = kea<welcomeDialogLogicType>([
             (s) => [s.welcomeData, s.user],
             (data, user): string => data.organization_name || user?.organization?.name || '',
         ],
-        // Only open for invitees (not the org creator) who haven't already dismissed it.
+        // Open for invitees (not the org creator) and for partner-provisioned accounts (which have no
+        // inviter, so they'd otherwise never see it), when not already dismissed.
         // `storageTick` is in the dependency list so cross-tab localStorage changes re-run the selector.
         shouldShowDialog: [
-            (s) => [s.user, s.locallyClosed, s.storageTick],
-            (user, locallyClosed): boolean => {
-                if (!user || user.is_organization_first_user !== false) {
+            (s) => [s.user, s.isProvisionedUser, s.locallyClosed, s.storageTick],
+            (user, isProvisionedUser, locallyClosed): boolean => {
+                if (!user || (user.is_organization_first_user !== false && !isProvisionedUser)) {
                     return false
                 }
                 const orgId = user.organization?.id


### PR DESCRIPTION
feat(onboarding): showcase flagship products in the welcome dialog

Show the welcome dialog to partner-provisioned accounts (previously invitee-only)
and add a "What you get with PostHog" section highlighting product analytics, web
analytics, session replay, error tracking and AI observability, reusing the
NavPanelAdvertisement hog+text hero. Provisioned users lead with the background
install + product tour; invited users see it lower down.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

chore(onboarding): add stories for the provisioned welcome dialog + install card

Adds a Provisioned WelcomeDialog story (background-install card + flagship product
tour ordering) and an InstallProgressCard story, so the provisioned welcome UI is
reviewable in CI visual regression.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>