### PR TITLE
fix(quill): match border token to outline button border

### DIFF
--- a/packages/quill/packages/tokens/src/colors.ts
+++ b/packages/quill/packages/tokens/src/colors.ts
@@ -137,8 +137,15 @@ export function buildSemanticColors(): Record<string, ColorTuple> {
         info: [oklch(0.882, 0.059, 254.128), oklch(0.4242, 0.1982, 265.5, 0.4), 'bg-info'],
         'info-foreground': [oklch(0.49, 0.02, 254), oklch(0.882, 0.059, 254.128), 'text-info-foreground'],
 
-        // ── Borders & rings (theme-derived) ───────────
-        border: [surface(0.9, 0.8, 'light'), surface(0.27, 1.2, 'dark'), 'border-border'],
+        // ── Borders & rings ───────────────────────────
+        // Matches the outline button's border (see button.css) so a standalone
+        // `border-border` reads identically to a button's edge. Relative overlay
+        // on `--foreground` rather than a theme-hue surface.
+        border: [
+            'color-mix(in oklab, var(--foreground) 10%, transparent)',
+            'color-mix(in oklab, var(--foreground) 15%, transparent)',
+            'border-border',
+        ],
         input: [surface(0.81, 0.5, 'light'), surface(0.3, 1.5, 'dark'), 'border-input'],
         ring: [oklch(0.446, 0.03, 257), oklch(0.709, 0, 0), 'border-ring'],
 
@@ -221,10 +228,10 @@ const THEME_DERIVED_TOKENS: ReadonlySet<string> = new Set([
     'muted',
     'chrome',
     'primary',
-    'border',
     'input',
     // Transitive: reference var(--foreground) / var(--muted) — must also live
     // on `*` to re-evaluate on local overrides.
+    'border',
     'fill-hover',
     'fill-expanded',
     'fill-selected',


### PR DESCRIPTION
## Problem

In `packages/quill` the `border` token and the outline button variant resolved to different colors. The `border` token was a theme-hue surface color, while the outline button draws its edge with a relative overlay on `--foreground`. So a standalone `border-border` didn't read the same as a button's border, in either light or dark mode.

## Changes

Point the `border` token at the same values the outline button uses (see `button.css`):

- light: `color-mix(in oklab, var(--foreground) 10%, transparent)`
- dark: `color-mix(in oklab, var(--foreground) 15%, transparent)`

Since `border` now references `--foreground` transitively rather than a theme var directly, I also moved it into the transitive group of `THEME_DERIVED_TOKENS` (alongside the `fill-*` tokens) so it keeps emitting on `*` and re-evaluates under local theme overrides.

> [!NOTE]
> This is a global token change. Every `border-border` consumer across quill now matches the button edge, which subtly lightens borders elsewhere. That's the intent, just flagging the blast radius.

## How did you test this code?

I (Claude) ran the token build (`src/build.ts`) via tsx. The load-time `assertThemeDerivedSyncedWithColors` guard passes, and the generated `dist/color-system.css` emits `--border` as the 10% mix under `*` and the 15% mix under the dark selector, matching `button.css`. `dist/*.css` is gitignored (built at publish time), so only the `.ts` source is committed. I did not run the full quill test suite or visually diff in Storybook.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Adam asked to make the `border` token match the outline button's border in both light and dark mode. I (Claude) traced the outline variant in `button.css` to its `color-mix` on `--foreground`, replaced the old `surface(...)` recipe for `border` in `colors.ts` with those exact values, and re-slotted `border` under the transitive section of `THEME_DERIVED_TOKENS` so the `*`-scoping and local-override behavior is preserved. Verified by running the token build and inspecting the generated CSS. No skills were needed for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
