### PR TITLE
feat(mcp): surface connected-server tools through exec gateway

### DIFF
--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -1,7 +1,7 @@
 import type { GroupType } from '@/api/client'
 import { hasScope } from '@/lib/api'
 import { MCPClientProfile } from '@/lib/client-detection'
-import { isCloudApi, isLocalApi } from '@/lib/constants'
+import { isCloudApi, isLocalApi, MCP_GATEWAY_FLAG } from '@/lib/constants'
 import { buildMCPAnalyticsGroups } from '@/lib/posthog/analytics'
 import {
     type EvaluatedFlags,
@@ -105,7 +105,9 @@ export class RequestStateResolver {
             cachedProjectId = (await reqCtx.tokenCache.get('projectId')) ?? undefined
         }
 
-        const allFlagKeys = [...new Set(getRequiredFeatureFlags())]
+        // Tool-definition flags plus the MCP gateway flag, which gates exec-level
+        // behavior (connected-server tools) rather than a catalog tool.
+        const allFlagKeys = [...new Set([...getRequiredFeatureFlags(), MCP_GATEWAY_FLAG])]
 
         const flagAnalyticsContext = await reqCtx.safelyGetAnalyticsContext(context)
         const flagGroups = flagAnalyticsContext ? buildMCPAnalyticsGroups(flagAnalyticsContext) : undefined

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -6,7 +6,9 @@ import {
     isToolCallPayload,
     type ToolResultPayload,
 } from '@/lib/build-tool-result'
+import { MCP_GATEWAY_FLAG } from '@/lib/constants'
 import {
+    ConnectedToolError,
     handleToolError,
     MissingOrganizationContextError,
     MissingProjectContextError,
@@ -19,6 +21,7 @@ import {
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { getPostHogClient } from '@/lib/posthog'
 import { createExecTool, formatInputValidationError, type ExecInnerCallTracker } from '@/tools/exec'
+import { createGatewayClient } from '@/tools/gateway'
 import { EXECUTE_SQL_TOOL_NAME } from '@/tools/posthogAiTools/executeSql'
 import { createRenderUiTool } from '@/tools/render-ui'
 import type { Context, ZodObjectAny } from '@/tools/types'
@@ -39,6 +42,8 @@ interface ResolvedTool {
 
 interface ExecMetricState {
     innerToolName: string | undefined
+    /** `'gateway'` when the inner call ran a connected external MCP server's tool. */
+    innerToolSource: 'gateway' | undefined
 }
 
 export class ToolExecutor {
@@ -275,7 +280,7 @@ export class ToolExecutor {
         state: ResolvedState,
         intentMeta?: ToolCallIntentMeta
     ): Promise<unknown> {
-        const execMetrics: ExecMetricState = { innerToolName: undefined }
+        const execMetrics: ExecMetricState = { innerToolName: undefined, innerToolSource: undefined }
         const resolved = this.resolveExecTool(state, execMetrics, intentMeta)
 
         const toolArgs = (params?.arguments ?? {}) as Record<string, unknown>
@@ -299,6 +304,11 @@ export class ToolExecutor {
         // it. Non-`call` verbs (tools/info/search/schema) resolve no inner tool and stay
         // attributed to `exec`.
         const execToolName = (): string => execMetrics.innerToolName ?? 'exec'
+        // Gateway calls override the default `$mcp_source` so dashboards can split
+        // connected-server executions from PostHog's own tools. Evaluated after the
+        // handler runs — the tracker sets the source during inner dispatch.
+        const execSourceProperties = (): Record<string, unknown> =>
+            execMetrics.innerToolSource === 'gateway' ? { $mcp_source: 'gateway' } : {}
 
         try {
             const handlerResult = await resolved.handler(state.context, validation.data)
@@ -323,6 +333,7 @@ export class ToolExecutor {
                 {
                     input_tokens: estimateTokens(validation.data),
                     output_tokens: estimateResponseTokens(response),
+                    ...execSourceProperties(),
                 },
                 intentMeta
             )
@@ -340,7 +351,7 @@ export class ToolExecutor {
                 Date.now() - startMs,
                 true,
                 state,
-                errorAnalyticsProperties(classification),
+                { ...errorAnalyticsProperties(classification), ...execSourceProperties() },
                 intentMeta
             )
 
@@ -367,6 +378,7 @@ export class ToolExecutor {
             // event (now relabelled to the inner tool name, with the inner tool's category
             // derived from it) already carries this call, so a second emit would double-count.
             execMetrics.innerToolName = toolName
+            execMetrics.innerToolSource = properties.source
             const status = properties.success ? 'success' : properties.validation_error ? 'validation_error' : 'error'
             toolCallsTotal.inc({ tool: toolName, status })
             // Mirror the native path: schema rejections never start a handler, so
@@ -403,6 +415,11 @@ export class ToolExecutor {
                 : tool
         )
 
+        // Connected external MCP servers are only reachable through exec when the
+        // `MCP_GATEWAY` flag is on for this user — flag off means no gateway client,
+        // which keeps every exec verb byte-identical to today.
+        const gatewayEnabled = state.toolFeatureFlags?.[MCP_GATEWAY_FLAG] === true
+
         const execTool = createExecTool(
             execTools,
             state.context,
@@ -411,7 +428,10 @@ export class ToolExecutor {
             clientContext.mcpConsumer,
             trackInnerCall,
             state.scopeGatedTools,
-            { isInlineExecUiHost: state.clientProfile.isInlineExecUiHost() }
+            {
+                isInlineExecUiHost: state.clientProfile.isInlineExecUiHost(),
+                ...(gatewayEnabled ? { gateway: createGatewayClient(state.context, clientContext.mcpConsumer) } : {}),
+            }
         )
 
         return {
@@ -477,6 +497,7 @@ type ToolErrorType =
     | 'rate_limited'
     | 'api_5xx'
     | 'api_4xx'
+    | 'upstream_tool'
     | 'internal'
 
 interface ToolErrorClassification {
@@ -504,6 +525,11 @@ function resolveToolErrorClassification(error: unknown): ToolErrorClassification
     }
     if (error instanceof ToolInputValidationError) {
         return { errorType: 'validation' }
+    }
+    // A connected MCP server's tool returned an error result (gateway path) —
+    // not a PostHog API failure, so it gets its own bucket.
+    if (error instanceof ConnectedToolError) {
+        return { errorType: 'upstream_tool' }
     }
     if (findPostHogPermissionError(error)) {
         return { errorType: 'permission' }

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -21,3 +21,10 @@ export const getAuthorizationServerUrl = (): string => resolveAuthorizationServe
 export const MCP_SERVER_NAME = 'PostHog'
 export const MCP_SERVER_VERSION = '1.0.0'
 export const MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
+
+/**
+ * Feature flag gating the MCP gateway surface: exec-level access to the tools
+ * of external MCP servers a team connected via the PostHog MCP store. Evaluated
+ * per user alongside the tool-definition flags in `request-state-resolver`.
+ */
+export const MCP_GATEWAY_FLAG = 'MCP_GATEWAY'

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -135,6 +135,20 @@ export class ToolInputValidationError extends Error {
     }
 }
 
+/**
+ * Thrown when a connected external MCP server's tool (called through the
+ * MCP gateway) returns a CallToolResult with `is_error: true`. That is the
+ * upstream tool telling the agent its input was wrong — an agent-recoverable
+ * failure, not a PostHog bug — so `handleToolError` returns the upstream
+ * message verbatim and skips exception capture, mirroring the 4xx path.
+ */
+export class ConnectedToolError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'ConnectedToolError'
+    }
+}
+
 export interface PostHogApiErrorOptions {
     status: number
     statusText: string
@@ -415,6 +429,22 @@ export function handleToolError(error: any, tool?: string, distinctId?: string, 
     // an agent slip-up, not a bug. The message already names the offending
     // field(s); skip exception capture like the API 4xx branch below.
     if (error instanceof ToolInputValidationError) {
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Error: [${toolName}]: ${error.message}`,
+                },
+            ],
+            isError: true,
+        }
+    }
+
+    // Recoverable: a connected MCP server's tool reported an error result. The
+    // message carries the upstream tool's own error text for the agent to act
+    // on; capturing it as an exception would file upstream-tool failures as
+    // PostHog issues.
+    if (error instanceof ConnectedToolError) {
         return {
             content: [
                 {

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -1,4 +1,5 @@
 import type { GroupType } from '@/api/client'
+import { MCP_GATEWAY_FLAG } from '@/lib/constants'
 import {
     buildDefinedGroupsBlock,
     buildQueryToolsBlock,
@@ -11,6 +12,7 @@ import type { EvaluatedFlags } from '@/lib/posthog/flags'
 import { formatPrompt } from '@/lib/utils'
 import AGENT_FEEDBACK from '@/templates/sections/agent-feedback.md'
 import BASIC_FUNCTIONALITY from '@/templates/sections/basic-functionality.md'
+import CLI_CONNECTED_SERVERS from '@/templates/sections/cli-connected-servers.md'
 import CLI_DATA_DISCOVERY from '@/templates/sections/cli-data-discovery.md'
 import CLI_ERROR_HANDLING from '@/templates/sections/cli-error-handling.md'
 import CLI_EXAMPLES from '@/templates/sections/cli-examples.md'
@@ -103,6 +105,9 @@ export class InstructionsFormatter {
     ): string {
         const sections = [
             CLI_SYNTAX,
+            // One line, flag-gated: the serialized exec entry has a hard size
+            // budget (see below) and the gateway is invisible when the flag is off.
+            ...(this.mcpGatewayEnabled(ctx.featureFlags) ? [CLI_CONNECTED_SERVERS] : []),
             CLI_SCHEMA_DRILLDOWN,
             CLI_DATA_DISCOVERY,
             CLI_EXAMPLES,
@@ -137,6 +142,12 @@ export class InstructionsFormatter {
      *  in `resolveToolFeatureFlags`. */
     private agentFeedbackEnabled(featureFlags: EvaluatedFlags | undefined): boolean {
         return featureFlags?.['mcp-feedback-tool'] === true
+    }
+
+    /** Connected-server (MCP gateway) tools only surface through exec when the
+     *  `MCP_GATEWAY` flag is on for the caller — the one-line pointer follows it. */
+    private mcpGatewayEnabled(featureFlags: EvaluatedFlags | undefined): boolean {
+        return featureFlags?.[MCP_GATEWAY_FLAG] === true
     }
 
     private compose(sections: string[], ctx: InstructionsContext, opts: { compact: boolean }): string {

--- a/services/mcp/src/templates/sections/cli-connected-servers.md
+++ b/services/mcp/src/templates/sections/cli-connected-servers.md
@@ -1,0 +1,1 @@
+Tool names containing `/` (e.g. `linear/create_issue`) come from MCP servers connected to this PostHog project: `search` lists them, `info`/`schema` inspect them, and `call` always requires `--confirm` for them.

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -3,10 +3,18 @@ import { z } from 'zod'
 
 import { markExecPayload, buildToolResultPayload, estimateResponseTokens } from '@/lib/build-tool-result'
 import { isPostHogCodeConsumer } from '@/lib/client-detection'
-import { ToolInputValidationError } from '@/lib/errors'
+import { ConnectedToolError, ToolInputValidationError } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { formatResponse } from '@/lib/response'
 
+import {
+    type GatewayCallResult,
+    type GatewayClient,
+    type GatewayTool,
+    isGatewayToolName,
+    renderGatewayCallContent,
+    unknownGatewayToolMessage,
+} from './gateway'
 import { TOKEN_CHAR_LIMIT, listAvailablePaths, resolveSchemaPath, summarizeSchema } from './schema-utils'
 import { isRegexPattern, searchToolsRanked, searchToolsRegex } from './tool-search'
 import type { ScopeGatedTool } from './toolDefinitions'
@@ -42,6 +50,12 @@ export interface ExecInnerCallProperties {
     input_tokens?: number
     output_tokens?: number
     input?: Record<string, unknown>
+    /**
+     * Set to `'gateway'` when the inner call executed a connected external MCP
+     * server's tool through the MCP gateway, so the canonical `$mcp_tool_call`
+     * event can carry `$mcp_source: "gateway"` alongside the namespaced name.
+     */
+    source?: 'gateway'
 }
 
 export type ExecInnerCallTracker = (toolName: string, properties: ExecInnerCallProperties) => void
@@ -55,6 +69,13 @@ export interface ExecToolOptions {
      * re-homed onto `_meta`. Computed from the client profile at the call site.
      */
     isInlineExecUiHost?: boolean
+    /**
+     * MCP gateway access to the tools of external MCP servers connected to the
+     * project. Only set when the `MCP_GATEWAY` feature flag is on for the
+     * caller — when unset, tool names containing `/` behave exactly as before
+     * (unknown tools) and `search` output is unchanged.
+     */
+    gateway?: GatewayClient
 }
 
 function makeExecSchema(commandReference: string): z.ZodObject<{ command: z.ZodString }> {
@@ -128,6 +149,12 @@ export function createExecInnerToolCallResolver(
         if (!innerName) {
             return
         }
+        // Namespaced `<server>/<tool>` names target connected external MCP
+        // servers through the gateway — they never appear in the PostHog
+        // catalog, so attribute them by name directly.
+        if (isGatewayToolName(innerName)) {
+            return { name: innerName, description: 'Connected MCP server tool (via the PostHog MCP gateway)' }
+        }
         const tool = allTools.find((t) => t.name === innerName)
         return tool ? { name: tool.name, description: tool.description } : undefined
     }
@@ -195,6 +222,38 @@ function schemaHasOutputFormat(schema: ZodObjectAny): boolean {
     return schema instanceof z.ZodObject && 'output_format' in schema.shape
 }
 
+/** One search-result line per connected-server tool — first line of the
+ *  upstream description, capped so a verbose server can't flood the output. */
+const MAX_CONNECTED_DESCRIPTION_LENGTH = 160
+
+interface ConnectedServerSearchExtras {
+    connected_server_tools: { name: string; server: string; description: string }[]
+    connected_server_hint: string
+}
+
+function summarizeConnectedDescription(description: string): string {
+    const firstLine = description.split('\n', 1)[0] ?? ''
+    if (firstLine.length <= MAX_CONNECTED_DESCRIPTION_LENGTH) {
+        return firstLine
+    }
+    return `${firstLine.slice(0, MAX_CONNECTED_DESCRIPTION_LENGTH - 1)}…`
+}
+
+function buildConnectedServerSearchExtras(gatewayTools: GatewayTool[]): ConnectedServerSearchExtras | undefined {
+    if (gatewayTools.length === 0) {
+        return undefined
+    }
+    return {
+        connected_server_tools: gatewayTools.map((t) => ({
+            name: t.name,
+            server: t.server.display_name || t.server.slug,
+            description: summarizeConnectedDescription(t.description),
+        })),
+        connected_server_hint:
+            'These tools come from MCP servers connected to this PostHog project. Inspect one with "info <server/tool>"; call it with "call --confirm <server/tool> <json_input>" (--confirm is always required for connected-server tools).',
+    }
+}
+
 /**
  * Exec mode owns output encoding through the `--json` call flag, so tools must
  * not also advertise their `output_format` input — an agent passing
@@ -210,6 +269,85 @@ function stripOutputFormatProperty(jsonSchema: Record<string, unknown>): Record<
     }
     const { output_format: _omitted, ...rest } = properties
     return { ...jsonSchema, properties: rest }
+}
+
+function parseCallJsonInput(jsonBody: string): Record<string, unknown> {
+    if (!jsonBody) {
+        return {}
+    }
+    try {
+        return JSON.parse(jsonBody) as Record<string, unknown>
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err)
+        throw new Error(`Invalid JSON input: ${detail}`)
+    }
+}
+
+/**
+ * Dispatch an exec `call` for a connected-server (`<server>/<tool>`) tool
+ * through the MCP gateway. External tools are treated as potentially
+ * destructive by default, so `--confirm` is always required. There is no
+ * client-side schema to validate against — the Django execution plane and the
+ * upstream server own input validation.
+ */
+async function callGatewayTool(args: {
+    gateway: GatewayClient
+    toolName: string
+    jsonBody: string
+    forceJson: boolean
+    confirmed: boolean
+    trackInnerCall: ExecInnerCallTracker | undefined
+}): Promise<string> {
+    const { gateway, toolName, jsonBody, forceJson, confirmed, trackInnerCall } = args
+    if (!confirmed) {
+        throw new Error(
+            `Tool "${toolName}" runs on a connected MCP server and requires confirmation. Re-run with "call --confirm ${toolName} ..." after verifying the arguments. Use "info ${toolName}" to inspect the tool first.`
+        )
+    }
+    const input = parseCallJsonInput(jsonBody)
+    const outputFormat = forceJson ? 'json' : 'text'
+
+    const startedAt = Date.now()
+    let result: GatewayCallResult
+    try {
+        result = await gateway.callTool(toolName, input)
+    } catch (err) {
+        trackInnerCall?.(toolName, {
+            duration_ms: Date.now() - startedAt,
+            success: false,
+            output_format: outputFormat,
+            error_message: err instanceof Error ? err.message : String(err),
+            input,
+            source: 'gateway',
+        })
+        throw err
+    }
+    const durationMs = Date.now() - startedAt
+
+    if (result.is_error) {
+        const message = `Connected server tool "${toolName}" returned an error: ${renderGatewayCallContent(result)}`
+        trackInnerCall?.(toolName, {
+            duration_ms: durationMs,
+            success: false,
+            output_format: outputFormat,
+            error_message: message,
+            input,
+            source: 'gateway',
+        })
+        throw new ConnectedToolError(message)
+    }
+
+    const outputText = forceJson ? JSON.stringify(result) : renderGatewayCallContent(result)
+    trackInnerCall?.(toolName, {
+        duration_ms: durationMs,
+        success: true,
+        output_format: outputFormat,
+        input_tokens: estimateTokens(input),
+        output_tokens: estimateTokens(outputText),
+        input,
+        source: 'gateway',
+    })
+    return outputText
 }
 
 function findTool(tools: Tool<ZodObjectAny>[], name: string): Tool<ZodObjectAny> {
@@ -295,6 +433,20 @@ export function createExecTool(
                             .filter((t): t is ScopeGatedTool => t !== undefined)
                     }
 
+                    // Merge in tools from connected external MCP servers (flag-gated:
+                    // `options.gateway` is only set when the gateway is enabled).
+                    // Best-effort — a gateway failure must never break tool search —
+                    // and additive: with no gateway or no connected matches, every
+                    // response shape below is byte-identical to the gateway-less one.
+                    let connectedExtras: ConnectedServerSearchExtras | undefined
+                    if (options.gateway) {
+                        try {
+                            connectedExtras = buildConnectedServerSearchExtras(await options.gateway.searchTools(rest))
+                        } catch {
+                            connectedExtras = undefined
+                        }
+                    }
+
                     if (gatedMatches.length > 0) {
                         const requiredScopes = [...new Set(gatedMatches.flatMap((t) => t.missingScopes))].sort()
                         return JSON.stringify({
@@ -306,9 +458,13 @@ export function createExecTool(
                             hint:
                                 `These tools also match but are hidden because the API key is missing the ` +
                                 `required scope(s): ${requiredScopes.join(', ')}. The user needs to re-authenticate the MCP or connector, if the harness supports OAuth, or add the scopes to the personal API key to use these tools.`,
+                            ...connectedExtras,
                         })
                     }
                     if (matches.length === 0) {
+                        if (connectedExtras) {
+                            return JSON.stringify({ matches: [], ...connectedExtras })
+                        }
                         return JSON.stringify({
                             matches: [],
                             hint: `No tools matched "${rest}". Run "tools" to see all available tool names.`,
@@ -319,7 +475,11 @@ export function createExecTool(
                             matches,
                             truncated: true,
                             hint: `Showing the top ${MAX_RANKED_SEARCH_RESULTS} of ${truncatedFrom} matches, ranked by relevance. Use a more specific query to narrow the results.`,
+                            ...connectedExtras,
                         })
+                    }
+                    if (connectedExtras) {
+                        return JSON.stringify({ matches, ...connectedExtras })
                     }
                     return JSON.stringify(matches)
                 }
@@ -333,8 +493,6 @@ export function createExecTool(
                     if (!infoArgs) {
                         throw new Error('Usage: info [--json] <tool_name>')
                     }
-                    const tool = findTool(allTools, infoArgs)
-                    const fullSchema = stripOutputFormatProperty(z.toJSONSchema(tool.schema) as Record<string, unknown>)
                     // YAML for the top shape, but inputSchema stays as a JSON
                     // string dumped inside the YAML — JSON Schema is conventionally
                     // JSON and converting it to YAML obscures `$ref`, `oneOf`, etc.
@@ -345,11 +503,34 @@ export function createExecTool(
                         return stringifyYaml({ ...payload, inputSchema: JSON.stringify(schema) }, { lineWidth: 0 })
                     }
 
-                    const topShape = {
-                        name: tool.name,
-                        title: tool.title,
-                        description: tool.description,
-                        annotations: tool.annotations,
+                    let topShape: Record<string, unknown>
+                    let fullSchema: Record<string, unknown>
+                    let hintToolName: string
+                    if (options.gateway && isGatewayToolName(infoArgs)) {
+                        const gatewayTool = await options.gateway.getTool(infoArgs)
+                        if (!gatewayTool) {
+                            throw new Error(unknownGatewayToolMessage(infoArgs))
+                        }
+                        topShape = {
+                            name: gatewayTool.name,
+                            title: `${gatewayTool.tool_name} (connected MCP server: ${gatewayTool.server.display_name})`,
+                            description: gatewayTool.description,
+                            // Surfaced so the agent knows a `needs_approval` tool will be
+                            // rejected at call time and can ask the user first.
+                            approval_state: gatewayTool.approval_state,
+                        }
+                        fullSchema = gatewayTool.input_schema
+                        hintToolName = gatewayTool.name
+                    } else {
+                        const tool = findTool(allTools, infoArgs)
+                        fullSchema = stripOutputFormatProperty(z.toJSONSchema(tool.schema) as Record<string, unknown>)
+                        topShape = {
+                            name: tool.name,
+                            title: tool.title,
+                            description: tool.description,
+                            annotations: tool.annotations,
+                        }
+                        hintToolName = tool.name
                     }
                     const fullOutput = serialize(topShape, fullSchema)
 
@@ -361,7 +542,7 @@ export function createExecTool(
                     // Each complex field's `hint` carries the imperative to run
                     // `schema` before populating it, so no separate directive is
                     // needed here.
-                    const summary = summarizeSchema(fullSchema as Record<string, unknown>, tool.name)
+                    const summary = summarizeSchema(fullSchema, hintToolName)
                     return serialize(topShape, summary)
                 }
 
@@ -370,10 +551,22 @@ export function createExecTool(
                         throw new Error('Usage: schema <tool_name> [field_path]')
                     }
                     const { verb: schemaToolName, rest: fieldPath } = parseCommand(rest)
-                    const schemaTool = findTool(allTools, schemaToolName)
-                    const fullJsonSchema = stripOutputFormatProperty(
-                        z.toJSONSchema(schemaTool.schema) as Record<string, unknown>
-                    )
+                    let fullJsonSchema: Record<string, unknown>
+                    if (options.gateway && isGatewayToolName(schemaToolName)) {
+                        const gatewayTool = await options.gateway.getTool(schemaToolName)
+                        if (!gatewayTool) {
+                            throw new Error(unknownGatewayToolMessage(schemaToolName))
+                        }
+                        // The upstream server's schema is passed through untouched —
+                        // `output_format` stripping only applies to PostHog's own
+                        // formatter-toggle convention.
+                        fullJsonSchema = gatewayTool.input_schema
+                    } else {
+                        const schemaTool = findTool(allTools, schemaToolName)
+                        fullJsonSchema = stripOutputFormatProperty(
+                            z.toJSONSchema(schemaTool.schema) as Record<string, unknown>
+                        )
+                    }
 
                     if (!fieldPath) {
                         // The bare `schema <tool>` view is always a summary. Any
@@ -418,23 +611,25 @@ export function createExecTool(
                         throw new Error('Usage: call [--json] [--confirm] <tool_name> <json_input>')
                     }
                     const { verb: toolName, rest: jsonBody } = parseCommand(callArgs)
+
+                    if (options.gateway && isGatewayToolName(toolName)) {
+                        return callGatewayTool({
+                            gateway: options.gateway,
+                            toolName,
+                            jsonBody,
+                            forceJson,
+                            confirmed,
+                            trackInnerCall,
+                        })
+                    }
+
                     const tool = findTool(allTools, toolName)
                     if (options.requireDestructiveConfirmation && tool.annotations.destructiveHint && !confirmed) {
                         throw new Error(
                             `Tool "${tool.name}" is destructive. Re-run with "call --confirm ${tool.name} ..." after verifying the target IDs. Use "info ${tool.name}" to inspect the tool first.`
                         )
                     }
-                    let input: Record<string, unknown>
-                    if (!jsonBody) {
-                        input = {}
-                    } else {
-                        try {
-                            input = JSON.parse(jsonBody) as Record<string, unknown>
-                        } catch (err) {
-                            const detail = err instanceof Error ? err.message : String(err)
-                            throw new Error(`Invalid JSON input: ${detail}`)
-                        }
-                    }
+                    let input = parseCallJsonInput(jsonBody)
 
                     // `output_format` is hidden from exec-mode schemas — `--json` owns output
                     // encoding. Honor a stray `output_format: "json"` as `--json` instead of

--- a/services/mcp/src/tools/gateway.ts
+++ b/services/mcp/src/tools/gateway.ts
@@ -1,0 +1,190 @@
+/**
+ * Client for the MCP gateway REST endpoints (`products/mcp_store`'s
+ * `mcp_gateway` viewset), which expose the tools of external MCP servers a
+ * team connected via the PostHog MCP store. The exec tool routes names
+ * containing `/` (`<server_slug>/<tool_name>`) here; see `ExecToolOptions.gateway`.
+ *
+ * Every request rides the caller's own bearer through the shared `ApiClient` —
+ * this service never holds upstream server secrets; the Django execution plane
+ * is the only place they are decrypted.
+ */
+import { PostHogApiError } from '@/lib/errors'
+
+import type { Context } from './types'
+
+/** Namespaced gateway tool names are `<server_slug>/<tool_name>`; `/` never
+ *  appears in PostHog's own kebab-case tool names, so it is the routing signal. */
+export function isGatewayToolName(name: string): boolean {
+    return name.includes('/')
+}
+
+export interface GatewayServerInfo {
+    slug: string
+    display_name: string
+    installation_id: string
+    scope: 'personal' | 'shared'
+}
+
+export type GatewayToolApprovalState = 'approved' | 'needs_approval' | 'do_not_use'
+
+export interface GatewayTool {
+    /** Namespaced `<server_slug>/<tool_name>`. */
+    name: string
+    server: GatewayServerInfo
+    tool_name: string
+    description: string
+    input_schema: Record<string, unknown>
+    approval_state: GatewayToolApprovalState
+}
+
+export interface GatewayCallContentBlock {
+    type: string
+    text?: string
+    [key: string]: unknown
+}
+
+/** Mirrors the MCP CallToolResult plus gateway call metadata. */
+export interface GatewayCallResult {
+    content: GatewayCallContentBlock[]
+    is_error: boolean
+    structured_content?: Record<string, unknown>
+    server_slug: string
+    tool_name: string
+    duration_ms: number
+}
+
+/** Surface the exec tool talks to; `createGatewayClient` is the API-backed
+ *  implementation, tests substitute their own. */
+export interface GatewayClient {
+    searchTools(query: string): Promise<GatewayTool[]>
+    getTool(name: string): Promise<GatewayTool | undefined>
+    callTool(name: string, args: Record<string, unknown>): Promise<GatewayCallResult>
+}
+
+/** Caps how many connected-server tools a single `exec search` merges in, so a
+ *  broad query can't crowd out the PostHog results. */
+const GATEWAY_SEARCH_LIMIT = 10
+
+export function unknownGatewayToolMessage(name: string): string {
+    return `Unknown connected-server tool: "${name}". Run "search <words>" to find tools from connected MCP servers.`
+}
+
+// The list endpoint is DRF-paginated in the default configuration but the
+// contract only pins the item shape — accept both a bare array and a
+// `{ results: [...] }` envelope.
+type GatewayToolListResponse = GatewayTool[] | { results?: GatewayTool[] }
+
+function toToolList(response: GatewayToolListResponse): GatewayTool[] {
+    if (Array.isArray(response)) {
+        return response
+    }
+    return response.results ?? []
+}
+
+function parseErrorBody(body: string): Record<string, unknown> | undefined {
+    try {
+        const parsed: unknown = JSON.parse(body)
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : undefined
+    } catch {
+        return undefined
+    }
+}
+
+/**
+ * Map a gateway `POST call/` failure to an actionable message. Re-thrown as a
+ * `PostHogApiError` with the same status so error classification and the
+ * 4xx/5xx capture split in `handleToolError` keep working; only the message is
+ * replaced with something the agent (and the user) can act on.
+ */
+function mapGatewayCallError(name: string, error: unknown): unknown {
+    if (!(error instanceof PostHogApiError)) {
+        return error
+    }
+    const body = parseErrorBody(error.body)
+    const code = typeof body?.code === 'string' ? body.code : undefined
+
+    let message: string | undefined
+    if (error.status === 403 && code === 'tool_needs_approval') {
+        const approvalUrl = typeof body?.approval_url === 'string' ? body.approval_url : undefined
+        message =
+            `Tool "${name}" needs approval before it can be called. ` +
+            `Ask the user to approve it in their PostHog MCP server settings${approvalUrl ? `: ${approvalUrl}` : '.'}`
+    } else if (error.status === 403 && code === 'tool_blocked') {
+        message = `Tool "${name}" is blocked ("do not use") in this project's MCP server settings and cannot be called.`
+    } else if (error.status === 404) {
+        message = unknownGatewayToolMessage(name)
+    } else if (error.status === 502) {
+        const detail = typeof body?.detail === 'string' ? body.detail : error.body
+        message = `The connected MCP server failed while executing "${name}": ${detail}`
+    }
+
+    if (!message) {
+        return error
+    }
+    return new PostHogApiError({
+        status: error.status,
+        statusText: error.statusText,
+        body: error.body,
+        url: error.url,
+        method: error.method,
+        message,
+    })
+}
+
+/** Render a gateway CallToolResult's content for the agent: text blocks joined,
+ *  non-text blocks noted by type, structured content as a JSON fallback. */
+export function renderGatewayCallContent(result: GatewayCallResult): string {
+    const parts = (result.content ?? []).map((block) =>
+        block.type === 'text' && typeof block.text === 'string' ? block.text : `[${block.type} content omitted]`
+    )
+    const text = parts.join('\n').trim()
+    if (text) {
+        return text
+    }
+    if (result.structured_content) {
+        return JSON.stringify(result.structured_content)
+    }
+    return '(empty result)'
+}
+
+export function createGatewayClient(context: Context, consumer?: string): GatewayClient {
+    const listTools = async (query: Record<string, unknown>): Promise<GatewayTool[]> => {
+        const projectId = await context.stateManager.getProjectId()
+        const response = await context.api.request<GatewayToolListResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(projectId)}/mcp_gateway/tools/`,
+            query,
+        })
+        return toToolList(response)
+    }
+
+    return {
+        async searchTools(query: string): Promise<GatewayTool[]> {
+            return listTools({ search: query, limit: GATEWAY_SEARCH_LIMIT })
+        },
+
+        async getTool(name: string): Promise<GatewayTool | undefined> {
+            const tools = await listTools({ name })
+            return tools.find((t) => t.name === name) ?? tools[0]
+        },
+
+        async callTool(name: string, args: Record<string, unknown>): Promise<GatewayCallResult> {
+            const projectId = await context.stateManager.getProjectId()
+            try {
+                return await context.api.request<GatewayCallResult>({
+                    method: 'POST',
+                    path: `/api/projects/${encodeURIComponent(projectId)}/mcp_gateway/call/`,
+                    body: {
+                        tool: name,
+                        arguments: args,
+                        ...(consumer ? { consumer } : {}),
+                    },
+                })
+            } catch (error) {
+                throw mapGatewayCallError(name, error)
+            }
+        },
+    }
+}

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -263,5 +263,73 @@ describe('ToolExecutor token estimates', () => {
             const trackEvent = state.reqCtx.trackEvent as ReturnType<typeof vi.fn>
             expect(trackEvent.mock.calls.some((call) => call[0] === 'mcp_tool_call')).toBe(false)
         })
+
+        it('attributes gateway calls to the namespaced tool with $mcp_source: "gateway" when the flag is on', async () => {
+            const tools = catalog
+                .getFilteredTools({ scopes: ['*'] })
+                .filter((tool) => tool.name === 'execute-sql' || tool.name === 'organization-get')
+            const request = vi.fn().mockResolvedValue({
+                content: [{ type: 'text', text: 'Created ABC-1' }],
+                is_error: false,
+                server_slug: 'linear',
+                tool_name: 'create_issue',
+                duration_ms: 42,
+            })
+            const state = makeState(tools, {
+                useSingleExec: true,
+                toolFeatureFlags: { MCP_GATEWAY: true },
+                context: {
+                    api: { request },
+                    cache: {},
+                    env: {},
+                    stateManager: { getProjectId: vi.fn().mockResolvedValue('123') },
+                    sessionManager: {},
+                    getDistinctId: vi.fn(),
+                    trackEvent: vi.fn(),
+                } as any,
+            })
+
+            await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'call --confirm linear/create_issue {"title":"t"}' } },
+                state
+            )
+
+            expect(request).toHaveBeenCalledTimes(1)
+            const gatewayCall = mockTrackToolCall.mock.calls.find((call) => call[0] === 'linear/create_issue')!
+            expect(gatewayCall).toBeTruthy()
+            expect(gatewayCall[2]).toBe(false)
+            expect(gatewayCall[4].$mcp_source).toBe('gateway')
+        })
+
+        it('never reaches the gateway when the MCP_GATEWAY flag is off', async () => {
+            const tools = catalog
+                .getFilteredTools({ scopes: ['*'] })
+                .filter((tool) => tool.name === 'execute-sql' || tool.name === 'organization-get')
+            const request = vi.fn()
+            const state = makeState(tools, {
+                useSingleExec: true,
+                toolFeatureFlags: { MCP_GATEWAY: false },
+                context: {
+                    api: { request },
+                    cache: {},
+                    env: {},
+                    stateManager: { getProjectId: vi.fn().mockResolvedValue('123') },
+                    sessionManager: {},
+                    getDistinctId: vi.fn(),
+                    trackEvent: vi.fn(),
+                } as any,
+            })
+
+            const response = (await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'call --confirm linear/create_issue {"title":"t"}' } },
+                state
+            )) as any
+
+            // Flag off ⇒ identical to today: the namespaced name is just an unknown tool.
+            expect(request).not.toHaveBeenCalled()
+            expect(response.isError).toBe(true)
+            expect(joinedText(response)).toContain('Unknown tool')
+            expect(mockTrackToolCall.mock.calls.some((call) => call[4]?.$mcp_source === 'gateway')).toBe(false)
+        })
     })
 })

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -1,15 +1,16 @@
 import guidelines from '@shared/guidelines.md'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { parse as parseYaml } from 'yaml'
 import { z } from 'zod'
 
-import { ToolInputValidationError } from '@/lib/errors'
+import { ConnectedToolError, PostHogApiError, ToolInputValidationError } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { buildQueryToolsBlock, buildToolDomainsCompact } from '@/lib/instructions'
 import { InstructionsFormatter } from '@/lib/instructions-formatter'
 import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
 import { createExecTool, type ExecInnerCallProperties, parseExecCallInnerToolName } from '@/tools/exec'
+import { createGatewayClient, type GatewayClient, type GatewayCallResult, type GatewayTool } from '@/tools/gateway'
 import { getToolDefinition } from '@/tools/toolDefinitions'
 import {
     POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
@@ -970,6 +971,315 @@ describe('exec tool', () => {
             const exec = createExec([makeMockTool()])
             await expect(exec.handler(mockContext, { command: 'search [invalid' })).rejects.toThrow(
                 /invalid regex pattern/i
+            )
+        })
+    })
+
+    describe('connected-server (gateway) tools', () => {
+        function makeGatewayTool(overrides: Partial<GatewayTool> = {}): GatewayTool {
+            return {
+                name: 'linear/create_issue',
+                server: { slug: 'linear', display_name: 'Linear', installation_id: 'inst-1', scope: 'shared' },
+                tool_name: 'create_issue',
+                description: 'Create a Linear issue\nSecond line that must not surface in search results.',
+                input_schema: {
+                    type: 'object',
+                    properties: {
+                        title: { type: 'string' },
+                        assignee: { type: 'object', properties: { id: { type: 'string' } } },
+                    },
+                    required: ['title'],
+                },
+                approval_state: 'approved',
+                ...overrides,
+            }
+        }
+
+        function makeCallResult(overrides: Partial<GatewayCallResult> = {}): GatewayCallResult {
+            return {
+                content: [{ type: 'text', text: 'Created ABC-1' }],
+                is_error: false,
+                server_slug: 'linear',
+                tool_name: 'create_issue',
+                duration_ms: 42,
+                ...overrides,
+            }
+        }
+
+        function makeGateway(overrides: Partial<GatewayClient> = {}): GatewayClient {
+            return {
+                searchTools: async () => [],
+                getTool: async () => undefined,
+                callTool: async () => {
+                    throw new Error('callTool not stubbed')
+                },
+                ...overrides,
+            }
+        }
+
+        function createExecWithGateway(
+            tools: Tool<ZodObjectAny>[],
+            gateway: GatewayClient,
+            tracker?: (toolName: string, properties: ExecInnerCallProperties) => void
+        ): Tool<any> {
+            return createExecTool(tools, mockContext, 'desc', 'cmd', undefined, tracker, [], { gateway })
+        }
+
+        it.each(['call linear/create_issue {"title":"t"}', 'info linear/create_issue', 'schema linear/create_issue'])(
+            'treats namespaced names as unknown tools when the gateway is not enabled ("%s")',
+            async (command) => {
+                const exec = createExec([makeMockTool()])
+                await expect(exec.handler(mockContext, { command })).rejects.toThrow(
+                    /Unknown tool: "linear\/create_issue"/
+                )
+            }
+        )
+
+        it.each([
+            ['reports no connected tools', async (): Promise<GatewayTool[]> => []],
+            [
+                'fails',
+                async (): Promise<GatewayTool[]> => {
+                    throw new Error('gateway down')
+                },
+            ],
+        ])('keeps the plain search output byte-identical when the gateway %s', async (_label, searchTools) => {
+            const flagTool = makeMockTool({ name: 'feature-flag-get-all', title: 'List feature flags' })
+            const exec = createExecWithGateway([flagTool], makeGateway({ searchTools }))
+            const result = await exec.handler(mockContext, { command: 'search feature-flag' })
+            expect(result).toBe(JSON.stringify(['feature-flag-get-all']))
+        })
+
+        it('merges connected-server matches into search results, labeled with their server', async () => {
+            const flagTool = makeMockTool({ name: 'feature-flag-get-all', title: 'List feature flags' })
+            const queries: string[] = []
+            const gateway = makeGateway({
+                searchTools: async (query) => {
+                    queries.push(query)
+                    return [makeGatewayTool()]
+                },
+            })
+            const exec = createExecWithGateway([flagTool], gateway)
+            const result = JSON.parse((await exec.handler(mockContext, { command: 'search feature-flag' })) as string)
+            expect(queries).toEqual(['feature-flag'])
+            expect(result.matches).toEqual(['feature-flag-get-all'])
+            expect(result.connected_server_tools).toEqual([
+                { name: 'linear/create_issue', server: 'Linear', description: 'Create a Linear issue' },
+            ])
+            expect(result.connected_server_hint).toContain('--confirm')
+        })
+
+        it('surfaces connected-server matches without a no-match hint when no PostHog tool matches', async () => {
+            const exec = createExecWithGateway(
+                [makeMockTool()],
+                makeGateway({ searchTools: async () => [makeGatewayTool()] })
+            )
+            const result = JSON.parse((await exec.handler(mockContext, { command: 'search linear' })) as string)
+            expect(result.matches).toEqual([])
+            expect(result.hint).toBeUndefined()
+            expect(result.connected_server_tools).toHaveLength(1)
+        })
+
+        it('routes info for a namespaced name to the gateway and renders its schema', async () => {
+            const exec = createExecWithGateway(
+                [makeMockTool()],
+                makeGateway({ getTool: async () => makeGatewayTool() })
+            )
+            const result = (await exec.handler(mockContext, { command: 'info linear/create_issue' })) as string
+            const envelope = parseYaml(result) as { name: string; approval_state: string; inputSchema: string }
+            expect(envelope.name).toBe('linear/create_issue')
+            expect(envelope.approval_state).toBe('approved')
+            const schema = JSON.parse(envelope.inputSchema)
+            expect(schema.properties.title.type).toBe('string')
+        })
+
+        it('drills into a gateway tool schema with the existing summarize/drill-down helpers', async () => {
+            const exec = createExecWithGateway(
+                [makeMockTool()],
+                makeGateway({ getTool: async () => makeGatewayTool() })
+            )
+            const bare = JSON.parse(
+                (await exec.handler(mockContext, { command: 'schema linear/create_issue' })) as string
+            )
+            expect(Object.keys(bare.properties)).toEqual(['title', 'assignee'])
+            const drilled = JSON.parse(
+                (await exec.handler(mockContext, { command: 'schema linear/create_issue assignee' })) as string
+            )
+            expect(drilled.field).toBe('assignee')
+            expect(drilled.schema.properties.id.type).toBe('string')
+        })
+
+        it.each(['info linear/nope', 'schema linear/nope'])(
+            'reports an unknown connected-server tool actionably for "%s"',
+            async (command) => {
+                const exec = createExecWithGateway([makeMockTool()], makeGateway())
+                await expect(exec.handler(mockContext, { command })).rejects.toThrow(
+                    /Unknown connected-server tool: "linear\/nope"/
+                )
+            }
+        )
+
+        it('requires --confirm before calling a connected-server tool', async () => {
+            let called = false
+            const gateway = makeGateway({
+                callTool: async () => {
+                    called = true
+                    return makeCallResult()
+                },
+            })
+            const exec = createExecWithGateway([makeMockTool()], gateway)
+            await expect(
+                exec.handler(mockContext, { command: 'call linear/create_issue {"title":"t"}' })
+            ).rejects.toThrow(/call --confirm linear\/create_issue/)
+            expect(called).toBe(false)
+        })
+
+        it('dispatches a confirmed call through the gateway, renders the result, and tracks the gateway source', async () => {
+            const received: { name: string; args: Record<string, unknown> }[] = []
+            const calls: { toolName: string; properties: ExecInnerCallProperties }[] = []
+            const gateway = makeGateway({
+                callTool: async (name, args) => {
+                    received.push({ name, args })
+                    return makeCallResult({
+                        content: [
+                            { type: 'text', text: 'Created ABC-1' },
+                            { type: 'image', data: 'aGk=' },
+                        ],
+                    })
+                },
+            })
+            const exec = createExecWithGateway([makeMockTool()], gateway, (toolName, properties) => {
+                calls.push({ toolName, properties })
+            })
+            const result = await exec.handler(mockContext, {
+                command: 'call --confirm linear/create_issue {"title":"t"}',
+            })
+            expect(received).toEqual([{ name: 'linear/create_issue', args: { title: 't' } }])
+            // Text blocks render verbatim; non-text blocks are noted, not dumped.
+            expect(result).toBe('Created ABC-1\n[image content omitted]')
+            expect(calls).toHaveLength(1)
+            expect(calls[0]!.toolName).toBe('linear/create_issue')
+            expect(calls[0]!.properties.success).toBe(true)
+            expect(calls[0]!.properties.source).toBe('gateway')
+        })
+
+        it('surfaces an is_error CallToolResult as the upstream tool error', async () => {
+            const calls: { toolName: string; properties: ExecInnerCallProperties }[] = []
+            const gateway = makeGateway({
+                callTool: async () =>
+                    makeCallResult({ is_error: true, content: [{ type: 'text', text: 'issue not found' }] }),
+            })
+            const exec = createExecWithGateway([makeMockTool()], gateway, (toolName, properties) => {
+                calls.push({ toolName, properties })
+            })
+            const error: unknown = await exec
+                .handler(mockContext, { command: 'call --confirm linear/create_issue {}' })
+                .then(
+                    () => null,
+                    (e: unknown) => e
+                )
+            expect(error).toBeInstanceOf(ConnectedToolError)
+            expect((error as Error).message).toContain('issue not found')
+            expect(calls[0]!.properties.success).toBe(false)
+            expect(calls[0]!.properties.source).toBe('gateway')
+        })
+
+        // End-to-end through the real API-backed client, mocking only the HTTP
+        // boundary — pins the documented wire contract with the Django gateway.
+        function makeApiContext(request: ReturnType<typeof vi.fn>): Context {
+            return {
+                api: { request },
+                stateManager: { getProjectId: async () => '123' },
+                getDistinctId: async () => 'test-distinct-id',
+            } as unknown as Context
+        }
+
+        it('POSTs gateway calls to the project-scoped call endpoint with the documented body', async () => {
+            const request = vi.fn(async () => makeCallResult({ content: [{ type: 'text', text: 'ok' }] }))
+            const context = makeApiContext(request)
+            const gateway = createGatewayClient(context, 'posthog-cli')
+            const exec = createExecTool([makeMockTool()], context, 'desc', 'cmd', undefined, undefined, [], {
+                gateway,
+            })
+            const result = await exec.handler(context, {
+                command: 'call --confirm linear/create_issue {"title":"t"}',
+            })
+            expect(result).toBe('ok')
+            expect(request).toHaveBeenCalledWith({
+                method: 'POST',
+                path: '/api/projects/123/mcp_gateway/call/',
+                body: { tool: 'linear/create_issue', arguments: { title: 't' }, consumer: 'posthog-cli' },
+            })
+        })
+
+        it('queries the gateway tools endpoint for search and exact-name lookups', async () => {
+            const request = vi.fn(async () => ({ results: [makeGatewayTool()] }))
+            const context = makeApiContext(request)
+            const gateway = createGatewayClient(context)
+            const exec = createExecTool([makeMockTool()], context, 'desc', 'cmd', undefined, undefined, [], {
+                gateway,
+            })
+
+            await exec.handler(context, { command: 'search linear' })
+            expect(request).toHaveBeenCalledWith({
+                method: 'GET',
+                path: '/api/projects/123/mcp_gateway/tools/',
+                query: { search: 'linear', limit: 10 },
+            })
+
+            await exec.handler(context, { command: 'info linear/create_issue' })
+            expect(request).toHaveBeenLastCalledWith({
+                method: 'GET',
+                path: '/api/projects/123/mcp_gateway/tools/',
+                query: { name: 'linear/create_issue' },
+            })
+        })
+
+        it.each([
+            {
+                case: 'a 403 tool_needs_approval with its approval URL',
+                status: 403,
+                body: {
+                    code: 'tool_needs_approval',
+                    approval_url: 'https://us.posthog.com/settings/environment-mcp-servers',
+                },
+                expected: /needs approval.*https:\/\/us\.posthog\.com\/settings\/environment-mcp-servers/,
+            },
+            {
+                case: 'a 403 tool_blocked',
+                status: 403,
+                body: { code: 'tool_blocked' },
+                expected: /blocked \("do not use"\)/,
+            },
+            {
+                case: 'a 404 unknown tool',
+                status: 404,
+                body: { detail: 'Not found.' },
+                expected: /Unknown connected-server tool: "linear\/create_issue"/,
+            },
+            {
+                case: 'a 502 upstream failure',
+                status: 502,
+                body: { detail: 'upstream timed out' },
+                expected: /failed while executing "linear\/create_issue": upstream timed out/,
+            },
+        ])('maps $case to an actionable error', async ({ status, body, expected }) => {
+            const request = vi.fn(async () => {
+                throw new PostHogApiError({
+                    status,
+                    statusText: 'error',
+                    body: JSON.stringify(body),
+                    url: 'https://us.posthog.com/api/projects/123/mcp_gateway/call/',
+                    method: 'POST',
+                })
+            })
+            const context = makeApiContext(request)
+            const gateway = createGatewayClient(context)
+            const exec = createExecTool([makeMockTool()], context, 'desc', 'cmd', undefined, undefined, [], {
+                gateway,
+            })
+            await expect(exec.handler(context, { command: 'call --confirm linear/create_issue {}' })).rejects.toThrow(
+                expected
             )
         })
     })

--- a/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
@@ -142,7 +142,9 @@ describe('InstructionsFormatter prompt snapshots', () => {
         const state = {
             allTools: Object.keys(getToolDefinitions()).map((name) => ({ name })),
             clientProfile: new MCPClientProfile({ vendorClient: 'ClaudeAI', userAgent: 'Claude-User' }),
-            toolFeatureFlags: { 'mcp-feedback-tool': true },
+            // Every prompt-gating flag on, so the worst case includes all gated lines
+            // (agent feedback, the connected-servers pointer).
+            toolFeatureFlags: { 'mcp-feedback-tool': true, MCP_GATEWAY: true },
             renderUiEnabled: true,
             metadata: worstCaseMetadata,
             groupTypes: worstCaseGroupTypes,

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -219,6 +219,20 @@ describe('InstructionsFormatter', () => {
             }
         })
 
+        it('includes the connected-servers line only when the MCP_GATEWAY flag is on', () => {
+            const formatter = new InstructionsFormatter()
+            const marker = 'come from MCP servers connected to this PostHog project'
+
+            // fullCtx has no MCP_GATEWAY flag — the line must not leak to ungated users.
+            expect(formatter.buildExecCommandReference(fullCtx, { stripEnvContext: false })).not.toContain(marker)
+            expect(
+                formatter.buildExecCommandReference(
+                    { ...fullCtx, featureFlags: { ...fullCtx.featureFlags, MCP_GATEWAY: true } },
+                    { stripEnvContext: false }
+                )
+            ).toContain(marker)
+        })
+
         it('includes the rendering section only when render-ui is available for the client', () => {
             const formatter = new InstructionsFormatter()
             for (const stripEnvContext of [true, false]) {


### PR DESCRIPTION
## Problem

Stacked on #70170. The `exec` indirection gives agents search and call access to PostHog's own tools, but a team's connected external MCP servers (the MCP store installations) are not reachable through the same access point. Agents should connect to the PostHog MCP once and reach everything.

## Changes

All in `services/mcp/`, gated on the `MCP_GATEWAY` feature flag (batch-evaluated with the existing tool flags, zero extra flag calls). Flag off means byte-identical behavior on every path.

- New `src/tools/gateway.ts`: typed client for the two gateway REST endpoints from #70170, always called with the caller's own bearer. This service holds no upstream credentials
- `exec search` merges connected-server tools into results as a labeled section
- `exec info` and `exec schema` route namespaced `server/tool` names to the gateway and render with the existing schema summarize and drill-down helpers
- `exec call` routes `server/tool` names to the gateway, requires `--confirm` (connected tools are treated as potentially destructive by default), and renders the approval 403 as an actionable message with the approval URL
- Analytics: gateway calls emit `$mcp_tool_call` re-attributed to the namespaced inner tool with `$mcp_source: "gateway"`. Upstream tool failures are classified as a new `upstream_tool` error type via `ConnectedToolError` so they do not mint PostHog error-tracking issues
- Exactly one flag-gated line added to the exec command reference. The ~32,600-char tool-entry budget test now measures with the flag forced on, making the guard stricter

> [!NOTE]
> The `posthog-cli` path passes no gateway option, so CLI behavior is unchanged.

## How did you test this code?

Automated only (agent-run, mocked Django responses):

- `pnpm vitest run`: 2096 unit tests pass (21 added); `pnpm test:hono`: 294 pass. The 4 workers-pool errors are pre-existing on master (miniflare and vitest expect version mismatch)
- The size-budget snapshot test passes with `MCP_GATEWAY: true`, which is the regression that matters most here: an oversized exec entry silently breaks the whole MCP in claude.ai
- New tests catch regressions no existing test did: `/`-name routing, search merge, approval-error rendering, and flag-off no-op behavior
- Typecheck clean on changed files; oxlint clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No `docs/` changes: behavior is flag-gated and not yet announced. Docs land with the rollout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) using parallel subagents, directed by @cvolzer3. Built in parallel with #70170 against a written endpoint contract, then restacked and re-verified once the Django side landed. Decisions: gateway list parsing tolerates both bare-array and paginated envelopes since the contract pins only item shape; upstream tool errors get a typed `ConnectedToolError` instead of riding the generic error path so exec output stays verbatim and uncaptured.
