### PR TITLE
feat(tasks): drop per-installation MCP configs behind mcp-gateway flag

### DIFF
--- a/products/agent_platform/services/agent-shared/src/runtime/mcp-connection-store.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/mcp-connection-store.ts
@@ -4,6 +4,9 @@
  * connection, every asker). DB-direct against `posthogDb`, no Django HTTP:
  * read → decrypt → refresh-on-expiry → write-back, duplicating mcp_store/oauth.py.
  * `FOR UPDATE` serialises the shared row; cross-pod single-flight is deferred.
+ * Intended successor: the PostHog MCP gateway surface backed by mcp_store's gateway
+ * module (products/mcp_store/backend/gateway.py) — migrating needs a runner
+ * token-minting design first.
  */
 
 import type { Pool, PoolClient } from 'pg'

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -7,6 +7,10 @@ SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
 AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG = "tasks-agent-proxy-keep-stream-open"
 MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
+# Drops per-installation MCP configs from sandboxes: with the flag on, the
+# sandbox's PostHog MCP config is the single access point and connected MCP
+# servers are reached through its gateway surface (backed by mcp_store).
+MCP_GATEWAY_FEATURE_FLAG = "mcp-gateway"
 
 
 def vm_sandbox_allowed_origin_products(payload: object) -> set[str]:

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -326,6 +326,13 @@ class TestFetchUserMcpServerConfigs(TestCase):
 
     MOCK_FACADE = "products.tasks.backend.temporal.process_task.utils.get_installations_for_sandbox"
     MOCK_API_URL = "products.tasks.backend.temporal.process_task.utils.get_sandbox_api_url"
+    MOCK_FLAG = "products.tasks.backend.temporal.process_task.utils.posthoganalytics.feature_enabled"
+
+    def setUp(self) -> None:
+        super().setUp()
+        flag_patcher = patch(self.MOCK_FLAG, return_value=False)
+        self.mock_feature_enabled = flag_patcher.start()
+        self.addCleanup(flag_patcher.stop)
 
     def _make_installation(self, **kwargs) -> ActiveInstallationInfo:
         defaults = {
@@ -430,6 +437,50 @@ class TestFetchUserMcpServerConfigs(TestCase):
         assert len(configs) == 2
         assert configs[0].name == "Linear"
         assert configs[1].name == "Notion"
+
+    @parameterized.expand(
+        [
+            ("flag_on", True),
+            ("flag_off", False),
+        ]
+    )
+    @patch(MOCK_API_URL)
+    @patch(MOCK_FACADE)
+    def test_gateway_flag_gates_per_installation_configs(
+        self, _name: str, flag_enabled: bool, mock_facade, mock_api_url
+    ) -> None:
+        mock_api_url.return_value = self.API_BASE
+        self.mock_feature_enabled.return_value = flag_enabled
+        installation = self._make_installation()
+        mock_facade.return_value = [installation]
+
+        configs = get_user_mcp_server_configs(self.TOKEN, self.TEAM_ID, self.USER_ID)
+
+        if flag_enabled:
+            assert configs == []
+            mock_facade.assert_not_called()
+        else:
+            assert configs == [
+                McpServerConfig(
+                    type="http",
+                    name="Linear",
+                    url=f"{self.API_BASE}{installation.proxy_path}",
+                    headers=self._expected_user_headers(),
+                )
+            ]
+
+    @patch(MOCK_API_URL)
+    @patch(MOCK_FACADE)
+    def test_gateway_flag_check_failure_falls_back_to_per_installation(self, mock_facade, mock_api_url) -> None:
+        mock_api_url.return_value = self.API_BASE
+        self.mock_feature_enabled.side_effect = Exception("flag service down")
+        installation = self._make_installation()
+        mock_facade.return_value = [installation]
+
+        configs = get_user_mcp_server_configs(self.TOKEN, self.TEAM_ID, self.USER_ID)
+
+        assert len(configs) == 1
+        assert configs[0].url == f"{self.API_BASE}{installation.proxy_path}"
 
 
 class TestGetGitIdentityEnvVars(TestCase):

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 
+import posthoganalytics
 from pydantic import BaseModel
 
 from posthog.models.integration import GitHubIntegration, Integration
@@ -19,6 +20,7 @@ from products.mcp_store.backend.facade.api import get_installations_for_sandbox
 from products.tasks.backend.constants import (
     ALLOWED_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATHS,
     DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
+    MCP_GATEWAY_FEATURE_FLAG,
     SNAPSHOT_KIND_DIRECTORY,
     SNAPSHOT_KIND_FILESYSTEM,
     InitialPermissionMode,
@@ -396,6 +398,23 @@ def get_sandbox_api_url() -> str:
     return settings.SANDBOX_API_URL or settings.SITE_URL
 
 
+def _is_mcp_gateway_enabled(team_id: int) -> bool:
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                MCP_GATEWAY_FEATURE_FLAG,
+                f"team-{team_id}",
+                groups={"project": str(team_id)},
+                group_properties={"project": {"id": str(team_id)}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        logger.warning("MCP gateway flag check failed; using per-installation configs", extra={"error": str(e)})
+        return False
+
+
 def get_user_mcp_server_configs(
     token: str,
     team_id: int,
@@ -410,6 +429,11 @@ def get_user_mcp_server_configs(
     ``include_personal`` is True and a ``user_id`` is provided, the user's
     personal installations are included too.
 
+    When the team has the MCP gateway flag enabled, no per-installation
+    configs are emitted at all: the sandbox's PostHog MCP config (see
+    ``get_sandbox_ph_mcp_configs``) is the single access point, and connected
+    MCP servers are reached through its gateway surface instead.
+
     The `x-posthog-mcp-consumer` header is set on every config so the agent's
     identity propagates through the MCP Store proxy to whichever upstream MCP
     the user installed. The PostHog MCP needs this to resolve single-exec mode
@@ -418,6 +442,9 @@ def get_user_mcp_server_configs(
 
     Returns an empty list on errors (non-fatal).
     """
+    if _is_mcp_gateway_enabled(team_id):
+        return []
+
     installations = get_installations_for_sandbox(
         team_id,
         user_id=user_id,


### PR DESCRIPTION
## Problem

Stacked on #70170 and the exec gateway PR. Sandbox task runs (PostHog Code, Slack, self-driving) currently receive one MCP server config per installed external server, each pointing at a separate per-installation proxy URL. With the PostHog MCP now surfacing connected servers through `exec`, those per-installation configs are redundant: the PostHog MCP config the sandbox already has is the single access point.

## Changes

- `get_user_mcp_server_configs` returns no per-installation configs when the team has the `mcp-gateway` feature flag enabled. Flag off is byte-identical to current behavior, and the flag check fails closed to the per-installation path on flag-service errors
- New `MCP_GATEWAY_FEATURE_FLAG` constant in `products/tasks/backend/constants.py`
- One-line comment in agent-platform's `mcp-connection-store.ts` pointing at the PostHog MCP gateway surface as its intended successor. No behavior change there; migrating the runner needs a token-minting design and is deliberately out of scope

> [!WARNING]
> Rollout must stay cloud-only for now. In environments where no PostHog MCP config is emitted (custom domains without `SANDBOX_MCP_URL`), enabling the flag would leave the sandbox with no MCP configs at all. Verified both call sites (`start_agent_server`, `send_followup_to_sandbox`) merge PostHog MCP configs and nothing depends on per-installation configs being present.

## How did you test this code?

Automated only (agent-run):

- `hogli test products/tasks/backend/temporal/process_task/tests/test_utils.py`: 86 tests pass, including new parameterized flag-on/flag-off cases (flag on: empty external configs and the store facade is not called; flag off: exact current per-installation output) and a flag-service-failure fallback test
- On the full stack tip, gateway plus tasks suites pass together (116 tests)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No `docs/` changes: flag-gated internal behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) using subagents, directed by @cvolzer3. Skill invoked: `/writing-tests`. This PR was originally scoped to also migrate Max's `call_mcp_server` tool onto the gateway; that refactor was fully built and tested, then reverted after we decided Max is moving to MCP-based infrastructure separately, so investing in its legacy path made no sense. The flag check pattern (`posthoganalytics.feature_enabled` with team group context and no user context) follows the existing convention in the tasks temporal code.
