### PR TITLE
fix(insights): stabilize breakdown-cap tooltip hover test

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.test.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.test.tsx
@@ -1,10 +1,17 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, screen, waitFor } from '@testing-library/react'
+import { cleanup, configure, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { buildTrendsQuery, renderInsightPage } from '~/test/insight-testing'
+
+// The disabled-reason copy shows through LemonButton's Tooltip, which has a 400ms open
+// delay. On contended CI shards that delay plus jsdom positioning can exceed the default
+// 1s waitFor budget, so the hover assertions flake. Give them room (and raise the per-test
+// timeout to match, so a single waitFor can't exhaust the 5s default test budget).
+configure({ asyncUtilTimeout: 5000 })
+jest.setTimeout(15000)
 
 jest.mock('lib/components/AutoSizer', () => ({
     AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>


### PR DESCRIPTION
## Problem

`TaxonomicBreakdownFilter › at the trends 3-breakdown cap › surfaces the trends cap explanation on hover` is flaky in CI (Trunk-flagged; observed failing on `master` on 2026-07-10 at 17:57Z). The test hovers the disabled + Breakdown button and asserts the cap copy appears:

```
Unable to find an element with the text: /up to 3 properties/i
```

## Changes

The cap copy (`addBreakdownDisabledReason`) is shown through `LemonButton`'s `Tooltip`, which has a **400ms open delay** (`delayMs = 400`). This test file had no `configure()` call, so `waitFor` used the default **1000ms** poll budget. On a contended CI shard the 400ms real-timer delay plus jsdom floating-ui positioning can exceed 1s, so the hover assertions occasionally miss the tooltip.

Set `asyncUtilTimeout` to 5s and `jest.setTimeout` to 15s — the exact idiom already used by the sibling `TrendsLineChart.test.tsx` for the same "default 1s waitFor too tight on contended shards" reason. Raising the per-test timeout alongside the async budget keeps a single 5s `waitFor` from exhausting the default 5s test budget. Several tests in this file share the same hover-tooltip pattern, so the file-level config covers them all.

No assertion is weakened and nothing masks a hang — the tooltip genuinely appears after a legitimate 400ms delay; the poll window was just mis-sized for a delayed tooltip under load.

## How did you test this code?

Automated only — I could not reproduce the flake locally (20x in isolation all passed; it needs the contended full-shard scheduling that delays the 400ms tooltip timer). The fix is grounded in the CI failure and the tooltip-delay root cause above.

- Ran the full `TaxonomicBreakdownFilter.test.tsx` file 10x with the fix: 10/10 green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Opus) while working a flaky-test backlog. Invoked the repo `/fixing-flaky-tests` skill. Classified from GitHub Actions run data (one master failure on this test), pulled the exact error from the failing shard log, traced the copy to `addBreakdownDisabledReason` → `LemonButton` `disabledReason` → `Tooltip` with `delayMs = 400`, and matched the established `TrendsLineChart.test.tsx` fix pattern. Reproduction was attempted (isolation loop) and did not fire, so validation is analytical plus a 10x green full-file run. Evidence here is a single observed failure, so this is a low-risk timeout-budget adjustment rather than a proven repro fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
