### PR TITLE
feat(experiments): sync axis scaling across primary / secondary metrics

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconInfo, IconList } from '@posthog/icons'
-import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
@@ -14,9 +14,15 @@ import { AddMetricButton } from '~/scenes/experiments/Metrics/AddMetricButton'
 import { METRIC_CONTEXTS } from '~/scenes/experiments/Metrics/experimentMetricModalLogic'
 import { MetricsReorderModal } from '~/scenes/experiments/MetricsView/MetricsReorderModal'
 import { modalsLogic } from '~/scenes/experiments/modalsLogic'
-import { getExperimentVariants, isSavedExperiment, metricResults } from '~/scenes/experiments/utils'
+import {
+    getExperimentVariants,
+    isSavedExperiment,
+    metricResults,
+    type MetricWithResult,
+} from '~/scenes/experiments/utils'
 import { Experiment } from '~/types'
 
+import { calculateAxisRange } from '../shared/utils'
 import { HowToReadTooltip } from './HowToReadTooltip'
 import { MetricsTable } from './MetricsTable'
 import { ResultDetails } from './ResultDetails'
@@ -39,7 +45,9 @@ function MetricsContent({ experiment, isSecondary }: { experiment: Experiment; i
         orderedPrimaryMetricsWithResults,
         orderedSecondaryMetricsWithResults,
         hasMinimumExposureForResults,
+        metricAxesSynced,
     } = useValues(experimentLogic)
+    const { setMetricAxesSynced } = useActions(experimentLogic)
     const {
         primaryMetricsResults,
         primaryMetricsResultsErrors,
@@ -51,22 +59,31 @@ function MetricsContent({ experiment, isSecondary }: { experiment: Experiment; i
 
     const { openPrimaryMetricsReorderModal, openSecondaryMetricsReorderModal } = useActions(modalsLogic)
 
-    const type = isSecondary ? 'secondary' : 'primary'
+    const resolveMetricsWithResults = (secondary: boolean): MetricWithResult[] =>
+        recalculationFlow
+            ? metricResults(experiment)(
+                  secondary ? secondaryMetricsResults : primaryMetricsResults,
+                  secondary ? secondaryMetricsResultsErrors : primaryMetricsResultsErrors,
+                  secondary ? 'secondary' : 'primary'
+              )
+            : secondary
+              ? orderedSecondaryMetricsWithResults
+              : orderedPrimaryMetricsWithResults
 
-    const metricsWithResults = recalculationFlow
-        ? metricResults(experiment)(
-              isSecondary ? secondaryMetricsResults : primaryMetricsResults,
-              isSecondary ? secondaryMetricsResultsErrors : primaryMetricsResultsErrors,
-              type
-          )
-        : isSecondary
-          ? orderedSecondaryMetricsWithResults
-          : orderedPrimaryMetricsWithResults
+    const metricsWithResults = resolveMetricsWithResults(!!isSecondary)
+    const otherSectionMetricsWithResults = resolveMetricsWithResults(!isSecondary)
 
     const metrics = metricsWithResults.map(({ metric }) => metric)
     const results = metricsWithResults.map(({ result }) => result)
     const errors = metricsWithResults.map(({ error }) => error)
     const metricIndexes = metricsWithResults.map(({ metricIndex }) => metricIndex)
+
+    const otherSectionResults = otherSectionMetricsWithResults.map(({ result }) => result)
+    const axisRange = calculateAxisRange(metricAxesSynced ? [...results, ...otherSectionResults] : results)
+    // Syncing only changes anything once both sections have chartable results
+    const sectionHasChartableResult = (sectionResults: MetricWithResult['result'][]): boolean =>
+        sectionResults.some((result) => !!result?.variant_results?.length)
+    const showAxisSyncToggle = sectionHasChartableResult(results) && sectionHasChartableResult(otherSectionResults)
 
     const showResultDetails = metrics.length === 1 && results[0] && hasMinimumExposureForResults && !isSecondary
     const hasSomeResults =
@@ -106,6 +123,17 @@ function MetricsContent({ experiment, isSecondary }: { experiment: Experiment; i
                     <div className="ml-auto">
                         {metrics.length > 0 && (
                             <div className="mb-2 mt-4 justify-end flex items-center gap-2">
+                                {showAxisSyncToggle && (
+                                    <LemonSwitch
+                                        checked={metricAxesSynced}
+                                        onChange={setMetricAxesSynced}
+                                        size="xsmall"
+                                        bordered
+                                        label="Sync axes"
+                                        tooltip="Use the same scale for primary and secondary metric charts. Turn off to scale each section to its own results."
+                                        data-attr="experiment-sync-metric-axes"
+                                    />
+                                )}
                                 <AddMetricButton
                                     metricContext={isSecondary ? METRIC_CONTEXTS.secondary : METRIC_CONTEXTS.primary}
                                 />
@@ -133,10 +161,11 @@ function MetricsContent({ experiment, isSecondary }: { experiment: Experiment; i
                         errors={errors}
                         metricIndexes={metricIndexes}
                         isSecondary={!!isSecondary}
+                        axisRange={axisRange}
                         getInsightType={getInsightType}
                         showDetailsModal={!showResultDetails}
                     />
-                    {showResultDetails && (
+                    {showResultDetails && results[0] && (
                         <div className="mt-4">
                             <ResultDetails
                                 metric={metrics[0] as ExperimentMetric}

--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -22,7 +22,7 @@ import {
 } from '~/scenes/experiments/utils'
 import { Experiment } from '~/types'
 
-import { calculateAxisRange } from '../shared/utils'
+import { calculateAxisRange, shouldOfferAxisSync } from '../shared/utils'
 import { HowToReadTooltip } from './HowToReadTooltip'
 import { MetricsTable } from './MetricsTable'
 import { ResultDetails } from './ResultDetails'
@@ -80,10 +80,7 @@ function MetricsContent({ experiment, isSecondary }: { experiment: Experiment; i
 
     const otherSectionResults = otherSectionMetricsWithResults.map(({ result }) => result)
     const axisRange = calculateAxisRange(metricAxesSynced ? [...results, ...otherSectionResults] : results)
-    // Syncing only changes anything once both sections have chartable results
-    const sectionHasChartableResult = (sectionResults: MetricWithResult['result'][]): boolean =>
-        sectionResults.some((result) => !!result?.variant_results?.length)
-    const showAxisSyncToggle = sectionHasChartableResult(results) && sectionHasChartableResult(otherSectionResults)
+    const showAxisSyncToggle = shouldOfferAxisSync(results, otherSectionResults)
 
     const showResultDetails = metrics.length === 1 && results[0] && hasMinimumExposureForResults && !isSecondary
     const hasSomeResults =
@@ -124,15 +121,18 @@ function MetricsContent({ experiment, isSecondary }: { experiment: Experiment; i
                         {metrics.length > 0 && (
                             <div className="mb-2 mt-4 justify-end flex items-center gap-2">
                                 {showAxisSyncToggle && (
-                                    <LemonSwitch
-                                        checked={metricAxesSynced}
-                                        onChange={setMetricAxesSynced}
-                                        size="xsmall"
-                                        bordered
-                                        label="Sync axes"
-                                        tooltip="Use the same scale for primary and secondary metric charts. Turn off to scale each section to its own results."
-                                        data-attr="experiment-sync-metric-axes"
-                                    />
+                                    <Tooltip title="Keep primary and secondary metric charts on the same scale so their effect sizes are comparable.">
+                                        <div className="flex items-center">
+                                            <LemonSwitch
+                                                checked={metricAxesSynced}
+                                                onChange={setMetricAxesSynced}
+                                                size="xsmall"
+                                                bordered
+                                                label="Sync axes"
+                                                data-attr="experiment-sync-metric-axes"
+                                            />
+                                        </div>
+                                    </Tooltip>
                                 )}
                                 <AddMetricButton
                                     metricContext={isSecondary ? METRIC_CONTEXTS.secondary : METRIC_CONTEXTS.primary}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricsTable.tsx
@@ -14,8 +14,6 @@ import { experimentLogic } from '../../experimentLogic'
 import { experimentMetricsLogic } from '../../experimentMetricsLogic'
 import { isLaunched } from '../../experimentsLogic'
 import { resolveSequentialEnabled } from '../../ExperimentView/sequential'
-import { type ExperimentVariantResult, getVariantInterval } from '../shared/utils'
-import { MAX_AXIS_RANGE } from './constants'
 import { MetricRowGroup } from './MetricRowGroup'
 import { TableHeader } from './TableHeader'
 
@@ -30,10 +28,11 @@ const sectionHasRecalculatingMetric =
 
 interface MetricsTableProps {
     metrics: ExperimentMetric[]
-    results: NewExperimentQueryResponse[]
+    results: (NewExperimentQueryResponse | undefined)[]
     errors: any[]
     metricIndexes: number[]
     isSecondary: boolean
+    axisRange: number
     getInsightType: (metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery) => InsightType
     showDetailsModal?: boolean
 }
@@ -44,6 +43,7 @@ export function MetricsTable({
     errors,
     metricIndexes,
     isSecondary,
+    axisRange,
     getInsightType,
     showDetailsModal = true,
 }: MetricsTableProps): JSX.Element {
@@ -63,38 +63,6 @@ export function MetricsTable({
         removeMetric,
         removeSharedMetricFromExperiment,
     } = useActions(experimentLogic)
-
-    // Calculate shared axisRange across all metrics
-    let hasBreakdowns = false
-    const allIntervalValues = results.flatMap((result: NewExperimentQueryResponse) => {
-        const allVariants: ExperimentVariantResult[] = []
-
-        // Include main variant results
-        if (result?.variant_results) {
-            allVariants.push(...result.variant_results)
-        }
-
-        // Include breakdown variant results
-        if (result?.breakdown_results && result.breakdown_results.length > 0) {
-            hasBreakdowns = true
-            result.breakdown_results.forEach((breakdownResult) => {
-                if (breakdownResult?.variants) {
-                    allVariants.push(...breakdownResult.variants)
-                }
-            })
-        }
-
-        return allVariants.flatMap((variant: ExperimentVariantResult) => {
-            const interval = getVariantInterval(variant)
-            return interval ? [Math.abs(interval[0]), Math.abs(interval[1])] : []
-        })
-    })
-
-    // Use 0 as default if no intervals exist, otherwise get the maximum value
-    const maxAbsValue = allIntervalValues.length > 0 ? Math.max(...allIntervalValues) : 0
-    const axisMargin = Math.max(maxAbsValue * 0.05, 0.1)
-    // When breakdowns are present, ignore MAX_AXIS_RANGE to show full range of breakdown data
-    const axisRange = hasBreakdowns ? maxAbsValue + axisMargin : Math.min(maxAbsValue + axisMargin, MAX_AXIS_RANGE)
 
     if (metrics.length === 0) {
         return (
@@ -142,7 +110,7 @@ export function MetricsTable({
                             <MetricRowGroup
                                 key={metric.uuid || index}
                                 metric={metric}
-                                result={result}
+                                result={result ?? null}
                                 experiment={experiment}
                                 metricType={getInsightType(metric)}
                                 metricIndex={metricIndex}

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -1,9 +1,15 @@
-import type { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
+import type {
+    ExperimentFunnelsQuery,
+    ExperimentMetric,
+    ExperimentTrendsQuery,
+    NewExperimentQueryResponse,
+} from '~/queries/schema/schema-general'
 import { ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { ExperimentMetricGoal, ExperimentMetricMathType, FunnelConversionWindowTimeUnit } from '~/types'
 
 import {
     type ExperimentVariantResult,
+    calculateAxisRange,
     formatChanceToWinForGoal,
     formatMetricValue,
     formatPValue,
@@ -90,6 +96,63 @@ describe('getDefaultMetricTitle', () => {
             },
         }
         expect(getDefaultMetricTitle(metric)).toBe('purchase_events')
+    })
+})
+
+describe('calculateAxisRange', () => {
+    const variant = (credible_interval: [number, number]): ExperimentVariantResult => ({
+        key: 'test',
+        sum: 100,
+        number_of_samples: 100,
+        sum_squares: 100,
+        significant: true,
+        method: 'bayesian',
+        credible_interval,
+        chance_to_win: 0.75,
+    })
+
+    const response = (
+        intervals: [number, number][],
+        breakdownIntervals?: [number, number][]
+    ): NewExperimentQueryResponse =>
+        ({
+            variant_results: intervals.map(variant),
+            ...(breakdownIntervals ? { breakdown_results: [{ variants: breakdownIntervals.map(variant) }] } : {}),
+        }) as NewExperimentQueryResponse
+
+    test.each<{ name: string; results: (NewExperimentQueryResponse | undefined | null)[]; expected: number }>([
+        {
+            name: 'no results falls back to the 0.1 margin floor',
+            results: [],
+            expected: 0.1,
+        },
+        {
+            name: 'undefined and null results (cold sections) are ignored',
+            results: [undefined, null],
+            expected: 0.1,
+        },
+        {
+            name: 'covers the widest interval bound plus the margin (5%, at least 0.1)',
+            results: [response([[-0.1, 0.2]])],
+            expected: 0.3,
+        },
+        {
+            name: 'caps at ±150% so outliers do not squish other charts',
+            results: [response([[-2, 2]])],
+            expected: 1.5,
+        },
+        {
+            name: 'breakdown results lift the ±150% cap',
+            results: [response([], [[-2, 2]])],
+            expected: 2.1,
+        },
+        {
+            name: 'combined sections scale to the global maximum',
+            results: [response([[-0.05, 0.05]]), response([[-0.4, 0.4]])],
+            expected: 0.5,
+        },
+    ])('$name', ({ results, expected }) => {
+        expect(calculateAxisRange(results)).toBeCloseTo(expected, 10)
     })
 })
 

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -20,6 +20,7 @@ import {
     getMetricTag,
     isProportionMetric,
     isWinning,
+    shouldOfferAxisSync,
 } from './utils'
 
 describe('getMetricTag', () => {
@@ -153,6 +154,51 @@ describe('calculateAxisRange', () => {
         },
     ])('$name', ({ results, expected }) => {
         expect(calculateAxisRange(results)).toBeCloseTo(expected, 10)
+    })
+})
+
+describe('shouldOfferAxisSync', () => {
+    const buildVariant = (credible_interval?: [number, number]): ExperimentVariantResult => ({
+        key: 'test',
+        sum: 100,
+        number_of_samples: 100,
+        sum_squares: 100,
+        significant: !!credible_interval,
+        method: 'bayesian',
+        credible_interval,
+        chance_to_win: 0.75,
+    })
+    const section = (...variants: ExperimentVariantResult[]): NewExperimentQueryResponse =>
+        ({ variant_results: variants }) as NewExperimentQueryResponse
+
+    type ResultList = (NewExperimentQueryResponse | undefined | null)[]
+    test.each<{ name: string; a: ResultList; b: ResultList; expected: boolean }>([
+        {
+            name: 'hidden when a section has bars but no intervals (only "not enough data" rows)',
+            a: [section(buildVariant([-0.1, 0.1]))],
+            b: [section(buildVariant())],
+            expected: false,
+        },
+        {
+            name: 'hidden when the other section is cold (undefined/null results)',
+            a: [section(buildVariant([-0.1, 0.1]))],
+            b: [undefined, null],
+            expected: false,
+        },
+        {
+            name: 'hidden when both sections scale to the same range',
+            a: [section(buildVariant([-0.2, 0.2]))],
+            b: [section(buildVariant([-0.2, 0.2]))],
+            expected: false,
+        },
+        {
+            name: 'shown when the sections scale to different ranges',
+            a: [section(buildVariant([-0.05, 0.05]))],
+            b: [section(buildVariant([-0.4, 0.4]))],
+            expected: true,
+        },
+    ])('$name', ({ a, b, expected }) => {
+        expect(shouldOfferAxisSync(a, b)).toBe(expected)
     })
 })
 

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.test.ts
@@ -170,6 +170,14 @@ describe('shouldOfferAxisSync', () => {
     })
     const section = (...variants: ExperimentVariantResult[]): NewExperimentQueryResponse =>
         ({ variant_results: variants }) as NewExperimentQueryResponse
+    const sectionWithBreakdown = (
+        variants: ExperimentVariantResult[],
+        breakdownVariants: ExperimentVariantResult[]
+    ): NewExperimentQueryResponse =>
+        ({
+            variant_results: variants,
+            breakdown_results: [{ variants: breakdownVariants }],
+        }) as NewExperimentQueryResponse
 
     type ResultList = (NewExperimentQueryResponse | undefined | null)[]
     test.each<{ name: string; a: ResultList; b: ResultList; expected: boolean }>([
@@ -196,6 +204,25 @@ describe('shouldOfferAxisSync', () => {
             a: [section(buildVariant([-0.05, 0.05]))],
             b: [section(buildVariant([-0.4, 0.4]))],
             expected: true,
+        },
+        {
+            // Both sections would cap at ±150% and match; the breakdown lifts one section's cap, so they diverge
+            name: 'shown when a breakdown lifts one section past the ±150% cap',
+            a: [sectionWithBreakdown([buildVariant([-2, 2])], [buildVariant([-2, 2])])],
+            b: [section(buildVariant([-2, 2]))],
+            expected: true,
+        },
+        {
+            name: 'shown when a section is chartable only through its breakdown results',
+            a: [sectionWithBreakdown([buildVariant()], [buildVariant([-0.4, 0.4])])],
+            b: [section(buildVariant([-0.05, 0.05]))],
+            expected: true,
+        },
+        {
+            name: 'hidden when both sections have identical breakdowns',
+            a: [sectionWithBreakdown([buildVariant([-2, 2])], [buildVariant([-2, 2])])],
+            b: [sectionWithBreakdown([buildVariant([-2, 2])], [buildVariant([-2, 2])])],
+            expected: false,
         },
     ])('$name', ({ a, b, expected }) => {
         expect(shouldOfferAxisSync(a, b)).toBe(expected)

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -21,9 +21,44 @@ import {
     isExperimentRatioMetric,
     isExperimentRetentionMetric,
 } from '~/queries/schema/schema-general'
+import { MAX_AXIS_RANGE } from '~/scenes/experiments/MetricsView/new/constants'
 import { ExperimentMetricGoal } from '~/types'
 
 export type ExperimentVariantResult = ExperimentVariantResultFrequentist | ExperimentVariantResultBayesian
+
+/**
+ * Computes the symmetric delta-chart axis range (±range) covering every variant and breakdown
+ * interval in the given results, with a margin (5%, at least 0.1). Capped at MAX_AXIS_RANGE unless
+ * breakdowns are present, whose wider spreads need the full range to stay readable.
+ */
+export function calculateAxisRange(results: (NewExperimentQueryResponse | undefined | null)[]): number {
+    let hasBreakdowns = false
+    const allIntervalValues = results.flatMap((result) => {
+        const allVariants: ExperimentVariantResult[] = []
+
+        if (result?.variant_results) {
+            allVariants.push(...result.variant_results)
+        }
+
+        if (result?.breakdown_results && result.breakdown_results.length > 0) {
+            hasBreakdowns = true
+            result.breakdown_results.forEach((breakdownResult) => {
+                if (breakdownResult?.variants) {
+                    allVariants.push(...breakdownResult.variants)
+                }
+            })
+        }
+
+        return allVariants.flatMap((variant: ExperimentVariantResult) => {
+            const interval = getVariantInterval(variant)
+            return interval ? [Math.abs(interval[0]), Math.abs(interval[1])] : []
+        })
+    })
+
+    const maxAbsValue = allIntervalValues.length > 0 ? Math.max(...allIntervalValues) : 0
+    const axisMargin = Math.max(maxAbsValue * 0.05, 0.1)
+    return hasBreakdowns ? maxAbsValue + axisMargin : Math.min(maxAbsValue + axisMargin, MAX_AXIS_RANGE)
+}
 
 export const getMetricTag = (metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery): string => {
     if (metric.kind === NodeKind.ExperimentMetric) {

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -60,6 +60,32 @@ export function calculateAxisRange(results: (NewExperimentQueryResponse | undefi
     return hasBreakdowns ? maxAbsValue + axisMargin : Math.min(maxAbsValue + axisMargin, MAX_AXIS_RANGE)
 }
 
+/**
+ * Whether a section renders at least one delta bar — any variant or breakdown result with an interval.
+ * A section showing only "not enough data yet" rows has nothing to scale, so it can't be compared.
+ */
+function sectionHasChartableResult(results: (NewExperimentQueryResponse | undefined | null)[]): boolean {
+    return results.some((result) => {
+        const variants: ExperimentVariantResult[] = [
+            ...(result?.variant_results ?? []),
+            ...(result?.breakdown_results?.flatMap((breakdown) => breakdown?.variants ?? []) ?? []),
+        ]
+        return variants.some((variant) => getVariantInterval(variant) !== null)
+    })
+}
+
+// Only show the toggle when both sections show metrics and the scale actually differs (hide for no-op)
+export function shouldOfferAxisSync(
+    sectionResults: (NewExperimentQueryResponse | undefined | null)[],
+    otherSectionResults: (NewExperimentQueryResponse | undefined | null)[]
+): boolean {
+    if (!sectionHasChartableResult(sectionResults) || !sectionHasChartableResult(otherSectionResults)) {
+        return false
+    }
+    const syncedRange = calculateAxisRange([...sectionResults, ...otherSectionResults])
+    return syncedRange !== calculateAxisRange(sectionResults) || syncedRange !== calculateAxisRange(otherSectionResults)
+}
+
 export const getMetricTag = (metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery): string => {
     if (metric.kind === NodeKind.ExperimentMetric) {
         return metric.metric_type.charAt(0).toUpperCase() + metric.metric_type.slice(1).toLowerCase()

--- a/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/utils.ts
@@ -66,10 +66,17 @@ export function calculateAxisRange(results: (NewExperimentQueryResponse | undefi
  */
 function sectionHasChartableResult(results: (NewExperimentQueryResponse | undefined | null)[]): boolean {
     return results.some((result) => {
-        const variants: ExperimentVariantResult[] = [
-            ...(result?.variant_results ?? []),
-            ...(result?.breakdown_results?.flatMap((breakdown) => breakdown?.variants ?? []) ?? []),
-        ]
+        // Collect via push() like calculateAxisRange: variant_results is a union of arrays, which
+        // breaks array-literal spread + flatMap type inference.
+        const variants: ExperimentVariantResult[] = []
+        if (result?.variant_results) {
+            variants.push(...result.variant_results)
+        }
+        result?.breakdown_results?.forEach((breakdown) => {
+            if (breakdown?.variants) {
+                variants.push(...breakdown.variants)
+            }
+        })
         return variants.some((variant) => getVariantInterval(variant) !== null)
     })
 }

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -601,6 +601,7 @@ export const experimentLogic = kea<experimentLogicType>([
         setFeatureFlagValidationError: (error: string) => ({ error }),
         validateFeatureFlag: (featureFlagKey: string) => ({ featureFlagKey }),
         setHogfettiTrigger: (trigger: (() => void) | null) => ({ trigger }),
+        setMetricAxesSynced: (synced: boolean) => ({ synced }),
         // METRICS
         setMetric: ({
             uuid,
@@ -731,6 +732,13 @@ export const experimentLogic = kea<experimentLogicType>([
             false,
             {
                 toggleDebugPanel: (state) => !state,
+            },
+        ],
+        // Session-local only: whether primary and secondary metric charts share one axis scale
+        metricAxesSynced: [
+            true,
+            {
+                setMetricAxesSynced: (_, { synced }) => synced,
             },
         ],
         currentRefresh: [


### PR DESCRIPTION
## Problem

On the experiment page, the primary / secondary metrics each auto-scale their delta-chart axis. Bars of similar visual length can therefore represent very different effect sizes. A reader comparing the two sections can misread the results as it happened in this case: [originating Slack thread](https://posthog.slack.com/archives/C07PXH2GTGV/p1783713949594389)

## Changes

- Primary / secondary metric charts now share one axis range by default, computed across both sections' credible/confidence intervals (it should be the default to prevent the described issue from happening)
- A new switch in each section's header turns this off and restores per-section scaling. It only appears once both sections have chartable results
- The range computation moved out of `MetricsTable` into a pure `calculateAxisRange` util (`MetricsView/shared/utils.ts`), unchanged in behavior: widest interval bound plus a margin (5%, at least 0.1), capped at ±150% unless breakdown results are present.
- `MetricsTable` now takes `axisRange` as a prop, and its `results` prop type reflects that entries can be `undefined` for metrics that haven't loaded yet (previously hidden by `any`).

Note:
- The state is not persisted anywhere, this is to keep this PR simple, can be improved if there is actual demand for it
- When synced, a wide-interval secondary metric compresses the primary metrics' bars toward zero. That is the intended trade-off of a shared scale, and the switch is the escape hatch. The "breakdowns lift the ±150% cap" rule now also applies across sections while synced.


<img width="1262" height="770" alt="sync-switch" src="https://github.com/user-attachments/assets/10efca3f-905e-4b99-857e-a59a80938c0d" />


## How did you test this code?

- Manually
- Some new tests

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) at Marcel's direction. Skills invoked: /writing-tests. The task started as an investigation into why the axes scale independently. It turned out there is no dual-axis chart here at all, rather two stacked tables each computing their own range, so the fix lifts the range computation to the section component and combines both sections' results by default. Considered computing the shared range in a kea selector instead, but the section components already branch on the metrics-recalculation feature flag to pick their data source, so resolving both sections where that branch lives was simpler. The MCP experiment results view and the legacy metrics view were checked and are unaffected (no shared axis code).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*