### PR TITLE
feat(ingestion): surface capture ingestion warnings by token

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -38,6 +38,19 @@ export const WARNING_TYPE_TO_DESCRIPTION: Record<string, string> = {
     set_on_exception: '$set or $set_once is ignored on exception events and should not be sent',
     schema_validation_failed: 'Event rejected due to schema validation failure',
     invalid_heatmap_data: 'Invalid heatmap data',
+    // Emitted by the capture service when it drops events at validation time
+    missing_event_name: 'Discarded event with no event name',
+    event_name_too_long: 'Discarded event whose name exceeds the length limit',
+    missing_distinct_id: 'Discarded event with no distinct ID',
+    distinct_id_too_large: 'Discarded event whose distinct ID exceeds the size limit',
+    invalid_event_timestamp: 'Discarded event with an invalid timestamp',
+    malformed_event_properties: 'Discarded event with malformed properties',
+    invalid_options: 'Discarded event with invalid capture options',
+    empty_batch: 'Rejected a request containing no events',
+    invalid_batch: 'Rejected a batch with invalid metadata',
+    missing_event_uuid: 'Rejected a batch containing an event with no UUID',
+    invalid_event_uuid: 'Rejected a batch containing an event with an invalid UUID',
+    duplicate_event_uuid: 'Rejected a batch containing duplicate event UUIDs',
 }
 
 // Explicit anchor on https://posthog.com/docs/data/ingestion-warnings for each warning type.

--- a/posthog/api/ingestion_warnings_v2.py
+++ b/posthog/api/ingestion_warnings_v2.py
@@ -183,7 +183,7 @@ FROM (
         {bucket_fn}(timestamp) AS bucket,
         count() OVER (PARTITION BY type, category, severity, {bucket_fn}(timestamp)) AS bucket_count
     FROM {table}
-    WHERE team_id = %(team_id)s
+    WHERE (team_id = %(team_id)s OR (team_id = 0 AND token = %(token)s))
         AND timestamp >= %(since)s
         AND timestamp <= %(until)s
         {filter_clauses}
@@ -226,6 +226,10 @@ class IngestionWarningsV2ViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
         query_params = {
             "team_id": self.team_id,
+            # Capture-sourced warnings are emitted without database access, so they
+            # carry team_id=0 and the project's API token instead; match them here.
+            # The team_id=0 guard keeps the token predicate off other teams' rows.
+            "token": self.team.api_token,
             "since": since.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M:%S"),
             "until": until.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M:%S"),
             "limit": filters.get("limit", DEFAULT_LIMIT),

--- a/posthog/api/test/test_ingestion_warnings_v2.py
+++ b/posthog/api/test/test_ingestion_warnings_v2.py
@@ -1,4 +1,5 @@
 import json
+from uuid import uuid4
 
 from freezegun.api import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
@@ -75,6 +76,14 @@ class TestIngestionWarningsV2API(ClickhouseTestMixin, APIBaseTest):
     def _list(self, **params) -> tuple[int, list]:
         response = self.client.get(f"/api/projects/{self.team.pk}/ingestion_warnings_v2/", params)
         return response.status_code, response.json()
+
+    def _use_unique_api_token(self) -> str:
+        # Test teams share the fixed CONFIG_API_TOKEN while ClickHouse rows outlive
+        # each test, so team_id=0 capture rows keyed by that token would leak between
+        # tests. A per-test token keeps them isolated.
+        self.team.api_token = f"phc_capture_test_{uuid4().hex}"
+        self.team.save()
+        return self.team.api_token
 
     def test_groups_warnings_by_type_with_counts_samples_and_sparkline(self):
         status_code, results = self._list()
@@ -167,3 +176,68 @@ class TestIngestionWarningsV2API(ClickhouseTestMixin, APIBaseTest):
     def test_invalid_params_return_400(self, params: dict):
         status_code, _ = self._list(**params)
         assert status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_capture_token_rows_surface_for_owning_team(self):
+        token = self._use_unique_api_token()
+        # Capture emits team_id=0 with the project's API token in details.
+        create_warning(
+            team_id=0,
+            type="missing_event_name",
+            timestamp="2026-07-07 11:30:00",
+            details={
+                "category": "event",
+                "severity": "error",
+                "pipelineStep": "capture_validation",
+                "token": token,
+                "distinctId": "capture-user",
+            },
+            source="capture",
+        )
+
+        status_code, results = self._list(type="missing_event_name")
+
+        assert status_code == status.HTTP_200_OK
+        assert [(r["type"], r["count"]) for r in results] == [("missing_event_name", 1)]
+        sample = results[0]["samples"][0]
+        assert sample["source"] == "capture"
+        assert sample["pipeline_step"] == "capture_validation"
+        assert sample["distinct_id"] == "capture-user"
+
+    def test_capture_rows_merge_with_plugin_server_rows_of_same_type(self):
+        token = self._use_unique_api_token()
+        # setUp created 3 in-window plugin-server message_size_too_large rows; a
+        # token-matched capture row of the same type must join that group.
+        create_warning(
+            team_id=0,
+            type="message_size_too_large",
+            timestamp="2026-07-07 11:45:00",
+            details={"category": "size", "severity": "error", "token": token},
+            source="capture",
+        )
+
+        _, results = self._list(type="message_size_too_large")
+
+        assert results[0]["count"] == 4
+        assert results[0]["samples"][0]["source"] == "capture"
+
+    @parameterized.expand(
+        [
+            ("other_team_token", {"token": "phc_other_team_secret_token"}),
+            ("no_token", {}),
+            ("empty_token", {"token": ""}),
+        ]
+    )
+    def test_team_zero_rows_without_matching_token_never_surface(self, _name: str, token_details: dict):
+        self._use_unique_api_token()
+        create_warning(
+            team_id=0,
+            type="missing_distinct_id",
+            timestamp="2026-07-07 11:30:00",
+            details={"category": "event", "severity": "error", **token_details},
+            source="capture",
+        )
+
+        status_code, results = self._list(type="missing_distinct_id")
+
+        assert status_code == status.HTTP_200_OK
+        assert results == []

--- a/products/cdp/backend/temporal/health_checks/ingestion_warnings.py
+++ b/products/cdp/backend/temporal/health_checks/ingestion_warnings.py
@@ -1,7 +1,11 @@
+from datetime import datetime
+
 import structlog
 
 from posthog.dags.common.owners import JobOwners
 from posthog.models.health_issue import HealthIssue
+from posthog.models.ingestion_warnings.sql_v2 import DISTRIBUTED_TABLE_NAME
+from posthog.models.team import Team
 from posthog.temporal.health_checks.detectors import CLICKHOUSE_BATCH_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import (
     _SEVERITY_WEIGHT,
@@ -35,13 +39,18 @@ INGESTION_WARNINGS_CRITICAL_THRESHOLDS: dict[str, int] = {
 
 # Ingestion warnings are written to ClickHouse during event ingestion (not detected here).
 # This query aggregates those pre-existing warnings to surface them as health issues.
-INGESTION_WARNINGS_SQL = """
-SELECT team_id, type, count() AS cnt, max(timestamp) AS last_seen_at
-FROM ingestion_warnings
-WHERE team_id IN %(team_ids)s
+#
+# Capture-sourced warnings carry team_id=0 and the project's API token (capture has no
+# database access to resolve the team), so the query also matches the batch's tokens and
+# returns the token column; rows are grouped per (team_id, token, type) here and merged
+# into per-team results in Python, where the min-count threshold is applied post-merge so
+# a team's direct and token-matched rows count together.
+INGESTION_WARNINGS_SQL = f"""
+SELECT team_id, token, type, count() AS cnt, max(timestamp) AS last_seen_at
+FROM {DISTRIBUTED_TABLE_NAME}
+WHERE (team_id IN %(team_ids)s OR (team_id = 0 AND token IN %(tokens)s))
   AND timestamp >= now() - INTERVAL %(lookback_days)s DAY
-GROUP BY team_id, type
-HAVING cnt >= %(min_count)s
+GROUP BY team_id, token, type
 """
 
 
@@ -99,15 +108,32 @@ class IngestionWarningsCheck(HealthCheck):
         )
 
     def detect(self, team_ids: list[int]) -> dict[int, list[HealthCheckResult]]:
+        token_to_team_id: dict[str, int] = {
+            token: team_id for team_id, token in Team.objects.filter(id__in=team_ids).values_list("id", "api_token")
+        }
         rows = execute_clickhouse_health_team_query(
             INGESTION_WARNINGS_SQL,
             team_ids=team_ids,
             lookback_days=INGESTION_WARNINGS_LOOKBACK_DAYS,
-            params={"min_count": INGESTION_WARNINGS_MIN_COUNT},
+            params={"tokens": list(token_to_team_id.keys())},
         )
 
+        # Merge direct (team_id) and token-matched (team_id=0) rows per team, then
+        # apply the min-count threshold to the merged totals.
+        merged_counts: dict[tuple[int, str], int] = {}
+        merged_last_seen: dict[tuple[int, str], datetime] = {}
+        for team_id, token, warning_type, affected_count, last_seen_at in rows:
+            resolved_team_id = team_id if team_id != 0 else token_to_team_id.get(token)
+            if resolved_team_id is None:
+                continue
+            key = (resolved_team_id, warning_type)
+            merged_counts[key] = merged_counts.get(key, 0) + affected_count
+            merged_last_seen[key] = max(merged_last_seen.get(key, last_seen_at), last_seen_at)
+
         issues: dict[int, list[HealthCheckResult]] = {}
-        for team_id, warning_type, affected_count, last_seen_at in rows:
+        for (team_id, warning_type), affected_count in merged_counts.items():
+            if affected_count < INGESTION_WARNINGS_MIN_COUNT:
+                continue
             threshold = INGESTION_WARNINGS_CRITICAL_THRESHOLDS.get(warning_type)
             severity = (
                 HealthIssue.Severity.CRITICAL
@@ -120,7 +146,7 @@ class IngestionWarningsCheck(HealthCheck):
                     payload={
                         "warning_type": warning_type,
                         "affected_count": affected_count,
-                        "last_seen_at": str(last_seen_at),
+                        "last_seen_at": str(merged_last_seen[(team_id, warning_type)]),
                     },
                     hash_keys=["warning_type"],
                 )

--- a/products/cdp/backend/temporal/health_checks/tests/test_ingestion_warnings.py
+++ b/products/cdp/backend/temporal/health_checks/tests/test_ingestion_warnings.py
@@ -1,0 +1,86 @@
+import json
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.health_issue import HealthIssue
+from posthog.models.ingestion_warnings.sql_v2 import TABLE_NAME
+from posthog.models.team import Team
+
+from products.cdp.backend.temporal.health_checks.ingestion_warnings import IngestionWarningsCheck
+
+INSERT_WARNINGS = f"""
+INSERT INTO {TABLE_NAME} (team_id, source, type, details, timestamp, _timestamp, _offset, _partition)
+SELECT %(team_id)s, %(source)s, %(type)s, %(details)s, %(timestamp)s, now(), 0, 0
+FROM numbers(%(copies)s)
+"""
+
+
+def insert_warnings(
+    team_id: int, type: str, copies: int, token: str | None = None, source: str = "plugin-server"
+) -> None:
+    details: dict = {"category": "event", "severity": "error"}
+    if token is not None:
+        details["token"] = token
+    sync_execute(
+        INSERT_WARNINGS,
+        {
+            "team_id": team_id,
+            "source": source,
+            "type": type,
+            "details": json.dumps(details),
+            "timestamp": (datetime.now(UTC) - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S"),
+            "copies": copies,
+        },
+    )
+
+
+class TestIngestionWarningsCheck(ClickhouseTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        # Test teams share the fixed CONFIG_API_TOKEN while ClickHouse rows outlive
+        # each test; a per-test token keeps team_id=0 capture rows isolated.
+        self.team.api_token = f"phc_capture_test_{uuid4().hex}"
+        self.team.save()
+
+    def test_merges_direct_and_token_matched_rows_against_min_count(self):
+        # 6 direct + 6 capture rows: each slice alone is under the min count of 10,
+        # only the merged total crosses it.
+        insert_warnings(self.team.id, "missing_event_name", copies=6)
+        insert_warnings(0, "missing_event_name", copies=6, token=self.team.api_token, source="capture")
+        # A type under the threshold even when merged must stay hidden.
+        insert_warnings(0, "missing_distinct_id", copies=5, token=self.team.api_token, source="capture")
+
+        issues = IngestionWarningsCheck().detect([self.team.id])
+
+        assert list(issues.keys()) == [self.team.id]
+        assert [(r.payload["warning_type"], r.payload["affected_count"]) for r in issues[self.team.id]] == [
+            ("missing_event_name", 12)
+        ]
+        assert issues[self.team.id][0].severity == HealthIssue.Severity.WARNING
+
+    def test_token_rows_of_other_teams_and_orphans_are_ignored(self):
+        other_team = Team.objects.create(organization=self.organization)
+        # Another team's token rows and token-less team_id=0 orphans must not
+        # count toward this team, even for a type it already has.
+        insert_warnings(self.team.id, "missing_event_name", copies=10)
+        insert_warnings(0, "missing_event_name", copies=10, token=other_team.api_token, source="capture")
+        insert_warnings(0, "missing_event_name", copies=10, source="capture")
+
+        issues = IngestionWarningsCheck().detect([self.team.id])
+
+        assert issues[self.team.id][0].payload["affected_count"] == 10
+
+    def test_critical_threshold_applies_to_merged_count(self):
+        # message_size_too_large escalates at 300; 200 direct + 150 capture rows
+        # only cross it merged.
+        insert_warnings(self.team.id, "message_size_too_large", copies=200)
+        insert_warnings(0, "message_size_too_large", copies=150, token=self.team.api_token, source="capture")
+
+        issues = IngestionWarningsCheck().detect([self.team.id])
+
+        result = issues[self.team.id][0]
+        assert result.payload["affected_count"] == 350
+        assert result.severity == HealthIssue.Severity.CRITICAL


### PR DESCRIPTION
## Problem

The capture service is gaining the ability to emit v2 ingestion warnings for events it drops at validation time (#70184). Capture has no database access, so it cannot resolve an API token to a `team_id` at write time: its rows land with `team_id: 0` and the token stamped in `details` (materialized into the `token` column added in #70178).

Without a read-side change those rows are invisible to everyone. This PR makes every v2 read surface match them to the owning team by token.

Stacked on #70178 (the `token` column must exist for the predicates and tests here).

## Changes

- **v2 API** (`posthog/api/ingestion_warnings_v2.py`): the team predicate becomes `(team_id = %(team_id)s OR (team_id = 0 AND token = %(token)s))`, with the project's API token passed as a parameter. The `team_id = 0` guard keeps the predicate index-friendly: the team's own rows still use the primary-key prefix, and the token match only scans the `team_id = 0` slice with the bloom-filter skip index. This one predicate covers the v2 UI page, the MCP `ingestion-warnings-list` tool, and signals scouts, which all go through this endpoint. Response shape is unchanged, so no OpenAPI or generated-type changes.
- **CDP ingestion-warnings health check** (`products/cdp/backend/temporal/health_checks/ingestion_warnings.py`): migrated from the legacy v1 `ingestion_warnings` table to `ingestion_warnings_v2_distributed` and made token-aware. The query returns per-`(team_id, token, type)` groups; Python resolves `team_id = 0` rows through a token→team map for the batch and merges them with direct rows, applying the min-count threshold to the merged totals so a team's capture and pipeline warnings count together. Unknown-token rows are skipped.
- **Frontend** (`IngestionWarningsView.tsx`): added `WARNING_TYPE_TO_DESCRIPTION` entries for the twelve capture validation warning types (missing event name, oversized distinct ID, duplicate event UUID, etc.) so the v2 page and health table render friendly labels instead of raw type strings. Docs anchors will follow once the docs page documents these types.

> [!NOTE]
> For CDP owners: this changes the health check's source table from v1 to v2. Coverage was verified against production before this change: daily row counts for `ingestion_warnings` (v1) and `ingestion_warnings_v2_distributed` match row-for-row across the trailing 10 days in both prod-us and prod-eu (differences <0.01%, replication timing), comfortably covering the check's 7-day lookback. v2 additionally carries a 90-day TTL. The check's thresholds were tuned against v1 distributions, which the parity data shows are identical in v2.

## How did you test this code?

Automated only (no manual testing):

- `posthog/api/test/test_ingestion_warnings_v2.py` (17 tests, ClickHouse-backed): 3 new tests covering regressions nothing else catches — a capture row (`team_id=0` + owning token) surfaces for the team with its samples; a capture row of an existing type merges into that type's group and count; and parameterized isolation cases proving `team_id=0` rows with another team's token, no token, or an empty token never surface. Existing tests pass unchanged, proving the predicate change is behavior-neutral for normal rows.
- `products/cdp/backend/temporal/health_checks/tests/test_ingestion_warnings.py` (3 new tests, ClickHouse-backed): direct + token rows merge across the min-count threshold (each slice alone is below it); other teams' token rows and token-less orphans are ignored; the per-type critical threshold applies to the merged count. These exercise the real SQL against the v2 table, so a wrong table or column name fails here.
- Test isolation note: test teams share a fixed API token while ClickHouse rows outlive each test, so the new tests give the team a unique per-test token before inserting `team_id=0` rows.
- `ruff check` / `ruff format` clean; lint-staged (oxfmt, ty) passed on commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The ingestion warnings docs page doesn't document the new capture warning types yet; that's tracked as a follow-up in the parent effort and the UI falls back to the docs page root.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Cursor (Fable) following a reviewed master plan; skills invoked: `/improving-drf-endpoints`, `/writing-tests`.
- Key decisions: read-time token matching (an OR predicate) over a write-time ClickHouse dictionary in the ingest MV — no new infra, no staleness window, and the token lives in `details` forever so a dictionary approach remains a clean future upgrade if the `team_id=0` slice ever dominates read cost. For the health check, the min-count HAVING moved from SQL to Python so a team's direct and token-matched rows are thresholded together rather than per-slice.
- Known tradeoff: rows emitted under a since-rotated API token stop matching. Accepted for ephemeral diagnostics with a 90-day TTL; matching historical tokens is a documented follow-up.

