### PR TITLE
fix(data-warehouse): handle transient Google auth errors in Sheets validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 from django.conf import settings
 
 import gspread
+from google.auth import exceptions as google_auth_exceptions
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
@@ -123,6 +124,15 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
                 False,
                 "Google Sheets could not open this spreadsheet. Please check the URL and that it is shared "
                 "with our service account as described at https://posthog.com/docs/cdp/sources/google-sheets",
+            )
+        except (google_auth_exceptions.RefreshError, google_auth_exceptions.TransportError):
+            # A transient failure fetching the service-account OAuth token (Google's token endpoint
+            # 5xx-ing) surfaces here rather than as a gspread APIError. Its str() is a raw server
+            # message like "A server error occurred." with nothing for the user to act on.
+            return (
+                False,
+                "PostHog couldn't verify access to your Google Sheet right now because Google returned a "
+                "temporary error. Please try again in a moment.",
             )
         except Exception as e:
             return False, str(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -125,14 +125,22 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
                 "Google Sheets could not open this spreadsheet. Please check the URL and that it is shared "
                 "with our service account as described at https://posthog.com/docs/cdp/sources/google-sheets",
             )
-        except (google_auth_exceptions.RefreshError, google_auth_exceptions.TransportError):
-            # A transient failure fetching the service-account OAuth token (Google's token endpoint
-            # 5xx-ing) surfaces here rather than as a gspread APIError. Its str() is a raw server
-            # message like "A server error occurred." with nothing for the user to act on.
+        except (google_auth_exceptions.RefreshError, google_auth_exceptions.TransportError) as e:
+            # These come from fetching PostHog's own service-account OAuth token (the user only shares
+            # their sheet with our service account), not from the user's credentials. google-auth flags
+            # a transient Google-side blip as retryable; its str() is otherwise a raw server message like
+            # "A server error occurred." A non-retryable failure (e.g. invalid_grant from a rotated key)
+            # is a persistent problem on our side, so don't dress it up as merely temporary.
+            if getattr(e, "retryable", False):
+                return (
+                    False,
+                    "PostHog couldn't verify access to your Google Sheet right now because Google returned a "
+                    "temporary error. Please try again in a moment.",
+                )
             return (
                 False,
-                "PostHog couldn't verify access to your Google Sheet right now because Google returned a "
-                "temporary error. Please try again in a moment.",
+                "PostHog couldn't authenticate with Google to verify access to your Google Sheet. This looks "
+                "like a problem on our side, so please contact support if it keeps happening.",
             )
         except Exception as e:
             return False, str(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -582,13 +582,17 @@ def test_validate_credentials_maps_api_error_to_friendly_message(api_message, ex
 
 
 @pytest.mark.parametrize(
-    "auth_error",
+    "auth_error,expect_retry_hint",
     [
-        google_auth_exceptions.RefreshError("A server error occurred."),
-        google_auth_exceptions.TransportError("A server error occurred."),
+        # Transient Google-side blip (token endpoint 5xx) — google-auth flags it retryable.
+        (google_auth_exceptions.RefreshError("A server error occurred.", retryable=True), True),
+        (google_auth_exceptions.TransportError("connection reset", retryable=True), True),
+        # Persistent problem with our own service-account key (e.g. invalid_grant) — not retryable,
+        # so the copy must not tell the user it's merely temporary.
+        (google_auth_exceptions.RefreshError({"error": "invalid_grant"}, retryable=False), False),
     ],
 )
-def test_validate_credentials_maps_transient_google_auth_error(auth_error):
+def test_validate_credentials_maps_google_auth_error(auth_error, expect_retry_hint):
     with mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.source.google_sheets_client"
     ) as mock_client:
@@ -599,4 +603,7 @@ def test_validate_credentials_maps_transient_google_auth_error(auth_error):
     assert is_valid is False
     # The raw Google token-endpoint message ("A server error occurred.") must not reach the user.
     assert "A server error occurred." not in (error_message or "")
-    assert "try again" in (error_message or "").lower()
+    if expect_retry_hint:
+        assert "try again in a moment" in (error_message or "").lower()
+    else:
+        assert "try again in a moment" not in (error_message or "").lower()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import gspread
 import requests
+from google.auth import exceptions as google_auth_exceptions
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GoogleSheetsSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets import (
@@ -578,3 +579,24 @@ def test_validate_credentials_maps_api_error_to_friendly_message(api_message, ex
     assert expected_fragment in (error_message or "")
     # The raw gspread "APIError: [400]: ..." dump must not reach the user.
     assert "APIError" not in (error_message or "")
+
+
+@pytest.mark.parametrize(
+    "auth_error",
+    [
+        google_auth_exceptions.RefreshError("A server error occurred."),
+        google_auth_exceptions.TransportError("A server error occurred."),
+    ],
+)
+def test_validate_credentials_maps_transient_google_auth_error(auth_error):
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.source.google_sheets_client"
+    ) as mock_client:
+        mock_client.return_value.open_by_url.side_effect = auth_error
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+        is_valid, error_message = GoogleSheetsSource().validate_credentials(config, team_id=1)
+
+    assert is_valid is False
+    # The raw Google token-endpoint message ("A server error occurred.") must not reach the user.
+    assert "A server error occurred." not in (error_message or "")
+    assert "try again" in (error_message or "").lower()


### PR DESCRIPTION
## Problem

Connecting a Google Sheets source sometimes failed with a bare, unactionable message surfaced straight from Google. When Google's OAuth token endpoint returns a transient 5xx while google-auth fetches the service-account token, it raises a `RefreshError`/`TransportError` whose text is a raw server string. That happens *inside* `open_by_url`, so it skips the gspread `APIError` branch and lands in the catch-all, which returned `str(e)` verbatim to the user.

**Why:** found while triaging failed data-warehouse source-creation attempts. A batch of Google Sheets failures showed a generic server-error string with no next step.

## Changes

`GoogleSheetsSource.validate_credentials` now catches `google.auth.exceptions.RefreshError` and `TransportError` and returns a short retry hint, instead of leaking the raw Google token-endpoint message. gspread `APIError`, `PermissionError`, and `SpreadsheetNotFound` handling is unchanged.

## How did you test this code?

Added a parameterized case to the existing validate-credentials tests that raises each transient auth error from `open_by_url` and asserts the raw server message does not reach the user and the copy tells them to retry. No existing case covered the google-auth error path (the others cover gspread `APIError`). Ran the validate-credentials tests locally, green.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a triage pass over data-warehouse source-creation failures, classifying each error as user-misconfiguration (left alone), internal-leak, or product bug. This is an internal-leak fix. Authored by Claude (Claude Code). Invoked the `/writing-tests` skill before adding the test. Scoped to Google Sheets only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
