### PR TITLE
chore(mcp-store): add catalog pipeline docs and adding-mcp-store-servers skill

### DIFF
--- a/.agents/skills/adding-mcp-store-servers/SKILL.md
+++ b/.agents/skills/adding-mcp-store-servers/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: adding-mcp-store-servers
+description: Add a third-party MCP server (Linear, Notion, GitHub, ...) to the PostHog MCP store catalog. Use when asked to "add X to the MCP store", expand the MCP server marketplace, or fix a broken catalog entry. Covers finding the vendor's remote MCP endpoint, probing it (handshake, OAuth discovery, DCR), authoring the catalog entry in products/mcp_store/backend/catalog.py, verification tiers, and the operator handoff for servers without Dynamic Client Registration.
+---
+
+# Adding a server to the MCP store
+
+The MCP store catalog is code: one entry in `products/mcp_store/backend/catalog.py` per server.
+On deploy, `sync_mcp_server_templates` upserts entries into `MCPServerTemplate` rows in every environment — there are no data migrations, no icon assets, and no manual admin steps for most servers.
+Adding a server is a small PR to that file.
+
+## Read first
+
+- `products/mcp_store/README.md` — the catalog pipeline, sync semantics, and operator runbook
+- `products/mcp_store/backend/catalog.py` — existing entries; match their tone and shape
+- `products/mcp_store/backend/probe.py` — what the probe verifies and what `passed_activation_gate` means
+
+## Workflow
+
+1. **Find the vendor's remote MCP endpoint.**
+   Check the vendor's docs (search "<vendor> MCP server"); most publish a hosted endpoint like `https://mcp.<vendor>.com/mcp`.
+   Only hosted (remote) MCP servers belong in the catalog — local/stdio servers do not.
+   Cross-check public MCP registries if the docs are unclear.
+
+2. **Probe it.**
+
+   ```sh
+   DEBUG=1 python manage.py probe_mcp_server https://mcp.example.com/mcp
+   ```
+
+   The JSON verdict tells you everything the entry needs:
+   - `speaks_mcp: false` → wrong URL or not an MCP server. Stop and re-research; never add an unverified URL.
+   - `auth_flavor: "oauth_dcr"` with `passed_activation_gate: true` → OAuth with Dynamic Client Registration. The entry is `auth_type="oauth"` and will **activate automatically on merge**.
+   - `auth_flavor: "oauth_shared"` → OAuth without DCR. The entry is `auth_type="oauth"` but ships **inactive**; an operator must register an OAuth app with the vendor and paste credentials in Django admin (see the operator checklist below — include it in your PR description).
+   - `auth_flavor: "api_key_or_unknown"` or `"open"` → `auth_type="api_key"`; activates automatically on merge.
+
+3. **Author the entry** in `catalog.py`, alphabetically by name:
+   - `name` — the vendor's own casing ("PagerDuty", not "Pagerduty").
+   - `description` — one sentence, sentence case, verb-first, matching the existing entries ("Manage Linear issues, projects, and team workflows."). No marketing copy.
+   - `category` — the closest of `business` / `data` / `design` / `dev` / `infra` / `productivity`.
+   - `icon_domain` — the vendor's primary brand domain (`linear.app`, not `mcp.linear.app`). Verify logo.dev has it: `GET /api/projects/@current/hog_functions/icons/?query=<vendor>` from a dev session, or check `https://img.logo.dev/<domain>` renders a real logo.
+   - `docs_url` — the vendor's MCP docs page when they have one.
+
+4. **Verify end-to-end when you can (Gate B).**
+   The probe covers everything up to the OAuth consent screen.
+   If you have an account with the vendor, complete one real install in local dev: run the stack, install the server from the store UI, finish the OAuth flow (or paste an API key), and confirm the tool list populates.
+   Record the verification tier in the PR description:
+   - **Tier 1**: probe passed + real install verified (tools listed).
+   - **Tier 2**: probe passed only (no vendor account available).
+
+5. **Run the checks.**
+
+   ```sh
+   hogli test products/mcp_store/backend/test/test_catalog_sync.py
+   ```
+
+   `test_catalog_entries_are_valid` catches malformed entries (bad category, duplicate URL, unnormalized icon_domain) before they hit production.
+
+6. **Open the PR** — one server per PR, title `feat(mcp-store): add <name> to the MCP server catalog`.
+   State the probe verdict and verification tier in the description.
+   For `oauth_shared` servers, include the operator checklist so activation isn't forgotten.
+
+## Operator checklist for oauth_shared servers (paste into the PR)
+
+```md
+This server does not support Dynamic Client Registration, so it ships inactive. To activate (per environment, US and EU):
+
+- [ ] Register an OAuth app in the vendor's developer console
+- [ ] Redirect URI: `https://us.posthog.com/api/mcp_store/oauth_redirect/` (and the EU equivalent)
+- [ ] Paste client ID + secret into Django admin → MCP server templates → <name>
+- [ ] OAuth metadata was auto-discovered by the sync; run the "Discover metadata" admin action only if it's empty
+- [ ] Tick "is active"
+```
+
+## What not to do
+
+- Don't add entries with unprobed URLs — a dead catalog entry is user-visible breakage.
+- Don't edit `is_active`, `oauth_credentials`, or `oauth_metadata` expectations into the catalog — those are operational state owned by the row, not by code.
+- Don't add icon assets or `icon_key` values — icons resolve from `icon_domain` via logo.dev at render time.
+- Don't batch unrelated servers into one PR unless explicitly doing a scaffold sweep; per-server PRs keep review and reverts clean.

--- a/.agents/skills/adding-mcp-store-servers/SKILL.md
+++ b/.agents/skills/adding-mcp-store-servers/SKILL.md
@@ -29,10 +29,11 @@ Adding a server is a small PR to that file.
    ```
 
    The JSON verdict tells you everything the entry needs:
-   - `speaks_mcp: false` → wrong URL or not an MCP server. Stop and re-research; never add an unverified URL.
+   - `speaks_mcp: false` → the probe could not verify MCP. Stop and re-research — with one exception: `reachable: true` plus the error "Initialize was rejected and no OAuth metadata was discovered" is the auth-walled API-key case (last bullet below).
    - `auth_flavor: "oauth_dcr"` with `passed_activation_gate: true` → OAuth with Dynamic Client Registration. The entry is `auth_type="oauth"` and will **activate automatically on merge**.
    - `auth_flavor: "oauth_shared"` → OAuth without DCR. The entry is `auth_type="oauth"` but ships **inactive**; an operator must register an OAuth app with the vendor and paste credentials in Django admin (see the operator checklist below — include it in your PR description).
-   - `auth_flavor: "api_key_or_unknown"` or `"open"` → `auth_type="api_key"`; activates automatically on merge.
+   - `auth_flavor: "open"` → the handshake completed without credentials. `auth_type="api_key"`; activates automatically on merge.
+   - `auth_flavor: "api_key_or_unknown"` with `reachable: true` → an auth-walled API-key server; a bare 401/403 gives the probe no MCP evidence. `auth_type="api_key"`, but the entry ships **inactive** — verify it with a real install (Gate B) before adding it, and note in the PR that an operator flips it active in Django admin per environment (users bring their own key; nothing to provision).
 
 3. **Author the entry** in `catalog.py`, alphabetically by name:
    - `name` — the vendor's own casing ("PagerDuty", not "Pagerduty").

--- a/.agents/skills/adding-mcp-store-servers/SKILL.md
+++ b/.agents/skills/adding-mcp-store-servers/SKILL.md
@@ -56,7 +56,7 @@ Adding a server is a small PR to that file.
 
    `test_catalog_entries_are_valid` catches malformed entries (bad category, duplicate URL, unnormalized icon_domain) before they hit production.
 
-6. **Open the PR** — one server per PR, title `feat(mcp-store): add <name> to the MCP server catalog`.
+6. **Open the PR** — one server per PR, on an `mcp-store/`-prefixed branch (e.g. `mcp-store/add-pagerduty`), with a `feat(mcp-store)` title: `feat(mcp-store): add <name> to the MCP server catalog`.
    State the probe verdict and verification tier in the description.
    For `oauth_shared` servers, include the operator checklist so activation isn't forgotten.
 

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -30,12 +30,13 @@ Only **hosted (remote) MCP servers** on a public HTTPS endpoint speaking the str
 Adds and auto-activates on merge:
 
 - OAuth servers with Dynamic Client Registration — the probe mints a real DCR client and verifies the authorization page.
-- API-key and unauthenticated servers that answer the MCP initialize handshake.
+- API-key and unauthenticated servers that answer the MCP initialize handshake without credentials.
 
 Adds but ships **inactive** until an operator finishes activation (see the runbook below):
 
 - OAuth servers without DCR ("shared creds") — someone must register an OAuth app with the vendor and provision credentials per environment.
 - Vendors whose DCR is gated (initial access token, software statement, partner allowlist) — the probe classifies these as shared-creds too.
+- API-key servers that auth-wall the handshake — a bare 401/403 carries no MCP evidence, so an operator vets and flips them active in admin (nothing to provision; users bring their own key).
 
 Can't be added:
 

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -8,7 +8,7 @@ This is unrelated to `products/*/mcp/tools.yaml`, which exposes PostHog's own en
 ## How the catalog works
 
 The catalog is **code**: `backend/catalog.py` holds one `CatalogEntry` per server.
-At app startup, every environment queues `sync_mcp_server_templates` (see `backend/tasks/tasks.py` and `posthog/apps.py`), which upserts entries into `MCPServerTemplate` rows:
+At app startup, every environment queues `sync_mcp_server_templates` (see `backend/tasks/tasks.py`, queued from `backend/apps.py`), which upserts entries into `MCPServerTemplate` rows:
 
 - Rows are keyed on `url`. New entries are created; existing rows get **content fields** updated (name, description, auth_type, category, icon_domain, docs_url). The catalog owns content — edit it in code, not admin.
 - **Operational state is never touched by the sync**: `is_active` after creation, `oauth_credentials`, and `oauth_metadata` once set belong to the row and to operators. Rows absent from the catalog (e.g. admin-added) are left alone.

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -27,12 +27,13 @@ DEBUG=1 python manage.py sync_mcp_server_templates --skip-probe  # local seed wi
 
 Catalog icons are not committed image assets.
 Templates carry an `icon_domain` (the vendor's brand domain, e.g. `linear.app`).
-The frontend renders them through the authenticated proxy endpoint `GET /api/projects/:team_id/mcp_servers/icon/?domain=<domain>`.
+The frontend renders them through the authenticated proxy endpoint `GET /api/projects/:team_id/mcp_servers/icon/?domain=<domain>&theme=<light|dark>`.
 The proxy fetches each brand icon from [logo.dev](https://logo.dev) through the egress-gated `CDPIconsService`.
+Logos are transparent retina PNGs matched to the active UI theme instead of logo.dev's default white-tiled JPGs.
 Icon bytes are never stored on PostHog infrastructure because our logo.dev plan does not include a data-caching license.
 Browsers cache responses via `Cache-Control`, and only the fact of a definitive miss is cached server-side.
 Custom installations without a template derive a best-effort brand domain from their server URL.
-Unknown domains fall back to a generic server glyph.
+Domains without a logo return 404 and the UI falls back to a generic server glyph.
 
 ### Self-hosted instances
 

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -23,6 +23,30 @@ DEBUG=1 python manage.py probe_mcp_server https://mcp.example.com/mcp
 DEBUG=1 python manage.py sync_mcp_server_templates --skip-probe  # local seed without network
 ```
 
+## What can and can't be added
+
+Only **hosted (remote) MCP servers** on a public HTTPS endpoint speaking the streamable-HTTP transport belong in the catalog.
+
+Adds and auto-activates on merge:
+
+- OAuth servers with Dynamic Client Registration — the probe mints a real DCR client and verifies the authorization page.
+- API-key and unauthenticated servers that answer the MCP initialize handshake.
+
+Adds but ships **inactive** until an operator finishes activation (see the runbook below):
+
+- OAuth servers without DCR ("shared creds") — someone must register an OAuth app with the vendor and provision credentials per environment.
+- Vendors whose DCR is gated (initial access token, software statement, partner allowlist) — the probe classifies these as shared-creds too.
+
+Can't be added:
+
+- Local/stdio servers (npx or docker packages with no hosted endpoint).
+- Servers that aren't publicly reachable — private IPs, VPN-only hosts, and internal domains are blocked by SSRF protection.
+- Non-HTTP transports (WebSocket-only) and legacy HTTP+SSE dual-endpoint servers — the probe and proxy speak streamable HTTP only.
+- Any URL that fails the probe (`speaks_mcp: false`) — never ship an unprobed URL.
+
+Known gap: API keys are sent as `Authorization: Bearer <key>`, so servers that require a custom header (`X-API-Key`, ...) or exotic auth (signed JWTs, mTLS, IP allowlists) pass the probe but fail at first real install.
+A real end-to-end install (Gate B in the skill) is the only check that catches these.
+
 ## Server icons (logo.dev)
 
 Catalog icons are not committed image assets.

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -1,18 +1,68 @@
 # MCP store
 
-A curated catalog of MCP servers that PostHog users can install with one click, plus support for custom per-team installations.
+A curated marketplace of third-party MCP servers (Linear, Notion, Sentry, ...) that users browse and connect from Settings → MCP servers (behind the `MCP_SERVERS` feature flag).
+Connected servers are consumed by agent surfaces via the `backend/facade/` package.
+
+This is unrelated to `products/*/mcp/tools.yaml`, which exposes PostHog's own endpoints as MCP tools.
+
+## How the catalog works
+
+The catalog is **code**: `backend/catalog.py` holds one `CatalogEntry` per server.
+At app startup, every environment queues `sync_mcp_server_templates` (see `backend/tasks/tasks.py` and `posthog/apps.py`), which upserts entries into `MCPServerTemplate` rows:
+
+- Rows are keyed on `url`. New entries are created; existing rows get **content fields** updated (name, description, auth_type, category, icon_domain, docs_url). The catalog owns content — edit it in code, not admin.
+- **Operational state is never touched by the sync**: `is_active` after creation, `oauth_credentials`, and `oauth_metadata` once set belong to the row and to operators. Rows absent from the catalog (e.g. admin-added) are left alone.
+- **Activation gate**: a newly created entry is probed live (`backend/probe.py` — MCP initialize handshake, OAuth metadata discovery, a real DCR registration, authorization-endpoint liveness). It is born active only when the probe passes for the auth model the catalog declares. Servers that need shared OAuth credentials (no DCR) are born inactive until an operator provisions them.
+- Probes run **only on creation** — a DCR probe mints a real client on the provider, so re-probing every sync would leak registrations.
+
+To add a server, follow the `adding-mcp-store-servers` skill (`.agents/skills/adding-mcp-store-servers/`).
+To probe a server by hand:
+
+```sh
+DEBUG=1 python manage.py probe_mcp_server https://mcp.example.com/mcp
+DEBUG=1 python manage.py sync_mcp_server_templates --skip-probe  # local seed without network
+```
 
 ## Server icons (logo.dev)
 
 Catalog icons are not committed image assets.
-Each `MCPServerTemplate` carries an `icon_domain` (the vendor's brand domain, e.g. `linear.app`), and the frontend renders it through the authenticated proxy endpoint `GET /api/projects/:team_id/mcp_servers/icon/?domain=<domain>`.
-The proxy fetches the brand icon from [logo.dev](https://logo.dev) via the egress-gated `CDPIconsService`.
-Icon bytes are never stored on PostHog infrastructure (our logo.dev plan does not include a data-caching license); browsers cache responses via `Cache-Control`, and only the fact of a definitive miss is cached server-side.
+Templates carry an `icon_domain` (the vendor's brand domain, e.g. `linear.app`).
+The frontend renders them through the authenticated proxy endpoint `GET /api/projects/:team_id/mcp_servers/icon/?domain=<domain>`.
+The proxy fetches each brand icon from [logo.dev](https://logo.dev) through the egress-gated `CDPIconsService`.
+Icon bytes are never stored on PostHog infrastructure because our logo.dev plan does not include a data-caching license.
+Browsers cache responses via `Cache-Control`, and only the fact of a definitive miss is cached server-side.
 Custom installations without a template derive a best-effort brand domain from their server URL.
+Unknown domains fall back to a generic server glyph.
 
 ### Self-hosted instances
 
-Icon resolution requires the `LOGO_DEV_TOKEN` environment variable (a logo.dev API token) and outbound network access to `img.logo.dev`.
-Without the token, which is the default on self-hosted and air-gapped deployments, the icon endpoint returns 404 and the UI falls back to a generic server glyph for every server.
-This is cosmetic only: installing and using MCP servers works exactly the same without icons.
-To get brand icons on a self-hosted instance, create a logo.dev account, generate an API token, and set `LOGO_DEV_TOKEN` in the environment of the web service.
+Icon resolution requires the `LOGO_DEV_TOKEN` environment variable and outbound network access to `img.logo.dev`.
+Without the token, which is the default on self-hosted and air-gapped deployments, the icon endpoint returns 404 and the UI falls back to the generic glyph.
+This is cosmetic only: installing and using MCP servers works the same without icons.
+To show brand icons on a self-hosted instance, create a logo.dev account, generate an API token, and set `LOGO_DEV_TOKEN` in the web service environment.
+
+## Auth models
+
+- **OAuth with DCR** (most modern remote servers): nothing to provision. Each install discovers OAuth metadata fresh and mints a per-user client via RFC 7591. Template `oauth_credentials`/`oauth_metadata` stay empty.
+- **OAuth without DCR** ("shared creds"): an operator registers one OAuth app with the vendor and pastes `client_id`/`client_secret` into Django admin (stored encrypted per template). The sync pre-fills `oauth_metadata` from discovery; installs then share the client while each user gets their own tokens. Redirect URI: `{SITE_URL}/api/mcp_store/oauth_redirect/`.
+- **API key**: users supply their own key at install; nothing on the template.
+
+## Operator runbook: activating a shared-creds server
+
+1. Register an OAuth app in the vendor's developer console with redirect URI `https://us.posthog.com/api/mcp_store/oauth_redirect/` (repeat for EU with the EU host).
+2. Django admin → MCP server templates → the server: paste client ID and client secret.
+3. `oauth_metadata` should already be populated by the sync; if empty, run the "Discover metadata" admin action.
+4. Tick "is active". Repeat per environment — templates are per-database rows.
+
+## Key modules
+
+| Path                                   | What it is                                                                      |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| `backend/catalog.py`                   | The curated catalog (source of truth for content)                               |
+| `backend/catalog_sync.py`              | Upsert + probe-gated activation semantics                                       |
+| `backend/probe.py`                     | Live server verification, up to the OAuth consent screen                        |
+| `backend/models.py`                    | `MCPServerTemplate`, `MCPServerInstallation` (+ per-install tools, OAuth state) |
+| `backend/oauth.py`                     | RFC 9728/8414 discovery, RFC 7591 DCR, token exchange/refresh                   |
+| `backend/proxy.py`, `backend/tools.py` | MCP request proxying and tool discovery                                         |
+| `backend/facade/`                      | The only cross-product import surface                                           |
+| `frontend/scene/`                      | Marketplace UI (`MarketplaceBrowser`, `ServerCard`, ...)                        |


### PR DESCRIPTION
Stacked on #70162

## Problem

Our agents need guidance on how to add servers to the MCP store

## Changes

- `products/mcp_store/README.md` — what the store is, how the code-defined catalog syncs (content vs operational state ownership, the probe-gated activation), the three auth models, the operator runbook for shared-creds servers, and a key-module map.
- `.agents/skills/adding-mcp-store-servers/SKILL.md` — the end-to-end workflow for "add X to the MCP store": find the vendor's remote endpoint, run `manage.py probe_mcp_server`, author the catalog entry (copy/category/icon-domain rules), verify end-to-end when a vendor account is available (verification tiers for the PR description), and the paste-ready operator checklist for non-DCR OAuth servers.

## How did you test this code?

`hogli lint:skills` passes (109 skills). Docs-only change, no runtime surface.

## Docs update

no

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PR 5 of the 5-PR MCP store catalog stack). Skills invoked: `/writing-skills`. The skill lives in `.agents/skills/` (repo-development skill, like `implementing-warehouse-sources`) rather than `products/*/skills/` since it targets contributors to this repo, not PostHog customers.
