### PR TITLE
fix(insights): retry drag-to-zoom gesture until chart is interactive

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.test.tsx
@@ -176,9 +176,12 @@ describe('TrendsLifecycleChart', () => {
             })
 
             const canvas = await screen.findByLabelText(/chart with/i)
-            dragSelection(canvas.parentElement!, 1, 3, LIFECYCLE_LABELS.length)
 
+            // The chart commits its interactive scales/dimensions in a post-render effect
+            // (useChartCanvas) after the labeled canvas mounts, so a drag fired immediately
+            // can be silently dropped. Retry it (like hoverUntilTooltip) until it lands.
             await waitFor(() => {
+                dragSelection(canvas.parentElement!, 1, 3, LIFECYCLE_LABELS.length)
                 expect(onDateRangeZoom).toHaveBeenCalledWith('2024-06-11', '2024-06-13')
             })
         })


### PR DESCRIPTION
## Problem

The lifecycle chart's drag-to-zoom test (`TrendsLifecycleChart > drag-to-zoom > reports the dragged range as day strings to context.onDateRangeZoom`, added in #69907) was flaky in CI, quarantined by our Trunk flaky-test detector.

## Changes

Root cause: the chart commits its interactive scales/dimensions in a post-render effect (`useChartCanvas`) that lands asynchronously after the labeled canvas element mounts. The test's `dragSelection` helper fired a one-shot mousedown/mousemove/mouseup/click sequence immediately after `findByLabelText` resolved. When that fired before the effect committed, the drag handler bailed out early (missing scales/dimensions) and the whole gesture was silently dropped, so `onDateRangeZoom` never got called. This is a test race, not a product bug.

The fix moves the `dragSelection(...)` call inside the `waitFor(...)` callback so it re-fires the drag gesture on each poll attempt until `onDateRangeZoom` has actually been invoked, instead of firing once before the wait. This mirrors the existing `hoverUntilTooltip` helper in the same test file, which already handles the equivalent race for hover/tooltip tests on this chart. No sleeps, no timeout bumps, no jest retries.

## How did you test this code?

Ran the target test file directly:

```
pnpm --filter=@posthog/frontend exec jest products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.test.tsx --watchman=false
```

All 7 tests pass, including both `drag-to-zoom` cases. Prior to landing this change, the fix was validated by running the affected test 60 times in a loop with no failures, and the full suite 15 times with no failures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - test-only change, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) investigated and fixed this flaky test, working from a Trunk flaky-test investigation that had already identified and validated the root cause and fix approach. My work in this session was to reconstruct the fix on a fresh worktree based on current master (the original working branch was far behind master and didn't contain this test yet), re-verify the test passes, and open this PR.

No repo skills were invoked for this change since it is a narrow test-only fix; the underlying investigation followed the `fixing-flaky-tests` skill's discipline of reproducing before changing, fixing the root cause rather than masking it, and validating with a repeated-run loop.