### PR TITLE
fix(web-analytics): manage live dashboard timers via kea disposables

### DIFF
--- a/frontend/src/kea-disposables.ts
+++ b/frontend/src/kea-disposables.ts
@@ -13,7 +13,7 @@ type DisposableEntry = {
     options: DisposableOptions
 }
 
-type DisposablesManager = {
+export type DisposablesManager = {
     add: (setup: SetupFunction, key?: string, options?: DisposableOptions) => void
     dispose: (key: string) => boolean
     registry: Map<string, DisposableEntry>

--- a/frontend/src/scenes/activity/live/deduplicateEvents.test.ts
+++ b/frontend/src/scenes/activity/live/deduplicateEvents.test.ts
@@ -1,0 +1,34 @@
+import { LiveEvent } from '~/types'
+
+import { deduplicateEvents } from './deduplicateEvents'
+
+function makeEvent(uuid: string): LiveEvent {
+    return {
+        uuid,
+        event: '$pageview',
+        properties: {},
+        timestamp: '2026-01-01T00:00:00Z',
+        team_id: 1,
+        distinct_id: 'user-1',
+        created_at: '2026-01-01T00:00:00Z',
+    }
+}
+
+describe('deduplicateEvents', () => {
+    it('prepends new events and drops duplicates by uuid', () => {
+        const state = [makeEvent('a')]
+        const result = deduplicateEvents(state, [makeEvent('b'), makeEvent('a')], 10)
+        expect(result.map((e) => e.uuid)).toEqual(['b', 'a'])
+    })
+
+    it('caps the result at the limit', () => {
+        const state = [makeEvent('a'), makeEvent('b')]
+        const result = deduplicateEvents(state, [makeEvent('c')], 2)
+        expect(result.map((e) => e.uuid)).toEqual(['c', 'a'])
+    })
+
+    it('returns the same array reference when the batch contains only duplicates', () => {
+        const state = [makeEvent('a')]
+        expect(deduplicateEvents(state, [makeEvent('a')], 10)).toBe(state)
+    })
+})

--- a/frontend/src/scenes/activity/live/deduplicateEvents.ts
+++ b/frontend/src/scenes/activity/live/deduplicateEvents.ts
@@ -12,5 +12,10 @@ export function deduplicateEvents(state: LiveEvent[], incoming: LiveEvent[], lim
         }
     }
 
+    // duplicate-only batches keep the existing array identity so downstream memoization holds
+    if (newEvents.length === 0) {
+        return state.length > limit ? state.slice(0, limit) : state
+    }
+
     return [...newEvents, ...state].slice(0, limit)
 }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -16,6 +16,7 @@ import { ProductTab } from 'scenes/web-analytics/common'
 import { webAnalyticsFilterLogic } from 'scenes/web-analytics/webAnalyticsFilterLogic'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
+import type { DisposablesManager } from '~/kea-disposables'
 import { performQuery } from '~/queries/query'
 import {
     HogQLQuery,
@@ -393,10 +394,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             cache.batch = []
             cache.geoBatch = []
             stopFlushInterval(cache as FlushCache)
-            if (cache.liveUserCountInterval) {
-                clearInterval(cache.liveUserCountInterval)
-                cache.liveUserCountInterval = null
-            }
+            cache.disposables.dispose('liveUserCountInterval')
         },
         resumeStream: () => {
             if (cache.hasInitialized) {
@@ -406,12 +404,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 })
             }
             startFlushInterval(cache as FlushCache, actions as FlushActions)
-            if (!cache.liveUserCountInterval) {
-                // Drives the "Users online" count so users drop off within ~5s of leaving the 60s window
-                cache.liveUserCountInterval = setInterval(() => {
-                    actions.tickLiveUserCount()
-                }, 5000)
-            }
+            startLiveUserCountInterval(cache as FlushCache, actions as FlushActions)
             actions.loadInitialData()
         },
         loadInitialData: async () => {
@@ -580,30 +573,24 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
 
             // Ensures that our graph continues to update and old data "falls off"
             // even if new events aren't coming in
-            const scheduleNextTick = (): void => {
-                const now = Date.now()
-                const msUntilNextMinute = 60000 - (now % 60000)
-                cache.minuteTickTimeout = setTimeout(() => {
-                    actions.tickCurrentMinute()
-                    scheduleNextTick()
-                }, msUntilNextMinute)
-            }
-            scheduleNextTick()
-            cache.liveUserCountInterval = setInterval(() => {
-                actions.tickLiveUserCount()
-            }, 5000)
+            cache.disposables.add(() => {
+                let minuteTickTimeout: ReturnType<typeof setTimeout>
+                const scheduleNextTick = (): void => {
+                    const now = Date.now()
+                    const msUntilNextMinute = 60000 - (now % 60000)
+                    minuteTickTimeout = setTimeout(() => {
+                        actions.tickCurrentMinute()
+                        scheduleNextTick()
+                    }, msUntilNextMinute)
+                }
+                scheduleNextTick()
+                return () => clearTimeout(minuteTickTimeout)
+            }, 'minuteTick')
+            startLiveUserCountInterval(cache as FlushCache, actions as FlushActions)
         },
         beforeUnmount: () => {
             cache.eventsConnection?.abort()
             cache.geoConnection?.abort()
-            stopFlushInterval(cache as FlushCache)
-            if (cache.minuteTickTimeout) {
-                clearTimeout(cache.minuteTickTimeout)
-            }
-            if (cache.liveUserCountInterval) {
-                clearInterval(cache.liveUserCountInterval)
-                cache.liveUserCountInterval = null
-            }
         },
     })),
 ])
@@ -612,19 +599,25 @@ interface FlushCache {
     batch: LiveEvent[]
     geoBatch: LiveGeoEvent[]
     newerThan: Date
-    flushInterval: ReturnType<typeof setInterval> | null
+    disposables: DisposablesManager
 }
 
 interface FlushActions {
     addEvents: (events: LiveEvent[], newerThan: Date) => void
     addGeoEvents: (events: LiveGeoEvent[]) => void
+    tickLiveUserCount: () => void
 }
 
 const stopFlushInterval = (cache: FlushCache): void => {
-    if (cache.flushInterval) {
-        clearInterval(cache.flushInterval)
-        cache.flushInterval = null
-    }
+    cache.disposables.dispose('flushInterval')
+}
+
+// Drives the "Users online" count so users drop off within ~5s of leaving the 60s window
+const startLiveUserCountInterval = (cache: FlushCache, actions: FlushActions): void => {
+    cache.disposables.add(() => {
+        const intervalId = setInterval(() => actions.tickLiveUserCount(), 5000)
+        return () => clearInterval(intervalId)
+    }, 'liveUserCountInterval')
 }
 
 // Translates the canonical filter list into repeated `?property=key=value` query params
@@ -648,19 +641,19 @@ export const appendFilterParams = (url: URL, filters: WebAnalyticsPropertyFilter
 // Flush both event and geo batches on a fixed interval
 // to cap kea dispatches at a predictable rate regardless of event volume
 const startFlushInterval = (cache: FlushCache, actions: FlushActions): void => {
-    if (cache.flushInterval) {
-        return
-    }
-    cache.flushInterval = setInterval(() => {
-        if (cache.batch.length > 0) {
-            actions.addEvents(cache.batch, cache.newerThan)
-            cache.batch = []
-        }
-        if (cache.geoBatch.length > 0) {
-            actions.addGeoEvents(cache.geoBatch)
-            cache.geoBatch = []
-        }
-    }, FLUSH_INTERVAL_MS)
+    cache.disposables.add(() => {
+        const intervalId = setInterval(() => {
+            if (cache.batch.length > 0) {
+                actions.addEvents(cache.batch, cache.newerThan)
+                cache.batch = []
+            }
+            if (cache.geoBatch.length > 0) {
+                actions.addGeoEvents(cache.geoBatch)
+                cache.geoBatch = []
+            }
+        }, FLUSH_INTERVAL_MS)
+        return () => clearInterval(intervalId)
+    }, 'flushInterval')
 }
 
 const loadQueryData = async ({

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
@@ -3,6 +3,8 @@ import { actions, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { getSeriesColor } from 'lib/colors'
 import { COUNTRY_CODE_TO_LONG_NAME, countryCodeToFlag } from 'lib/utils/country'
 
+import type { DisposablesManager } from '~/kea-disposables'
+
 import { CountryBreakdownItem } from './LiveWebAnalyticsMetricsTypes'
 import type { liveWorldMapLogicType } from './liveWorldMapLogicType'
 
@@ -175,9 +177,6 @@ export const liveWorldMapLogic = kea<liveWorldMapLogicType>([
             cache.prevCounts = {}
             cache.lastActivity = {}
         },
-        beforeUnmount: () => {
-            stopHeatInterval(cache as HeatCache)
-        },
     })),
 ])
 
@@ -198,7 +197,8 @@ function computeHeat(lastActivity: Record<string, number>): Record<string, numbe
 
 interface HeatCache {
     lastActivity: Record<string, number>
-    heatInterval: ReturnType<typeof setInterval> | null
+    heatIntervalRunning?: boolean
+    disposables: DisposablesManager
 }
 
 // Only run the heat decay interval while there are active heat values.
@@ -207,23 +207,25 @@ function startHeatInterval(
     cache: HeatCache,
     actions: { setCountryHeat: (heat: Record<string, number>) => void }
 ): void {
-    if (cache.heatInterval) {
+    if (cache.heatIntervalRunning) {
         return
     }
-    cache.heatInterval = setInterval(() => {
-        const heat = computeHeat(cache.lastActivity || {})
-        if (Object.keys(heat).length === 0) {
-            stopHeatInterval(cache as HeatCache)
-            actions.setCountryHeat({})
-            return
-        }
-        actions.setCountryHeat(heat)
-    }, HEAT_UPDATE_INTERVAL_MS)
+    cache.heatIntervalRunning = true
+    cache.disposables.add(() => {
+        const intervalId = setInterval(() => {
+            const heat = computeHeat(cache.lastActivity || {})
+            if (Object.keys(heat).length === 0) {
+                stopHeatInterval(cache)
+                actions.setCountryHeat({})
+                return
+            }
+            actions.setCountryHeat(heat)
+        }, HEAT_UPDATE_INTERVAL_MS)
+        return () => clearInterval(intervalId)
+    }, 'heatInterval')
 }
 
 function stopHeatInterval(cache: HeatCache): void {
-    if (cache.heatInterval) {
-        clearInterval(cache.heatInterval)
-        cache.heatInterval = null
-    }
+    cache.heatIntervalRunning = false
+    cache.disposables.dispose('heatInterval')
 }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
@@ -197,9 +197,10 @@ function computeHeat(lastActivity: Record<string, number>): Record<string, numbe
 
 interface HeatCache {
     lastActivity: Record<string, number>
-    heatIntervalRunning?: boolean
     disposables: DisposablesManager
 }
+
+const HEAT_INTERVAL_KEY = 'heatInterval'
 
 // Only run the heat decay interval while there are active heat values.
 // Stops automatically when all heat has decayed to 0.
@@ -207,10 +208,9 @@ function startHeatInterval(
     cache: HeatCache,
     actions: { setCountryHeat: (heat: Record<string, number>) => void }
 ): void {
-    if (cache.heatIntervalRunning) {
+    if (cache.disposables.registry.has(HEAT_INTERVAL_KEY)) {
         return
     }
-    cache.heatIntervalRunning = true
     cache.disposables.add(() => {
         const intervalId = setInterval(() => {
             const heat = computeHeat(cache.lastActivity || {})
@@ -222,10 +222,9 @@ function startHeatInterval(
             actions.setCountryHeat(heat)
         }, HEAT_UPDATE_INTERVAL_MS)
         return () => clearInterval(intervalId)
-    }, 'heatInterval')
+    }, HEAT_INTERVAL_KEY)
 }
 
 function stopHeatInterval(cache: HeatCache): void {
-    cache.heatIntervalRunning = false
-    cache.disposables.dispose('heatInterval')
+    cache.disposables.dispose(HEAT_INTERVAL_KEY)
 }


### PR DESCRIPTION
## Problem

We track detached DOM elements as a proxy for frontend memory pressure, and the latest per-path digest showed `/web/live` regressing (~11% p90). Two contributors in the live metrics dashboard:

- The flush, minute-tick, and "users online" timers in `liveWebAnalyticsMetricsLogic` (and the heat-decay timer in `liveWorldMapLogic`) were raw `setInterval`/`setTimeout` handles stashed on the kea `cache`, with cleanup duplicated across `pauseStream`, `beforeUnmount`, and the schedulers themselves. `liveUserCountLogic` one file over already uses the `cache.disposables` pattern, which owns teardown centrally and pauses timers in hidden tabs.
- `deduplicateEvents` rebuilt the recent-events array on every 300ms flush even when the batch contained only duplicates, breaking array identity for downstream memoization each tick.

## Changes

- Migrate all four timers to keyed `cache.disposables` entries. `pauseStream` disposes them, `resumeStream`/`afterMount` (re-)add them, and the plugin handles unmount teardown - the hand-written `beforeUnmount` cleanup shrinks to just the stream connection aborts. Keyed re-adds replace the previous entry, which subsumes the old "already running" guards (the heat interval keeps an explicit running flag so per-flush activity doesn't restart its decay cadence).
- Export the `DisposablesManager` type from `kea-disposables.ts` so the module-level helper functions in these logics can type their cache parameter.
- `deduplicateEvents` returns the existing array reference when a flush adds nothing new.

Timers now also pause in hidden tabs via the plugin's default. That's belt-and-braces here: the dashboard already pauses the whole stream on page hide through `usePageVisibility` -> `pauseStream`, and the disposables registry composes with that (`dispose()` removes the entry; `add()` while hidden registers it paused until the tab is shown).

## How did you test this code?

Ran the live-analytics jest suites (`deduplicateEvents`, `liveEventsLogic`, and all of `LiveMetricsDashboard/`): 7 suites, 116 tests, all passing. Added a small pure-function test for `deduplicateEvents` covering prepend/dedupe, the cap, and the new same-reference-on-duplicate-only-batch behavior - that last case is new behavior nothing covered, and it catches a revert to always-clone that would silently re-break downstream memoization. The timer migration itself is covered by the plugin's existing `kea-disposables` tests rather than new per-logic tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session) directed by Paul, part of the ongoing detached-elements reduction program (follows #69250; sibling PRs #70213 and #70214 cover the actions and person scenes).
- Skills invoked: /using-kea-disposables (pattern and pause semantics), /writing-tests (gate for the new test).
- Read the `disposablesPlugin` source before migrating to confirm the interaction with the existing visibility-driven `pauseStream`/`resumeStream`: `dispose()` fully removes entries so the plugin won't resurrect them on tab-show, and `add()` on a hidden page defers setup until visible.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*