### PR TITLE
fix(snowflake): stop the query timebomb cancelling long syncs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py
@@ -82,16 +82,20 @@ _SNOWFLAKE_IDENTIFIER_QUOTER = AnsiIdentifierQuoter()
 # Snowflake exposes one metadata schema per database; everything else is user data.
 SNOWFLAKE_SYSTEM_SCHEMA = "INFORMATION_SCHEMA"
 
-# Bound the connector's per-request retry budget. `network_timeout` defaults to infinite, so a
-# stalled/half-open connection mid-request (peer or network drop) retries forever in the worker
-# thread. The sync activities are threaded and the heartbeater runs on a separate event-loop task,
-# so the stall isn't surfaced by a missed heartbeat — the activity just runs until Temporal's
-# `start_to_close_timeout` cancels the thread mid socket-read, surfacing a misleading
-# `WantReadError`/`CancelledError`. Bounding it turns the stall into a fast, retryable
-# `OperationalError` well before the activity is cancelled. It applies per request, so it never caps
-# a long-running streaming sync. Kept comfortably under the schema-discovery activity's 10-minute
-# `start_to_close_timeout` while leaving ample room for legitimate per-request round-trips and retries.
-_SNOWFLAKE_NETWORK_TIMEOUT_SECONDS = 300
+# Bound each socket connect/read so a stalled/half-open connection (peer or network drop) fails fast
+# instead of hanging the worker thread. The sync activities are threaded and the heartbeater runs on
+# a separate event-loop task, so the stall isn't surfaced by a missed heartbeat — without a bound the
+# activity just runs until Temporal's `start_to_close_timeout` cancels the thread mid socket-read,
+# surfacing a misleading `WantReadError`/`CancelledError`. `socket_timeout` turns that into a fast,
+# retryable error well before the activity is cancelled.
+#
+# This deliberately uses `socket_timeout`, not `network_timeout`: the connector reuses
+# `network_timeout` as a client-side query "timebomb" that cancels the running query once it elapses
+# (raising `ProgrammingError` 000604/57014), so a finite `network_timeout` caps every query's total
+# wall-clock and kills legitimate long-running syncs of large tables. `socket_timeout` bounds only
+# each individual request; Snowflake executes queries via bounded polling round-trips, so a long
+# query never trips it.
+_SNOWFLAKE_SOCKET_TIMEOUT_SECONDS = 300
 
 
 def _split_display_name(display_name: str, default_schema: Optional[str]) -> tuple[Optional[str], str]:
@@ -278,7 +282,7 @@ class SnowflakeImplementation(
             # `schema=""` would try `USE SCHEMA ""`, an invalid identifier, and fail at connect time.
             schema=normalize_namespace(config.schema),
             role=config.role,
-            network_timeout=_SNOWFLAKE_NETWORK_TIMEOUT_SECONDS,
+            socket_timeout=_SNOWFLAKE_SOCKET_TIMEOUT_SECONDS,
             **auth_connect_args,
         ) as connection:
             yield connection

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py
@@ -82,20 +82,25 @@ _SNOWFLAKE_IDENTIFIER_QUOTER = AnsiIdentifierQuoter()
 # Snowflake exposes one metadata schema per database; everything else is user data.
 SNOWFLAKE_SYSTEM_SCHEMA = "INFORMATION_SCHEMA"
 
-# Bound each socket connect/read so a stalled/half-open connection (peer or network drop) fails fast
-# instead of hanging the worker thread. The sync activities are threaded and the heartbeater runs on
-# a separate event-loop task, so the stall isn't surfaced by a missed heartbeat — without a bound the
-# activity just runs until Temporal's `start_to_close_timeout` cancels the thread mid socket-read,
-# surfacing a misleading `WantReadError`/`CancelledError`. `socket_timeout` turns that into a fast,
-# retryable error well before the activity is cancelled.
-#
-# This deliberately uses `socket_timeout`, not `network_timeout`: the connector reuses
-# `network_timeout` as a client-side query "timebomb" that cancels the running query once it elapses
-# (raising `ProgrammingError` 000604/57014), so a finite `network_timeout` caps every query's total
-# wall-clock and kills legitimate long-running syncs of large tables. `socket_timeout` bounds only
-# each individual request; Snowflake executes queries via bounded polling round-trips, so a long
-# query never trips it.
-_SNOWFLAKE_SOCKET_TIMEOUT_SECONDS = 300
+# Bound the connector's per-request retry budget. `network_timeout` defaults to infinite, so a
+# stalled/half-open connection mid-request (peer or network drop) retries forever in the worker
+# thread. The sync activities are threaded and the heartbeater runs on a separate event-loop task,
+# so the stall isn't surfaced by a missed heartbeat — the activity just runs until Temporal's
+# `start_to_close_timeout` cancels the thread mid socket-read, surfacing a misleading
+# `WantReadError`/`CancelledError`. Bounding it turns the stall into a fast, retryable error well
+# before the activity is cancelled. It applies per HTTP request, so it never caps the total wall-clock
+# of a long-running query.
+_SNOWFLAKE_NETWORK_TIMEOUT_SECONDS = 300
+
+# The connector also reuses `network_timeout` as a client-side query "timebomb": it arms a timer on
+# `cursor.execute()` and cancels the running query once the timeout elapses, raising
+# `ProgrammingError` 000604 (57014, "SQL execution was cancelled by the client due to a timeout").
+# That's harmless for the short metadata queries, but it must not cancel a legitimately long
+# full-table data scan — so those pass this explicit, much larger per-query `timeout`, overriding the
+# timebomb while leaving the retry budget above intact. It mirrors the import activity's 6h
+# `start_to_close_timeout`, which is the real ceiling: the connector defers to Temporal rather than
+# pre-empting a sync that is still making progress.
+_SNOWFLAKE_QUERY_TIMEOUT_SECONDS = 6 * 60 * 60
 
 
 def _split_display_name(display_name: str, default_schema: Optional[str]) -> tuple[Optional[str], str]:
@@ -282,7 +287,7 @@ class SnowflakeImplementation(
             # `schema=""` would try `USE SCHEMA ""`, an invalid identifier, and fail at connect time.
             schema=normalize_namespace(config.schema),
             role=config.role,
-            socket_timeout=_SNOWFLAKE_SOCKET_TIMEOUT_SECONDS,
+            network_timeout=_SNOWFLAKE_NETWORK_TIMEOUT_SECONDS,
             **auth_connect_args,
         ) as connection:
             yield connection
@@ -536,7 +541,7 @@ class SnowflakeImplementation(
         try:
             query = f"SELECT COUNT(*) FROM ({inner_query}) as t"
 
-            cursor.execute(query, inner_query_args)
+            cursor.execute(query, inner_query_args, timeout=_SNOWFLAKE_QUERY_TIMEOUT_SECONDS)
             row = cursor.fetchone()
 
             if row is None:
@@ -615,7 +620,7 @@ class SnowflakeImplementation(
                         row_filters=row_filters,
                     )
                     logger.debug(f"Snowflake query: {query.format(params)}")
-                    streaming_cursor.execute(query, params)
+                    streaming_cursor.execute(query, params, timeout=_SNOWFLAKE_QUERY_TIMEOUT_SECONDS)
 
                     # We cant control the batch size from snowflake when using the arrow function
                     # https://github.com/snowflakedb/snowflake-connector-python/issues/1712

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -17,7 +17,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SnowflakeSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import source_requires_ssl
 from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.snowflake import (
-    _SNOWFLAKE_NETWORK_TIMEOUT_SECONDS,
+    _SNOWFLAKE_SOCKET_TIMEOUT_SECONDS,
     SnowflakeImplementation,
     _build_query,
     _parse_clustering_key_leading_column,
@@ -339,19 +339,25 @@ class TestConnect:
                 pass
             assert mock_connect.call_args.kwargs["schema"] == "SALES"
 
-    def test_bounds_network_timeout(self, impl):
-        # Without a bounded `network_timeout` the connector retries a stalled request forever, so the
-        # threaded sync activity hangs until Temporal cancels it mid socket-read (a noisy WantReadError
-        # / "Cancelled"). Keep a finite bound so the stall becomes a fast, retryable error instead.
+    def test_bounds_socket_timeout(self, impl):
+        # A stalled/half-open connection must fail fast instead of hanging the threaded sync activity
+        # until Temporal cancels it mid socket-read (a noisy WantReadError / "Cancelled"). The bound
+        # goes on `socket_timeout`, not `network_timeout`: the connector reuses `network_timeout` as a
+        # client-side query timebomb that cancels the running query when it elapses (ProgrammingError
+        # 000604/57014), so a finite `network_timeout` would cap every query and kill legitimate
+        # long-running syncs of large tables.
         with patch("snowflake.connector.connect") as mock_connect:
             mock_connect.return_value.__enter__.return_value = MagicMock()
             with impl.connect(_make_config()):
                 pass
-            network_timeout = mock_connect.call_args.kwargs["network_timeout"]
+            kwargs = mock_connect.call_args.kwargs
+            socket_timeout = kwargs["socket_timeout"]
             # A finite, positive bound is the invariant. `0` reads as infinite to the connector, so
             # guard that explicitly — equality alone can't catch the constant regressing to `0`.
-            assert network_timeout == _SNOWFLAKE_NETWORK_TIMEOUT_SECONDS
-            assert network_timeout > 0
+            assert socket_timeout == _SNOWFLAKE_SOCKET_TIMEOUT_SECONDS
+            assert socket_timeout > 0
+            # No finite `network_timeout` — it would arm the query timebomb and cancel long queries.
+            assert kwargs.get("network_timeout") is None
 
 
 class TestSourceRequiresSsl:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -17,7 +17,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SnowflakeSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import source_requires_ssl
 from products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.snowflake import (
-    _SNOWFLAKE_SOCKET_TIMEOUT_SECONDS,
+    _SNOWFLAKE_NETWORK_TIMEOUT_SECONDS,
+    _SNOWFLAKE_QUERY_TIMEOUT_SECONDS,
     SnowflakeImplementation,
     _build_query,
     _parse_clustering_key_leading_column,
@@ -339,25 +340,19 @@ class TestConnect:
                 pass
             assert mock_connect.call_args.kwargs["schema"] == "SALES"
 
-    def test_bounds_socket_timeout(self, impl):
-        # A stalled/half-open connection must fail fast instead of hanging the threaded sync activity
-        # until Temporal cancels it mid socket-read (a noisy WantReadError / "Cancelled"). The bound
-        # goes on `socket_timeout`, not `network_timeout`: the connector reuses `network_timeout` as a
-        # client-side query timebomb that cancels the running query when it elapses (ProgrammingError
-        # 000604/57014), so a finite `network_timeout` would cap every query and kill legitimate
-        # long-running syncs of large tables.
+    def test_bounds_network_timeout(self, impl):
+        # Without a bounded `network_timeout` the connector retries a stalled request forever, so the
+        # threaded sync activity hangs until Temporal cancels it mid socket-read (a noisy WantReadError
+        # / "Cancelled"). Keep a finite bound so the stall becomes a fast, retryable error instead.
         with patch("snowflake.connector.connect") as mock_connect:
             mock_connect.return_value.__enter__.return_value = MagicMock()
             with impl.connect(_make_config()):
                 pass
-            kwargs = mock_connect.call_args.kwargs
-            socket_timeout = kwargs["socket_timeout"]
+            network_timeout = mock_connect.call_args.kwargs["network_timeout"]
             # A finite, positive bound is the invariant. `0` reads as infinite to the connector, so
             # guard that explicitly — equality alone can't catch the constant regressing to `0`.
-            assert socket_timeout == _SNOWFLAKE_SOCKET_TIMEOUT_SECONDS
-            assert socket_timeout > 0
-            # No finite `network_timeout` — it would arm the query timebomb and cancel long queries.
-            assert kwargs.get("network_timeout") is None
+            assert network_timeout == _SNOWFLAKE_NETWORK_TIMEOUT_SECONDS
+            assert network_timeout > 0
 
 
 class TestSourceRequiresSsl:
@@ -567,6 +562,9 @@ class TestGetRowsToSync:
     def test_returns_count(self, impl, cursor, logger):
         cursor.fetchone.return_value = (321,)
         assert impl.get_rows_to_sync(cursor, "SELECT 1", (), logger) == 321
+        # The COUNT(*) probe scans the same table, so it carries the same long per-query timeout —
+        # otherwise a large table trips the connector timebomb and the probe spuriously logs a 604.
+        assert cursor.execute.call_args.kwargs["timeout"] == _SNOWFLAKE_QUERY_TIMEOUT_SECONDS
 
     def test_returns_zero_on_exception(self, impl, cursor, logger):
         # Sync must never bail because the COUNT(*) probe failed
@@ -611,6 +609,11 @@ class TestBuildPipeline:
             assert list(response.items()) == [b"batch-1", b"batch-2"]
             # Pin a single timestamp unit so mixed ns/us batches don't break pyarrow assembly.
             streaming_cursor.fetch_arrow_batches.assert_called_once_with(force_microsecond_precision=True)
+            # The streaming scan must run with a per-query timeout well above `network_timeout`, or the
+            # connector's timebomb cancels a legitimately long full-table sync with ProgrammingError
+            # 000604/57014. Guards the regression that reused the 300s `network_timeout` as the cap.
+            assert streaming_cursor.execute.call_args.kwargs["timeout"] == _SNOWFLAKE_QUERY_TIMEOUT_SECONDS
+            assert _SNOWFLAKE_QUERY_TIMEOUT_SECONDS > _SNOWFLAKE_NETWORK_TIMEOUT_SECONDS
 
     def test_multi_schema_row_routes_to_qualified_namespace(self, impl):
         # A blank-namespace source pins each row's schema via the dotted schema_name.


### PR DESCRIPTION
## Problem

Snowflake imports were failing with a `ProgrammingError`:

> `000604 (57014): <redacted>: SQL execution was cancelled by the client due to a timeout. Error message received from the server: SQL execution canceled`

Surfaced by error tracking: [issue `019f5495`](https://us.posthog.com/project/2/error_tracking/019f5495-6333-7671-b0e8-d91fbe003d8d). The raising frame is `get_rows` in `snowflake.py`, at `streaming_cursor.execute(query, params)` — the streaming data query for a table sync.

Root cause is our own config, not the customer's. We set `network_timeout=300` on the connection to bound the per-request retry budget (so a stalled/half-open connection fails fast instead of hanging the worker thread). But the connector reuses `network_timeout` for a second, unrelated thing: a client-side query **timebomb** that arms a timer on `cursor.execute()` and cancels the running query once the timeout elapses (`cursor.py`: `real_timeout = timeout or network_timeout`, then cancel → `ProgrammingError` 000604/57014).

So the 300s `network_timeout` capped **every** query's total wall-clock at 300s. The import sync activity has a 6h `start_to_close_timeout`, and a large table's streaming `SELECT ... ORDER BY` (or the `COUNT(*)` estimate) can easily take longer than 5 minutes to execute — at which point the timebomb cancels it. Retrying can't help because it's a fixed function of table size, so this is a bug in our code, not a transient or upstream error.

## Changes

Keep `network_timeout` for the retry budget, but stop it from cancelling long queries.

The retry budget is applied **per HTTP request**, so it never caps a query's total wall-clock — only the timebomb does. The connector lets you override the timebomb **per query** via `cursor.execute(timeout=...)`. So the full-table data scans (the `COUNT(*)` estimate and the streaming `SELECT`) now pass an explicit, much larger per-query timeout, which overrides the timebomb for those queries while leaving the retry budget intact. That value mirrors the import activity's 6h `start_to_close_timeout` — Temporal's activity timeout is the real ceiling; the connector defers to it rather than pre-empting a sync that's still making progress.

```diff
-            cursor.execute(query, inner_query_args)
+            cursor.execute(query, inner_query_args, timeout=_SNOWFLAKE_QUERY_TIMEOUT_SECONDS)
...
-                    streaming_cursor.execute(query, params)
+                    streaming_cursor.execute(query, params, timeout=_SNOWFLAKE_QUERY_TIMEOUT_SECONDS)
```

Short metadata queries (schema/PK discovery) keep the default 300s timebomb — they're fast and run in the 10-minute discovery activity, so an early bound there is fine.

## How did you test this code?

Automated tests only (I'm an agent — no manual Snowflake run):

- Extended `TestBuildPipeline::test_builds_source_response_and_streams` to assert the streaming scan runs with a per-query `timeout` above `network_timeout` — the regression guard: reusing the 300s `network_timeout` as the query cap is exactly what caused the incident.
- Extended `TestGetRowsToSync::test_returns_count` to assert the `COUNT(*)` probe carries the same long timeout (otherwise a large table trips the timebomb and the probe spuriously logs a 604).
- `TestConnect::test_bounds_network_timeout` still guards the retry-budget bound.
- Ran the full source test file: `pytest .../snowflake/tests/test_snowflake.py` — 97 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (PostHog Code). Confirmed the issue and frame via the error-tracking MCP tools, then read the installed `snowflake-connector-python` source to establish that `network_timeout` does double duty: per-request retry budget (`network.py`) **and** a per-query cancellation timebomb (`cursor.py`). Initially considered swapping to `socket_timeout`, but that drops the aggregate retry-budget protection (a flaky connection could then spin until the 6h Temporal activity timeout). The per-query `execute(timeout=...)` override keeps the retry budget and only lifts the cap where queries are legitimately long. Invoked the `/writing-tests` skill before touching tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
