### PR TITLE
fix(data-warehouse): give an actionable message for Mixpanel 402

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/mixpanel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/mixpanel.py
@@ -183,6 +183,13 @@ def validate_credentials(
         if schema_name is None:
             return True, None
         return False, "The service account does not have access to this resource in the selected project."
+    if response.status_code == 402:
+        return (
+            False,
+            "Mixpanel denied the request (402 Payment Required). Raw data access usually needs a Mixpanel "
+            "plan that includes the data export API, and the account must be in good standing. Check your "
+            "Mixpanel plan and billing, then try again.",
+        )
 
     return False, f"Mixpanel returned an unexpected status ({response.status_code}) while validating credentials."
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
@@ -260,6 +260,16 @@ class TestValidateCredentials:
         assert ok is False
         assert error is not None
 
+    def test_payment_required_gets_actionable_message(self) -> None:
+        session = MagicMock()
+        session.post.return_value = FakeResponse(status_code=402)
+        with patch.object(mp, "make_tracked_session", return_value=session):
+            ok, error = validate_credentials("us", "user", "secret", "123")
+        assert ok is False
+        assert error is not None
+        assert "402" in error
+        assert "plan" in error.lower()
+
 
 class TestExportIterator:
     def _run(self, manager: FakeManager, start: date, end: date, responses: list[FakeResponse]) -> list[dict]:


### PR DESCRIPTION
## Problem

When a user connects a Mixpanel source and Mixpanel replies `402 Payment Required` during credential validation, we surfaced a generic "Mixpanel returned an unexpected status (402) while validating credentials" message. That gives the user nothing to act on. A 402 from Mixpanel is a plan/billing signal, not a wrong-credential signal.

**Why:** this came out of a triage of failed data-warehouse source-creation attempts, where a batch of Mixpanel failures all showed the unactionable 402 text.

## Changes

Add an explicit `402` branch to Mixpanel's `validate_credentials` that points the user at their Mixpanel plan (raw data export access) and account standing, so they know where to look instead of seeing a raw status code.

## How did you test this code?

Added `test_payment_required_gets_actionable_message` to the existing `TestValidateCredentials` group. It catches the regression where the 402 branch is removed and the message silently falls back to the unactionable generic status text — no existing case asserted on the 402 copy. Ran the `TestValidateCredentials` suite locally, all green.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged data-warehouse source-creation failures and classified each error message as user-misconfiguration (leave), internal-leak, or product bug. This one is an internal-leak style fix: a raw upstream status reaching the user. Authored by Claude (Claude Code). Invoked the `/writing-tests` skill before adding the test. Kept the change to a single source type per the triage guidance.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
