### PR TITLE
feat(cdp): route logo.dev calls through egress and cache icon responses

### DIFF
--- a/posthog/cdp/services/icons.py
+++ b/posthog/cdp/services/icons.py
@@ -4,16 +4,20 @@ from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse
 
-import requests
 from rest_framework.exceptions import NotFound
+
+from posthog.egress.limiter.policies import Priority
+from posthog.egress.logodev.transport import LogoDevEgressBudgetExhausted, logodev_request
+
+ICON_CACHE_SECONDS = 60 * 60 * 24
 
 
 class CDPIconsService:
     @property
-    def supported(self):
+    def supported(self) -> bool:
         return bool(settings.LOGO_DEV_TOKEN)
 
-    def list_icons(self, query: str, icon_url_base: str):
+    def list_icons(self, query: str, icon_url_base: str) -> list[dict[str, str]]:
         if not self.supported:
             return []
 
@@ -21,15 +25,19 @@ class CDPIconsService:
         data = cache.get(cache_key)
 
         if data is None:
-            res = requests.get(
-                f"https://search.logo.dev/api/icons",
-                params={
-                    "token": settings.LOGO_DEV_TOKEN,
-                    "query": query,
-                },
-                timeout=10,
-            )
-            data = res.json() or []
+            try:
+                # NORMAL: a typeahead search degrades to no results when the shared budget is tight,
+                # leaving headroom for CRITICAL icon renders.
+                res = logodev_request(
+                    "GET",
+                    "https://search.logo.dev/api/icons",
+                    source="cdp_icons",
+                    priority=Priority.NORMAL,
+                    params={"token": settings.LOGO_DEV_TOKEN, "query": query},
+                    timeout=10,
+                )
+            except LogoDevEgressBudgetExhausted:
+                return []
 
             data = [
                 {
@@ -40,20 +48,33 @@ class CDPIconsService:
                 for item in res.json() or []
             ]
 
-            cache.set(cache_key, data, 60 * 60 * 24)
+            cache.set(cache_key, data, ICON_CACHE_SECONDS)
 
         return data
 
-    def get_icon_http_response(self, id: str):
+    def get_icon_http_response(self, id: str) -> HttpResponse:
         if not self.supported:
             raise NotFound()
 
-        res = requests.get(
-            f"https://img.logo.dev/{id}",
-            params={
-                "token": settings.LOGO_DEV_TOKEN,
-            },
-            timeout=10,
-        )
+        cache_key = f"@cdp/icon/{b64encode(id.encode()).decode()}"
+        cached = cache.get(cache_key)
 
-        return HttpResponse(res.content, content_type=res.headers["Content-Type"])
+        if cached is None:
+            res = logodev_request(
+                "GET",
+                f"https://img.logo.dev/{id}",
+                source="cdp_icons",
+                priority=Priority.CRITICAL,
+                params={"token": settings.LOGO_DEV_TOKEN},
+                timeout=10,
+            )
+            if res.status_code != 200:
+                raise NotFound()
+            cached = (res.content, res.headers.get("Content-Type", "image/png"))
+            cache.set(cache_key, cached, ICON_CACHE_SECONDS)
+
+        content, content_type = cached
+        response = HttpResponse(content, content_type=content_type)
+        # Public brand assets — let browsers and any CDN cache them instead of re-proxying per render.
+        response["Cache-Control"] = f"public, max-age={ICON_CACHE_SECONDS}"
+        return response

--- a/posthog/cdp/services/icons.py
+++ b/posthog/cdp/services/icons.py
@@ -52,28 +52,47 @@ class CDPIconsService:
 
         return data
 
-    def get_icon_http_response(self, id: str) -> HttpResponse:
+    def get_icon_http_response(self, id: str, theme: str | None = None, fallback: str = "monogram") -> HttpResponse:
         if not self.supported:
             raise NotFound()
 
-        cache_key = f"@cdp/icon/{b64encode(id.encode()).decode()}"
+        # Every parameter that changes logo.dev's response bytes must be part of the key.
+        cache_key = f"@cdp/icon/2/{b64encode(id.encode()).decode()}/{theme or ''}/{fallback}"
         cached = cache.get(cache_key)
 
         if cached is None:
+            params = {
+                "token": settings.LOGO_DEV_TOKEN,
+                # PNG keeps the logo's transparency — the jpg default flattens it onto a white tile.
+                "format": "png",
+                "retina": "true",
+                "fallback": fallback,
+            }
+            if theme:
+                params["theme"] = theme
             res = logodev_request(
                 "GET",
                 f"https://img.logo.dev/{id}",
                 source="cdp_icons",
                 priority=Priority.CRITICAL,
-                params={"token": settings.LOGO_DEV_TOKEN},
+                params=params,
                 timeout=10,
             )
-            if res.status_code != 200:
+            if res.status_code == 404 and fallback == "404":
+                # A definitive "no logo for this domain" — cache the miss so rendering an
+                # unknown domain doesn't re-proxy to logo.dev for a day. Other upstream
+                # errors are treated as transient and stay uncached.
+                cached = (None, None)
+                cache.set(cache_key, cached, ICON_CACHE_SECONDS)
+            elif res.status_code != 200:
                 raise NotFound()
-            cached = (res.content, res.headers.get("Content-Type", "image/png"))
-            cache.set(cache_key, cached, ICON_CACHE_SECONDS)
+            else:
+                cached = (res.content, res.headers.get("Content-Type", "image/png"))
+                cache.set(cache_key, cached, ICON_CACHE_SECONDS)
 
         content, content_type = cached
+        if content is None:
+            raise NotFound()
         response = HttpResponse(content, content_type=content_type)
         # Public brand assets — let browsers and any CDN cache them instead of re-proxying per render.
         response["Cache-Control"] = f"public, max-age={ICON_CACHE_SECONDS}"

--- a/posthog/cdp/services/icons.py
+++ b/posthog/cdp/services/icons.py
@@ -12,10 +12,6 @@ from posthog.egress.logodev.transport import LogoDevEgressBudgetExhausted, logod
 
 ICON_CACHE_SECONDS = 60 * 60 * 24
 
-# Icons are tens of KB even at retina — the cap keeps user-triggered fetches from squatting in the
-# shared cache with oversized bodies.
-MAX_CACHED_ICON_BYTES = 512 * 1024
-
 # Dot-separated LDH labels, lowercase — the only shape logo.dev serves. Rejecting everything else
 # keeps caller-supplied ids from reaching logo.dev or minting cache entries.
 _DOMAIN_RE = re.compile(r"^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
@@ -79,61 +75,56 @@ class CDPIconsService:
         if len(domain) > _MAX_DOMAIN_LENGTH or not _DOMAIN_RE.match(domain):
             raise NotFound()
 
-        # Every parameter that changes logo.dev's response bytes must be part of the key. The
-        # validated charset ([a-z0-9.-]) is cache-key-safe raw.
-        cache_key = f"@cdp/icon/3/{domain}/{theme or ''}/{fallback}"
-        cached = cache.get(cache_key)
-
-        if cached is None:
-            params = {
-                "token": settings.LOGO_DEV_TOKEN,
-                # PNG keeps the logo's transparency — the jpg default flattens it onto a white tile.
-                "format": "png",
-                "retina": "true",
-                "fallback": fallback,
-            }
-            if theme:
-                params["theme"] = theme
-            try:
-                # NORMAL, not CRITICAL: steady-state renders are served by the cache, and `id` is
-                # user-controlled — an exhausted budget must actually stop upstream fetches (and
-                # cache fill) rather than being advisory, so this lane is sheddable too.
-                res = logodev_request(
-                    "GET",
-                    f"https://img.logo.dev/{domain}",
-                    source="cdp_icons",
-                    priority=Priority.NORMAL,
-                    params=params,
-                    timeout=10,
-                )
-            except LogoDevEgressBudgetExhausted:
-                # Transient and uncached — the next render retries once the budget window rolls over.
-                raise NotFound() from None
-            if res.status_code == 404 and fallback == "404":
-                # A definitive "no logo for this domain" — cache the miss so rendering an
-                # unknown domain doesn't re-proxy to logo.dev for a day. Other upstream
-                # errors are treated as transient and stay uncached.
-                cached = (None, None)
-                cache.set(cache_key, cached, ICON_CACHE_SECONDS)
-            elif res.status_code != 200:
-                raise NotFound()
-            else:
-                content_type = res.headers.get("Content-Type", "image/png")
-                if not content_type.startswith("image/"):
-                    # A 200 that isn't an image (upstream anomaly, error page) must not be proxied
-                    # from our origin — and certainly not cached and served publicly for a day.
-                    raise NotFound()
-                cached = (res.content, content_type)
-                # Oversized bodies still render (served through) but must not squat in the cache.
-                if len(res.content) <= MAX_CACHED_ICON_BYTES:
-                    cache.set(cache_key, cached, ICON_CACHE_SECONDS)
-
-        content, content_type = cached
-        if content is None:
+        # Only the *fact* of a definitive miss is ever cached. Logo bytes must not be stored on our
+        # infrastructure — logo.dev gates that behind a data-caching license our plan doesn't
+        # include — so byte-level dedup is delegated to browser caching via Cache-Control below.
+        # Every parameter that changes logo.dev's answer is part of the key; the validated charset
+        # ([a-z0-9.-]) is cache-key-safe raw.
+        miss_cache_key = f"@cdp/icon_miss/1/{domain}/{theme or ''}/{fallback}"
+        if cache.get(miss_cache_key):
             raise NotFound()
-        response = HttpResponse(content, content_type=content_type)
-        # Public brand assets — let browsers and any CDN cache them instead of re-proxying per render.
-        response["Cache-Control"] = f"public, max-age={ICON_CACHE_SECONDS}"
+
+        params = {
+            "token": settings.LOGO_DEV_TOKEN,
+            # PNG keeps the logo's transparency — the jpg default flattens it onto a white tile.
+            "format": "png",
+            "retina": "true",
+            "fallback": fallback,
+        }
+        if theme:
+            params["theme"] = theme
+        try:
+            # NORMAL, not CRITICAL: `id` is user-controlled — an exhausted budget must actually
+            # stop upstream fetches rather than being advisory, so this lane is sheddable too.
+            res = logodev_request(
+                "GET",
+                f"https://img.logo.dev/{domain}",
+                source="cdp_icons",
+                priority=Priority.NORMAL,
+                params=params,
+                timeout=10,
+            )
+        except LogoDevEgressBudgetExhausted:
+            # Transient and uncached — the next render retries once the budget window rolls over.
+            raise NotFound() from None
+        if res.status_code == 404 and fallback == "404":
+            # A definitive "no logo for this domain" — cache the miss so rendering an unknown
+            # domain doesn't re-proxy to logo.dev for a day. Other upstream errors are treated
+            # as transient and stay uncached.
+            cache.set(miss_cache_key, True, ICON_CACHE_SECONDS)
+            raise NotFound()
+        if res.status_code != 200:
+            raise NotFound()
+        content_type = res.headers.get("Content-Type", "image/png")
+        if not content_type.startswith("image/"):
+            # A 200 that isn't an image (upstream anomaly, error page) must not be proxied from
+            # our origin.
+            raise NotFound()
+
+        response = HttpResponse(res.content, content_type=content_type)
+        # Public brand assets — browser caching is the only dedup layer, so honor logo.dev's own
+        # caching directive when present (their TTL tuning propagates) and match it otherwise.
+        response["Cache-Control"] = res.headers.get("Cache-Control", f"public, max-age={ICON_CACHE_SECONDS}")
         # The body is upstream-controlled — never let a browser sniff it into something executable.
         response["X-Content-Type-Options"] = "nosniff"
         return response

--- a/posthog/cdp/services/icons.py
+++ b/posthog/cdp/services/icons.py
@@ -7,10 +7,42 @@ from django.http import HttpResponse
 
 from rest_framework.exceptions import NotFound
 
-from posthog.egress.limiter.policies import Priority
+from posthog.egress.limiter.outbound import get_outbound_rate_limiter
+from posthog.egress.limiter.policies import Priority, RatePolicy, register_policy
 from posthog.egress.logodev.transport import LogoDevEgressBudgetExhausted, logodev_request
 
 ICON_CACHE_SECONDS = 60 * 60 * 24
+
+# Per-team fairness gate in front of the instance-wide logo.dev account budget. Icon domains and
+# search queries are caller-supplied and only definitive misses are cached, so without a per-team
+# ceiling one team requesting endless unique domains could drain the shared account budget and
+# blank icons for every other team on the instance. The ceilings leave a cold catalog render (tens
+# of uncached icons) untouched while sitting well below the account budget, so a single team can't
+# sustain instance-wide exhaustion. This is a consumer-side concern: the logodev egress limiter
+# stays a pure account-budget mirror of what logo.dev actually meters.
+_TEAM_BUDGET_DOMAIN = "cdp_icons"
+_DEFAULT_TEAM_PER_MINUTE_BUDGET = 120
+_DEFAULT_TEAM_HOURLY_BUDGET = 1_000
+
+
+# Registered as a provider so the budgets are read at acquire time — a settings override applies
+# without a process restart, matching the egress domains.
+def _team_budget_policy(key: str) -> RatePolicy:
+    per_minute = int(getattr(settings, "CDP_ICONS_TEAM_PER_MINUTE_BUDGET", _DEFAULT_TEAM_PER_MINUTE_BUDGET))
+    hourly = int(getattr(settings, "CDP_ICONS_TEAM_HOURLY_BUDGET", _DEFAULT_TEAM_HOURLY_BUDGET))
+    return RatePolicy(limits=((per_minute, 60.0), (hourly, 3600.0)), in_memory_divider=4)
+
+
+register_policy(_TEAM_BUDGET_DOMAIN, _team_budget_policy)
+
+
+def _consume_team_icon_budget(team_id: int) -> bool:
+    """Reserve one upstream logo.dev call against ``team_id``'s icon budget. Returns False when the
+    team's budget is exhausted — degrade for that team only, before touching the account budget."""
+    return get_outbound_rate_limiter().consume_sync(
+        f"{_TEAM_BUDGET_DOMAIN}:team:{team_id}", priority=Priority.NORMAL, source="cdp_icons"
+    )
+
 
 # Dot-separated LDH labels, lowercase — the only shape logo.dev serves. Rejecting everything else
 # keeps caller-supplied ids from reaching logo.dev or minting cache entries.
@@ -26,7 +58,7 @@ class CDPIconsService:
     def supported(self) -> bool:
         return bool(settings.LOGO_DEV_TOKEN)
 
-    def list_icons(self, query: str, icon_url_base: str) -> list[dict[str, str]]:
+    def list_icons(self, query: str, icon_url_base: str, *, team_id: int) -> list[dict[str, str]]:
         if not self.supported:
             return []
 
@@ -34,6 +66,10 @@ class CDPIconsService:
         data = cache.get(cache_key)
 
         if data is None:
+            # Queries are free-text, so cached entries don't bound upstream volume — gate uncached
+            # searches on the caller's team budget before they reach the shared account budget.
+            if not _consume_team_icon_budget(team_id):
+                return []
             try:
                 # NORMAL: a typeahead search degrades to no results when the shared budget is tight.
                 res = logodev_request(
@@ -60,7 +96,9 @@ class CDPIconsService:
 
         return data
 
-    def get_icon_http_response(self, id: str, theme: str | None = None, fallback: str = "monogram") -> HttpResponse:
+    def get_icon_http_response(
+        self, id: str, theme: str | None = None, fallback: str = "monogram", *, team_id: int
+    ) -> HttpResponse:
         if not self.supported:
             raise NotFound()
         if theme not in _ALLOWED_THEMES:
@@ -82,6 +120,11 @@ class CDPIconsService:
         # ([a-z0-9.-]) is cache-key-safe raw.
         miss_cache_key = f"@cdp/icon_miss/1/{domain}/{theme or ''}/{fallback}"
         if cache.get(miss_cache_key):
+            raise NotFound()
+
+        # Unique domains bypass the miss cache by construction, so gate the uncached fetch on the
+        # caller's team budget. Transient and uncached, like account-budget exhaustion below.
+        if not _consume_team_icon_budget(team_id):
             raise NotFound()
 
         params = {

--- a/posthog/cdp/services/icons.py
+++ b/posthog/cdp/services/icons.py
@@ -1,3 +1,4 @@
+import re
 from base64 import b64encode
 
 from django.conf import settings
@@ -10,6 +11,18 @@ from posthog.egress.limiter.policies import Priority
 from posthog.egress.logodev.transport import LogoDevEgressBudgetExhausted, logodev_request
 
 ICON_CACHE_SECONDS = 60 * 60 * 24
+
+# Icons are tens of KB even at retina — the cap keeps user-triggered fetches from squatting in the
+# shared cache with oversized bodies.
+MAX_CACHED_ICON_BYTES = 512 * 1024
+
+# Dot-separated LDH labels, lowercase — the only shape logo.dev serves. Rejecting everything else
+# keeps caller-supplied ids from reaching logo.dev or minting cache entries.
+_DOMAIN_RE = re.compile(r"^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_MAX_DOMAIN_LENGTH = 253
+
+_ALLOWED_THEMES: frozenset[str | None] = frozenset({None, "dark", "light"})
+_ALLOWED_FALLBACKS: frozenset[str] = frozenset({"monogram", "404"})
 
 
 class CDPIconsService:
@@ -26,8 +39,7 @@ class CDPIconsService:
 
         if data is None:
             try:
-                # NORMAL: a typeahead search degrades to no results when the shared budget is tight,
-                # leaving headroom for CRITICAL icon renders.
+                # NORMAL: a typeahead search degrades to no results when the shared budget is tight.
                 res = logodev_request(
                     "GET",
                     "https://search.logo.dev/api/icons",
@@ -55,9 +67,21 @@ class CDPIconsService:
     def get_icon_http_response(self, id: str, theme: str | None = None, fallback: str = "monogram") -> HttpResponse:
         if not self.supported:
             raise NotFound()
+        if theme not in _ALLOWED_THEMES:
+            raise ValueError(f"Unsupported logo.dev theme: {theme!r}")
+        if fallback not in _ALLOWED_FALLBACKS:
+            raise ValueError(f"Unsupported logo.dev fallback mode: {fallback!r}")
 
-        # Every parameter that changes logo.dev's response bytes must be part of the key.
-        cache_key = f"@cdp/icon/2/{b64encode(id.encode()).decode()}/{theme or ''}/{fallback}"
+        # `id` is caller-supplied (a query param on the icon endpoint) — anything not domain-shaped
+        # must never reach logo.dev nor mint a 24h entry in the shared cache. Domains are
+        # case-insensitive, so lowercase first or each case variant would cache separately.
+        domain = id.lower()
+        if len(domain) > _MAX_DOMAIN_LENGTH or not _DOMAIN_RE.match(domain):
+            raise NotFound()
+
+        # Every parameter that changes logo.dev's response bytes must be part of the key. The
+        # validated charset ([a-z0-9.-]) is cache-key-safe raw.
+        cache_key = f"@cdp/icon/3/{domain}/{theme or ''}/{fallback}"
         cached = cache.get(cache_key)
 
         if cached is None:
@@ -70,14 +94,21 @@ class CDPIconsService:
             }
             if theme:
                 params["theme"] = theme
-            res = logodev_request(
-                "GET",
-                f"https://img.logo.dev/{id}",
-                source="cdp_icons",
-                priority=Priority.CRITICAL,
-                params=params,
-                timeout=10,
-            )
+            try:
+                # NORMAL, not CRITICAL: steady-state renders are served by the cache, and `id` is
+                # user-controlled — an exhausted budget must actually stop upstream fetches (and
+                # cache fill) rather than being advisory, so this lane is sheddable too.
+                res = logodev_request(
+                    "GET",
+                    f"https://img.logo.dev/{domain}",
+                    source="cdp_icons",
+                    priority=Priority.NORMAL,
+                    params=params,
+                    timeout=10,
+                )
+            except LogoDevEgressBudgetExhausted:
+                # Transient and uncached — the next render retries once the budget window rolls over.
+                raise NotFound() from None
             if res.status_code == 404 and fallback == "404":
                 # A definitive "no logo for this domain" — cache the miss so rendering an
                 # unknown domain doesn't re-proxy to logo.dev for a day. Other upstream
@@ -87,8 +118,15 @@ class CDPIconsService:
             elif res.status_code != 200:
                 raise NotFound()
             else:
-                cached = (res.content, res.headers.get("Content-Type", "image/png"))
-                cache.set(cache_key, cached, ICON_CACHE_SECONDS)
+                content_type = res.headers.get("Content-Type", "image/png")
+                if not content_type.startswith("image/"):
+                    # A 200 that isn't an image (upstream anomaly, error page) must not be proxied
+                    # from our origin — and certainly not cached and served publicly for a day.
+                    raise NotFound()
+                cached = (res.content, content_type)
+                # Oversized bodies still render (served through) but must not squat in the cache.
+                if len(res.content) <= MAX_CACHED_ICON_BYTES:
+                    cache.set(cache_key, cached, ICON_CACHE_SECONDS)
 
         content, content_type = cached
         if content is None:
@@ -96,4 +134,6 @@ class CDPIconsService:
         response = HttpResponse(content, content_type=content_type)
         # Public brand assets — let browsers and any CDN cache them instead of re-proxying per render.
         response["Cache-Control"] = f"public, max-age={ICON_CACHE_SECONDS}"
+        # The body is upstream-controlled — never let a browser sniff it into something executable.
+        response["X-Content-Type-Options"] = "nosniff"
         return response

--- a/posthog/cdp/test/test_icons.py
+++ b/posthog/cdp/test/test_icons.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import SimpleTestCase, override_settings
+
+import requests
+from requests.structures import CaseInsensitiveDict
+from rest_framework.exceptions import NotFound
+
+from posthog.cdp.services.icons import CDPIconsService
+
+
+def _response(status: int = 200, content: bytes = b"", content_type: str = "image/png") -> requests.Response:
+    response = requests.models.Response()
+    response.status_code = status
+    response._content = content
+    response.headers = CaseInsensitiveDict({"Content-Type": content_type})
+    prepared = requests.models.PreparedRequest()
+    prepared.method = "GET"
+    prepared.url = "https://img.logo.dev/linear.app"
+    response.request = prepared
+    return response
+
+
+@override_settings(LOGO_DEV_TOKEN="test-token")
+class TestCDPIconsService(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.clear()
+        self.service = CDPIconsService()
+
+    def test_icon_is_served_from_cache_after_first_fetch(self) -> None:
+        # The store/CDP UIs render dozens of icons per page view — without the cache every render
+        # proxies to logo.dev again, which is the regression this locks out.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(content=b"png-bytes")) as upstream,
+        ):
+            first = self.service.get_icon_http_response("linear.app")
+            second = self.service.get_icon_http_response("linear.app")
+
+        assert upstream.call_count == 1
+        assert first.content == b"png-bytes"
+        assert second.content == b"png-bytes"
+        assert first["Cache-Control"] == "public, max-age=86400"
+
+    def test_upstream_error_raises_not_found_and_is_not_cached(self) -> None:
+        # A logo.dev error body must not be proxied through as an image nor poison the cache for a day.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(status=500, content=b"boom")),
+        ):
+            with self.assertRaises(NotFound):
+                self.service.get_icon_http_response("linear.app")
+
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(content=b"png-bytes")),
+        ):
+            recovered = self.service.get_icon_http_response("linear.app")
+
+        assert recovered.content == b"png-bytes"
+
+    def test_search_degrades_to_empty_when_budget_exhausted(self) -> None:
+        # Icon search is sheddable (NORMAL lane) — when the shared budget is spent it must return no
+        # results, not surface a 500 to the icon picker.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=False),
+            patch("requests.request") as upstream,
+        ):
+            assert self.service.list_icons("linear", icon_url_base="/base?id=") == []
+
+        upstream.assert_not_called()

--- a/posthog/cdp/test/test_icons.py
+++ b/posthog/cdp/test/test_icons.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 from django.test import SimpleTestCase, override_settings
 
 import requests
+from parameterized import parameterized
 from requests.structures import CaseInsensitiveDict
 from rest_framework.exceptions import NotFound
 
@@ -60,6 +61,50 @@ class TestCDPIconsService(SimpleTestCase):
             recovered = self.service.get_icon_http_response("linear.app")
 
         assert recovered.content == b"png-bytes"
+
+    def test_theme_and_fallback_partition_the_cache(self) -> None:
+        # A dark-variant logo must never be served to the light UI (nor a monogram where the
+        # caller expects a 404) — every parameter that changes logo.dev's bytes keys the cache.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch(
+                "requests.request",
+                side_effect=[_response(content=b"dark-png"), _response(content=b"light-png")],
+            ) as upstream,
+        ):
+            dark = self.service.get_icon_http_response("linear.app", theme="dark", fallback="404")
+            light = self.service.get_icon_http_response("linear.app", theme="light", fallback="404")
+
+        assert upstream.call_count == 2
+        assert dark.content == b"dark-png"
+        assert light.content == b"light-png"
+        params = upstream.call_args.kwargs["params"]
+        assert params["format"] == "png"
+        assert params["retina"] == "true"
+        assert params["fallback"] == "404"
+        assert params["theme"] == "light"
+
+    @parameterized.expand(
+        [
+            ("definitive_miss_is_cached", "404", 1),
+            ("monogram_mode_stays_transient", "monogram", 2),
+        ]
+    )
+    def test_upstream_404_caching_depends_on_fallback_mode(
+        self, _name: str, fallback: str, expected_calls: int
+    ) -> None:
+        # With fallback="404" a miss is a definitive answer — without negative caching, every
+        # render of an unknown domain would re-proxy to logo.dev. Monogram-mode 404s are
+        # anomalies and must stay transient (uncached), as before.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(status=404)) as upstream,
+        ):
+            for _ in range(2):
+                with self.assertRaises(NotFound):
+                    self.service.get_icon_http_response("unknown.example", fallback=fallback)
+
+        assert upstream.call_count == expected_calls
 
     def test_search_degrades_to_empty_when_budget_exhausted(self) -> None:
         # Icon search is sheddable (NORMAL lane) — when the shared budget is spent it must return no

--- a/posthog/cdp/test/test_icons.py
+++ b/posthog/cdp/test/test_icons.py
@@ -8,7 +8,7 @@ from parameterized import parameterized
 from requests.structures import CaseInsensitiveDict
 from rest_framework.exceptions import NotFound
 
-from posthog.cdp.services.icons import CDPIconsService
+from posthog.cdp.services.icons import MAX_CACHED_ICON_BYTES, CDPIconsService
 
 
 def _response(status: int = 200, content: bytes = b"", content_type: str = "image/png") -> requests.Response:
@@ -44,12 +44,24 @@ class TestCDPIconsService(SimpleTestCase):
         assert first.content == b"png-bytes"
         assert second.content == b"png-bytes"
         assert first["Cache-Control"] == "public, max-age=86400"
+        assert first["X-Content-Type-Options"] == "nosniff"
 
-    def test_upstream_error_raises_not_found_and_is_not_cached(self) -> None:
-        # A logo.dev error body must not be proxied through as an image nor poison the cache for a day.
+    @parameterized.expand(
+        [
+            ("server_error", 500, "image/png"),
+            ("non_image_200", 200, "text/html"),
+        ]
+    )
+    def test_bad_upstream_response_raises_not_found_and_is_not_cached(
+        self, _name: str, status: int, content_type: str
+    ) -> None:
+        # A logo.dev error body — or a 200 that isn't an image — must not be proxied through from
+        # our origin nor poison the cache for a day.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
-            patch("requests.request", return_value=_response(status=500, content=b"boom")),
+            patch(
+                "requests.request", return_value=_response(status=status, content=b"boom", content_type=content_type)
+            ),
         ):
             with self.assertRaises(NotFound):
                 self.service.get_icon_http_response("linear.app")
@@ -61,6 +73,66 @@ class TestCDPIconsService(SimpleTestCase):
             recovered = self.service.get_icon_http_response("linear.app")
 
         assert recovered.content == b"png-bytes"
+
+    def test_oversized_icon_is_served_but_not_cached(self) -> None:
+        # An oversized body must not squat in the shared cache — but it still renders, so a
+        # legitimate huge asset degrades to a re-fetch per render rather than a 404.
+        big = b"x" * (MAX_CACHED_ICON_BYTES + 1)
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(content=big)) as upstream,
+        ):
+            first = self.service.get_icon_http_response("linear.app")
+            second = self.service.get_icon_http_response("linear.app")
+
+        assert upstream.call_count == 2
+        assert first.content == big
+        assert second.content == big
+
+    @parameterized.expand(
+        [
+            ("free_text", "not a domain!"),
+            ("no_tld", "linear"),
+            ("path_traversal", "../../etc/passwd"),
+            ("query_injection", "linear.app?fallback=monogram"),
+            ("extra_path_segment", "linear.app/evil"),
+            ("overlong", "a" * 250 + ".app"),
+        ]
+    )
+    def test_non_domain_id_is_rejected_without_upstream_call(self, _name: str, icon_id: str) -> None:
+        # `id` is a caller-supplied query param — anything not domain-shaped must never reach
+        # logo.dev nor mint a 24h entry in the shared cache.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request") as upstream,
+        ):
+            with self.assertRaises(NotFound):
+                self.service.get_icon_http_response(icon_id)
+
+        upstream.assert_not_called()
+
+    def test_id_case_variants_share_one_cache_entry(self) -> None:
+        # Domains are case-insensitive — without normalization each case variant would mint its
+        # own cache entry and upstream fetch.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(content=b"png-bytes")) as upstream,
+        ):
+            self.service.get_icon_http_response("Linear.App")
+            self.service.get_icon_http_response("linear.app")
+
+        assert upstream.call_count == 1
+
+    @parameterized.expand([("theme", {"theme": "sepia"}), ("fallback", {"fallback": "icon"})])
+    def test_unsupported_response_shaping_params_are_rejected(self, _name: str, kwargs: dict[str, str]) -> None:
+        # theme/fallback become user-suppliable via the icon endpoint later in this stack — an
+        # unvalidated value would partition the cache with unbounded keys.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response()),
+        ):
+            with self.assertRaises(ValueError):
+                self.service.get_icon_http_response("linear.app", **kwargs)
 
     def test_theme_and_fallback_partition_the_cache(self) -> None:
         # A dark-variant logo must never be served to the light UI (nor a monogram where the
@@ -105,6 +177,28 @@ class TestCDPIconsService(SimpleTestCase):
                     self.service.get_icon_http_response("unknown.example", fallback=fallback)
 
         assert upstream.call_count == expected_calls
+
+    def test_icon_fetch_degrades_to_not_found_when_budget_exhausted(self) -> None:
+        # The icon id is user-controlled, so the fetch runs on a sheddable lane: an exhausted
+        # budget must stop upstream calls (and cache fill), not proceed as an advisory limit.
+        # Nothing is cached, so the next render retries once the budget window rolls over.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=False),
+            patch("requests.request") as upstream,
+        ):
+            with self.assertRaises(NotFound):
+                self.service.get_icon_http_response("linear.app")
+
+        upstream.assert_not_called()
+
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(content=b"png-bytes")) as upstream,
+        ):
+            recovered = self.service.get_icon_http_response("linear.app")
+
+        assert upstream.call_count == 1
+        assert recovered.content == b"png-bytes"
 
     def test_search_degrades_to_empty_when_budget_exhausted(self) -> None:
         # Icon search is sheddable (NORMAL lane) — when the shared budget is spent it must return no

--- a/posthog/cdp/test/test_icons.py
+++ b/posthog/cdp/test/test_icons.py
@@ -8,14 +8,21 @@ from parameterized import parameterized
 from requests.structures import CaseInsensitiveDict
 from rest_framework.exceptions import NotFound
 
-from posthog.cdp.services.icons import MAX_CACHED_ICON_BYTES, CDPIconsService
+from posthog.cdp.services.icons import CDPIconsService
 
 
-def _response(status: int = 200, content: bytes = b"", content_type: str = "image/png") -> requests.Response:
+def _response(
+    status: int = 200,
+    content: bytes = b"",
+    content_type: str = "image/png",
+    cache_control: str | None = None,
+) -> requests.Response:
     response = requests.models.Response()
     response.status_code = status
     response._content = content
     response.headers = CaseInsensitiveDict({"Content-Type": content_type})
+    if cache_control:
+        response.headers["Cache-Control"] = cache_control
     prepared = requests.models.PreparedRequest()
     prepared.method = "GET"
     prepared.url = "https://img.logo.dev/linear.app"
@@ -30,20 +37,27 @@ class TestCDPIconsService(SimpleTestCase):
         cache.clear()
         self.service = CDPIconsService()
 
-    def test_icon_is_served_from_cache_after_first_fetch(self) -> None:
-        # The store/CDP UIs render dozens of icons per page view — without the cache every render
-        # proxies to logo.dev again, which is the regression this locks out.
+    def test_icon_bytes_are_never_stored_and_browser_caching_is_directed(self) -> None:
+        # Storing logo bytes server-side needs a logo.dev data-caching license our plan lacks —
+        # every render must re-fetch upstream, with dedup delegated to the browser: logo.dev's own
+        # Cache-Control passed through when present, our 24h directive otherwise.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
-            patch("requests.request", return_value=_response(content=b"png-bytes")) as upstream,
+            patch(
+                "requests.request",
+                side_effect=[
+                    _response(content=b"png-bytes", cache_control="max-age=86400, stale-while-revalidate=600"),
+                    _response(content=b"png-bytes"),
+                ],
+            ) as upstream,
         ):
             first = self.service.get_icon_http_response("linear.app")
             second = self.service.get_icon_http_response("linear.app")
 
-        assert upstream.call_count == 1
+        assert upstream.call_count == 2
         assert first.content == b"png-bytes"
-        assert second.content == b"png-bytes"
-        assert first["Cache-Control"] == "public, max-age=86400"
+        assert first["Cache-Control"] == "max-age=86400, stale-while-revalidate=600"
+        assert second["Cache-Control"] == "public, max-age=86400"
         assert first["X-Content-Type-Options"] == "nosniff"
 
     @parameterized.expand(
@@ -56,7 +70,7 @@ class TestCDPIconsService(SimpleTestCase):
         self, _name: str, status: int, content_type: str
     ) -> None:
         # A logo.dev error body — or a 200 that isn't an image — must not be proxied through from
-        # our origin nor poison the cache for a day.
+        # our origin, nor mint a 24h miss entry for a transient failure.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
             patch(
@@ -73,21 +87,6 @@ class TestCDPIconsService(SimpleTestCase):
             recovered = self.service.get_icon_http_response("linear.app")
 
         assert recovered.content == b"png-bytes"
-
-    def test_oversized_icon_is_served_but_not_cached(self) -> None:
-        # An oversized body must not squat in the shared cache — but it still renders, so a
-        # legitimate huge asset degrades to a re-fetch per render rather than a 404.
-        big = b"x" * (MAX_CACHED_ICON_BYTES + 1)
-        with (
-            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
-            patch("requests.request", return_value=_response(content=big)) as upstream,
-        ):
-            first = self.service.get_icon_http_response("linear.app")
-            second = self.service.get_icon_http_response("linear.app")
-
-        assert upstream.call_count == 2
-        assert first.content == big
-        assert second.content == big
 
     @parameterized.expand(
         [
@@ -111,22 +110,23 @@ class TestCDPIconsService(SimpleTestCase):
 
         upstream.assert_not_called()
 
-    def test_id_case_variants_share_one_cache_entry(self) -> None:
+    def test_id_case_variants_share_one_cached_miss(self) -> None:
         # Domains are case-insensitive — without normalization each case variant would mint its
-        # own cache entry and upstream fetch.
+        # own miss entry and upstream fetch.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
-            patch("requests.request", return_value=_response(content=b"png-bytes")) as upstream,
+            patch("requests.request", return_value=_response(status=404)) as upstream,
         ):
-            self.service.get_icon_http_response("Linear.App")
-            self.service.get_icon_http_response("linear.app")
+            for icon_id in ("Unknown.Example", "unknown.example"):
+                with self.assertRaises(NotFound):
+                    self.service.get_icon_http_response(icon_id, fallback="404")
 
         assert upstream.call_count == 1
 
     @parameterized.expand([("theme", {"theme": "sepia"}), ("fallback", {"fallback": "icon"})])
     def test_unsupported_response_shaping_params_are_rejected(self, _name: str, kwargs: dict[str, str]) -> None:
         # theme/fallback become user-suppliable via the icon endpoint later in this stack — an
-        # unvalidated value would partition the cache with unbounded keys.
+        # unvalidated value would partition the miss cache with unbounded keys.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
             patch("requests.request", return_value=_response()),
@@ -134,27 +134,21 @@ class TestCDPIconsService(SimpleTestCase):
             with self.assertRaises(ValueError):
                 self.service.get_icon_http_response("linear.app", **kwargs)
 
-    def test_theme_and_fallback_partition_the_cache(self) -> None:
-        # A dark-variant logo must never be served to the light UI (nor a monogram where the
-        # caller expects a 404) — every parameter that changes logo.dev's bytes keys the cache.
+    def test_response_shaping_params_are_forwarded_upstream(self) -> None:
+        # format/retina/theme/fallback shape logo.dev's bytes — dropping any of them regresses the
+        # rendered icon (white-tiled jpg, wrong theme, monogram where the caller expects a 404).
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
-            patch(
-                "requests.request",
-                side_effect=[_response(content=b"dark-png"), _response(content=b"light-png")],
-            ) as upstream,
+            patch("requests.request", return_value=_response(content=b"dark-png")) as upstream,
         ):
-            dark = self.service.get_icon_http_response("linear.app", theme="dark", fallback="404")
-            light = self.service.get_icon_http_response("linear.app", theme="light", fallback="404")
+            response = self.service.get_icon_http_response("linear.app", theme="dark", fallback="404")
 
-        assert upstream.call_count == 2
-        assert dark.content == b"dark-png"
-        assert light.content == b"light-png"
+        assert response.content == b"dark-png"
         params = upstream.call_args.kwargs["params"]
         assert params["format"] == "png"
         assert params["retina"] == "true"
         assert params["fallback"] == "404"
-        assert params["theme"] == "light"
+        assert params["theme"] == "dark"
 
     @parameterized.expand(
         [
@@ -178,10 +172,27 @@ class TestCDPIconsService(SimpleTestCase):
 
         assert upstream.call_count == expected_calls
 
+    def test_cached_miss_is_scoped_to_fallback_mode(self) -> None:
+        # A 404-mode miss means "no real logo" — monogram mode can still render a generated
+        # monogram for the same domain, so the cached miss must not leak across modes.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch(
+                "requests.request",
+                side_effect=[_response(status=404), _response(content=b"monogram-png")],
+            ) as upstream,
+        ):
+            with self.assertRaises(NotFound):
+                self.service.get_icon_http_response("unknown.example", fallback="404")
+            monogram = self.service.get_icon_http_response("unknown.example", fallback="monogram")
+
+        assert upstream.call_count == 2
+        assert monogram.content == b"monogram-png"
+
     def test_icon_fetch_degrades_to_not_found_when_budget_exhausted(self) -> None:
         # The icon id is user-controlled, so the fetch runs on a sheddable lane: an exhausted
-        # budget must stop upstream calls (and cache fill), not proceed as an advisory limit.
-        # Nothing is cached, so the next render retries once the budget window rolls over.
+        # budget must stop upstream calls, not proceed as an advisory limit. Nothing is cached,
+        # so the next render retries once the budget window rolls over.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=False),
             patch("requests.request") as upstream,

--- a/posthog/cdp/test/test_icons.py
+++ b/posthog/cdp/test/test_icons.py
@@ -1,3 +1,6 @@
+import time
+from itertools import count
+
 from unittest.mock import patch
 
 from django.core.cache import cache
@@ -9,6 +12,11 @@ from requests.structures import CaseInsensitiveDict
 from rest_framework.exceptions import NotFound
 
 from posthog.cdp.services.icons import CDPIconsService
+from posthog.egress.limiter.outbound import get_outbound_rate_limiter
+
+# Fresh team id per test (and per run) so consuming the real per-team budget never accumulates
+# into a denial across tests or repeated local runs against a persistent Redis.
+_TEAM_IDS = count(time.time_ns() % 1_000_000_000)
 
 
 def _response(
@@ -36,6 +44,7 @@ class TestCDPIconsService(SimpleTestCase):
         super().setUp()
         cache.clear()
         self.service = CDPIconsService()
+        self.team_id = next(_TEAM_IDS)
 
     def test_icon_bytes_are_never_stored_and_browser_caching_is_directed(self) -> None:
         # Storing logo bytes server-side needs a logo.dev data-caching license our plan lacks —
@@ -51,8 +60,8 @@ class TestCDPIconsService(SimpleTestCase):
                 ],
             ) as upstream,
         ):
-            first = self.service.get_icon_http_response("linear.app")
-            second = self.service.get_icon_http_response("linear.app")
+            first = self.service.get_icon_http_response("linear.app", team_id=self.team_id)
+            second = self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
         assert upstream.call_count == 2
         assert first.content == b"png-bytes"
@@ -78,13 +87,13 @@ class TestCDPIconsService(SimpleTestCase):
             ),
         ):
             with self.assertRaises(NotFound):
-                self.service.get_icon_http_response("linear.app")
+                self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
             patch("requests.request", return_value=_response(content=b"png-bytes")),
         ):
-            recovered = self.service.get_icon_http_response("linear.app")
+            recovered = self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
         assert recovered.content == b"png-bytes"
 
@@ -106,7 +115,7 @@ class TestCDPIconsService(SimpleTestCase):
             patch("requests.request") as upstream,
         ):
             with self.assertRaises(NotFound):
-                self.service.get_icon_http_response(icon_id)
+                self.service.get_icon_http_response(icon_id, team_id=self.team_id)
 
         upstream.assert_not_called()
 
@@ -119,7 +128,7 @@ class TestCDPIconsService(SimpleTestCase):
         ):
             for icon_id in ("Unknown.Example", "unknown.example"):
                 with self.assertRaises(NotFound):
-                    self.service.get_icon_http_response(icon_id, fallback="404")
+                    self.service.get_icon_http_response(icon_id, fallback="404", team_id=self.team_id)
 
         assert upstream.call_count == 1
 
@@ -132,7 +141,7 @@ class TestCDPIconsService(SimpleTestCase):
             patch("requests.request", return_value=_response()),
         ):
             with self.assertRaises(ValueError):
-                self.service.get_icon_http_response("linear.app", **kwargs)
+                self.service.get_icon_http_response("linear.app", team_id=self.team_id, **kwargs)
 
     def test_response_shaping_params_are_forwarded_upstream(self) -> None:
         # format/retina/theme/fallback shape logo.dev's bytes — dropping any of them regresses the
@@ -141,7 +150,9 @@ class TestCDPIconsService(SimpleTestCase):
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
             patch("requests.request", return_value=_response(content=b"dark-png")) as upstream,
         ):
-            response = self.service.get_icon_http_response("linear.app", theme="dark", fallback="404")
+            response = self.service.get_icon_http_response(
+                "linear.app", theme="dark", fallback="404", team_id=self.team_id
+            )
 
         assert response.content == b"dark-png"
         params = upstream.call_args.kwargs["params"]
@@ -168,7 +179,7 @@ class TestCDPIconsService(SimpleTestCase):
         ):
             for _ in range(2):
                 with self.assertRaises(NotFound):
-                    self.service.get_icon_http_response("unknown.example", fallback=fallback)
+                    self.service.get_icon_http_response("unknown.example", fallback=fallback, team_id=self.team_id)
 
         assert upstream.call_count == expected_calls
 
@@ -183,8 +194,8 @@ class TestCDPIconsService(SimpleTestCase):
             ) as upstream,
         ):
             with self.assertRaises(NotFound):
-                self.service.get_icon_http_response("unknown.example", fallback="404")
-            monogram = self.service.get_icon_http_response("unknown.example", fallback="monogram")
+                self.service.get_icon_http_response("unknown.example", fallback="404", team_id=self.team_id)
+            monogram = self.service.get_icon_http_response("unknown.example", fallback="monogram", team_id=self.team_id)
 
         assert upstream.call_count == 2
         assert monogram.content == b"monogram-png"
@@ -198,7 +209,7 @@ class TestCDPIconsService(SimpleTestCase):
             patch("requests.request") as upstream,
         ):
             with self.assertRaises(NotFound):
-                self.service.get_icon_http_response("linear.app")
+                self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
         upstream.assert_not_called()
 
@@ -206,7 +217,7 @@ class TestCDPIconsService(SimpleTestCase):
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
             patch("requests.request", return_value=_response(content=b"png-bytes")) as upstream,
         ):
-            recovered = self.service.get_icon_http_response("linear.app")
+            recovered = self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
         assert upstream.call_count == 1
         assert recovered.content == b"png-bytes"
@@ -218,6 +229,47 @@ class TestCDPIconsService(SimpleTestCase):
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=False),
             patch("requests.request") as upstream,
         ):
-            assert self.service.list_icons("linear", icon_url_base="/base?id=") == []
+            assert self.service.list_icons("linear", icon_url_base="/base?id=", team_id=self.team_id) == []
 
         upstream.assert_not_called()
+
+    def test_icon_fetch_degrades_to_not_found_when_team_budget_exhausted(self) -> None:
+        # The account budget is instance-wide, so the per-team gate is what stops one team's
+        # arbitrary-domain requests from blanking icons for every other team. Denial must be
+        # charged to the calling team's own key, stay uncached, and never reach upstream.
+        with (
+            patch("posthog.cdp.services.icons.get_outbound_rate_limiter") as limiter,
+            patch("requests.request") as upstream,
+        ):
+            limiter.return_value.consume_sync.return_value = False
+            with self.assertRaises(NotFound):
+                self.service.get_icon_http_response("linear.app", team_id=self.team_id)
+
+        upstream.assert_not_called()
+        assert limiter.return_value.consume_sync.call_args.args == (f"cdp_icons:team:{self.team_id}",)
+
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", return_value=_response(content=b"png-bytes")) as upstream,
+        ):
+            recovered = self.service.get_icon_http_response("linear.app", team_id=self.team_id)
+
+        assert upstream.call_count == 1
+        assert recovered.content == b"png-bytes"
+
+    def test_search_degrades_to_empty_when_team_budget_exhausted(self) -> None:
+        # Search queries are free text — the same per-team gate must cover them or a team could
+        # drain the shared account budget through the search path instead.
+        with (
+            patch("posthog.cdp.services.icons.get_outbound_rate_limiter") as limiter,
+            patch("requests.request") as upstream,
+        ):
+            limiter.return_value.consume_sync.return_value = False
+            assert self.service.list_icons("linear", icon_url_base="/base?id=", team_id=self.team_id) == []
+
+        upstream.assert_not_called()
+
+    def test_team_budget_policy_is_registered(self) -> None:
+        # consume raises for a domain with no registered policy — this catches the registration
+        # side effect being lost (e.g. an import shuffle dropping the register_policy call).
+        assert get_outbound_rate_limiter().consume_sync(f"cdp_icons:team:{self.team_id}", source="test") is True

--- a/posthog/egress/README.md
+++ b/posthog/egress/README.md
@@ -1,7 +1,7 @@
 # Outbound egress: rate limiting, observability, transport
 
 General-purpose controls for the calls PostHog makes _out_ to third-party APIs.
-GitHub is the first consumer, but the package is built for more.
+GitHub was the first consumer and logo.dev (`logodev/`) is the second, but the package is built for more.
 A new outbound integration that needs rate-limiting or egress telemetry belongs here as a `<domain>/` incarnation (see [Adding a new egress domain](#adding-a-new-egress-domain)), never hand-rolled around `requests`.
 Three lanes, one per subpackage:
 
@@ -12,7 +12,7 @@ Three lanes, one per subpackage:
 This is _outbound_ egress — what PostHog sends.
 It is unrelated to `posthog.rate_limit`, which throttles _inbound_ DRF requests from clients.
 
-All three lanes are **domain-generic** and domain-free; each third-party API is an incarnation under its own subpackage (`github/`), supplying a budget policy, a metric set + parser, and a transport subclass.
+All three lanes are **domain-generic** and domain-free; each third-party API is an incarnation under its own subpackage (`github/`, `logodev/`), supplying a budget policy, a metric set + parser, and a transport subclass.
 Adding a new outbound API is another `<domain>/` folder, not a change to the mechanisms.
 
 ## Rate limiting
@@ -47,6 +47,10 @@ GitHub meters its REST resources on **separate per-installation counters**, so i
 
 The two search budgets are static because GitHub's search rate limits are fixed regardless of the account's plan tier, so there is no tier to observe (unlike core).
 Budgets stay deliberately under the real ceiling so reactive backoff absorbs drift (clock skew, multi-process races, untracked PAT traffic on the same account).
+
+logo.dev (`logodev/`) meters per account token, and each instance holds exactly one (`LOGO_DEV_TOKEN`), so a single `logodev` domain carries one instance-wide budget under a constant scope.
+logo.dev publishes no rate-limit numbers, so the budgets are static operator ceilings read from settings at acquire time: `LOGODEV_EGRESS_PER_MINUTE_BUDGET` (default 300) smooths bursts and `LOGODEV_EGRESS_HOURLY_BUDGET` (default 5,000) caps total spend.
+Every logo.dev call runs on a sheddable lane — the icon id is user-controlled, so nothing in this domain runs `CRITICAL` — and the consumer-side icon cache (`posthog/cdp/services/icons.py`) keeps steady-state traffic far below the ceilings.
 
 ### Priority lanes
 

--- a/posthog/egress/README.md
+++ b/posthog/egress/README.md
@@ -50,7 +50,8 @@ Budgets stay deliberately under the real ceiling so reactive backoff absorbs dri
 
 logo.dev (`logodev/`) meters per account token, and each instance holds exactly one (`LOGO_DEV_TOKEN`), so a single `logodev` domain carries one instance-wide budget under a constant scope.
 logo.dev publishes no rate-limit numbers, so the budgets are static operator ceilings read from settings at acquire time: `LOGODEV_EGRESS_PER_MINUTE_BUDGET` (default 300) smooths bursts and `LOGODEV_EGRESS_HOURLY_BUDGET` (default 5,000) caps total spend.
-Every logo.dev call runs on a sheddable lane — the icon id is user-controlled, so nothing in this domain runs `CRITICAL` — and the consumer-side icon cache (`posthog/cdp/services/icons.py`) keeps steady-state traffic far below the ceilings.
+Every logo.dev call runs on a sheddable lane — the icon id is user-controlled, so nothing in this domain runs `CRITICAL`.
+Icon bytes are never stored server-side (logo.dev licenses that separately), so steady-state traffic is deduped only by browser caching (`posthog/cdp/services/icons.py` sets `Cache-Control`) and tracks unique (user, icon) first views per day — raise the settings if that outgrows the defaults.
 
 ### Priority lanes
 

--- a/posthog/egress/logodev/limiter.py
+++ b/posthog/egress/logodev/limiter.py
@@ -1,0 +1,56 @@
+"""logo.dev egress budget.
+
+logo.dev meters usage per account token, and each PostHog instance holds exactly one
+(``settings.LOGO_DEV_TOKEN``), so the whole instance draws from a single shared budget under a
+constant scope. logo.dev publishes no hard rate-limit numbers, so the defaults are deliberately
+modest operator ceilings — icon responses are cached for a day by the consumer
+(:mod:`posthog.cdp.services.icons`), so steady-state traffic sits far below them.
+
+Importing this module registers the policy as a side effect — import it (directly or via
+``consume_logodev_sync``) before using a ``logodev:...`` limiter key.
+"""
+
+from django.conf import settings
+
+from posthog.egress.limiter.outbound import get_outbound_rate_limiter
+from posthog.egress.limiter.policies import Priority, RatePolicy, register_policy
+
+LOGODEV_DOMAIN = "logodev"
+
+# One account per instance — the constant id for the instance-wide shared budget.
+_ACCOUNT_SCOPE_ID = "default"
+
+# Same reserved-floor ladder as the other egress domains: sheddable lanes are denied first as the
+# budget fills, CRITICAL (user-facing icon renders) may use the full budget.
+_RESERVE: dict[Priority, float] = {Priority.BATCH: 0.30, Priority.NORMAL: 0.10}
+
+# Operator ceilings, not observed provider limits (logo.dev exposes none to observe). The per-minute
+# rate smooths bursts (a catalog page fanning out cache misses), the hourly rate caps total spend.
+_DEFAULT_PER_MINUTE_BUDGET = 300
+_DEFAULT_HOURLY_BUDGET = 5_000
+
+
+# Registered as a provider so the budgets are read at acquire time — a settings override applies
+# without a process restart, matching the other egress domains.
+def _logodev_policy(key: str) -> RatePolicy:
+    per_minute = int(getattr(settings, "LOGODEV_EGRESS_PER_MINUTE_BUDGET", _DEFAULT_PER_MINUTE_BUDGET))
+    hourly = int(getattr(settings, "LOGODEV_EGRESS_HOURLY_BUDGET", _DEFAULT_HOURLY_BUDGET))
+    return RatePolicy(
+        limits=((per_minute, 60.0), (hourly, 3600.0)),
+        in_memory_divider=4,
+        reserve=_RESERVE,
+    )
+
+
+register_policy(LOGODEV_DOMAIN, _logodev_policy)
+
+
+def logodev_account_key() -> str:
+    """Limiter key for the instance's single logo.dev account — the unit logo.dev meters."""
+    return f"{LOGODEV_DOMAIN}:account:{_ACCOUNT_SCOPE_ID}"
+
+
+def consume_logodev_sync(n: int = 1, *, priority: Priority = Priority.NORMAL, source: str = "unknown") -> bool:
+    """Reserve ``n`` requests against the instance's logo.dev budget. Returns False when the budget
+    (or this ``priority``'s reserved floor) is exhausted — degrade gracefully rather than calling out."""
+    return get_outbound_rate_limiter().consume_sync(logodev_account_key(), n, priority=priority, source=source)

--- a/posthog/egress/logodev/limiter.py
+++ b/posthog/egress/logodev/limiter.py
@@ -3,8 +3,10 @@
 logo.dev meters usage per account token, and each PostHog instance holds exactly one
 (``settings.LOGO_DEV_TOKEN``), so the whole instance draws from a single shared budget under a
 constant scope. logo.dev publishes no hard rate-limit numbers, so the defaults are deliberately
-modest operator ceilings — icon responses are cached for a day by the consumer
-(:mod:`posthog.cdp.services.icons`), so steady-state traffic sits far below them.
+modest operator ceilings. Icon bytes are never stored server-side (logo.dev gates that behind a
+data-caching license), so upstream volume is deduped only per user, by the browser caching that
+:mod:`posthog.cdp.services.icons` directs — steady-state traffic tracks unique (user, icon) first
+views per day. Raise the settings below if that outgrows the defaults.
 
 Importing this module registers the policy as a side effect — import it (directly or via
 ``consume_logodev_sync``) before using a ``logodev:...`` limiter key.

--- a/posthog/egress/logodev/limiter.py
+++ b/posthog/egress/logodev/limiter.py
@@ -20,8 +20,9 @@ LOGODEV_DOMAIN = "logodev"
 # One account per instance — the constant id for the instance-wide shared budget.
 _ACCOUNT_SCOPE_ID = "default"
 
-# Same reserved-floor ladder as the other egress domains: sheddable lanes are denied first as the
-# budget fills, CRITICAL (user-facing icon renders) may use the full budget.
+# Same reserved-floor ladder as the other egress domains: BATCH is denied first as the budget
+# fills, then NORMAL. All icon traffic runs NORMAL — the icon id is user-controlled, so nothing in
+# this domain should run CRITICAL (a never-shed lane would make the budget advisory).
 _RESERVE: dict[Priority, float] = {Priority.BATCH: 0.30, Priority.NORMAL: 0.10}
 
 # Operator ceilings, not observed provider limits (logo.dev exposes none to observe). The per-minute

--- a/posthog/egress/logodev/observability.py
+++ b/posthog/egress/logodev/observability.py
@@ -1,0 +1,91 @@
+"""logo.dev egress telemetry.
+
+Every logo.dev call funnels through these recorders so request volume lands on one metric set
+whichever subsystem made the call (CDP icon picker, MCP store icons, ...), attributed by the
+``source`` label. logo.dev reports no rate-limit response headers, so the parser returns an empty
+snapshot and the gauges stay unset — they exist because :class:`EgressMetrics` requires the full
+instrument set, and they start reporting the moment logo.dev grows the headers.
+"""
+
+from urllib.parse import urlparse
+
+import requests
+from prometheus_client import Counter, Gauge
+
+from posthog.egress.observability.observability import (
+    EgressMetrics,
+    EgressObservability,
+    RateLimitSnapshot,
+    register_egress_observability,
+)
+
+LOGODEV_DOMAIN = "logodev"
+
+_metrics = EgressMetrics(
+    request_counter=Counter(
+        "logodev_api_requests",
+        "Number of logo.dev API requests made through the logo.dev egress client.",
+        labelnames=["account", "method", "endpoint", "status_code", "source"],
+    ),
+    remaining_gauge=Gauge(
+        "logodev_api_rate_limit_remaining",
+        "Most recently observed logo.dev rate limit remaining count (unset: logo.dev reports no rate-limit headers).",
+        labelnames=["account", "resource"],
+    ),
+    limit_gauge=Gauge(
+        "logodev_api_rate_limit_limit",
+        "Most recently observed logo.dev rate limit (unset: logo.dev reports no rate-limit headers).",
+        labelnames=["account", "resource"],
+    ),
+    reset_gauge=Gauge(
+        "logodev_api_rate_limit_reset_timestamp_seconds",
+        "Most recently observed logo.dev rate limit reset timestamp (unset: logo.dev reports no rate-limit headers).",
+        labelnames=["account", "resource"],
+    ),
+)
+
+
+def _parse_logodev_rate_limit(response: requests.Response) -> RateLimitSnapshot:
+    return RateLimitSnapshot()
+
+
+def _normalize_logodev_endpoint(url: str | None) -> str:
+    """Collapse a logo.dev URL to a low-cardinality endpoint label. ``img.logo.dev/{brand-domain}``
+    would otherwise mint one label per brand, so the brand path is templated to ``/img/{domain}``;
+    the search API's fixed path is kept verbatim."""
+    if not url:
+        return "unknown"
+    parsed = urlparse(url)
+    if parsed.netloc == "img.logo.dev":
+        return "/img/{domain}"
+    path = parsed.path.rstrip("/")
+    return path or "/"
+
+
+logodev_egress = EgressObservability(
+    LOGODEV_DOMAIN, _metrics, _parse_logodev_rate_limit, endpoint_normalizer=_normalize_logodev_endpoint
+)
+register_egress_observability(logodev_egress)
+
+
+def record_logodev_api_response(
+    response: requests.Response,
+    *,
+    source: str,
+    method: str | None = None,
+    endpoint: str | None = None,
+) -> None:
+    """Record one logo.dev API response. The scope is always the instance's single account —
+    logo.dev meters per token and each instance holds exactly one."""
+    logodev_egress.record_response(response, source=source, scope="default", method=method, endpoint=endpoint)
+
+
+def record_logodev_api_exception(
+    *,
+    source: str,
+    method: str,
+    endpoint: str | None = None,
+    url: str | None = None,
+) -> None:
+    """Record a request that raised before a response (timeout, connection error)."""
+    logodev_egress.record_exception(source=source, scope="default", method=method, endpoint=endpoint, url=url)

--- a/posthog/egress/logodev/transport.py
+++ b/posthog/egress/logodev/transport.py
@@ -1,0 +1,73 @@
+"""logo.dev incarnation of the egress transport.
+
+``logodev_request`` is the one way to call logo.dev from anywhere in the codebase: it gates on the
+instance's shared account budget and records telemetry by construction. The caller owns auth —
+logo.dev takes the token as a ``token`` query parameter, so pass it via ``params``.
+"""
+
+from typing import Any
+
+import requests
+
+from posthog.egress.limiter.policies import Priority
+from posthog.egress.logodev.limiter import consume_logodev_sync
+from posthog.egress.logodev.observability import record_logodev_api_exception, record_logodev_api_response
+from posthog.egress.transport.transport import EgressBudgetExhausted, EgressClient
+
+# The whole instance shares one logo.dev account, so every call carries the same scope.
+_ACCOUNT_SCOPE = "default"
+
+
+class LogoDevEgressBudgetExhausted(EgressBudgetExhausted):
+    """A sheddable (BATCH/NORMAL) logo.dev call was shed by our egress limiter before it was sent.
+    Callers that can degrade (e.g. an icon search returning no results) catch this and do so."""
+
+
+class LogoDevClient(EgressClient):
+    """The logo.dev incarnation of :class:`EgressClient`. Stateless — one shared instance serves
+    every caller; wire it through :func:`logodev_request`."""
+
+    def _standard_headers(self) -> dict[str, str]:
+        return {}
+
+    def _consume(self, scope: str, priority: Priority, source: str, url: str) -> bool:
+        return consume_logodev_sync(priority=priority, source=source)
+
+    def _record_response(
+        self, response: requests.Response, *, source: str, scope: str | None, method: str, endpoint: str | None
+    ) -> None:
+        record_logodev_api_response(response, source=source, method=method, endpoint=endpoint)
+
+    def _record_exception(self, *, source: str, scope: str | None, method: str, url: str, endpoint: str | None) -> None:
+        record_logodev_api_exception(source=source, method=method, url=url, endpoint=endpoint)
+
+    def _budget_exhausted_error(self, scope: str) -> LogoDevEgressBudgetExhausted:
+        return LogoDevEgressBudgetExhausted("logo.dev egress budget exhausted; degrading")
+
+
+# Stateless — one shared instance for the whole process.
+_logodev_client = LogoDevClient()
+
+
+def logodev_request(
+    method: str,
+    url: str,
+    *,
+    source: str,
+    priority: Priority = Priority.CRITICAL,
+    endpoint: str | None = None,
+    timeout: float | tuple[float, float] | None = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """Make a gated, recorded logo.dev request. ``source`` attributes the call to a subsystem; pass
+    the account token via ``params`` (logo.dev's auth is a query parameter, not a header)."""
+    return _logodev_client.request(
+        method,
+        url,
+        source=source,
+        scope=_ACCOUNT_SCOPE,
+        priority=priority,
+        endpoint=endpoint,
+        timeout=timeout,
+        **kwargs,
+    )

--- a/posthog/egress/test/test_logodev.py
+++ b/posthog/egress/test/test_logodev.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.egress.logodev.limiter import consume_logodev_sync, logodev_account_key
+from posthog.egress.logodev.observability import _normalize_logodev_endpoint
+
+
+class TestLogoDevEgress(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("img_brand_path", "https://img.logo.dev/linear.app?token=x", "/img/{domain}"),
+            ("img_nested_brand_path", "https://img.logo.dev/some.brand.co", "/img/{domain}"),
+            ("search_api", "https://search.logo.dev/api/icons?query=linear", "/api/icons"),
+            ("no_url", None, "unknown"),
+        ]
+    )
+    def test_endpoint_normalizer_bounds_cardinality(self, _name: str, url: str | None, expected: str) -> None:
+        # Every brand domain minting its own endpoint label would blow up Prometheus cardinality —
+        # the normalizer collapsing img paths to one label is what this domain's telemetry relies on.
+        assert _normalize_logodev_endpoint(url) == expected
+
+    def test_policy_is_registered_for_the_account_key(self) -> None:
+        # consume raises for a domain with no registered policy — this catches the registration
+        # side effect being lost (e.g. an import shuffle dropping the register_policy call).
+        assert logodev_account_key() == "logodev:account:default"
+        assert consume_logodev_sync(source="test") is True

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -629,7 +629,9 @@ class HogFunctionViewSet(
         if not query:
             return Response([])
 
-        icons = CDPIconsService().list_icons(query, icon_url_base="/api/projects/@current/hog_functions/icon/?id=")
+        icons = CDPIconsService().list_icons(
+            query, icon_url_base="/api/projects/@current/hog_functions/icon/?id=", team_id=self.team_id
+        )
 
         return Response(icons)
 
@@ -641,7 +643,7 @@ class HogFunctionViewSet(
 
         icon_service = CDPIconsService()
 
-        return icon_service.get_icon_http_response(id)
+        return icon_service.get_icon_http_response(id, team_id=self.team_id)
 
     @extend_schema(
         request=HogFunctionInvocationSerializer,


### PR DESCRIPTION
## Problem

- `CDPIconsService` is making raw requests to logo.dev with no caching directives, so every icon render re-proxies upstream
- MCP store is going to use logo.dev, so many more requests (15+ per view)
- Repo policy says rate-limited third-party calling should live in `posthog/egress/`
- The icon endpoint accepts an arbitrary user-supplied `id`, so unvalidated ids could drive unbounded upstream fetches and unbounded 24h entries in the shared cache

## Changes

- New `posthog/egress/logodev/` incarnation following the `github/` reference: a static settings-overridable budget (`LOGODEV_EGRESS_PER_MINUTE_BUDGET` / `LOGODEV_EGRESS_HOURLY_BUDGET`, defaults 300/min and 5000/h) keyed on the instance's single logo.dev account, a `logodev_api_requests_total` metric set with a cardinality-bounding endpoint normalizer (`img.logo.dev/<brand>` collapses to `/img/{domain}`), and a `logodev_request` transport composing both.
- `CDPIconsService` now goes through `logodev_request`. Both logo.dev calls run on the sheddable NORMAL lane — the icon id is user-controlled, so nothing in this domain runs CRITICAL (which never sheds and would make the budget advisory). When the shared budget is exhausted, icon fetches degrade to an uncached 404 (renders retry once the window rolls over) and icon searches to empty results.
- The icon `id` is validated as a domain (lowercased; dot-separated LDH labels; ≤253 chars) before any upstream call or cache write, so junk ids can't reach logo.dev or mint cache entries. `theme` and `fallback` are allowlisted so they can't partition the cache with unbounded keys once the endpoint exposes them.
- **Icon bytes are never stored on our infrastructure** — logo.dev gates that behind a [data-caching license](https://www.logo.dev/docs/platform/self-hosting) that isn't part of our plan. Byte-level dedup is instead delegated to the browser, [as logo.dev's own caching model does](https://www.logo.dev/docs/platform/caching): `get_icon_http_response` passes through logo.dev's `Cache-Control` when present (falling back to `public, max-age=86400`) plus `X-Content-Type-Options: nosniff`, so browsers stop re-fetching per render. Non-image 200s and other upstream non-200s raise `NotFound`.
- Icon fetches request `format=png` (transparent, instead of logo.dev's white-tiled jpg default) at retina density, and callers can pass a UI `theme` plus a `fallback` mode (`monogram` keeps today's behavior; `404` lets the caller render its own fallback). The only thing cached server-side is the *fact* of a definitive `fallback=404` miss (24h, keyed by every response-shaping parameter) — no logo data.

- **Per-team fairness gate in front of the instance-wide account budget** (review follow-up): uncached icon fetches and searches first consume a per-team budget (`cdp_icons:team:<team_id>`, settings-overridable `CDP_ICONS_TEAM_PER_MINUTE_BUDGET` / `CDP_ICONS_TEAM_HOURLY_BUDGET`, defaults 120/min and 1000/h) sitting well below the account ceilings — so one team requesting endless unique (thus uncached) domains degrades only its own icons instead of blanking them for every team on the instance. The gate lives in `CDPIconsService` as a consumer-side concern; the logodev egress limiter stays a pure mirror of the single account logo.dev actually meters. The `hog_functions` icon/search endpoints now pass the requesting team.

## How did you test this code?

Automated only, no manual testing:

- `posthog/egress/test/test_logodev.py` — endpoint normalizer cases (guards Prometheus label cardinality) and policy registration round-trip (catches the register_policy side effect being lost).
- `posthog/cdp/test/test_icons.py` — two fetches make two upstream calls with browser-cache headers passed through/defaulted (guards against byte storage being reintroduced, which the license doesn't allow), upstream 500 or non-image 200 → `NotFound` and no miss entry minted, budget-exhausted search returns `[]` and budget-exhausted icon fetch returns an uncached 404 instead of proceeding, non-domain ids (free text, traversal, query injection, overlong) rejected without an upstream call, case variants share one cached miss, unsupported theme/fallback values rejected, response-shaping params forwarded upstream.
- Per-team budget: exhaustion degrades the icon fetch to an uncached 404 and the search to `[]` without an upstream call, charged to the calling team's own limiter key; policy registration round-trip mirrors the logodev one. Existing tests thread a fresh `team_id` per test so the real per-team counter never accumulates across tests.
- 404 negative-caching applies only to `fallback="404"` mode — monogram-mode misses stay transient, and a cached 404-mode miss doesn't leak into monogram mode (which can still render a generated monogram).
- Full `posthog/egress/` suite (78 tests) passes.

## Docs update

- `posthog/egress/README.md` now documents the `logodev` domain: its single account-scoped budget, the `LOGODEV_EGRESS_*` settings and defaults, why every call in the domain runs on a sheddable lane, and that icon dedup is browser-side only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (this is PR 1 of a 5-PR stack moving the MCP store catalog to code-defined, agent-maintainable entries with logo.dev-resolved icons). Skills invoked: `/writing-tests`. Key decisions: one shared budget domain for both logo.dev endpoints (unlike GitHub's per-resource split) since logo.dev meters per account token and publishes no per-endpoint limits. A follow-up review pass hardened the icon path: because the id is user-controlled and logo.dev's monogram fallback returns 200 for nonexistent domains, icon fetches were moved off the never-shed CRITICAL lane and inputs are bounded by id validation plus an image/* content-type check. A later pass removed server-side caching of icon bytes entirely — logo.dev licenses on-infrastructure logo storage separately and our plan doesn't include it — so steady-state upstream volume now tracks unique (user, icon) first views per day, deduped by browser caching; the `LOGODEV_EGRESS_*` budgets are runtime-tunable via settings if that outgrows the defaults.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

