### PR TITLE
chore(tests): stop signals emit fixture leaking committed orgs across product suites

### DIFF
--- a/products/signals/backend/test/test_scout_harness_tools.py
+++ b/products/signals/backend/test/test_scout_harness_tools.py
@@ -700,7 +700,12 @@ async def aorganization_emit():
     org = await database_sync_to_async(Organization.objects.create)(
         name="signals-scout-emit", is_ai_data_processing_approved=True
     )
-    return org
+    yield org
+    # database_sync_to_async writes commit on an executor-thread connection, outside the
+    # test's transaction, so this delete is the only cleanup these rows get. Without it every
+    # emit test leaks a committed org into the shared --reuse-db database and poisons later
+    # product suites in the same CI job (cascade also removes the team/config/run fixtures).
+    await database_sync_to_async(org.delete)()
 
 
 @pytest_asyncio.fixture

--- a/products/web_analytics/backend/test/test_digest_notification_activities.py
+++ b/products/web_analytics/backend/test/test_digest_notification_activities.py
@@ -384,9 +384,12 @@ class TestGetOrgBatchPage(_DigestNotificationTestBase):
         assert page.cursor is None
 
     def test_keyset_pagination_pages_through_orgs(self):
-        orgs = [self.organization]
-        orgs.extend(Organization.objects.create(name=f"Org {i}") for i in range(4))
-        expected_ids = sorted(str(org.id) for org in orgs)
+        for i in range(4):
+            Organization.objects.create(name=f"Org {i}")
+        # Expected ids come from the database rather than just the orgs created above:
+        # committed strays from earlier suites can survive in CI's shared --reuse-db
+        # database, and pagination pages over whatever exists.
+        expected_ids = sorted(str(oid) for oid in Organization.objects.values_list("id", flat=True))
 
         first_page = _get_org_batch_page(
             OrgBatchPageInput(workflow_input=WADigestNotificationInput(batch_size=2), page_size=2)

--- a/products/web_analytics/backend/test/test_weekly_digest_activities.py
+++ b/products/web_analytics/backend/test/test_weekly_digest_activities.py
@@ -374,9 +374,12 @@ class TestGetOrgBatchPage(APIBaseTest):
         assert page.cursor is None
 
     def test_keyset_pagination_returns_first_middle_and_final_pages(self):
-        orgs = [self.organization]
-        orgs.extend(Organization.objects.create(name=f"Org {i}") for i in range(4))
-        expected_ids = sorted(str(org.id) for org in orgs)
+        for i in range(4):
+            Organization.objects.create(name=f"Org {i}")
+        # Expected ids come from the database rather than just the orgs created above:
+        # committed strays from earlier suites can survive in CI's shared --reuse-db
+        # database, and pagination pages over whatever exists.
+        expected_ids = sorted(str(oid) for oid in Organization.objects.values_list("id", flat=True))
 
         first_page = _get_org_batch_page(
             OrgBatchPageInput(
@@ -387,25 +390,20 @@ class TestGetOrgBatchPage(APIBaseTest):
         assert [oid for batch in first_page.batches for oid in batch] == expected_ids[:2]
         assert first_page.cursor == expected_ids[1]
 
-        middle_page = _get_org_batch_page(
-            OrgBatchPageInput(
-                workflow_input=WAWeeklyDigestInput(active_since_days=None, batch_size=2),
-                cursor=first_page.cursor,
-                page_size=2,
+        final_ids: list[str] = []
+        cursor: str | None = first_page.cursor
+        while cursor is not None:
+            page = _get_org_batch_page(
+                OrgBatchPageInput(
+                    workflow_input=WAWeeklyDigestInput(active_since_days=None, batch_size=2),
+                    cursor=cursor,
+                    page_size=2,
+                )
             )
-        )
-        assert [oid for batch in middle_page.batches for oid in batch] == expected_ids[2:4]
-        assert middle_page.cursor == expected_ids[3]
+            final_ids.extend(oid for batch in page.batches for oid in batch)
+            cursor = page.cursor
 
-        final_page = _get_org_batch_page(
-            OrgBatchPageInput(
-                workflow_input=WAWeeklyDigestInput(active_since_days=None, batch_size=2),
-                cursor=middle_page.cursor,
-                page_size=2,
-            )
-        )
-        assert [oid for batch in final_page.batches for oid in batch] == expected_ids[4:]
-        assert final_page.cursor is None
+        assert expected_ids[:2] + final_ids == expected_ids
 
     def test_active_since_filter_excludes_orgs_with_only_dormant_members(self):
         self.user.last_login = timezone.now()


### PR DESCRIPTION
## Problem

The web analytics `TestGetOrgBatchPage` keyset pagination tests (in both `test_digest_notification_activities.py` and `test_weekly_digest_activities.py`) have been failing at ~38% on CI since July 10 and were auto-quarantined by Trunk, so the failures are invisible to CI while still burning signal.

Root cause is a test-isolation leak in another product. The `aorganization_emit` fixture in `products/signals/backend/test/test_scout_harness_tools.py` creates an `Organization` via `database_sync_to_async(...)` and `return`s it with no teardown. `database_sync_to_async` runs the ORM call on an executor-thread connection, outside pytest-django's per-test transaction (plain `@pytest.mark.django_db` only wraps the main-thread connection), so the row is committed for real — one leaked org per emit test, 16 per suite run.

CI's Product tests jobs bin several products into one job and run them sequentially against a single test database with `--reuse-db` (kept to avoid ClickHouse drop/create races). When signals runs before web-analytics in the same job, the leaked orgs are still in the database, and the pagination tests — which assume `Organization.objects.all()` contains only the orgs they created — fail on the extra ids. The failure rate tracks how often the duration-based bin-packing pairs the two products.

## Changes

- `aorganization_emit` now `yield`s and cascade-deletes the org on teardown, with a comment explaining why the explicit delete is load-bearing (the cascade also removes the team/config/run rows the sibling emit fixtures create).
- Both `TestGetOrgBatchPage` keyset tests derive `expected_ids` from the database instead of assuming it is empty, so a committed stray from any earlier suite can no longer flake them. The weekly variant switches to the same walk-to-exhaustion shape its digest-notification sibling already used, since fixed `[4:]`/cursor-is-None assertions don't survive a variable org count.

## How did you test this code?

Automated, on a devbox against the real postgres/ClickHouse stack (tests can't run on the authoring machine — no container runtime):

- Reproduced the CI failure: seeded one committed stray org, ran the unmodified pagination tests — both keyset tests fail with the exact id-list mismatch seen in CI; the fixed versions pass under the same conditions (9/9).
- Verified the leak and the fix: before — one full signals suite run left 16 committed `signals-scout-emit` orgs; after — the emit test file (91 tests) and the full signals suite (1378 passed) both leave 0 orgs.
- End-to-end CI sequence: full signals suite then both pagination test classes with `--reuse-db` against the same database — green.

Test changes justification: no new tests — the fixture change closes the leak at the source, and the assertion change removes the tests' reliance on state other suites control (the isolation violation, seen from the victim side) while keeping ordering/cursor/paging assertions exact.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code; skills invoked: `/fixing-flaky-tests`, `/writing-tests`, `/setting-up-devbox`.
- Found while triaging the Trunk quarantine backlog: these tests were the highest-rate active flakes in the repo (~38%/24h) and invisible because quarantined. Trunk's failure summary ("expected list of IDs did not match the actual list") plus the `--reuse-db` comment in `ci-backend.yml` led to the cross-product leak hypothesis, confirmed empirically on a devbox before any code change.
- Considered fixing only the fixture; kept the test hardening too because any product binned before web-analytics can reintroduce a committed stray, and the pagination code genuinely pages over whatever exists.
- A repo-wide audit for the same bug class (async fixtures committing rows via `sync_to_async` under plain `django_db`) found more instances in `posthog/temporal` tests — follow-up work, tracked separately.
