### PR TITLE
feat(quill): add DateRangeFilter block — presets-first date filter

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -87,6 +87,7 @@ function rootDirectories(): string[] {
         '<rootDir>/../products',
         '<rootDir>/../packages/quill/packages/charts/src',
         '<rootDir>/../packages/quill/packages/components/src',
+        '<rootDir>/../packages/quill/packages/blocks/src',
     ]
 }
 

--- a/packages/quill/packages/blocks/AGENTS.md
+++ b/packages/quill/packages/blocks/AGENTS.md
@@ -1,7 +1,42 @@
 # Blocks — Agent Reference
 
-`@posthog/quill-blocks` is the product-level patterns layer of quill (tokens > primitives > components > blocks). It is currently an empty placeholder — `src/index.ts` exports nothing so downstream `export *` re-exports keep working while the layer is unimplemented.
+`@posthog/quill-blocks` is the product-level patterns layer of quill (tokens > primitives > components > blocks): opinionated, product-shaped compositions that stay consistent across every PostHog surface.
+Import from `@posthog/quill` (the aggregate), not from this package directly.
 
-Do not add components here without checking the layering: reusable UI built only on Base UI belongs in `primitives`; compositions of primitives with logic (data wiring, state machines) belong in `components`; blocks are reserved for opinionated, product-shaped patterns (page headers, settings panels, command palettes).
+Layering check before adding here: reusable UI built only on Base UI belongs in `primitives`; compositions of primitives with internal wiring (state machines, data plumbing) belong in `components`; blocks are for full product patterns (a filter, a page header, a command palette) that a product drops in wholesale.
 
-When the first block lands, replace this file with a consumer guide following the structure of `../primitives/AGENTS.md`.
+## Catalog
+
+| Block             | Use for                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| `DateRangeFilter` | A date filter button: preset list with instant apply, calendar range picker on demand |
+
+## DateRangeFilter
+
+Presets-first date filter. The trigger opens a vertical quick-range list; selecting a preset applies immediately and closes. An optional "Custom range…" row swaps in `DateTimePicker` as a pure calendar (`ranges={[]}`), which applies concrete `Date`s.
+
+Rules:
+
+- **The block never interprets preset meaning.** Each preset carries an opaque `value` payload returned verbatim through `onPresetSelect(preset)`. Persistence vocabulary (e.g. PostHog's relative date strings like `-7d`) belongs to the host, never here.
+- `onCustomApply(start, end)` receives concrete browser-local `Date`s — hosts that need timezone-resolved or rolling semantics must convert on their side.
+- `customActive` marks the current value as a custom range: the row highlights and the popover opens straight to the calendar (seeded from `customStart`/`customEnd`).
+- `previewStart`/`previewEnd` on a preset only seed the calendar preview; they are not the source of truth for what the preset means.
+- `listFooter` pins host content below the preset list (shown in the list view only). Use it for host-specific controls; don't add host concepts as block props.
+- `trigger` overrides the default outline button when the host needs its own chrome (icons, data-attrs, skins).
+- Day-granular by default; pass `showTime` for time-of-day entry.
+
+```tsx
+<DateRangeFilter
+  label="Last 7 days"
+  presets={[{ id: '7d', label: 'Last 7 days', value: '-7d', previewStart: (now) => subDays(now, 7) }]}
+  selectedPresetId="7d"
+  onPresetSelect={(preset) => persist(preset.value)}
+  onCustomApply={(start, end) => persistConcrete(start, end)}
+  customActive={isCustom}
+  listFooter={<MyExtraControls />}
+/>
+```
+
+## Conventions
+
+Same as the other packages: Tailwind utilities only, semantic tokens, `data-slot` on structural elements, stories co-located (`*.stories.tsx`), jest tests co-located (`*.test.tsx`, run via the frontend jest project). Update this file's catalog and rules in the same PR as any block change — a lint-staged warning fires otherwise.

--- a/packages/quill/packages/blocks/package.json
+++ b/packages/quill/packages/blocks/package.json
@@ -32,7 +32,8 @@
     "dependencies": {
         "@posthog/quill-components": "workspace:^",
         "@posthog/quill-primitives": "workspace:^",
-        "@posthog/quill-tokens": "workspace:^"
+        "@posthog/quill-tokens": "workspace:^",
+        "date-fns": "^4.0.0"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.1.17",

--- a/packages/quill/packages/blocks/src/date-range-filter.stories.tsx
+++ b/packages/quill/packages/blocks/src/date-range-filter.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { subDays, subMonths } from 'date-fns'
+import * as React from 'react'
 
-import { Label, Switch } from '@posthog/quill-primitives'
+import { Button, Label, Switch, ToggleGroup, ToggleGroupItem } from '@posthog/quill-primitives'
 
 import { DateRangeFilter, type DateRangeFilterPreset } from './date-range-filter'
 
@@ -38,9 +39,67 @@ export const PresetList: Story = {
     ),
 }
 
+// Mirrors the insight date filter's footer: a compact "Days" row that expands day-of-week
+// chips on demand, plus an exclude toggle — all host-supplied through the listFooter slot.
+function DayOfWeekFooter(): React.ReactElement {
+    const [days, setDays] = React.useState<string[]>([])
+    const [expanded, setExpanded] = React.useState(false)
+    const labels: Record<string, string> = { 1: 'M', 2: 'T', 3: 'W', 4: 'T', 5: 'F', 6: 'S', 7: 'S' }
+    const summary =
+        days.length === 0 || days.length === 7
+            ? 'All days'
+            : ['1', '2', '3', '4', '5'].every((d) => days.includes(d)) && days.length === 5
+              ? 'Weekdays'
+              : days.length === 2 && days.includes('6') && days.includes('7')
+                ? 'Weekends'
+                : `${days.length} days`
+    return (
+        <div className="flex flex-col p-1">
+            <Button
+                variant="default"
+                left
+                className="w-full justify-between"
+                aria-expanded={expanded}
+                onClick={() => setExpanded((prev) => !prev)}
+            >
+                <span>Days</span>
+                <span className="text-muted-foreground">
+                    {summary} {expanded ? '▴' : '▾'}
+                </span>
+            </Button>
+            {expanded && (
+                <div className="flex flex-col gap-1 px-1 py-1">
+                    <ToggleGroup multiple size="sm" className="w-full max-w-60" value={days} onValueChange={setDays}>
+                        {Object.keys(labels).map((day) => (
+                            <ToggleGroupItem key={day} value={day} className="flex-1">
+                                {labels[day]}
+                            </ToggleGroupItem>
+                        ))}
+                    </ToggleGroup>
+                    <div className="flex w-full max-w-60 items-center justify-center gap-2">
+                        <Button variant="link" size="xs" onClick={() => setDays(['1', '2', '3', '4', '5'])}>
+                            Weekdays
+                        </Button>
+                        <Button variant="link" size="xs" onClick={() => setDays(['6', '7'])}>
+                            Weekends
+                        </Button>
+                        <Button variant="link" size="xs" onClick={() => setDays([])}>
+                            All days
+                        </Button>
+                    </div>
+                </div>
+            )}
+            <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+                <Label htmlFor="story-exclude-incomplete">Exclude incomplete period</Label>
+                <Switch id="story-exclude-incomplete" size="sm" />
+            </div>
+        </div>
+    )
+}
+
 export const WithListFooter: Story = {
     render: () => (
-        <div className="h-96">
+        <div className="h-120">
             <DateRangeFilter
                 label="Last 7 days"
                 presets={ANALYTICS_PRESETS}
@@ -48,12 +107,7 @@ export const WithListFooter: Story = {
                 onPresetSelect={() => {}}
                 onCustomApply={() => {}}
                 defaultOpen
-                listFooter={
-                    <div className="flex items-center gap-2 px-2 py-2">
-                        <Label htmlFor="story-exclude-incomplete">Exclude incomplete period</Label>
-                        <Switch id="story-exclude-incomplete" size="sm" />
-                    </div>
-                }
+                listFooter={<DayOfWeekFooter />}
             />
         </div>
     ),

--- a/packages/quill/packages/blocks/src/date-range-filter.stories.tsx
+++ b/packages/quill/packages/blocks/src/date-range-filter.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { subDays, subMonths } from 'date-fns'
+
+import { Label, Switch } from '@posthog/quill-primitives'
+
+import { DateRangeFilter, type DateRangeFilterPreset } from './date-range-filter'
+
+const ANALYTICS_PRESETS: DateRangeFilterPreset<string>[] = [
+    { id: 'today', label: 'Today', value: 'dStart', previewStart: (now) => now },
+    { id: '7d', label: 'Last 7 days', value: '-7d', previewStart: (now) => subDays(now, 7) },
+    { id: '30d', label: 'Last 30 days', value: '-30d', previewStart: (now) => subDays(now, 30) },
+    { id: '90d', label: 'Last 90 days', value: '-90d', previewStart: (now) => subDays(now, 90) },
+    { id: 'mStart', label: 'This month', value: 'mStart', previewStart: (now) => subMonths(now, 1) },
+    { id: 'all', label: 'All time', value: 'all', previewStart: (now) => subMonths(now, 60) },
+]
+
+const meta: Meta<typeof DateRangeFilter> = {
+    title: 'Blocks/DateRangeFilter',
+    component: DateRangeFilter,
+    parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<typeof DateRangeFilter>
+
+export const PresetList: Story = {
+    render: () => (
+        <div className="h-96">
+            <DateRangeFilter
+                label="Last 7 days"
+                presets={ANALYTICS_PRESETS}
+                selectedPresetId="7d"
+                onPresetSelect={() => {}}
+                onCustomApply={() => {}}
+                defaultOpen
+            />
+        </div>
+    ),
+}
+
+export const WithListFooter: Story = {
+    render: () => (
+        <div className="h-96">
+            <DateRangeFilter
+                label="Last 7 days"
+                presets={ANALYTICS_PRESETS}
+                selectedPresetId="7d"
+                onPresetSelect={() => {}}
+                onCustomApply={() => {}}
+                defaultOpen
+                listFooter={
+                    <div className="flex items-center gap-2 px-2 py-2">
+                        <Label htmlFor="story-exclude-incomplete">Exclude incomplete period</Label>
+                        <Switch id="story-exclude-incomplete" size="sm" />
+                    </div>
+                }
+            />
+        </div>
+    ),
+}
+
+export const CustomRangeActive: Story = {
+    render: () => (
+        <div className="h-120">
+            <DateRangeFilter
+                label="Jan 10 – Jan 20"
+                presets={ANALYTICS_PRESETS}
+                customActive
+                customStart={new Date(2023, 0, 10)}
+                customEnd={new Date(2023, 0, 20)}
+                onPresetSelect={() => {}}
+                onCustomApply={() => {}}
+                defaultOpen
+            />
+        </div>
+    ),
+}

--- a/packages/quill/packages/blocks/src/date-range-filter.test.tsx
+++ b/packages/quill/packages/blocks/src/date-range-filter.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { DateRangeFilter, type DateRangeFilterPreset } from './date-range-filter'
+
+const PRESETS: DateRangeFilterPreset<string>[] = [
+    { id: '7d', label: 'Last 7 days', value: '-7d', previewStart: (now) => new Date(now.getFullYear(), 0, 1) },
+    { id: '30d', label: 'Last 30 days', value: '-30d' },
+]
+
+describe('DateRangeFilter', () => {
+    afterEach(cleanup)
+
+    it('applies a preset on click, couriering its value payload, and closes the popover', async () => {
+        const onPresetSelect = jest.fn()
+        render(
+            <DateRangeFilter label="Dates" presets={PRESETS} onPresetSelect={onPresetSelect} defaultOpen />
+        )
+
+        await userEvent.click(screen.getByText('Last 30 days'))
+
+        expect(onPresetSelect).toHaveBeenCalledTimes(1)
+        expect(onPresetSelect.mock.calls[0][0]).toMatchObject({ id: '30d', value: '-30d' })
+        await waitFor(() => expect(screen.queryByText('Last 7 days')).toBeNull())
+    })
+
+    it('reveals the calendar behind the custom row, applies concrete dates, and cancel returns to the list', async () => {
+        const onCustomApply = jest.fn()
+        render(
+            <DateRangeFilter
+                label="Dates"
+                presets={PRESETS}
+                selectedPresetId="7d"
+                onPresetSelect={jest.fn()}
+                onCustomApply={onCustomApply}
+                defaultOpen
+            />
+        )
+
+        await userEvent.click(screen.getByText('Custom range…'))
+        expect(screen.queryByText('Last 7 days')).toBeNull()
+
+        await userEvent.click(screen.getByLabelText('Cancel'))
+        expect(screen.getByText('Last 7 days')).not.toBeNull()
+        expect(onCustomApply).not.toHaveBeenCalled()
+
+        await userEvent.click(screen.getByText('Custom range…'))
+        await userEvent.click(screen.getByLabelText('Apply date range'))
+        expect(onCustomApply).toHaveBeenCalledTimes(1)
+        const [start, end] = onCustomApply.mock.calls[0]
+        expect(start).toBeInstanceOf(Date)
+        expect(end).toBeInstanceOf(Date)
+        expect(start.getTime()).toBeLessThanOrEqual(end.getTime())
+    })
+
+    it('opens straight to the calendar when a custom range is active', async () => {
+        render(
+            <DateRangeFilter
+                label="Dates"
+                presets={PRESETS}
+                customActive
+                customStart={new Date(2023, 0, 10)}
+                customEnd={new Date(2023, 0, 20)}
+                onPresetSelect={jest.fn()}
+                onCustomApply={jest.fn()}
+            />
+        )
+
+        await userEvent.click(screen.getByText('Dates'))
+
+        expect(screen.queryByText('Last 7 days')).toBeNull()
+        expect(screen.getByLabelText('Apply date range')).not.toBeNull()
+    })
+
+    it('renders listFooter in the list view only', async () => {
+        render(
+            <DateRangeFilter
+                label="Dates"
+                presets={PRESETS}
+                onPresetSelect={jest.fn()}
+                onCustomApply={jest.fn()}
+                listFooter={<div>Footer controls</div>}
+                defaultOpen
+            />
+        )
+
+        expect(screen.getByText('Footer controls')).not.toBeNull()
+
+        await userEvent.click(screen.getByText('Custom range…'))
+        expect(screen.queryByText('Footer controls')).toBeNull()
+    })
+})

--- a/packages/quill/packages/blocks/src/date-range-filter.tsx
+++ b/packages/quill/packages/blocks/src/date-range-filter.tsx
@@ -1,0 +1,176 @@
+import { subDays } from 'date-fns'
+import * as React from 'react'
+
+import {
+    CUSTOM_RANGE,
+    DateTimePicker,
+    type DateFormatOrder,
+    type DateTimeValue,
+    type Day,
+} from '@posthog/quill-components'
+import { Button, Popover, PopoverContent, PopoverTrigger, cn } from '@posthog/quill-primitives'
+
+export interface DateRangeFilterPreset<T = unknown> {
+    id: string
+    label: string
+    /** Opaque payload couriered back through `onPresetSelect`; the block never interprets it. */
+    value?: T
+    /** Preview span shown in the custom calendar while this preset is active. */
+    previewStart?: (now: Date) => Date
+    previewEnd?: (now: Date) => Date
+}
+
+export interface DateRangeFilterProps<T = unknown> {
+    presets: DateRangeFilterPreset<T>[]
+    selectedPresetId?: string | null
+    /** Selecting a preset applies immediately and closes the popover. */
+    onPresetSelect: (preset: DateRangeFilterPreset<T>) => void
+    /** Enables the custom-range calendar view. Omit to hide the "Custom range…" row. */
+    onCustomApply?: (start: Date, end: Date) => void
+    /** Marks the current value as a custom range: highlights the row and opens straight to the calendar. */
+    customActive?: boolean
+    customStart?: Date
+    customEnd?: Date
+    customLabel?: string
+    /** Text for the default trigger button; ignored when `trigger` is provided. */
+    label?: React.ReactNode
+    /** Trigger element override; defaults to an outline Button showing `label`. */
+    trigger?: React.ReactElement
+    disabled?: boolean
+    /** Host content pinned below the preset list (hidden in the calendar view). */
+    listFooter?: React.ReactNode
+    showTime?: boolean
+    weekStartsOn?: Day
+    dateFormat?: DateFormatOrder
+    minDate?: Date
+    maxDate?: Date
+    defaultOpen?: boolean
+    className?: string
+}
+
+/** Presets-first date filter: a trigger opening a quick-range list (instant apply), with an
+ *  optional calendar range picker revealed behind a "Custom range…" row. The block owns the
+ *  interaction shell only — what a preset *means* (and how it persists) stays with the host,
+ *  which gets its `value` payload back verbatim on selection. */
+export function DateRangeFilter<T = unknown>({
+    presets,
+    selectedPresetId,
+    onPresetSelect,
+    onCustomApply,
+    customActive = false,
+    customStart,
+    customEnd,
+    customLabel = 'Custom range…',
+    label,
+    trigger,
+    disabled = false,
+    listFooter,
+    showTime = false,
+    weekStartsOn,
+    dateFormat,
+    minDate,
+    maxDate,
+    defaultOpen = false,
+    className,
+}: DateRangeFilterProps<T>): React.ReactElement {
+    const hasCustom = onCustomApply != null
+    const [open, setOpen] = React.useState(defaultOpen)
+    const [customView, setCustomView] = React.useState(defaultOpen && customActive && hasCustom)
+
+    const handleOpenChange = (nextOpen: boolean): void => {
+        if (nextOpen) {
+            // Start on the preset list; jump straight to the calendar only if a custom range is active
+            setCustomView(customActive && hasCustom)
+        }
+        setOpen(nextOpen)
+    }
+
+    const calendarValue = React.useMemo((): DateTimeValue => {
+        const now = new Date()
+        if (customActive && customStart && customEnd) {
+            return { start: customStart, end: customEnd, range: CUSTOM_RANGE }
+        }
+        const selected = presets.find((preset) => preset.id === selectedPresetId)
+        return {
+            start: selected?.previewStart?.(now) ?? subDays(now, 7),
+            end: selected?.previewEnd?.(now) ?? now,
+            range: CUSTOM_RANGE,
+        }
+    }, [customActive, customStart, customEnd, presets, selectedPresetId])
+
+    return (
+        <Popover open={open} onOpenChange={handleOpenChange}>
+            <PopoverTrigger
+                render={
+                    trigger ?? (
+                        <Button variant="outline" disabled={disabled} data-slot="date-range-filter-trigger">
+                            {label}
+                        </Button>
+                    )
+                }
+            />
+            <PopoverContent
+                align="start"
+                className={cn('w-auto overflow-hidden p-0', className)}
+                data-slot="date-range-filter"
+            >
+                {customView && hasCustom ? (
+                    <DateTimePicker
+                        value={calendarValue}
+                        ranges={[]}
+                        showHeader={false}
+                        showTime={showTime}
+                        weekStartsOn={weekStartsOn}
+                        dateFormat={dateFormat}
+                        minDate={minDate}
+                        maxDate={maxDate}
+                        onApply={(value) => {
+                            onCustomApply(value.start, value.end)
+                            setOpen(false)
+                        }}
+                        onCancel={() => setCustomView(false)}
+                        className="rounded-none shadow-none ring-0"
+                    />
+                ) : (
+                    <div className="flex flex-col" data-slot="date-range-filter-list">
+                        <div className="flex max-h-100 flex-col overflow-y-auto p-1">
+                            {presets.map((preset) => (
+                                <Button
+                                    key={preset.id}
+                                    variant="default"
+                                    left
+                                    className="w-full justify-start"
+                                    aria-selected={preset.id === selectedPresetId}
+                                    onClick={() => {
+                                        onPresetSelect(preset)
+                                        setOpen(false)
+                                    }}
+                                    data-attr={`date-range-filter-preset-${preset.id}`}
+                                >
+                                    {preset.label}
+                                </Button>
+                            ))}
+                            {hasCustom && (
+                                <Button
+                                    variant="default"
+                                    left
+                                    className="w-full justify-start"
+                                    aria-selected={customActive}
+                                    onClick={() => setCustomView(true)}
+                                    data-attr="date-range-filter-custom"
+                                >
+                                    {customLabel}
+                                </Button>
+                            )}
+                        </div>
+                        {listFooter != null && (
+                            <div className="border-t" data-slot="date-range-filter-footer">
+                                {listFooter}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </PopoverContent>
+        </Popover>
+    )
+}

--- a/packages/quill/packages/blocks/src/date-range-filter.tsx
+++ b/packages/quill/packages/blocks/src/date-range-filter.tsx
@@ -46,6 +46,8 @@ export interface DateRangeFilterProps<T = unknown> {
     maxDate?: Date
     defaultOpen?: boolean
     className?: string
+    /** Extra props for the popover surface (portaled to <body>) — e.g. skin opt-in data attributes. */
+    contentProps?: React.ComponentPropsWithoutRef<typeof PopoverContent>
 }
 
 /** Presets-first date filter: a trigger opening a quick-range list (instant apply), with an
@@ -72,6 +74,7 @@ export function DateRangeFilter<T = unknown>({
     maxDate,
     defaultOpen = false,
     className,
+    contentProps,
 }: DateRangeFilterProps<T>): React.ReactElement {
     const hasCustom = onCustomApply != null
     const [open, setOpen] = React.useState(defaultOpen)
@@ -111,7 +114,8 @@ export function DateRangeFilter<T = unknown>({
             />
             <PopoverContent
                 align="start"
-                className={cn('w-auto overflow-hidden p-0', className)}
+                {...contentProps}
+                className={cn('w-auto overflow-hidden p-0', className, contentProps?.className)}
                 data-slot="date-range-filter"
             >
                 {customView && hasCustom ? (

--- a/packages/quill/packages/blocks/src/index.ts
+++ b/packages/quill/packages/blocks/src/index.ts
@@ -7,12 +7,8 @@
 // opinionated shapes that stay consistent across every PostHog product
 // surface.
 //
-// None of these are implemented yet. This file is an empty module so
-// TypeScript treats it as one and downstream packages (the @posthog/quill
-// aggregate in particular) can `export * from '@posthog/quill-blocks'`
-// without hitting a "not a module" error while the layer is still empty.
-// Each new block should be added here as a named export and will flow
-// through to the public @posthog/quill surface automatically on the next
-// build.
-
-export {}
+export {
+    DateRangeFilter,
+    type DateRangeFilterPreset,
+    type DateRangeFilterProps,
+} from './date-range-filter'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1952,6 +1952,9 @@ importers:
       '@posthog/quill-tokens':
         specifier: workspace:^
         version: link:../tokens
+      date-fns:
+        specifier: ^4.0.0
+        version: 4.1.0
       react:
         specifier: 18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Problem

Nearly every product surface has the same date filter shape: a button that opens a preset list, with "Custom range…" revealing a calendar. Today each surface hand-rolls it (the insight date filter rebuild in #68359 being the latest), so the pattern drifts per product and every rebuild re-solves the same interaction.

Quill's blocks layer exists for exactly this — opinionated, product-shaped patterns — and has been an empty placeholder until now.

## Changes

Adds `DateRangeFilter`, the first block in `@posthog/quill-blocks`:

- Trigger (default outline button, or a `trigger` element override) opens a popover with a vertical preset list; clicking a preset applies immediately and closes.
- An optional "Custom range…" row swaps in `DateTimePicker` as a pure calendar range picker (`ranges={[]}`, header hidden, day-granular by default) — the embed props from #68398. Cancel returns to the list.
- `customActive` highlights the custom row and opens straight to the calendar, seeded from `customStart`/`customEnd`.
- `listFooter` slot pins host content below the preset list (list view only).

The boundary rule, enforced by the API: **the block never interprets what a preset means.** Presets carry an opaque `value` payload (`DateRangeFilterPreset<T>`) returned verbatim through `onPresetSelect`; `onCustomApply` hands back concrete `Date`s. Host persistence vocabulary — like PostHog's relative date strings (`-7d`, `mStart`) — stays out of the design system, which is why this is a block composing `DateTimePicker` rather than mode props on the picker itself (that approach was tried and closed in #69870).

Also: replaces the blocks placeholder `AGENTS.md` with a consumer guide, exports the block through the `@posthog/quill` aggregate, and adds `blocks/src` to the frontend jest roots.

First consumer: the insight date filter (#68359) will collapse onto this block next.

## How did you test this code?

- 4 jest tests, each guarding a distinct contract: preset click couriers the `value` payload and closes (catches the payload/instant-apply breaking), custom row ↔ calendar swap with Cancel returning and Apply emitting concrete dates (catches the view-swap and apply plumbing), `customActive` opening straight to the calendar (catches the jump logic), and `listFooter` rendering in the list view only (catches the slot being dropped — the bug shape the old design hit). Run via the frontend jest project.
- Stories for the three states (preset list, list with footer slot, custom-active calendar) snapshot in light and dark.
- `@posthog/quill-blocks` and the `@posthog/quill` aggregate build clean (vite-plugin-dts type-checks the package).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`packages/quill/packages/blocks/AGENTS.md` rewritten as the blocks consumer guide (was a placeholder).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session), directed by Sam. Follows a design discussion on where the presets-first pattern belongs: not as mode props on `DateTimePicker` (#69870, closed — wrong altitude), not consumer-local per product (drifts), but as a block — Sam called block-first, so the block ships before its first consumer is converted.
- Skills invoked: /writing-tests.
- Decisions: presets are generic over an opaque `value` rather than typed to PostHog date strings, keeping the design system app-agnostic; day-granular default (`showTime={false}`) since filters are the dominant use; `defaultOpen` exists chiefly so stories and snapshots can render the open states.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
