### PR TITLE
fix(clickhouse): skip migration 0270 outside cloud

### DIFF
--- a/posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py
+++ b/posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py
@@ -10,14 +10,14 @@ from posthog.clickhouse.property_values import (
 
 # Length and empty-value filtering now lives in the property-vals service, so the
 # MV passes everything from the Kafka table straight through. property_values lives
-# on AUX in prod but on DATA in dev (dev's aux nodes don't host it), matching
+# on AUX except in dev (dev's aux nodes don't host it), matching
 # 0262/0268. Single-node local/hobby get overridden to ALL by the migration runner.
 if settings.CLOUD_DEPLOYMENT in ("US", "EU"):
     _ROLES = [NodeRole.AUX]
 elif settings.CLOUD_DEPLOYMENT == "DEV":
     _ROLES = [NodeRole.DATA]
 else:
-    _ROLES = [NodeRole.DATA]
+    _ROLES = [NodeRole.AUX]
 
 operations = [
     run_sql_with_exceptions(DROP_PROPERTY_VALUES_MV_SQL(), node_roles=_ROLES),

--- a/posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py
+++ b/posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py
@@ -1,18 +1,33 @@
 from posthog import settings
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.clickhouse.property_values import DROP_PROPERTY_VALUES_MV_SQL, PROPERTY_VALUES_MV_SQL
+from posthog.clickhouse.property_values import (
+    DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL,
+    DROP_PROPERTY_VALUES_MV_SQL,
+    KAFKA_PROPERTY_VALUES_TABLE_SQL_FN,
+    PROPERTY_VALUES_MV_SQL,
+)
 
 # Length and empty-value filtering now lives in the property-vals service, so the
 # MV passes everything from the Kafka table straight through. property_values lives
 # on AUX in prod but on DATA in dev (dev's aux nodes don't host it), matching
 # 0262/0268. Single-node local/hobby get overridden to ALL by the migration runner.
-if settings.CLOUD_DEPLOYMENT == "DEV":
+if settings.CLOUD_DEPLOYMENT in ("US", "EU"):
+    _ROLES = [NodeRole.AUX]
+elif settings.CLOUD_DEPLOYMENT == "DEV":
     _ROLES = [NodeRole.DATA]
 else:
-    _ROLES = [NodeRole.AUX]
+    _ROLES = [NodeRole.DATA]
 
 operations = [
     run_sql_with_exceptions(DROP_PROPERTY_VALUES_MV_SQL(), node_roles=_ROLES),
+    *(
+        [
+            run_sql_with_exceptions(DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL(), node_roles=_ROLES),
+            run_sql_with_exceptions(KAFKA_PROPERTY_VALUES_TABLE_SQL_FN(), node_roles=_ROLES),
+        ]
+        if settings.CLOUD_DEPLOYMENT not in ("US", "EU", "DEV")
+        else []
+    ),
     run_sql_with_exceptions(PROPERTY_VALUES_MV_SQL(), node_roles=_ROLES),
 ]

--- a/posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py
+++ b/posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py
@@ -1,33 +1,22 @@
 from posthog import settings
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.clickhouse.property_values import (
-    DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL,
-    DROP_PROPERTY_VALUES_MV_SQL,
-    KAFKA_PROPERTY_VALUES_TABLE_SQL_FN,
-    PROPERTY_VALUES_MV_SQL,
-)
+from posthog.clickhouse.property_values import DROP_PROPERTY_VALUES_MV_SQL, PROPERTY_VALUES_MV_SQL
 
 # Length and empty-value filtering now lives in the property-vals service, so the
 # MV passes everything from the Kafka table straight through. property_values lives
-# on AUX except in dev (dev's aux nodes don't host it), matching
+# on AUX in prod but on DATA in dev (dev's aux nodes don't host it), matching
 # 0262/0268. Single-node local/hobby get overridden to ALL by the migration runner.
-if settings.CLOUD_DEPLOYMENT in ("US", "EU"):
-    _ROLES = [NodeRole.AUX]
-elif settings.CLOUD_DEPLOYMENT == "DEV":
+if settings.CLOUD_DEPLOYMENT == "DEV":
     _ROLES = [NodeRole.DATA]
 else:
     _ROLES = [NodeRole.AUX]
 
-operations = [
-    run_sql_with_exceptions(DROP_PROPERTY_VALUES_MV_SQL(), node_roles=_ROLES),
-    *(
-        [
-            run_sql_with_exceptions(DROP_KAFKA_PROPERTY_VALUES_TABLE_SQL(), node_roles=_ROLES),
-            run_sql_with_exceptions(KAFKA_PROPERTY_VALUES_TABLE_SQL_FN(), node_roles=_ROLES),
-        ]
-        if settings.CLOUD_DEPLOYMENT not in ("US", "EU", "DEV")
-        else []
-    ),
-    run_sql_with_exceptions(PROPERTY_VALUES_MV_SQL(), node_roles=_ROLES),
-]
+operations = (
+    [
+        run_sql_with_exceptions(DROP_PROPERTY_VALUES_MV_SQL(), node_roles=_ROLES),
+        run_sql_with_exceptions(PROPERTY_VALUES_MV_SQL(), node_roles=_ROLES),
+    ]
+    if settings.CLOUD_DEPLOYMENT in ("US", "EU", "DEV")
+    else []
+)


### PR DESCRIPTION
## Problem

Migration 0257 intentionally leaves self-hosted deployments on the original `kafka_property_values` schema. Migration 0270 ignored that boundary, dropped `property_values_mv`, and then tried to recreate it with the cloud-only schema.

Addresses #64148.

## Changes

Make migration 0270 a no-op outside US, EU, and DEV, matching migrations 0257 and 0268.

> [!NOTE]
> This prevents 0270 from damaging self-hosted installations. It intentionally does not add recovery work for a view already dropped by an earlier failed run.

## How did you test this code?

- `uv run ruff check posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py`
- `uv run ruff format --check posthog/clickhouse/migrations/0270_property_values_drop_mv_length_filter.py`
- Focused Python check confirming 0270 produces zero operations with `CLOUD_DEPLOYMENT` unset and two operations for US, EU, and DEV
- `uv run hogli ci:preflight --fix`

The full migration test module could not run from the sparse checkout because the Django settings package was not present.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the repository's `/clickhouse-migrations` skill and Ponytail. Investigation showed that the property-count schema change was deliberately cloud-only, so rebuilding the self-hosted Kafka table was unnecessary. The final change only gates 0270 to the same deployments as 0257 and 0268.
