### PR TITLE
fix(data-warehouse): resolve duckgres backfill Delta path from url_pattern

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/backfill_snapshot.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/backfill_snapshot.py
@@ -15,6 +15,7 @@ from urllib.parse import unquote
 from django.conf import settings
 
 from products.warehouse_sources.backend.models import ExternalDataSchema
+from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 
 CHUNK_TARGET_BYTES = 1024**3  # ~1 GiB of parquet per chunk statement
 MAX_FILES_PER_CHUNK = 512  # bound the read_parquet([...]) literal list
@@ -54,12 +55,17 @@ def _delta_table_folder(schema: ExternalDataSchema) -> str:
     catalog table's url_pattern is the authoritative location — it is what the
     query engine reads — so take the leaf from there, and fall back to
     normalized_name only when no table row exists yet (nothing to backfill).
+
+    url_pattern is a user-writable field, so the leaf is normalized through the
+    same convention the writer used to produce it. This is a no-op for every
+    legitimate folder (they are already normalize_identifier output) and strips
+    any injected separators so the leaf can never escape the schema's own prefix.
     """
     table = schema.table
     if table and table.url_pattern:
         segments = [seg for seg in table.url_pattern.rstrip("/").split("/") if seg and seg not in ("*", "**")]
         if segments:
-            return segments[-1]
+            return NamingConvention.normalize_identifier(segments[-1])
     return schema.normalized_name
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/backfill_snapshot.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/backfill_snapshot.py
@@ -40,7 +40,27 @@ class BackfillSnapshotPlan:
 
 
 def delta_table_uri(schema: ExternalDataSchema) -> str:
-    return f"{settings.BUCKET_URL}/{schema.folder_path()}/{schema.normalized_name}"
+    return f"{settings.BUCKET_URL}/{schema.folder_path()}/{_delta_table_folder(schema)}"
+
+
+def _delta_table_folder(schema: ExternalDataSchema) -> str:
+    """The Delta table's own folder segment, as the loader actually wrote it.
+
+    The loader names the folder after the DLT resource (the unqualified table
+    name), so it diverges from schema.normalized_name for schema-qualified
+    sources: Postgres "public.foo" normalizes to "public_foo", but the Delta
+    folder is "foo". Reading normalized_name here points the backfill at a
+    prefix with no _delta_log (surfaces as "No files in log segment"). The
+    catalog table's url_pattern is the authoritative location — it is what the
+    query engine reads — so take the leaf from there, and fall back to
+    normalized_name only when no table row exists yet (nothing to backfill).
+    """
+    table = schema.table
+    if table and table.url_pattern:
+        segments = [seg for seg in table.url_pattern.rstrip("/").split("/") if seg and seg not in ("*", "**")]
+        if segments:
+            return segments[-1]
+    return schema.normalized_name
 
 
 def _delta_storage_options() -> dict[str, str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill_snapshot.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill_snapshot.py
@@ -61,3 +61,16 @@ class TestDeltaTableUri(SimpleTestCase):
         uri = delta_table_uri(schema)
 
         assert uri == f"s3://test-bucket/dlt/{schema.folder_path()}/{schema.normalized_name}"
+
+    def test_injected_url_pattern_leaf_cannot_escape_schema_prefix(self) -> None:
+        # url_pattern is a user-writable field. A leaf crafted with encoded
+        # separators (percent-encoded slashes survive split("/") as one segment)
+        # must not let the backfill target a prefix outside the schema's folder.
+        schema = self._schema("public.posthog_hogfunction", leaf="..%2f..%2fteam_2_postgres_secret%2fusers")
+
+        uri = delta_table_uri(schema)
+
+        prefix = f"s3://test-bucket/dlt/{schema.folder_path()}/"
+        assert uri.startswith(prefix)
+        leaf = uri[len(prefix) :]
+        assert "/" not in leaf and "." not in leaf and "%" not in leaf

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill_snapshot.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_backfill_snapshot.py
@@ -1,0 +1,63 @@
+import uuid
+
+from django.test import SimpleTestCase, override_settings
+
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.backfill_snapshot import (
+    delta_table_uri,
+)
+
+_SCHEMA_ID = uuid.UUID("0190c6a4-6641-0000-0f7a-d9482771b742")
+
+
+@override_settings(BUCKET_URL="s3://test-bucket/dlt")
+class TestDeltaTableUri(SimpleTestCase):
+    def _schema(self, name: str, leaf: str | None) -> ExternalDataSchema:
+        # Built in memory (no save): exercises the real normalized_name and
+        # folder_path. leaf=None models a schema with no catalog table yet.
+        schema = ExternalDataSchema(id=_SCHEMA_ID, team_id=1, name=name)
+        schema.source = ExternalDataSource(source_type="Postgres")
+        if leaf is None:
+            schema.table = None
+        else:
+            url = f"https://bucket.s3.amazonaws.com/dlt/{schema.folder_path()}/{leaf}"
+            schema.table = DataWarehouseTable(url_pattern=url)
+        return schema
+
+    @parameterized.expand(
+        [
+            # Schema-qualified Postgres source: the loader wrote the Delta folder
+            # under the unqualified table name, but normalized_name keeps the
+            # "public_" qualifier. Reading normalized_name pointed the backfill at
+            # a prefix with no _delta_log ("No files in log segment").
+            ("schema_qualified", "public.posthog_hogfunction", "posthog_hogfunction/", "posthog_hogfunction"),
+            # Unqualified name: folder and normalized_name already agree.
+            (
+                "unqualified",
+                "campaign_performance_report",
+                "campaign_performance_report/",
+                "campaign_performance_report",
+            ),
+            # url_pattern may carry a trailing glob token instead of a bare slash.
+            ("glob_suffix", "public.posthog_team", "posthog_team/*", "posthog_team"),
+        ]
+    )
+    def test_uri_folder_comes_from_url_pattern_not_normalized_name(
+        self, _name: str, schema_name: str, leaf: str, expected_leaf: str
+    ) -> None:
+        schema = self._schema(schema_name, leaf)
+
+        uri = delta_table_uri(schema)
+
+        assert uri == f"s3://test-bucket/dlt/{schema.folder_path()}/{expected_leaf}"
+
+    def test_falls_back_to_normalized_name_when_no_table(self) -> None:
+        schema = self._schema("public.posthog_hogfunction", leaf=None)
+
+        uri = delta_table_uri(schema)
+
+        assert uri == f"s3://test-bucket/dlt/{schema.folder_path()}/{schema.normalized_name}"


### PR DESCRIPTION
## Problem

Newly-enabled incremental schemas from schema-qualified sources (Postgres `public.foo`) never prime into duckgres. Their backfill fails every retry with:

```
Generic delta kernel error: No files in log segment
```

`delta_table_uri` builds the Delta S3 path from `schema.normalized_name`, which keeps the source schema qualifier: `public.posthog_hogfunction` normalizes to `public_posthog_hogfunction`. But the v3 loader writes the Delta folder under the unqualified DLT resource name, `posthog_hogfunction`. So the backfill opens a prefix that has no `_delta_log`, delta-kernel reports "No files in log segment", and the schema retries forever until it hits the failure threshold and its live batches pile up in the failing-blocked bucket.

It only bites **schema-qualified incremental** sources: `full_refresh` tables never touch this path (they replace-write and prime immediately), and unqualified names (e.g. ad-report sources) already have `normalized_name == folder`. That's why it stayed latent since the backfill primer landed (#63144) and surfaced in prod-eu, where the internal project mirrors `public.posthog_*` app tables — 33 schemas stuck, all identical error.

> [!NOTE]
> This is the **source** Delta read path only. The duckgres **target** table naming (e.g. `postgres_eu_public_posthog_alertconfiguration`) is a separate concern and is intentionally left unchanged.

## Changes

`delta_table_uri` now takes the table's folder from the catalog `url_pattern` — the authoritative location the query engine already reads — instead of recomputing it from `normalized_name`. The environment-correct base (`settings.BUCKET_URL` + `folder_path()`, both shared with the writer) is kept as-is, so only the diverging leaf segment changes. Falls back to `normalized_name` when a schema has no catalog table yet (nothing to backfill).

```diff
-def delta_table_uri(schema: ExternalDataSchema) -> str:
-    return f"{settings.BUCKET_URL}/{schema.folder_path()}/{schema.normalized_name}"
+def delta_table_uri(schema: ExternalDataSchema) -> str:
+    return f"{settings.BUCKET_URL}/{schema.folder_path()}/{_delta_table_folder(schema)}"
```

I kept `BUCKET_URL` as the base rather than reconstructing the whole `s3://` URI from `url_pattern`, because `url_pattern` is an https URL and parsing its host into a bucket differs across prod (virtual-hosted S3) and local dev (MinIO endpoint). Rebasing only the leaf fixes the exact divergence without host-parsing fragility.

## How did you test this code?

I (Claude) ran these automated tests. No manual testing beyond the read-only prod-eu diagnostics that root-caused it (opening both the `normalized_name` path and the `url_pattern` path for the stuck schemas — the former failed, the latter opened with files).

Added `test_backfill_snapshot.py::TestDeltaTableUri` — an in-memory `SimpleTestCase` (no DB; exercises the real `normalized_name` and `folder_path`). What it catches that nothing did before: `delta_table_uri` had zero coverage, and this locks in that a schema-qualified source resolves the folder from `url_pattern` (`posthog_hogfunction`), not `normalized_name` (`public_posthog_hogfunction`) — the exact prod regression. Cases: schema-qualified, unqualified (agreement guard), trailing-glob `url_pattern`, and the no-table fallback.

Verified by mutation: reverting `delta_table_uri` to the old `normalized_name` form fails the schema_qualified and glob_suffix cases and leaves the other two green, so the test is pinned to the behavior, not the implementation.

- `test_backfill_snapshot.py`: 4 passed.
- `test_backfill.py` + `test_processor.py` + `test_backfill_snapshot.py`: 48 passed (no regression from the changed URI).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable. Internal sink-path fix, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code, Opus 4.8) root-caused this from a prod-eu dashboard showing 499 failing-blocked batches. Read-only diagnostics on the `warehouse-sources-duckgres-load` pod narrowed it: all 33 stuck schemas shared one error, region and bucket were correct (ruling out a region gap), and opening the Delta table at the catalog `url_pattern` succeeded while the sink's computed path failed. That isolated the divergence to `delta_table_uri` using `normalized_name`.

Decisions: fix the source read path only, not the duckgres target naming (separate, working, intentional). Derive the leaf from `url_pattern` rather than reconstructing the full `s3://` URI from its https host (fragile across prod S3 vs local MinIO). Standalone PR rather than folding into #69098 ("unify duckgres data-import table naming"), which is already approved and concerns the target-write path — this is the source-read path in a different file.

Skills invoked: `/writing-tests` (to gate and shape the regression test).
