### PR TITLE
feat(notebooks): add input widgets that re-run dependent cells

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeInputV2.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeInputV2.test.ts
@@ -1,0 +1,21 @@
+import { buildInputAssignmentCode, parseInputOptions } from './NotebookNodeInputV2'
+
+describe('NotebookNodeInputV2 assignment building', () => {
+    // The assignment executes in the kernel: a malformed literal or an unvalidated variable
+    // name would let widget input break out of the assignment statement.
+    test.each([
+        ['text value is a quoted literal', 'date_from', 'text', '2026-07-01', 'date_from = "2026-07-01"'],
+        ['quotes and newlines stay inside the literal', 'label', 'text', 'a"b\nc', 'label = "a\\"b\\nc"'],
+        ['number passes through numerically', 'limit', 'number', '50', 'limit = 50'],
+        ['non-numeric number input is rejected', 'limit', 'number', 'abc', null],
+        ['blank number input is rejected', 'limit', 'number', '  ', null],
+        ['invalid variable name is rejected', 'not a name', 'text', 'x', null],
+        ['expression-shaped variable is rejected', 'x; import os', 'text', 'x', null],
+    ] as const)('%s', (_name, variable, widgetType, value, expected) => {
+        expect(buildInputAssignmentCode(variable, widgetType, value)).toEqual(expected)
+    })
+
+    it('parses select options from commas and newlines, dropping blanks', () => {
+        expect(parseInputOptions('a, b\nc,\n , d')).toEqual(['a', 'b', 'c', 'd'])
+    })
+})

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeInputV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeInputV2.tsx
@@ -1,0 +1,224 @@
+import { useActions, useMountedLogic, useValues } from 'kea'
+import { useState } from 'react'
+
+import { dayjs } from 'lib/dayjs'
+import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { createPostHogWidgetNode } from 'scenes/notebooks/Nodes/NodeWrapper'
+
+import { NotebookNodeAttributeProperties, NotebookNodeProps, NotebookNodeType } from '../types'
+import { notebookNodeLogic } from './notebookNodeLogic'
+import type { NotebookNodeSQLV2Result } from './NotebookNodeSQLV2'
+import { notebookNodeSQLV2Logic } from './notebookNodeSQLV2Logic'
+
+// Journey 11: an input widget bound to a kernel variable. Applying a new value runs a tiny
+// python assignment cell in the sandbox kernel; the run's completion marks dependent cells
+// stale (Journey 10) and re-runs them automatically.
+
+export type NotebookNodeInputV2WidgetType = 'text' | 'number' | 'date' | 'select'
+
+export type NotebookNodeInputV2Attributes = {
+    // The kernel variable this widget sets, e.g. date_from.
+    variable: string
+    widgetType: NotebookNodeInputV2WidgetType
+    // Newline- or comma-separated choices for the select widget.
+    options: string
+    value: string
+    runId?: string | null
+    result?: NotebookNodeSQLV2Result | null
+}
+
+const VARIABLE_PATTERN = /^[A-Za-z_]\w*$/
+
+export const buildInputAssignmentCode = (
+    variable: string,
+    widgetType: NotebookNodeInputV2WidgetType,
+    value: string
+): string | null => {
+    if (!VARIABLE_PATTERN.test(variable)) {
+        return null
+    }
+    if (widgetType === 'number') {
+        const numeric = Number(value)
+        if (value.trim() === '' || !isFinite(numeric)) {
+            return null
+        }
+        return `${variable} = ${numeric}`
+    }
+    // A JSON string literal is a valid python string literal (escapes are a shared subset).
+    return `${variable} = ${JSON.stringify(value)}`
+}
+
+export const parseInputOptions = (options: string): string[] =>
+    options
+        .split(/[\n,]/)
+        .map((option) => option.trim())
+        .filter(Boolean)
+
+const Component = ({ attributes, updateAttributes }: NotebookNodeProps<NotebookNodeInputV2Attributes>): JSX.Element => {
+    const nodeLogic = useMountedLogic(notebookNodeLogic)
+    const { nodeId, notebookLogic } = useValues(nodeLogic)
+    const notebookShortId = notebookLogic.props.shortId
+
+    const dataLogic = notebookNodeSQLV2Logic({
+        nodeId,
+        notebookShortId,
+        updateAttributes,
+        runId: attributes.runId ?? null,
+        hasResult: true, // an assignment has no result to recover on mount
+        getContent: () => notebookLogic.values.content ?? null,
+    })
+    const { isRunning, runError, operationBlockReason, isChainRunning } = useValues(dataLogic)
+    const { runQuery } = useActions(dataLogic)
+
+    // Text and number commit on blur/Enter, so the draft tracks keystrokes locally.
+    const [draft, setDraft] = useState<string | null>(null)
+    const value = draft ?? attributes.value ?? ''
+
+    const apply = (nextValue: string): void => {
+        setDraft(null)
+        const code = buildInputAssignmentCode(attributes.variable ?? '', attributes.widgetType ?? 'text', nextValue)
+        if (code === null || nextValue === attributes.value) {
+            return
+        }
+        // Pin nodeId for the same reason runs do; persist the value for reloads.
+        updateAttributes({ nodeId, variable: attributes.variable, value: nextValue })
+        // The assignment reads nothing, so no refs; the run's completion marks dependents
+        // stale and autoRunDependents re-runs them.
+        runQuery(code, {}, { nodeType: 'python', autoRunDependents: true })
+    }
+
+    const disabledReason = isChainRunning
+        ? 'Stale cells are being re-run'
+        : isRunning
+          ? 'Applying the previous change'
+          : (operationBlockReason ?? undefined)
+    const widgetType = attributes.widgetType ?? 'text'
+
+    return (
+        <div
+            data-attr="notebook-node-input-v2"
+            className="flex items-center gap-2 p-2"
+            onClick={(event) => event.stopPropagation()}
+            onMouseDown={(event) => event.stopPropagation()}
+        >
+            <LemonLabel className="font-mono shrink-0">{attributes.variable || 'variable'}</LemonLabel>
+            <div className="max-w-80 flex-1">
+                {widgetType === 'select' ? (
+                    <LemonSelect
+                        size="small"
+                        fullWidth
+                        value={attributes.value || null}
+                        options={parseInputOptions(attributes.options ?? '').map((option) => ({
+                            value: option,
+                            label: option,
+                        }))}
+                        onChange={(next) => (next === null ? undefined : apply(next))}
+                        disabledReason={disabledReason}
+                        placeholder="Pick a value"
+                    />
+                ) : widgetType === 'date' ? (
+                    <LemonCalendarSelectInput
+                        value={attributes.value ? dayjs(attributes.value) : null}
+                        onChange={(date) => date && apply(date.format('YYYY-MM-DD'))}
+                        format="YYYY-MM-DD"
+                        placeholder="Pick a date"
+                        buttonProps={{ size: 'small', disabledReason }}
+                    />
+                ) : (
+                    <LemonInput
+                        size="small"
+                        fullWidth
+                        value={value}
+                        onChange={setDraft}
+                        onBlur={() => draft !== null && apply(draft)}
+                        onPressEnter={() => draft !== null && apply(draft)}
+                        disabledReason={disabledReason}
+                        placeholder={widgetType === 'number' ? '0' : 'Value'}
+                    />
+                )}
+            </div>
+            {isRunning ? <span className="text-xs text-muted shrink-0">Applying…</span> : null}
+            {runError ? <span className="text-xs text-danger shrink-0">{runError}</span> : null}
+            {attributes.variable && !VARIABLE_PATTERN.test(attributes.variable) ? (
+                <span className="text-xs text-danger shrink-0">Not a valid python variable name</span>
+            ) : null}
+        </div>
+    )
+}
+
+const Settings = ({
+    attributes,
+    updateAttributes,
+}: NotebookNodeAttributeProperties<NotebookNodeInputV2Attributes>): JSX.Element => {
+    return (
+        <div className="flex flex-wrap items-center gap-2 p-2" onClick={(event) => event.stopPropagation()}>
+            <LemonLabel>Variable</LemonLabel>
+            <LemonInput
+                size="small"
+                className="font-mono"
+                value={attributes.variable ?? ''}
+                onChange={(variable) => updateAttributes({ variable })}
+                placeholder="date_from"
+            />
+            <LemonLabel>Type</LemonLabel>
+            <LemonSelect
+                size="small"
+                value={attributes.widgetType ?? 'text'}
+                options={[
+                    { value: 'text' as const, label: 'Text' },
+                    { value: 'number' as const, label: 'Number' },
+                    { value: 'date' as const, label: 'Date' },
+                    { value: 'select' as const, label: 'Dropdown' },
+                ]}
+                onChange={(widgetType) => updateAttributes({ widgetType })}
+            />
+            {attributes.widgetType === 'select' ? (
+                <>
+                    <LemonLabel>Choices</LemonLabel>
+                    <LemonInput
+                        size="small"
+                        value={attributes.options ?? ''}
+                        onChange={(options) => updateAttributes({ options })}
+                        placeholder="Comma-separated choices"
+                    />
+                </>
+            ) : null}
+        </div>
+    )
+}
+
+export const NotebookNodeInputV2 = createPostHogWidgetNode<NotebookNodeInputV2Attributes>({
+    nodeType: NotebookNodeType.InputV2,
+    titlePlaceholder: 'Input',
+    Component,
+    heightEstimate: 48,
+    minHeight: 40,
+    resizeable: false,
+    startExpanded: true,
+    attributes: {
+        variable: {
+            default: 'input_value',
+        },
+        widgetType: {
+            default: 'text',
+        },
+        options: {
+            default: '',
+        },
+        value: {
+            default: '',
+        },
+        runId: {
+            default: null,
+        },
+        result: {
+            default: null,
+        },
+    },
+    Settings,
+    settingsPlacement: 'inline',
+    serializedText: (attrs) => `${attrs.variable} = ${attrs.value}`,
+})

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.test.ts
@@ -135,6 +135,20 @@ describe('buildNotebookDependencyGraph', () => {
         expect(identifiers).not.toContain('head')
     })
 
+    it('links an InputV2 widget to the cells that read its variable', () => {
+        // Journey 11: changing a widget must find its dependents to re-run; without the
+        // widget in the graph the change applies to the kernel but nothing refreshes.
+        const content = {
+            type: 'doc',
+            content: [
+                { type: NotebookNodeType.InputV2, attrs: { nodeId: 'w', variable: 'date_from' } },
+                pythonV2Node('py', 'filtered', 'filtered = df[df.date >= date_from]'),
+            ],
+        }
+        const graph = buildNotebookDependencyGraph(content)
+        expect(graph.downstreamUsageByNode['w'].date_from.map((usage) => usage.nodeId)).toEqual(['py'])
+    })
+
     it('links SQLV2 cells inside a markdown notebook', () => {
         // Markdown notebooks hold cells as tags inside one markdown attribute; without
         // expanding them the graph is empty and the "Used in" back-links never render.

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -845,11 +845,27 @@ export const buildNotebookDependencyGraph = (content?: JSONContent | null): Note
             })
         }
 
+        if (node.type === NotebookNodeType.InputV2) {
+            const attrs = node.attrs ?? {}
+            const variable = typeof attrs.variable === 'string' ? attrs.variable.trim() : ''
+            nodes.push({
+                nodeId: attrs.nodeId ?? '',
+                nodeType: NotebookNodeType.InputV2,
+                nodeIndex: 0,
+                title: typeof attrs.title === 'string' ? attrs.title : '',
+                // A widget is a pure source: it sets one kernel variable and reads nothing.
+                exports: variable ? [variable] : [],
+                uses: [],
+                returnVariable: variable,
+            })
+        }
+
         if (node.type === NotebookNodeType.MarkdownNotebook) {
-            // Markdown notebooks (the only V2 surface) store cells as component tags, so both
+            // Markdown notebooks (the only V2 surface) store cells as component tags, so all
             // V2 cell types must be expanded or the graph misses every markdown-held cell.
             expandMarkdownNotebookSqlV2Nodes(node).forEach(walk)
             expandMarkdownNotebookNodesOfType(node, NotebookNodeType.PythonV2).forEach(walk)
+            expandMarkdownNotebookNodesOfType(node, NotebookNodeType.InputV2).forEach(walk)
         }
 
         if (Array.isArray(node.content)) {

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
@@ -91,6 +91,9 @@ export type SqlV2RunLane = 'direct' | 'kernel'
 export interface RunQueryOptions {
     nodeType?: 'hogql' | 'python'
     outputName?: string
+    // When the run lands, automatically re-run the cells it made stale (input widgets,
+    // Journey 11) instead of waiting for a banner click.
+    autoRunDependents?: boolean
 }
 
 export interface NotebookNodeSQLV2LogicProps {
@@ -505,6 +508,7 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                     }
                 }
                 actions.startOperation(runOperation)
+                cache.autoRunDependents = !!opts.autoRunDependents
                 try {
                     const { run_id } = await api.notebooks.sqlV2Run(props.notebookShortId, {
                         node_id: props.nodeId,
@@ -618,6 +622,12 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                         // Downstream cells now derive from outdated data — mark them stale
                         // against the document as it stands now (Journey 10).
                         actions.nodeRunFinished(props.nodeId, 'done', props.getContent?.() ?? null)
+                        // Input widgets (Journey 11): the change should propagate without a
+                        // second click, so run the newly stale cells right away.
+                        if (cache.autoRunDependents) {
+                            cache.autoRunDependents = false
+                            actions.runStaleChain(props.getContent?.() ?? null)
+                        }
                     } else if (status === 'interrupted') {
                         // A user-requested stop: the envelope still carries whatever stdout,
                         // stderr, and figures the cell produced before the interrupt landed.

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -20,6 +20,7 @@ import '../Nodes/NotebookNodePersonFeed/NotebookNodePersonFeed'
 import '../Nodes/NotebookNodePersonProperties'
 import '../Nodes/NotebookNodePlaylist'
 import '../Nodes/NotebookNodePython'
+import '../Nodes/NotebookNodeInputV2'
 import '../Nodes/NotebookNodePythonV2'
 import '../Nodes/NotebookNodeQuery'
 import '../Nodes/NotebookNodeRecording'
@@ -114,6 +115,7 @@ export const MARKDOWN_TAG_TO_NOTEBOOK_NODE_TYPE: Partial<Record<string, Notebook
     DuckSQL: NotebookNodeType.DuckSQL,
     HogQLSQL: NotebookNodeType.HogQLSQL,
     SQLV2: NotebookNodeType.SQLV2,
+    InputV2: NotebookNodeType.InputV2,
     Recording: NotebookNodeType.Recording,
     RecordingPlaylist: NotebookNodeType.RecordingPlaylist,
     FeatureFlag: NotebookNodeType.FeatureFlag,
@@ -182,6 +184,16 @@ export const MARKDOWN_NODE_DEFINITIONS: {
             // fingerprints, so without a persisted id every prop change (running the cell
             // writes runId/result) would orphan the cell's run history and cross-cell refs.
             defaultProps: () => ({ ...getDefaultPropsForNodeType(NotebookNodeType.SQLV2), nodeId: uuid() }),
+        },
+    },
+    // Journey 11 input widget; insertion gated with the other revamped cells.
+    {
+        tagName: 'InputV2',
+        category: 'Code',
+        label: 'Input',
+        insertCommand: {
+            aliases: ['input', 'widget'],
+            defaultProps: () => ({ ...getDefaultPropsForNodeType(NotebookNodeType.InputV2), nodeId: uuid() }),
         },
     },
     { tagName: 'RecordingPlaylist', category: 'Data', label: 'Session recordings' },
@@ -266,7 +278,7 @@ export const NOTEBOOK_MARKDOWN_REGISTRY: NotebookComponentRegistry = createMarkd
 export function getMarkdownRegistryForFeatureFlags(featureFlags: FeatureFlagsSet): NotebookComponentRegistry {
     const hiddenTags: string[] = []
     if (!featureFlags[FEATURE_FLAGS.REVAMPED_PY_NOTEBOOKS]) {
-        hiddenTags.push('SQLV2', 'PythonV2')
+        hiddenTags.push('SQLV2', 'PythonV2', 'InputV2')
     }
 
     if (hiddenTags.length === 0) {

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
@@ -50,6 +50,7 @@ export const NOTEBOOK_NODE_TYPE_TO_MARKDOWN_TAG: Partial<Record<NotebookNodeType
     [NotebookNodeType.DuckSQL]: 'DuckSQL',
     [NotebookNodeType.HogQLSQL]: 'HogQLSQL',
     [NotebookNodeType.SQLV2]: 'SQLV2',
+    [NotebookNodeType.InputV2]: 'InputV2',
     [NotebookNodeType.Recording]: 'Recording',
     [NotebookNodeType.RecordingPlaylist]: 'RecordingPlaylist',
     [NotebookNodeType.FeatureFlag]: 'FeatureFlag',

--- a/frontend/src/scenes/notebooks/Notebook/notebookNodeStalenessLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookNodeStalenessLogic.test.ts
@@ -170,6 +170,46 @@ describe('notebookNodeStalenessLogic', () => {
         expect(stalenessLogic.values.staleNodeIds).toEqual({ b: true, c: true })
     })
 
+    it('a run with autoRunDependents chains its stale dependents without a click (input widgets)', async () => {
+        // Journey 11: a widget's assignment landing must refresh the cells that read the
+        // variable, not just mark them stale behind a banner.
+        const widgetContent: JSONContent = {
+            type: 'doc',
+            content: [
+                { type: NotebookNodeType.InputV2, attrs: { nodeId: 'w', variable: 'date_from' } },
+                {
+                    type: NotebookNodeType.PythonV2,
+                    attrs: { nodeId: 'p', returnVariable: 'filtered', code: 'filtered = raw[raw.d >= date_from]' },
+                },
+            ],
+        }
+        const widgetLogic = notebookNodeSQLV2Logic({
+            nodeId: 'w',
+            notebookShortId: 'nb1',
+            updateAttributes: jest.fn(),
+            getContent: () => widgetContent,
+        })
+        widgetLogic.mount()
+        nodeLogics.push(widgetLogic)
+        const dependentLogic = notebookNodeSQLV2Logic({
+            nodeId: 'p',
+            notebookShortId: 'nb1',
+            updateAttributes: jest.fn(),
+            getContent: () => widgetContent,
+        })
+        dependentLogic.mount()
+        nodeLogics.push(dependentLogic)
+
+        widgetLogic.actions.runQuery('date_from = "2026-07-01"', {}, { nodeType: 'python', autoRunDependents: true })
+        await expectLogic(stalenessLogic).toFinishAllListeners()
+        await expectLogic(dependentLogic).toFinishAllListeners()
+
+        // First run is the assignment, second is the dependent cell, no banner click involved.
+        expect(runSpy).toHaveBeenCalledTimes(2)
+        expect(runSpy.mock.calls[1][1]).toMatchObject({ node_id: 'p', node_type: 'python' })
+        expect(stalenessLogic.values.staleNodeIds).toEqual({})
+    })
+
     it('a second runStaleChain while one is active is refused', async () => {
         mountNode('b')
         // Keep the first link running so the chain stays active.

--- a/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/ContainsTypeFilter.tsx
@@ -27,6 +27,7 @@ export const fromNodeTypeToLabel: Omit<
     [NotebookNodeType.Query]: 'Queries',
     [NotebookNodeType.Python]: 'Python',
     [NotebookNodeType.PythonV2]: 'Python (v2)',
+    [NotebookNodeType.InputV2]: 'Input widget',
     [NotebookNodeType.DuckSQL]: 'SQL (DuckDB)',
     [NotebookNodeType.HogQLSQL]: 'SQL (HogQL)',
     [NotebookNodeType.SQLV2]: 'SQL (v2)',

--- a/frontend/src/scenes/notebooks/nodeIcons.tsx
+++ b/frontend/src/scenes/notebooks/nodeIcons.tsx
@@ -35,6 +35,7 @@ export const NODE_ICONS: Partial<Record<NotebookNodeType, JSX.Element>> = {
     [NotebookNodeType.SQLV2]: <IconBracketsChart />,
     [NotebookNodeType.Python]: <IconPython />,
     [NotebookNodeType.PythonV2]: <IconPython />,
+    [NotebookNodeType.InputV2]: <IconCode />,
     [NotebookNodeType.Latex]: <IconSquareRoot />,
     [NotebookNodeType.Recording]: <IconRewindPlay />,
     [NotebookNodeType.RecordingPlaylist]: <IconRewindPlay />,

--- a/frontend/src/scenes/notebooks/types.ts
+++ b/frontend/src/scenes/notebooks/types.ts
@@ -45,6 +45,8 @@ export enum NotebookNodeType {
     DuckSQL = 'ph-duck-sql',
     HogQLSQL = 'ph-hogql-sql',
     SQLV2 = 'ph-sql-v2',
+    // An input widget bound to a kernel variable; changing it re-runs dependent V2 cells.
+    InputV2 = 'ph-input-v2',
     Recording = 'ph-recording',
     RecordingPlaylist = 'ph-recording-playlist',
     FeatureFlag = 'ph-feature-flag',


### PR DESCRIPTION
## Problem

Journey 11 of the revamped notebooks plan: parameterizing an analysis (a date range, a limit, a segment) means editing code in every cell that uses the value and re-running them by hand, in the right order.

## Changes

All frontend, zero backend. Builds on the Journey 10 staleness + chain machinery (#70176, now merged to master), which does the re-running.

- New input widget cell (`InputV2`) for revamped markdown notebooks, insertable as `/input` (gated by the same `revamped-py-notebooks` flag as the other V2 cells). Four widget types: text, number, date (calendar picker), dropdown (configurable choices). The variable name, type, and choices are edited in the cell's settings.
- Applying a change runs a tiny python assignment (`date_from = "2026-07-01"`) through the existing SQLV2 run path, so operation serialization, RBAC, flag gating, and Journey 9 interrupt all apply. Text and number commit on blur or Enter; date and dropdown on selection.
- The widget joins the notebook dependency graph as a pure source (exports its variable, reads nothing). When the assignment lands, cells reading the variable are marked stale, and a new `autoRunDependents` run option fires the Journey 10 chain automatically, so outputs refresh from a single widget change with no banner click.
- Assignment literals are validated: the variable must match `^[A-Za-z_]\w*$`, strings are JSON-quoted (a JSON string literal is a valid python string literal), numbers must be finite. Widget input cannot escape the assignment statement.

> [!NOTE]
> Downstream cells read the kernel variable directly from the namespace, so refs plumbing is untouched. A cell run before the widget ever applied fails with python's own NameError, which is the honest error. A kernel restart loses the variable until the widget re-applies, the same recovery story as any kernel value.

## How did you test this code?

Automated tests only:

- `NotebookNodeInputV2.test.ts` (new, 8 cases): assignment building is the security-relevant seam, so the parameterized cases pin quoting (quotes and newlines stay inside the literal), numeric validation, and rejection of non-identifier variable names like `x; import os`.
- `notebookNodeStalenessLogic.test.ts` (+1): a widget-style run with `autoRunDependents` chains its stale dependent without a banner click, the end-to-end wiring of this journey.
- `notebookNodeContent.test.ts` (+1): the widget-to-dependent graph edge exists, without which the change applies to the kernel but nothing refreshes.
- Full suites for the three touched test files: 26 passed. `pnpm typescript:check` clean; `hogli ci:preflight --strict` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` cover the revamped notebook cells yet; design rationale is in the journey plan and this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code as part of the revamped-notebooks journey series; rebased onto master after Journey 10 (#70176) merged, so the diff is now just Journey 11's 11 files. Skills invoked: /writing-tests.

Decisions worth knowing about while reviewing:

- The apply run reuses `notebookNodeSQLV2Logic` wholesale (the widget is "a python cell whose code is generated"), rather than a bespoke run path, to inherit every existing guard.
- Widgets are sources only: never marked stale, never queued by the chain runner.
- `LemonCalendarSelectInput` for dates because `LemonInput` has no date type; number input stays a text input with numeric validation because LemonInput's number variant changes the onChange contract mid-union.

