### PR TITLE
feat(mcp_store): add MCP gateway execution plane

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -539,6 +539,8 @@ SPECTACULAR_SETTINGS = {
         "HogFlowStatusEnum": "products.workflows.backend.models.hog_flow.hog_flow.HogFlow.State",
         "MCPAuthTypeEnum": "products.mcp_store.backend.models.AUTH_TYPE_CHOICES",
         "MCPInstallationScopeEnum": ["personal", "shared"],
+        "MCPServerScopeEnum": "products.mcp_store.backend.models.SCOPE_CHOICES",
+        "MCPToolApprovalStateEnum": "products.mcp_store.backend.models.APPROVAL_STATES",
         "TaskRunStatusEnum": "products.tasks.backend.models.TaskRun.Status",
         "TaskRunEnvironmentEnum": "products.tasks.backend.models.TaskRun.Environment",
         "ModelEnum": "products.batch_exports.backend.models.batch_export.BatchExport.Model",

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -92,6 +92,7 @@ from products.feature_flags.backend.tasks import (
     refresh_expiring_flags_cache_entries,
 )
 from products.logs.backend.facade.tasks import logs_alert_events_cleanup_task
+from products.mcp_store.backend.facade.tasks import maintain_shared_installations
 from products.reminders.backend.tasks import process_due_reminders
 from products.streamlit_apps.backend.facade.api import (
     auto_restart_crashed_streamlit_sandboxes,
@@ -712,6 +713,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="3", minute="30"),
         cleanup_expired_test_saved_queries.s(),
         name="cleanup expired test saved queries",
+    )
+
+    # Refresh expiring OAuth tokens and re-sync stale tool catalogs for shared MCP installations
+    sender.add_periodic_task(
+        crontab(minute="45"),
+        maintain_shared_installations.s(),
+        name="maintain shared MCP installations",
     )
 
     # Reopen snoozed conversation tickets whose snooze period has expired

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -1,0 +1,32 @@
+# MCP Store
+
+Connect external MCP (Model Context Protocol) servers to a PostHog project, and give agents one aggregated access point to all of them.
+
+## Store
+
+- **Templates** (`MCPServerTemplate`): curated catalog entries seeded by operators, optionally carrying shared OAuth client credentials. Users can also add custom servers by URL.
+- **Installations** (`MCPServerInstallation`): a connected server for a team. `personal` installations belong to one user; `shared` ones are team-wide (admin-gated, executed under the installer's credential). Secrets live in an encrypted `sensitive_configuration` field and never leave the Django side.
+- **Auth**: API key or OAuth. OAuth installs run discovery plus Dynamic Client Registration (or use template/user-supplied clients), with PKCE and token refresh (`oauth.py`). Refresh is single-flight per installation via a Redis lock.
+- **Tools** (`MCPServerInstallationTool`): a cached catalog of each server's tools with a per-tool approval state (`approved` / `needs_approval` / `do_not_use`), synced from upstream `tools/list` (`tools.py`).
+- **Proxy**: `POST /api/environments/:team_id/mcp_server_installations/:id/proxy/` forwards JSON-RPC to one server with SSRF protection, tool-approval enforcement, and credential injection (`proxy.py`).
+
+## Gateway
+
+The aggregated gateway (`gateway.py`) exposes every connected server through a single team-scoped surface. Resolution per caller is shared installations ∪ the caller's personal ones (enabled and credential-ready only); a personal installation shadows a shared one for the same URL. Tools are namespaced as `{server_slug}/{tool_name}`, with deterministic `-2`/`-3` suffixes on slug collisions.
+
+Endpoints (`presentation/gateway_views.py`, dual-routed under `/api/projects/` and `/api/environments/`):
+
+- `POST .../mcp_gateway/mcp/` — stateless JSON-RPC (MCP streamable HTTP): `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`. Batches are rejected.
+- `GET .../mcp_gateway/tools/` — REST catalog with `search`, exact `name`, and `limit`/`offset`.
+- `POST .../mcp_gateway/call/` — REST execution. Errors map to 403 (`tool_needs_approval` with an `approval_url`, or `tool_blocked`), 404 (`tool_not_found`), and 502 (`upstream_error` with an `error_type`).
+
+Dispatch is one shared path: resolve → enforce approval → refresh token → SSRF check → upstream `tools/call` (`client.py`) → analytics. Every call emits a `$mcp_tool_call` event (`$mcp_source: "gateway"`; the per-installation proxy emits `$mcp_source: "store_proxy"`) with metadata only — never tool arguments, results, or credentials.
+
+## Integration surface
+
+Other apps may only import from `backend/facade/`:
+
+- `get_active_installations` / `get_installations_for_sandbox` — ready-to-use installations (e.g. for sandbox agents).
+- `list_gateway_tools` / `call_gateway_tool` — in-process access to the aggregated gateway; failures raise the `Gateway*Error` types from `facade/contracts.py`.
+
+An hourly Celery beat task (`maintain_shared_installations`) refreshes expiring OAuth tokens for shared installations and re-syncs tool catalogs that haven't been seen in over 24 hours.

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -14,9 +14,8 @@ Connect external MCP (Model Context Protocol) servers to a PostHog project, and 
 
 The aggregated gateway (`gateway.py`) exposes every connected server through a single team-scoped surface. Resolution per caller is shared installations ∪ the caller's personal ones (enabled and credential-ready only); a personal installation shadows a shared one for the same URL. Tools are namespaced as `{server_slug}/{tool_name}`, with deterministic `-2`/`-3` suffixes on slug collisions.
 
-Endpoints (`presentation/gateway_views.py`, dual-routed under `/api/projects/` and `/api/environments/`):
+Agents — external and internal — reach the gateway through the PostHog MCP (`services/mcp`), which consumes these REST endpoints (`presentation/gateway_views.py`, dual-routed under `/api/projects/` and `/api/environments/`):
 
-- `POST .../mcp_gateway/mcp/` — stateless JSON-RPC (MCP streamable HTTP): `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`. Batches are rejected.
 - `GET .../mcp_gateway/tools/` — REST catalog with `search`, exact `name`, and `limit`/`offset`.
 - `POST .../mcp_gateway/call/` — REST execution. Errors map to 403 (`tool_needs_approval` with an `approval_url`, or `tool_blocked`), 404 (`tool_not_found`), and 502 (`upstream_error` with an `error_type`).
 
@@ -27,6 +26,5 @@ Dispatch is one shared path: resolve → enforce approval → refresh token → 
 Other apps may only import from `backend/facade/`:
 
 - `get_active_installations` / `get_installations_for_sandbox` — ready-to-use installations (e.g. for sandbox agents).
-- `list_gateway_tools` / `call_gateway_tool` — in-process access to the aggregated gateway; failures raise the `Gateway*Error` types from `facade/contracts.py`.
 
 An hourly Celery beat task (`maintain_shared_installations`) refreshes expiring OAuth tokens for shared installations and re-syncs tool catalogs that haven't been seen in over 24 hours.

--- a/products/mcp_store/backend/analytics.py
+++ b/products/mcp_store/backend/analytics.py
@@ -1,0 +1,77 @@
+"""Server-side `$mcp_tool_call` emission for MCP Store traffic.
+
+Both the aggregated gateway (`$mcp_source: "gateway"`) and the per-installation
+proxy (`$mcp_source: "store_proxy"`) report through here. Property naming is
+aligned with the Hono MCP server's analytics (services/mcp/src/hono/analytics.ts)
+so both surfaces land in the same MCP analytics dashboards.
+
+Only metadata is ever captured — tool names, durations, error types. Tool
+arguments, results, headers, and credentials must never flow through here.
+"""
+
+from urllib.parse import urlparse
+
+from django.utils.text import slugify
+
+import structlog
+
+from posthog.event_usage import report_user_action
+from posthog.models import Team, User
+
+from .models import MCPServerInstallation
+
+logger = structlog.get_logger(__name__)
+
+# Keep in sync with MCP_TOOL_CALL_EVENT in products/mcp_analytics/backend/constants.py.
+# Defined locally because mcp_store is isolated and must not import other products' internals.
+MCP_TOOL_CALL_EVENT = "$mcp_tool_call"
+
+# Consumers identify themselves with this header (same convention as the Hono MCP server).
+MCP_CONSUMER_HEADER = "x-posthog-mcp-consumer"
+
+
+def installation_display_name(installation: MCPServerInstallation) -> str:
+    if installation.display_name:
+        return installation.display_name
+    if installation.template and installation.template.name:
+        return installation.template.name
+    return installation.url
+
+
+def base_server_slug(installation: MCPServerInstallation) -> str:
+    return slugify(installation_display_name(installation)) or "server"
+
+
+def report_mcp_tool_call(
+    user: User,
+    team: Team,
+    *,
+    tool_name: str,
+    source: str,
+    server_slug: str,
+    installation: MCPServerInstallation,
+    duration_ms: int,
+    is_error: bool,
+    error_type: str | None = None,
+    consumer: str | None = None,
+) -> None:
+    """Capture a `$mcp_tool_call` event. Never raises — analytics must not break the request."""
+    try:
+        properties: dict[str, str | int | bool | None] = {
+            "$ai_product": "mcp",
+            "$mcp_source": source,
+            "$mcp_tool_name": tool_name,
+            "$mcp_gateway_server": server_slug,
+            "$mcp_gateway_installation_id": str(installation.id),
+            "$mcp_upstream_host": urlparse(installation.url).hostname or "",
+            "$mcp_duration_ms": duration_ms,
+            "$mcp_is_error": is_error,
+            "$mcp_error_type": error_type,
+            "$mcp_consumer": consumer or None,
+            "$mcp_scope": installation.scope,
+            "$mcp_project_id": team.id,
+            "team_id": team.id,
+        }
+        report_user_action(user, MCP_TOOL_CALL_EVENT, properties, team=team)
+    except Exception:
+        logger.warning("Failed to report $mcp_tool_call", installation_id=str(installation.id), exc_info=True)

--- a/products/mcp_store/backend/client.py
+++ b/products/mcp_store/backend/client.py
@@ -1,0 +1,136 @@
+"""Sync upstream MCP client for ``tools/call``.
+
+Extends the streamable-HTTP handshake used by ``tools.py`` for ``tools/list``:
+``initialize`` → ``notifications/initialized`` → ``tools/call`` → ``DELETE``.
+A fresh handshake per call keeps the client stateless — upstream sessions are
+short-lived and terminated best-effort after each call.
+"""
+
+import json
+from typing import Any
+
+import httpx
+import structlog
+
+from posthog.security.url_validation import is_url_allowed
+
+from .models import MCPServerInstallation
+from .proxy import (
+    MAX_PROXY_BODY_SIZE,
+    UPSTREAM_TIMEOUT,
+    build_upstream_auth_headers,
+    validated_same_origin_redirect_url,
+)
+from .tools import (
+    HANDSHAKE_TIMEOUT,
+    ToolsFetchError,
+    _mcp_initialize,
+    _mcp_send_initialized,
+    _mcp_terminate_session,
+    _parse_jsonrpc_response,
+)
+
+logger = structlog.get_logger(__name__)
+
+_CALL_TOOL_ID = 3
+
+
+class UpstreamToolCallError(Exception):
+    """Raised when the upstream MCP server can't be called or returns a JSON-RPC error.
+
+    ``error_type`` is a stable machine-readable category surfaced in REST 502
+    responses and ``$mcp_error_type`` analytics.
+    """
+
+    def __init__(self, message: str, *, error_type: str = "upstream_error") -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
+def call_upstream_tool(
+    installation: MCPServerInstallation, tool_name: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Execute a single ``tools/call`` against the installation's MCP server.
+
+    Returns the raw JSON-RPC ``result`` (MCP ``CallToolResult``: ``content``,
+    ``isError``, optional ``structuredContent``). Approval enforcement and token
+    refresh are the caller's responsibility (see ``gateway.py``).
+    """
+    allowed, reason = is_url_allowed(installation.url)
+    if not allowed:
+        raise UpstreamToolCallError(f"URL not allowed: {reason}", error_type="ssrf_blocked")
+
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": _CALL_TOOL_ID,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+    ).encode()
+    if len(body) > MAX_PROXY_BODY_SIZE:
+        raise UpstreamToolCallError("Tool arguments too large", error_type="payload_too_large")
+
+    auth_headers = build_upstream_auth_headers(installation)
+    base_headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        **auth_headers,
+    }
+
+    try:
+        with httpx.Client(timeout=HANDSHAKE_TIMEOUT) as client:
+            session_id, upstream_url = _mcp_initialize(client, installation.url, base_headers)
+            session_headers = dict(base_headers)
+            if session_id:
+                session_headers["Mcp-Session-Id"] = session_id
+
+            _mcp_send_initialized(client, upstream_url, session_headers)
+            try:
+                return _send_tool_call(client, upstream_url, body, session_headers)
+            finally:
+                # Best-effort session cleanup; failures here must not mask the call result.
+                if session_id:
+                    _mcp_terminate_session(client, upstream_url, session_headers)
+    except UpstreamToolCallError:
+        raise
+    except ToolsFetchError as exc:
+        raise UpstreamToolCallError(str(exc)) from exc
+    except httpx.ConnectError as exc:
+        raise UpstreamToolCallError("Upstream MCP server unreachable", error_type="unreachable") from exc
+    except httpx.TimeoutException as exc:
+        raise UpstreamToolCallError("Upstream MCP server timed out", error_type="timeout") from exc
+
+
+def _send_tool_call(client: httpx.Client, url: str, body: bytes, headers: dict[str, str]) -> dict[str, Any]:
+    # Tool execution can be slow (matches the proxy's budget); the handshake
+    # steps keep the aggressive HANDSHAKE_TIMEOUT set on the client.
+    response = client.post(url, content=body, headers=headers, timeout=UPSTREAM_TIMEOUT)
+    redirect_url = validated_same_origin_redirect_url(url, response)
+    if redirect_url:
+        response.close()
+        response = client.post(redirect_url, content=body, headers=headers, timeout=UPSTREAM_TIMEOUT)
+        url = redirect_url
+
+    if response.status_code >= 400:
+        logger.warning(
+            "Upstream tools/call returned error status",
+            url=url,
+            status_code=response.status_code,
+        )
+        raise UpstreamToolCallError(f"Upstream returned status {response.status_code}")
+
+    payload = _parse_jsonrpc_response(
+        response.text, response.headers.get("content-type", ""), _CALL_TOOL_ID, request_name="tools/call"
+    )
+    if isinstance(payload, dict) and payload.get("error"):
+        error = payload["error"]
+        message = (
+            error.get("message", "Upstream tools/call returned an error") if isinstance(error, dict) else str(error)
+        )
+        raise UpstreamToolCallError(message)
+
+    result = payload.get("result") if isinstance(payload, dict) else None
+    if not isinstance(result, dict):
+        raise UpstreamToolCallError("tools/call response missing 'result' object")
+    return result

--- a/products/mcp_store/backend/facade/api.py
+++ b/products/mcp_store/backend/facade/api.py
@@ -4,20 +4,11 @@ Facade API for mcp_store.
 This is the ONLY module other apps are allowed to import.
 """
 
-from typing import Any
-
 import structlog
 
-from posthog.models import Team, User
-
 from products.mcp_store.backend.analytics import installation_display_name
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo, GatewayCallResult, GatewayToolInfo
-from products.mcp_store.backend.gateway import (
-    call_gateway_tool as _call_gateway_tool,
-    is_credential_ready,
-    list_gateway_tools as _list_gateway_tools,
-    resolve_active_installations,
-)
+from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
+from products.mcp_store.backend.gateway import is_credential_ready, resolve_active_installations
 from products.mcp_store.backend.models import MCPServerInstallation
 
 logger = structlog.get_logger(__name__)
@@ -93,33 +84,3 @@ def get_installations_for_sandbox(
         include_personal=include_personal,
     )
     return results
-
-
-def list_gateway_tools(
-    team_id: int,
-    user_id: int,
-    query: str | None = None,
-    name: str | None = None,
-) -> list[GatewayToolInfo]:
-    """List the namespaced tools available to a user through the aggregated MCP gateway.
-
-    ``query`` is a substring search over tool name and description;
-    ``name`` filters to an exact namespaced tool name.
-    """
-    return _list_gateway_tools(team_id, user_id, search=query, name=name)
-
-
-def call_gateway_tool(
-    team_id: int,
-    user_id: int,
-    tool: str,
-    arguments: dict[str, Any],
-    consumer: str | None = None,
-) -> GatewayCallResult:
-    """Execute a namespaced gateway tool (``{server_slug}/{tool_name}``) as a user.
-
-    Raises the ``Gateway*Error`` types from ``facade.contracts`` on failure.
-    """
-    team = Team.objects.get(id=team_id)
-    user = User.objects.get(id=user_id)
-    return _call_gateway_tool(team=team, user=user, tool=tool, arguments=arguments, consumer=consumer)

--- a/products/mcp_store/backend/facade/api.py
+++ b/products/mcp_store/backend/facade/api.py
@@ -4,39 +4,29 @@ Facade API for mcp_store.
 This is the ONLY module other apps are allowed to import.
 """
 
-from django.db.models import Q
+from typing import Any
 
 import structlog
 
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
+from posthog.models import Team, User
+
+from products.mcp_store.backend.analytics import installation_display_name
+from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo, GatewayCallResult, GatewayToolInfo
+from products.mcp_store.backend.gateway import (
+    call_gateway_tool as _call_gateway_tool,
+    is_credential_ready,
+    list_gateway_tools as _list_gateway_tools,
+    resolve_active_installations,
+)
 from products.mcp_store.backend.models import MCPServerInstallation
 
 logger = structlog.get_logger(__name__)
 
 
-def _resolve_name(installation: MCPServerInstallation) -> str:
-    if installation.display_name:
-        return installation.display_name
-    if installation.template and installation.template.name:
-        return installation.template.name
-    return installation.url
-
-
-def _is_oauth_ready(installation: MCPServerInstallation) -> bool:
-    if installation.auth_type != "oauth":
-        return True
-    sensitive = installation.sensitive_configuration or {}
-    if sensitive.get("needs_reauth"):
-        return False
-    if not sensitive.get("access_token"):
-        return False
-    return True
-
-
 def _to_info(installation: MCPServerInstallation, team_id: int) -> ActiveInstallationInfo:
     return ActiveInstallationInfo(
         id=str(installation.id),
-        name=_resolve_name(installation),
+        name=installation_display_name(installation),
         proxy_path=f"/api/environments/{team_id}/mcp_server_installations/{installation.id}/proxy/",
         scope=installation.scope,
     )
@@ -61,7 +51,7 @@ def get_active_installations(team_id: int, user_id: int) -> list[ActiveInstallat
 
     results: list[ActiveInstallationInfo] = []
     for installation in installations:
-        if not _is_oauth_ready(installation):
+        if not is_credential_ready(installation):
             logger.debug(
                 "Skipping MCP installation not ready",
                 installation_id=str(installation.id),
@@ -89,28 +79,10 @@ def get_installations_for_sandbox(
     credential.
     """
     try:
-        scope_filter = Q(scope="shared")
-        if include_personal and user_id is not None:
-            scope_filter = scope_filter | Q(scope="personal", user_id=user_id)
-
-        # list() evaluates the lazy queryset here so DB errors hit this handler.
-        installations = list(
-            MCPServerInstallation.objects.filter(team_id=team_id, is_enabled=True)
-            .filter(scope_filter)
-            .select_related("template")
-        )
+        ready = resolve_active_installations(team_id, user_id=user_id, include_personal=include_personal)
     except Exception as e:
         logger.warning("Error fetching MCP installations for sandbox", error=str(e), team_id=team_id)
         return []
-
-    ready = [installation for installation in installations if _is_oauth_ready(installation)]
-    if include_personal and user_id is not None:
-        personal_urls = {installation.url for installation in ready if installation.scope == "personal"}
-        ready = [
-            installation
-            for installation in ready
-            if installation.scope == "personal" or installation.url not in personal_urls
-        ]
 
     results = [_to_info(installation, team_id) for installation in ready]
 
@@ -121,3 +93,33 @@ def get_installations_for_sandbox(
         include_personal=include_personal,
     )
     return results
+
+
+def list_gateway_tools(
+    team_id: int,
+    user_id: int,
+    query: str | None = None,
+    name: str | None = None,
+) -> list[GatewayToolInfo]:
+    """List the namespaced tools available to a user through the aggregated MCP gateway.
+
+    ``query`` is a substring search over tool name and description;
+    ``name`` filters to an exact namespaced tool name.
+    """
+    return _list_gateway_tools(team_id, user_id, search=query, name=name)
+
+
+def call_gateway_tool(
+    team_id: int,
+    user_id: int,
+    tool: str,
+    arguments: dict[str, Any],
+    consumer: str | None = None,
+) -> GatewayCallResult:
+    """Execute a namespaced gateway tool (``{server_slug}/{tool_name}``) as a user.
+
+    Raises the ``Gateway*Error`` types from ``facade.contracts`` on failure.
+    """
+    team = Team.objects.get(id=team_id)
+    user = User.objects.get(id=user_id)
+    return _call_gateway_tool(team=team, user=user, tool=tool, arguments=arguments, consumer=consumer)

--- a/products/mcp_store/backend/facade/contracts.py
+++ b/products/mcp_store/backend/facade/contracts.py
@@ -6,6 +6,7 @@ exposes to the rest of the codebase. No Django imports.
 """
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -16,3 +17,69 @@ class ActiveInstallationInfo:
     name: str
     proxy_path: str
     scope: str = "personal"
+
+
+@dataclass(frozen=True)
+class GatewayServerInfo:
+    """The connected MCP server a gateway tool belongs to."""
+
+    slug: str
+    display_name: str
+    installation_id: str
+    scope: str
+
+
+@dataclass(frozen=True)
+class GatewayToolInfo:
+    """A tool exposed through the aggregated MCP gateway.
+
+    ``name`` is namespaced as ``{server_slug}/{tool_name}`` — the ``/`` keeps
+    connected-server tools distinct from PostHog's own kebab-case tools.
+    """
+
+    name: str
+    server: GatewayServerInfo
+    tool_name: str
+    description: str
+    input_schema: dict[str, Any]
+    approval_state: str
+
+
+@dataclass(frozen=True)
+class GatewayCallResult:
+    """Result of a gateway tool call, mirroring the MCP ``CallToolResult``."""
+
+    content: list[Any]
+    is_error: bool
+    server_slug: str
+    tool_name: str
+    duration_ms: int
+    structured_content: dict[str, Any] | None = None
+
+
+class GatewayError(Exception):
+    """Base class for gateway dispatch failures."""
+
+
+class GatewayToolNotFoundError(GatewayError):
+    """The namespaced tool doesn't resolve to a live tool on a connected server."""
+
+
+class GatewayToolNeedsApprovalError(GatewayError):
+    """The tool exists but requires user approval before it can be called."""
+
+    def __init__(self, message: str, *, approval_url: str) -> None:
+        super().__init__(message)
+        self.approval_url = approval_url
+
+
+class GatewayToolBlockedError(GatewayError):
+    """The tool has been marked "do not use" by the user."""
+
+
+class GatewayUpstreamError(GatewayError):
+    """The upstream MCP server couldn't be called (auth, network, or protocol failure)."""
+
+    def __init__(self, message: str, *, error_type: str = "upstream_error") -> None:
+        super().__init__(message)
+        self.error_type = error_type

--- a/products/mcp_store/backend/facade/contracts.py
+++ b/products/mcp_store/backend/facade/contracts.py
@@ -6,7 +6,6 @@ exposes to the rest of the codebase. No Django imports.
 """
 
 from dataclasses import dataclass
-from typing import Any
 
 
 @dataclass(frozen=True)
@@ -17,69 +16,3 @@ class ActiveInstallationInfo:
     name: str
     proxy_path: str
     scope: str = "personal"
-
-
-@dataclass(frozen=True)
-class GatewayServerInfo:
-    """The connected MCP server a gateway tool belongs to."""
-
-    slug: str
-    display_name: str
-    installation_id: str
-    scope: str
-
-
-@dataclass(frozen=True)
-class GatewayToolInfo:
-    """A tool exposed through the aggregated MCP gateway.
-
-    ``name`` is namespaced as ``{server_slug}/{tool_name}`` — the ``/`` keeps
-    connected-server tools distinct from PostHog's own kebab-case tools.
-    """
-
-    name: str
-    server: GatewayServerInfo
-    tool_name: str
-    description: str
-    input_schema: dict[str, Any]
-    approval_state: str
-
-
-@dataclass(frozen=True)
-class GatewayCallResult:
-    """Result of a gateway tool call, mirroring the MCP ``CallToolResult``."""
-
-    content: list[Any]
-    is_error: bool
-    server_slug: str
-    tool_name: str
-    duration_ms: int
-    structured_content: dict[str, Any] | None = None
-
-
-class GatewayError(Exception):
-    """Base class for gateway dispatch failures."""
-
-
-class GatewayToolNotFoundError(GatewayError):
-    """The namespaced tool doesn't resolve to a live tool on a connected server."""
-
-
-class GatewayToolNeedsApprovalError(GatewayError):
-    """The tool exists but requires user approval before it can be called."""
-
-    def __init__(self, message: str, *, approval_url: str) -> None:
-        super().__init__(message)
-        self.approval_url = approval_url
-
-
-class GatewayToolBlockedError(GatewayError):
-    """The tool has been marked "do not use" by the user."""
-
-
-class GatewayUpstreamError(GatewayError):
-    """The upstream MCP server couldn't be called (auth, network, or protocol failure)."""
-
-    def __init__(self, message: str, *, error_type: str = "upstream_error") -> None:
-        super().__init__(message)
-        self.error_type = error_type

--- a/products/mcp_store/backend/facade/tasks.py
+++ b/products/mcp_store/backend/facade/tasks.py
@@ -1,0 +1,9 @@
+"""
+Celery-task wiring for mcp_store.
+
+Re-exports the beat-scheduled maintenance task that core's scheduler registers.
+"""
+
+from products.mcp_store.backend.tasks.tasks import maintain_shared_installations
+
+__all__ = ["maintain_shared_installations"]

--- a/products/mcp_store/backend/gateway.py
+++ b/products/mcp_store/backend/gateway.py
@@ -10,13 +10,14 @@ computed on the fly from the installation display name; collisions within the
 resolved set get deterministic ``-2``/``-3`` suffixes ordered by ``created_at``
 then id.
 
-Dispatch (shared by the JSON-RPC endpoint, the REST endpoint, and the facade):
-resolve → enforce approval → refresh token (single-flight) → SSRF check →
-upstream ``tools/call`` → analytics → result. Only metadata is ever logged or
-captured — never tool arguments, results, or credentials.
+Dispatch (the REST ``call/`` endpoint): resolve → enforce approval →
+refresh token (single-flight) → SSRF check → upstream ``tools/call`` →
+analytics → result. Only metadata is ever logged or captured — never tool
+arguments, results, or credentials.
 """
 
 import time
+from dataclasses import dataclass
 from typing import Any
 
 from django.conf import settings
@@ -28,19 +29,76 @@ from posthog.models import Team, User
 
 from .analytics import base_server_slug, installation_display_name, report_mcp_tool_call
 from .client import UpstreamToolCallError, call_upstream_tool
-from .facade.contracts import (
-    GatewayCallResult,
-    GatewayServerInfo,
-    GatewayToolBlockedError,
-    GatewayToolInfo,
-    GatewayToolNeedsApprovalError,
-    GatewayToolNotFoundError,
-    GatewayUpstreamError,
-)
 from .models import MCPServerInstallation, MCPServerInstallationTool
 from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token_single_flight
 
 logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class GatewayServerInfo:
+    """The connected MCP server a gateway tool belongs to."""
+
+    slug: str
+    display_name: str
+    installation_id: str
+    scope: str
+
+
+@dataclass(frozen=True)
+class GatewayToolInfo:
+    """A tool exposed through the aggregated MCP gateway.
+
+    ``name`` is namespaced as ``{server_slug}/{tool_name}`` — the ``/`` keeps
+    connected-server tools distinct from PostHog's own kebab-case tools.
+    """
+
+    name: str
+    server: GatewayServerInfo
+    tool_name: str
+    description: str
+    input_schema: dict[str, Any]
+    approval_state: str
+
+
+@dataclass(frozen=True)
+class GatewayCallResult:
+    """Result of a gateway tool call, mirroring the MCP ``CallToolResult``."""
+
+    content: list[Any]
+    is_error: bool
+    server_slug: str
+    tool_name: str
+    duration_ms: int
+    structured_content: dict[str, Any] | None = None
+
+
+class GatewayError(Exception):
+    """Base class for gateway dispatch failures."""
+
+
+class GatewayToolNotFoundError(GatewayError):
+    """The namespaced tool doesn't resolve to a live tool on a connected server."""
+
+
+class GatewayToolNeedsApprovalError(GatewayError):
+    """The tool exists but requires user approval before it can be called."""
+
+    def __init__(self, message: str, *, approval_url: str) -> None:
+        super().__init__(message)
+        self.approval_url = approval_url
+
+
+class GatewayToolBlockedError(GatewayError):
+    """The tool has been marked "do not use" by the user."""
+
+
+class GatewayUpstreamError(GatewayError):
+    """The upstream MCP server couldn't be called (auth, network, or protocol failure)."""
+
+    def __init__(self, message: str, *, error_type: str = "upstream_error") -> None:
+        super().__init__(message)
+        self.error_type = error_type
 
 
 def is_credential_ready(installation: MCPServerInstallation) -> bool:
@@ -222,11 +280,11 @@ def call_gateway_tool(
     arguments: dict[str, Any],
     consumer: str | None = None,
 ) -> GatewayCallResult:
-    """Shared dispatch path for the JSON-RPC endpoint, the REST endpoint, and the facade.
+    """Dispatch path for the REST ``call/`` endpoint.
 
     Raises ``GatewayToolNotFoundError`` / ``GatewayToolNeedsApprovalError`` /
-    ``GatewayToolBlockedError`` / ``GatewayUpstreamError`` (see facade contracts);
-    callers map these to their transport's error shape.
+    ``GatewayToolBlockedError`` / ``GatewayUpstreamError``; callers map these
+    to their transport's error shape.
     """
     installation, server_slug, tool_row = _resolve_tool_for_call(team.id, user.id, tool)
 

--- a/products/mcp_store/backend/gateway.py
+++ b/products/mcp_store/backend/gateway.py
@@ -1,0 +1,280 @@
+"""Aggregated MCP gateway: one team-scoped access point over all connected servers.
+
+Resolution: a caller sees the team's shared installations plus their own
+personal ones (enabled and credential-ready only); when both exist for the
+same URL the personal one wins, so the user acts as themselves rather than
+through the shared credential.
+
+Namespacing: tools are exposed as ``{server_slug}/{tool_name}``. Slugs are
+computed on the fly from the installation display name; collisions within the
+resolved set get deterministic ``-2``/``-3`` suffixes ordered by ``created_at``
+then id.
+
+Dispatch (shared by the JSON-RPC endpoint, the REST endpoint, and the facade):
+resolve → enforce approval → refresh token (single-flight) → SSRF check →
+upstream ``tools/call`` → analytics → result. Only metadata is ever logged or
+captured — never tool arguments, results, or credentials.
+"""
+
+import time
+from typing import Any
+
+from django.conf import settings
+from django.db.models import Q
+
+import structlog
+
+from posthog.models import Team, User
+
+from .analytics import base_server_slug, installation_display_name, report_mcp_tool_call
+from .client import UpstreamToolCallError, call_upstream_tool
+from .facade.contracts import (
+    GatewayCallResult,
+    GatewayServerInfo,
+    GatewayToolBlockedError,
+    GatewayToolInfo,
+    GatewayToolNeedsApprovalError,
+    GatewayToolNotFoundError,
+    GatewayUpstreamError,
+)
+from .models import MCPServerInstallation, MCPServerInstallationTool
+from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token_single_flight
+
+logger = structlog.get_logger(__name__)
+
+
+def is_credential_ready(installation: MCPServerInstallation) -> bool:
+    """True when the installation can authenticate upstream without user action."""
+    if installation.auth_type != "oauth":
+        return True
+    sensitive = installation.sensitive_configuration or {}
+    if sensitive.get("needs_reauth"):
+        return False
+    if not sensitive.get("access_token"):
+        return False
+    return True
+
+
+def resolve_active_installations(
+    team_id: int,
+    *,
+    user_id: int | None = None,
+    include_personal: bool = False,
+) -> list[MCPServerInstallation]:
+    """Resolve the installation set for a caller.
+
+    Shared (team-wide) installations, optionally united with the user's
+    personal ones. Disabled and credential-pending installations are dropped;
+    a ready personal installation shadows a shared one for the same URL.
+    """
+    scope_filter = Q(scope="shared")
+    if include_personal and user_id is not None:
+        scope_filter = scope_filter | Q(scope="personal", user_id=user_id)
+
+    installations = list(
+        MCPServerInstallation.objects.filter(team_id=team_id, is_enabled=True)
+        .filter(scope_filter)
+        .select_related("template")
+    )
+
+    ready = [installation for installation in installations if is_credential_ready(installation)]
+    if include_personal and user_id is not None:
+        personal_urls = {installation.url for installation in ready if installation.scope == "personal"}
+        ready = [
+            installation
+            for installation in ready
+            if installation.scope == "personal" or installation.url not in personal_urls
+        ]
+    return ready
+
+
+def compute_server_slugs(
+    installations: list[MCPServerInstallation],
+) -> list[tuple[MCPServerInstallation, str]]:
+    """Assign a unique slug to every installation in a resolved set.
+
+    Deterministic: installations are ordered by ``created_at`` then id, the
+    first taker keeps the bare slug, later collisions get ``-2``, ``-3``, …
+    """
+    ordered = sorted(installations, key=lambda installation: (installation.created_at, str(installation.id)))
+    used: set[str] = set()
+    result: list[tuple[MCPServerInstallation, str]] = []
+    for installation in ordered:
+        base = base_server_slug(installation)
+        slug = base
+        suffix = 1
+        while slug in used:
+            suffix += 1
+            slug = f"{base}-{suffix}"
+        used.add(slug)
+        result.append((installation, slug))
+    return result
+
+
+def _tool_info(tool: MCPServerInstallationTool, installation: MCPServerInstallation, slug: str) -> GatewayToolInfo:
+    return GatewayToolInfo(
+        name=f"{slug}/{tool.tool_name}",
+        server=GatewayServerInfo(
+            slug=slug,
+            display_name=installation_display_name(installation),
+            installation_id=str(installation.id),
+            scope=installation.scope,
+        ),
+        tool_name=tool.tool_name,
+        description=tool.description,
+        input_schema=tool.input_schema or {},
+        approval_state=tool.approval_state,
+    )
+
+
+def list_gateway_tools(
+    team_id: int,
+    user_id: int,
+    *,
+    search: str | None = None,
+    name: str | None = None,
+) -> list[GatewayToolInfo]:
+    """The merged, namespaced tool catalog for a caller (from the Postgres cache).
+
+    ``do_not_use`` tools are hidden; ``needs_approval`` tools are listed but
+    blocked at call time (matching the per-installation proxy semantics).
+    """
+    installations = resolve_active_installations(team_id, user_id=user_id, include_personal=True)
+    slugged = compute_server_slugs(installations)
+    installations_by_id = {installation.id: (installation, slug) for installation, slug in slugged}
+
+    tools = (
+        MCPServerInstallationTool.objects.filter(
+            installation_id__in=installations_by_id.keys(), removed_at__isnull=True
+        )
+        .exclude(approval_state="do_not_use")
+        .order_by("tool_name")
+    )
+
+    infos: list[GatewayToolInfo] = []
+    for tool in tools:
+        installation, slug = installations_by_id[tool.installation_id]
+        infos.append(_tool_info(tool, installation, slug))
+    infos.sort(key=lambda info: info.name)
+
+    if name is not None:
+        return [info for info in infos if info.name == name]
+
+    if search:
+        needle = search.lower()
+        name_matches: list[GatewayToolInfo] = []
+        description_matches: list[GatewayToolInfo] = []
+        for info in infos:
+            if needle in info.name.lower():
+                name_matches.append(info)
+            elif needle in info.description.lower():
+                description_matches.append(info)
+        return name_matches + description_matches
+
+    return infos
+
+
+def gateway_approval_url(team_id: int) -> str:
+    return f"{settings.SITE_URL}/project/{team_id}/settings/mcp-servers"
+
+
+def _resolve_tool_for_call(
+    team_id: int, user_id: int, tool: str
+) -> tuple[MCPServerInstallation, str, MCPServerInstallationTool]:
+    server_slug, separator, tool_name = tool.partition("/")
+    if not separator or not server_slug or not tool_name:
+        raise GatewayToolNotFoundError(f"Unknown tool '{tool}' — expected '{{server_slug}}/{{tool_name}}'")
+
+    installations = resolve_active_installations(team_id, user_id=user_id, include_personal=True)
+    installation = next(
+        (candidate for candidate, slug in compute_server_slugs(installations) if slug == server_slug), None
+    )
+    if installation is None:
+        raise GatewayToolNotFoundError(f"Unknown server '{server_slug}'")
+
+    tool_row = installation.tools.filter(tool_name=tool_name, removed_at__isnull=True).first()
+    if tool_row is None:
+        raise GatewayToolNotFoundError(f"Tool '{tool_name}' is not available on server '{server_slug}'")
+    return installation, server_slug, tool_row
+
+
+def _ensure_ready_credentials(installation: MCPServerInstallation) -> None:
+    sensitive = installation.sensitive_configuration or {}
+    if sensitive.get("needs_reauth"):
+        raise GatewayUpstreamError("Installation needs re-authentication", error_type="auth_failed")
+    if installation.auth_type == "oauth":
+        if not sensitive.get("access_token"):
+            raise GatewayUpstreamError("No credentials configured", error_type="auth_failed")
+        if is_token_expiring(sensitive):
+            try:
+                refresh_installation_token_single_flight(installation)
+            except TokenRefreshError as exc:
+                raise GatewayUpstreamError("Authentication failed", error_type="auth_failed") from exc
+    elif installation.auth_type == "api_key" and not sensitive.get("api_key"):
+        raise GatewayUpstreamError("No credentials configured", error_type="auth_failed")
+
+
+def call_gateway_tool(
+    *,
+    team: Team,
+    user: User,
+    tool: str,
+    arguments: dict[str, Any],
+    consumer: str | None = None,
+) -> GatewayCallResult:
+    """Shared dispatch path for the JSON-RPC endpoint, the REST endpoint, and the facade.
+
+    Raises ``GatewayToolNotFoundError`` / ``GatewayToolNeedsApprovalError`` /
+    ``GatewayToolBlockedError`` / ``GatewayUpstreamError`` (see facade contracts);
+    callers map these to their transport's error shape.
+    """
+    installation, server_slug, tool_row = _resolve_tool_for_call(team.id, user.id, tool)
+
+    started_at = time.monotonic()
+    is_error = True
+    error_type: str | None = "unknown"
+    try:
+        if tool_row.approval_state == "needs_approval":
+            error_type = "needs_approval"
+            raise GatewayToolNeedsApprovalError(
+                f"Tool '{tool}' requires approval before it can be called",
+                approval_url=gateway_approval_url(team.id),
+            )
+        if tool_row.approval_state == "do_not_use":
+            error_type = "blocked"
+            raise GatewayToolBlockedError(f"Tool '{tool}' has been disabled by the user")
+
+        try:
+            _ensure_ready_credentials(installation)
+            result = call_upstream_tool(installation, tool_row.tool_name, arguments)
+        except GatewayUpstreamError as exc:
+            error_type = exc.error_type
+            raise
+        except UpstreamToolCallError as exc:
+            error_type = exc.error_type
+            raise GatewayUpstreamError(str(exc), error_type=exc.error_type) from exc
+
+        is_error = bool(result.get("isError", False))
+        error_type = "tool_error" if is_error else None
+        structured_content = result.get("structuredContent")
+        return GatewayCallResult(
+            content=result.get("content") or [],
+            is_error=is_error,
+            server_slug=server_slug,
+            tool_name=tool_row.tool_name,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            structured_content=structured_content if isinstance(structured_content, dict) else None,
+        )
+    finally:
+        report_mcp_tool_call(
+            user,
+            team,
+            tool_name=tool,
+            source="gateway",
+            server_slug=server_slug,
+            installation=installation,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            is_error=is_error,
+            error_type=error_type,
+            consumer=consumer,
+        )

--- a/products/mcp_store/backend/oauth.py
+++ b/products/mcp_store/backend/oauth.py
@@ -3,12 +3,15 @@ import base64
 import hashlib
 import secrets
 from collections.abc import Callable
+from contextlib import suppress
 from urllib.parse import urlparse
 
 import requests
 import structlog
 import tldextract
+from redis.exceptions import LockError
 
+from posthog.redis import get_client
 from posthog.security.url_validation import is_url_allowed
 
 from .models import MCPServerInstallation
@@ -545,6 +548,46 @@ def refresh_installation_token(installation: MCPServerInstallation) -> dict:
 
     logger.info("OAuth token refreshed successfully", installation_id=str(installation.id))
     return updated
+
+
+# Refresh should finish in well under TIMEOUT (10s); the TTL only bounds a crashed holder.
+TOKEN_REFRESH_LOCK_TTL_SECONDS = 30
+TOKEN_REFRESH_LOCK_WAIT_SECONDS = 15
+
+
+def _token_refresh_lock_key(installation_id: str) -> str:
+    return f"mcp_store:token_refresh:{installation_id}"
+
+
+def refresh_installation_token_single_flight(installation: MCPServerInstallation) -> dict:
+    """Refresh with a per-installation Redis lock so concurrent callers mint once.
+
+    Providers commonly rotate the refresh token on use, so parallel refreshes
+    would revoke each other's tokens. Waiters re-read the row after the holder
+    finishes; if it's fresh they skip the mint entirely.
+    """
+    lock = get_client().lock(
+        _token_refresh_lock_key(str(installation.id)),
+        timeout=TOKEN_REFRESH_LOCK_TTL_SECONDS,
+        blocking_timeout=TOKEN_REFRESH_LOCK_WAIT_SECONDS,
+    )
+    if not lock.acquire():
+        # Waited out the budget — trust the holder's result if it landed.
+        installation.refresh_from_db(fields=["sensitive_configuration"])
+        if is_token_expiring(installation.sensitive_configuration or {}):
+            raise TokenRefreshError("Timed out waiting for a concurrent token refresh")
+        return installation.sensitive_configuration
+
+    try:
+        # Another holder may have refreshed while we waited for the lock.
+        installation.refresh_from_db(fields=["sensitive_configuration"])
+        if not is_token_expiring(installation.sensitive_configuration or {}):
+            return installation.sensitive_configuration
+        return refresh_installation_token(installation)
+    finally:
+        # The lock may have expired mid-refresh; releasing someone else's lock raises.
+        with suppress(LockError):
+            lock.release()
 
 
 def exchange_oauth_token(

--- a/products/mcp_store/backend/presentation/gateway_views.py
+++ b/products/mcp_store/backend/presentation/gateway_views.py
@@ -1,0 +1,356 @@
+"""Aggregated MCP gateway endpoints.
+
+One team-scoped access point over every connected MCP server installation:
+
+- ``POST .../mcp_gateway/mcp/`` — stateless JSON-RPC (MCP streamable HTTP) for
+  external agents: initialize, notifications/initialized, ping, tools/list,
+  tools/call.
+- ``GET .../mcp_gateway/tools/`` — REST tool catalog (search / exact name /
+  pagination) for the Hono MCP front door and internal consumers.
+- ``POST .../mcp_gateway/call/`` — REST tool execution with typed error mapping.
+"""
+
+import json
+import uuid
+from typing import Any, cast
+
+from django.http import HttpResponse
+
+import structlog
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_field
+from rest_framework import serializers, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.mixins import ValidatedRequest, validated_request
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models import User
+from posthog.rate_limit import MCPProxyBurstThrottle, MCPProxySustainedThrottle
+
+from ..analytics import MCP_CONSUMER_HEADER
+from ..facade.contracts import (
+    GatewayToolBlockedError,
+    GatewayToolNeedsApprovalError,
+    GatewayToolNotFoundError,
+    GatewayUpstreamError,
+)
+from ..gateway import call_gateway_tool, list_gateway_tools
+from ..models import APPROVAL_STATES, SCOPE_CHOICES
+from ..proxy import BATCH_REJECTED_CODE, METHOD_NOT_FOUND_CODE, TOOL_DISABLED_CODE, TOOL_NEEDS_APPROVAL_CODE
+from ..tools import _PROTOCOL_VERSION
+from .views import MCPProxyRenderer
+
+logger = structlog.get_logger(__name__)
+
+# JSON-RPC implementation-defined server error, used for upstream failures.
+SERVER_ERROR_CODE = -32000
+
+_SERVER_INFO = {"name": "posthog-mcp-gateway", "version": "1.0"}
+
+
+@extend_schema_field(OpenApiTypes.OBJECT)
+class JSONObjectField(serializers.JSONField):
+    """A JSON object with server-defined structure (typed as a generic object downstream)."""
+
+
+class GatewayServerSerializer(serializers.Serializer):
+    slug = serializers.CharField(help_text="URL-safe server identifier, unique within the caller's resolved set.")
+    display_name = serializers.CharField(help_text="Human-readable server name.")
+    installation_id = serializers.CharField(help_text="UUID of the MCP server installation backing this server.")
+    scope = serializers.ChoiceField(
+        choices=SCOPE_CHOICES, help_text="'personal' is the caller's own installation; 'shared' is team-wide."
+    )
+
+
+class GatewayToolSerializer(serializers.Serializer):
+    name = serializers.CharField(help_text="Namespaced tool name: {server_slug}/{tool_name}.")
+    server = GatewayServerSerializer(help_text="The connected server this tool belongs to.")
+    tool_name = serializers.CharField(help_text="The tool's name on the upstream server (not namespaced).")
+    description = serializers.CharField(allow_blank=True, help_text="Tool description from the upstream server.")
+    input_schema = JSONObjectField(help_text="JSON Schema describing the tool's arguments.")
+    approval_state = serializers.ChoiceField(
+        choices=APPROVAL_STATES,
+        help_text="Per-tool approval state. 'needs_approval' tools are listed but blocked at call time.",
+    )
+
+
+class GatewayToolsQuerySerializer(serializers.Serializer):
+    search = serializers.CharField(
+        required=False, help_text="Substring search over tool name and description; name matches rank first."
+    )
+    name = serializers.CharField(required=False, help_text="Exact namespaced tool name ({server_slug}/{tool_name}).")
+    limit = serializers.IntegerField(
+        required=False, default=100, min_value=1, max_value=500, help_text="Maximum number of tools to return."
+    )
+    offset = serializers.IntegerField(
+        required=False, default=0, min_value=0, help_text="Number of tools to skip (for pagination)."
+    )
+
+
+class GatewayToolsResponseSerializer(serializers.Serializer):
+    results = GatewayToolSerializer(many=True, help_text="The page of matching tools.")
+    count = serializers.IntegerField(help_text="Total number of matching tools before pagination.")
+
+
+class GatewayCallRequestSerializer(serializers.Serializer):
+    tool = serializers.CharField(help_text="Namespaced tool name to execute: {server_slug}/{tool_name}.")
+    arguments = serializers.DictField(
+        child=serializers.JSONField(),
+        required=False,
+        default=dict,
+        help_text="Arguments passed to the tool, matching its input_schema.",
+    )
+    consumer = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="Optional consumer identifier for analytics attribution (e.g. 'tasks', 'max').",
+    )
+
+
+class GatewayCallResponseSerializer(serializers.Serializer):
+    content = serializers.ListField(
+        child=JSONObjectField(), help_text="MCP CallToolResult content blocks (e.g. {type: 'text', text: ...})."
+    )
+    is_error = serializers.BooleanField(help_text="True when the tool itself reported an execution error.")
+    structured_content = JSONObjectField(
+        required=False, allow_null=True, help_text="Structured result payload, when the tool provides one."
+    )
+    server_slug = serializers.CharField(help_text="Slug of the server that executed the tool.")
+    tool_name = serializers.CharField(help_text="The tool's name on the upstream server (not namespaced).")
+    duration_ms = serializers.IntegerField(help_text="Upstream execution time in milliseconds.")
+
+
+class GatewayCallErrorSerializer(serializers.Serializer):
+    code = serializers.ChoiceField(
+        choices=["tool_not_found", "tool_needs_approval", "tool_blocked", "upstream_error"],
+        help_text="Machine-readable error code.",
+    )
+    detail = serializers.CharField(help_text="Human-readable error description.")
+    approval_url = serializers.CharField(
+        required=False, help_text="Settings URL where the tool can be approved (tool_needs_approval only)."
+    )
+    error_type = serializers.CharField(
+        required=False,
+        help_text="Upstream failure category (upstream_error only): e.g. unreachable, timeout, auth_failed.",
+    )
+
+
+def _jsonrpc_error_dict(request_id: Any, code: int, message: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": request_id, "error": error}
+
+
+def _json_response(payload: dict[str, Any] | list[Any], http_status: int = 200) -> HttpResponse:
+    return HttpResponse(json.dumps(payload), content_type="application/json", status=http_status)
+
+
+def _jsonrpc_result_response(request_id: Any, result: dict[str, Any]) -> HttpResponse:
+    return _json_response({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def _jsonrpc_error_response(
+    request_id: Any, code: int, message: str, data: dict[str, Any] | None = None
+) -> HttpResponse:
+    return _json_response(_jsonrpc_error_dict(request_id, code, message, data))
+
+
+class MCPGatewayViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """Aggregated MCP gateway over all of a team's connected MCP server installations.
+
+    Resolution is per caller: shared installations plus the caller's personal
+    ones, with a personal installation shadowing a shared one for the same URL.
+    Tool names are namespaced as ``{server_slug}/{tool_name}``.
+    """
+
+    scope_object = "project"
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        summary="Aggregated MCP endpoint",
+        description=(
+            "Stateless JSON-RPC (MCP streamable HTTP) over the caller's connected MCP servers. "
+            "Supports initialize, notifications/initialized, ping, tools/list, and tools/call "
+            "with {server_slug}/{tool_name} tool names. Batch requests are rejected."
+        ),
+        request=OpenApiTypes.OBJECT,
+        responses={200: OpenApiTypes.OBJECT},
+    )
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="mcp",
+        throttle_classes=[MCPProxyBurstThrottle, MCPProxySustainedThrottle],
+        required_scopes=["project:read"],
+        renderer_classes=[MCPProxyRenderer],
+    )
+    def mcp(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        data = request.data
+        if isinstance(data, list):
+            return _json_response(
+                [
+                    _jsonrpc_error_dict(
+                        (item.get("id") if isinstance(item, dict) else None),
+                        BATCH_REJECTED_CODE,
+                        "Batch requests are not supported by the MCP gateway; send items individually",
+                    )
+                    for item in data
+                ]
+            )
+        if not isinstance(data, dict):
+            return HttpResponse(
+                '{"error": "Request body must be valid JSON"}',
+                content_type="application/json",
+                status=400,
+            )
+
+        method = data.get("method")
+        rpc_id = data.get("id")
+
+        if method == "initialize":
+            params = data.get("params")
+            requested_version = params.get("protocolVersion") if isinstance(params, dict) else None
+            protocol_version = (
+                requested_version if isinstance(requested_version, str) and requested_version else _PROTOCOL_VERSION
+            )
+            response = _jsonrpc_result_response(
+                rpc_id,
+                {
+                    "protocolVersion": protocol_version,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": _SERVER_INFO,
+                },
+            )
+            # The gateway is stateless; mint an id for clients that require one
+            # and accept any value on subsequent requests.
+            response["Mcp-Session-Id"] = uuid.uuid4().hex
+            return response
+
+        if method == "notifications/initialized":
+            return HttpResponse(status=202)
+
+        if method == "ping":
+            return _jsonrpc_result_response(rpc_id, {})
+
+        if method == "tools/list":
+            infos = list_gateway_tools(self.team_id, cast(User, request.user).id)
+            return _jsonrpc_result_response(
+                rpc_id,
+                {
+                    "tools": [
+                        {"name": info.name, "description": info.description, "inputSchema": info.input_schema}
+                        for info in infos
+                    ]
+                },
+            )
+
+        if method == "tools/call":
+            return self._handle_tools_call(request, data)
+
+        return _jsonrpc_error_response(rpc_id, METHOD_NOT_FOUND_CODE, f"Method '{method}' not found")
+
+    def _handle_tools_call(self, request: Request, data: dict[str, Any]) -> HttpResponse:
+        rpc_id = data.get("id")
+        params = data.get("params")
+        tool_name = params.get("name") if isinstance(params, dict) else None
+        if not tool_name or not isinstance(tool_name, str):
+            return _jsonrpc_error_response(rpc_id, METHOD_NOT_FOUND_CODE, "tools/call missing 'name' parameter")
+
+        raw_arguments = params.get("arguments") if isinstance(params, dict) else None
+        arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
+
+        try:
+            result = call_gateway_tool(
+                team=self.team,
+                user=cast(User, request.user),
+                tool=tool_name,
+                arguments=arguments,
+                consumer=request.headers.get(MCP_CONSUMER_HEADER),
+            )
+        except GatewayToolNotFoundError as exc:
+            return _jsonrpc_error_response(rpc_id, METHOD_NOT_FOUND_CODE, str(exc))
+        except GatewayToolNeedsApprovalError as exc:
+            return _jsonrpc_error_response(
+                rpc_id, TOOL_NEEDS_APPROVAL_CODE, str(exc), data={"approval_url": exc.approval_url}
+            )
+        except GatewayToolBlockedError as exc:
+            return _jsonrpc_error_response(rpc_id, TOOL_DISABLED_CODE, str(exc))
+        except GatewayUpstreamError as exc:
+            return _jsonrpc_error_response(rpc_id, SERVER_ERROR_CODE, str(exc), data={"error_type": exc.error_type})
+
+        payload: dict[str, Any] = {"content": result.content, "isError": result.is_error}
+        if result.structured_content is not None:
+            payload["structuredContent"] = result.structured_content
+        return _jsonrpc_result_response(rpc_id, payload)
+
+    @validated_request(
+        query_serializer=GatewayToolsQuerySerializer,
+        responses={200: OpenApiResponse(response=GatewayToolsResponseSerializer)},
+        summary="List gateway tools",
+        description="The merged, namespaced tool catalog across the caller's connected MCP servers.",
+    )
+    @action(detail=False, methods=["get"], url_path="tools", required_scopes=["project:read"])
+    def tools(self, request: ValidatedRequest, *args: Any, **kwargs: Any) -> Response:
+        query = request.validated_query_data
+        infos = list_gateway_tools(
+            self.team_id,
+            cast(User, request.user).id,
+            search=query.get("search"),
+            name=query.get("name"),
+        )
+        offset = query.get("offset", 0)
+        limit = query.get("limit", 100)
+        page = infos[offset : offset + limit]
+        return Response({"results": GatewayToolSerializer(page, many=True).data, "count": len(infos)})
+
+    @validated_request(
+        GatewayCallRequestSerializer,
+        responses={
+            200: OpenApiResponse(response=GatewayCallResponseSerializer),
+            403: OpenApiResponse(response=GatewayCallErrorSerializer),
+            404: OpenApiResponse(response=GatewayCallErrorSerializer),
+            502: OpenApiResponse(response=GatewayCallErrorSerializer),
+        },
+        summary="Call a gateway tool",
+        description="Execute a namespaced tool ({server_slug}/{tool_name}) on the connected server that owns it.",
+    )
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="call",
+        throttle_classes=[MCPProxyBurstThrottle, MCPProxySustainedThrottle],
+        required_scopes=["project:read"],
+    )
+    def call(self, request: ValidatedRequest, *args: Any, **kwargs: Any) -> Response:
+        data = request.validated_data
+        consumer = data.get("consumer") or request.headers.get(MCP_CONSUMER_HEADER) or None
+
+        try:
+            result = call_gateway_tool(
+                team=self.team,
+                user=cast(User, request.user),
+                tool=data["tool"],
+                arguments=data.get("arguments") or {},
+                consumer=consumer,
+            )
+        except GatewayToolNotFoundError as exc:
+            return Response({"code": "tool_not_found", "detail": str(exc)}, status=status.HTTP_404_NOT_FOUND)
+        except GatewayToolNeedsApprovalError as exc:
+            return Response(
+                {"code": "tool_needs_approval", "detail": str(exc), "approval_url": exc.approval_url},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        except GatewayToolBlockedError as exc:
+            return Response({"code": "tool_blocked", "detail": str(exc)}, status=status.HTTP_403_FORBIDDEN)
+        except GatewayUpstreamError as exc:
+            return Response(
+                {"code": "upstream_error", "detail": str(exc), "error_type": exc.error_type},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(GatewayCallResponseSerializer(result).data)

--- a/products/mcp_store/backend/presentation/gateway_views.py
+++ b/products/mcp_store/backend/presentation/gateway_views.py
@@ -1,28 +1,20 @@
 """Aggregated MCP gateway endpoints.
 
-One team-scoped access point over every connected MCP server installation:
+One team-scoped access point over every connected MCP server installation,
+consumed by the PostHog MCP (``services/mcp``):
 
-- ``POST .../mcp_gateway/mcp/`` — stateless JSON-RPC (MCP streamable HTTP) for
-  external agents: initialize, notifications/initialized, ping, tools/list,
-  tools/call.
 - ``GET .../mcp_gateway/tools/`` — REST tool catalog (search / exact name /
-  pagination) for the Hono MCP front door and internal consumers.
+  pagination).
 - ``POST .../mcp_gateway/call/`` — REST tool execution with typed error mapping.
 """
 
-import json
-import uuid
 from typing import Any, cast
 
-from django.http import HttpResponse
-
-import structlog
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_field
+from drf_spectacular.utils import OpenApiResponse, extend_schema_field
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.mixins import ValidatedRequest, validated_request
@@ -31,24 +23,15 @@ from posthog.models import User
 from posthog.rate_limit import MCPProxyBurstThrottle, MCPProxySustainedThrottle
 
 from ..analytics import MCP_CONSUMER_HEADER
-from ..facade.contracts import (
+from ..gateway import (
     GatewayToolBlockedError,
     GatewayToolNeedsApprovalError,
     GatewayToolNotFoundError,
     GatewayUpstreamError,
+    call_gateway_tool,
+    list_gateway_tools,
 )
-from ..gateway import call_gateway_tool, list_gateway_tools
 from ..models import APPROVAL_STATES, SCOPE_CHOICES
-from ..proxy import BATCH_REJECTED_CODE, METHOD_NOT_FOUND_CODE, TOOL_DISABLED_CODE, TOOL_NEEDS_APPROVAL_CODE
-from ..tools import _PROTOCOL_VERSION
-from .views import MCPProxyRenderer
-
-logger = structlog.get_logger(__name__)
-
-# JSON-RPC implementation-defined server error, used for upstream failures.
-SERVER_ERROR_CODE = -32000
-
-_SERVER_INFO = {"name": "posthog-mcp-gateway", "version": "1.0"}
 
 
 @extend_schema_field(OpenApiTypes.OBJECT)
@@ -139,27 +122,6 @@ class GatewayCallErrorSerializer(serializers.Serializer):
     )
 
 
-def _jsonrpc_error_dict(request_id: Any, code: int, message: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
-    error: dict[str, Any] = {"code": code, "message": message}
-    if data is not None:
-        error["data"] = data
-    return {"jsonrpc": "2.0", "id": request_id, "error": error}
-
-
-def _json_response(payload: dict[str, Any] | list[Any], http_status: int = 200) -> HttpResponse:
-    return HttpResponse(json.dumps(payload), content_type="application/json", status=http_status)
-
-
-def _jsonrpc_result_response(request_id: Any, result: dict[str, Any]) -> HttpResponse:
-    return _json_response({"jsonrpc": "2.0", "id": request_id, "result": result})
-
-
-def _jsonrpc_error_response(
-    request_id: Any, code: int, message: str, data: dict[str, Any] | None = None
-) -> HttpResponse:
-    return _json_response(_jsonrpc_error_dict(request_id, code, message, data))
-
-
 class MCPGatewayViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """Aggregated MCP gateway over all of a team's connected MCP server installations.
 
@@ -170,123 +132,6 @@ class MCPGatewayViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     scope_object = "project"
     permission_classes = [IsAuthenticated]
-
-    @extend_schema(
-        summary="Aggregated MCP endpoint",
-        description=(
-            "Stateless JSON-RPC (MCP streamable HTTP) over the caller's connected MCP servers. "
-            "Supports initialize, notifications/initialized, ping, tools/list, and tools/call "
-            "with {server_slug}/{tool_name} tool names. Batch requests are rejected."
-        ),
-        request=OpenApiTypes.OBJECT,
-        responses={200: OpenApiTypes.OBJECT},
-    )
-    @action(
-        detail=False,
-        methods=["post"],
-        url_path="mcp",
-        throttle_classes=[MCPProxyBurstThrottle, MCPProxySustainedThrottle],
-        required_scopes=["project:read"],
-        renderer_classes=[MCPProxyRenderer],
-    )
-    def mcp(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        data = request.data
-        if isinstance(data, list):
-            return _json_response(
-                [
-                    _jsonrpc_error_dict(
-                        (item.get("id") if isinstance(item, dict) else None),
-                        BATCH_REJECTED_CODE,
-                        "Batch requests are not supported by the MCP gateway; send items individually",
-                    )
-                    for item in data
-                ]
-            )
-        if not isinstance(data, dict):
-            return HttpResponse(
-                '{"error": "Request body must be valid JSON"}',
-                content_type="application/json",
-                status=400,
-            )
-
-        method = data.get("method")
-        rpc_id = data.get("id")
-
-        if method == "initialize":
-            params = data.get("params")
-            requested_version = params.get("protocolVersion") if isinstance(params, dict) else None
-            protocol_version = (
-                requested_version if isinstance(requested_version, str) and requested_version else _PROTOCOL_VERSION
-            )
-            response = _jsonrpc_result_response(
-                rpc_id,
-                {
-                    "protocolVersion": protocol_version,
-                    "capabilities": {"tools": {}},
-                    "serverInfo": _SERVER_INFO,
-                },
-            )
-            # The gateway is stateless; mint an id for clients that require one
-            # and accept any value on subsequent requests.
-            response["Mcp-Session-Id"] = uuid.uuid4().hex
-            return response
-
-        if method == "notifications/initialized":
-            return HttpResponse(status=202)
-
-        if method == "ping":
-            return _jsonrpc_result_response(rpc_id, {})
-
-        if method == "tools/list":
-            infos = list_gateway_tools(self.team_id, cast(User, request.user).id)
-            return _jsonrpc_result_response(
-                rpc_id,
-                {
-                    "tools": [
-                        {"name": info.name, "description": info.description, "inputSchema": info.input_schema}
-                        for info in infos
-                    ]
-                },
-            )
-
-        if method == "tools/call":
-            return self._handle_tools_call(request, data)
-
-        return _jsonrpc_error_response(rpc_id, METHOD_NOT_FOUND_CODE, f"Method '{method}' not found")
-
-    def _handle_tools_call(self, request: Request, data: dict[str, Any]) -> HttpResponse:
-        rpc_id = data.get("id")
-        params = data.get("params")
-        tool_name = params.get("name") if isinstance(params, dict) else None
-        if not tool_name or not isinstance(tool_name, str):
-            return _jsonrpc_error_response(rpc_id, METHOD_NOT_FOUND_CODE, "tools/call missing 'name' parameter")
-
-        raw_arguments = params.get("arguments") if isinstance(params, dict) else None
-        arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
-
-        try:
-            result = call_gateway_tool(
-                team=self.team,
-                user=cast(User, request.user),
-                tool=tool_name,
-                arguments=arguments,
-                consumer=request.headers.get(MCP_CONSUMER_HEADER),
-            )
-        except GatewayToolNotFoundError as exc:
-            return _jsonrpc_error_response(rpc_id, METHOD_NOT_FOUND_CODE, str(exc))
-        except GatewayToolNeedsApprovalError as exc:
-            return _jsonrpc_error_response(
-                rpc_id, TOOL_NEEDS_APPROVAL_CODE, str(exc), data={"approval_url": exc.approval_url}
-            )
-        except GatewayToolBlockedError as exc:
-            return _jsonrpc_error_response(rpc_id, TOOL_DISABLED_CODE, str(exc))
-        except GatewayUpstreamError as exc:
-            return _jsonrpc_error_response(rpc_id, SERVER_ERROR_CODE, str(exc), data={"error_type": exc.error_type})
-
-        payload: dict[str, Any] = {"content": result.content, "isError": result.is_error}
-        if result.structured_content is not None:
-            payload["structuredContent"] = result.structured_content
-        return _jsonrpc_result_response(rpc_id, payload)
 
     @validated_request(
         query_serializer=GatewayToolsQuerySerializer,

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -1,4 +1,5 @@
 import json
+import time
 from collections.abc import Iterator
 from typing import Any
 from urllib.parse import urljoin, urlparse
@@ -14,8 +15,9 @@ from posthog.settings import SERVER_GATEWAY_INTERFACE
 
 from ee.hogai.utils.asgi import SyncIterableToAsync
 
+from .analytics import MCP_CONSUMER_HEADER, base_server_slug, report_mcp_tool_call
 from .models import MCPServerInstallation, MCPServerInstallationTool
-from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token
+from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token_single_flight
 
 logger = structlog.get_logger(__name__)
 
@@ -131,7 +133,7 @@ def build_upstream_auth_headers(installation: MCPServerInstallation) -> dict[str
 def ensure_valid_token(installation: MCPServerInstallation) -> None:
     if not is_token_expiring(installation.sensitive_configuration or {}):
         return
-    refresh_installation_token(installation)
+    refresh_installation_token_single_flight(installation)
 
 
 def validate_installation_auth(
@@ -317,6 +319,47 @@ def enforce_tool_approval(
     return HttpResponse(json.dumps(blocked), content_type="application/json", status=200)
 
 
+def _tool_call_names(data: dict[str, Any] | list[Any]) -> list[str]:
+    items = data if isinstance(data, list) else [data]
+    names: list[str] = []
+    for item in items:
+        if not _is_tools_call(item):
+            continue
+        params = item.get("params")
+        name = params.get("name") if isinstance(params, dict) else None
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names
+
+
+def _report_proxy_tool_calls(
+    request: Any,
+    installation: MCPServerInstallation,
+    tool_names: list[str],
+    *,
+    duration_ms: int,
+    is_error: bool,
+    error_type: str | None = None,
+) -> None:
+    if not tool_names:
+        return
+    slug = base_server_slug(installation)
+    consumer = request.headers.get(MCP_CONSUMER_HEADER)
+    for name in tool_names:
+        report_mcp_tool_call(
+            request.user,
+            installation.team,
+            tool_name=f"{slug}/{name}",
+            source="store_proxy",
+            server_slug=slug,
+            installation=installation,
+            duration_ms=duration_ms,
+            is_error=is_error,
+            error_type=error_type,
+            consumer=consumer,
+        )
+
+
 def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> HttpResponse | StreamingHttpResponse:
     allowed, error = is_url_allowed(installation.url)
     if not allowed:
@@ -336,7 +379,12 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
             status=400,
         )
 
+    tool_names = _tool_call_names(data)
+
     if enforcement_response := enforce_tool_approval(installation, data):
+        _report_proxy_tool_calls(
+            request, installation, tool_names, duration_ms=0, is_error=True, error_type="approval_blocked"
+        )
         return enforcement_response
 
     body = json.dumps(data).encode()
@@ -372,6 +420,7 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
         headers["Mcp-Session-Id"] = mcp_session_id
 
     client = httpx.Client(timeout=UPSTREAM_TIMEOUT)
+    started_at = time.monotonic()
     try:
         upstream_response, upstream_url = send_mcp_request_with_same_origin_redirect(
             client,
@@ -384,6 +433,14 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
     except httpx.ConnectError:
         client.close()
         logger.warning("Upstream MCP server unreachable", url=installation.url)
+        _report_proxy_tool_calls(
+            request,
+            installation,
+            tool_names,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            is_error=True,
+            error_type="unreachable",
+        )
         return HttpResponse(
             '{"error": "Upstream MCP server unreachable"}',
             content_type="application/json",
@@ -392,6 +449,14 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
     except httpx.TimeoutException:
         client.close()
         logger.warning("Upstream MCP server timed out", url=installation.url)
+        _report_proxy_tool_calls(
+            request,
+            installation,
+            tool_names,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            is_error=True,
+            error_type="timeout",
+        )
         return HttpResponse(
             '{"error": "Upstream MCP server timed out"}',
             content_type="application/json",
@@ -404,6 +469,14 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
     content_type = upstream_response.headers.get("content-type", "")
 
     if "text/event-stream" in content_type:
+        # Duration covers time-to-headers only; the stream body is still in flight.
+        _report_proxy_tool_calls(
+            request,
+            installation,
+            tool_names,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            is_error=upstream_response.status_code >= 400,
+        )
         return _build_sse_response(upstream_response, client)
 
     # Read body then close to avoid memory leaks from buffered responses
@@ -411,6 +484,15 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
         upstream_response.read()
     finally:
         client.close()
+
+    _report_proxy_tool_calls(
+        request,
+        installation,
+        tool_names,
+        duration_ms=int((time.monotonic() - started_at) * 1000),
+        is_error=upstream_response.status_code >= 400,
+        error_type="upstream_status" if upstream_response.status_code >= 400 else None,
+    )
 
     if upstream_response.status_code >= 400:
         logger.warning(

--- a/products/mcp_store/backend/routes.py
+++ b/products/mcp_store/backend/routes.py
@@ -1,6 +1,7 @@
 from posthog.api.routing import RouterRegistry
 
 import products.mcp_store.backend.presentation.views as mcp_store
+import products.mcp_store.backend.presentation.gateway_views as mcp_gateway
 
 
 def register_routes(routers: RouterRegistry) -> None:
@@ -10,5 +11,14 @@ def register_routes(routers: RouterRegistry) -> None:
         r"mcp_server_installations",
         mcp_store.MCPServerInstallationViewSet,
         "project_mcp_server_installations",
+        ["team_id"],
+    )
+    # Dual-routed to match the rest of the mcp_store surface: agent-facing
+    # consumers reach the store through /api/environments/ paths (see
+    # ActiveInstallationInfo.proxy_path), so the gateway must resolve there too.
+    routers.register_legacy_dual_route(
+        r"mcp_gateway",
+        mcp_gateway.MCPGatewayViewSet,
+        "project_mcp_gateway",
         ["team_id"],
     )

--- a/products/mcp_store/backend/tasks/__init__.py
+++ b/products/mcp_store/backend/tasks/__init__.py
@@ -1,4 +1,4 @@
 # Re-export tasks for Celery autodiscover
-from products.mcp_store.backend.tasks.tasks import sync_installation_tools_task
+from products.mcp_store.backend.tasks.tasks import maintain_shared_installations, sync_installation_tools_task
 
-__all__ = ["sync_installation_tools_task"]
+__all__ = ["maintain_shared_installations", "sync_installation_tools_task"]

--- a/products/mcp_store/backend/tasks/tasks.py
+++ b/products/mcp_store/backend/tasks/tasks.py
@@ -1,12 +1,20 @@
+from datetime import timedelta
+
+from django.db.models import Max
+from django.utils import timezone
+
 import structlog
 from celery import shared_task
 
 from posthog.scoping_audit import skip_team_scope_audit
 
 from ..models import MCPServerInstallation
+from ..oauth import TokenRefreshError, is_token_expiring, refresh_installation_token_single_flight
 from ..tools import ToolsFetchError, sync_installation_tools
 
 logger = structlog.get_logger(__name__)
+
+STALE_TOOL_SYNC_CUTOFF = timedelta(hours=24)
 
 
 @shared_task(ignore_result=True)
@@ -25,3 +33,44 @@ def sync_installation_tools_task(installation_id: str) -> None:
             installation_id=installation_id,
             error=str(exc),
         )
+
+
+@shared_task(ignore_result=True)
+@skip_team_scope_audit
+def maintain_shared_installations() -> None:
+    """Hourly upkeep for shared installations, which back gateway calls for the whole team:
+    refresh expiring OAuth tokens ahead of demand and re-sync tool catalogs stale for >24h.
+    Personal installations refresh lazily on use instead."""
+    stale_cutoff = timezone.now() - STALE_TOOL_SYNC_CUTOFF
+    installations = (
+        MCPServerInstallation.objects.filter(scope="shared", is_enabled=True)
+        .select_related("template")
+        .annotate(latest_tool_seen_at=Max("tools__last_seen_at"))
+    )
+    for installation in installations:
+        sensitive = installation.sensitive_configuration or {}
+        if (
+            installation.auth_type == "oauth"
+            and not sensitive.get("needs_reauth")
+            and sensitive.get("refresh_token")
+            and is_token_expiring(sensitive)
+        ):
+            try:
+                refresh_installation_token_single_flight(installation)
+            except TokenRefreshError as exc:
+                logger.info(
+                    "maintain_shared_installations: token refresh failed",
+                    installation_id=str(installation.id),
+                    error=str(exc),
+                )
+
+        latest_tool_seen_at = installation.latest_tool_seen_at
+        if latest_tool_seen_at is None or latest_tool_seen_at < stale_cutoff:
+            try:
+                sync_installation_tools(installation)
+            except ToolsFetchError as exc:
+                logger.info(
+                    "maintain_shared_installations: tool sync failed",
+                    installation_id=str(installation.id),
+                    error=str(exc),
+                )

--- a/products/mcp_store/backend/test/test_gateway.py
+++ b/products/mcp_store/backend/test/test_gateway.py
@@ -92,9 +92,6 @@ class GatewayTestBase(APIBaseTest):
     def _call_url(self) -> str:
         return f"/api/projects/{self.team.id}/mcp_gateway/call/"
 
-    def _mcp_url(self) -> str:
-        return f"/api/projects/{self.team.id}/mcp_gateway/mcp/"
-
 
 class TestGatewayToolsEndpoint(GatewayTestBase):
     def test_lists_namespaced_tools_with_server_metadata(self):
@@ -298,111 +295,6 @@ class TestGatewayCallEndpoint(GatewayTestBase):
         response = self.client.post(self._call_url(), data={"arguments": {}}, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-
-class TestGatewayMCPEndpoint(GatewayTestBase):
-    def _rpc(self, payload):
-        return self.client.post(self._mcp_url(), data=payload, format="json")
-
-    def test_initialize_echoes_protocol_version_and_mints_session(self):
-        response = self._rpc(
-            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26"}}
-        )
-
-        assert response.status_code == 200
-        assert response["Mcp-Session-Id"]
-        result = response.json()["result"]
-        assert result["protocolVersion"] == "2025-03-26"
-        assert result["serverInfo"]["name"] == "posthog-mcp-gateway"
-
-    def test_notifications_initialized_returns_202(self):
-        response = self._rpc({"jsonrpc": "2.0", "method": "notifications/initialized"})
-
-        assert response.status_code == 202
-
-    def test_ping_returns_empty_result(self):
-        response = self._rpc({"jsonrpc": "2.0", "id": 7, "method": "ping"})
-
-        body = response.json()
-        assert body["id"] == 7
-        assert body["result"] == {}
-
-    def test_tools_list_returns_namespaced_catalog(self):
-        installation = self._installation()
-        self._tool(installation, "create_issue", input_schema={"type": "object"})
-
-        response = self._rpc({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
-
-        tools = response.json()["result"]["tools"]
-        assert [tool["name"] for tool in tools] == ["linear/create_issue"]
-        assert tools[0]["inputSchema"] == {"type": "object"}
-
-    @patch("products.mcp_store.backend.client.httpx.Client")
-    def test_tools_call_dispatches_and_returns_call_tool_result(self, mock_client_cls):
-        installation = self._installation()
-        self._tool(installation, "create_issue")
-        self._mock_upstream_call(mock_client_cls, {"content": [{"type": "text", "text": "ok"}], "isError": False})
-
-        response = self._rpc(
-            {
-                "jsonrpc": "2.0",
-                "id": 5,
-                "method": "tools/call",
-                "params": {"name": "linear/create_issue", "arguments": {}},
-            }
-        )
-
-        body = response.json()
-        assert body["id"] == 5
-        assert body["result"] == {"content": [{"type": "text", "text": "ok"}], "isError": False}
-
-    @parameterized.expand(
-        [
-            ("needs_approval", "needs_approval", "linear/create_issue", -32001),
-            ("do_not_use", "do_not_use", "linear/create_issue", -32002),
-            ("unknown_tool", "approved", "linear/ghost", -32601),
-            ("unknown_server", "approved", "ghost/tool", -32601),
-        ]
-    )
-    @patch("products.mcp_store.backend.client.httpx.Client")
-    def test_tools_call_error_codes(self, _name, approval_state, tool, expected_code, mock_client_cls):
-        installation = self._installation()
-        self._tool(installation, "create_issue", approval_state=approval_state)
-
-        response = self._rpc({"jsonrpc": "2.0", "id": 9, "method": "tools/call", "params": {"name": tool}})
-
-        body = response.json()
-        assert body["id"] == 9
-        assert body["error"]["code"] == expected_code
-        mock_client_cls.assert_not_called()
-
-    def test_needs_approval_error_carries_approval_url(self):
-        installation = self._installation()
-        self._tool(installation, "create_issue", approval_state="needs_approval")
-
-        response = self._rpc(
-            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "linear/create_issue"}}
-        )
-
-        error = response.json()["error"]
-        assert error["data"]["approval_url"].endswith(f"/project/{self.team.id}/settings/mcp-servers")
-
-    def test_unknown_method_returns_method_not_found(self):
-        response = self._rpc({"jsonrpc": "2.0", "id": 4, "method": "resources/list"})
-
-        assert response.json()["error"]["code"] == -32601
-
-    def test_batch_requests_are_rejected(self):
-        response = self._rpc(
-            [
-                {"jsonrpc": "2.0", "id": 1, "method": "ping"},
-                {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
-            ]
-        )
-
-        body = response.json()
-        assert isinstance(body, list)
-        assert [entry["error"]["code"] for entry in body] == [-32000, -32000]
 
 
 class TestGatewayAnalytics(GatewayTestBase):

--- a/products/mcp_store/backend/test/test_gateway.py
+++ b/products/mcp_store/backend/test/test_gateway.py
@@ -1,0 +1,619 @@
+import json
+import time
+import uuid
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest, BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+import httpx
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import User
+
+from products.mcp_store.backend.models import MCPServerInstallation, MCPServerInstallationTool
+from products.mcp_store.backend.oauth import TokenRefreshError, refresh_installation_token_single_flight
+from products.mcp_store.backend.tasks.tasks import maintain_shared_installations
+
+
+def _initialize_response(session_id: str | None = "session-1") -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    headers = {"content-type": "application/json"}
+    if session_id:
+        headers["mcp-session-id"] = session_id
+    response.headers = headers
+    response.text = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2024-11-05"}})
+    return response
+
+
+def _accepted_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 202
+    response.headers = {"content-type": "application/json"}
+    response.text = ""
+    return response
+
+
+def _call_response(result: dict) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"content-type": "application/json"}
+    response.text = json.dumps({"jsonrpc": "2.0", "id": 3, "result": result})
+    return response
+
+
+class GatewayTestBase(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        for target in (
+            "products.mcp_store.backend.client.is_url_allowed",
+            "products.mcp_store.backend.tools.is_url_allowed",
+            "products.mcp_store.backend.proxy.is_url_allowed",
+        ):
+            patcher = patch(target, return_value=(True, None))
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _installation(self, **kwargs) -> MCPServerInstallation:
+        defaults = {
+            "team": self.team,
+            "user": self.user,
+            "display_name": "Linear",
+            "url": f"https://mcp-{uuid.uuid4().hex[:8]}.example.com/mcp",
+            "auth_type": "api_key",
+            "sensitive_configuration": {"api_key": "sk-test"},
+        }
+        defaults.update(kwargs)
+        return MCPServerInstallation.objects.create(**defaults)
+
+    def _tool(self, installation, name, approval_state="approved", **kwargs) -> MCPServerInstallationTool:
+        defaults = {
+            "installation": installation,
+            "tool_name": name,
+            "approval_state": approval_state,
+            "last_seen_at": timezone.now(),
+        }
+        defaults.update(kwargs)
+        return MCPServerInstallationTool.objects.create(**defaults)
+
+    def _mock_upstream_call(self, mock_client_cls, result: dict) -> MagicMock:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = [_initialize_response(), _accepted_response(), _call_response(result)]
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+        return mock_client
+
+    def _tools_url(self) -> str:
+        return f"/api/projects/{self.team.id}/mcp_gateway/tools/"
+
+    def _call_url(self) -> str:
+        return f"/api/projects/{self.team.id}/mcp_gateway/call/"
+
+    def _mcp_url(self) -> str:
+        return f"/api/projects/{self.team.id}/mcp_gateway/mcp/"
+
+
+class TestGatewayToolsEndpoint(GatewayTestBase):
+    def test_lists_namespaced_tools_with_server_metadata(self):
+        other_user = User.objects.create_and_join(self.organization, "owner@posthog.com", "password")
+        shared = self._installation(user=other_user, scope="shared", display_name="Notion")
+        personal = self._installation(display_name="Linear")
+        self._tool(shared, "search_pages", description="Search Notion pages")
+        self._tool(personal, "create_issue", approval_state="needs_approval")
+
+        response = self.client.get(self._tools_url())
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 2
+        by_name = {item["name"]: item for item in body["results"]}
+        assert set(by_name) == {"notion/search_pages", "linear/create_issue"}
+        assert by_name["notion/search_pages"]["server"] == {
+            "slug": "notion",
+            "display_name": "Notion",
+            "installation_id": str(shared.id),
+            "scope": "shared",
+        }
+        assert by_name["linear/create_issue"]["approval_state"] == "needs_approval"
+        assert by_name["linear/create_issue"]["tool_name"] == "create_issue"
+
+    def test_personal_installation_shadows_shared_for_same_url(self):
+        other_user = User.objects.create_and_join(self.organization, "owner@posthog.com", "password")
+        url = "https://mcp.linear.app/mcp"
+        shared = self._installation(user=other_user, scope="shared", url=url)
+        personal = self._installation(url=url)
+        self._tool(shared, "create_issue")
+        self._tool(personal, "create_issue")
+
+        response = self.client.get(self._tools_url())
+
+        body = response.json()
+        assert body["count"] == 1
+        assert body["results"][0]["server"]["installation_id"] == str(personal.id)
+        assert body["results"][0]["server"]["scope"] == "personal"
+
+    def test_slug_collisions_get_deterministic_suffixes(self):
+        first = self._installation(display_name="Linear")
+        second = self._installation(display_name="Linear")
+        MCPServerInstallation.objects.filter(id=first.id).update(created_at=timezone.now() - timedelta(days=1))
+        self._tool(first, "a")
+        self._tool(second, "a")
+
+        response = self.client.get(self._tools_url())
+
+        by_slug = {item["server"]["slug"]: item["server"]["installation_id"] for item in response.json()["results"]}
+        assert by_slug == {"linear": str(first.id), "linear-2": str(second.id)}
+
+    def test_excludes_hidden_tools_and_unavailable_installations(self):
+        installation = self._installation()
+        self._tool(installation, "approved_tool")
+        self._tool(installation, "pending_tool", approval_state="needs_approval")
+        self._tool(installation, "banned_tool", approval_state="do_not_use")
+        self._tool(installation, "gone_tool", removed_at=timezone.now())
+        disabled = self._installation(display_name="Disabled", is_enabled=False)
+        self._tool(disabled, "unreachable_tool")
+        stranger = User.objects.create_and_join(self.organization, "stranger@posthog.com", "password")
+        others_personal = self._installation(user=stranger, display_name="Private")
+        self._tool(others_personal, "private_tool")
+
+        response = self.client.get(self._tools_url())
+
+        names = {item["name"] for item in response.json()["results"]}
+        assert names == {"linear/approved_tool", "linear/pending_tool"}
+
+    @parameterized.expand(
+        [
+            ("search_matches_name", {"search": "create"}, ["linear/create_issue"]),
+            ("search_ranks_name_before_description", {"search": "issue"}, ["linear/create_issue", "linear/list_teams"]),
+            ("exact_name", {"name": "linear/list_teams"}, ["linear/list_teams"]),
+            ("exact_name_miss", {"name": "linear/ghost"}, []),
+        ]
+    )
+    def test_search_and_name_filters(self, _name, params, expected_names):
+        installation = self._installation()
+        self._tool(installation, "create_issue", description="Create a new issue")
+        self._tool(installation, "list_teams", description="List teams that contain issues")
+
+        response = self.client.get(self._tools_url(), params)
+
+        assert [item["name"] for item in response.json()["results"]] == expected_names
+
+    def test_pagination_slices_results_and_keeps_total_count(self):
+        installation = self._installation()
+        for index in range(3):
+            self._tool(installation, f"tool_{index}")
+
+        response = self.client.get(self._tools_url(), {"limit": 1, "offset": 1})
+
+        body = response.json()
+        assert body["count"] == 3
+        assert [item["name"] for item in body["results"]] == ["linear/tool_1"]
+
+
+class TestGatewayCallEndpoint(GatewayTestBase):
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_call_executes_approved_tool_upstream(self, mock_client_cls):
+        installation = self._installation()
+        self._tool(installation, "create_issue")
+        mock_client = self._mock_upstream_call(
+            mock_client_cls, {"content": [{"type": "text", "text": "created"}], "isError": False}
+        )
+
+        response = self.client.post(
+            self._call_url(),
+            data={"tool": "linear/create_issue", "arguments": {"title": "Bug"}},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["content"] == [{"type": "text", "text": "created"}]
+        assert body["is_error"] is False
+        assert body["server_slug"] == "linear"
+        assert body["tool_name"] == "create_issue"
+        assert isinstance(body["duration_ms"], int)
+        call_request = json.loads(mock_client.post.call_args_list[2].kwargs["content"])
+        assert call_request["method"] == "tools/call"
+        assert call_request["params"] == {"name": "create_issue", "arguments": {"title": "Bug"}}
+        assert mock_client.post.call_args_list[2].kwargs["headers"]["Authorization"] == "Bearer sk-test"
+
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_call_returns_tool_error_result_as_200(self, mock_client_cls):
+        installation = self._installation()
+        self._tool(installation, "create_issue")
+        self._mock_upstream_call(mock_client_cls, {"content": [{"type": "text", "text": "boom"}], "isError": True})
+
+        response = self.client.post(self._call_url(), data={"tool": "linear/create_issue"}, format="json")
+
+        assert response.status_code == 200
+        assert response.json()["is_error"] is True
+
+    @parameterized.expand(
+        [
+            ("needs_approval", "needs_approval", None, 403, "tool_needs_approval"),
+            ("do_not_use", "do_not_use", None, 403, "tool_blocked"),
+            ("unknown_tool", "approved", "linear/ghost", 404, "tool_not_found"),
+            ("unknown_server", "approved", "ghost/create_issue", 404, "tool_not_found"),
+            ("unnamespaced_name", "approved", "create_issue", 404, "tool_not_found"),
+            ("removed_tool", "approved", None, 404, "tool_not_found"),
+        ]
+    )
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_call_error_mapping_short_circuits_upstream(
+        self, case, approval_state, override_tool, expected_status, expected_code, mock_client_cls
+    ):
+        installation = self._installation()
+        removed_at = timezone.now() if case == "removed_tool" else None
+        self._tool(installation, "create_issue", approval_state=approval_state, removed_at=removed_at)
+
+        response = self.client.post(
+            self._call_url(),
+            data={"tool": override_tool or "linear/create_issue"},
+            format="json",
+        )
+
+        assert response.status_code == expected_status
+        body = response.json()
+        assert body["code"] == expected_code
+        if expected_code == "tool_needs_approval":
+            assert body["approval_url"].endswith(f"/project/{self.team.id}/settings/mcp-servers")
+        mock_client_cls.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("connect_error", httpx.ConnectError("refused"), "unreachable"),
+            ("timeout", httpx.TimeoutException("slow"), "timeout"),
+        ]
+    )
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_call_upstream_failures_map_to_502(self, _name, side_effect, expected_error_type, mock_client_cls):
+        installation = self._installation()
+        self._tool(installation, "create_issue")
+        mock_client = MagicMock()
+        mock_client.post.side_effect = side_effect
+        mock_client_cls.return_value.__enter__.return_value = mock_client
+
+        response = self.client.post(self._call_url(), data={"tool": "linear/create_issue"}, format="json")
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+        body = response.json()
+        assert body["code"] == "upstream_error"
+        assert body["error_type"] == expected_error_type
+
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_call_cannot_reach_another_users_personal_installation(self, mock_client_cls):
+        stranger = User.objects.create_and_join(self.organization, "stranger@posthog.com", "password")
+        installation = self._installation(user=stranger, display_name="Private")
+        self._tool(installation, "secret_tool")
+
+        response = self.client.post(self._call_url(), data={"tool": "private/secret_tool"}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_client_cls.assert_not_called()
+
+    def test_call_requires_tool_field(self):
+        response = self.client.post(self._call_url(), data={"arguments": {}}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestGatewayMCPEndpoint(GatewayTestBase):
+    def _rpc(self, payload):
+        return self.client.post(self._mcp_url(), data=payload, format="json")
+
+    def test_initialize_echoes_protocol_version_and_mints_session(self):
+        response = self._rpc(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-03-26"}}
+        )
+
+        assert response.status_code == 200
+        assert response["Mcp-Session-Id"]
+        result = response.json()["result"]
+        assert result["protocolVersion"] == "2025-03-26"
+        assert result["serverInfo"]["name"] == "posthog-mcp-gateway"
+
+    def test_notifications_initialized_returns_202(self):
+        response = self._rpc({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        assert response.status_code == 202
+
+    def test_ping_returns_empty_result(self):
+        response = self._rpc({"jsonrpc": "2.0", "id": 7, "method": "ping"})
+
+        body = response.json()
+        assert body["id"] == 7
+        assert body["result"] == {}
+
+    def test_tools_list_returns_namespaced_catalog(self):
+        installation = self._installation()
+        self._tool(installation, "create_issue", input_schema={"type": "object"})
+
+        response = self._rpc({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+
+        tools = response.json()["result"]["tools"]
+        assert [tool["name"] for tool in tools] == ["linear/create_issue"]
+        assert tools[0]["inputSchema"] == {"type": "object"}
+
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_tools_call_dispatches_and_returns_call_tool_result(self, mock_client_cls):
+        installation = self._installation()
+        self._tool(installation, "create_issue")
+        self._mock_upstream_call(mock_client_cls, {"content": [{"type": "text", "text": "ok"}], "isError": False})
+
+        response = self._rpc(
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {"name": "linear/create_issue", "arguments": {}},
+            }
+        )
+
+        body = response.json()
+        assert body["id"] == 5
+        assert body["result"] == {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+    @parameterized.expand(
+        [
+            ("needs_approval", "needs_approval", "linear/create_issue", -32001),
+            ("do_not_use", "do_not_use", "linear/create_issue", -32002),
+            ("unknown_tool", "approved", "linear/ghost", -32601),
+            ("unknown_server", "approved", "ghost/tool", -32601),
+        ]
+    )
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_tools_call_error_codes(self, _name, approval_state, tool, expected_code, mock_client_cls):
+        installation = self._installation()
+        self._tool(installation, "create_issue", approval_state=approval_state)
+
+        response = self._rpc({"jsonrpc": "2.0", "id": 9, "method": "tools/call", "params": {"name": tool}})
+
+        body = response.json()
+        assert body["id"] == 9
+        assert body["error"]["code"] == expected_code
+        mock_client_cls.assert_not_called()
+
+    def test_needs_approval_error_carries_approval_url(self):
+        installation = self._installation()
+        self._tool(installation, "create_issue", approval_state="needs_approval")
+
+        response = self._rpc(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "linear/create_issue"}}
+        )
+
+        error = response.json()["error"]
+        assert error["data"]["approval_url"].endswith(f"/project/{self.team.id}/settings/mcp-servers")
+
+    def test_unknown_method_returns_method_not_found(self):
+        response = self._rpc({"jsonrpc": "2.0", "id": 4, "method": "resources/list"})
+
+        assert response.json()["error"]["code"] == -32601
+
+    def test_batch_requests_are_rejected(self):
+        response = self._rpc(
+            [
+                {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+                {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            ]
+        )
+
+        body = response.json()
+        assert isinstance(body, list)
+        assert [entry["error"]["code"] for entry in body] == [-32000, -32000]
+
+
+class TestGatewayAnalytics(GatewayTestBase):
+    @patch("products.mcp_store.backend.analytics.report_user_action")
+    @patch("products.mcp_store.backend.client.httpx.Client")
+    def test_gateway_call_emits_metadata_only_event(self, mock_client_cls, mock_report):
+        installation = self._installation()
+        self._tool(installation, "create_issue")
+        self._mock_upstream_call(
+            mock_client_cls, {"content": [{"type": "text", "text": "top-secret-result"}], "isError": False}
+        )
+
+        response = self.client.post(
+            self._call_url(),
+            data={"tool": "linear/create_issue", "arguments": {"title": "top-secret-arg"}, "consumer": "tasks"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        mock_report.assert_called_once()
+        args, kwargs = mock_report.call_args
+        assert args[1] == "$mcp_tool_call"
+        properties = args[2]
+        assert properties["$mcp_source"] == "gateway"
+        assert properties["$mcp_tool_name"] == "linear/create_issue"
+        assert properties["$mcp_gateway_server"] == "linear"
+        assert properties["$mcp_gateway_installation_id"] == str(installation.id)
+        assert properties["$mcp_scope"] == "personal"
+        assert properties["$mcp_consumer"] == "tasks"
+        assert properties["$mcp_is_error"] is False
+        serialized = json.dumps(properties)
+        assert "top-secret-arg" not in serialized
+        assert "top-secret-result" not in serialized
+
+    @patch("products.mcp_store.backend.analytics.report_user_action")
+    def test_gateway_blocked_call_emits_error_event(self, mock_report):
+        installation = self._installation()
+        self._tool(installation, "create_issue", approval_state="needs_approval")
+
+        self.client.post(self._call_url(), data={"tool": "linear/create_issue"}, format="json")
+
+        properties = mock_report.call_args[0][2]
+        assert properties["$mcp_is_error"] is True
+        assert properties["$mcp_error_type"] == "needs_approval"
+
+    @patch("products.mcp_store.backend.analytics.report_user_action")
+    @patch("products.mcp_store.backend.proxy.httpx.Client")
+    def test_store_proxy_tools_call_emits_event(self, mock_client_cls, mock_report):
+        installation = self._installation()
+        self._tool(installation, "create_issue")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.content = b'{"jsonrpc":"2.0","id":1,"result":{}}'
+        mock_client = MagicMock()
+        mock_client.build_request.return_value = MagicMock()
+        mock_client.send.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/{installation.id}/proxy/",
+            data={"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "create_issue"}},
+            format="json",
+            headers={"x-posthog-mcp-consumer": "posthog-code"},
+        )
+
+        assert response.status_code == 200
+        tool_call_events = [call for call in mock_report.call_args_list if call.args[1] == "$mcp_tool_call"]
+        assert len(tool_call_events) == 1
+        properties = tool_call_events[0].args[2]
+        assert properties["$mcp_source"] == "store_proxy"
+        assert properties["$mcp_tool_name"] == "linear/create_issue"
+        assert properties["$mcp_consumer"] == "posthog-code"
+
+    @patch("products.mcp_store.backend.analytics.report_user_action")
+    @patch("products.mcp_store.backend.proxy.httpx.Client")
+    def test_store_proxy_non_tool_methods_do_not_emit(self, mock_client_cls, mock_report):
+        installation = self._installation()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.content = b'{"jsonrpc":"2.0","id":1,"result":{}}'
+        mock_client = MagicMock()
+        mock_client.build_request.return_value = MagicMock()
+        mock_client.send.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/{installation.id}/proxy/",
+            data={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            format="json",
+        )
+
+        assert all(call.args[1] != "$mcp_tool_call" for call in mock_report.call_args_list)
+
+
+class TestSingleFlightTokenRefresh(BaseTest):
+    def _oauth_installation(self, sensitive) -> MCPServerInstallation:
+        return MCPServerInstallation.objects.create(
+            team=self.team,
+            user=self.user,
+            display_name="OAuth Server",
+            url="https://mcp.example.com/mcp",
+            auth_type="oauth",
+            oauth_metadata={"token_endpoint": "https://auth.example.com/token"},
+            sensitive_configuration=sensitive,
+        )
+
+    def _fresh_sensitive(self) -> dict:
+        return {
+            "access_token": "fresh-token",
+            "refresh_token": "rt",
+            "token_retrieved_at": int(time.time()),
+            "expires_in": 3600,
+            "dcr_client_id": "client-123",
+        }
+
+    def _stale_sensitive(self) -> dict:
+        return {
+            "access_token": "stale-token",
+            "refresh_token": "rt",
+            "token_retrieved_at": int(time.time()) - 7200,
+            "expires_in": 3600,
+            "dcr_client_id": "client-123",
+        }
+
+    @patch("products.mcp_store.backend.oauth.refresh_oauth_token")
+    def test_holder_refreshes_when_row_still_expiring(self, mock_refresh):
+        mock_refresh.return_value = {"access_token": "new-token", "expires_in": 3600}
+        installation = self._oauth_installation(self._stale_sensitive())
+
+        result = refresh_installation_token_single_flight(installation)
+
+        mock_refresh.assert_called_once()
+        assert result["access_token"] == "new-token"
+
+    @patch("products.mcp_store.backend.oauth.refresh_oauth_token")
+    def test_holder_skips_refresh_when_another_holder_already_refreshed(self, mock_refresh):
+        installation = self._oauth_installation(self._fresh_sensitive())
+        # Simulate a stale in-memory copy: the DB row was refreshed by a concurrent holder.
+        installation.sensitive_configuration = self._stale_sensitive()
+
+        result = refresh_installation_token_single_flight(installation)
+
+        mock_refresh.assert_not_called()
+        assert result["access_token"] == "fresh-token"
+
+    @parameterized.expand(
+        [
+            ("db_row_fresh", True),
+            ("db_row_still_stale", False),
+        ]
+    )
+    @patch("products.mcp_store.backend.oauth.refresh_oauth_token")
+    @patch("products.mcp_store.backend.oauth.get_client")
+    def test_lock_wait_timeout_falls_back_to_db_state(self, _name, db_fresh, mock_get_client, mock_refresh):
+        lock = MagicMock()
+        lock.acquire.return_value = False
+        mock_get_client.return_value.lock.return_value = lock
+        installation = self._oauth_installation(self._fresh_sensitive() if db_fresh else self._stale_sensitive())
+        installation.sensitive_configuration = self._stale_sensitive()
+
+        if db_fresh:
+            result = refresh_installation_token_single_flight(installation)
+            assert result["access_token"] == "fresh-token"
+        else:
+            with self.assertRaises(TokenRefreshError):
+                refresh_installation_token_single_flight(installation)
+        mock_refresh.assert_not_called()
+
+
+class TestMaintainSharedInstallations(BaseTest):
+    def _installation(self, *, scope, auth_type="oauth", sensitive=None, tool_seen_at=None) -> MCPServerInstallation:
+        installation = MCPServerInstallation.objects.create(
+            team=self.team,
+            user=self.user,
+            display_name="Server",
+            url=f"https://mcp-{uuid.uuid4().hex[:8]}.example.com/mcp",
+            auth_type=auth_type,
+            scope=scope,
+            sensitive_configuration=sensitive or {},
+        )
+        if tool_seen_at is not None:
+            MCPServerInstallationTool.objects.create(
+                installation=installation,
+                tool_name="tool",
+                approval_state="approved",
+                last_seen_at=tool_seen_at,
+            )
+        return installation
+
+    @patch("products.mcp_store.backend.tasks.tasks.sync_installation_tools")
+    @patch("products.mcp_store.backend.tasks.tasks.refresh_installation_token_single_flight")
+    def test_only_expiring_shared_tokens_and_stale_catalogs_are_touched(self, mock_refresh, mock_sync):
+        expiring = {
+            "access_token": "t",
+            "refresh_token": "rt",
+            "token_retrieved_at": int(time.time()) - 7200,
+            "expires_in": 3600,
+        }
+        stale_shared = self._installation(scope="shared", sensitive=expiring)
+        fresh_shared = self._installation(
+            scope="shared", auth_type="api_key", sensitive={"api_key": "sk"}, tool_seen_at=timezone.now()
+        )
+        personal = self._installation(scope="personal", sensitive=expiring)
+
+        maintain_shared_installations()
+
+        refreshed_ids = {call.args[0].id for call in mock_refresh.call_args_list}
+        synced_ids = {call.args[0].id for call in mock_sync.call_args_list}
+        assert refreshed_ids == {stale_shared.id}
+        assert synced_ids == {stale_shared.id}
+        assert personal.id not in refreshed_ids | synced_ids
+        assert fresh_shared.id not in refreshed_ids | synced_ids

--- a/products/mcp_store/backend/tools.py
+++ b/products/mcp_store/backend/tools.py
@@ -16,7 +16,7 @@ import structlog
 from posthog.security.url_validation import is_url_allowed
 
 from .models import MCPServerInstallation, MCPServerInstallationTool
-from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token
+from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token_single_flight
 from .proxy import build_upstream_auth_headers, validated_same_origin_redirect_url
 
 logger = structlog.get_logger(__name__)
@@ -49,7 +49,7 @@ def _ensure_valid_token_for_fetch(installation: MCPServerInstallation) -> None:
     if not is_token_expiring(sensitive):
         return
     try:
-        refresh_installation_token(installation)
+        refresh_installation_token_single_flight(installation)
     except TokenRefreshError as exc:
         raise ToolsFetchError(f"Token refresh failed: {exc}") from exc
 

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -355,14 +355,6 @@ export interface PaginatedMCPServerTemplateListApi {
     results: MCPServerTemplateApi[]
 }
 
-export type McpGatewayMcpCreateBodyOne = { [key: string]: unknown }
-
-export type McpGatewayMcpCreateBodyTwo = { [key: string]: unknown }
-
-export type McpGatewayMcpCreateBodyThree = { [key: string]: unknown }
-
-export type McpGatewayMcpCreate200 = { [key: string]: unknown }
-
 export type McpGatewayToolsRetrieveParams = {
     /**
      * Maximum number of tools to return.

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -8,6 +8,146 @@
  * OpenAPI spec version: 1.0.0
  */
 /**
+ * Arguments passed to the tool, matching its input_schema.
+ */
+export type GatewayCallRequestApiArguments = { [key: string]: unknown }
+
+export interface GatewayCallRequestApi {
+    /** Namespaced tool name to execute: {server_slug}/{tool_name}. */
+    tool: string
+    /** Arguments passed to the tool, matching its input_schema. */
+    arguments?: GatewayCallRequestApiArguments
+    /** Optional consumer identifier for analytics attribution (e.g. 'tasks', 'max'). */
+    consumer?: string
+}
+
+export type GatewayCallResponseApiContentItem = { [key: string]: unknown }
+
+/**
+ * Structured result payload, when the tool provides one.
+ * @nullable
+ */
+export type GatewayCallResponseApiStructuredContent = { [key: string]: unknown } | null
+
+export interface GatewayCallResponseApi {
+    /** MCP CallToolResult content blocks (e.g. {type: 'text', text: ...}). */
+    content: GatewayCallResponseApiContentItem[]
+    /** True when the tool itself reported an execution error. */
+    is_error: boolean
+    /**
+     * Structured result payload, when the tool provides one.
+     * @nullable
+     */
+    structured_content?: GatewayCallResponseApiStructuredContent
+    /** Slug of the server that executed the tool. */
+    server_slug: string
+    /** The tool's name on the upstream server (not namespaced). */
+    tool_name: string
+    /** Upstream execution time in milliseconds. */
+    duration_ms: number
+}
+
+/**
+ * * `tool_not_found` - tool_not_found
+ * * `tool_needs_approval` - tool_needs_approval
+ * * `tool_blocked` - tool_blocked
+ * * `upstream_error` - upstream_error
+ */
+export type CodeEnumApi = (typeof CodeEnumApi)[keyof typeof CodeEnumApi]
+
+export const CodeEnumApi = {
+    ToolNotFound: 'tool_not_found',
+    ToolNeedsApproval: 'tool_needs_approval',
+    ToolBlocked: 'tool_blocked',
+    UpstreamError: 'upstream_error',
+} as const
+
+export interface GatewayCallErrorApi {
+    /** Machine-readable error code.
+     *
+     * * `tool_not_found` - tool_not_found
+     * * `tool_needs_approval` - tool_needs_approval
+     * * `tool_blocked` - tool_blocked
+     * * `upstream_error` - upstream_error */
+    code: CodeEnumApi
+    /** Human-readable error description. */
+    detail: string
+    /** Settings URL where the tool can be approved (tool_needs_approval only). */
+    approval_url?: string
+    /** Upstream failure category (upstream_error only): e.g. unreachable, timeout, auth_failed. */
+    error_type?: string
+}
+
+/**
+ * * `personal` - Personal
+ * * `shared` - Shared
+ */
+export type MCPServerScopeEnumApi = (typeof MCPServerScopeEnumApi)[keyof typeof MCPServerScopeEnumApi]
+
+export const MCPServerScopeEnumApi = {
+    Personal: 'personal',
+    Shared: 'shared',
+} as const
+
+export interface GatewayServerApi {
+    /** URL-safe server identifier, unique within the caller's resolved set. */
+    slug: string
+    /** Human-readable server name. */
+    display_name: string
+    /** UUID of the MCP server installation backing this server. */
+    installation_id: string
+    /** 'personal' is the caller's own installation; 'shared' is team-wide.
+     *
+     * * `personal` - Personal
+     * * `shared` - Shared */
+    scope: MCPServerScopeEnumApi
+}
+
+/**
+ * * `approved` - Approved
+ * * `needs_approval` - Needs approval
+ * * `do_not_use` - Do not use
+ */
+export type MCPToolApprovalStateEnumApi = (typeof MCPToolApprovalStateEnumApi)[keyof typeof MCPToolApprovalStateEnumApi]
+
+export const MCPToolApprovalStateEnumApi = {
+    Approved: 'approved',
+    NeedsApproval: 'needs_approval',
+    DoNotUse: 'do_not_use',
+} as const
+
+/**
+ * JSON Schema describing the tool's arguments.
+ */
+export type GatewayToolApiInputSchema = { [key: string]: unknown }
+
+export interface GatewayToolApi {
+    /** Namespaced tool name: {server_slug}/{tool_name}. */
+    name: string
+    /** The connected server this tool belongs to. */
+    server: GatewayServerApi
+    /** The tool's name on the upstream server (not namespaced). */
+    tool_name: string
+    /** Tool description from the upstream server. */
+    description: string
+    /** JSON Schema describing the tool's arguments. */
+    input_schema: GatewayToolApiInputSchema
+    /** Per-tool approval state. 'needs_approval' tools are listed but blocked at call time.
+     *
+     * * `approved` - Approved
+     * * `needs_approval` - Needs approval
+     * * `do_not_use` - Do not use */
+    approval_state: MCPToolApprovalStateEnumApi
+}
+
+export interface GatewayToolsResponseApi {
+    /** The page of matching tools. */
+    results: GatewayToolApi[]
+    /** Total number of matching tools before pagination. */
+    count: number
+}
+
+/**
  * * `api_key` - API Key
  * * `oauth` - OAuth
  */
@@ -16,18 +156,6 @@ export type MCPAuthTypeEnumApi = (typeof MCPAuthTypeEnumApi)[keyof typeof MCPAut
 export const MCPAuthTypeEnumApi = {
     ApiKey: 'api_key',
     Oauth: 'oauth',
-} as const
-
-/**
- * * `personal` - Personal
- * * `shared` - Shared
- */
-export type MCPServerInstallationScopeEnumApi =
-    (typeof MCPServerInstallationScopeEnumApi)[keyof typeof MCPServerInstallationScopeEnumApi]
-
-export const MCPServerInstallationScopeEnumApi = {
-    Personal: 'personal',
-    Shared: 'shared',
 } as const
 
 export interface MCPServerInstallationApi {
@@ -44,7 +172,7 @@ export interface MCPServerInstallationApi {
     description?: string
     auth_type?: MCPAuthTypeEnumApi
     is_enabled?: boolean
-    readonly scope: MCPServerInstallationScopeEnumApi
+    readonly scope: MCPServerScopeEnumApi
     /** True when the requesting user owns this installation. Lets clients gate owner-only controls instead of surfacing 403s. */
     readonly is_owner: boolean
     readonly needs_reauth: boolean
@@ -72,27 +200,13 @@ export interface PatchedMCPServerInstallationUpdateApi {
     is_enabled?: boolean
 }
 
-/**
- * * `approved` - Approved
- * * `needs_approval` - Needs approval
- * * `do_not_use` - Do not use
- */
-export type MCPServerInstallationToolApprovalStateEnumApi =
-    (typeof MCPServerInstallationToolApprovalStateEnumApi)[keyof typeof MCPServerInstallationToolApprovalStateEnumApi]
-
-export const MCPServerInstallationToolApprovalStateEnumApi = {
-    Approved: 'approved',
-    NeedsApproval: 'needs_approval',
-    DoNotUse: 'do_not_use',
-} as const
-
 export interface MCPServerInstallationToolApi {
     readonly id: string
     readonly tool_name: string
     readonly display_name: string
     readonly description: string
     readonly input_schema: unknown
-    approval_state?: MCPServerInstallationToolApprovalStateEnumApi
+    approval_state?: MCPToolApprovalStateEnumApi
     readonly last_seen_at: string
     /** @nullable */
     readonly removed_at: string | null
@@ -239,6 +353,38 @@ export interface PaginatedMCPServerTemplateListApi {
     /** @nullable */
     previous?: string | null
     results: MCPServerTemplateApi[]
+}
+
+export type McpGatewayMcpCreateBodyOne = { [key: string]: unknown }
+
+export type McpGatewayMcpCreateBodyTwo = { [key: string]: unknown }
+
+export type McpGatewayMcpCreateBodyThree = { [key: string]: unknown }
+
+export type McpGatewayMcpCreate200 = { [key: string]: unknown }
+
+export type McpGatewayToolsRetrieveParams = {
+    /**
+     * Maximum number of tools to return.
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number
+    /**
+     * Exact namespaced tool name ({server_slug}/{tool_name}).
+     * @minLength 1
+     */
+    name?: string
+    /**
+     * Number of tools to skip (for pagination).
+     * @minimum 0
+     */
+    offset?: number
+    /**
+     * Substring search over tool name and description; name matches rank first.
+     * @minLength 1
+     */
+    search?: string
 }
 
 export type McpServerInstallationsListParams = {

--- a/products/mcp_store/frontend/generated/api.ts
+++ b/products/mcp_store/frontend/generated/api.ts
@@ -9,10 +9,18 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    GatewayCallRequestApi,
+    GatewayCallResponseApi,
+    GatewayToolsResponseApi,
     InstallCustomApi,
     InstallTemplateApi,
     MCPServerInstallationApi,
     MCPServerInstallationToolApi,
+    McpGatewayMcpCreate200,
+    McpGatewayMcpCreateBodyOne,
+    McpGatewayMcpCreateBodyThree,
+    McpGatewayMcpCreateBodyTwo,
+    McpGatewayToolsRetrieveParams,
     McpServerInstallationsAuthorizeRetrieveParams,
     McpServerInstallationsListParams,
     McpServersListParams,
@@ -40,6 +48,78 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
           [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
       }
     : DistributeReadOnlyOverUnions<T>
+
+export const getMcpGatewayCallCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/mcp_gateway/call/`
+}
+
+/**
+ * Execute a namespaced tool ({server_slug}/{tool_name}) on the connected server that owns it.
+ * @summary Call a gateway tool
+ */
+export const mcpGatewayCallCreate = async (
+    projectId: string,
+    gatewayCallRequestApi: GatewayCallRequestApi,
+    options?: RequestInit
+): Promise<GatewayCallResponseApi> => {
+    return apiMutator<GatewayCallResponseApi>(getMcpGatewayCallCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(gatewayCallRequestApi),
+    })
+}
+
+export const getMcpGatewayMcpCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/mcp_gateway/mcp/`
+}
+
+/**
+ * Stateless JSON-RPC (MCP streamable HTTP) over the caller's connected MCP servers. Supports initialize, notifications/initialized, ping, tools/list, and tools/call with {server_slug}/{tool_name} tool names. Batch requests are rejected.
+ * @summary Aggregated MCP endpoint
+ */
+export const mcpGatewayMcpCreate = async (
+    projectId: string,
+    mcpGatewayMcpCreateBody?: McpGatewayMcpCreateBodyOne | McpGatewayMcpCreateBodyTwo | McpGatewayMcpCreateBodyThree,
+    options?: RequestInit
+): Promise<McpGatewayMcpCreate200> => {
+    return apiMutator<McpGatewayMcpCreate200>(getMcpGatewayMcpCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        body: JSON.stringify(mcpGatewayMcpCreateBody),
+    })
+}
+
+export const getMcpGatewayToolsRetrieveUrl = (projectId: string, params?: McpGatewayToolsRetrieveParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/mcp_gateway/tools/?${stringifiedParams}`
+        : `/api/projects/${projectId}/mcp_gateway/tools/`
+}
+
+/**
+ * The merged, namespaced tool catalog across the caller's connected MCP servers.
+ * @summary List gateway tools
+ */
+export const mcpGatewayToolsRetrieve = async (
+    projectId: string,
+    params?: McpGatewayToolsRetrieveParams,
+    options?: RequestInit
+): Promise<GatewayToolsResponseApi> => {
+    return apiMutator<GatewayToolsResponseApi>(getMcpGatewayToolsRetrieveUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
 
 export const getMcpServerInstallationsListUrl = (projectId: string, params?: McpServerInstallationsListParams) => {
     const normalizedParams = new URLSearchParams()

--- a/products/mcp_store/frontend/generated/api.ts
+++ b/products/mcp_store/frontend/generated/api.ts
@@ -16,10 +16,6 @@ import type {
     InstallTemplateApi,
     MCPServerInstallationApi,
     MCPServerInstallationToolApi,
-    McpGatewayMcpCreate200,
-    McpGatewayMcpCreateBodyOne,
-    McpGatewayMcpCreateBodyThree,
-    McpGatewayMcpCreateBodyTwo,
     McpGatewayToolsRetrieveParams,
     McpServerInstallationsAuthorizeRetrieveParams,
     McpServerInstallationsListParams,
@@ -67,26 +63,6 @@ export const mcpGatewayCallCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(gatewayCallRequestApi),
-    })
-}
-
-export const getMcpGatewayMcpCreateUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/mcp_gateway/mcp/`
-}
-
-/**
- * Stateless JSON-RPC (MCP streamable HTTP) over the caller's connected MCP servers. Supports initialize, notifications/initialized, ping, tools/list, and tools/call with {server_slug}/{tool_name} tool names. Batch requests are rejected.
- * @summary Aggregated MCP endpoint
- */
-export const mcpGatewayMcpCreate = async (
-    projectId: string,
-    mcpGatewayMcpCreateBody?: McpGatewayMcpCreateBodyOne | McpGatewayMcpCreateBodyTwo | McpGatewayMcpCreateBodyThree,
-    options?: RequestInit
-): Promise<McpGatewayMcpCreate200> => {
-    return apiMutator<McpGatewayMcpCreate200>(getMcpGatewayMcpCreateUrl(projectId), {
-        ...options,
-        method: 'POST',
-        body: JSON.stringify(mcpGatewayMcpCreateBody),
     })
 }
 

--- a/products/mcp_store/frontend/generated/api.zod.ts
+++ b/products/mcp_store/frontend/generated/api.zod.ts
@@ -27,12 +27,6 @@ export const McpGatewayCallCreateBody = /* @__PURE__ */ zod.object({
         .describe("Optional consumer identifier for analytics attribution (e.g. 'tasks', 'max')."),
 })
 
-/**
- * Stateless JSON-RPC (MCP streamable HTTP) over the caller's connected MCP servers. Supports initialize, notifications/initialized, ping, tools/list, and tools/call with {server_slug}/{tool_name} tool names. Batch requests are rejected.
- * @summary Aggregated MCP endpoint
- */
-export const McpGatewayMcpCreateBody = /* @__PURE__ */ zod.record(zod.string(), zod.unknown())
-
 export const mcpServerInstallationsCreateBodyDisplayNameMax = 200
 
 export const mcpServerInstallationsCreateBodyUrlMax = 2048

--- a/products/mcp_store/frontend/generated/api.zod.ts
+++ b/products/mcp_store/frontend/generated/api.zod.ts
@@ -9,6 +9,30 @@
  */
 import * as zod from 'zod'
 
+/**
+ * Execute a namespaced tool ({server_slug}/{tool_name}) on the connected server that owns it.
+ * @summary Call a gateway tool
+ */
+export const mcpGatewayCallCreateBodyConsumerDefault = ``
+
+export const McpGatewayCallCreateBody = /* @__PURE__ */ zod.object({
+    tool: zod.string().describe('Namespaced tool name to execute: {server_slug}\/{tool_name}.'),
+    arguments: zod
+        .record(zod.string(), zod.unknown())
+        .optional()
+        .describe('Arguments passed to the tool, matching its input_schema.'),
+    consumer: zod
+        .string()
+        .default(mcpGatewayCallCreateBodyConsumerDefault)
+        .describe("Optional consumer identifier for analytics attribution (e.g. 'tasks', 'max')."),
+})
+
+/**
+ * Stateless JSON-RPC (MCP streamable HTTP) over the caller's connected MCP servers. Supports initialize, notifications/initialized, ping, tools/list, and tools/call with {server_slug}/{tool_name} tool names. Batch requests are rejected.
+ * @summary Aggregated MCP endpoint
+ */
+export const McpGatewayMcpCreateBody = /* @__PURE__ */ zod.record(zod.string(), zod.unknown())
+
 export const mcpServerInstallationsCreateBodyDisplayNameMax = 200
 
 export const mcpServerInstallationsCreateBodyUrlMax = 2048

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -63342,14 +63342,6 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type EnvironmentsMcpGatewayMcpCreateBodyOne = { [key: string]: unknown };
-
-    export type EnvironmentsMcpGatewayMcpCreateBodyTwo = { [key: string]: unknown };
-
-    export type EnvironmentsMcpGatewayMcpCreateBodyThree = { [key: string]: unknown };
-
-    export type EnvironmentsMcpGatewayMcpCreate200 = { [key: string]: unknown };
-
     export type EnvironmentsMcpGatewayToolsRetrieveParams = {
     /**
      * Maximum number of tools to return.
@@ -70778,14 +70770,6 @@ export namespace Schemas {
      */
     offset?: number;
     };
-
-    export type McpGatewayMcpCreateBodyOne = { [key: string]: unknown };
-
-    export type McpGatewayMcpCreateBodyTwo = { [key: string]: unknown };
-
-    export type McpGatewayMcpCreateBodyThree = { [key: string]: unknown };
-
-    export type McpGatewayMcpCreate200 = { [key: string]: unknown };
 
     export type McpGatewayToolsRetrieveParams = {
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13429,6 +13429,22 @@ export namespace Schemas {
       clustering_job_id?: string | null;
     }
 
+    /**
+     * * `tool_not_found` - tool_not_found
+     * * `tool_needs_approval` - tool_needs_approval
+     * * `tool_blocked` - tool_blocked
+     * * `upstream_error` - upstream_error
+     */
+    export type CodeEnum = typeof CodeEnum[keyof typeof CodeEnum];
+
+
+    export const CodeEnum = {
+      ToolNotFound: 'tool_not_found',
+      ToolNeedsApproval: 'tool_needs_approval',
+      ToolBlocked: 'tool_blocked',
+      UpstreamError: 'upstream_error',
+    } as const;
+
     export interface CodeInviteRedeemRequest {
       /** @maxLength 50 */
       code: string;
@@ -25776,6 +25792,133 @@ export namespace Schemas {
       readonly updated: number;
     }
 
+    export interface GatewayCallError {
+      /** Machine-readable error code.
+       *
+       * * `tool_not_found` - tool_not_found
+       * * `tool_needs_approval` - tool_needs_approval
+       * * `tool_blocked` - tool_blocked
+       * * `upstream_error` - upstream_error */
+      code: CodeEnum;
+      /** Human-readable error description. */
+      detail: string;
+      /** Settings URL where the tool can be approved (tool_needs_approval only). */
+      approval_url?: string;
+      /** Upstream failure category (upstream_error only): e.g. unreachable, timeout, auth_failed. */
+      error_type?: string;
+    }
+
+    /**
+     * Arguments passed to the tool, matching its input_schema.
+     */
+    export type GatewayCallRequestArguments = { [key: string]: unknown };
+
+    export interface GatewayCallRequest {
+      /** Namespaced tool name to execute: {server_slug}/{tool_name}. */
+      tool: string;
+      /** Arguments passed to the tool, matching its input_schema. */
+      arguments?: GatewayCallRequestArguments;
+      /** Optional consumer identifier for analytics attribution (e.g. 'tasks', 'max'). */
+      consumer?: string;
+    }
+
+    export type GatewayCallResponseContentItem = { [key: string]: unknown };
+
+    /**
+     * Structured result payload, when the tool provides one.
+     * @nullable
+     */
+    export type GatewayCallResponseStructuredContent = { [key: string]: unknown } | null;
+
+    export interface GatewayCallResponse {
+      /** MCP CallToolResult content blocks (e.g. {type: 'text', text: ...}). */
+      content: GatewayCallResponseContentItem[];
+      /** True when the tool itself reported an execution error. */
+      is_error: boolean;
+      /**
+         * Structured result payload, when the tool provides one.
+         * @nullable
+         */
+      structured_content?: GatewayCallResponseStructuredContent;
+      /** Slug of the server that executed the tool. */
+      server_slug: string;
+      /** The tool's name on the upstream server (not namespaced). */
+      tool_name: string;
+      /** Upstream execution time in milliseconds. */
+      duration_ms: number;
+    }
+
+    /**
+     * * `personal` - Personal
+     * * `shared` - Shared
+     */
+    export type MCPServerScopeEnum = typeof MCPServerScopeEnum[keyof typeof MCPServerScopeEnum];
+
+
+    export const MCPServerScopeEnum = {
+      Personal: 'personal',
+      Shared: 'shared',
+    } as const;
+
+    export interface GatewayServer {
+      /** URL-safe server identifier, unique within the caller's resolved set. */
+      slug: string;
+      /** Human-readable server name. */
+      display_name: string;
+      /** UUID of the MCP server installation backing this server. */
+      installation_id: string;
+      /** 'personal' is the caller's own installation; 'shared' is team-wide.
+       *
+       * * `personal` - Personal
+       * * `shared` - Shared */
+      scope: MCPServerScopeEnum;
+    }
+
+    /**
+     * JSON Schema describing the tool's arguments.
+     */
+    export type GatewayToolInputSchema = { [key: string]: unknown };
+
+    /**
+     * * `approved` - Approved
+     * * `needs_approval` - Needs approval
+     * * `do_not_use` - Do not use
+     */
+    export type MCPToolApprovalStateEnum = typeof MCPToolApprovalStateEnum[keyof typeof MCPToolApprovalStateEnum];
+
+
+    export const MCPToolApprovalStateEnum = {
+      Approved: 'approved',
+      NeedsApproval: 'needs_approval',
+      DoNotUse: 'do_not_use',
+    } as const;
+
+    export interface GatewayTool {
+      /** Namespaced tool name: {server_slug}/{tool_name}. */
+      name: string;
+      /** The connected server this tool belongs to. */
+      server: GatewayServer;
+      /** The tool's name on the upstream server (not namespaced). */
+      tool_name: string;
+      /** Tool description from the upstream server. */
+      description: string;
+      /** JSON Schema describing the tool's arguments. */
+      input_schema: GatewayToolInputSchema;
+      /** Per-tool approval state. 'needs_approval' tools are listed but blocked at call time.
+       *
+       * * `approved` - Approved
+       * * `needs_approval` - Needs approval
+       * * `do_not_use` - Do not use */
+      approval_state: MCPToolApprovalStateEnum;
+    }
+
+    export interface GatewayToolsResponse {
+      /** The page of matching tools. */
+      results: GatewayTool[];
+      /** Total number of matching tools before pagination. */
+      count: number;
+    }
+
     export type GenerateRequestStepsItem = { [key: string]: unknown };
 
     export interface GenerateRequest {
@@ -31656,18 +31799,6 @@ export namespace Schemas {
       blocked?: boolean;
     }
 
-    /**
-     * * `personal` - Personal
-     * * `shared` - Shared
-     */
-    export type MCPServerInstallationScopeEnum = typeof MCPServerInstallationScopeEnum[keyof typeof MCPServerInstallationScopeEnum];
-
-
-    export const MCPServerInstallationScopeEnum = {
-      Personal: 'personal',
-      Shared: 'shared',
-    } as const;
-
     export interface MCPServerInstallation {
       readonly id: string;
       /** @nullable */
@@ -31682,7 +31813,7 @@ export namespace Schemas {
       description?: string;
       auth_type?: MCPAuthTypeEnum;
       is_enabled?: boolean;
-      readonly scope: MCPServerInstallationScopeEnum;
+      readonly scope: MCPServerScopeEnum;
       /** True when the requesting user owns this installation. Lets clients gate owner-only controls instead of surfacing 403s. */
       readonly is_owner: boolean;
       readonly needs_reauth: boolean;
@@ -31695,27 +31826,13 @@ export namespace Schemas {
       readonly updated_at: string | null;
     }
 
-    /**
-     * * `approved` - Approved
-     * * `needs_approval` - Needs approval
-     * * `do_not_use` - Do not use
-     */
-    export type MCPServerInstallationToolApprovalStateEnum = typeof MCPServerInstallationToolApprovalStateEnum[keyof typeof MCPServerInstallationToolApprovalStateEnum];
-
-
-    export const MCPServerInstallationToolApprovalStateEnum = {
-      Approved: 'approved',
-      NeedsApproval: 'needs_approval',
-      DoNotUse: 'do_not_use',
-    } as const;
-
     export interface MCPServerInstallationTool {
       readonly id: string;
       readonly tool_name: string;
       readonly display_name: string;
       readonly description: string;
       readonly input_schema: unknown;
-      approval_state?: MCPServerInstallationToolApprovalStateEnum;
+      approval_state?: MCPToolApprovalStateEnum;
       readonly last_seen_at: string;
       /** @nullable */
       readonly removed_at: string | null;
@@ -63225,6 +63342,38 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type EnvironmentsMcpGatewayMcpCreateBodyOne = { [key: string]: unknown };
+
+    export type EnvironmentsMcpGatewayMcpCreateBodyTwo = { [key: string]: unknown };
+
+    export type EnvironmentsMcpGatewayMcpCreateBodyThree = { [key: string]: unknown };
+
+    export type EnvironmentsMcpGatewayMcpCreate200 = { [key: string]: unknown };
+
+    export type EnvironmentsMcpGatewayToolsRetrieveParams = {
+    /**
+     * Maximum number of tools to return.
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Exact namespaced tool name ({server_slug}/{tool_name}).
+     * @minLength 1
+     */
+    name?: string;
+    /**
+     * Number of tools to skip (for pagination).
+     * @minimum 0
+     */
+    offset?: number;
+    /**
+     * Substring search over tool name and description; name matches rank first.
+     * @minLength 1
+     */
+    search?: string;
+    };
+
     export type EnvironmentsMcpServerInstallationsListParams = {
     /**
      * Number of results to return per page.
@@ -70628,6 +70777,38 @@ export namespace Schemas {
      * @minimum 0
      */
     offset?: number;
+    };
+
+    export type McpGatewayMcpCreateBodyOne = { [key: string]: unknown };
+
+    export type McpGatewayMcpCreateBodyTwo = { [key: string]: unknown };
+
+    export type McpGatewayMcpCreateBodyThree = { [key: string]: unknown };
+
+    export type McpGatewayMcpCreate200 = { [key: string]: unknown };
+
+    export type McpGatewayToolsRetrieveParams = {
+    /**
+     * Maximum number of tools to return.
+     * @minimum 1
+     * @maximum 500
+     */
+    limit?: number;
+    /**
+     * Exact namespaced tool name ({server_slug}/{tool_name}).
+     * @minLength 1
+     */
+    name?: string;
+    /**
+     * Number of tools to skip (for pagination).
+     * @minimum 0
+     */
+    offset?: number;
+    /**
+     * Substring search over tool name and description; name matches rank first.
+     * @minLength 1
+     */
+    search?: string;
     };
 
     export type McpServerInstallationsListParams = {

--- a/tach.toml
+++ b/tach.toml
@@ -116,6 +116,7 @@ depends_on = [
     "products.tracing",
     "products.user_interviews",
     "products.mcp_analytics",
+    "products.mcp_store",
     "products.web_analytics",
     "products.workflows",
     "products.actions",


### PR DESCRIPTION
## Problem

Teams can connect external MCP servers in the MCP store, but every agent surface consumes them through its own code path. The tasks sandbox gets one proxy URL per installation, Max keeps its own MCP client and token refresh, and the agent-platform runner re-implements credential decryption and OAuth refresh in TypeScript. None of these paths emit per-call analytics, and the refresh logic exists in triplicate.

This PR adds the gateway execution plane: one place that resolves a team's connected servers, enforces per-tool approval, refreshes and injects credentials server-side, and traces every call. It is the base of a three-PR stack that ends with agents reaching every connected MCP through a single access point.

**Before** (three independent consumption paths):

```mermaid
flowchart LR
  S{{"Sandbox agent"}} --> P1["Per-installation proxy A"]
  S --> P2["Per-installation proxy B"]
  M{{"Max"}} --> C["Own MCP client + refresh"]
  R{{"agent-platform runner"}} --> D["Own decrypt + refresh"]
  P1 --> U1["Upstream MCP A"]
  P2 --> U2["Upstream MCP B"]
  C --> U1
  D --> U2
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class S,M,R phBlue;
  class U1,U2 phRed;
  class P1,P2,C,D phGray;
```

**After** (this stack; agents connect through the PostHog MCP, which consumes the gateway REST endpoints):

```mermaid
flowchart LR
  A{{"Any agent"}} --> PH["PostHog MCP exec"]
  PH --> G["Gateway REST: tools + call"]
  G --> E["Dispatch: approval, refresh, SSRF, inject, trace"]
  E --> U1["Upstream MCP A"]
  E --> U2["Upstream MCP B"]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  class A phBlue;
  class U1,U2 phRed;
  class PH,G,E phYellow;
```

## Changes

- `backend/gateway.py`: installation resolution (team-shared plus caller's personal, personal wins per URL, extracted so the sandbox facade now delegates instead of duplicating), deterministic server-slug namespacing (`server/tool`), and the single dispatch path (approval, single-flight token refresh, SSRF check, upstream call, analytics)
- `backend/client.py`: sync upstream `tools/call` client reusing the existing handshake helpers, with typed error categories
- New `MCPGatewayViewSet` under `mcp_gateway/`: `GET tools/` (search, exact name, pagination) and `POST call/` with typed error mapping (403 `tool_needs_approval` with an approval deep link, 403 `tool_blocked`, 404 unknown tool, 502 upstream failures). Upstream tool-level errors return 200 with `is_error: true`
- `$mcp_tool_call` analytics from the gateway dispatch, and retrofitted onto the existing per-installation proxy path. Metadata only, tool arguments and results are never captured
- Redis single-flight lock around OAuth token refresh (previously N concurrent refreshes could race per installation)
- Hourly maintenance task: refresh expiring shared-installation tokens, re-sync tool catalogs stale for over 24h
- `README.md` for the product

Per-tool approval semantics are unchanged (`approved` / `needs_approval` / `do_not_use`, enforced at dispatch).

## How did you test this code?

Automated only, no manual testing against a live external MCP server (the agent ran against mocked upstreams).

- `hogli test products/mcp_store/backend/test/` passes: 307 tests, including 30 new gateway tests covering resolution and slug collisions, approval enforcement, REST error mapping, analytics emission (including an assertion that credentials and arguments never appear in captured properties), single-flight refresh, and maintenance-task filtering
- New tests catch regressions no existing test did: nothing previously covered cross-installation resolution, namespaced dispatch, or analytics emission on the proxy path
- `hogli build:openapi` ran clean; regenerated files committed. `ruff`, `tach check`, and `hogli ci:preflight --fix` all pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`products/mcp_store/README.md` added. No `docs/` changes: the user-facing surface ships flag-gated in the stacked PRs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) using parallel subagents, directed by @cvolzer3. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`.

Decisions worth knowing for review: an aggregated JSON-RPC MCP endpoint and Python facade wrappers were built and tested first, then removed in the final commit once we decided every agent reaches the gateway through the PostHog MCP, which consumes these REST endpoints. The dropped surface is one revert away if a protocol-pure consumer appears. Dual project/environment routing follows the existing mcp_store viewsets, though the routing helper's docstring suggests new endpoints should be projects-only. Flagging that as a review question.
