### PR TITLE
fix(data-warehouse): name the wrong ID when GA4 property ID is rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -118,6 +118,23 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
     ) -> tuple[bool, str | None]:
         property_id = normalize_property_id(config.property_id)
         if not property_id.isdigit():
+            # Name the two IDs users most often paste by mistake — both are non-numeric and
+            # look plausible, so the generic "use a numeric ID" hint leaves them hunting.
+            upper_id = property_id.upper()
+            if upper_id.startswith("G-"):
+                return (
+                    False,
+                    f"'{config.property_id}' looks like a Measurement ID (from your GA4 data stream / "
+                    "website tag), not a property ID. Use the numeric property ID from Google Analytics "
+                    "Admin → Property settings → Property details (e.g. '123456789').",
+                )
+            if upper_id.startswith("UA-"):
+                return (
+                    False,
+                    f"'{config.property_id}' is a Universal Analytics property ID. This connector supports "
+                    "Google Analytics 4 only — use the numeric GA4 property ID from Admin → Property "
+                    "settings → Property details (e.g. '123456789').",
+                )
             return (
                 False,
                 f"'{config.property_id}' is not a valid GA4 property ID. Use the numeric ID from "

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -148,6 +148,21 @@ def test_validate_credentials_rejects_non_numeric_property_id(bad_property_id):
     assert "not a valid GA4 property ID" in (message or "")
 
 
+@pytest.mark.parametrize(
+    "wrong_id,expected_substring",
+    [
+        ("G-ABC123XYZ", "Measurement ID"),
+        ("g-abc123xyz", "Measurement ID"),
+        ("UA-12345678-1", "Universal Analytics"),
+    ],
+)
+def test_validate_credentials_names_common_wrong_ids(wrong_id, expected_substring):
+    ok, message = GoogleAnalyticsSource().validate_credentials(_config(wrong_id), team_id=1)
+
+    assert ok is False
+    assert expected_substring in (message or "")
+
+
 def _http_error(status_code: int) -> requests.HTTPError:
     response = mock.MagicMock()
     response.status_code = status_code


### PR DESCRIPTION
## Problem

When onboarding a Google Analytics data warehouse source, users commonly paste the wrong Google Analytics identifier into the **Property ID** field:

- a **Measurement ID** (`G-…`) — the value from the GA4 data stream / website tag, and the most visible ID in the GA UI
- a **Universal Analytics property ID** (`UA-…`) — from the old, GA4-predecessor property

Both are non-numeric, so they fell through to the generic "not a valid GA4 property ID" error. That message tells the user *what* is wrong but not that the string they have is a *different, real* identifier they need to stop using — so they retry variations of the same wrong value instead of going to fetch the numeric property ID.

## Changes

In the GA source `validate_credentials`, before the generic non-numeric error, detect the `G-` and `UA-` prefixes and return a message that names the specific mistake and points at where the numeric GA4 property ID lives (Admin → Property settings → Property details). Everything else still hits the unchanged generic message.

Copy-only / validation-message change — no change to sync behaviour, schemas, or the connection flow.

## How did you test this code?

Extended the existing `validate_credentials` unit tests with cases for `G-…` (upper and lower case) and `UA-…` values asserting the new targeted messages, and kept the generic-rejection test. Ran the suite:

`pytest products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py -k validate_credentials` → 14 passed.

The new tests catch a regression the existing ones didn't: that a `G-`/`UA-` value gets the *specific* guidance rather than the generic fallback.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude Code) while reviewing recurring friction in data-warehouse new-source onboarding. Session summaries showed users repeatedly rejected at the GA4 property-ID step after entering a `G-`-prefixed value. The surrounding validation and error-classification code is already thorough, so this is a narrow, additive copy improvement rather than a behavioural change. No repo skills were required for a copy-only backend change; touched files were linted with ruff and covered by unit tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
