### PR TITLE
fix(mysql): retry transient Vitess reparent errors during metadata discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -475,6 +475,23 @@ def _is_transient_tablet_unavailable(e: BaseException) -> bool:
     return _GRPC_UNAVAILABLE_TOKEN in " ".join(str(arg) for arg in e.args)
 
 
+# Vitess/PlanetScale also fails a query against a shard mid-failover with pymysql
+# OperationalError(1105) whose message carries "primary is not serving, there may be a
+# reparent operation in progress": a planned/emergency reparent is promoting a new primary,
+# so the old one briefly stops serving. Like the `code = Unavailable` case this is transient —
+# a fresh attempt after a short backoff lands on the newly promoted primary. Key on the stable
+# `reparent operation in progress` phrase: the target keyspace/shard/tablet-type prefix is
+# volatile, and this stays robust to the primary/master wording difference across Vitess versions.
+_VITESS_REPARENT_TOKEN = "reparent operation in progress"
+
+
+def _is_transient_vitess_reparent(e: BaseException) -> bool:
+    """Return True if a Vitess shard is mid-reparent and its primary is briefly not serving."""
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    return _VITESS_REPARENT_TOKEN in " ".join(str(arg) for arg in e.args)
+
+
 def _retry_on_transient_tablet_unavailable(
     operation: Callable[[], _T],
     logger: FilteringBoundLogger,
@@ -488,8 +505,8 @@ def _retry_on_transient_tablet_unavailable(
     handshake succeeds and only the first query hits an unavailable tablet, so retry the
     whole operation (which reopens the connection) with a bounded backoff instead of
     failing sync setup on the first blip and surfacing it as captured error-tracking
-    noise. Non-transient errors re-raise immediately because
-    `_is_transient_tablet_unavailable` only matches the gRPC `Unavailable` status.
+    noise. Non-transient errors re-raise immediately because the predicates only match
+    the gRPC `Unavailable` status or a mid-reparent primary — both self-healing.
     """
     attempt = 0
     while True:
@@ -497,7 +514,7 @@ def _retry_on_transient_tablet_unavailable(
             return operation()
         except pymysql.err.OperationalError as e:
             attempt += 1
-            if attempt >= max_attempts or not _is_transient_tablet_unavailable(e):
+            if attempt >= max_attempts or not (_is_transient_tablet_unavailable(e) or _is_transient_vitess_reparent(e)):
                 raise
             logger.warning(
                 "Transient MySQL tablet-unavailable error during metadata discovery; retrying",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -29,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _is_transient_packet_sequence_error,
     _is_transient_tablet_unavailable,
     _is_transient_vitess_dial_timeout,
+    _is_transient_vitess_reparent,
     _release_streaming_cursor,
     _retry_on_transient_tablet_unavailable,
     _safe_convert_date,
@@ -1216,6 +1217,40 @@ class TestIsTransientTabletUnavailable:
         assert not _is_transient_tablet_unavailable(ValueError("code = Unavailable"))
 
 
+class TestIsTransientVitessReparent:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # The shape Vitess/PlanetScale surfaces while a shard is mid-failover — the target
+            # keyspace/shard prefix varies, the `reparent operation in progress` phrase is stable.
+            "unknown: target: keyspace.-.primary: primary is not serving, "
+            "there may be a reparent operation in progress",
+            # Older Vitess used "master" wording; the tail phrase we match is unchanged.
+            "target: keyspace.0.master: master is not serving, there may be a reparent operation in progress",
+        ],
+    )
+    def test_matches_reparent(self, message):
+        assert _is_transient_vitess_reparent(pymysql.err.OperationalError(1105, message))
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            # Other 1105 payloads and the tablet-unavailable sibling are not this class.
+            (1105, "vttablet: rpc error: code = Unavailable desc = node is shutting down"),
+            (1105, "vttablet: rpc error: code = InvalidArgument desc = some bad request"),
+            (1045, "Access denied for user"),
+        ],
+    )
+    def test_does_not_match_other_errors(self, code, message):
+        assert not _is_transient_vitess_reparent(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_vitess_reparent(pymysql.err.OperationalError())
+
+    def test_does_not_match_non_operational_error(self):
+        assert not _is_transient_vitess_reparent(ValueError("reparent operation in progress"))
+
+
 class TestRetryOnTransientTabletUnavailable:
     @staticmethod
     def _unavailable() -> pymysql.err.OperationalError:
@@ -1240,6 +1275,19 @@ class TestRetryOnTransientTabletUnavailable:
 
         assert operation.call_count == fail_count + 1
         assert [c.args[0] for c in sleep.call_args_list] == expected_sleeps
+
+    def test_retries_vitess_reparent_then_succeeds(self, mocker):
+        mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        reparent = pymysql.err.OperationalError(
+            1105,
+            "unknown: target: keyspace.-.primary: primary is not serving, "
+            "there may be a reparent operation in progress",
+        )
+        operation = MagicMock(side_effect=[reparent, "ok"])
+
+        assert _retry_on_transient_tablet_unavailable(operation, MagicMock()) == "ok"
+
+        assert operation.call_count == 2
 
     def test_gives_up_after_max_attempts(self, mocker):
         mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")


### PR DESCRIPTION
## Problem

MySQL/MariaDB imports fronted by Vitess (PlanetScale) intermittently fail metadata discovery with:

```
OperationalError: (1105, 'unknown: target: <redacted>: primary is not serving, there may be a reparent operation in progress')
```

This is a transient failover: a planned or emergency reparent is promoting a new primary, so the old one briefly stops serving. It self-heals within seconds once the new primary is up. But it was surfacing as captured error-tracking noise and stopping sync setup on the first blip.

We already retry the sibling case, a Vitess tablet reporting `code = Unavailable`, via `_retry_on_transient_tablet_unavailable` around the metadata-discovery block. The reparent message just wasn't recognised, so the retry wrapper re-raised it immediately.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f4e2f-7a28-7931-b01e-f8a836d45bf8

## Changes

- Add `_is_transient_vitess_reparent`, matching the stable `reparent operation in progress` phrase on a pymysql `OperationalError`. The volatile keyspace/shard/tablet-type prefix stays untouched, and the phrase is robust to the primary/master wording difference across Vitess versions.
- `_retry_on_transient_tablet_unavailable` now retries when either the tablet-unavailable or the reparent predicate matches, so metadata discovery reopens the connection with the existing bounded backoff instead of failing on the first blip.

This stays scoped to the observed transient error. It does not touch the global retry policy, and it is not added to `NonRetryableErrors` (this is transient infra, not a user/upstream config error, so it should remain retryable).

## How did you test this code?

Added unit tests in `test_mysql.py`:

- `TestIsTransientVitessReparent` — the reparent message is recognised (both `primary` and older `master` wording), while other 1105 payloads, the `code = Unavailable` sibling, an access-denied error, an arg-less error, and a non-`OperationalError` are not. Catches a regression where the predicate stops matching the failover message (or starts swallowing unrelated 1105s).
- `TestRetryOnTransientTabletUnavailable::test_retries_vitess_reparent_then_succeeds` — a reparent error is retried and then succeeds. Guards the wiring that routes the new predicate through the retry wrapper; no existing case exercised the reparent path.

I (Claude) could not run the suite in this environment (no pytest available). I ran `ruff check` and `ruff format` (both clean) and byte-compiled both files. The new predicate is structurally identical to the existing, well-tested `_is_transient_tablet_unavailable`, differing only in the matched token.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MySQL warehouse import source. I confirmed the issue in error tracking (3 occurrences, stack originating in `mysql.py` `get_primary_keys_for_table` → `_discover_metadata`, wrapped by `_retry_on_transient_tablet_unavailable`), read the source to find the existing transient-Vitess retry seam, and classified the error as transient infrastructure rather than a user/upstream error, so it stays retryable rather than going into `NonRetryableErrors`. Skill invoked: `/writing-tests`. I checked open PRs (including the maintainer's) for a duplicate and found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
