### PR TITLE
fix(web-analytics): stop prefilter registrations breaking later scope collection

### DIFF
--- a/products/web_analytics/backend/hogql_queries/events_prefilter.py
+++ b/products/web_analytics/backend/hogql_queries/events_prefilter.py
@@ -18,9 +18,12 @@ if TYPE_CHECKING:
 class _EventsFieldCollector(TraversingVisitor):
     """Collects events-table field names and property accesses from the entire query."""
 
-    def __init__(self, events_table_type: ast.Type):
+    def __init__(self, events_table_type: ast.Type, synthetic_fields: set[str] | None = None):
         super().__init__()
         self.events_table_type = events_table_type
+        # Columns the transformer itself registered on the shared table while wrapping
+        # earlier scopes in the same query; excluded from the subset comparison below.
+        self.synthetic_fields = synthetic_fields or set()
         self.fields: set[str] = set()
         self.property_accesses: set[tuple[str, str]] = set()  # (property_name, table_column)
 
@@ -51,7 +54,13 @@ class _EventsFieldCollector(TraversingVisitor):
         if not isinstance(candidate, ast.TableType) or not isinstance(target, ast.TableType):
             return False
         # An augmented copy is the same table class with the original's fields plus the synthetic ones.
-        return type(candidate.table) is type(target.table) and set(target.table.fields).issubset(candidate.table.fields)
+        # The target may be the SHARED table already mutated by this transformer while wrapping an
+        # earlier scope of the same query (temp mat_* registrations); property-resolution copies were
+        # made before that mutation and only carry their own synthetic column, so those registrations
+        # must not participate in the comparison — or every later scope's property reads are dropped
+        # and the outer query fails with UNKNOWN_IDENTIFIER (code 47).
+        target_fields = set(target.table.fields) - self.synthetic_fields
+        return type(candidate.table) is type(target.table) and target_fields.issubset(candidate.table.fields)
 
     def visit_property_access(self, node: ast.PropertyAccess):
         # After the lowering pass an unmaterialized `properties.$x` read is a `PropertyAccess` over the blob `Field`,
@@ -140,7 +149,8 @@ class EventsPrefilterTransformer(TraversingVisitor):
         )
 
         # Collect ALL events-table fields from the entire query (SELECT, WHERE, GROUP BY, JOINs)
-        collector = _EventsFieldCollector(events_table_type)
+        registered_names = {name for _, name in self._temp_schema_fields}
+        collector = _EventsFieldCollector(events_table_type, synthetic_fields=registered_names)
         collector.visit(node)
         events_columns = collector.fields
         # Always include columns needed by JOIN constraints and the prefilter itself

--- a/products/web_analytics/backend/hogql_queries/test/test_events_prefilter.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_events_prefilter.py
@@ -2,6 +2,7 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin, also_test_with_m
 from unittest.mock import patch
 
 from posthog.schema import (
+    CompareFilter,
     DateRange,
     EventPropertyFilter,
     PersonPropertyFilter,
@@ -194,6 +195,38 @@ class TestEventsPrefilterTransformer(ClickhouseTestMixin, APIBaseTest):
         assert sql.count("mat_customProperty") >= 2, (
             "subquery must SELECT the materialized column the outer query reads"
         )
+
+    def test_host_filter_with_path_cleaning_and_host_prepend(self):
+        # The dashboard's domain dropdown: a materialized $host property filter combined
+        # with includeHost + doPathCleaning. The host-prepended breakdown reads $host in
+        # a scope the prefilter wrapper must still satisfy; prod failed with code 47
+        # (Identifier 'events.mat_$host' cannot be resolved from subquery with name events).
+        self.team.path_cleaning_filters = [
+            {"regex": "/person/[^/#]+", "alias": "/person/<id>", "order": 0},
+            {"regex": "/insights/[A-Za-z0-9]+", "alias": "/insights/<id>", "order": 1},
+        ]
+        self.team.test_account_filters = [{"key": "$ip", "type": "event", "value": "127.0.0.1", "operator": "is_not"}]
+        self.team.save()
+        with materialized("events", "$host"), materialized("events", "$ip"):
+            sql = self._run_prefiltered_query(
+                includeBounceRate=True,
+                includeHost=True,
+                doPathCleaning=True,
+                filterTestAccounts=True,
+                compareFilter=CompareFilter(compare=True),
+                properties=[
+                    EventPropertyFilter(
+                        key="$host",
+                        operator=PropertyOperator.EXACT,
+                        value=["posthog.com"],
+                    )
+                ],
+            )
+
+        assert "toDate(events.timestamp)" in sql
+        # Both wrapped scopes (counts + bounce) filter on $host, so both prefilter
+        # subqueries must project the materialized column.
+        assert sql.count("mat_$host") >= 4
 
     def test_deep_key_read_off_materialized_column_kept_in_subquery(self):
         # A deep read (properties.customProperty.bar) through a materialized column becomes a JSON extract over the


### PR DESCRIPTION
## Problem

On events-prefilter teams, the paths tile errors instantly (`ExceptionBeforeStart`, code 47: `Identifier 'events.mat_$host' cannot be resolved from subquery with name events`) whenever the query combines two or more distinct materialized property filters - e.g. the dashboard's domain dropdown (`$host`) together with ip- or host-based test-account filters. Observed daily on the enrolled teams since at least Jul 1; it also blocks widening the prefilter rollout.

## Changes

Root cause: `EventsPrefilterTransformer` wraps each `FROM events` scope in turn, and each wrap registers temporary synthetic `mat_*` columns on the **shared** events table object so the printer can resolve them. When the collector then runs for the *next* scope, `_matches_events_table`'s subset check compares the now-mutated table (original + all previously registered columns) against each property's augmented copy (original + one column) - the subset fails, the match is rejected, and that scope's property reads are silently dropped from its wrapper projection. The outer query then references a column the subquery never selected.

Fix: the transformer passes its accumulated registrations into each collector, and the subset comparison excludes them. Single-property queries were never affected (the sets still matched), which is why existing coverage passed.

## How did you test this code?

- New test reproduces the exact prod failure (bounce + host prepend + path cleaning + materialized `$host` domain filter + materialized `$ip` test-account filter): code 47 before the fix, passes after, and asserts both wrapped scopes project the materialized column. Executes against ClickHouse, so a regression fails the query itself.
- Full prefilter suite: 15 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Diagnosed from prod query_log: the failing SQL showed one prefilter wrapper projecting 11 columns and the second only the 4 always-included ones, which pointed at cross-scope state. The repro required two *distinct* materialized properties - single-property variants pass, which is why existing tests missed it.