### PR TITLE
fix(actions): stop remounting property filters on every match group keystroke

### DIFF
--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -334,7 +334,10 @@ export function ActionEdit({ action: loadedAction, id, actionLoading, attachTo }
                                     {({ value: stepsValue, onChange }) => (
                                         <div className="@container grid @4xl:grid-cols-2 gap-3">
                                             {stepsValue.map((step: ActionStepType, index: number) => {
-                                                const identifier = String(JSON.stringify(step))
+                                                // stable per-position key: deriving it from the step's content would
+                                                // remount the PropertyFilters subtree (and its kea logics) on every
+                                                // keystroke; propertyFilterLogic syncs content changes via propsChanged
+                                                const identifier = `action-${action.id || 'new'}-step-${index}`
                                                 return (
                                                     <ActionStep
                                                         key={index}


### PR DESCRIPTION
## Problem

We track detached DOM elements as a proxy for frontend memory pressure. The latest per-path digest showed `/data-management/actions/new` regressing (~7% p90). The proximate cause is pre-existing: `ActionEdit` derives each match group's `identifier` from `JSON.stringify(step)` and passes it as `pageKey` into `PropertyFilters`. `propertyFilterLogic` keys on `pageKey`, so **every keystroke in a match group produces a new kea key and remounts the entire PropertyFilters/TaxonomicFilter subtree** (popovers, portals, comboboxes all orphaned per character typed). #68983 added a new typing surface (multi screen-name input) that exercises this harder, which lines up with the regression window.

## Changes

- Derive the step `identifier` from the action id + step position (`action-<id>-step-<index>`) instead of the step's serialized content, so the property filter logic and its DOM survive edits.

This is safe because `propertyFilterLogic` already re-syncs filter content via `propsChanged` (deep-equality check on `props.propertyFilters`) - the content-derived key was never load-bearing for keeping the UI in sync. `ScreenNameField`'s once-seeded operator state is also unaffected: it's conditionally rendered on `step.event === '$screen'`, so it still remounts on event-type changes regardless of this key. As a bonus, the stable key fixes the operator snapping back to the default mid-edit, since the field no longer remounts per keystroke.

## How did you test this code?

Existing lint/format pass; `hogli ci:preflight --strict` clean. No new test: the only realistic regression is reverting this one-line key derivation, and observing it requires a full `ActionEdit` render with the TaxonomicFilter's large DOM - an expensive, flake-prone jsdom test to guard a single expression that now carries an explanatory comment. Manual verification (typing in a match group and confirming the filter UI no longer flickers/remounts) is worth doing on review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session) directed by Paul, as part of the ongoing detached-elements reduction program (follows #69250).
- Skills invoked: /writing-tests (concluded no new test earns its cost here - reasoning above).
- Verified before changing: read `propertyFilterLogic` to confirm `propsChanged` re-syncs filters with a stable key, and confirmed `ScreenNameField` relies on conditional rendering (not this key) for its remount-on-type-change assumption.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*