### PR TITLE
chore(personhog): add person creation claim table

### DIFF
--- a/rust/persons_migrations/20260710000001_add_personhog_distinct_id_claims.sql
+++ b/rust/persons_migrations/20260710000001_add_personhog_distinct_id_claims.sql
@@ -1,0 +1,28 @@
+-- Distinct-id claims: the call-time arbiter for person creation through
+-- the personhog leader path.
+--
+-- A claim records "this (team_id, distinct_id) belongs to person_id"
+-- BEFORE the person exists anywhere readable: a leader-path create is
+-- acked once its changelog record is durable, but the person row and its
+-- distinct-id mappings only reach Postgres after writer lag. During that
+-- window an existence check cannot see the person, so a crashed creator's
+-- restart (or a racing twin) would mint a duplicate. The primary key
+-- makes claiming atomic and first-writer-wins: the loser learns the
+-- winner's person_id at call time, adopts it, and idempotently re-issues
+-- the create instead of allocating a new person.
+--
+-- Rows are transient bookkeeping. Once the writer applies the durable
+-- posthog_persondistinctid mapping, the claim is redundant; the writer
+-- reaps it in the same transaction that inserts the mapping. Correctness
+-- never depends on reaping (or on any TTL) — a claim lives exactly as
+-- long as the window it covers.
+--
+-- Deliberately no FK to posthog_person: the person's row does not exist
+-- yet at claim time. That is the point of the table.
+CREATE TABLE IF NOT EXISTS personhog_distinct_id_claims (
+    team_id INTEGER NOT NULL,
+    distinct_id VARCHAR(400) NOT NULL,
+    person_id BIGINT NOT NULL,
+    claimed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (team_id, distinct_id)
+);


### PR DESCRIPTION
## Problem
  
Person creation through the personhog leader path is acked when the changelog record is durable, but the person row and its distinct-id mappings only reach Postgres after writer lag. During that window, no read anywhere can see the new person — so a creator that crashes after the ack and retries (or a concurrent creator racing for the same distinct id) passes its existence check and mints a duplicate person. Read-based checks cannot close this: the state they need to see is structurally unreadable until the writer applies. Only an atomic write can arbitrate.

## Changes

One new table, `personhog_distinct_id_claims`: a call-time, first-writer-wins arbiter for distinct-id ownership during the creation window. The composite primary key `(team_id, distinct_id)` is the entire mechanism — claiming is an atomic insert that either wins or reveals the winning `person_id`, letting the loser adopt the existing person and idempotently re-issue its create instead of duplicating.

Rows are transient bookkeeping: once the writer applies the durable `posthog_persondistinctid` mapping, the claim is redundant and gets reaped by the writer in the same transaction (follow-up PR). Correctness never depends on reaping or any TTL — a claim lives exactly as long as the window it covers. There is deliberately no FK to `posthog_person`, since the person's row does not exist yet at claim time — that's the point of the table.

Schema-only PR so the table is applied everywhere (dev, prod-EU, prod-US via the sqlx-migrations jobs) before the RPC that uses it lands. The table is inert until callers exist: `CREATE TABLE IF NOT EXISTS`, no existing objects touched, no locks on hot tables. Applied uniformly to all environments rather than dev-scoped — sqlx's ordered migration model has no per-environment gating, and intentional schema divergence between environments is a known footgun here.

Follow-up (separate PR): a `ClaimPersonForDistinctIds` RPC on the replica that resolves-or-claims in one primary transaction (allocation included), plus the writer-side reap.

## How did you test this code?

Applied via `sqlx migrate run` against a local persons database and verified the resulting table shape and primary key. CI applies the full migration sequence on every run. No code references the table yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The design was settled through extended analysis of the create-path crash-twin race: read-based existence checks were ruled out (unreadable window), Redis was ruled out (claims must be transactional with the PDI mapping check, durability must survive arbiter failover, and reaping must be event-gated rather than TTL-gated), and time-partitioning was ruled out (a partitioned unique constraint must include the partition key, which would break the first-writer-wins arbiter). Writer-side same-transaction reaping replaces any external cleanup job.

Once this merges and the ApplicationSet jobs sync it through the environments, the RPC PR follows with the claim/allocate combined call and the writer reap. Meanwhile still pending from before: the create branch's millis changes await your commit, and the delete branch rebases after that.