### PR TITLE
feat(notebooks): dispatch concurrent runs and fail fast on bad syntax

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeInputV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeInputV2.tsx
@@ -70,7 +70,7 @@ const Component = ({ attributes, updateAttributes }: NotebookNodeProps<NotebookN
         hasResult: true, // an assignment has no result to recover on mount
         getContent: () => notebookLogic.values.content ?? null,
     })
-    const { isRunning, runError, operationBlockReason, isChainRunning } = useValues(dataLogic)
+    const { isRunning, runError, runBlockReason, isChainRunning } = useValues(dataLogic)
     const { runQuery } = useActions(dataLogic)
 
     // Text and number commit on blur/Enter, so the draft tracks keystrokes locally.
@@ -94,7 +94,7 @@ const Component = ({ attributes, updateAttributes }: NotebookNodeProps<NotebookN
         ? 'Stale cells are being re-run'
         : isRunning
           ? 'Applying the previous change'
-          : (operationBlockReason ?? undefined)
+          : (runBlockReason ?? undefined)
     const widgetType = attributes.widgetType ?? 'text'
 
     return (

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
@@ -63,6 +63,7 @@ const Component = ({
         pageResult,
         pageLoading,
         operationBlockReason,
+        runBlockReason,
         isStale,
         staleCount,
         isChainRunning,
@@ -107,7 +108,7 @@ const Component = ({
                                     ? 'Stale cells are already being re-run'
                                     : isRunning
                                       ? 'This cell is running'
-                                      : (operationBlockReason ?? undefined)
+                                      : (runBlockReason ?? undefined)
                             }
                         />
                     </div>
@@ -200,7 +201,7 @@ const Settings = ({
         hasResult: !!attributes.result,
         getContent: () => notebookLogic.values.content ?? null,
     })
-    const { isRunning, isInterrupting, operationBlockReason } = useValues(dataLogic)
+    const { isRunning, isInterrupting, runBlockReason } = useValues(dataLogic)
     const { runQuery, interruptRun } = useActions(dataLogic)
 
     const run = (): void => {
@@ -234,7 +235,7 @@ const Settings = ({
                         }
                     }}
                     loading={isInterrupting}
-                    disabledReason={operationBlockReason ?? undefined}
+                    disabledReason={runBlockReason ?? undefined}
                     tooltip={isRunning ? 'Stop the running cell' : 'Run Python (⌘⏎)'}
                 >
                     {isRunning ? 'Cancel' : 'Run'}

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
@@ -98,6 +98,7 @@ const Component = ({
         pageResult,
         pageLoading,
         operationBlockReason,
+        runBlockReason,
         isStale,
         staleCount,
         isChainRunning,
@@ -160,7 +161,7 @@ const Component = ({
                                     ? 'Stale cells are already being re-run'
                                     : isRunning
                                       ? 'This cell is running'
-                                      : (operationBlockReason ?? undefined)
+                                      : (runBlockReason ?? undefined)
                             }
                         />
                     </div>
@@ -299,7 +300,7 @@ const Settings = ({
         hasResult: !!attributes.result,
         getContent: () => notebookLogic.values.content ?? null,
     })
-    const { isRunning, isInterrupting, operationBlockReason } = useValues(dataLogic)
+    const { isRunning, isInterrupting, runBlockReason } = useValues(dataLogic)
     const { runQuery, interruptRun } = useActions(dataLogic)
 
     return (
@@ -311,7 +312,7 @@ const Settings = ({
             // (the only surface with SQLV2 cells) have no tiptap editor at all.
             onRunQuery={(code) => runQuery(code, collectSqlV2Refs(notebookLogic.values.content, nodeId))}
             runQueryLoading={isRunning}
-            runQueryDisabledReason={operationBlockReason ?? undefined}
+            runQueryDisabledReason={runBlockReason ?? undefined}
             runQueryTooltip="Run SQL (v2) query"
             onCancelQuery={interruptRun}
             cancelQueryLoading={isInterrupting}

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
@@ -309,19 +309,55 @@ describe('notebookNodeSQLV2Logic', () => {
         expect(logic.values.isRunning).toBe(true)
     })
 
-    it('blocks a second node while another node has a run in flight', async () => {
-        // Default resultSpy keeps r1 'running', so the notebook stays busy after n1 dispatches.
+    it('a second node dispatches its run while another run is in flight (Journey 14)', async () => {
+        // Default resultSpy keeps r1 'running'; the second run must still be acked and
+        // dispatched — the sandbox, not the UI, orders execution.
         mount()
         const other = notebookNodeSQLV2Logic({ nodeId: 'n2', notebookShortId: 'nb1', updateAttributes })
         other.mount()
         logic.actions.runQuery('select 1')
         await expectLogic(logic).toFinishAllListeners()
+        runSpy.mockResolvedValueOnce({ run_id: 'r2' })
         other.actions.runQuery('select 2')
         await expectLogic(other).toFinishAllListeners()
-        expect(runSpy).toHaveBeenCalledTimes(1)
-        expect(other.values.isRunning).toBe(false)
-        expect(other.values.operationBlockReason).toBeTruthy()
+        expect(runSpy).toHaveBeenCalledTimes(2)
+        expect(logic.values.isRunning).toBe(true)
+        expect(other.values.isRunning).toBe(true)
         other.unmount()
+    })
+
+    it('a run is refused while a page fetch from another node is in flight', async () => {
+        // A page fetch holds a web worker; unlike runs, it still gates new dispatches.
+        let resolvePage: (value: unknown) => void = () => {}
+        jest.spyOn(api.notebooks, 'sqlV2RunPage').mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolvePage = resolve
+                }) as any
+        )
+        const pager = notebookNodeSQLV2Logic({
+            nodeId: 'n2',
+            notebookShortId: 'nb1',
+            updateAttributes,
+            runId: 'r9',
+            hasResult: true,
+        })
+        pager.mount()
+        pager.actions.setPage(2)
+        await expectLogic(pager).toDispatchActions(['setPageLoading'])
+
+        mount()
+        logic.actions.runQuery('select 1')
+        // The refusal dispatches synchronously; toFinishAllListeners would hang on the
+        // deliberately still-pending page fetch.
+        await expectLogic(logic).toDispatchActions(['runQuery', 'setIsRunning'])
+        expect(runSpy).not.toHaveBeenCalled()
+        expect(logic.values.isRunning).toBe(false)
+        expect(logic.values.runBlockReason).toBeTruthy()
+
+        resolvePage({ columns: [], types: [], rows: [], has_more: false })
+        await expectLogic(pager).toFinishAllListeners()
+        pager.unmount()
     })
 
     it('blocks page fetches while another node is busy', async () => {

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
@@ -44,8 +44,9 @@ export function collectSqlV2Refs(doc: JSONContent | null | undefined, selfNodeId
 
 const POLL_INTERVAL_MS = 1000
 // Must outlast the backend's own run budgets (180s data-plane poll deadline, 300s kernel
-// execute timeout) plus slack, or a slow-but-successful run gets reported as timed out.
-const MAX_POLL_ATTEMPTS = 330 // ~5.5 minutes at 1s
+// execute timeout) plus slack — twice over, because a dispatched run can queue in the
+// sandbox behind another full-budget run (Journey 14) before its own budget even starts.
+const MAX_POLL_ATTEMPTS = 690 // ~11.5 minutes at 1s
 
 export const SQL_V2_DEFAULT_PAGE_SIZE = 50
 
@@ -86,7 +87,7 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
     connect((props: NotebookNodeSQLV2LogicProps) => ({
         values: [
             notebookOperationsLogic({ shortId: props.notebookShortId }),
-            ['activeOperation', 'isBusy'],
+            ['activeOperation', 'isBusy', 'activePageOperation'],
             notebookNodeStalenessLogic({ shortId: props.notebookShortId }),
             ['staleNodeIds', 'staleCount', 'chainQueue', 'isChainRunning'],
         ],
@@ -248,10 +249,11 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                     actions.nodeRunFinished(props.nodeId, 'failed', null)
                     return
                 }
-                // The run button is disabled while the notebook is busy; this guards Cmd+Enter
-                // and programmatic dispatch. Re-running our own node supersedes as before.
-                if (values.isBusy && values.activeOperation?.nodeId !== props.nodeId) {
-                    lemonToast.info('Another operation is running in this notebook — wait for it to finish.')
+                // Journey 14: another node's run no longer blocks — the second run dispatches
+                // immediately and the sandbox orders execution. Only an in-flight page fetch
+                // (which holds a web worker) still gates; own-node operations supersede.
+                if (values.activePageOperation && values.activePageOperation.nodeId !== props.nodeId) {
+                    lemonToast.info('A page fetch is in progress in this notebook. Try again in a moment.')
                     actions.setIsRunning(false)
                     actions.nodeRunFinished(props.nodeId, 'failed', null)
                     return
@@ -274,8 +276,10 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
                     // would orphan this run's node_id and break refs to this cell.
                     props.updateAttributes({ nodeId: props.nodeId, runId: run_id, result: null })
                     actions.startPolling(run_id)
-                } catch (error) {
-                    actions.setRunError(error instanceof Error ? error.message : 'Failed to run query')
+                } catch (error: any) {
+                    // A 400 at dispatch (e.g. Journey 15's syntax fail-fast) carries the real
+                    // message in `detail`; fall back to the generic error message otherwise.
+                    actions.setRunError(error?.detail || error?.message || 'Failed to run query')
                     actions.setIsRunning(false)
                     actions.finishOperation(runOperation.id)
                     actions.nodeRunFinished(props.nodeId, 'failed', null)
@@ -419,6 +423,14 @@ export const notebookNodeSQLV2Logic = kea<notebookNodeSQLV2LogicType>([
         ],
         // An upstream cell's run landed after this cell last ran (Journey 10).
         isStale: [(s) => [s.staleNodeIds], (staleNodeIds): boolean => !!staleNodeIds[props.nodeId]],
+        // Journey 14: only a page fetch blocks dispatching a run — wire into Run buttons.
+        runBlockReason: [
+            (s) => [s.activePageOperation],
+            (activePageOperation): string | null =>
+                activePageOperation && activePageOperation.nodeId !== props.nodeId
+                    ? 'A page fetch is in progress in this notebook'
+                    : null,
+        ],
     })),
     afterMount(({ props, actions }) => {
         // Recover after a reload/remount: a persisted runId with no result means the run may still be

--- a/frontend/src/scenes/notebooks/Notebook/notebookOperationsLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookOperationsLogic.ts
@@ -56,5 +56,12 @@ export const notebookOperationsLogic = kea<notebookOperationsLogicType>([
                 Object.values(operations)[0] ?? null,
         ],
         isBusy: [(s) => [s.operations], (operations): boolean => Object.keys(operations).length > 0],
+        // Journey 14: runs dispatch concurrently (the backend and sandbox order execution),
+        // so only an in-flight page fetch — which holds a web worker — still gates new runs.
+        activePageOperation: [
+            (s) => [s.operations],
+            (operations: Record<string, NotebookOperation>): NotebookOperation | null =>
+                Object.values(operations).find((operation) => operation.kind === 'page') ?? null,
+        ],
     }),
 ])

--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -52,7 +52,11 @@ from products.notebooks.backend.activity_logging import log_notebook_activity
 from products.notebooks.backend.collab import submit_steps
 from products.notebooks.backend.kernel_runtime import build_notebook_sandbox_config, get_kernel_runtime
 from products.notebooks.backend.models import KernelRuntime, Notebook, NotebookNodeRun
-from products.notebooks.backend.python_analysis import analyze_python_globals, annotate_python_nodes
+from products.notebooks.backend.python_analysis import (
+    analyze_python_globals,
+    annotate_python_nodes,
+    find_python_syntax_error,
+)
 from products.notebooks.backend.query_validation import InvalidNotebookQueryError, normalize_notebook_query_nodes
 from products.notebooks.backend.sql_v2 import (
     PAGE_LOCK_TTL_SECONDS,
@@ -962,6 +966,11 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
         output_name = serializer.validated_data["output_name"]
         try:
             if node_type == "python":
+                # Fail fast on broken syntax (Journey 15): the run must be rejected here,
+                # not accepted and queued behind an in-flight run in the sandbox.
+                syntax_error = find_python_syntax_error(code)
+                if syntax_error:
+                    return Response({"detail": syntax_error}, status=400)
                 # A python node stores its code as-is; referenced frames become kernel inputs.
                 run_code, inputs = code, resolve_python_node_inputs(code, refs)
             else:

--- a/products/notebooks/backend/python_analysis.py
+++ b/products/notebooks/backend/python_analysis.py
@@ -279,6 +279,22 @@ def collect_exported_types(body: list[ast.stmt]) -> dict[str, str]:
     return exported_types
 
 
+def find_python_syntax_error(code: str) -> str | None:
+    """User-facing syntax-error message for a python cell, or None when it parses.
+
+    Journey 15: a run with broken syntax must fail at dispatch, before it is accepted and
+    queued behind an in-flight run in the sandbox.
+    """
+    if not code or not code.strip():
+        return None
+    try:
+        ast.parse(code)
+    except SyntaxError as exc:
+        location = f" (line {exc.lineno})" if exc.lineno else ""
+        return f"Python syntax error: {exc.msg}{location}"
+    return None
+
+
 def analyze_python_globals(code: str) -> PythonGlobalsAnalysis:
     if not code or not code.strip():
         return PythonGlobalsAnalysis(used=[], exported_with_types=[])

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -218,6 +218,21 @@ class TestSQLV2Run(APIBaseTest):
         self.assertEqual(NotebookNodeRun.objects.for_team(self.team.id).filter(notebook=self.notebook).count(), 0)
         mock_start.assert_not_called()
 
+    @patch("products.notebooks.backend.presentation.views.notebook.start_sql_v2_run_workflow")
+    @patch("products.notebooks.backend.presentation.views.notebook.is_sql_v2_enabled", return_value=True)
+    def test_python_syntax_error_is_rejected_before_dispatch(self, _mock_enabled, mock_start):
+        # Journey 15: broken syntax must fail at dispatch, not get accepted and queued
+        # behind an in-flight run in the sandbox only to die there.
+        response = self.client.post(
+            self.run_url,
+            data={"node_id": "n1", "code": "def = 1", "node_type": "python", "output_name": "df"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Python syntax error", response.json()["detail"])
+        self.assertEqual(NotebookNodeRun.objects.for_team(self.team.id).filter(notebook=self.notebook).count(), 0)
+        mock_start.assert_not_called()
+
     def _record_done_run(self, node_id: str, code: str) -> None:
         with team_scope(self.team.id):
             NotebookNodeRun.objects.create(


### PR DESCRIPTION
## Problem

Journeys 14/15 of the revamped notebooks plan: running a second cell while one is in flight gets refused with a toast today, and a python cell with broken syntax is accepted, queued behind the running cell in the sandbox, and only fails minutes later when its turn comes.

## Changes

Stacks on #70201 (Journey 12).

The serialization these journeys describe already exists below the UI: the kernel-server accepts concurrent run dispatches and kernel nodes queue on the executor's namespace lock (with Journey 9's run-scoped interrupt handling concurrency correctly), and pure-HogQL runs execute concurrently in ClickHouse. HogQL also already parses at dispatch, failing bad SQL immediately. So:

- Frontend (Journey 14): another node's run no longer blocks dispatching a run. The second run POSTs immediately, gets acked with its own `run_id`, and shows in-progress while the sandbox orders execution. Only an in-flight page fetch, which genuinely holds a web worker, still gates new runs (new `runBlockReason` feeding the run affordances; pagination's one-at-a-time behavior unchanged). The poll budget doubles to ~11.5 min since a queued kernel run can legitimately wait a full execute budget before its own starts.
- Backend (Journey 15): python cells with syntax errors are rejected at dispatch with a 400 carrying the parse message and line, before a run row or Temporal workflow exists. The cell now surfaces the endpoint's `detail` instead of a generic failure message.

> [!NOTE]
> Resource envelope is unchanged in kind: each extra concurrent run is one Temporal dispatch and one sandbox thread, kernel execution stays strictly serial per sandbox, and ClickHouse runs remain bounded by the existing per-team async query caps. Running a cell before its upstream finishes behaves exactly as if clicked in that order today, and Journey 10's staleness then flags it.

## How did you test this code?

Automated tests only:

- `test_sql_v2.py` (108 passed, 1 new): a python run with `def = 1` is rejected 400 with the syntax message, creating no run row and starting no workflow — pins the fail-fast against regressing into queue-then-die.
- `notebookNodeSQLV2Logic.test.ts` (updated): the old "blocks a second node" case asserted exactly the behavior these journeys remove, so it now asserts the second run dispatches with both cells in-progress; a new case pins that an in-flight page fetch still refuses a run.
- `notebookNodeStalenessLogic.test.ts` still green (the chain runner serializes by its own queue, unaffected by the gate change). TypeScript check clean for touched files; `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public docs cover the revamped notebook run flow yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5) as part of the stacked revamped-notebooks journey series (stacks on #70201). Skills invoked: /writing-tests.

The main decision: implement queueing by deleting the artificial UI gate rather than building a frontend queue, since the sandbox executor already provides exactly the FIFO semantics Journey 14 describes and the backend already provides Journey 15's fail-fast for SQL. The only new backend code is the python syntax check at dispatch.
