### PR TITLE
fix(data-warehouse): explain the error when a table lacks a usable primary key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -100,8 +100,15 @@ Any_Source_Errors: dict[str, str | None] = {
         "(private key, passphrase, or username and password) on the source's SSH tunnel "
         "configuration, then re-enable the sync."
     ),
-    "Primary key required for incremental syncs": None,
-    "The primary keys for this table are not unique": None,
+    "Primary key required for incremental syncs": (
+        "This table needs a primary key to sync incrementally, but none is set. Choose a primary key "
+        "for the table in its sync settings, or switch it to full table replication, then re-enable the sync."
+    ),
+    "The primary keys for this table are not unique": (
+        "The primary key set for this table isn't unique, so incremental syncing can't reliably match "
+        "rows to update. Choose a unique primary key in the table's sync settings, or switch it to full "
+        "table replication, then re-enable the sync."
+    ),
     "Integration matching query does not exist": "The connected account for this source is no longer available — it may have been disconnected. Please reconnect the source's account.",
     # A fatal TLS alert from the remote host (raised in the shared HTTP transport for every
     # REST-based source). The server refused the handshake, which is deterministic for a given

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -168,7 +168,11 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "Can't connect to MySQL server on": None,
-            "No primary key defined for table": None,
+            "No primary key defined for table": (
+                "This table needs a primary key to sync incrementally, but none is set. Choose a primary "
+                "key for the table in its sync settings, or switch it to full table replication, then "
+                "re-enable the sync."
+            ),
             # MySQL/MariaDB error 1045 (ER_ACCESS_DENIED_ERROR): the user/password (or the
             # user's host grant) is wrong. Surface it as an auth failure — mirroring the Postgres
             # source — so the user fixes credentials instead of the generic "check connection

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -349,7 +349,11 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "and password configured for this source match what the proxy expects, then "
                 "re-enable the sync."
             ),
-            "No primary key defined for table": None,
+            "No primary key defined for table": (
+                "This table needs a primary key to sync incrementally, but none is set. Choose a primary "
+                "key for the table in its sync settings, or switch it to full table replication, then "
+                "re-enable the sync."
+            ),
             "failed: timeout expired": None,
             # NOTE: "SSL connection has been closed unexpectedly" is intentionally NOT listed here.
             # It denotes an established SSL connection being dropped on connect or mid-stream (idle

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -141,7 +141,11 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
             "could not translate host name": None,
             "timeout expired connection to server at": None,
             "password authentication failed for user": None,
-            "No primary key defined for table": None,
+            "No primary key defined for table": (
+                "This table needs a primary key to sync incrementally, but none is set. Choose a primary "
+                "key for the table in its sync settings, or switch it to full table replication, then "
+                "re-enable the sync."
+            ),
             "failed: timeout expired": None,
             "SSL connection has been closed unexpectedly": None,
             "server does not support SSL": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -2732,7 +2732,7 @@ async def test_postgres_duplicate_primary_key(team, postgres_config, postgres_co
     assert job.status == ExternalDataJob.Status.FAILED
     assert job.latest_error is not None
     assert (
-        "The primary keys for this table are not unique. We can't sync incrementally until the table has a unique primary key"
+        "The primary key set for this table isn't unique, so incremental syncing can't reliably match rows to update"
         in job.latest_error
     )
 


### PR DESCRIPTION
## Problem

Data warehouse onboarding for SQL sources (Postgres, MySQL, Redshift) trips up when a table can't sync incrementally because it has no primary key, or has a non-unique one. When that happens the sync fails and the source/schema tabs show the raw library exception text verbatim (for example dlt's `No primary key defined for table ...` or an internal "primary keys are not unique" string). Session scans of the new-source flow showed users hitting primary-key friction during incremental setup, and a raw exception is not something a user can act on.

Under the hood these patterns were already recognized as non-retryable, but they were mapped to `None`, which means "recognized, show the raw text anyway". So the classification knew the failure mode yet still surfaced internal wording.

## Changes

Give the three primary-key failure patterns actionable copy instead of `None`:

- `Primary key required for incremental syncs` and `No primary key defined for table` (per-source, Postgres/MySQL/Redshift) now explain that the table needs a primary key to sync incrementally, and to either pick one in the table's sync settings or switch it to full table replication, then re-enable the sync.
- `The primary keys for this table are not unique` explains the key isn't unique so rows can't be matched reliably, and to choose a unique key or switch to full table replication.

The wording uses the same labels the sync-method UI shows ("full table replication", incremental). No sync behavior or classification changes, only the customer-visible message.

## How did you test this code?

Automated only (I'm an agent and did not run the app manually):

- Updated the existing Postgres duplicate-primary-key e2e assertion in `test_end_to_end.py` to expect the new friendly message instead of the raw string. This is the same regression it caught before (the non-unique-PK case surfaces guidance), just against the improved copy.
- Confirmed the `pipeline_v3` postgres-queue consumer path is unaffected: it classifies retryability from its own `NON_RETRYABLE_ERROR_PATTERNS` and intentionally keeps the raw reason, independent of the `Any_Source_Errors` map changed here.
- `ruff check` and `ruff format --check` pass on all touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Produced by Claude (PostHog Code) while reviewing friction in the data-warehouse new-source onboarding flow. I traced how sync errors reach the UI (`external_data_job.py` classifies the internal error against per-source `get_non_retryable_errors()` plus the shared `Any_Source_Errors`, and writes the result to `latest_error`, which the source/schema tabs render verbatim). The primary-key patterns were the clearest case of a known failure mode still shown as raw text. I kept the change to copy only and left classification/retry behavior untouched. Invoked the `/writing-tests` skill before adjusting the e2e assertion.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
