### PR TITLE
chore: add HogQL access control architecture readme

### DIFF
--- a/.agents/skills/debugging-table-access-denied/SKILL.md
+++ b/.agents/skills/debugging-table-access-denied/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: debugging-table-access-denied
+description: Debug a TableAccessDeniedError — the "You don't have access to table `X`." error — from an error tracking issue, a Slack alert, or a user report. Use when investigating why HogQL denied a table (system.* or warehouse) and whether the occurrence is a real bug or working-as-designed. Trigger terms: TableAccessDeniedError, table_access_denied, "You don't have access to table".
+---
+
+# Debugging "You don't have access to table"
+
+`TableAccessDeniedError` (`posthog/hogql/errors.py`, code `table_access_denied`) means the query referenced a table that access control removed from the HogQL schema.
+The mechanism — how and why tables get removed — is documented in [`posthog/hogql/ACCESS_CONTROL.md`](../../../posthog/hogql/ACCESS_CONTROL.md); read it first.
+
+Hints:
+
+- The error proves the table exists and was denied. A nonexistent table raises `Unknown table` instead.
+- On an HTTP request this is an expected 4xx, never captured. An error tracking issue means it was raised in a background context — figure out which from the event's query tags (`team_id`, `user_id`, `product`, `celery_task_id`, `temporal.*`).
+- A `system.*` name is a system-table decision; a bare name is a warehouse table/view denial.
+- No `user_id` on the event usually means a userless `Database.create_for` — it fails closed, and `bypass_warehouse_access_control` does not cover system tables. That's a bug in the calling code.
+- Background jobs run as the resource's `created_by`; a creator who left the org is the known benign cause (cache warming, alerts, and exports already suppress capture for it via `creator_access_revoked`).
+- Otherwise it's a real access rule (RBAC or entitlement) — see the readme for how a table's access level resolves, and check the `AccessControl` rows for the table's `access_scope`.

--- a/.github/scripts/check-access-control-doc-sync.sh
+++ b/.github/scripts/check-access-control-doc-sync.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Warn when a commit touches HogQL access control code without also staging the
+# doc that describes it. Never blocks: a script can check that these files
+# changed together, not whether behavior actually changed.
+
+DOC="posthog/hogql/ACCESS_CONTROL.md"
+[ -f "$DOC" ] || exit 0
+
+# The enforcement core the doc describes. Deliberately excludes big shared files
+# (database.py, printer/clickhouse.py) where most edits are unrelated.
+CORE_FILES="
+posthog/hogql/printer/access_control.py
+posthog/hogql/restricted_properties.py
+posthog/hogql/transforms/clickhouse_property_resolution.py
+posthog/hogql_queries/access_controlled_resources.py
+posthog/query_creator_access.py
+posthog/rbac/user_access_control.py
+posthog/shared_link_user.py
+posthog/synthetic_user.py
+"
+CORE_DIRS="products/access_control/backend/"
+
+STAGED=$(git diff --cached --name-only)
+printf '%s\n' "$STAGED" | grep -qx "$DOC" && exit 0
+
+HITS=""
+for f in $CORE_FILES; do
+    if printf '%s\n' "$STAGED" | grep -qx "$f"; then
+        HITS="$HITS    $f
+"
+    fi
+done
+# No grep | while read here: the pipeline would run the loop in a subshell and
+# lose the HITS accumulation. sed indents inside the substitution instead, which
+# also keeps filenames with spaces intact.
+for d in $CORE_DIRS; do
+    dir_hits=$(printf '%s\n' "$STAGED" | grep "^$d" | sed 's/^/    /')
+    [ -n "$dir_hits" ] && HITS="$HITS$dir_hits
+"
+done
+[ -z "$HITS" ] && exit 0
+
+printf '\n\033[33mThis commit changes HogQL access control code documented in %s:\n%sIf the behavior described there changed, update the doc in the same PR.\033[0m\n\n' "$DOC" "$HITS"
+exit 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -27,6 +27,12 @@ if [ -x .github/scripts/check-fixture-provenance.sh ]; then
     .github/scripts/check-fixture-provenance.sh || true
 fi
 
+# Same deal for the HogQL access control doc: warn when documented files change
+# without the doc, never block.
+if [ -x .github/scripts/check-access-control-doc-sync.sh ]; then
+    .github/scripts/check-access-control-doc-sync.sh || true
+fi
+
 # Activate Flox environment if available and not already active
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
 if command -v flox > /dev/null 2>&1 && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -1,0 +1,171 @@
+# HogQL access controls
+
+HogQL enforces access control in three layers:
+
+| Layer | What it protects | Where it's enforced | Effect when denied |
+|---|---|---|---|
+| [System tables](#1-system-tables) | `system.*` tables (dashboards, notebooks, error tracking issues, ...) | Schema build time + print time | Table removed from schema, query errors; denied objects filtered via `WHERE` |
+| [Warehouse tables and views](#2-warehouse-tables-and-views) | `DataWarehouseTable`, `DataWarehouseSavedQuery` (views and materialized views) | Schema build time | Table/view removed from schema, query errors |
+| [Property access control](#3-property-access-control) | Sensitive event/person properties (PII like email) | Compile time (AST transform + printing) | Values masked to `NULL` / stripped from JSON, no error |
+
+All three layers share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
+See [cache partitioning](#query-cache-partitioning).
+
+## Passing the user into HogQL
+
+Access control needs to know who is querying.
+The user is threaded through `Database.create_for()` and `HogQLContext` (`posthog/hogql/context.py`):
+
+```python
+from posthog.hogql.query import execute_hogql_query
+
+# The standard path: query runners pass the request user through
+execute_hogql_query(query="SELECT * FROM system.dashboards", team=team, user=request.user)
+```
+
+```python
+from posthog.hogql.database.database import Database
+
+# Building the schema directly
+database = Database.create_for(team=team, user=user, user_access_control=user_access_control)
+```
+
+`HogQLQueryRunner` and `QueryRunnerWithHogQLContext` (`posthog/hogql_queries/query_runner.py`) do this automatically when constructed with a user.
+The MCP `execute-sql` tool goes through the same path (`posthog/api/query.py` runs queries as `request.user`).
+
+**Fail closed:** if you forget to pass the user, the schema is built as if for an anonymous principal.
+All access-controlled system tables are removed (`_compute_system_table_access_decision` in `posthog/hogql/database/database.py` returns every scoped table as denied for `user=None`), and all warehouse tables/views are denied (`_is_warehouse_table_denied` / `_is_warehouse_view_denied` fail closed when `user_access_control is None`).
+This is deliberate: a forgotten user degrades to "no access" instead of "default access".
+In practice the user is available anywhere system tables are queried; for user-initiated background work, see [contexts without a request user](#contexts-without-a-request-user).
+
+## 1. System tables
+
+System tables are Postgres-backed tables under the `system.` namespace, defined in `SystemTables` (`posthog/hogql/database/schema/system.py`).
+They're primarily used by the MCP `execute-sql` tool and the SQL editor.
+
+### Resource-level access
+
+Each access-controlled system table declares an `access_scope` (e.g. `system.dashboards` → `"dashboard"`, `system.error_tracking_issues` → `"error_tracking"`).
+At schema build time, `_compute_system_table_access_decision()` checks `UserAccessControl.access_level_for_resource(access_scope)` for each scoped table and removes denied ones from the schema (`Database._apply_system_table_access()`).
+
+Removed tables are tracked in `Database._denied_tables`, so referencing one raises a clear error instead of pretending the table doesn't exist (`Database.get_table()`):
+
+```text
+You don't have access to table `system.error_tracking_issues`.
+```
+
+This is a `QueryError` (`posthog/hogql/errors.py`), so it's exposed to the user.
+
+### Object-level access
+
+For resources with per-object access controls (dashboards, notebooks, ...), denied objects are filtered out of results rather than erroring.
+At print time, `ClickHousePrinter._ensure_access_control_where_clause()` (`posthog/hogql/printer/clickhouse.py`) injects a `WHERE` guard built by `build_access_control_guard()` (`posthog/hogql/printer/access_control.py`) from `UserAccessControl.blocked_resource_ids_by_scope`.
+Child tables filter on the parent's FK (e.g. `system.dashboard_tiles` uses `access_control_id_field="dashboard_id"`).
+When rows are filtered, the response carries a warning: "Results may exclude {resources} you don't have access to".
+
+**Edge case:** object-level access does not override a resource-level deny in HogQL.
+In the app UI you can open a specific dashboard you were granted access to even if the dashboard resource is denied for you; in HogQL the resource-level deny removes `system.dashboards` entirely, so the object grant doesn't help.
+HogQL is intentionally more restrictive here, and it's a known limitation.
+
+## 2. Warehouse tables and views
+
+Gated by the `hogql-warehouse-access-control` feature flag (checked in `Database._fetch_sources`).
+
+### Resource-level: the `warehouse_objects` umbrella
+
+`warehouse_table` and `warehouse_view` both inherit from the umbrella resource `warehouse_objects` (`RESOURCE_INHERITANCE_MAP` in `posthog/rbac/user_access_control.py`).
+Denying `warehouse_objects` for a user filters every warehouse table and view out of their schema at build time.
+
+### Object-level: per-table and per-view
+
+Specific tables and views can be restricted individually.
+There's UI for this in the SQL editor: open a table's "More" menu → "Access controls".
+A denied table/view is dropped from the schema entirely (`_is_warehouse_table_denied` / `_is_warehouse_view_denied` in `posthog/hogql/database/database.py`), and its name lands in `_denied_tables` so queries get "You don't have access to table" instead of "Unknown table".
+
+The creator always has access: `UserAccessControl.access_level_for_object()` grants the object's `created_by` user the highest level regardless of explicit denies.
+`Database._fetch_sources()` preloads `created_by` on warehouse tables and saved queries so this check is query-free.
+
+### Views vs materialized views
+
+The two behave differently when the user has access to the view but not the underlying table:
+
+- **View (non-materialized):** the view's HogQL is inlined and re-resolved at query resolution time (`Resolver.visit_join_expr` in `posthog/hogql/resolver.py` parses `database_table.query` and walks it like user SQL). The nested lookup of the underlying table hits the denied schema and raises `You don't have access to table ...`. So a view cannot be used to grant indirect access to a restricted table.
+- **Materialized view:** `DataWarehouseSavedQuery.hogql_definition()` (`products/data_modeling/backend/models/datawarehouse_saved_query.py`) returns the backing `DataWarehouseTable` directly; it's a real table, no re-resolution of the source query happens. Access is checked on the view object only, so this works even when the underlying table is denied. **This is the supported way to expose a subset of columns from a restricted table.**
+
+### Contexts without a request user
+
+Warehouse access control fails closed without a user, so every caller needs one of these:
+
+1. **User is on the request:** pass it through, as shown in [passing the user into HogQL](#passing-the-user-into-hogql).
+2. **Background job acting for a user:** use the resource's `created_by`. Alerts evaluate as `alert.created_by` (`products/alerts/backend/evaluation/hogql.py`), exports render as `exported_asset.created_by` (`products/exports/backend/tasks/csv_exporter.py`).
+3. **Trusted internal job with no user at all:** pass `bypass_warehouse_access_control=True` explicitly. Used by materialization workflows (`posthog/temporal/data_modeling/`), insight cache warming, and ducklake compilation (`posthog/ducklake/client.py`). **Be very skeptical before adding a new bypass** — only do it when the job genuinely has no acting user and the output isn't served to a specific user with narrower access. The bypass never relaxes system-table access control (`_compute_system_table_access_decision` runs regardless).
+
+```python
+# Background materialization job — no user exists, bypass explicitly
+execute_hogql_query(query=..., team=team, bypass_warehouse_access_control=True)
+```
+
+4. **Public dashboards / notebooks / shared insights:** the viewer is anonymous, and queries run as `SharedLinkUser` (`posthog/shared_link_user.py`, built in `SharingViewerPageViewSet`). `SharedLinkUser` is a `SyntheticUser`, which auto-sets the warehouse bypass in `Database.create_for` — shared queries execute regardless of warehouse ACLs. That's by design: the gate is at publish time instead. Enabling sharing requires editor-level access to the resource (`SharingResourceEditCheck` in `posthog/api/sharing.py`), so only someone with access can publish it. System tables stay fully denied for shared links (`readable_system_table_access_scopes()` returns an empty set).
+5. **Project secret API keys:** `ProjectSecretAPIKeyUser` (a `SyntheticUser`, `posthog/auth.py`) also bypasses warehouse access control. That's intentional: PSAKs are authorized by their scopes, not by role-based access control. System tables are gated by the key's scopes via `readable_system_table_access_scopes()`.
+
+## 3. Property access control
+
+Hides sensitive event and person properties (e.g. `email`) from query results.
+Rules live in the `PropertyAccessControl` model (`products/access_control/backend/models/property_access_control.py`), one row per property definition per target (team default, organization member, or role).
+Resolution (`products/access_control/backend/property_access_control.py`): org admins bypass, then user-specific rule → role rules (most permissive wins) → team default rule → allow.
+Requires the `PROPERTY_ACCESS_CONTROL` feature; without it everything short-circuits to no restrictions.
+
+### Enforcement: masking, not errors
+
+Unlike the table layers, restricted properties do not error.
+They're masked at compile time, so a restricted read is indistinguishable from a nonexistent property (anti-enumeration):
+
+- **Explicit reads** (`properties.email`): `ClickHousePropertyResolver` (`posthog/hogql/transforms/clickhouse_property_resolution.py`) replaces the property access with `NULL`, and refuses to resolve it to a materialized column.
+- **Whole-blob reads** (`SELECT properties` or `SELECT *`): `ClickHousePrinter._maybe_apply_json_drop_keys()` (`posthog/hogql/printer/clickhouse.py`) wraps the column in `JSONDropKeys(...)` so restricted keys are stripped from the returned JSON.
+
+(The REST events API behaves differently: filtering on a restricted property there raises a `ValidationError`, see `posthog/api/event.py`.)
+
+Restrictions are batch-loaded once per query in `prepare_ast_for_printing()` (`posthog/hogql/printer/utils.py`) via `get_restricted_properties_for_team()` onto `HogQLContext.restricted_properties`, memoized per `(team_id, user_id)` for the request lifetime.
+`restricted_property_keys_for_table_type()` (`posthog/hogql/restricted_properties.py`) maps table types to event vs person restrictions.
+
+### No user: default rules apply
+
+When no user is present (including `SharedLinkUser` and `SyntheticUser`, which are treated as userless here), only the team **default** rules apply — see `get_restricted_properties_for_team()`.
+So public dashboards mask exactly what the team default masks, instead of failing every query closed.
+Note the asymmetry with the warehouse layer, which bypasses entirely for shared links rather than applying a default; that may be aligned later.
+
+## Query cache partitioning
+
+**The critical invariant:** if a query reads access-controlled tables, its cache key must include the user's restrictions.
+Otherwise a cache hit short-circuits the schema strip, and a denied user gets served an allowed user's cached rows.
+
+The cache key is derived from `get_cache_payload()`:
+
+- `QueryRunner.get_cache_payload()` (`posthog/hogql_queries/query_runner.py`) adds `restricted_properties` (sorted `(name, type)` pairs) when the user has property restrictions.
+- `AnalyticsQueryRunner.get_cache_payload()` adds `restricted_resources` (denied scopes) and `restricted_objects` (denied object IDs per scope) for the table layers.
+
+Two things keep cache hit rates high:
+
+1. **Feature gate:** if the organization doesn't have `AvailableFeature.ACCESS_CONTROL`, no resource/object restrictions exist, so nothing is added and the cache isn't partitioned by user at all.
+2. **Scoped to queried tables:** `queried_access_controlled_resources()` (`posthog/hogql_queries/access_controlled_resources.py`) parses the query and returns only the access-controlled scopes it actually reads. A plain events query returns an empty set and skips access-control payload entirely, so it shares one cache entry across all users (including userless cache warming). Warehouse scopes are only included when the query actually references warehouse tables or views. When a non-materialized view is referenced, `warehouse_table` is folded in too, because the view re-resolves its underlying tables at execution and a cache hit would skip that check.
+
+Userless runs fail closed in the fingerprint too (`restricted_resources: ["*"]`), and synthetic principals partition on their readable scopes so a narrow token can't reuse a broader token's cache.
+
+## One preloaded `UserAccessControl` everywhere
+
+`UserAccessControl` (`posthog/rbac/user_access_control.py`) bulk-fetches every access control row relevant to the user on the team in a single query (`_cached_access_controls`, covering team defaults, the user's membership, and the user's roles), then answers all checks in memory (`access_level_for_resource`, `check_access_level_for_object`, `blocked_resource_ids_by_scope`, ...).
+
+The same instance is reused across:
+
+- **Schema filtering:** passed into `Database.create_for()`, warmed by `_compute_system_table_access_decision()`, stored as `database.user_access_control`.
+- **Cache fingerprint:** `QueryRunnerWithHogQLContext.user_access_control` returns `self.database.user_access_control`, so the fingerprint and the schema strip resolve access from the same preloaded rows.
+- **Print-time row guards:** `build_access_control_guard()` reads `blocked_resource_ids_by_scope` off the same instance.
+- **API-level (viewset) access control:** `TeamAndOrgViewSetMixin.user_access_control` (`posthog/api/routing.py`) creates one instance per request, and dashboard rendering passes it down into each tile's query runner (`products/product_analytics/backend/api/insight.py`), so N insights share one access-control fetch.
+
+Net cost when both access-control types are active: one bulk `AccessControl` fetch plus one `PropertyAccessControl` fetch per query run.
+
+## Tests
+
+- Table layers: `posthog/hogql/printer/test/test_hogql_access_control.py` (full matrix: resource/object denies, views vs materialized views, bypass, shared links, cache keys)
+- Property layer: `posthog/hogql/printer/test/test_property_access_control.py`
+- Cache partitioning: `posthog/hogql_queries/test/test_query_runner.py`

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -2,14 +2,17 @@
 
 HogQL enforces access control in three layers:
 
-| Layer | What it protects | Where it's enforced | Effect when denied |
-|---|---|---|---|
-| [System tables](#1-system-tables) | `system.*` tables (dashboards, notebooks, error tracking issues, ...) | Schema build time + print time | Table removed from schema, query errors; denied objects filtered via `WHERE` |
-| [Warehouse tables and views](#2-warehouse-tables-and-views) | `DataWarehouseTable`, `DataWarehouseSavedQuery` (views and materialized views) | Schema build time | Table/view removed from schema, query errors |
-| [Property access control](#3-property-access-control) | Sensitive event/person properties (PII like email) | Compile time (AST transform + printing) | Values masked to `NULL` / stripped from JSON, no error |
+1. **[System tables](#1-system-tables)** — the `system.*` tables (dashboards, notebooks, error tracking issues, ...).
+   - Enforced at schema build time and print time.
+   - When denied: the whole table is removed from the schema and the query errors; individual denied objects are filtered out with a `WHERE` guard.
+2. **[Warehouse tables and views](#2-warehouse-tables-and-views)** — `DataWarehouseTable` and `DataWarehouseSavedQuery` (views and materialized views).
+   - Enforced at schema build time.
+   - When denied: the table or view is removed from the schema and the query errors.
+3. **[Property access control](#3-property-access-control)** — sensitive event and person properties (PII like email).
+   - Enforced when the query is printed to ClickHouse SQL (AST transform, then printing).
+   - When denied: values are masked to `NULL` or stripped from the JSON blob, with no error.
 
 All three layers share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
-See [cache partitioning](#query-cache-partitioning).
 
 ## Passing the user into HogQL
 
@@ -33,22 +36,22 @@ database = Database.create_for(team=team, user=user, user_access_control=user_ac
 `HogQLQueryRunner` and `QueryRunnerWithHogQLContext` (`posthog/hogql_queries/query_runner.py`) do this automatically when constructed with a user.
 The MCP `execute-sql` tool goes through the same path (`posthog/api/query.py` runs queries as `request.user`).
 
-**Fail closed:** if you forget to pass the user, the schema is built as if for an anonymous principal.
-All access-controlled system tables are removed (`_compute_system_table_access_decision` in `posthog/hogql/database/database.py` returns every scoped table as denied for `user=None`), and all warehouse tables/views are denied (`_is_warehouse_table_denied` / `_is_warehouse_view_denied` fail closed when `user_access_control is None`).
-This is deliberate: a forgotten user degrades to "no access" instead of "default access".
+**Fail closed:** if you forget to pass the user, all access-controlled system tables are removed (`_compute_system_table_access_decision` in `posthog/hogql/database/database.py` returns every scoped table as denied for `user=None`), and all warehouse tables/views are denied (`_is_warehouse_table_denied` / `_is_warehouse_view_denied` fail closed when `user_access_control is None`).
+This is deliberate: if someone forgets to pass the user, the query fails outright and makes the mistake obvious, instead of silently falling back to a permissive "default access" that would leak data.
 In practice the user is available anywhere system tables are queried; for user-initiated background work, see [contexts without a request user](#contexts-without-a-request-user).
 
 ## 1. System tables
 
 System tables are Postgres-backed tables under the `system.` namespace, defined in `SystemTables` (`posthog/hogql/database/schema/system.py`).
-They're primarily used by the MCP `execute-sql` tool and the SQL editor.
+They're primarily used by the MCP `execute-sql` tool for retrieval.
 
 ### Resource-level access
 
 Each access-controlled system table declares an `access_scope` (e.g. `system.dashboards` → `"dashboard"`, `system.error_tracking_issues` → `"error_tracking"`).
+
 At schema build time, `_compute_system_table_access_decision()` checks `UserAccessControl.access_level_for_resource(access_scope)` for each scoped table and removes denied ones from the schema (`Database._apply_system_table_access()`).
 
-Removed tables are tracked in `Database._denied_tables`, so referencing one raises a clear error instead of pretending the table doesn't exist (`Database.get_table()`):
+Removed tables are tracked in `Database._denied_tables`, so referencing one raises a clear error instead of pretending the table doesn't exist — that way the user knows the table is there and can request access from an admin if they need it:
 
 ```text
 You don't have access to table `system.error_tracking_issues`.
@@ -58,9 +61,12 @@ This is a `QueryError` (`posthog/hogql/errors.py`), so it's exposed to the user.
 
 ### Object-level access
 
-For resources with per-object access controls (dashboards, notebooks, ...), denied objects are filtered out of results rather than erroring.
-At print time, `ClickHousePrinter._ensure_access_control_where_clause()` (`posthog/hogql/printer/clickhouse.py`) injects a `WHERE` guard built by `build_access_control_guard()` (`posthog/hogql/printer/access_control.py`) from `UserAccessControl.blocked_resource_ids_by_scope`.
-Child tables filter on the parent's FK (e.g. `system.dashboard_tiles` uses `access_control_id_field="dashboard_id"`).
+Some resources support per-object access controls - dashboards, insights, notebooks, feature flags, experiments, surveys, error tracking issues, session recordings, etc.
+For these, denied objects are filtered out of the results.
+
+At print time the printer appends a guard that excludes the user's denied object IDs by primary key — effectively `WHERE <id> NOT IN (<denied ids>)`.
+Child tables filter on the parent's FK — e.g. `system.dashboard_tiles` uses `access_control_id_field="dashboard_id"`.
+
 When rows are filtered, the response carries a warning: "Results may exclude {resources} you don't have access to".
 
 **Edge case:** object-level access does not override a resource-level deny in HogQL.
@@ -80,80 +86,86 @@ Denying `warehouse_objects` for a user filters every warehouse table and view ou
 
 Specific tables and views can be restricted individually.
 There's UI for this in the SQL editor: open a table's "More" menu → "Access controls".
-A denied table/view is dropped from the schema entirely (`_is_warehouse_table_denied` / `_is_warehouse_view_denied` in `posthog/hogql/database/database.py`), and its name lands in `_denied_tables` so queries get "You don't have access to table" instead of "Unknown table".
+A denied table or view is dropped from the schema entirely, and its name lands in `_denied_tables` so queries get "You don't have access to table" instead of "Unknown table".
+The deny checks are `_is_warehouse_table_denied` and `_is_warehouse_view_denied` in `posthog/hogql/database/database.py`.
 
-The creator always has access: `UserAccessControl.access_level_for_object()` grants the object's `created_by` user the highest level regardless of explicit denies.
-`Database._fetch_sources()` preloads `created_by` on warehouse tables and saved queries so this check is query-free.
+The creator always keeps access: `UserAccessControl.access_level_for_object()` grants the object's `created_by` user the highest level regardless of explicit denies.
+"Creator" here is the `created_by` on the object — for a view, whoever authored it; for a warehouse table, whoever created the row (for an externally synced source, the user who connected the source).
 
 ### Views vs materialized views
 
 The two behave differently when the user has access to the view but not the underlying table:
 
-- **View (non-materialized):** the view's HogQL is inlined and re-resolved at query resolution time (`Resolver.visit_join_expr` in `posthog/hogql/resolver.py` parses `database_table.query` and walks it like user SQL). The nested lookup of the underlying table hits the denied schema and raises `You don't have access to table ...`. So a view cannot be used to grant indirect access to a restricted table.
-- **Materialized view:** `DataWarehouseSavedQuery.hogql_definition()` (`products/data_modeling/backend/models/datawarehouse_saved_query.py`) returns the backing `DataWarehouseTable` directly; it's a real table, no re-resolution of the source query happens. Access is checked on the view object only, so this works even when the underlying table is denied. **This is the supported way to expose a subset of columns from a restricted table.**
+- **View (non-materialized):** the view's HogQL is inlined and re-resolved at query resolution time — `Resolver.visit_join_expr` (`posthog/hogql/resolver.py`) parses `database_table.query` and walks it like user SQL.
+  That nested lookup of the underlying table hits the denied schema and raises `You don't have access to table ...`.
+  So if you can't query the table directly, you can't reach it through the view either.
+- **Materialized view:** the view resolves straight to its backing `DataWarehouseTable` — a real table, so no re-resolution of the source query happens.
+  Access is checked on the view object only, so this works even when access to the table used in the materialized view is denied.
+  **This is the supported way to expose a subset of columns from a restricted table.**
 
 ### Contexts without a request user
 
-Warehouse access control fails closed without a user, so every caller needs one of these:
+Without a user, warehouse access control denies every warehouse table and view, so every caller needs one of these:
 
 1. **User is on the request:** pass it through, as shown in [passing the user into HogQL](#passing-the-user-into-hogql).
 2. **Background job acting for a user:** use the resource's `created_by`. Alerts evaluate as `alert.created_by` (`products/alerts/backend/evaluation/hogql.py`), exports render as `exported_asset.created_by` (`products/exports/backend/tasks/csv_exporter.py`).
-3. **Trusted internal job with no user at all:** pass `bypass_warehouse_access_control=True` explicitly. Used by materialization workflows (`posthog/temporal/data_modeling/`), insight cache warming, and ducklake compilation (`posthog/ducklake/client.py`). **Be very skeptical before adding a new bypass** — only do it when the job genuinely has no acting user and the output isn't served to a specific user with narrower access. The bypass never relaxes system-table access control (`_compute_system_table_access_decision` runs regardless).
+3. **Trusted internal job with no user at all:** pass `bypass_warehouse_access_control=True` explicitly. Used by materialization workflows (`posthog/temporal/data_modeling/`), insight cache warming, and ducklake compilation (`posthog/ducklake/client.py`). **Be very skeptical before adding a new bypass** — only do it when the job genuinely has no acting user and the output isn't served to a specific user with narrower access.
 
 ```python
 # Background materialization job — no user exists, bypass explicitly
 execute_hogql_query(query=..., team=team, bypass_warehouse_access_control=True)
 ```
 
-4. **Public dashboards / notebooks / shared insights:** the viewer is anonymous, and queries run as `SharedLinkUser` (`posthog/shared_link_user.py`, built in `SharingViewerPageViewSet`). `SharedLinkUser` is a `SyntheticUser`, which auto-sets the warehouse bypass in `Database.create_for` — shared queries execute regardless of warehouse ACLs. That's by design: the gate is at publish time instead. Enabling sharing requires editor-level access to the resource (`SharingResourceEditCheck` in `posthog/api/sharing.py`), so only someone with access can publish it. System tables stay fully denied for shared links (`readable_system_table_access_scopes()` returns an empty set).
-5. **Project secret API keys:** `ProjectSecretAPIKeyUser` (a `SyntheticUser`, `posthog/auth.py`) also bypasses warehouse access control. That's intentional: PSAKs are authorized by their scopes, not by role-based access control. System tables are gated by the key's scopes via `readable_system_table_access_scopes()`.
+4. **Public dashboards / notebooks / shared insights:** the viewer is anonymous, so queries run as `SharedLinkUser` (`posthog/shared_link_user.py`, built in `SharingViewerPageViewSet`).
+   `Database.create_for` doesn't restrict any warehouse tables or views for a shared-link viewer; the access gate is at publish time instead.
+   Enabling sharing requires editor-level access to the resource, so only someone who already has access can publish it.
+   System tables stay fully denied for shared links — `readable_system_table_access_scopes()` returns an empty set.
+5. **Project secret API keys:** these run as a `SyntheticUser` — `ProjectSecretAPIKeyUser` (`posthog/auth.py`) — which also isn't restricted on warehouse tables or views.
+   That's intentional: a project secret API key is authorized by the scopes granted to the key, not by role-based access control.
+   System tables are gated by the key's scopes via `readable_system_table_access_scopes()`.
 
 ## 3. Property access control
 
 Hides sensitive event and person properties (e.g. `email`) from query results.
-Rules live in the `PropertyAccessControl` model (`products/access_control/backend/models/property_access_control.py`), one row per property definition per target (team default, organization member, or role).
-Resolution (`products/access_control/backend/property_access_control.py`): org admins bypass, then user-specific rule → role rules (most permissive wins) → team default rule → allow.
-Requires the `PROPERTY_ACCESS_CONTROL` feature; without it everything short-circuits to no restrictions.
+Rules live in the `PropertyAccessControl` model (`products/access_control/backend/models/property_access_control.py`).
+
+Property access control is a paid feature, available on the Scale and Enterprise plans: it needs the `PROPERTY_ACCESS_CONTROL` entitlement, and without it resolution short-circuits to no restrictions.
 
 ### Enforcement: masking, not errors
 
 Unlike the table layers, restricted properties do not error.
-They're masked at compile time, so a restricted read is indistinguishable from a nonexistent property (anti-enumeration):
+They're masked when the query is printed to ClickHouse SQL, so a restricted read is indistinguishable from a property that was never set (anti-enumeration):
 
-- **Explicit reads** (`properties.email`): `ClickHousePropertyResolver` (`posthog/hogql/transforms/clickhouse_property_resolution.py`) replaces the property access with `NULL`, and refuses to resolve it to a materialized column.
-- **Whole-blob reads** (`SELECT properties` or `SELECT *`): `ClickHousePrinter._maybe_apply_json_drop_keys()` (`posthog/hogql/printer/clickhouse.py`) wraps the column in `JSONDropKeys(...)` so restricted keys are stripped from the returned JSON.
+- **Explicit reads** (`properties.email`) are replaced with `NULL`, and the resolver refuses to back them with a materialized column — `ClickHousePropertyResolver` in `posthog/hogql/transforms/clickhouse_property_resolution.py`.
+- **Whole-blob reads** (`SELECT properties` or `SELECT *`) have the restricted keys stripped from the returned JSON via `JSONDropKeys(...)` — `ClickHousePrinter._maybe_apply_json_drop_keys()` in `posthog/hogql/printer/clickhouse.py`.
 
-(The REST events API behaves differently: filtering on a restricted property there raises a `ValidationError`, see `posthog/api/event.py`.)
-
-Restrictions are batch-loaded once per query in `prepare_ast_for_printing()` (`posthog/hogql/printer/utils.py`) via `get_restricted_properties_for_team()` onto `HogQLContext.restricted_properties`, memoized per `(team_id, user_id)` for the request lifetime.
-`restricted_property_keys_for_table_type()` (`posthog/hogql/restricted_properties.py`) maps table types to event vs person restrictions.
+The restriction set is loaded once per query in `prepare_ast_for_printing()` and cached per `(team_id, user_id)` for the request lifetime.
 
 ### No user: default rules apply
 
-When no user is present (including `SharedLinkUser` and `SyntheticUser`, which are treated as userless here), only the team **default** rules apply — see `get_restricted_properties_for_team()`.
-So public dashboards mask exactly what the team default masks, instead of failing every query closed.
-Note the asymmetry with the warehouse layer, which bypasses entirely for shared links rather than applying a default; that may be aligned later.
+When no user is present, only the team **default** rules apply instead of failing every query — see `get_restricted_properties_for_team()`.
+There is the asymmetry with the warehouse access control, which bypasses entirely for shared links rather than applying a default; that may be aligned later.
 
 ## Query cache partitioning
 
 **The critical invariant:** if a query reads access-controlled tables, its cache key must include the user's restrictions.
-Otherwise a cache hit short-circuits the schema strip, and a denied user gets served an allowed user's cached rows.
+Otherwise a denied user gets served an allowed user's cached rows.
 
 The cache key is derived from `get_cache_payload()`:
 
-- `QueryRunner.get_cache_payload()` (`posthog/hogql_queries/query_runner.py`) adds `restricted_properties` (sorted `(name, type)` pairs) when the user has property restrictions.
+- `QueryRunner.get_cache_payload()` adds `restricted_properties` (sorted `(name, type)` pairs) when the user has property restrictions.
 - `AnalyticsQueryRunner.get_cache_payload()` adds `restricted_resources` (denied scopes) and `restricted_objects` (denied object IDs per scope) for the table layers.
 
 Two things keep cache hit rates high:
 
 1. **Feature gate:** if the organization doesn't have `AvailableFeature.ACCESS_CONTROL`, no resource/object restrictions exist, so nothing is added and the cache isn't partitioned by user at all.
-2. **Scoped to queried tables:** `queried_access_controlled_resources()` (`posthog/hogql_queries/access_controlled_resources.py`) parses the query and returns only the access-controlled scopes it actually reads. A plain events query returns an empty set and skips access-control payload entirely, so it shares one cache entry across all users (including userless cache warming). Warehouse scopes are only included when the query actually references warehouse tables or views. When a non-materialized view is referenced, `warehouse_table` is folded in too, because the view re-resolves its underlying tables at execution and a cache hit would skip that check.
+2. **Scoped to queried tables:** `queried_access_controlled_resources()` (`posthog/hogql_queries/access_controlled_resources.py`) parses the query and returns only the access-controlled scopes it actually reads, so warehouse scopes are added to the payload only when the query references warehouse tables or views — a plain **events or persons query shares one cache entry across all users**
 
-Userless runs fail closed in the fingerprint too (`restricted_resources: ["*"]`), and synthetic principals partition on their readable scopes so a narrow token can't reuse a broader token's cache.
+When a run has no user but does read access-controlled resources, the fingerprint uses `restricted_resources: ["*"]` so it can never collide with a real user's cache, and synthetic principals partition on their readable scopes so a narrow token can't reuse a broader token's cached rows.
 
 ## One preloaded `UserAccessControl` everywhere
 
-`UserAccessControl` (`posthog/rbac/user_access_control.py`) bulk-fetches every access control row relevant to the user on the team in a single query (`_cached_access_controls`, covering team defaults, the user's membership, and the user's roles), then answers all checks in memory (`access_level_for_resource`, `check_access_level_for_object`, `blocked_resource_ids_by_scope`, ...).
+`UserAccessControl` (`posthog/rbac/user_access_control.py`) bulk-fetches every access control row relevant to the user on the team in a single query (`_cached_access_controls`, covering team defaults, the user's membership, and the user's roles), then resolves all checks in memory (`access_level_for_resource`, `check_access_level_for_object`, `blocked_resource_ids_by_scope`, ...).
 
 The same instance is reused across:
 
@@ -162,10 +174,4 @@ The same instance is reused across:
 - **Print-time row guards:** `build_access_control_guard()` reads `blocked_resource_ids_by_scope` off the same instance.
 - **API-level (viewset) access control:** `TeamAndOrgViewSetMixin.user_access_control` (`posthog/api/routing.py`) creates one instance per request, and dashboard rendering passes it down into each tile's query runner (`products/product_analytics/backend/api/insight.py`), so N insights share one access-control fetch.
 
-Net cost when both access-control types are active: one bulk `AccessControl` fetch plus one `PropertyAccessControl` fetch per query run.
-
-## Tests
-
-- Table layers: `posthog/hogql/printer/test/test_hogql_access_control.py` (full matrix: resource/object denies, views vs materialized views, bypass, shared links, cache keys)
-- Property layer: `posthog/hogql/printer/test/test_property_access_control.py`
-- Cache partitioning: `posthog/hogql_queries/test/test_query_runner.py`
+When both access-control types are active, a query run makes just one query to `AccessControl` and one to `PropertyAccessControl`.

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -14,6 +14,28 @@ HogQL enforces access control in three layers:
 
 All three layers share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
 
+Sitting underneath all of them is a separate, more fundamental guard: the [`team_id` guard](#tenant-isolation-the-team_id-guard) that keeps one team's rows out of another team's query results.
+It's not part of RBAC and doesn't touch `UserAccessControl` — it's the multi-tenancy boundary, and it applies to every query regardless of who (or whether anyone) is asking.
+
+## Tenant isolation: the `team_id` guard
+
+PostHog's ClickHouse tables (`events`, `persons`, `sessions`, ...) are shared: one physical table holds the rows for every team, keyed by a `team_id` column.
+Multi-tenancy therefore depends on every query being scoped to a single team.
+HogQL guarantees this by injecting a mandatory `team_id = <context.team_id>` filter onto **every** table it reads, so a query can never see another team's rows even if it tries.
+
+This is enforced at the lowest level, at print time.
+When the printer emits each table in a `FROM` / `JOIN`, `_ensure_team_id_where_clause()` adds the guard built by `team_id_guard_for_table()` (`posthog/hogql/printer/clickhouse.py`), applied in `BasePrinter.visit_join_expr` (`posthog/hogql/printer/base.py`).
+Because it's added during printing, query-supplied `WHERE` clauses and modifiers can't remove or widen it.
+For `LEFT JOIN`s the guard goes in the `ON` clause instead of `WHERE`, so unmatched rows aren't dropped.
+
+**Fail closed:** `team_id_guard_for_table()` raises `InternalHogQLError` if `context.team_id` is missing, so a query with no team never runs against shared data.
+Unlike the RBAC layers, this guard needs no user — only a team.
+
+A few tables opt out, and only these:
+
+- **Warehouse tables and views** (`DataWarehouseTable`, `SavedQuery`): external data or subqueries that carry their own scoping — a saved query's inner tables get guarded individually.
+- **`DANGEROUS_NoTeamIdCheckTable`** (`posthog/hogql/database/models.py`): an explicit escape hatch for tables that hold no team data — `numbers`, `exchange_rate`, `information_schema`, and similar. As the name warns, don't use it for anything that touches user data.
+
 ## Passing the user into HogQL
 
 Access control needs to know who is querying.

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -23,7 +23,7 @@ Multi-tenancy therefore depends on every query being scoped to a single team.
 HogQL guarantees this by injecting a mandatory `team_id = <context.team_id>` filter onto **every** table it reads that holds team data, so a query can never see another team's rows even if it tries.
 
 This is enforced at the lowest level, at print time.
-When the printer emits each table in a `FROM` / `JOIN`, `_ensure_team_id_where_clause()` adds the guard built by `team_id_guard_for_table()` (`posthog/hogql/printer/clickhouse.py`), applied in `BasePrinter.visit_join_expr` (`posthog/hogql/printer/base.py`).
+When the printer emits each table in a `FROM` / `JOIN`, `_ensure_team_id_where_clause()` adds the guard built by `team_id_guard_for_table()` (`posthog/hogql/printer/clickhouse.py`).
 Because it's added during printing, query-supplied `WHERE` clauses and modifiers can't remove or widen it.
 For `LEFT JOIN`s the guard goes in the `ON` clause instead of `WHERE`, so unmatched rows aren't dropped.
 
@@ -100,14 +100,24 @@ Gated by the `hogql-warehouse-access-control` feature flag (checked in `Database
 `warehouse_table` and `warehouse_view` both inherit from the umbrella resource `warehouse_objects` (`RESOURCE_INHERITANCE_MAP` in `posthog/rbac/user_access_control.py`).
 Denying `warehouse_objects` for a user filters every warehouse table and view out of their schema at build time.
 
-### Object-level: per-table and per-view
+### Object-level: per-source, per-table, and per-view
 
-Specific tables and views can be restricted individually.
-There's UI for this in the SQL editor: open a table's "More" menu → "Access controls".
+Specific sources, tables, and views can be restricted individually.
+There's UI for this in the SQL editor: open a table's or a source's "More" menu → "Access controls".
 A denied table or view is dropped from the schema entirely, and its name lands in `_denied_tables` so queries get "You don't have access to table" instead of "Unknown table".
 The deny checks are `_is_warehouse_table_denied` and `_is_warehouse_view_denied` in `posthog/hogql/database/database.py`.
 
-The creator always keeps access: `UserAccessControl.access_level_for_object()` grants the object's `created_by` user the highest level regardless of explicit denies.
+### How a table's access level resolves
+
+`external_data_source` is its own access-control resource, and `warehouse_table` falls back to it (`RESOURCE_FALLBACK_MAP` in `posthog/rbac/user_access_control.py`).
+That's a different relationship from the `warehouse_objects` umbrella above: inheritance means the child has no rules of its own and just uses the parent's, while fallback means the child's own rules win and the parent's apply only when the child has none.
+
+`get_user_access_level()` takes the first tier that has a rule, most specific first: this table → this source → all tables and views → all sources → the team default.
+
+So denying one source denies every table it syncs, but a rule on a specific table still beats it.
+Tables with no source (self-managed, S3, manually linked) skip the source tiers, and views never resolve through a source.
+
+The creator always keeps access: the object's `created_by` user resolves to the highest level regardless of explicit denies, ahead of every tier above.
 "Creator" here is the `created_by` on the object — for a view, whoever authored it; for a warehouse table, whoever created the row (for an externally synced source, the user who connected the source).
 
 ### Views vs materialized views
@@ -177,7 +187,8 @@ The cache key is derived from `get_cache_payload()`:
 Two things keep cache hit rates high:
 
 1. **Feature gate:** if the organization doesn't have `AvailableFeature.ACCESS_CONTROL`, no resource/object restrictions exist, so nothing is added and the cache isn't partitioned by user at all.
-2. **Scoped to queried tables:** `queried_access_controlled_resources()` (`posthog/hogql_queries/access_controlled_resources.py`) parses the query and returns only the access-controlled scopes it actually reads, so warehouse scopes are added to the payload only when the query references warehouse tables or views — a plain **events or persons query shares one cache entry across all users**
+2. **Scoped to queried tables:** `queried_access_controlled_resources()` (`posthog/hogql_queries/access_controlled_resources.py`) parses the query and returns only the access-controlled scopes it actually reads, so warehouse scopes are added to the payload only when the query references warehouse tables or views — a plain **events or persons query shares one cache entry across all users**.
+   `external_data_source` is folded in wherever `warehouse_table` is (`_with_fallback_parents`), since a table's access can come from its source.
 
 When a run has no user but does read access-controlled resources, the fingerprint uses `restricted_resources: ["*"]` so it can never collide with a real user's cache, and synthetic principals partition on their readable scopes so a narrow token can't reuse a broader token's cached rows.
 

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -137,6 +137,12 @@ Without a user, warehouse access control denies every warehouse table and view, 
 
 1. **User is on the request:** pass it through, as shown in [passing the user into HogQL](#passing-the-user-into-hogql).
 2. **Background job acting for a user:** use the resource's `created_by`. Alerts evaluate as `alert.created_by` (`products/alerts/backend/evaluation/hogql.py`), exports render as `exported_asset.created_by` (`products/exports/backend/tasks/csv_exporter.py`).
+
+   **Known limitation:** if that user has left the organization, the run fails and the error surfaces in error tracking.
+   This is intentional for now. The plan is to check access when the resource is created, then run it with a bypass afterwards.
+   Cache warming runs as the insight's creator, on the assumption that their access is the one most viewers of that insight share.
+   Warming without access control would more often end in a cache miss.
+
 3. **Trusted internal job with no user at all:** pass `bypass_warehouse_access_control=True` explicitly. Used by materialization workflows (`posthog/temporal/data_modeling/`), insight cache warming, and ducklake compilation (`posthog/ducklake/client.py`). **Be very skeptical before adding a new bypass** — only do it when the job genuinely has no acting user and the output isn't served to a specific user with narrower access.
 
 ```python

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -102,9 +102,9 @@ Denying `warehouse_objects` for a user filters every warehouse table and view ou
 
 ### Object-level: per-source, per-table, and per-view
 
-A whole source can be restricted — Stripe, Zendesk, and so on — by setting object access on the `external_data_source` resource.
+A whole source can be restricted (e.g. Stripe, Zendesk, ...) by setting object access on the `external_data_source` resource.
 Access can also be set on one specific table (`warehouse_table`) or view (`warehouse_view`).
-Both are in the SQL editor: open a table's or a source's "More" menu → "Access controls".
+There's UI for both in the SQL editor, under a table's or a source's "More" menu → "Access controls".
 
 A denied table or view is dropped from the schema entirely, and its name lands in `_denied_tables` so queries get "You don't have access to table" instead of "Unknown table".
 The deny checks are `_is_warehouse_table_denied` and `_is_warehouse_view_denied` in `posthog/hogql/database/database.py`.
@@ -123,7 +123,7 @@ A table can be part of a source, so rules can exist at both levels.
 So denying one source denies every table it syncs, but a rule on a specific table still beats it.
 Tables with no source (self-managed, S3, manually linked) skip tiers 2 and 4, and views never resolve through a source.
 
-The creator always keeps access: the object's `created_by` user resolves to the highest level regardless of explicit denies, ahead of every tier above.
+The creator always keeps access: the object's `created_by` user resolves to the highest level regardless of explicit denies.
 "Creator" here is the `created_by` on the object — for a view, whoever authored it; for a warehouse table, whoever created the row (for an externally synced source, the user who connected the source).
 
 ### Views vs materialized views
@@ -199,8 +199,7 @@ The cache key is derived from `get_cache_payload()`:
 Two things keep cache hit rates high:
 
 1. **Feature gate:** if the organization doesn't have `AvailableFeature.ACCESS_CONTROL`, no resource/object restrictions exist, so nothing is added and the cache isn't partitioned by user at all.
-2. **Scoped to queried tables:** `queried_access_controlled_resources()` (`posthog/hogql_queries/access_controlled_resources.py`) parses the query and returns only the access-controlled scopes it actually reads, so warehouse scopes are added to the payload only when the query references warehouse tables or views — a plain **events or persons query shares one cache entry across all users**.
-   `external_data_source` is folded in wherever `warehouse_table` is (`_with_fallback_parents`), since a table's access can come from its source.
+2. **Scoped to queried tables:** `queried_access_controlled_resources()` (`posthog/hogql_queries/access_controlled_resources.py`) parses the query and returns only the access-controlled scopes it actually reads, so warehouse scopes are added to the payload only when the query references warehouse tables or views — a plain **events or persons query shares one cache entry across all users**
 
 When a run has no user but does read access-controlled resources, the fingerprint uses `restricted_resources: ["*"]` so it can never collide with a real user's cache, and synthetic principals partition on their readable scopes so a narrow token can't reuse a broader token's cached rows.
 

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -1,7 +1,11 @@
 # HogQL access controls
 
-HogQL enforces access control in three layers:
+HogQL enforces access control in layers.
+Layer 0 is the multi-tenancy boundary and applies to every query. Layers 1 to 3 are role-based access control on top of it.
 
+0. **[Tenant isolation](#0-tenant-isolation-the-team_id-guard)** — every table read, keeping one team's rows out of another team's results.
+   - Enforced when the query is printed to SQL.
+   - Always on: a mandatory `team_id` filter on every table. Not part of RBAC, and needs no user.
 1. **[System tables](#1-system-tables)** — the `system.*` tables (dashboards, notebooks, error tracking issues, ...).
    - Enforced at schema build time and print time.
    - When denied: the whole table is removed from the schema and the query errors; individual denied objects are filtered out with a `WHERE` guard.
@@ -12,12 +16,9 @@ HogQL enforces access control in three layers:
    - Enforced when the query is printed to ClickHouse SQL (AST transform, then printing).
    - When denied: values are masked to `NULL` or stripped from the JSON blob, with no error.
 
-All three layers share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
+Layers 1 to 3 share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
 
-Sitting underneath all of them is a separate, more fundamental guard: the [`team_id` guard](#tenant-isolation-the-team_id-guard) that keeps one team's rows out of another team's query results.
-It's not part of RBAC and doesn't touch `UserAccessControl` — it's the multi-tenancy boundary, and it applies to every query regardless of who (or whether anyone) is asking.
-
-## Tenant isolation: the `team_id` guard
+## 0. Tenant isolation: the `team_id` guard
 
 PostHog's ClickHouse tables (`events`, `persons`, `sessions`, ...) are shared: one physical table holds the rows for every team, keyed by a `team_id` column.
 Multi-tenancy therefore depends on every query being scoped to a single team.
@@ -29,7 +30,7 @@ Because it's added during printing, query-supplied `WHERE` clauses and modifiers
 For `LEFT JOIN`s the guard goes in the `ON` clause instead of `WHERE`, so unmatched rows aren't dropped.
 
 **Fail closed:** `team_id_guard_for_table()` raises `InternalHogQLError` if `context.team_id` is missing, so a query with no team never runs against shared data.
-Unlike the RBAC layers, this guard needs no user — only a team.
+This layer is independent of the ones below it: it never consults `UserAccessControl`, and it needs no user — only a team.
 
 A few tables opt out, and only these:
 
@@ -38,7 +39,7 @@ A few tables opt out, and only these:
 
 ## Passing the user into HogQL
 
-Access control needs to know who is querying.
+Layers 1 to 3 need to know who is querying.
 The user is threaded through `Database.create_for()` and `HogQLContext` (`posthog/hogql/context.py`):
 
 ```python

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -102,20 +102,26 @@ Denying `warehouse_objects` for a user filters every warehouse table and view ou
 
 ### Object-level: per-source, per-table, and per-view
 
-Specific sources, tables, and views can be restricted individually.
-There's UI for this in the SQL editor: open a table's or a source's "More" menu → "Access controls".
+A whole source can be restricted — Stripe, Zendesk, and so on — by setting object access on the `external_data_source` resource.
+Access can also be set on one specific table (`warehouse_table`) or view (`warehouse_view`).
+Both are in the SQL editor: open a table's or a source's "More" menu → "Access controls".
+
 A denied table or view is dropped from the schema entirely, and its name lands in `_denied_tables` so queries get "You don't have access to table" instead of "Unknown table".
 The deny checks are `_is_warehouse_table_denied` and `_is_warehouse_view_denied` in `posthog/hogql/database/database.py`.
 
 ### How a table's access level resolves
 
-`external_data_source` is its own access-control resource, and `warehouse_table` falls back to it (`RESOURCE_FALLBACK_MAP` in `posthog/rbac/user_access_control.py`).
-That's a different relationship from the `warehouse_objects` umbrella above: inheritance means the child has no rules of its own and just uses the parent's, while fallback means the child's own rules win and the parent's apply only when the child has none.
+A table can be part of a source, so rules can exist at both levels.
+`RESOURCE_FALLBACK_MAP` (`posthog/rbac/user_access_control.py`) resolves this by applying the most specific rule that exists:
 
-`get_user_access_level()` takes the first tier that has a rule, most specific first: this table → this source → all tables and views → all sources → the team default.
+1. This table
+2. Its source
+3. All tables and views (the `warehouse_objects` umbrella)
+4. All sources
+5. The team default
 
 So denying one source denies every table it syncs, but a rule on a specific table still beats it.
-Tables with no source (self-managed, S3, manually linked) skip the source tiers, and views never resolve through a source.
+Tables with no source (self-managed, S3, manually linked) skip tiers 2 and 4, and views never resolve through a source.
 
 The creator always keeps access: the object's `created_by` user resolves to the highest level regardless of explicit denies, ahead of every tier above.
 "Creator" here is the `created_by` on the object — for a view, whoever authored it; for a warehouse table, whoever created the row (for an externally synced source, the user who connected the source).

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -117,8 +117,8 @@ A table can be part of a source, so rules can exist at both levels.
 1. This table
 2. Its source
 3. All tables and views (the `warehouse_objects` umbrella)
-4. All sources
-5. The team default
+4. All sources (the `external_data_source` resource)
+5. The built-in default from `default_access_level()`, which is `editor` for warehouse resources
 
 So denying one source denies every table it syncs, but a rule on a specific table still beats it.
 Tables with no source (self-managed, S3, manually linked) skip tiers 2 and 4, and views never resolve through a source.

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -1,11 +1,11 @@
 # HogQL access controls
 
-HogQL enforces access at different levels, from whole tables down to individual properties.
+HogQL enforces access at different levels.
 Level 0 is the multi-tenancy boundary and applies to every query. Levels 1 to 3 are access control (aka RBAC) on top of it.
 
 0. **[Tenant isolation](#0-tenant-isolation-the-team_id-guard)** — every table read, keeping one team's rows out of another team's results.
    - Enforced when the query is printed to SQL.
-   - Always on: a mandatory `team_id` filter on every table. Not part of RBAC, and doesn't require a user, only a team.
+   - Always on: a mandatory `team_id` filter on every table.
 1. **[System tables](#1-system-tables)** — the `system.*` tables (dashboards, notebooks, error tracking issues, ...).
    - Enforced at schema build time and print time.
    - When denied: the whole table is removed from the schema and the query errors; individual denied objects are filtered out with a `WHERE` guard.
@@ -16,13 +16,11 @@ Level 0 is the multi-tenancy boundary and applies to every query. Levels 1 to 3 
    - Enforced when the query is printed to ClickHouse SQL (AST transform, then printing).
    - When denied: values are masked to `NULL` or stripped from the JSON blob, with no error.
 
-Levels 1 to 3 share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
-
 ## 0. Tenant isolation: the `team_id` guard
 
 PostHog's ClickHouse tables (`events`, `persons`, `sessions`, ...) are shared: one physical table holds the rows for every team, keyed by a `team_id` column.
 Multi-tenancy therefore depends on every query being scoped to a single team.
-HogQL guarantees this by injecting a mandatory `team_id = <context.team_id>` filter onto **every** table it reads, so a query can never see another team's rows even if it tries.
+HogQL guarantees this by injecting a mandatory `team_id = <context.team_id>` filter onto **every** table it reads that holds team data, so a query can never see another team's rows even if it tries.
 
 This is enforced at the lowest level, at print time.
 When the printer emits each table in a `FROM` / `JOIN`, `_ensure_team_id_where_clause()` adds the guard built by `team_id_guard_for_table()` (`posthog/hogql/printer/clickhouse.py`), applied in `BasePrinter.visit_join_expr` (`posthog/hogql/printer/base.py`).
@@ -32,14 +30,11 @@ For `LEFT JOIN`s the guard goes in the `ON` clause instead of `WHERE`, so unmatc
 **Fail closed:** `team_id_guard_for_table()` raises `InternalHogQLError` if `context.team_id` is missing, so a query with no team never runs against shared data.
 This level is independent of the ones below it: it never consults `UserAccessControl`, and doesn't require a user, only a team.
 
-A few tables opt out, and only these:
-
-- **Warehouse tables and views** (`DataWarehouseTable`, `SavedQuery`): external data or subqueries that carry their own scoping — a saved query's inner tables get guarded individually.
-- **`DANGEROUS_NoTeamIdCheckTable`** (`posthog/hogql/database/models.py`): an explicit escape hatch for tables that hold no team data — `numbers`, `exchange_rate`, `information_schema`, and similar. As the name warns, don't use it for anything that touches user data.
-
 ## Passing the user into HogQL
 
 Levels 1 to 3 need to know who is querying.
+They share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
+
 The user is threaded through `Database.create_for()` and `HogQLContext` (`posthog/hogql/context.py`):
 
 ```python

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -1,11 +1,11 @@
 # HogQL access controls
 
-HogQL enforces access control in layers.
-Layer 0 is the multi-tenancy boundary and applies to every query. Layers 1 to 3 are role-based access control on top of it.
+HogQL enforces access at different levels, from whole tables down to individual properties.
+Level 0 is the multi-tenancy boundary and applies to every query. Levels 1 to 3 are access control (aka RBAC) on top of it.
 
 0. **[Tenant isolation](#0-tenant-isolation-the-team_id-guard)** — every table read, keeping one team's rows out of another team's results.
    - Enforced when the query is printed to SQL.
-   - Always on: a mandatory `team_id` filter on every table. Not part of RBAC, and needs no user.
+   - Always on: a mandatory `team_id` filter on every table. Not part of RBAC, and doesn't require a user, only a team.
 1. **[System tables](#1-system-tables)** — the `system.*` tables (dashboards, notebooks, error tracking issues, ...).
    - Enforced at schema build time and print time.
    - When denied: the whole table is removed from the schema and the query errors; individual denied objects are filtered out with a `WHERE` guard.
@@ -16,7 +16,7 @@ Layer 0 is the multi-tenancy boundary and applies to every query. Layers 1 to 3 
    - Enforced when the query is printed to ClickHouse SQL (AST transform, then printing).
    - When denied: values are masked to `NULL` or stripped from the JSON blob, with no error.
 
-Layers 1 to 3 share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
+Levels 1 to 3 share one preloaded `UserAccessControl` instance and partition the query cache so a restricted user can never be served an unrestricted user's cached rows.
 
 ## 0. Tenant isolation: the `team_id` guard
 
@@ -30,7 +30,7 @@ Because it's added during printing, query-supplied `WHERE` clauses and modifiers
 For `LEFT JOIN`s the guard goes in the `ON` clause instead of `WHERE`, so unmatched rows aren't dropped.
 
 **Fail closed:** `team_id_guard_for_table()` raises `InternalHogQLError` if `context.team_id` is missing, so a query with no team never runs against shared data.
-This layer is independent of the ones below it: it never consults `UserAccessControl`, and it needs no user — only a team.
+This level is independent of the ones below it: it never consults `UserAccessControl`, and doesn't require a user, only a team.
 
 A few tables opt out, and only these:
 
@@ -39,7 +39,7 @@ A few tables opt out, and only these:
 
 ## Passing the user into HogQL
 
-Layers 1 to 3 need to know who is querying.
+Levels 1 to 3 need to know who is querying.
 The user is threaded through `Database.create_for()` and `HogQLContext` (`posthog/hogql/context.py`):
 
 ```python
@@ -156,7 +156,7 @@ Property access control is a paid feature, available on the Scale and Enterprise
 
 ### Enforcement: masking, not errors
 
-Unlike the table layers, restricted properties do not error.
+Unlike levels 1 and 2, restricted properties do not error.
 They're masked when the query is printed to ClickHouse SQL, so a restricted read is indistinguishable from a property that was never set (anti-enumeration):
 
 - **Explicit reads** (`properties.email`) are replaced with `NULL`, and the resolver refuses to back them with a materialized column — `ClickHousePropertyResolver` in `posthog/hogql/transforms/clickhouse_property_resolution.py`.
@@ -177,7 +177,7 @@ Otherwise a denied user gets served an allowed user's cached rows.
 The cache key is derived from `get_cache_payload()`:
 
 - `QueryRunner.get_cache_payload()` adds `restricted_properties` (sorted `(name, type)` pairs) when the user has property restrictions.
-- `AnalyticsQueryRunner.get_cache_payload()` adds `restricted_resources` (denied scopes) and `restricted_objects` (denied object IDs per scope) for the table layers.
+- `AnalyticsQueryRunner.get_cache_payload()` adds `restricted_resources` (denied scopes) and `restricted_objects` (denied object IDs per scope) for levels 1 and 2.
 
 Two things keep cache hit rates high:
 


### PR DESCRIPTION
## Problem

The HogQL access control system spans several layers (tenant isolation, system tables, warehouse tables/views, property masking) and the logic is spread across many files. There was no single place explaining how it fits together, so it's hard to onboard or reason about changes.

## Changes

Adds `posthog/hogql/ACCESS_CONTROL.md`, a reference doc covering the enforcement layers: the `team_id` tenant-isolation guard as the base layer, then the three RBAC layers on top of it. Also covers how the user is threaded into HogQL, fail-closed behavior, the views vs materialized views distinction, query cache partitioning, and the shared `UserAccessControl` instance. Also adds a small `debugging-table-access-denied` agent skill that points at the doc for triaging "You don't have access to table" errors. Docs only, no code changes.

## How did you test this code?

N/A - documentation only. Cross-checked every file path, class, and method name against the current code.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drafted the doc and then iterated on it, mostly tightening wording and fixing a few inaccuracies I'd verified against the code - notably that `SharedLinkUser` is an `AnonymousUser` (not a `SyntheticUser`), and that object-level filtering guards on the table's `access_control_id`. Per @mariusandra's review, added the `team_id` guard as layer 0, since it's a form of access control that's separate from the `UserAccessControl` logic. 
