### PR TITLE
fix(data-warehouse): stop leaking raw HTTP error on Polar token validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/polar/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/polar/source.py
@@ -108,6 +108,8 @@ class PolarSource(ResumableSource[PolarSourceConfig, PolarResumeConfig]):
                     False,
                     "Your Polar Organization Access Token does not have the required permissions. Please check the token's scopes in Polar and reconnect.",
                 )
+            if status_code is None:
+                return False, "Polar returned an unexpected error while validating your token. Please try again."
             return (
                 False,
                 f"Polar returned an unexpected error (HTTP {status_code}) while validating your token. Please try again.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/polar/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/polar/source.py
@@ -108,8 +108,6 @@ class PolarSource(ResumableSource[PolarSourceConfig, PolarResumeConfig]):
                     False,
                     "Your Polar Organization Access Token does not have the required permissions. Please check the token's scopes in Polar and reconnect.",
                 )
-            if status_code is None:
-                return False, "Polar returned an unexpected error while validating your token. Please try again."
             return (
                 False,
                 f"Polar returned an unexpected error (HTTP {status_code}) while validating your token. Please try again.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/polar/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/polar/source.py
@@ -1,5 +1,7 @@
 from typing import Optional, cast
 
+import requests
+
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
@@ -92,6 +94,24 @@ class PolarSource(ResumableSource[PolarSourceConfig, PolarResumeConfig]):
             return True, None
         except PolarPermissionError as e:
             return False, f"Polar Organization Access Token lacks permissions: {e}"
+        except requests.exceptions.HTTPError as e:
+            # A failed probe surfaces via raise_for_status(): its str() leaks the full request URL
+            # (with query params) and tells the user nothing to act on. Map the status instead.
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code == 401:
+                return (
+                    False,
+                    "Your Polar Organization Access Token is invalid or expired. Please generate a new token in Polar and reconnect.",
+                )
+            if status_code == 403:
+                return (
+                    False,
+                    "Your Polar Organization Access Token does not have the required permissions. Please check the token's scopes in Polar and reconnect.",
+                )
+            return (
+                False,
+                f"Polar returned an unexpected error (HTTP {status_code}) while validating your token. Please try again.",
+            )
         except Exception as e:
             return False, str(e)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/polar/test_polar_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/polar/test_polar_source.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import PolarSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.polar import polar as polar_module
+from products.warehouse_sources.backend.temporal.data_imports.sources.polar.source import PolarSource
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 400
+
+    def raise_for_status(self) -> None:
+        if not self.ok:
+            # Mirror the shape of requests' error whose str() would otherwise leak the request URL.
+            raise requests.HTTPError(
+                f"{self.status_code} Client Error: Unauthorized for url: https://api.polar.sh/v1/organizations/?limit=1",
+                response=self,  # type: ignore[arg-type]
+            )
+
+
+class TestPolarValidateCredentials:
+    def test_invalid_token_maps_401_without_leaking_url(self) -> None:
+        session = MagicMock()
+        session.request.return_value = _FakeResponse(401)
+        with patch.object(polar_module, "_get_polar_session", return_value=session):
+            ok, error = PolarSource().validate_credentials(PolarSourceConfig(polar_api_key="polar_oat_test"), team_id=1)
+        assert ok is False
+        assert error is not None
+        assert "api.polar.sh" not in error
+        assert "invalid or expired" in error


### PR DESCRIPTION
## Problem

When a Polar source failed credential validation at create time, the user saw a raw `requests` HTTP error whose text includes the full probe URL and query string and no guidance. That's an internal error leaking through as user-facing copy.

**Why:** found while triaging failed data-warehouse source-creation attempts. A batch of Polar failures surfaced the raw `401 Client Error: Unauthorized for url: <redacted>` string instead of anything actionable.

## Changes

`PolarSource.validate_credentials` now catches `requests.exceptions.HTTPError` and maps the status code to a clear message:

- `401` → token is invalid or expired, generate a new one and reconnect
- `403` → token is missing the required scopes
- anything else → a generic "unexpected error (HTTP N), try again"

These mirror the messages already defined in `get_non_retryable_errors` for the sync path, so create-time and sync-time failures now read consistently. No probe or sync behavior changes.

## How did you test this code?

Added `test_polar_source.py` with a case that drives the create-probe path to a `401` and asserts the returned message is the friendly one and does **not** contain the probe host. This catches the regression where the raw `raise_for_status()` string reaches the user. There was no existing test file for this source. Ran it locally, green.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a triage pass over data-warehouse source-creation failures, classifying each error as user-misconfiguration (left alone), internal-leak, or product bug. This is an internal-leak fix. Authored by Claude (Claude Code). Invoked the `/writing-tests` skill before adding the test. Scoped to Polar only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
