### PR TITLE
fix(persons): stop per-render rebuild churn on the person scene

### DIFF
--- a/frontend/src/scenes/groups/RelatedGroups.tsx
+++ b/frontend/src/scenes/groups/RelatedGroups.tsx
@@ -1,4 +1,5 @@
 import { useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { IconPerson } from '@posthog/icons'
 import { LemonTag, Tooltip } from '@posthog/lemon-ui'
@@ -45,52 +46,60 @@ export function RelatedGroups({
     const { relatedActors, relatedPeople, relatedActorsLoading } = useValues(relatedGroupsLogic({ groupTypeIndex, id }))
     const { aggregationLabel } = useValues(groupsModel)
 
-    const extraGroups = (extraActors ?? []).filter((extra) => !relatedActors.some((actor) => actor.id === extra.id))
-    const dataSource = type === 'person' ? relatedPeople : [...relatedActors, ...extraGroups]
+    const dataSource = useMemo(() => {
+        if (type === 'person') {
+            return relatedPeople
+        }
+        const extraGroups = (extraActors ?? []).filter((extra) => !relatedActors.some((actor) => actor.id === extra.id))
+        return [...relatedActors, ...extraGroups]
+    }, [type, relatedPeople, relatedActors, extraActors])
 
-    const columns: LemonTableColumns<ActorType> = [
-        {
-            title: 'Type',
-            key: 'type',
-            render: function RenderActor(_, actor: ActorType) {
-                if (actor.type === 'group') {
-                    return <>{capitalizeFirstLetter(aggregationLabel(actor.group_type_index).singular)}</>
-                }
-                return (
-                    <>
-                        <IconPerson /> Person
-                    </>
-                )
-            },
-        },
-        {
-            title: 'id',
-            key: 'id',
-            render: function RenderActor(_, actor: ActorType) {
-                if (actor.type === 'group') {
-                    const isHighlighted = highlightGroupKey != null && actor.group_key === highlightGroupKey
+    const columns: LemonTableColumns<ActorType> = useMemo(
+        () => [
+            {
+                title: 'Type',
+                key: 'type',
+                render: function RenderActor(_, actor: ActorType) {
+                    if (actor.type === 'group') {
+                        return <>{capitalizeFirstLetter(aggregationLabel(actor.group_type_index).singular)}</>
+                    }
                     return (
-                        <div className="flex items-center gap-2">
-                            <GroupActorDisplay actor={actor} />
-                            {isHighlighted && highlightLabel && (
-                                <LemonTag type="muted" size="small">
-                                    {highlightLabel}
-                                </LemonTag>
-                            )}
-                            {isHighlighted && highlightStale && (
-                                <Tooltip title={highlightStaleTooltip}>
-                                    <LemonTag type="warning" size="small">
-                                        Stale
-                                    </LemonTag>
-                                </Tooltip>
-                            )}
-                        </div>
+                        <>
+                            <IconPerson /> Person
+                        </>
                     )
-                }
-                return <PersonDisplay person={actor} withIcon={false} />
+                },
             },
-        },
-    ]
+            {
+                title: 'id',
+                key: 'id',
+                render: function RenderActor(_, actor: ActorType) {
+                    if (actor.type === 'group') {
+                        const isHighlighted = highlightGroupKey != null && actor.group_key === highlightGroupKey
+                        return (
+                            <div className="flex items-center gap-2">
+                                <GroupActorDisplay actor={actor} />
+                                {isHighlighted && highlightLabel && (
+                                    <LemonTag type="muted" size="small">
+                                        {highlightLabel}
+                                    </LemonTag>
+                                )}
+                                {isHighlighted && highlightStale && (
+                                    <Tooltip title={highlightStaleTooltip}>
+                                        <LemonTag type="warning" size="small">
+                                            Stale
+                                        </LemonTag>
+                                    </Tooltip>
+                                )}
+                            </div>
+                        )
+                    }
+                    return <PersonDisplay person={actor} withIcon={false} />
+                },
+            },
+        ],
+        [aggregationLabel, highlightGroupKey, highlightLabel, highlightStale, highlightStaleTooltip]
+    )
 
     const nouns: [string, string] =
         type === 'person' ? ['related person', 'related people'] : ['related group', 'related groups']

--- a/frontend/src/scenes/persons/PersonProfileCanvas.tsx
+++ b/frontend/src/scenes/persons/PersonProfileCanvas.tsx
@@ -30,31 +30,35 @@ const PersonProfileCanvas = ({ person, attachTo }: PersonProfileCanvasProps): JS
         }),
         [id, person.distinct_ids]
     )
-    const customerProfileLogicProps = {
-        attrs,
-        scope: CustomerProfileScope.PERSON,
-        key: `person-${id}`,
-        canvasShortId: shortId,
-    }
+    const customerProfileLogicProps = useMemo(
+        () => ({
+            attrs,
+            scope: CustomerProfileScope.PERSON,
+            key: `person-${id}`,
+            canvasShortId: shortId,
+        }),
+        [attrs, id, shortId]
+    )
     const { content } = useValues(customerProfileLogic(customerProfileLogicProps))
-
-    const personFilter: AnyPropertyFilter[] = [
-        {
-            type: PropertyFilterType.EventMetadata,
-            key: 'person_id',
-            value: id,
-            operator: PropertyOperator.Exact,
-        },
-    ]
 
     useOnMountEffect(() => {
         reportPersonProfileViewed()
     })
-    const notebookLogicProps: NotebookLogicProps = {
-        shortId,
-        mode,
-        canvasFiltersOverride: personFilter,
-    }
+    const notebookLogicProps: NotebookLogicProps = useMemo(() => {
+        const personFilter: AnyPropertyFilter[] = [
+            {
+                type: PropertyFilterType.EventMetadata,
+                key: 'person_id',
+                value: id,
+                operator: PropertyOperator.Exact,
+            },
+        ]
+        return {
+            shortId,
+            mode,
+            canvasFiltersOverride: personFilter,
+        }
+    }, [id, shortId, mode])
     const mountedNotebookLogic = notebookLogic(notebookLogicProps)
     useAttachedLogic(mountedNotebookLogic, attachTo)
 

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -1,4 +1,5 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
+import { memo } from 'react'
 
 import { IconChevronDown, IconCopy, IconInfo, IconRefresh, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, LemonDivider, LemonMenu, LemonSelect, LemonTag, Link } from '@posthog/lemon-ui'
@@ -452,54 +453,14 @@ export function PersonScene(): JSX.Element | null {
                               key: PersonsTabType.FEATURE_FLAGS,
                               tooltip: `Only shows feature flags with targeting conditions based on person properties.`,
                               label: <span data-attr="persons-related-flags-tab">Feature flags</span>,
-                              content: (() => {
-                                  const selectedDistinctId = distinctId || primaryDistinctId
-                                  return (
-                                      <>
-                                          <div className="flex deprecated-space-x-2 items-center mb-2">
-                                              <div className="flex items-center">
-                                                  Choose ID:
-                                                  <Tooltip
-                                                      docLink="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
-                                                      title={
-                                                          <div className="deprecated-space-y-2">
-                                                              <div>
-                                                                  Feature flags values can depend on a person's distinct
-                                                                  ID.
-                                                              </div>
-                                                              <div>
-                                                                  If you want your flag values to stay consistent for
-                                                                  each user, you can enable flag persistence in the
-                                                                  feature flag settings.
-                                                              </div>
-                                                              <div>
-                                                                  This option may depend on your specific setup and
-                                                                  isn't always suitable.
-                                                              </div>
-                                                          </div>
-                                                      }
-                                                  >
-                                                      <IconInfo className="ml-1 text-base" />
-                                                  </Tooltip>
-                                              </div>
-                                              <LemonSelect
-                                                  value={selectedDistinctId}
-                                                  onChange={(value) => value && setDistinctId(value)}
-                                                  options={person.distinct_ids.map((distinct_id) => ({
-                                                      label: distinct_id,
-                                                      value: distinct_id,
-                                                  }))}
-                                                  data-attr="person-feature-flags-select"
-                                              />
-                                              {selectedDistinctId && (
-                                                  <LaunchToolbarButton distinctId={selectedDistinctId} />
-                                              )}
-                                          </div>
-                                          <LemonDivider className="mb-4" />
-                                          <RelatedFeatureFlags distinctId={selectedDistinctId} />
-                                      </>
-                                  )
-                              })(),
+                              content: (
+                                  <PersonFeatureFlagsTab
+                                      person={person}
+                                      distinctId={distinctId}
+                                      primaryDistinctId={primaryDistinctId}
+                                      setDistinctId={setDistinctId}
+                                  />
+                              ),
                           }
                         : false,
                     {
@@ -525,6 +486,57 @@ export function PersonScene(): JSX.Element | null {
         </SceneContent>
     )
 }
+
+// memoized with stable props so edits elsewhere in the scene don't re-render the mounted tab
+const PersonFeatureFlagsTab = memo(function PersonFeatureFlagsTab({
+    person,
+    distinctId,
+    primaryDistinctId,
+    setDistinctId,
+}: {
+    person: PersonType
+    distinctId: string | null
+    primaryDistinctId: string | null
+    setDistinctId: (distinctId: string) => void
+}): JSX.Element {
+    const selectedDistinctId = distinctId || primaryDistinctId
+    return (
+        <>
+            <div className="flex deprecated-space-x-2 items-center mb-2">
+                <div className="flex items-center">
+                    Choose ID:
+                    <Tooltip
+                        docLink="https://posthog.com/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps"
+                        title={
+                            <div className="deprecated-space-y-2">
+                                <div>Feature flags values can depend on a person's distinct ID.</div>
+                                <div>
+                                    If you want your flag values to stay consistent for each user, you can enable flag
+                                    persistence in the feature flag settings.
+                                </div>
+                                <div>This option may depend on your specific setup and isn't always suitable.</div>
+                            </div>
+                        }
+                    >
+                        <IconInfo className="ml-1 text-base" />
+                    </Tooltip>
+                </div>
+                <LemonSelect
+                    value={selectedDistinctId}
+                    onChange={(value) => value && setDistinctId(value)}
+                    options={person.distinct_ids.map((distinct_id) => ({
+                        label: distinct_id,
+                        value: distinct_id,
+                    }))}
+                    data-attr="person-feature-flags-select"
+                />
+                {selectedDistinctId && <LaunchToolbarButton distinctId={selectedDistinctId} />}
+            </div>
+            <LemonDivider className="mb-4" />
+            <RelatedFeatureFlags distinctId={selectedDistinctId} />
+        </>
+    )
+})
 
 function OpenInAdminPanelButton({ size = 'small' }: { size?: LemonButtonProps['size'] }): JSX.Element {
     const { person } = useValues(personsLogic)

--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -36,115 +36,115 @@ const featureFlagMatchMapping = {
     [FeatureFlagMatchReason.Disabled]: 'Disabled',
 }
 
+const columns: LemonTableColumns<RelatedFeatureFlag> = [
+    {
+        title: 'Key',
+        dataIndex: 'key',
+        className: 'ph-no-capture',
+        sticky: true,
+        width: '40%',
+        sorter: (a: RelatedFeatureFlag, b: RelatedFeatureFlag) => (a.key || '').localeCompare(b.key || ''),
+        render: function Render(_, featureFlag: RelatedFeatureFlag) {
+            const isExperiment = (featureFlag.experiment_set || []).length > 0
+            return (
+                <LemonTableLink
+                    to={featureFlag.id ? urls.featureFlag(featureFlag.id) : undefined}
+                    title={
+                        <>
+                            {stringWithWBR(featureFlag.key, 17)}
+                            <LemonTag type={isExperiment ? 'completion' : 'default'} className="ml-2">
+                                {isExperiment ? 'Experiment' : 'Feature flag'}
+                            </LemonTag>
+                        </>
+                    }
+                    description={featureFlag.name}
+                />
+            )
+        },
+    },
+    {
+        title: 'Type',
+        width: 100,
+        render: function Render(_, featureFlag: RelatedFeatureFlag) {
+            return featureFlag.filters.multivariate
+                ? FeatureFlagReleaseType.Variants
+                : FeatureFlagReleaseType.ReleaseToggle
+        },
+    },
+    {
+        title: 'Value',
+        dataIndex: 'value',
+        width: 150,
+        render: function Render(_, featureFlag: RelatedFeatureFlag) {
+            return (
+                <div className="break-words">
+                    {featureFlag.active && featureFlag.value ? featureFlag.value.toString() : 'false'}
+                </div>
+            )
+        },
+    },
+    {
+        title: (
+            <div className="inline-flex items-center deprecated-space-x-1">
+                <div>Match evaluation</div>
+                <Tooltip
+                    docLink="https://posthog.com/docs/feature-flags/local-evaluation#step-3-evaluate-your-feature-flag"
+                    title={
+                        <div className="deprecated-space-y-2">
+                            <div>
+                                This column simulates the feature flag evaluation based on the selected distinct ID,
+                                current properties, and groups associated with the user. If the actual flag value
+                                differs, it could be due to different inputs used during evaluation.
+                            </div>
+                            <div>
+                                If you are using local flag evaluation, you must ensure that you provide any person
+                                properties, groups, or group properties used to evaluate the release conditions of the
+                                flag.
+                            </div>
+                        </div>
+                    }
+                >
+                    <IconInfo className="text-secondary text-base ml-1" />
+                </Tooltip>
+            </div>
+        ),
+        dataIndex: 'evaluation',
+        width: 150,
+        render: function Render(_, featureFlag: RelatedFeatureFlag) {
+            const matchesSet = featureFlag.evaluation.reason === FeatureFlagMatchReason.ConditionMatch
+            return (
+                <div>
+                    {featureFlag.active ? <>{featureFlagMatchMapping[featureFlag.evaluation.reason]}</> : '--'}
+
+                    {matchesSet && <LemonSnack>Set {(featureFlag.evaluation.condition_index ?? 0) + 1}</LemonSnack>}
+                </div>
+            )
+        },
+    },
+    {
+        title: 'Status',
+        dataIndex: 'active',
+        sorter: (a: RelatedFeatureFlag, b: RelatedFeatureFlag) => Number(a.active) - Number(b.active),
+        width: 100,
+        render: function RenderActive(_, featureFlag: RelatedFeatureFlag) {
+            return <span className="font-normal">{featureFlag.active ? 'Enabled' : 'Disabled'}</span>
+        },
+    },
+]
+
+const options = [
+    { label: 'All types', value: 'all' },
+    {
+        label: FeatureFlagReleaseType.ReleaseToggle,
+        value: FeatureFlagReleaseType.ReleaseToggle,
+    },
+    { label: FeatureFlagReleaseType.Variants, value: FeatureFlagReleaseType.Variants },
+]
+
 export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Props): JSX.Element {
     const relatedFlagsLogic = relatedFeatureFlagsLogic({ distinctId, groupTypeIndex, groups })
     const { filteredMappedFlags, isLoading, searchTerm, filters, pagination } = useValues(relatedFlagsLogic)
     const { setSearchTerm, setFilters } = useActions(relatedFlagsLogic)
-
-    const columns: LemonTableColumns<RelatedFeatureFlag> = [
-        {
-            title: 'Key',
-            dataIndex: 'key',
-            className: 'ph-no-capture',
-            sticky: true,
-            width: '40%',
-            sorter: (a: RelatedFeatureFlag, b: RelatedFeatureFlag) => (a.key || '').localeCompare(b.key || ''),
-            render: function Render(_, featureFlag: RelatedFeatureFlag) {
-                const isExperiment = (featureFlag.experiment_set || []).length > 0
-                return (
-                    <LemonTableLink
-                        to={featureFlag.id ? urls.featureFlag(featureFlag.id) : undefined}
-                        title={
-                            <>
-                                {stringWithWBR(featureFlag.key, 17)}
-                                <LemonTag type={isExperiment ? 'completion' : 'default'} className="ml-2">
-                                    {isExperiment ? 'Experiment' : 'Feature flag'}
-                                </LemonTag>
-                            </>
-                        }
-                        description={featureFlag.name}
-                    />
-                )
-            },
-        },
-        {
-            title: 'Type',
-            width: 100,
-            render: function Render(_, featureFlag: RelatedFeatureFlag) {
-                return featureFlag.filters.multivariate
-                    ? FeatureFlagReleaseType.Variants
-                    : FeatureFlagReleaseType.ReleaseToggle
-            },
-        },
-        {
-            title: 'Value',
-            dataIndex: 'value',
-            width: 150,
-            render: function Render(_, featureFlag: RelatedFeatureFlag) {
-                return (
-                    <div className="break-words">
-                        {featureFlag.active && featureFlag.value ? featureFlag.value.toString() : 'false'}
-                    </div>
-                )
-            },
-        },
-        {
-            title: (
-                <div className="inline-flex items-center deprecated-space-x-1">
-                    <div>Match evaluation</div>
-                    <Tooltip
-                        docLink="https://posthog.com/docs/feature-flags/local-evaluation#step-3-evaluate-your-feature-flag"
-                        title={
-                            <div className="deprecated-space-y-2">
-                                <div>
-                                    This column simulates the feature flag evaluation based on the selected distinct ID,
-                                    current properties, and groups associated with the user. If the actual flag value
-                                    differs, it could be due to different inputs used during evaluation.
-                                </div>
-                                <div>
-                                    If you are using local flag evaluation, you must ensure that you provide any person
-                                    properties, groups, or group properties used to evaluate the release conditions of
-                                    the flag.
-                                </div>
-                            </div>
-                        }
-                    >
-                        <IconInfo className="text-secondary text-base ml-1" />
-                    </Tooltip>
-                </div>
-            ),
-            dataIndex: 'evaluation',
-            width: 150,
-            render: function Render(_, featureFlag: RelatedFeatureFlag) {
-                const matchesSet = featureFlag.evaluation.reason === FeatureFlagMatchReason.ConditionMatch
-                return (
-                    <div>
-                        {featureFlag.active ? <>{featureFlagMatchMapping[featureFlag.evaluation.reason]}</> : '--'}
-
-                        {matchesSet && <LemonSnack>Set {(featureFlag.evaluation.condition_index ?? 0) + 1}</LemonSnack>}
-                    </div>
-                )
-            },
-        },
-        {
-            title: 'Status',
-            dataIndex: 'active',
-            sorter: (a: RelatedFeatureFlag, b: RelatedFeatureFlag) => Number(a.active) - Number(b.active),
-            width: 100,
-            render: function RenderActive(_, featureFlag: RelatedFeatureFlag) {
-                return <span className="font-normal">{featureFlag.active ? 'Enabled' : 'Disabled'}</span>
-            },
-        },
-    ]
-
-    const options = [
-        { label: 'All types', value: 'all' },
-        {
-            label: FeatureFlagReleaseType.ReleaseToggle,
-            value: FeatureFlagReleaseType.ReleaseToggle,
-        },
-        { label: FeatureFlagReleaseType.Variants, value: FeatureFlagReleaseType.Variants },
-    ]
 
     return (
         <>


### PR DESCRIPTION
## Problem

We track detached DOM elements as a proxy for frontend memory pressure, and the latest per-path digest showed `/person/:id` regressing (~13% p90). No single recent commit explains it - the scene has structural render churn that each newly added tab compounds:

- `RelatedFeatureFlags` and `RelatedGroups` rebuilt their `LemonTable` column arrays (with inline render closures) on every render, so every keystroke in the tab's search box re-derived the whole table.
- The feature flags tab content was built through an inline IIFE inside the `tabs` array, re-running on any scene state change and pushing fresh props into the mounted tab.
- `PersonProfileCanvas` rebuilt `personFilter` and the notebook/customer-profile logic props objects per render.

## Changes

- Hoist `RelatedFeatureFlags` columns and select options to module scope (they capture no component state).
- Memoize `RelatedGroups` columns and `dataSource` with their real dependencies.
- Extract the feature flags tab into a memoized `PersonFeatureFlagsTab` with stable props (kea action refs are stable), so unrelated scene state changes no longer re-render the mounted tab.
- Memoize the logic props objects in `PersonProfileCanvas`.

No behavior change intended anywhere - this is identity stabilization only.

## How did you test this code?

Lint and format pass locally; `hogli ci:preflight --strict` clean on push. Local `typescript:check` can't run meaningfully in this worktree (kea typegen files absent), so CI typecheck is the arbiter - errors reported locally on the touched files are the pre-existing missing-typegen cascade on unchanged expressions. No new tests: these are render-identity refactors with no observable behavior change to assert through a public interface; the existing `relatedFeatureFlagsLogic` and `personsLogic` tests cover the untouched logic layer.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session) directed by Paul, part of the ongoing detached-elements reduction program (follows #69250; sibling PR #70213 covers the actions scene).
- Skills invoked: /writing-tests (concluded no new test earns its cost - reasoning above).
- Considered memoizing the whole `tabs` array in `PersonScene` but rejected it: the dependency list would be most of the scene's state, and only the mounted tab's re-renders matter - the memoized extracted component addresses that directly.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*