### PR TITLE
chore(marketing-analytics): instrument conversion-goal query build in base runner

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -928,19 +928,23 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
                     union_subquery = self._factory(date_range=self.query_date_range).build_union_query_ast(adapters)
 
             # Get conversion goals and filter out invalid ones
-            conversion_goals = self._get_team_conversion_goals()
-            valid_conversion_goals, self._conversion_goal_warnings = self._filter_invalid_conversion_goals(
-                conversion_goals
-            )
-            self._valid_conversion_goals_count = len(valid_conversion_goals)
+            with self.timings.measure("ma_get_conversion_goals"):
+                conversion_goals = self._get_team_conversion_goals()
+            with self.timings.measure("ma_filter_conversion_goals"):
+                valid_conversion_goals, self._conversion_goal_warnings = self._filter_invalid_conversion_goals(
+                    conversion_goals
+                )
+                self._valid_conversion_goals_count = len(valid_conversion_goals)
 
             # Create processors only for valid conversion goals
-            processors = (
-                self._create_conversion_goal_processors(valid_conversion_goals) if valid_conversion_goals else []
-            )
+            with self.timings.measure("ma_create_conversion_processors"):
+                processors = (
+                    self._create_conversion_goal_processors(valid_conversion_goals) if valid_conversion_goals else []
+                )
 
             # Build the complete query with CTEs using AST
-            return self._build_complete_query_ast(union_subquery, processors, self.query_date_range)
+            with self.timings.measure("ma_build_complete_query"):
+                return self._build_complete_query_ast(union_subquery, processors, self.query_date_range)
 
     def _generate_aggregated_conversion_goals_cte(self, conversion_aggregator, date_range) -> Optional[ast.CTE]:
         """Generate aggregated conversion goals CTE without GROUP BY for aggregated queries"""


### PR DESCRIPTION
## Problem

On a warm marketing analytics dashboard load, `marketing_analytics_base_query` takes ~8.6s, but the existing timing spans only explain ~1.7s of it (`ma_build_database` ≈ 1.0s, `ma_build_costs_precompute` ≈ 0.7s).
The other ~6.9s is invisible, so we can't tell what to optimize next.
The cost precompute is already fast, so the remaining cost is elsewhere in query build.

## Changes

Wrap the four previously un-instrumented calls at the end of `to_query()` in `self.timings.measure(...)` spans:

- `ma_get_conversion_goals` — resolve the team's conversion goals
- `ma_filter_conversion_goals` — drop invalid goals
- `ma_create_conversion_processors` — build the per-goal processors
- `ma_build_complete_query` — assemble the CTEs via `_build_complete_query_ast` (the likely culprit)

No behavior change, timings only.
Same `self.timings.measure(...)` pattern the method already uses for `ma_build_database` and `ma_build_costs_precompute`.

## How did you test this code?

Ran ruff lint/format and ty (via lint-staged) and `hogli ci:preflight`, all green.
I (Claude) did not drive the dashboard against this exact branch.
The new spans mirror the existing `ma_*` measures, which already surface in the query response `timings`, so the next warm load will break out where the ~6.9s goes.
No automated tests added: this only adds observability spans around existing calls, so there's no new behavior for a test to pin.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Javier was profiling a slow marketing analytics dashboard load and noticed the `marketing_analytics_base_query` span (8.6s) wasn't explained by its children.
I (Claude Code) traced `to_query()` and found the conversion-goal path — goal resolution, filtering, processor creation, and `_build_complete_query_ast` — had no timing spans, leaving ~6.9s uncaptured.
This PR adds those spans to close the gap and aim the next optimization at the right layer (query build in Python, not ClickHouse and not the cost precompute).
No skills were invoked.
