### PR TITLE
fix(api): return UTC timestamps from /events endpoint instead of project timezone

### DIFF
--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -355,8 +355,7 @@ class ClickhouseEventSerializer(serializers.Serializer):
 
     @extend_schema_field(serializers.DateTimeField())
     def get_timestamp(self, event):
-        dt = event["timestamp"].replace(tzinfo=UTC)
-        return dt.astimezone().isoformat()
+        return event["timestamp"].replace(tzinfo=UTC).isoformat()
 
     @extend_schema_field(serializers.DictField(allow_null=True))
     def get_person(self, event):


### PR DESCRIPTION
## The Bug

`ClickhouseEventSerializer.get_timestamp()` applies `.astimezone()` without arguments to a UTC-tagged datetime:

```python
dt = event["timestamp"].replace(tzinfo=UTC)
return dt.astimezone().isoformat()  # uses PROJECT timezone, not UTC
```

On a project with `Africa/Algiers (UTC+1)`, a UTC timestamp of `20:44` becomes `21:44+00:00` — hour shifted but offset preserved, creating a contradictory value.

## The Fix

Skip `.astimezone()`. The timestamp is already marked UTC — just use `.isoformat()`:

```python
return event["timestamp"].replace(tzinfo=UTC).isoformat()
```

Guarantees the /events endpoint always returns UTC timestamps regardless of project timezone.

Closes #67175
