### PR TITLE
feat(ingestion): add token column to ingestion_warnings_v2 for capture-sourced warnings

### DIFF
--- a/posthog/clickhouse/hcl/golden/local-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/local-aux.hcl
@@ -369,32 +369,36 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+    }
+    column "token" {
+      type    = "LowCardinality(String)"
+      default = "JSONExtractString(details, 'token')"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -404,6 +408,11 @@ database "posthog" {
     }
     column "_partition" {
       type = "UInt64"
+    }
+    index "idx_token" {
+      expr        = "token"
+      type        = "bloom_filter(0.01)"
+      granularity = 1
     }
     engine "replicated_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.ingestion_warnings_v2"
@@ -428,32 +437,36 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+    }
+    column "token" {
+      type    = "LowCardinality(String)"
+      default = "JSONExtractString(details, 'token')"
     }
     column "_timestamp" {
       type = "DateTime"

--- a/posthog/clickhouse/hcl/golden/local-data.hcl
+++ b/posthog/clickhouse/hcl/golden/local-data.hcl
@@ -1764,32 +1764,36 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+    }
+    column "token" {
+      type    = "LowCardinality(String)"
+      default = "JSONExtractString(details, 'token')"
     }
     column "_timestamp" {
       type = "DateTime"

--- a/posthog/clickhouse/hcl/golden/prod-eu-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu-aux.hcl
@@ -370,32 +370,36 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+    }
+    column "token" {
+      type    = "LowCardinality(String)"
+      default = "JSONExtractString(details, 'token')"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -405,6 +409,11 @@ database "posthog" {
     }
     column "_partition" {
       type = "UInt64"
+    }
+    index "idx_token" {
+      expr        = "token"
+      type        = "bloom_filter(0.01)"
+      granularity = 1
     }
     engine "replicated_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.ingestion_warnings_v2"
@@ -429,32 +438,36 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+    }
+    column "token" {
+      type    = "LowCardinality(String)"
+      default = "JSONExtractString(details, 'token')"
     }
     column "_timestamp" {
       type = "DateTime"

--- a/posthog/clickhouse/hcl/golden/prod-us-aux.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us-aux.hcl
@@ -404,32 +404,36 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+    }
+    column "token" {
+      type    = "LowCardinality(String)"
+      default = "JSONExtractString(details, 'token')"
     }
     column "_timestamp" {
       type = "DateTime"
@@ -439,6 +443,11 @@ database "posthog" {
     }
     column "_partition" {
       type = "UInt64"
+    }
+    index "idx_token" {
+      expr        = "token"
+      type        = "bloom_filter(0.01)"
+      granularity = 1
     }
     engine "replicated_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.ingestion_warnings_v2"
@@ -463,32 +472,36 @@ database "posthog" {
       type = "DateTime64(6, 'UTC')"
     }
     column "category" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'category'), ''), 'unknown')"
     }
     column "severity" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'severity'), ''), 'warning')"
     }
     column "pipeline_step" {
-      type         = "LowCardinality(String)"
-      default      = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
+      type    = "LowCardinality(String)"
+      default = "coalesce(nullIf(JSONExtractString(details, 'pipelineStep'), ''), 'unknown')"
     }
     column "event_uuid" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'eventUuid'))"
     }
     column "distinct_id" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'distinctId'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'distinctId'), '')"
     }
     column "group_key" {
-      type         = "Nullable(String)"
-      default      = "nullIf(JSONExtractString(details, 'groupKey'), '')"
+      type    = "Nullable(String)"
+      default = "nullIf(JSONExtractString(details, 'groupKey'), '')"
     }
     column "person_id" {
-      type         = "Nullable(UUID)"
-      default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+      type    = "Nullable(UUID)"
+      default = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
+    }
+    column "token" {
+      type    = "LowCardinality(String)"
+      default = "JSONExtractString(details, 'token')"
     }
     column "_timestamp" {
       type = "DateTime"

--- a/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
@@ -140,6 +140,10 @@ database "posthog" {
       type         = "Nullable(UUID)"
       default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
+    column "token" {
+      type         = "LowCardinality(String)"
+      default      = "JSONExtractString(details, 'token')"
+    }
     column "_timestamp" {
       type = "DateTime"
     }
@@ -1037,6 +1041,11 @@ database "posthog" {
       index_granularity = "8192"
     }
     extend = "_ingestion_warnings_v2_columns"
+    index "idx_token" {
+      expr        = "token"
+      type        = "bloom_filter(0.01)"
+      granularity = 1
+    }
     engine "replicated_merge_tree" {
       zoo_path     = "/clickhouse/tables/noshard/posthog.ingestion_warnings_v2"
       replica_name = "{replica}-{shard}"

--- a/posthog/clickhouse/hcl/roles/data/local/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/data/local/tables.hcl
@@ -1764,6 +1764,10 @@ database "posthog" {
       type         = "Nullable(UUID)"
       default      = "toUUIDOrNull(JSONExtractString(details, 'personId'))"
     }
+    column "token" {
+      type         = "LowCardinality(String)"
+      default      = "JSONExtractString(details, 'token')"
+    }
     column "_timestamp" {
       type = "DateTime"
     }

--- a/posthog/clickhouse/hcl/sql/local-aux.sql
+++ b/posthog/clickhouse/hcl/sql/local-aux.sql
@@ -44,9 +44,11 @@ CREATE TABLE posthog.ingestion_warnings_v2 (
   distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
   group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
   person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+  token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
   _timestamp DateTime,
   _offset UInt64,
-  _partition UInt64
+  _partition UInt64,
+  INDEX idx_token token TYPE bloom_filter(0.01) GRANULARITY 1
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.ingestion_warnings_v2', '{replica}-{shard}') ORDER BY (team_id, type, timestamp) PARTITION BY toYYYYMM(timestamp) TTL toDateTime(timestamp) + toIntervalDay(90) SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.ingestion_warnings_v2_distributed (
   team_id Int64,
@@ -61,6 +63,7 @@ CREATE TABLE posthog.ingestion_warnings_v2_distributed (
   distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
   group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
   person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+  token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
   _timestamp DateTime,
   _offset UInt64,
   _partition UInt64

--- a/posthog/clickhouse/hcl/sql/local-data.sql
+++ b/posthog/clickhouse/hcl/sql/local-data.sql
@@ -297,6 +297,7 @@ CREATE TABLE posthog.ingestion_warnings_v2_distributed (
   distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
   group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
   person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+  token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
   _timestamp DateTime,
   _offset UInt64,
   _partition UInt64

--- a/posthog/clickhouse/hcl/sql/prod-eu-aux.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu-aux.sql
@@ -44,9 +44,11 @@ CREATE TABLE posthog.ingestion_warnings_v2 (
   distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
   group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
   person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+  token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
   _timestamp DateTime,
   _offset UInt64,
-  _partition UInt64
+  _partition UInt64,
+  INDEX idx_token token TYPE bloom_filter(0.01) GRANULARITY 1
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.ingestion_warnings_v2', '{replica}-{shard}') ORDER BY (team_id, type, timestamp) PARTITION BY toYYYYMM(timestamp) TTL toDateTime(timestamp) + toIntervalDay(90) SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.ingestion_warnings_v2_distributed (
   team_id Int64,
@@ -61,6 +63,7 @@ CREATE TABLE posthog.ingestion_warnings_v2_distributed (
   distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
   group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
   person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+  token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
   _timestamp DateTime,
   _offset UInt64,
   _partition UInt64

--- a/posthog/clickhouse/hcl/sql/prod-us-aux.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us-aux.sql
@@ -44,9 +44,11 @@ CREATE TABLE posthog.ingestion_warnings_v2 (
   distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
   group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
   person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+  token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
   _timestamp DateTime,
   _offset UInt64,
-  _partition UInt64
+  _partition UInt64,
+  INDEX idx_token token TYPE bloom_filter(0.01) GRANULARITY 1
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.ingestion_warnings_v2', '{replica}-{shard}') ORDER BY (team_id, type, timestamp) PARTITION BY toYYYYMM(timestamp) TTL toDateTime(timestamp) + toIntervalDay(90) SETTINGS index_granularity = 8192;
 CREATE TABLE posthog.ingestion_warnings_v2_distributed (
   team_id Int64,
@@ -61,6 +63,7 @@ CREATE TABLE posthog.ingestion_warnings_v2_distributed (
   distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
   group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
   person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+  token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
   _timestamp DateTime,
   _offset UInt64,
   _partition UInt64

--- a/posthog/clickhouse/migrations/0288_ingestion_warnings_v2_token.py
+++ b/posthog/clickhouse/migrations/0288_ingestion_warnings_v2_token.py
@@ -1,0 +1,40 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.ingestion_warnings.sql_v2 import DISTRIBUTED_TABLE_NAME, TABLE_NAME
+
+# Adds a `token` column (derived from the `details` JSON) so producers that only know the
+# API token (e.g. capture, which has no database access) can emit warnings with team_id=0
+# and have the read side match them to a team by token. Bloom-filter indexed because token
+# lookups can't use the (team_id, type, timestamp) primary key.
+ADD_TOKEN_COLUMN = (
+    "ALTER TABLE {table} "
+    "ADD COLUMN IF NOT EXISTS token LowCardinality(String) DEFAULT JSONExtractString(details, 'token') "
+    "AFTER person_id"
+)
+
+operations = [
+    run_sql_with_exceptions(
+        ADD_TOKEN_COLUMN.format(table=TABLE_NAME),
+        node_roles=[NodeRole.AUX],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        f"ALTER TABLE {TABLE_NAME} ADD INDEX IF NOT EXISTS idx_token token TYPE bloom_filter(0.01) GRANULARITY 1",
+        node_roles=[NodeRole.AUX],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        f"ALTER TABLE {TABLE_NAME} MATERIALIZE INDEX idx_token",
+        node_roles=[NodeRole.AUX],
+        sharded=False,
+        is_alter_on_replicated_table=True,
+    ),
+    run_sql_with_exceptions(
+        ADD_TOKEN_COLUMN.format(table=DISTRIBUTED_TABLE_NAME),
+        node_roles=[NodeRole.AUX, NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0287_events_recent_inserted_at_not_nullable
+0288_ingestion_warnings_v2_token

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1967,10 +1967,12 @@
       distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
       group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
       person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+      token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
       _timestamp DateTime,
       _offset UInt64,
       _partition UInt64
   
+      , INDEX idx_token token TYPE bloom_filter(0.01) GRANULARITY 1
   ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.ingestion_warnings_v2', '{replica}-{shard}')
   PARTITION BY toYYYYMM(timestamp)
   ORDER BY (team_id, type, timestamp)
@@ -1996,6 +1998,7 @@
       distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
       group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
       person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+      token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
       _timestamp DateTime,
       _offset UInt64,
       _partition UInt64
@@ -9361,10 +9364,12 @@
       distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
       group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
       person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+      token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
       _timestamp DateTime,
       _offset UInt64,
       _partition UInt64
   
+      , INDEX idx_token token TYPE bloom_filter(0.01) GRANULARITY 1
   ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.ingestion_warnings_v2', '{replica}-{shard}')
   PARTITION BY toYYYYMM(timestamp)
   ORDER BY (team_id, type, timestamp)

--- a/posthog/clickhouse/test/test_ingestion_warnings_v2_token.py
+++ b/posthog/clickhouse/test/test_ingestion_warnings_v2_token.py
@@ -1,0 +1,54 @@
+import json
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from parameterized import parameterized
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.ingestion_warnings.sql_v2 import TABLE_NAME
+
+INSERT_WARNING = f"""
+INSERT INTO {TABLE_NAME} (team_id, source, type, details, timestamp, _timestamp, _offset, _partition)
+SELECT %(team_id)s, %(source)s, %(type)s, %(details)s, %(timestamp)s, now(), 0, 0
+"""
+
+
+class TestIngestionWarningsV2TokenColumn(ClickhouseTestMixin, BaseTest):
+    @parameterized.expand(
+        [
+            (
+                "capture_shaped_row_materializes_token",
+                0,
+                "capture",
+                {"token": "phc_test_token", "category": "event", "severity": "error", "count": 3},
+                "phc_test_token",
+            ),
+            (
+                "node_shaped_row_without_token_reads_empty",
+                42,
+                "plugin-server",
+                {"category": "size", "severity": "error", "distinctId": "user-1"},
+                "",
+            ),
+        ]
+    )
+    def test_token_column_derivation(
+        self, _name: str, team_id: int, source: str, details: dict, expected_token: str
+    ) -> None:
+        warning_type = f"type_{_name}"
+        sync_execute(
+            INSERT_WARNING,
+            {
+                "team_id": team_id,
+                "source": source,
+                "type": warning_type,
+                "details": json.dumps(details),
+                "timestamp": "2026-07-10 12:00:00",
+            },
+        )
+
+        rows = sync_execute(
+            f"SELECT token, category, severity FROM {TABLE_NAME} WHERE type = %(type)s",
+            {"type": warning_type},
+        )
+        assert rows == [(expected_token, details["category"], details["severity"])]

--- a/posthog/models/ingestion_warnings/sql_v2.py
+++ b/posthog/models/ingestion_warnings/sql_v2.py
@@ -22,6 +22,11 @@ DISTRIBUTED_TABLE_NAME = f"{TABLE_NAME}_distributed"
 # Storage columns for the data + distributed tables. Derived dimensions and entity ids have
 # DEFAULT expressions over the raw `details` JSON; the JSON key names must match what the
 # producers emit (a mismatch just yields the default/NULL, it does not break ingestion).
+#
+# `token`: producers that cannot resolve a team_id (e.g. the capture service, which has no
+# database access) emit team_id=0 and stamp the request's API token in `details`; the read
+# side matches those rows to a team by token. Bloom-filter indexed on the data table since
+# token lookups can't use the (team_id, type, timestamp) primary key.
 INGESTION_WARNINGS_V2_COLUMNS = """
     team_id Int64,
     source LowCardinality(String),
@@ -35,6 +40,7 @@ INGESTION_WARNINGS_V2_COLUMNS = """
     distinct_id Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'distinctId'), ''),
     group_key Nullable(String) DEFAULT nullIf(JSONExtractString(details, 'groupKey'), ''),
     person_id Nullable(UUID) DEFAULT toUUIDOrNull(JSONExtractString(details, 'personId')),
+    token LowCardinality(String) DEFAULT JSONExtractString(details, 'token'),
     _timestamp DateTime,
     _offset UInt64,
     _partition UInt64
@@ -57,6 +63,7 @@ def INGESTION_WARNINGS_V2_DATA_TABLE_SQL() -> str:
 CREATE TABLE IF NOT EXISTS {table_name}
 (
     {columns}
+    , INDEX idx_token token TYPE bloom_filter(0.01) GRANULARITY 1
 ) ENGINE = {engine}
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (team_id, type, timestamp)


### PR DESCRIPTION
## Problem

The Rust capture service will soon emit ingestion warnings (e.g. `missing_event_name`, `distinct_id_too_large`) for events it drops during validation. Capture is not allowed to access databases, so it cannot resolve an API token to a `team_id` the way the Node.js ingestion worker does — it can only emit `team_id = 0` with the request's token stamped inside the `details` JSON.

For those rows to ever reach a user, the v2 warnings table needs a queryable, indexed `token` column so the read side (which can trivially resolve a team to its token) can match capture-sourced rows to the owning team.

This is the schema half, shipped migration-only per convention. The capture producer, the read-side filter, and the deploy config follow in separate stacked PRs.

## Changes

- `ingestion_warnings_v2` (aux cluster) gains `token LowCardinality(String) DEFAULT JSONExtractString(details, 'token')` — same derive-from-`details` pattern as the existing `category`/`severity`/entity-id columns, so the Kafka engine table and MV need **no change** (they are 5-column pass-throughs).
- Bloom-filter skip index `idx_token` (`bloom_filter(0.01)`, granularity 1) on the data table, since token lookups can't use the `(team_id, type, timestamp)` primary key. Same index shape as `message_assets_data` on the same cluster.
- `ingestion_warnings_v2_distributed` gains the matching column on AUX + DATA nodes (mirrors the reader placement from migration 0286).
- Migration `0288`: `ADD COLUMN IF NOT EXISTS ... AFTER person_id`, `ADD INDEX IF NOT EXISTS`, `MATERIALIZE INDEX` (cheap: all pre-existing rows are Node-produced and have no token key, so they correctly materialize as `''`), then the distributed-table column.
- Declarative HCL layers updated (`roles/auxiliary/shared`, `roles/data/local`) with goldens and generated SQL regenerated, so the convergence gate stays green.

Existing rows and all current producers are unaffected: the column is purely additive and defaults to `''` when `details` has no `token` key.

## How did you test this code?

- New `posthog/clickhouse/test/test_ingestion_warnings_v2_token.py` (parameterized round-trip): a capture-shaped row (`team_id=0`, token in `details`) materializes the `token` column, and a Node-shaped row without a token reads back `''`. Catches a regression no existing test does: if the DEFAULT expression or the `token` JSON key ever drifts from what producers emit, capture rows would silently become unmatchable.
- Smoke-tested the exact ALTER sequence against a scratch table built with the **pre-migration** schema and pre-existing rows on the local ClickHouse 26.3 container: column lands after `person_id`, index materializes, old rows read `''`, new rows populate.
- `posthog/clickhouse/test/test_migrations.py` (conventions: flags, ON CLUSTER absence) passes.
- `posthog/clickhouse/test/test_schema.py --snapshot-update` (3 snapshots updated) and `posthog/api/test/test_ingestion_warnings_v2.py` (12 passed) confirm the read path is undisturbed.
- `posthog/clickhouse/hcl/check.sh` green (HCL validate + golden diff + sql freshness).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change; behavior is additive schema only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Cursor (Claude). Skills invoked: /clickhouse-migrations, /writing-tests.
- Migration was first generated from the HCL diff via `codegen/gen_migration.py`, then hand-adjusted: bare table names instead of a hardcoded `posthog.` database prefix (tests run against `posthog_test`; no existing migration hardcodes the db), `IF NOT EXISTS` guards, explicit `AFTER person_id` so the live column order converges to the golden, and the column/index ALTERs split to match the 0250/0262 index-migration precedent.
- Considered write-time token→team_id resolution via a ClickHouse dictionary in the MV instead; rejected for now (new infra, staleness window, failure coupling to the ingest MV). The token lives in `details` permanently, so that remains a clean future upgrade path.