### PR TITLE
fix(metrics): render dashboard tiles from the cached insight result shape

### DIFF
--- a/products/metrics/frontend/nodes/MetricsQueryNode.tsx
+++ b/products/metrics/frontend/nodes/MetricsQueryNode.tsx
@@ -6,10 +6,11 @@ import { SpinnerOverlay } from '@posthog/lemon-ui'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
-import { AnyResponseType, MetricsQuery, MetricsQueryResponse } from '~/queries/schema/schema-general'
+import { AnyResponseType, MetricsQuery } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
 import { MetricsSeriesChart } from '../components/MetricsSeriesChart'
+import { seriesFromMetricsResponse } from './metricsResponseSeries'
 
 let uniqueNode = 0
 
@@ -35,8 +36,7 @@ export function MetricsQueryNode(props: {
     useAttachedLogic(logic, props.attachTo)
 
     const { response, responseLoading } = useValues(logic)
-    const queryResponse = response as MetricsQueryResponse | undefined
-    const series = queryResponse?.results ?? []
+    const series = seriesFromMetricsResponse(response)
     const hasPoints = series.some((s) => s.points.length > 0)
     const fallbackName = props.query.clauses[0]?.metricName ?? 'metric'
 

--- a/products/metrics/frontend/nodes/metricsResponseSeries.test.ts
+++ b/products/metrics/frontend/nodes/metricsResponseSeries.test.ts
@@ -1,0 +1,15 @@
+import { seriesFromMetricsResponse } from './metricsResponseSeries'
+
+describe('seriesFromMetricsResponse', () => {
+    const series = [{ metricName: 'logs_pii_replacements_total', labels: {}, points: [[1, 2]] }]
+
+    it.each([
+        ['a live query response (results)', { results: series }, series],
+        ['a cached dashboard insight (result)', { id: 123, short_id: 'abc', result: series }, series],
+        ['an insight with a null result', { id: 123, result: null }, []],
+        ['no response yet', undefined, []],
+        ['a response with neither key', {}, []],
+    ])('reads series from %s', (_name, response, expected) => {
+        expect(seriesFromMetricsResponse(response)).toEqual(expected)
+    })
+})

--- a/products/metrics/frontend/nodes/metricsResponseSeries.ts
+++ b/products/metrics/frontend/nodes/metricsResponseSeries.ts
@@ -1,0 +1,20 @@
+import { MetricsQuerySeries } from '~/queries/schema/schema-general'
+
+/**
+ * Dashboard tiles hand dataNodeLogic the cached insight object, whose data sits
+ * under `result` (singular); live query responses carry `results`. Accept both
+ * so a metrics tile renders from cache instead of blank.
+ */
+export function seriesFromMetricsResponse(response: unknown): MetricsQuerySeries[] {
+    if (!response || typeof response !== 'object') {
+        return []
+    }
+    const { results, result } = response as { results?: unknown; result?: unknown }
+    if (Array.isArray(results)) {
+        return results as MetricsQuerySeries[]
+    }
+    if (Array.isArray(result)) {
+        return result as MetricsQuerySeries[]
+    }
+    return []
+}


### PR DESCRIPTION
## Problem

Adding a metric insight to a dashboard (via #70103) produced a tile that showed the empty state ("No data for this metric in the selected range") even though the insight had fresh cached data. Opening the insight ran a live query and the chart appeared, so the bug was only on dashboard tiles.

Root cause: on dashboards, `InsightCard` passes the whole cached insight object into `dataNodeLogic` as `cachedResults`, and `dataNodeLogic` sets that object as the response without loading (by design, to avoid refetching per tile). An insight object carries its data under `result` (singular) - the API maps the query response's `results` into it (`insight_result` in `products/product_analytics/backend/api/insight.py`). `MetricsQueryNode` only read `results`, the live query-response key, so on dashboards it always saw an empty series list. The InsightViz family already tolerates the insight-object shape (e.g. `trendsDataLogic` reads `insightData?.result`); the metrics node didn't.

## Changes

- New `seriesFromMetricsResponse()` accepts both response shapes (`results` from live queries, `result` from cached dashboard insights) and returns the series array, or `[]` for null/malformed input.
- `MetricsQueryNode` uses it instead of reading `results` directly.

## How did you test this code?

TDD. New parameterized jest test for `seriesFromMetricsResponse` covering the live-response shape, the cached-insight shape (the dashboard regression: reading only `results` renders tiles blank), null result, and missing/undefined responses. Confirmed red before the implementation existed, 5/5 green after.

Diagnosed against a real dashboard: the tile's insight (`MetricsQuery` kind) returned `is_cached: true` from the dashboard API while the tile rendered empty, and the insight page (live query path) showed data.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel reported the blank-tile symptom; Claude (PostHog Code) traced the cached-results flow from `InsightCard` through `dataNodeLogic` into `MetricsQueryNode` and confirmed the serializer-side `result` mapping before writing the fix. Skills invoked: /writing-tests. A component-level render test was considered and rejected as too heavy for the regression; the shape-tolerant accessor is tested at the pure-function rung instead.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*