### PR TITLE
fix(experiments): freeze clock in metricQueryUtils getQuery tests

### DIFF
--- a/frontend/src/scenes/experiments/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/metricQueryUtils.test.ts
@@ -26,6 +26,18 @@ import {
     getQuery,
 } from './metricQueryUtils'
 
+// getQuery builds date_from/date_to from dayjs() at call time, formatted to the minute.
+// The expected values below recompute dayjs() independently, so a minute rollover between
+// the two reads makes the strings differ and toEqual flakes. Freeze the clock (no
+// advanceTimers, so it cannot move) to make both reads resolve to the same instant.
+beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-15T12:00:00'))
+})
+
+afterAll(() => {
+    jest.useRealTimers()
+})
+
 describe('getFilter', () => {
     it('returns the correct filter for an event', () => {
         const metric: ExperimentMetric = {


### PR DESCRIPTION
## Problem

`metricQueryUtils.test.ts` is auto-quarantined as flaky by Trunk (e.g. `getQuery returns the correct query for a mean metric with sum math type`). The `getQuery` tests compare a query object whose `date_from`/`date_to` are built from `dayjs()`.

## Changes

`getQuery` (in `metricQueryUtils.ts`) computes the default date range at call time:

```ts
date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
```

Each `getQuery` test recomputes the identical `dayjs()` expressions independently in its expected value. Both are formatted to the **minute**. When a minute rollover falls between `getQuery`'s internal `dayjs()` read and the test's read, the two minute strings differ (e.g. `12:34` vs `12:35`) and `toEqual` fails. Seven tests in the file share this pattern — a rare (~ms-per-minute) timing race, exactly the profile of an auto-quarantined flake.

Freeze the system clock file-wide with fake timers at a fixed midday instant so both reads resolve to the same time. Deliberately **not** using `advanceTimers` — the clock must not move, or the race persists. The freeze is harmless to the file's other (pure, date-independent) describe blocks.

## How did you test this code?

- **Deterministically demonstrated the mechanism**: a scratch test froze the clock at `:59.999`, read the `date_from` expression (as `getQuery` does), advanced ~2ms across the minute boundary, and read it again (as the test's expected value does) — the two minute strings differed, which is precisely what makes `toEqual` fail. (Scratch test removed; not part of this PR.)
- Ran the full `metricQueryUtils.test.ts` file 10x with the freeze: 10/10 green, no impact on the non-date describe blocks.

The natural flake rate is far too low to catch in a practical repro loop, so validation is the deterministic mechanism demonstration above plus the frozen-clock fix that removes the nondeterminism at its source.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Opus) working a flaky-test backlog. Pulled the quarantined-test list from Trunk's `list-quarantined-tests` REST API (998 auto-quarantined tests), filtered to frontend, and picked this one because a *pure-function* test flaking points to a definite nondeterminism (here: unfrozen `dayjs()`) rather than an environment race. Invoked the repo `/fixing-flaky-tests` skill. Fix follows the existing `LemonCalendarSelect.test.tsx` fake-timers idiom, adjusted to a frozen (non-advancing) clock so the minute-precision reads can't diverge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
