### PR TITLE
fix(logs): swallow otel recording errors so telemetry can't mask ingestion failures

### DIFF
--- a/nodejs/src/logs/ingestion-otel-metrics.test.ts
+++ b/nodejs/src/logs/ingestion-otel-metrics.test.ts
@@ -123,6 +123,43 @@ describe('ingestion-otel-metrics', () => {
         expect(names.map((name) => dataPointsFor(name).length)).toEqual([0, 0, 0, 0, 0])
     })
 
+    it.each([
+        ['recordLogsReceived', () => recordLogsReceived(1, 1)],
+        ['recordLogsAllowed', () => recordLogsAllowed(1, 1)],
+        ['recordLogsDropped', () => recordLogsDropped(42, 1, 1)],
+        ['recordLogMessageDropped', () => recordLogMessageDropped('rate_limited', '42')],
+        ['recordLogMessageDlq', () => recordLogMessageDlq('KafkaError', '42')],
+        [
+            'recordLogProcessingDuration',
+            () =>
+                recordLogProcessingDuration(0.02, {
+                    json_parse_enabled: 'true',
+                    pii_scrub_enabled: 'false',
+                    compression_codec: 'snappy',
+                }),
+        ],
+    ] as const)(
+        '%s swallows a throwing OTel SDK so callers in finally blocks keep the original error',
+        (_name, record) => {
+            // These run in finally blocks and error handlers of the ingestion hot path;
+            // a throw here would mask the real processing error and DLQ with the wrong reason.
+            const throwing = () => {
+                throw new Error('otel exploded')
+            }
+            metricsApi.disable() // the API ignores a second setGlobalMeterProvider without this
+            metricsApi.setGlobalMeterProvider({
+                getMeter: () =>
+                    ({
+                        createCounter: () => ({ add: throwing }),
+                        createHistogram: () => ({ record: throwing }),
+                    }) as any,
+            } as any)
+            resetLogsIngestionInstrumentsForTests()
+
+            expect(record).not.toThrow()
+        }
+    )
+
     it('records processing duration with the prom bucket ladder and pipeline attributes', async () => {
         const attributes = { json_parse_enabled: 'true', pii_scrub_enabled: 'false', compression_codec: 'snappy' }
         recordLogProcessingDuration(0.02, attributes)

--- a/nodejs/src/logs/ingestion-otel-metrics.ts
+++ b/nodejs/src/logs/ingestion-otel-metrics.ts
@@ -77,39 +77,56 @@ function addPositive(counter: Counter, value: number, attributes?: Attributes): 
     }
 }
 
-export function recordLogsReceived(bytes: number, records: number): void {
+/**
+ * These run in finally blocks and error handlers of the ingestion hot path — a throw
+ * here would mask the real processing error and DLQ the message with the wrong reason,
+ * so recording failures are swallowed.
+ */
+function swallowing<Args extends unknown[]>(record: (...args: Args) => void): (...args: Args) => void {
+    return (...args: Args): void => {
+        try {
+            record(...args)
+        } catch {
+            // never let telemetry break ingestion
+        }
+    }
+}
+
+export const recordLogsReceived = swallowing((bytes: number, records: number): void => {
     const { bytesReceived, recordsReceived } = getInstruments()
     addPositive(bytesReceived, bytes)
     addPositive(recordsReceived, records)
-}
+})
 
-export function recordLogsAllowed(bytes: number, records: number): void {
+export const recordLogsAllowed = swallowing((bytes: number, records: number): void => {
     const { bytesAllowed, recordsAllowed } = getInstruments()
     addPositive(bytesAllowed, bytes)
     addPositive(recordsAllowed, records)
-}
+})
 
-export function recordLogsDropped(teamId: number, bytes: number, records: number): void {
+export const recordLogsDropped = swallowing((teamId: number, bytes: number, records: number): void => {
     const { bytesDropped, recordsDropped } = getInstruments()
     const attributes = { team_id: teamId.toString() }
     addPositive(bytesDropped, bytes, attributes)
     addPositive(recordsDropped, records, attributes)
-}
+})
 
-export function recordLogMessageDropped(reason: string, teamId: string, count: number = 1): void {
+export const recordLogMessageDropped = swallowing((reason: string, teamId: string, count: number = 1): void => {
     addPositive(getInstruments().messagesDropped, count, { reason, team_id: teamId })
-}
+})
 
-export function recordLogMessageDlq(reason: string, teamId: string): void {
+export const recordLogMessageDlq = swallowing((reason: string, teamId: string): void => {
     getInstruments().messagesDlq.add(1, { reason, team_id: teamId })
-}
+})
 
-export function recordLogProcessingDuration(
-    seconds: number,
-    attributes: { json_parse_enabled: string; pii_scrub_enabled: string; compression_codec: string }
-): void {
-    getInstruments().processingDuration.record(seconds, attributes)
-}
+export const recordLogProcessingDuration = swallowing(
+    (
+        seconds: number,
+        attributes: { json_parse_enabled: string; pii_scrub_enabled: string; compression_codec: string }
+    ): void => {
+        getInstruments().processingDuration.record(seconds, attributes)
+    }
+)
 
 /** Test seam: forget cached instruments so a test-installed provider is picked up. */
 export function resetLogsIngestionInstrumentsForTests(): void {


### PR DESCRIPTION
## Problem

Follow-up to #69560, addressing the review comment it merged with. The `record*` helpers in `nodejs/src/logs/ingestion-otel-metrics.ts` run in `finally` blocks and error handlers of the logs-ingestion hot path. If the OTel meter acquisition or a record call throws, that error replaces the original processing error, so the consumer can DLQ a message with the metrics failure as the reason instead of the real decode/scrub/encode failure.

## Changes

Every exported `record*` function is now wrapped in a `swallowing()` guard that catches and discards any error from the OTel SDK path. Telemetry can never break ingestion or rewrite the error a message is DLQ'd with.

## How did you test this code?

TDD. Added a parameterized case to `ingestion-otel-metrics.test.ts` that installs a throwing fake meter provider and asserts each `record*` function does not throw. All 6 cases failed before the fix (the throw propagated) and pass after. No existing test exercised a throwing meter path, and a future refactor that drops the guard would resurface exactly the error-masking bug the review flagged.

Ran locally:
- `ingestion-otel-metrics.test.ts`: 16 passed
- `logs-ingestion-consumer.test.ts`: 68 passed

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, internal instrumentation only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) authored this fix while addressing review comments on #69560, which merged before the fix could land on its branch. Skills invoked: /writing-tests. The alternative of catching at each call site was rejected in favor of a single wrapper so new record functions get the guard by construction.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*