### PR TITLE
fix(ingestion): produce group flush results during shutdown cleanup

### DIFF
--- a/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/flush-batch-stores-step.ts
@@ -194,8 +194,12 @@ function createPersonProducePromises(personsStoreMessages: FlushResult[], output
  * Creates Kafka produce promises for all group store flush results, mirroring
  * the person handling: MessageSizeTooLarge emits a group-specific ingestion
  * warning (non-fatal), other errors fail the side effect.
+ *
+ * Exported so callers outside the batch pipeline (e.g. the ingestion API
+ * server's shutdown cleanup) can produce a bare `groupStore.flush()` result
+ * without duplicating the MessageSizeTooLarge handling.
  */
-function createGroupProducePromises(
+export function createGroupProducePromises(
     groupResults: GroupFlushResult[],
     outputs: FlushBatchStoresOutputs
 ): Promise<unknown>[] {

--- a/nodejs/src/servers/ingestion-api-server.test.ts
+++ b/nodejs/src/servers/ingestion-api-server.test.ts
@@ -1,4 +1,8 @@
+import { GROUPS_OUTPUT } from '~/common/outputs'
+import { GroupFlushResult } from '~/ingestion/common/groups/group-store.interface'
+
 import { IngestBatchResponse, SerializedKafkaMessage } from '../ingestion/api/types'
+import { CleanupResources } from './base-server'
 import { IngestionApiServer } from './ingestion-api-server'
 
 describe('IngestionApiServer', () => {
@@ -85,5 +89,39 @@ describe('IngestionApiServer', () => {
         expect(res.body()).toMatchObject({ status: 'ok', accepted: 1 })
         expect(isHealthy().status).toBe('ok')
         expect(stopSpy).not.toHaveBeenCalled()
+    })
+
+    describe('cleanup', () => {
+        // groupStore.flush() no longer produces ClickHouse messages itself (see
+        // batch-writing-group-store.ts) — it returns them for the caller to
+        // produce, mirroring personsStore.flushAndProduceMessages(). The shutdown
+        // cleanup path must produce them itself or dirty entries flushed at
+        // shutdown (e.g. a pod drain mid-batch) are written to Postgres but never
+        // reach ClickHouse, and a redelivery of the same batch finds no property
+        // diff and never regenerates the message.
+        it('produces ClickHouse messages returned by groupStore.flush() during shutdown cleanup', async () => {
+            const flushResult: GroupFlushResult = {
+                messages: [{ output: GROUPS_OUTPUT, value: Buffer.from('group-payload') }],
+                teamId: 1,
+                groupTypeIndex: 0,
+                groupKey: 'test-group',
+            }
+            const groupStore = {
+                flush: jest.fn().mockResolvedValue([flushResult]),
+                shutdown: jest.fn().mockResolvedValue(undefined),
+            }
+            const ingestionOutputs = { produce: jest.fn().mockResolvedValue(undefined) }
+            ;(server as any).groupStore = groupStore
+            ;(server as any).ingestionOutputs = ingestionOutputs
+
+            const cleanup: CleanupResources = (server as any).getCleanupResources()
+            await cleanup.additionalCleanup?.()
+
+            expect(ingestionOutputs.produce).toHaveBeenCalledWith(GROUPS_OUTPUT, {
+                key: null,
+                value: flushResult.messages[0].value,
+                teamId: flushResult.teamId,
+            })
+        })
     })
 })

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -36,6 +36,10 @@ import {
 } from '~/ingestion/common/outputs/producers'
 import { BatchWritingPersonsStore } from '~/ingestion/common/persons/batch-writing-person-store'
 import { PersonsStore } from '~/ingestion/common/persons/persons-store'
+import {
+    FlushBatchStoresOutputs,
+    createGroupProducePromises,
+} from '~/ingestion/common/steps/event-processing/flush-batch-stores-step'
 import { createOkContext } from '~/ingestion/framework/helpers'
 import { TopHog } from '~/ingestion/framework/tophog'
 import { createAiEventSubpipeline } from '~/ingestion/pipelines/ai'
@@ -164,6 +168,10 @@ export class IngestionApiServer implements NodeServer {
     private pubsub?: PubSub
     private personsStore?: BatchWritingPersonsStore
     private groupStore?: BatchWritingGroupStore
+    // Held so shutdown cleanup can produce ClickHouse messages returned by a
+    // bare groupStore.flush() — the store itself no longer holds outputs
+    // (moved to caller-side production so create and flush share one path).
+    private ingestionOutputs?: FlushBatchStoresOutputs
 
     private joinedPipeline!: ReturnType<
         typeof createJoinedIngestionPipeline<JoinedIngestionPipelineInput, JoinedIngestionPipelineContext>
@@ -279,6 +287,7 @@ export class IngestionApiServer implements NodeServer {
             this.config
         )
         const ingestionOutputs = createOutputsRegistry().build(this.ingestionProducerRegistry, this.config)
+        this.ingestionOutputs = ingestionOutputs
         const clickhouseGroupRepository = new ClickhouseGroupRepository(ingestionOutputs)
 
         const topicFailures = await ingestionOutputs.checkTopics()
@@ -546,7 +555,15 @@ export class IngestionApiServer implements NodeServer {
                     await this.personsStore.shutdown()
                 }
                 if (this.groupStore) {
-                    await this.groupStore.flush()
+                    const groupFlushResults = await this.groupStore.flush()
+                    // flush() returns messages for the caller to produce (it no
+                    // longer awaits ClickHouse delivery inline) — mirror
+                    // personsStore.flushAndProduceMessages() so a drain at
+                    // shutdown doesn't write Postgres but silently drop the
+                    // corresponding ClickHouse row.
+                    if (groupFlushResults.length > 0 && this.ingestionOutputs) {
+                        await Promise.all(createGroupProducePromises(groupFlushResults, this.ingestionOutputs))
+                    }
                     await this.groupStore.shutdown()
                 }
                 this.cookielessManager?.shutdown()


### PR DESCRIPTION
## Problem

#69946 changed `BatchWritingGroupStore.flush()` to return ClickHouse messages for the caller to produce, instead of producing them inline, so group creates could ride the same side-effect production as flushed updates. The ingestion API server's shutdown cleanup path still called `flush()` directly and discarded whatever it returned. A graceful shutdown (SIGTERM/SIGINT, or the scheduled pod-termination timer in `base-server.ts`, both routine on rolling deploys) that flushes dirty groups now writes them to Postgres but silently drops the corresponding ClickHouse row — and since a later redelivery of the same batch finds no property diff, the message never regenerates.

## Changes

- Hold a reference to the ingestion outputs on `IngestionApiServer` (the store itself no longer holds them after #69946's refactor).
- In shutdown cleanup, produce any messages returned by `groupStore.flush()`, reusing `createGroupProducePromises` (exported here) instead of duplicating its `MessageSizeTooLarge` handling.

## How did you test this code?

- Added a regression test in `ingestion-api-server.test.ts`. Verified it fails against the unfixed code (`Number of calls: 0` on the mocked `produce`) by stashing just the production-code change, then passes once restored.
- Ran the full `ingestion-api-server.test.ts` and `flush-batch-stores-step.test.ts` suites: 23 passing.
- Ran typecheck and lint on the changed files: no new errors (18 pre-existing typecheck errors from missing optional native modules, 2 pre-existing `no-else-return` lint warnings elsewhere in the touched file — both unrelated to this change and present before it).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed — internal ingestion regression fix, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while reviewing #69946's Greptile findings with an AI coding agent (Cursor); this regression follows directly from that PR's change to defer group ClickHouse produces into `flush()`'s return value instead of awaiting them inline. Skills invoked: `/writing-tests` — wrote the failing regression test first, confirmed it reproduces the bug against the unfixed shutdown path, then implemented the fix and re-confirmed the test flips from failing to passing.

This PR targets `jose-sequeira/group-batch-store-optimizations` directly rather than `master`, since the bug only exists in that branch's diff and doesn't exist on `master`.
