### PR TITLE
feat(insights): migrate the metric insight to the composable quill Metric

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2733,9 +2733,9 @@ snapshots:
     insights-insightstable--sql-breakdown--light:
         hash: v1.k794b7964.710a5fa22da7eff24e97e754426977214d9cdb9fd0252415534110bc7d9bbf95.EmqhUt-YOAWJV1nbFZ2BA-Let9QcaeDgslu9bcPR_mE
     insights-metric--default--dark:
-        hash: v1.k794b7964.1cebe69afb359b708a6769148047246697c99e189310fe55272267130c647782.QYAUjI9RJ3FeBPlsStBw2DGM5gMlabSChpozM9kc48w
+        hash: v1.k794b7964.bdc893ac78b0c99cb12fe2d3fa70346f932cccab0ae49df0d8e47e4740224266.KsZ8mkjoktS-Fzlo_tl1EQBX5t3-L0MWAbrR6yO2yCo
     insights-metric--default--light:
-        hash: v1.k794b7964.f3d7a94051dbeb60fc73755c1f3f96e06db2c7b240a4c9226e153db9d9152403.2nDJVbZQAVhYH4dlA12MNwqdLbHYRdEDFHLUGtFkplY
+        hash: v1.k794b7964.48725db2ac1e33838b543ca02ec02a9531421ae1b72a906e08769203b062878a.FYtwisigBj0inQ6P1fYQm_mYSl94iSjrfM-o0EKI8S8
     insights-paths--edit-scene--dark:
         hash: v1.k794b7964.c10a62416e61fe00c19684959755b06e2a88c87594a1d290d11c9fadcd78fc83.I3vjwPG_Juw_6WMzb3VYtPeeLkGEC6997iPSmY8EbQs
     insights-paths--edit-scene--light:

--- a/frontend/src/scenes/insights/views/Metric/Metric.stories.tsx
+++ b/frontend/src/scenes/insights/views/Metric/Metric.stories.tsx
@@ -5,13 +5,13 @@ import { InsightVizStory } from 'scenes/insights/__mocks__/createInsightVizStory
 
 import __trendsMetric from '~/mocks/fixtures/api/projects/team_id/insights/trendsMetric.json'
 
-import { Metric } from './Metric'
+import { MetricCard } from './Metric'
 
 type Story = StoryObj<{}>
 
 const meta: Meta = {
     title: 'Insights/Metric',
-    component: Metric,
+    component: MetricCard,
     parameters: {
         layout: 'centered',
         mockDate: '2022-04-01',

--- a/frontend/src/scenes/insights/views/Metric/Metric.tsx
+++ b/frontend/src/scenes/insights/views/Metric/Metric.tsx
@@ -1,7 +1,15 @@
 import clsx from 'clsx'
 import { useValues } from 'kea'
 
-import { MetricCard, useChartTheme } from '@posthog/quill-charts'
+import { useChartTheme } from '@posthog/quill-charts'
+import {
+    Metric,
+    MetricDelta,
+    MetricHeader,
+    MetricSparkline,
+    MetricSubtitle,
+    MetricValue,
+} from '@posthog/quill-components/metric'
 
 import { dayjs } from 'lib/dayjs'
 import { hexToRGBA } from 'lib/utils/colors'
@@ -37,7 +45,7 @@ const makeChangeColor = (hex: string): { background: string; foreground: string 
     foreground: hex,
 })
 
-export function Metric({ inCardView }: ChartParams): JSX.Element {
+export function MetricCard({ inCardView }: ChartParams): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { insightData, trendsFilter, interval } = useValues(insightVizDataLogic(insightProps))
     const { incompletenessOffsetFromEnd } = useValues(trendsDataLogic(insightProps))
@@ -89,14 +97,10 @@ export function Metric({ inCardView }: ChartParams): JSX.Element {
 
     return (
         <div className={clsx('Metric ph-no-capture flex flex-col w-full p-2', inCardView && 'flex-1')}>
-            <MetricCard
-                className={inCardView ? 'flex-1' : undefined}
+            <Metric
+                className={clsx('px-0', inCardView && 'flex-1')}
                 sparklineFill={inCardView}
-                // No title — the insight/card header already shows the name.
-                title={null}
                 value={headlineValue}
-                changeSize="md"
-                changeInline
                 change={change}
                 changeTooltip={changeTooltip}
                 hoverChangeFromPreviousPoint
@@ -112,9 +116,16 @@ export function Metric({ inCardView }: ChartParams): JSX.Element {
                 }
                 sparklineDashedFromIndex={dashedFromIndex}
                 sparklineHeight={120}
-                sparklineClassName="mt-4 -mx-2"
                 dataAttr="metric-value"
-            />
+            >
+                {/* No title — the insight/card header already shows the name; the pill sits inline. */}
+                <MetricHeader className="items-center">
+                    <MetricValue />
+                    <MetricDelta className="h-auto gap-1 px-2.5 py-1 text-sm [&>svg]:size-3!" />
+                </MetricHeader>
+                <MetricSubtitle className="mt-1" />
+                <MetricSparkline className="mt-4 -mx-2 -mb-2" />
+            </Metric>
         </div>
     )
 }

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -8,7 +8,7 @@ import { lazyWithRetry } from 'lib/utils/retryImport'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { BoldNumber } from 'scenes/insights/views/BoldNumber'
 import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
-import { Metric } from 'scenes/insights/views/Metric/Metric'
+import { MetricCard } from 'scenes/insights/views/Metric/Metric'
 
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
@@ -116,7 +116,7 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
             return <BoldNumber {...commonProps} />
         }
         if (display === ChartDisplayType.Metric) {
-            return <Metric {...commonProps} />
+            return <MetricCard {...commonProps} />
         }
         if (display === ChartDisplayType.ActionsTable) {
             return (


### PR DESCRIPTION
## Problem

The metric insight renders the legacy monolithic `MetricCard` from `@posthog/quill-charts`. The composable `Metric` in `@posthog/quill-components/metric` is the direction of travel and reached feature parity in #70142 (user-configured pill colors, working change-pill tooltip); the insight should compose it instead.

## Changes

Stacked on #70142.

`frontend/src/scenes/insights/views/Metric/Metric.tsx` swaps `MetricCard` for the composed parts. All data wiring — summary modes, comparison change, labels, dashed in-progress period, axis formatting — is unchanged; only the presentation layer moves:

- `MetricCard`'s `title={null}` + `changeInline` + `changeSize="md"` props become composition: no `MetricTitle`, and a `MetricHeader` row of `MetricValue` + `MetricDelta` with the insight's larger-pill classes passed via `className`
- The scene component keeps the name `MetricCard` (quill's `Metric` is imported un-aliased)

At rest and hovering a period:

![resting](https://raw.githubusercontent.com/PostHog/pr-assets/5758c492740df05eabbe19ea90c6f0d89348db83/2026/07/613df3b2-5007-41cb-a5c3-2874fc211846.png)
![hover](https://raw.githubusercontent.com/PostHog/pr-assets/0ea991fa020d1bdcff07ec77e231bbc990f714db/2026/07/9d7ebd57-0b34-41b7-bb7a-3c15aa2e9b26.png)

The Metric chart type stays gated on the `metric-insight` flag (the flag only gates the picker option; saved insights render regardless).

## How did you test this code?

- Verified in the running app with Playwright: resting/hover states, headline following the hovered point, subtitle swapping to the period label, pill swapping to point-vs-previous, custom pill colors, and the change tooltip opening — no console errors
- The existing `Insights/Metric` story snapshot covers the rendered scene; no new tests, since the change is presentational and the data wiring is untouched

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Split out of #70142 on request so the quill/MCP work and the insight migration review independently.
- The insight's pill sizing intentionally lives at this call site (a `className` on `MetricDelta`) rather than as a quill Badge size variant — the larger pill is an insight need, not a design-system concept.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
