### PR TITLE
fix(data-warehouse): suggest incremental sync when postgres CDC lacks replication permission

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
@@ -62,7 +62,7 @@ def _slot_setup_error_message(exc: Exception) -> str:
             f"Failed to create replication slot: {exc} "
             "The database user lacks permission to create logical replication slots. "
             "Either grant it replication access, or switch these tables to Incremental sync "
-            "instead of CDC — Incremental needs only SELECT permission."
+            "instead of CDC. Incremental needs only SELECT permission."
         )
     return f"Failed to create replication slot: {exc}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/adapter.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal
 
+import psycopg
 import structlog
 
 from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import cdc_error_info
@@ -43,6 +44,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _retry_logger = structlog.get_logger(__name__)
+
+
+def _slot_setup_error_message(exc: Exception) -> str:
+    """User-facing message for a failed slot/publication setup.
+
+    When the failure is a lack of replication privilege — the most common CDC blocker —
+    point at the simplest fix rather than only echoing the raw error: switch the affected
+    tables to Incremental sync, which needs only SELECT.
+    """
+    message = str(exc).lower()
+    is_permission_error = isinstance(exc, psycopg.errors.InsufficientPrivilege) or (
+        "permission denied" in message or "must be superuser" in message
+    )
+    if is_permission_error:
+        return (
+            f"Failed to create replication slot: {exc} "
+            "The database user lacks permission to create logical replication slots. "
+            "Either grant it replication access, or switch these tables to Incremental sync "
+            "instead of CDC — Incremental needs only SELECT permission."
+        )
+    return f"Failed to create replication slot: {exc}"
 
 
 def _split_qualified_table(qualified: str, default_schema: str) -> tuple[str, str]:
@@ -233,7 +255,7 @@ class PostgresCDCAdapter:
                             drop_publication(conn, pub_name)
                 except Exception as rollback_error:
                     logger.exception("Failed to roll back partial CDC slot/publication: %s", rollback_error)
-                return {}, f"Failed to create replication slot: {e}"
+                return {}, _slot_setup_error_message(e)
             return resource_fields, None
 
         # self_managed: the publication is customer-owned; PostHog only creates the slot.
@@ -258,7 +280,7 @@ class PostgresCDCAdapter:
                     drop_slot(conn, slot_name)
             except Exception as rollback_error:
                 logger.exception("Failed to roll back partial self-managed CDC slot: %s", rollback_error)
-            return {}, f"Failed to create replication slot: {e}"
+            return {}, _slot_setup_error_message(e)
         return resource_fields, None
 
     def cleanup_resources(self, source: ExternalDataSource) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
@@ -161,7 +161,9 @@ def _check_replication_role(conn: psycopg.Connection) -> list[str]:
             return [
                 "The database user cannot create logical replication slots. "
                 "Grant one of: REPLICATION attribute (ALTER USER <username> WITH REPLICATION), "
-                "superuser, or membership in rds_replication / rds_superuser on RDS."
+                "superuser, or membership in rds_replication / rds_superuser on RDS. "
+                "If you can't grant replication access, switch these tables to Incremental sync "
+                "instead of CDC — it needs only SELECT permission."
             ]
     return []
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/prerequisite_validator.py
@@ -163,7 +163,7 @@ def _check_replication_role(conn: psycopg.Connection) -> list[str]:
                 "Grant one of: REPLICATION attribute (ALTER USER <username> WITH REPLICATION), "
                 "superuser, or membership in rds_replication / rds_superuser on RDS. "
                 "If you can't grant replication access, switch these tables to Incremental sync "
-                "instead of CDC — it needs only SELECT permission."
+                "instead of CDC. Incremental needs only SELECT permission."
             ]
     return []
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_adapter.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import psycopg.errors
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.adapter import PostgresCDCAdapter
+from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.adapter import (
+    PostgresCDCAdapter,
+    _slot_setup_error_message,
+)
 
 _ADAPTER = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.adapter"
 _POSTGRES = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres"
@@ -166,6 +169,23 @@ class TestSetupResourcesPreflight:
         mock_drop_slot.assert_not_called()
         mock_drop_pub.assert_called_once()
         assert mock_drop_pub.call_args.args[1] == "p"
+
+
+class TestSlotSetupErrorMessage:
+    def test_permission_error_suggests_incremental_sync(self) -> None:
+        error = _slot_setup_error_message(
+            psycopg.errors.InsufficientPrivilege("permission denied to create replication slot")
+        )
+        assert "Incremental sync" in error
+        assert "permission denied to create replication slot" in error
+
+    def test_must_be_superuser_message_suggests_incremental_sync(self) -> None:
+        error = _slot_setup_error_message(Exception("ERROR: must be superuser or replication role"))
+        assert "Incremental sync" in error
+
+    def test_non_permission_error_keeps_raw_message_only(self) -> None:
+        error = _slot_setup_error_message(RuntimeError("connection reset"))
+        assert error == "Failed to create replication slot: connection reset"
 
 
 class TestRecreateSlot:


### PR DESCRIPTION
## Problem

Session recordings of the data-warehouse new-source flow show users hitting the same wall when connecting a Postgres source with CDC (Change Data Capture): slot creation fails because the connecting role can't create a logical replication slot. The error only echoed the raw permission failure (or listed GRANT statements), so users had to discover on their own that switching the tables to Incremental sync clears the blocker. Multiple users independently found that workaround the hard way.

## Changes

When the CDC slot/publication setup fails for lack of replication privilege, the message now names the simplest fix: switch the affected tables to Incremental sync, which needs only SELECT permission. This covers both places the friction surfaces:

- The pre-creation prerequisite check (`_check_replication_role`), which already explained how to grant replication, now adds the Incremental fallback.
- The runtime slot-setup failure path, which previously returned only `Failed to create replication slot: <raw error>`, now appends the actionable hint when the underlying error is a permission problem. Non-permission failures keep the raw message unchanged.

No sync behaviour or schema changes - copy only.

## How did you test this code?

Added unit tests for the new message helper (permission error surfaces the Incremental hint, superuser-role error surfaces it, generic error keeps the raw message only). Ran the CDC adapter and prerequisite-validator test suites locally - 15 passed. I (Claude) did not manually exercise the live Postgres onboarding flow.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code while synthesising friction themes from Replay Vision scans of the new-source onboarding flow. The recurring, high-confidence theme was the CDC replication-permission blocker with a known safe workaround (Incremental sync), so this PR surfaces that workaround in the error copy. Other themes seen in the scans (connectors only available as "coming soon", already-thorough Google Search Console and Stripe error messages) were left as recommendations rather than changes, since they need product decisions or are already handled.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
