### PR TITLE
fix(ai-observability): serve OpenAI-model playground requests with an Azure OpenAI key

### DIFF
--- a/products/ai_observability/backend/llm/client.py
+++ b/products/ai_observability/backend/llm/client.py
@@ -22,6 +22,23 @@ if TYPE_CHECKING:
     from products.ai_observability.backend.models.provider_keys import LLMProviderKey
 
 
+# Some provider keys serve models that the model registry tags under a different
+# provider. Azure OpenAI hosts the same models (gpt-4.1, ...) that the registry
+# labels "openai", so a request built from that registry arrives with
+# provider="openai" even though the key is "azure_openai". Map a key provider to
+# the request providers it may legitimately serve so those requests validate and
+# route through the key's provider instead of being rejected.
+_COMPATIBLE_REQUEST_PROVIDERS: dict[str, frozenset[str]] = {
+    "azure_openai": frozenset({"openai"}),
+}
+
+
+def _providers_compatible(key_provider: str, request_provider: str) -> bool:
+    return key_provider == request_provider or request_provider in _COMPATIBLE_REQUEST_PROVIDERS.get(
+        key_provider, frozenset()
+    )
+
+
 class Client:
     """Unified LLM client for llm_analytics."""
 
@@ -52,21 +69,31 @@ class Client:
         return self.provider_key.encrypted_config.get("api_key")
 
     def _validate_provider(self, request_provider: str) -> None:
-        """Validate that request provider matches provider key's provider."""
-        if self.provider_key is not None and self.provider_key.provider != request_provider:
+        """Validate that the request provider is served by the provider key."""
+        if self.provider_key is not None and not _providers_compatible(self.provider_key.provider, request_provider):
             raise ProviderMismatchError(self.provider_key.provider, request_provider)
+
+    def _resolve_provider(self, request_provider: str) -> str:
+        """Return the provider to route through, treating the key as authoritative.
+
+        An azure_openai key serves the OpenAI model namespace, so an "openai"
+        request is routed through Azure rather than the OpenAI adapter.
+        """
+        if self.provider_key is not None and _providers_compatible(self.provider_key.provider, request_provider):
+            return self.provider_key.provider
+        return request_provider
 
     def complete(self, request: CompletionRequest) -> CompletionResponse:
         """Non-streaming completion."""
         self._validate_provider(request.provider)
-        provider = _get_provider(request.provider, self.provider_key)
+        provider = _get_provider(self._resolve_provider(request.provider), self.provider_key)
         api_key, base_url = self._resolve_credentials()
         return provider.complete(request, api_key, self.analytics, base_url)
 
     def stream(self, request: CompletionRequest) -> Generator[StreamChunk]:
         """Streaming completion."""
         self._validate_provider(request.provider)
-        provider = _get_provider(request.provider, self.provider_key)
+        provider = _get_provider(self._resolve_provider(request.provider), self.provider_key)
         api_key, base_url = self._resolve_credentials()
         yield from provider.stream(request, api_key, self.analytics, base_url)
 

--- a/products/ai_observability/backend/llm/test/test_client.py
+++ b/products/ai_observability/backend/llm/test/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
@@ -88,6 +88,31 @@ class TestProviderRouting(SimpleTestCase):
         assert provider.azure_endpoint == ""
         assert provider.api_version == DEFAULT_API_VERSION
 
+    def test_azure_key_routes_openai_model_request_to_azure_adapter(self):
+        """An openai-registry model under an Azure key reaches the Azure adapter (#60297)."""
+        from products.ai_observability.backend.llm.providers.azure_openai import AzureOpenAIAdapter
+
+        mock_key = MagicMock()
+        mock_key.provider = "azure_openai"
+        mock_key.encrypted_config = {
+            "api_key": "test-key",
+            "azure_endpoint": "https://contoso.openai.azure.com/",
+            "api_version": "2025-01-01",
+        }
+
+        client = Client(provider_key=mock_key)
+        request = CompletionRequest(
+            model="gpt-4.1",
+            messages=[{"role": "user", "content": "hi"}],
+            provider="openai",
+        )
+
+        with patch.object(AzureOpenAIAdapter, "complete", return_value="ok") as mock_complete:
+            result = client.complete(request)
+
+        assert result == "ok"
+        assert mock_complete.called
+
 
 class TestProviderMismatchValidation(SimpleTestCase):
     def test_provider_mismatch_raises_error(self):
@@ -127,6 +152,30 @@ class TestProviderMismatchValidation(SimpleTestCase):
         client._validate_provider("fireworks")
         client._validate_provider("minimax")
         client._validate_provider("zeabur")
+
+    def test_azure_key_serves_openai_model_request(self):
+        # Models like gpt-4.1 are registered under the "openai" provider, so a
+        # request built from the model registry arrives with provider="openai"
+        # even when an Azure key is selected. An azure_openai key must serve it
+        # rather than raise. Regression test for #60297.
+        mock_key = MagicMock()
+        mock_key.provider = "azure_openai"
+        mock_key.encrypted_config = {"api_key": "test-key"}
+
+        client = Client(provider_key=mock_key)
+
+        client._validate_provider("openai")
+        assert client._resolve_provider("openai") == "azure_openai"
+
+    def test_azure_key_still_rejects_unrelated_provider(self):
+        mock_key = MagicMock()
+        mock_key.provider = "azure_openai"
+        mock_key.encrypted_config = {"api_key": "test-key"}
+
+        client = Client(provider_key=mock_key)
+
+        with pytest.raises(ProviderMismatchError):
+            client._validate_provider("anthropic")
 
 
 class TestApiKeyExtraction(SimpleTestCase):


### PR DESCRIPTION
## Problem

Closes #60297.

When a user configures an **Azure OpenAI** provider key and selects an Azure model (e.g. `gpt-4.1`) in the LLM playground, clicking **Run** fails with `LLM Error: An internal error occurred`, and the console shows:

> `Provider key is for 'azure_openai' but request specifies 'openai'`

Models like `gpt-4.1` live in `OpenAIConfig.SUPPORTED_MODELS`, so the model registry tags them `provider: "openai"`. The playground builds its `CompletionRequest` with `provider="openai"` even though the selected key is `azure_openai`. `Client._validate_provider()` then rejects the mismatch, and routing (`_get_provider(request.provider, ...)`) would have used the OpenAI adapter with the Azure key anyway.

## Changes

Treat the provider key as **authoritative for compatible providers**. Azure OpenAI hosts the same models the registry labels `openai`, so:

- `_validate_provider` accepts an `azure_openai` key for an `openai` request (via a small `_COMPATIBLE_REQUEST_PROVIDERS` map), and
- a new `_resolve_provider` routes such requests through the key's provider, so `complete`/`stream` reach the **Azure** adapter instead of the OpenAI one.

Genuine mismatches (e.g. an OpenAI key against an Anthropic request) still raise `ProviderMismatchError`. Backend-only, no schema/migration/frontend changes; the frontend keeps sending `provider="openai"` and it now works.

## How did you test this code?

I (the agent) **could not run the Django test suite locally** (no configured posthog env on this machine — `posthog.settings` import + deps). What I actually ran:

- `python -m ast` parse of both changed files — OK.
- A standalone replication of the new `_providers_compatible` / `_resolve_provider` / `_validate_provider` logic over the full truth table:

  | key | request | validate | routes to |
  |---|---|---|---|
  | `azure_openai` | `openai` | ok | **`azure_openai`** ✅ (the bug) |
  | `openai` | `openai` | ok | `openai` |
  | `openai` | `anthropic` | **raises** | — |
  | `azure_openai` | `anthropic` | **raises** | — |
  | none | `openai`/`anthropic` | ok | unchanged |

Added tests (relying on CI to execute the `SimpleTestCase` suite), each catching a distinct regression no existing test covered:

- `test_azure_key_serves_openai_model_request` — an Azure key must not raise on an `openai`-registry model, and must resolve routing to `azure_openai` (the #60297 failure).
- `test_azure_key_routes_openai_model_request_to_azure_adapter` — `complete()` actually dispatches to `AzureOpenAIAdapter`, not the OpenAI one.
- `test_azure_key_still_rejects_unrelated_provider` — guards the relaxation from over-broadening (Azure key still can't serve Anthropic).

## 🤖 Agent context

Human-driven (agent-assisted) — please assign @Lakshya77089 as DRI.
