### PR TITLE
fix(postgres): surface leaked transaction nesting as retryable during setup

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -410,11 +410,17 @@ def _raise_if_setup_connection_broken(connection: psycopg.Connection) -> None:
     swallow the follow-up "connection closed" errors, so discovery finishes "successfully"
     and the implicit commit in the enclosing `with connection:` raises a misleading
     `ProgrammingError: Explicit commit() forbidden within a Transaction context`, burying
-    the real cause. Detect the broken connection first and raise the actual
-    dropped-connection error (transient, so it stays retryable) — the activity then retries
-    on a fresh connection instead of failing on a self-inflicted commit error.
+    the real cause.
+
+    A hard drop flips the connection to `broken`, but a drop that lands precisely while
+    psycopg is entering or leaving the probe's `transaction()` block can leave the nesting
+    counter incremented while `broken` stays False (the connection is `INERROR`, not BAD).
+    `commit()` refuses outright whenever that counter is non-zero, so checking `broken` alone
+    misses this case. Detect either signal and raise the actual dropped-connection error
+    (transient, so it stays retryable) — the activity then retries on a fresh connection
+    instead of failing on the self-inflicted commit error.
     """
-    if connection.broken:
+    if connection.broken or getattr(connection, "_num_transactions", 0) > 0:
         raise psycopg.OperationalError("connection to server was lost during table metadata discovery")
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1365,6 +1365,7 @@ class TestRaiseIfSetupConnectionBroken:
     def test_broken_connection_raises_retryable_dropped_error(self):
         connection = mock.MagicMock()
         connection.broken = True
+        connection._num_transactions = 0
 
         with pytest.raises(psycopg.OperationalError) as exc_info:
             _raise_if_setup_connection_broken(cast(Any, connection))
@@ -1375,11 +1376,27 @@ class TestRaiseIfSetupConnectionBroken:
         message = str(exc_info.value)
         assert not any(key in message for key in PostgresSource().get_non_retryable_errors())
 
+    def test_leaked_transaction_counter_raises_retryable_dropped_error(self):
+        # A drop while psycopg was entering/leaving a probe's transaction() block leaves the
+        # nesting counter incremented without flipping `broken` — the exact state (`INERROR`,
+        # not BAD) that made the exit-commit raise the masked ProgrammingError in production.
+        connection = mock.MagicMock()
+        connection.broken = False
+        connection._num_transactions = 1
+
+        with pytest.raises(psycopg.OperationalError) as exc_info:
+            _raise_if_setup_connection_broken(cast(Any, connection))
+
+        assert _is_connection_dropped_error(exc_info.value) is True
+        message = str(exc_info.value)
+        assert not any(key in message for key in PostgresSource().get_non_retryable_errors())
+
     def test_healthy_connection_is_a_noop(self):
         connection = mock.MagicMock()
         connection.broken = False
+        connection._num_transactions = 0
 
-        # A healthy connection must not raise.
+        # A healthy connection with no leaked transaction nesting must not raise.
         _raise_if_setup_connection_broken(cast(Any, connection))
 
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a Postgres data-warehouse import failing with:

> `ProgrammingError: Explicit commit() forbidden within a Transaction context. (Transaction will be automatically committed on successful exit from context.)`

The real stack originates in the Postgres source's metadata-discovery setup (`postgres_source` → `source_for_pipeline`), and the failing operation is the implicit `commit()` that psycopg runs when the `with connection:` setup block exits successfully. The connection in the captured event is alive but `INERROR`, not broken.

Root cause: during setup we run best-effort probes, one of which isolates its query in a `connection.transaction()` block. psycopg increments a transaction-nesting counter on enter and only decrements it on exit when the connection is still OK. A connection dropped precisely while entering or leaving that block can leave the counter incremented **without** flipping `connection.broken` (the connection reads `INERROR`, not `BAD`). psycopg's `commit()` refuses outright whenever that counter is non-zero, so the exit-commit raises the misleading `ProgrammingError` and buries the real, transient cause.

There is already a guard (`_raise_if_setup_connection_broken`) meant to convert exactly this masked error into a retryable dropped-connection error. It only checked `connection.broken`, so it missed the not-broken-but-counter-leaked case.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f5687-17a3-7e81-b64c-07904c6b4fca

## Changes

Broaden `_raise_if_setup_connection_broken` to fire on **either** signal: a broken connection **or** a leaked transaction-nesting counter (`_num_transactions > 0`). The counter is the exact predicate psycopg's `commit()` checks, so this preempts the misleading error precisely.

The raised error is the same retryable `OperationalError` the broken-connection path already used, so it's classified as a transient drop (matches `_is_connection_dropped_error`, matches no `NonRetryableErrors` substring) and the activity retries on a fresh connection instead of failing on a self-inflicted commit error.

> [!NOTE]
> This is deliberately kept retryable. A statement error inside the probe (e.g. a `statement_timeout`) tears its transaction down cleanly and does **not** leak the counter, so this change does not turn genuine query failures into infinite retries — the counter only leaks on a connection-level problem mid-probe, which is transient.

## How did you test this code?

Automated only. I (Claude) added a regression test and ran the guard's unit tests locally with the repo venv:

```
python -m pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py::TestRaiseIfSetupConnectionBroken -q
3 passed
```

New test `test_leaked_transaction_counter_raises_retryable_dropped_error` reproduces the production state — a non-broken connection (`broken = False`) with a leaked counter (`_num_transactions = 1`) — and asserts the guard raises a retryable error not matched by any `NonRetryableErrors` substring. No existing test covered the not-broken-but-counter-leaked path; the existing tests only covered `broken = True` and a fully healthy connection. ruff check and format are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) pulled the issue's stack trace and a representative event via the PostHog MCP error-tracking tools, confirmed the failure genuinely originates in the Postgres source setup (not just serialized log context), and read psycopg's `transaction.py` / `_connection_base.py` to pin down that `commit()` gates purely on the transaction-nesting counter and that `Transaction.__exit__` skips the decrement when the connection is not OK.

Decision: this is a fragile-code bug, not a user/upstream error, so I fixed the code rather than extending `NonRetryableErrors`. The masked `ProgrammingError` hides a transient dropped-connection condition that should stay retryable, so the fix surfaces the real retryable error rather than suppressing it. Scope kept to the existing guard; no retry-policy or unrelated changes.

Skills invoked: `/writing-tests` (before adding the regression test).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
