### PR TITLE
feat(tasks): add command to expire PostHog Code invite codes

### DIFF
--- a/products/tasks/backend/management/commands/expire_code_invites.py
+++ b/products/tasks/backend/management/commands/expire_code_invites.py
@@ -25,29 +25,43 @@ class Command(BaseCommand):
             action="store_true",
             help="Show how many codes would be expired without changing anything.",
         )
+        parser.add_argument(
+            "--yes",
+            action="store_true",
+            help="Skip the interactive confirmation prompt required by --all.",
+        )
 
     def handle(self, *args, **options):
         expire_all = options["all"]
         dry_run = options["dry_run"]
 
-        # is_redeemable checks is_active first, so flipping it to False is enough to block redemption
-        # while preserving the codes and their redemption audit trail.
+        # Deactivate rather than delete: access is gated on a user's CodeInviteRedemption row existing
+        # (see has_tasks_access), and those rows cascade-delete with the CodeInvite. Flipping is_active
+        # blocks future redemptions (is_redeemable checks it first) without touching redemptions, so
+        # users who already redeemed keep access.
         codes = CodeInvite.objects.filter(is_active=True)
         if not expire_all:
             codes = codes.filter(redemption_count=0)
 
         scope = "all active" if expire_all else "unused (never redeemed)"
-        count = codes.count()
 
         if dry_run:
-            self.stdout.write(self.style.WARNING(f"DRY RUN: would expire {count} {scope} invite code(s)"))
+            self.stdout.write(self.style.WARNING(f"DRY RUN: would expire {codes.count()} {scope} invite code(s)"))
             return
 
-        if count == 0:
-            self.stdout.write(self.style.SUCCESS(f"No {scope} invite codes to expire"))
-            return
+        if expire_all and not options["yes"]:
+            confirm = input(
+                "This expires ALL active invite codes and blocks any further redemptions. Type 'yes' to continue: "
+            )
+            if confirm.strip().lower() != "yes":
+                self.stdout.write(self.style.ERROR("Aborted"))
+                return
 
         updated = codes.update(is_active=False)
+
+        if updated == 0:
+            self.stdout.write(self.style.SUCCESS(f"No {scope} invite codes to expire"))
+            return
 
         logger.info("code_invites_expired", expired_count=updated, expire_all=expire_all)
         self.stdout.write(self.style.SUCCESS(f"Expired {updated} {scope} invite code(s)"))

--- a/products/tasks/backend/management/commands/expire_code_invites.py
+++ b/products/tasks/backend/management/commands/expire_code_invites.py
@@ -1,0 +1,53 @@
+from django.core.management.base import BaseCommand
+
+import structlog
+
+from products.tasks.backend.models import CodeInvite
+
+logger = structlog.get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Deactivate PostHog Code invite codes so they can no longer be redeemed. "
+        "By default only unused (never-redeemed) codes are expired; pass --all to expire every active code."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Expire every active code, including ones that have already been redeemed at least once. "
+            "Use this to stop all further redemptions immediately.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show how many codes would be expired without changing anything.",
+        )
+
+    def handle(self, *args, **options):
+        expire_all = options["all"]
+        dry_run = options["dry_run"]
+
+        # is_redeemable checks is_active first, so flipping it to False is enough to block redemption
+        # while preserving the codes and their redemption audit trail.
+        codes = CodeInvite.objects.filter(is_active=True)
+        if not expire_all:
+            codes = codes.filter(redemption_count=0)
+
+        scope = "all active" if expire_all else "unused (never redeemed)"
+        count = codes.count()
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING(f"DRY RUN: would expire {count} {scope} invite code(s)"))
+            return
+
+        if count == 0:
+            self.stdout.write(self.style.SUCCESS(f"No {scope} invite codes to expire"))
+            return
+
+        updated = codes.update(is_active=False)
+
+        logger.info("code_invites_expired", expired_count=updated, expire_all=expire_all)
+        self.stdout.write(self.style.SUCCESS(f"Expired {updated} {scope} invite code(s)"))


### PR DESCRIPTION
## Problem

We saw a large, geographically diffuse jump in new PostHog Code users (both the CLI and cloud surfaces) that looks like it came from previously distributed invite codes still being redeemed. We want a fast, safe way to stop further redemptions — either just the unused codes, or all of them — across regions.

## Changes

Adds an `expire_code_invites` management command (`products/tasks/backend/management/commands/expire_code_invites.py`).

- Default: expires **unused** codes only — `is_active=True, redemption_count=0`.
- `--all`: expires **every active** code (including partially-redeemed and unlimited ones), to stop all further redemptions immediately.
- `--dry-run`: prints the count that would be affected and changes nothing.

Expiry sets `is_active=False` rather than deleting. `CodeInvite.is_redeemable` checks `is_active` first, so this immediately blocks redemption while preserving the codes and their `CodeInviteRedemption` audit trail (which would otherwise cascade-delete).

`CodeInvite` is not team-scoped (it's user/org-level), so the command operates on the whole table. It is region-agnostic — run it once per deployment (US and EU) to cover both.

```bash
# preview
./bin/hogli manage expire_code_invites --dry-run          # unused only
./bin/hogli manage expire_code_invites --all --dry-run    # everything

# apply
./bin/hogli manage expire_code_invites                    # unused only
./bin/hogli manage expire_code_invites --all              # stop the bleeding
```

## How did you test this code?

`python3 -m py_compile` and `ruff check` pass on the new file. No automated tests added and no manual run against a real database was performed by the agent — the command mirrors the existing `cleanup_expired_sharing_configs` pattern and uses a plain `.filter().update()`. Reviewer may want to `--dry-run` in each region before applying.

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Adam Bowker via a Slack thread investigating the new-user spike. The PostHog Slack app first analyzed the acquisition data (confirming a sharp, multi-country spike around June 10) and then was asked to write this command.

Decisions:
- Chose `is_active=False` over row deletion so the redemption audit trail survives (the `CodeInviteRedemption` FK cascades on delete) and because `is_redeemable` gates on `is_active` first.
- Defaulted to unused-only with an explicit `--all` opt-in, since "expire unused" was the primary ask and querying redeemed vs. unused is trivial (`redemption_count`), while still supporting the "just kill everything" fallback.
- No new DB index added; the table is small and this is an infrequent ops command.

Current gh user for this session is `k11kirky`; left unassigned rather than guessing the DRI's GitHub handle — please assign the human driver on triage.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783715992631009?thread_ts=1783715992.631009&cid=C09G8Q32R6F)*
