### PR TITLE
feat(taxonomic-filter): promote primary properties in the rebuild menu and add taxonomy defaults

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.test.tsx
@@ -87,6 +87,38 @@ describe('useTaxonomicGroupsContext', () => {
         expect(result.current).toBe(first)
     })
 
+    it.each([
+        {
+            description: 'promotes the taxonomy-default primary property for $pageview',
+            eventNames: ['$pageview'],
+            expectedPromoted: ['$pathname'],
+            expectedSuggestedOptions: ['$pathname'],
+        },
+        {
+            description: 'promotes the taxonomy-default primary property for $mcp_tool_call',
+            eventNames: ['$mcp_tool_call'],
+            expectedPromoted: ['$mcp_tool_name'],
+            // The Suggested tab also seeds MCP_TOOL_CALL_SUGGESTED_PROPERTIES
+            // ($mcp_is_error) after the promoted primary property.
+            expectedSuggestedOptions: ['$mcp_tool_name', '$mcp_is_error'],
+        },
+        {
+            description: 'promotes nothing when no event is in context',
+            eventNames: [] as string[],
+            expectedPromoted: [],
+            expectedSuggestedOptions: [],
+        },
+    ])('$description', ({ eventNames, expectedPromoted, expectedSuggestedOptions }) => {
+        const { result } = renderHook(() => useTaxonomicGroupsContext({ eventNames }), { wrapper })
+        expect(result.current.promotedPropertiesForContextEvents).toEqual(expectedPromoted)
+        const suggestedGroup = buildTaxonomicGroups(result.current).find(
+            (g) => g.type === TaxonomicFilterGroupType.SuggestedFilters
+        )
+        expect(suggestedGroup?.options).toEqual(
+            expectedSuggestedOptions.map((name) => ({ name, group: TaxonomicFilterGroupType.EventProperties }))
+        )
+    })
+
     it('feeds buildTaxonomicGroups end-to-end and produces a non-empty groups array', () => {
         const { result } = renderHook(() => useTaxonomicGroupsContext({ eventNames: ['$pageview'] }), {
             wrapper,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.ts
@@ -23,7 +23,7 @@ import {
 } from 'lib/components/TaxonomicFilter/utils/buildGroupAnalyticsGroups'
 import { BuildTaxonomicGroupsContext } from 'lib/components/TaxonomicFilter/utils/buildTaxonomicGroups'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { getPrimaryPropertyForEvent } from 'lib/utils/events'
+import { distinctPrimaryPropertiesForEvents } from 'lib/utils/events'
 import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic'
 import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 import { projectLogic } from 'scenes/projectLogic'
@@ -97,17 +97,11 @@ export function useTaxonomicGroupsContext(input: UseTaxonomicGroupsContextInput)
     // Mirrors the `eventNamesWithPrimaryProperties` selector in
     // taxonomicFilterLogic: the distinct promoted properties for the events in
     // context (taxonomy default first, then team override).
-    const promotedPropertiesForContextEvents = useMemo(() => {
-        const distinct = new Set<string>()
-        for (const eventName of eventNames ?? []) {
-            const primary = getPrimaryPropertyForEvent(eventName, primaryProperties)
-            if (primary) {
-                distinct.add(primary)
-            }
-        }
-        return Array.from(distinct)
+    const promotedPropertiesForContextEvents = useMemo(
+        () => distinctPrimaryPropertiesForEvents(eventNames ?? [], primaryProperties),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [eventNamesKey, primaryProperties])
+        [eventNamesKey, primaryProperties]
+    )
 
     return useMemo<BuildTaxonomicGroupsContext>(() => {
         const propertyFilters = {

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.ts
@@ -8,8 +8,8 @@
  * Everything else operates on the returned plain-object context, so swapping
  * kea for direct API calls later is a single-file change.
  */
-import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { useActions, useValues } from 'kea'
+import { useEffect, useMemo } from 'react'
 
 import {
     AllowedProperties,
@@ -23,12 +23,14 @@ import {
 } from 'lib/components/TaxonomicFilter/utils/buildGroupAnalyticsGroups'
 import { BuildTaxonomicGroupsContext } from 'lib/components/TaxonomicFilter/utils/buildTaxonomicGroups'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { getPrimaryPropertyForEvent } from 'lib/utils/events'
 import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic'
 import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { groupsModel } from '~/models/groupsModel'
+import { primaryEventPropertiesModel } from '~/models/primaryEventPropertiesModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { AnyDataNode, DatabaseSchemaField, NodeKind } from '~/queries/schema/schema-general'
 
@@ -75,6 +77,37 @@ export function useTaxonomicGroupsContext(input: UseTaxonomicGroupsContextInput)
     useValues(joinsLogic)
     const { eventMetadataPropertyDefinitions, personMetadataPropertyDefinitions } = useValues(propertyDefinitionsModel)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { primaryProperties } = useValues(primaryEventPropertiesModel)
+    const { ensureLoadedForEvents } = useActions(primaryEventPropertiesModel)
+
+    // Mirrors taxonomicFilterLogic's afterMount/propsChanged: fetch any
+    // team-configured primary-property overrides for the events in context.
+    // Content-keyed like the ctx memo below — consumers pass fresh array
+    // literals per render, and ensureLoadedForEvents shouldn't refire for a
+    // referentially-new-but-equal list.
+    const eventNames = input.eventNames
+    const eventNamesKey = JSON.stringify(eventNames ?? [])
+    useEffect(() => {
+        if (eventNames?.length) {
+            ensureLoadedForEvents(eventNames)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [eventNamesKey, ensureLoadedForEvents])
+
+    // Mirrors the `eventNamesWithPrimaryProperties` selector in
+    // taxonomicFilterLogic: the distinct promoted properties for the events in
+    // context (taxonomy default first, then team override).
+    const promotedPropertiesForContextEvents = useMemo(() => {
+        const distinct = new Set<string>()
+        for (const eventName of eventNames ?? []) {
+            const primary = getPrimaryPropertyForEvent(eventName, primaryProperties)
+            if (primary) {
+                distinct.add(primary)
+            }
+        }
+        return Array.from(distinct)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [eventNamesKey, primaryProperties])
 
     return useMemo<BuildTaxonomicGroupsContext>(() => {
         const propertyFilters = {
@@ -109,6 +142,7 @@ export function useTaxonomicGroupsContext(input: UseTaxonomicGroupsContextInput)
             ),
             eventNames: input.eventNames ?? (EMPTY_ARRAY as unknown as string[]),
             taxonomicGroupTypes: input.taxonomicGroupTypes,
+            promotedPropertiesForContextEvents,
             schemaColumns: input.schemaColumns ?? (EMPTY_ARRAY as unknown as DatabaseSchemaField[]),
             schemaColumnsLoading: input.schemaColumnsLoading,
             metadataSource: input.metadataSource ?? DEFAULT_METADATA_SOURCE,
@@ -134,6 +168,7 @@ export function useTaxonomicGroupsContext(input: UseTaxonomicGroupsContextInput)
         eventMetadataPropertyDefinitions,
         personMetadataPropertyDefinitions,
         featureFlags,
+        promotedPropertiesForContextEvents,
         // Content-keyed: consumers pass fresh array literals per render. The legacy logic
         // stabilizes the same props differently — reference-equality inputs with objectsEqual
         // on the selector result (see eventNamesWithPrimaryProperties) — same end effect.

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -60,6 +60,7 @@ function renderAll(options: {
     pinnedEntries?: any[]
     searchQuery?: string
     onCommit?: any
+    eventNames?: string[]
 }): ReturnType<typeof render> {
     return render(
         <Provider>
@@ -67,6 +68,7 @@ function renderAll(options: {
                 taxonomicGroupTypes={options.groupTypes}
                 onChange={jest.fn()}
                 searchQuery={options.searchQuery ?? ''}
+                eventNames={options.eventNames}
             >
                 <MenuFilterCombobox
                     drillTo="all"
@@ -432,6 +434,37 @@ describe('MenuFilterCombobox', () => {
         const recentIdx = rows.findIndex((t) => t.includes('my_recent_event'))
         const contentIdx = rows.findIndex((t) => t.includes('autocapture'))
         expect(contentIdx).toBeGreaterThan(recentIdx)
+    })
+
+    it("promotes the context event's primary property after recents, above the content rows", async () => {
+        apiGet.mockResolvedValue({ results: [{ id: 1, name: 'autocapture' }], count: 1 })
+
+        renderAll({
+            groupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.EventProperties],
+            eventNames: ['$mcp_tool_call'],
+            recentEntries: [makeEntry(TaxonomicFilterGroupType.Events, 'my_recent_event', 'Events')],
+        })
+
+        await waitFor(() => expect(rowTexts().some((t) => t.includes('autocapture'))).toBe(true))
+        const rows = rowTexts()
+        expect(rows[0]).toContain('my_recent_event')
+        expect(rows[1]).toContain('MCP tool name')
+        const contentIdx = rows.findIndex((t) => t.includes('autocapture'))
+        expect(contentIdx).toBeGreaterThan(1)
+    })
+
+    it('shows a promoted property that is also a recent only once, under recents', async () => {
+        apiGet.mockResolvedValue({ results: [{ id: 1, name: 'autocapture' }], count: 1 })
+
+        renderAll({
+            groupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.EventProperties],
+            eventNames: ['$mcp_tool_call'],
+            recentEntries: [makeEntry(TaxonomicFilterGroupType.EventProperties, '$mcp_tool_name', 'Event properties')],
+        })
+
+        await waitFor(() => expect(rowTexts().some((t) => t.includes('autocapture'))).toBe(true))
+        const promotedRows = rowTexts().filter((t) => t.includes('MCP tool name') || t.includes('$mcp_tool_name'))
+        expect(promotedRows).toHaveLength(1)
     })
 
     it('shows a recent that is also in the catalog only once (deduped from content)', async () => {

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -377,12 +377,7 @@ export function MenuFilterCombobox({
                 continue
             }
             for (const item of items) {
-                merged.push({
-                    item,
-                    group,
-                    name: getRawName(item, group),
-                    friendlyLabel: getFriendlyLabel(item, group),
-                })
+                merged.push(buildMenuFilterEntry(item, group))
             }
         }
         // Make sure the committed selection is reachable from the list
@@ -521,12 +516,7 @@ export function MenuFilterCombobox({
                 continue
             }
             const item = { name: option.name } as unknown as TaxonomicDefinitionTypes
-            const entry: MenuFilterEntry = {
-                item,
-                group: realGroup,
-                name: getRawName(item, realGroup),
-                friendlyLabel: getFriendlyLabel(item, realGroup),
-            }
+            const entry = buildMenuFilterEntry(item, realGroup)
             if (!prefixKeys.has(entryKey(entry))) {
                 entries.push(entry)
             }
@@ -1436,6 +1426,15 @@ function getFriendlyLabel(item: TaxonomicDefinitionTypes, group: TaxonomicFilter
         return undefined
     }
     return getCoreFilterDefinition(raw, group.type)?.label
+}
+
+function buildMenuFilterEntry(item: TaxonomicDefinitionTypes, group: TaxonomicFilterGroup): MenuFilterEntry {
+    return {
+        item,
+        group,
+        name: getRawName(item, group),
+        friendlyLabel: getFriendlyLabel(item, group),
+    }
 }
 
 // Mirrors the legacy `taxonomicFilterLogic` classifier (kept in sync until the legacy picker is retired).

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -73,12 +73,11 @@ const FUSE_OPTIONS = {
 
 /** Categories filtered out of the chip row when drillTo === 'all'. */
 const HIDDEN_FROM_CHIPS: ReadonlySet<TaxonomicFilterGroupType> = new Set([
-    // `SuggestedFilters` from taxonomicFilterLogic is a tiny set of
-    // primary-property promotions for the *currently-selected event* +
-    // autocapture text/selector. It's empty for almost every flow that
-    // doesn't have an event-in-context, and even when populated it
-    // duplicates what shows up under Event properties. Hide entirely;
-    // recents/pinned now lead the "All" surface directly.
+    // `SuggestedFilters` is a tiny set of primary-property promotions for the
+    // *currently-selected event* + autocapture text/selector. It's empty for
+    // almost every flow without an event-in-context, so it doesn't earn a chip
+    // — its options surface via `suggestedPrefix` on the idle "All" list
+    // instead, right after recents/pinned.
     TaxonomicFilterGroupType.SuggestedFilters,
     // RecentFilters / PinnedFilters surface via the dropdown menu
     // (Recent / Pinned entries with chevrons) and lead the "All" surface;
@@ -236,7 +235,14 @@ export function MenuFilterCombobox({
     // search we hold the result list behind skeletons until every visible group's
     // fetch settles (or a 5s fallback), so slower groups don't render on top of a
     // stale/partial list and rows don't jump around. Mirrors `revealBarrierOpen`.
-    const [revealBarrierOpen, setRevealBarrierOpen] = useState(true)
+    // Only engages while actively searching a fetching scope. Recent/Pinned
+    // drills read pre-resolved `drillItems` (no fetch) so they're never gated.
+    const searching = !drillItems && !!searchQuery.trim()
+    // Start closed when mounting already searching (e.g. a drilled-in query
+    // preserved across reopen); otherwise recents/pinned, which render from
+    // props with no fetch involved, paint immediately while the async groups
+    // sharing this same list are still in flight.
+    const [revealBarrierOpen, setRevealBarrierOpen] = useState(() => !searching)
     const [barrierQuery, setBarrierQuery] = useState(searchQuery)
     // Seed the highlight with the committed selection so the preview
     // pane shows the right definition before any row hovers fire. Once
@@ -493,6 +499,41 @@ export function MenuFilterCombobox({
         return [...recentSegment, ...pinnedSegment]
     }, [showChips, activeChip, drillTo, recentEntries, pinnedEntries, searchQuery])
 
+    // Promoted properties for the events in context (the SuggestedFilters
+    // group's options, e.g. `$pageview` -> `$pathname`, `$mcp_tool_call` ->
+    // `$mcp_tool_name`). The group itself is hidden from chips, but its
+    // options lead the idle "All" surface right after recents/pinned — the
+    // rebuild counterpart of the legacy Suggested tab's promotion. Deduped
+    // against recents/pinned so a promoted property the user already has to
+    // hand shows once, under the section that renders first.
+    const suggestedPrefix = useMemo<MenuFilterEntry[]>(() => {
+        const scope = showChips ? activeChip : drillTo
+        if (scope !== 'all' || searchQuery.trim()) {
+            return []
+        }
+        const suggestedGroup = groups.find((g) => g.type === TaxonomicFilterGroupType.SuggestedFilters)
+        const options = (suggestedGroup?.options ?? []) as { name: string; group: TaxonomicFilterGroupType }[]
+        const prefixKeys = new Set(recentsPinnedPrefix.map(entryKey))
+        const entries: MenuFilterEntry[] = []
+        for (const option of options) {
+            const realGroup = groups.find((g) => g.type === option.group)
+            if (!realGroup) {
+                continue
+            }
+            const item = { name: option.name } as unknown as TaxonomicDefinitionTypes
+            const entry: MenuFilterEntry = {
+                item,
+                group: realGroup,
+                name: getRawName(item, realGroup),
+                friendlyLabel: getFriendlyLabel(item, realGroup),
+            }
+            if (!prefixKeys.has(entryKey(entry))) {
+                entries.push(entry)
+            }
+        }
+        return entries
+    }, [showChips, activeChip, drillTo, searchQuery, groups, recentsPinnedPrefix])
+
     // Recency lookup so any row that is one of the user's recents/pinned gets a
     // "- recent" / "- pinned" tag on its category label, wherever it appears
     // (matching the pill variant's per-row source tags).
@@ -554,15 +595,17 @@ export function MenuFilterCombobox({
         // the cross-tab content with `email`/`url` promotion. Recents/pinned
         // stay above the content rows so users can learn the order.
         if (scope === 'all') {
-            const prefixKeys = new Set(recentsPinnedPrefix.map(entryKey))
+            const prefixKeys = new Set([...recentsPinnedPrefix, ...suggestedPrefix].map(entryKey))
             const content = prefixKeys.size > 0 ? base.filter((e) => !prefixKeys.has(entryKey(e))) : base
             // The "URL contains <query>" shortcut leads the whole list — ahead of
             // recents/pinned/content — because a URL search almost always means the user
-            // wants the contains match. Everything else keeps the recents-then-pinned order.
+            // wants the contains match. Everything else keeps the recents-then-pinned order,
+            // with the promoted properties for the events in context leading the content.
             const [shortcuts, rest] = partitionContainsShortcuts(content, (e) => e.item)
             const assembled = [
                 ...shortcuts,
                 ...recentsPinnedPrefix,
+                ...suggestedPrefix,
                 ...promoteMatchingBy(rest, searchQuery, (e) => (e.item as { name?: string }).name ?? e.name),
             ]
             // Idle (no search): float the committed selection to the very first row so the
@@ -576,7 +619,7 @@ export function MenuFilterCombobox({
             return assembled
         }
         return base
-    }, [indexed, searchQuery, selectedRowId, recentsPinnedPrefix, showChips, activeChip, drillTo])
+    }, [indexed, searchQuery, selectedRowId, recentsPinnedPrefix, suggestedPrefix, showChips, activeChip, drillTo])
 
     // O(1) row -> rendered-position lookup, rebuilt with `filtered`. Avoids an
     // O(n) `indexOf` per commit and the stale-index risk if `filtered`'s identity
@@ -616,9 +659,6 @@ export function MenuFilterCombobox({
     }, [drillItems, targetGroups, loadingByType])
 
     // ---- Reveal barrier ----------------------------------------------------
-    // Only engages while actively searching a fetching scope. Recent/Pinned
-    // drills read pre-resolved `drillItems` (no fetch) so they're never gated.
-    const searching = !drillItems && !!searchQuery.trim()
     // Close synchronously the instant the query changes (React "adjust state
     // while rendering" pattern) so a stale list never paints between keystroke
     // and the fetch starting. Re-opens immediately for empty/drill scopes.

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -1106,6 +1106,15 @@ describe('taxonomicFilterLogic', () => {
                 expectedOptions: [{ name: '$pathname', group: TaxonomicFilterGroupType.EventProperties }],
             },
             {
+                description:
+                    "SuggestedFilters surfaces the event's primary property then its MCP suggested properties when eventNames=['$mcp_tool_call']",
+                eventNames: ['$mcp_tool_call'],
+                expectedOptions: [
+                    { name: '$mcp_tool_name', group: TaxonomicFilterGroupType.EventProperties },
+                    { name: '$mcp_is_error', group: TaxonomicFilterGroupType.EventProperties },
+                ],
+            },
+            {
                 description: 'SuggestedFilters has empty options when eventNames is empty',
                 eventNames: [] as string[],
                 expectedOptions: [],

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -61,7 +61,7 @@ import { IconCohort } from 'lib/lemon-ui/icons'
 import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isDefinitionStale } from 'lib/utils/definitions'
-import { getPrimaryPropertyForEvent } from 'lib/utils/events'
+import { distinctPrimaryPropertiesForEvents } from 'lib/utils/events'
 import { isString } from 'lib/utils/guards'
 import { objectsEqual } from 'lib/utils/objects'
 import { capitalizeFirstLetter, pluralize } from 'lib/utils/strings'
@@ -511,16 +511,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 primaryPropertiesForContextEvents: string[]
                 mcpExcludedEventProperties: string[]
             } => {
-                const distinct = new Set<string>()
-                for (const eventName of eventNames) {
-                    const primary = getPrimaryPropertyForEvent(eventName, primaryProperties)
-                    if (primary) {
-                        distinct.add(primary)
-                    }
-                }
                 return {
                     eventNames,
-                    primaryPropertiesForContextEvents: Array.from(distinct),
+                    primaryPropertiesForContextEvents: distinctPrimaryPropertiesForEvents(
+                        eventNames,
+                        primaryProperties
+                    ),
                     mcpExcludedEventProperties: getMCPExcludedEventProperties(eventNames, taxonomicGroupTypes),
                 }
             },

--- a/frontend/src/lib/components/TaxonomicFilter/utils/mcpProperties.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/mcpProperties.ts
@@ -48,10 +48,10 @@ export function getMCPPropertyFilterOptions(): string[] {
 }
 
 /** Seeded into the Suggested tab when the picker is scoped to `$mcp_tool_call`, so
- *  success/failure splits are one click away. In the legacy picker `$mcp_tool_name`
- *  also lands there via the event's `primary_property`; the rebuild doesn't seed
- *  primary properties yet (`promotedPropertiesForContextEvents` is unwired), so it
- *  shows only this list. */
+ *  success/failure splits are one click away. `$mcp_tool_name` also lands there via
+ *  the event's `primary_property` — in the legacy picker through taxonomicFilterLogic,
+ *  and in the rebuild through `promotedPropertiesForContextEvents` (computed by
+ *  `useTaxonomicGroupsContext`). */
 export const MCP_TOOL_CALL_SUGGESTED_PROPERTIES: string[] = ['$mcp_is_error']
 
 /** When the MCP properties group is available in a picker, the known schema is

--- a/frontend/src/lib/utils/events.test.ts
+++ b/frontend/src/lib/utils/events.test.ts
@@ -1,5 +1,6 @@
 import {
     autoCaptureEventToDescription,
+    distinctPrimaryPropertiesForEvents,
     eventToDescription,
     getEventsWithPrimaryProperty,
     getPrimaryPropertyForEvent,
@@ -303,6 +304,29 @@ describe('events utils', () => {
                 { event: 'arbitrary_custom', id: 2 },
             ]
             expect(getEventsWithPrimaryProperty(events)).toEqual([])
+        })
+    })
+
+    describe('distinctPrimaryPropertiesForEvents', () => {
+        it('returns the distinct taxonomy defaults for a list of events', () => {
+            expect(distinctPrimaryPropertiesForEvents(['$pageview', '$pageleave', '$screen'])).toEqual([
+                '$pathname',
+                '$screen_name',
+            ])
+        })
+
+        it('includes team overrides for events with no taxonomy default', () => {
+            expect(
+                distinctPrimaryPropertiesForEvents(['$pageview', 'order_placed'], { order_placed: 'order_id' })
+            ).toEqual(['$pathname', 'order_id'])
+        })
+
+        it('returns an empty list for no event names', () => {
+            expect(distinctPrimaryPropertiesForEvents([])).toEqual([])
+        })
+
+        it('returns an empty list when nothing has a primary property', () => {
+            expect(distinctPrimaryPropertiesForEvents(['$autocapture', 'arbitrary_custom'])).toEqual([])
         })
     })
 

--- a/frontend/src/lib/utils/events.test.ts
+++ b/frontend/src/lib/utils/events.test.ts
@@ -220,11 +220,24 @@ describe('events utils', () => {
     })
 
     describe('getPrimaryPropertyForEvent', () => {
-        it('returns the core taxonomy default for built-in events', () => {
-            expect(getPrimaryPropertyForEvent('$pageview')).toBe('$pathname')
-            expect(getPrimaryPropertyForEvent('$pageleave')).toBe('$pathname')
-            expect(getPrimaryPropertyForEvent('$screen')).toBe('$screen_name')
-            expect(getPrimaryPropertyForEvent('$feature_flag_called')).toBe('$feature_flag')
+        it.each([
+            ['$pageview', '$pathname'],
+            ['$pageleave', '$pathname'],
+            ['$screen', '$screen_name'],
+            ['$feature_flag_called', '$feature_flag'],
+            ['$exception', '$exception_type'],
+            ['$ai_generation', '$ai_model'],
+            ['$ai_trace', '$ai_span_name'],
+            ['$ai_span', '$ai_span_name'],
+            ['$ai_metric', '$ai_metric_name'],
+            ['$ai_evaluation', '$ai_evaluation_name'],
+            ['$csp_violation', '$csp_violated_directive'],
+            ['$mcp_tool_call', '$mcp_tool_name'],
+            ['$mcp_resource_read', '$mcp_resource_name'],
+            ['$mcp_prompt_get', '$mcp_resource_name'],
+            ['Deep link opened', 'url'],
+        ])('returns the core taxonomy default for %s', (eventName, expected) => {
+            expect(getPrimaryPropertyForEvent(eventName)).toBe(expected)
         })
 
         it('returns null for events with no taxonomy default and no override', () => {

--- a/frontend/src/lib/utils/events.ts
+++ b/frontend/src/lib/utils/events.ts
@@ -42,6 +42,27 @@ export function getEventsWithPrimaryProperty<T extends { event: string }>(
     return events.filter((e) => getPrimaryPropertyForEvent(e.event, overrides) !== null)
 }
 
+/**
+ * The distinct set of primary properties promoted for a list of event names
+ * (taxonomy default first, then team override). Pure client-side — shared by
+ * `taxonomicFilterLogic`'s `eventNamesWithPrimaryProperties` selector and
+ * `useTaxonomicGroupsContext`'s headless equivalent so both express
+ * "taxonomy default first, then team override, distinct" once.
+ */
+export function distinctPrimaryPropertiesForEvents(
+    eventNames: string[],
+    overrides?: Record<string, string | null | undefined>
+): string[] {
+    const distinct = new Set<string>()
+    for (const eventName of eventNames) {
+        const primary = getPrimaryPropertyForEvent(eventName, overrides)
+        if (primary) {
+            distinct.add(primary)
+        }
+    }
+    return Array.from(distinct)
+}
+
 export function eventToDescription(
     event: Pick<EventType, 'elements' | 'event' | 'properties'>,
     shortForm: boolean = false

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -3789,7 +3789,8 @@
         },
         "$ai_evaluation": {
             "description": "An evaluation of an AI event. Contains the result of the evaluation, the target event, and the evaluation metadata.",
-            "label": "AI evaluation (LLM)"
+            "label": "AI evaluation (LLM)",
+            "primary_property": "$ai_evaluation_name"
         },
         "$ai_feedback": {
             "description": "User-provided feedback for a trace of a generative AI model (LLM).",
@@ -3797,15 +3798,18 @@
         },
         "$ai_generation": {
             "description": "A call to an LLM model. Contains the input prompt, output, model used and costs.",
-            "label": "AI generation (LLM)"
+            "label": "AI generation (LLM)",
+            "primary_property": "$ai_model"
         },
         "$ai_metric": {
             "description": "An evaluation metric for a trace of a generative AI model (LLM). Contains the trace ID, metric name, and metric value.",
-            "label": "AI metric (LLM)"
+            "label": "AI metric (LLM)",
+            "primary_property": "$ai_metric_name"
         },
         "$ai_span": {
             "description": "A generative AI span. Usually a span tracks a unit of work for a trace of generative AI models (LLMs).",
-            "label": "AI span (LLM)"
+            "label": "AI span (LLM)",
+            "primary_property": "$ai_span_name"
         },
         "$ai_tag": {
             "description": "A tag classification of an AI event. Contains the assigned tags, reasoning, and tagger metadata.",
@@ -3813,7 +3817,8 @@
         },
         "$ai_trace": {
             "description": "A generative AI trace. Usually a trace tracks a single user interaction and contains one or more AI generation calls.",
-            "label": "AI trace (LLM)"
+            "label": "AI trace (LLM)",
+            "primary_property": "$ai_span_name"
         },
         "$autocapture": {
             "description": "User interactions that were automatically captured.",
@@ -3868,7 +3873,8 @@
                 "Unauthorized inline script",
                 "Trying to load resources from unauthorized domain"
             ],
-            "label": "CSP violation"
+            "label": "CSP violation",
+            "primary_property": "$csp_violated_directive"
         },
         "$dead_click": {
             "description": "A user has clicked on something that is probably not clickable.",
@@ -3893,7 +3899,8 @@
         },
         "$exception": {
             "description": "An unexpected error or unhandled exception in your application.",
-            "label": "Exception"
+            "label": "Exception",
+            "primary_property": "$exception_type"
         },
         "$feature_enrollment_update": {
             "description": "When a user enrolls with a feature.",
@@ -3943,7 +3950,8 @@
         },
         "$mcp_prompt_get": {
             "description": "Fires when an MCP prompt is fetched by a client. Includes the prompt name.",
-            "label": "MCP prompt fetched"
+            "label": "MCP prompt fetched",
+            "primary_property": "$mcp_resource_name"
         },
         "$mcp_prompts_list": {
             "description": "Fires when an MCP client requests the list of available prompts.",
@@ -3951,7 +3959,8 @@
         },
         "$mcp_resource_read": {
             "description": "Fires when an MCP resource is fetched by a client. Includes the resource name.",
-            "label": "MCP resource read"
+            "label": "MCP resource read",
+            "primary_property": "$mcp_resource_name"
         },
         "$mcp_resources_list": {
             "description": "Fires when an MCP client requests the list of available resources.",
@@ -4036,7 +4045,8 @@
         },
         "Deep link opened": {
             "description": "When a user opens the mobile app via a deep link.",
-            "label": "Deep link opened"
+            "label": "Deep link opened",
+            "primary_property": "url"
         },
         "mcp feedback submitted": {
             "description": "Fires when feedback is submitted through the MCP server's feedback tool \u2014 about any PostHog product, the MCP server itself, or the docs.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -226,6 +226,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$exception": {
             "label": "Exception",
             "description": "An unexpected error or unhandled exception in your application.",
+            "primary_property": "$exception_type",
         },
         "$web_vitals": {
             "label": "Web vitals",
@@ -234,10 +235,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$ai_generation": {
             "label": "AI generation (LLM)",
             "description": "A call to an LLM model. Contains the input prompt, output, model used and costs.",
+            "primary_property": "$ai_model",
         },
         "$ai_evaluation": {
             "label": "AI evaluation (LLM)",
             "description": "An evaluation of an AI event. Contains the result of the evaluation, the target event, and the evaluation metadata.",
+            "primary_property": "$ai_evaluation_name",
         },
         "$ai_tag": {
             "label": "AI tag (LLM)",
@@ -246,6 +249,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$ai_metric": {
             "label": "AI metric (LLM)",
             "description": "An evaluation metric for a trace of a generative AI model (LLM). Contains the trace ID, metric name, and metric value.",
+            "primary_property": "$ai_metric_name",
         },
         "$ai_feedback": {
             "label": "AI feedback (LLM)",
@@ -254,10 +258,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$ai_trace": {
             "label": "AI trace (LLM)",
             "description": "A generative AI trace. Usually a trace tracks a single user interaction and contains one or more AI generation calls.",
+            "primary_property": "$ai_span_name",
         },
         "$ai_span": {
             "label": "AI span (LLM)",
             "description": "A generative AI span. Usually a span tracks a unit of work for a trace of generative AI models (LLMs).",
+            "primary_property": "$ai_span_name",
         },
         "$ai_embedding": {
             "label": "AI embedding (LLM)",
@@ -267,6 +273,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "CSP violation",
             "description": "Content Security Policy violation reported by a browser to our csp endpoint.",
             "examples": ["Unauthorized inline script", "Trying to load resources from unauthorized domain"],
+            "primary_property": "$csp_violated_directive",
         },
         "Application opened": {
             "label": "Application opened",
@@ -291,6 +298,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "Deep link opened": {
             "label": "Deep link opened",
             "description": "When a user opens the mobile app via a deep link.",
+            "primary_property": "url",
         },
         # Canonical @posthog/mcp SDK events, and the only MCP events to build on. They cover all
         # traffic since 2026-06-16; the legacy non-`$` names below are frozen (older history only).
@@ -314,6 +322,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$mcp_resource_read": {
             "label": "MCP resource read",
             "description": "Fires when an MCP resource is fetched by a client. Includes the resource name.",
+            "primary_property": "$mcp_resource_name",
         },
         "$mcp_prompts_list": {
             "label": "MCP prompts listed",
@@ -322,6 +331,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$mcp_prompt_get": {
             "label": "MCP prompt fetched",
             "description": "Fires when an MCP prompt is fetched by a client. Includes the prompt name.",
+            "primary_property": "$mcp_resource_name",
         },
         "$mcp_custom": {
             "label": "MCP custom event",


### PR DESCRIPTION
## Problem

When an event is in context in the taxonomic filter (e.g. filtering an "MCP tool call" series), the property a user almost certainly wants — MCP tool name, AI model, exception type — sat unranked at the bottom of the list while unrelated recents led it.

The `primary_property` mechanism already solves this for `$pageview -> $pathname` etc, but:

1. Only 5 core events had one configured.
2. The rebuild menu (`taxonomic-filter-menu-rebuild`) hides the `SuggestedFilters` group entirely, so promotions never reached it at all — only the two legacy surfaces benefited.

## Changes

**Taxonomy: 10 new `primary_property` defaults** (same pattern as `$pageview`):

| Event | Primary property |
|---|---|
| `$exception` | `$exception_type` |
| `$ai_generation` | `$ai_model` |
| `$ai_trace` / `$ai_span` | `$ai_span_name` |
| `$ai_metric` | `$ai_metric_name` |
| `$ai_evaluation` | `$ai_evaluation_name` |
| `$csp_violation` | `$csp_violated_directive` |
| `$mcp_resource_read` / `$mcp_prompt_get` | `$mcp_resource_name` |
| `Deep link opened` | `url` |

(`$mcp_tool_call -> $mcp_tool_name` landed on master separately.)

**Rebuild menu support:**

- `useTaxonomicGroupsContext` now computes `promotedPropertiesForContextEvents` (the pure `buildTaxonomicGroups` already accepted the field — it was never fed) and loads team overrides, mirroring `taxonomicFilterLogic`'s selector. Content-keyed deps to match the hook's existing stabilization.
- `Combobox` leads the idle "All" surface with the promoted properties, right after recents/pinned, deduped both ways (a promoted property that's already recent shows once, under recents).

Legacy surfaces need no code change — they pick the new taxonomy entries up through the existing `SuggestedFilters` path.

## Tests

- Parameterized `getPrimaryPropertyForEvent` coverage of all 15 event->property mappings
- Legacy: `$mcp_tool_call` case in the existing SuggestedFilters options test
- Rebuild: bridge-hook promotion (parameterized) + Combobox ordering and dedup tests

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*