### PR TITLE
fix(ml-image-scrub): run tsx directly so the sidecar needs no runtime egress

### DIFF
--- a/Dockerfile.ml-mirror-image-scrub
+++ b/Dockerfile.ml-mirror-image-scrub
@@ -36,4 +36,4 @@ USER posthog
 
 ENV NODE_ENV=production
 
-CMD ["pnpm", "start"]
+CMD ["node_modules/.bin/tsx", "src/main.ts"]


### PR DESCRIPTION
## Problem

The sidecar image ran `pnpm start` as its entrypoint. At container start, that re-invokes corepack, which re-downloads pnpm from the npm registry every boot:

> `! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-10.29.3.tgz`

The build populates corepack's cache as `root`, but the container runs as the `posthog` user, so the runtime download is never a cache hit. In production this image has no direct internet egress, so the download is fragile as well as pointless.

## Fix

Run the `tsx` binary directly. It's a production dependency, so it's already installed in the image, and startup does no network I/O.

```diff
-CMD ["pnpm", "start"]
+CMD ["node_modules/.bin/tsx", "src/main.ts"]
```

## Related

- [PostHog/charts#13096](https://github.com/PostHog/charts/pull/13096) — runs this image as the scrub sidecar, where the isolated container makes the runtime download fail rather than just being wasteful.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*