### PR TITLE
feat(warehouse-sources): add catalog search aliases for connector alternate names

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
@@ -145,7 +145,7 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig]):
             name=SchemaExternalDataSourceType.META_ADS,
             category=DataWarehouseSourceCategory.ADVERTISING,
             featured=True,
-            keywords=["facebook ads", "instagram ads"],
+            keywords=["facebook ads", "instagram ads", "facebook", "instagram", "fb"],
             label="Meta Ads",
             caption="Ensure you have granted PostHog access to your Meta Ads account, learn how to do this in the [documentation](https://posthog.com/docs/cdp/sources/meta-ads).",
             iconPath="/static/services/meta-ads.png",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -153,7 +153,7 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
         return SourceConfig(
             name=SchemaExternalDataSourceType.MSSQL,
             category=DataWarehouseSourceCategory.DATABASES,
-            keywords=["sql server"],
+            keywords=["sql server", "sql", "mssql"],
             label="Microsoft SQL Server",
             caption="Enter your Microsoft SQL Server/Azure SQL Server credentials to automatically pull your SQL data into the PostHog Data warehouse.",
             iconPath="/static/services/sql-azure.png",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -95,6 +95,7 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             name=SchemaExternalDataSourceType.MY_SQL,
             category=DataWarehouseSourceCategory.DATABASES,
             featured=True,
+            keywords=["sql", "mariadb"],
             caption="Enter your MySQL/MariaDB credentials to automatically pull your MySQL data into the PostHog Data warehouse.",
             iconPath="/static/services/mysql.png",
             docsUrl="https://posthog.com/docs/cdp/sources/mysql",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -194,7 +194,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         return SourceConfig(
             name=SchemaExternalDataSourceType.POSTGRES,
             category=DataWarehouseSourceCategory.DATABASES,
-            keywords=["postgresql"],
+            keywords=["postgresql", "sql"],
             caption="Enter your Postgres credentials to automatically pull your Postgres data into the PostHog Data warehouse",
             iconPath="/static/services/postgres.png",
             docsUrl="https://posthog.com/docs/cdp/sources/postgres",


### PR DESCRIPTION
## Problem

Session-replay observations of real users in the data-warehouse new-source onboarding flow show people searching the connector catalog by an alternate name and finding nothing:

- A user typed **"fb"** trying to reach Meta Ads. The catalog only knew the keywords `facebook ads` / `instagram ads`, so a short query like `fb` (and even bare `facebook`) didn't match, and the connector stayed hidden.
- A user searched **"sql"** looking for a relational database source. Postgres only carried `postgresql`, MySQL had no keywords, and MSSQL only had `sql server`, so a bare `sql` query didn't reliably surface any of them.

The catalog already supports search aliases via each source's `keywords` list (indexed by the Fuse search alongside name/label/category) — the affected connectors were just missing the obvious ones.

## Changes

Add the missing lowercase keyword aliases:

- **Meta Ads**: `facebook`, `instagram`, `fb`
- **Postgres**: `sql`
- **MySQL**: `sql`, `mariadb` (the connector already handles MariaDB credentials)
- **MSSQL**: `sql`, `mssql`

No search-plumbing change — these feed the existing `keywords` field.

## How did you test this code?

The Python toolchain isn't bootstrapped in this sandbox, so I couldn't run the suite locally; CI will run it. The change is pure data — lowercase strings appended to existing `keywords` lists — which satisfies the existing format check in `test_source_categories.py::test_source_keywords_are_a_list_of_strings` (asserts every keyword is a lowercase string). Ruff check + format pass on all four files.

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) from Replay Vision observations of the data-warehouse onboarding flow. The friction ("users can't find a connector by the name they search") recurred across sessions; this is the self-contained, low-risk slice. Deeper themes (OAuth transient-error copy, Google Ads MCC-vs-client ID hinting) were left as recommendations since existing maintainer PRs already cover that ground.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*