### PR TITLE
feat(replay): let users set a default sort for the recordings list

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -25,6 +25,7 @@ import { playerSettingsLogic } from '../player/playerSettingsLogic'
 import {
     DELETE_CONFIRMATION_TEXT,
     MAX_SELECTED_RECORDINGS,
+    RecordingSortPreference,
     sessionRecordingsPlaylistLogic,
 } from './sessionRecordingsPlaylistLogic'
 
@@ -54,7 +55,7 @@ function getLabel(filters: RecordingUniversalFilters): string {
     return SortingKeyToLabel[order_field as keyof typeof SortingKeyToLabel]
 }
 
-type RecordingSort = { order: NonNullable<RecordingUniversalFilters['order']>; order_direction: 'ASC' | 'DESC' }
+type RecordingSort = RecordingSortPreference
 
 /** The analytics payload for a sort change, or null when the sort is unchanged so we don't log no-op switches. */
 export function getSortChangedEvent(
@@ -84,6 +85,16 @@ function SortedBy({
     const surfacingScoreEnabled = useFeatureFlag('REPLAY_PLAYLIST_SURFACING_SCORE')
     const inRelevanceSortExperiment = useFeatureFlag('REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT', 'test')
     const showRelevanceSort = surfacingScoreEnabled || inRelevanceSortExperiment
+
+    const { defaultSort } = useValues(sessionRecordingsPlaylistLogic)
+    const { setDefaultSort } = useActions(sessionRecordingsPlaylistLogic)
+
+    const currentSort: RecordingSort = {
+        order: filters.order || 'start_time',
+        order_direction: filters.order_direction || 'DESC',
+    }
+    const isCurrentSortDefault =
+        defaultSort?.order === currentSort.order && defaultSort?.order_direction === currentSort.order_direction
 
     // Track sort changes for the relevance-sort experiment
     const changeSort = (sort: RecordingSort): void => {
@@ -179,6 +190,14 @@ function SortedBy({
                     label: 'Expiration',
                     onClick: () => changeSort({ order: 'recording_ttl', order_direction: 'ASC' }),
                     active: filters.order === 'recording_ttl',
+                },
+                {
+                    label: isCurrentSortDefault ? 'Clear default sort' : 'Set as default sort',
+                    tooltip: isCurrentSortDefault
+                        ? 'Session replay opens with this sort by default. Clear it to go back to the standard sort.'
+                        : 'Open session replay with this sort by default. Saved for this project in this browser.',
+                    onClick: () => setDefaultSort(isCurrentSortDefault ? null : currentSort),
+                    'data-attr': 'session-recordings-set-default-sort',
                 },
             ]}
             icon={<IconSort className="text-lg" />}

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -1,3 +1,5 @@
+import { MOCK_TEAM_ID } from 'lib/api.mock'
+
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 import posthog from 'posthog-js'
@@ -28,6 +30,7 @@ import {
     convertUniversalFiltersToRecordingsQuery,
     getDefaultFilters,
     sessionRecordingsPlaylistLogic,
+    setDefaultRecordingSort,
 } from './sessionRecordingsPlaylistLogic'
 
 describe('sessionRecordingsPlaylistLogic', () => {
@@ -1330,6 +1333,90 @@ describe('sessionRecordingsPlaylistLogic', () => {
             const result = getDefaultFilters(undefined, pinnedFilters)
             const firstGroup = result.filter_group.values[0] as any
             expect(firstGroup.values).toContainEqual(pinnedFilters.values[0])
+        })
+    })
+
+    describe('default sort preference', () => {
+        const storageKey = `replay_default_sort_${MOCK_TEAM_ID}`
+
+        beforeEach(() => {
+            localStorage.clear()
+        })
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it.each<
+            [
+                string,
+                Record<string, string | boolean>,
+                { personUUID?: string; urlFilters?: Partial<RecordingUniversalFilters> },
+                string,
+                string,
+            ]
+        >([
+            ['applies the saved sort on the landing page', {}, {}, 'start_time', 'ASC'],
+            [
+                'wins over the surfacing-score rollout flag',
+                { [FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE]: true },
+                {},
+                'start_time',
+                'ASC',
+            ],
+            [
+                'is ignored on person pages',
+                {},
+                { personUUID: 'person-uuid' },
+                DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                'DESC',
+            ],
+            [
+                'is ignored for deep links with pre-applied filters',
+                {},
+                { urlFilters: { date_from: '-7d' } },
+                DEFAULT_RECORDING_FILTERS_ORDER_BY,
+                'DESC',
+            ],
+        ])('%s', (_name, flags, { personUUID, urlFilters }, expectedOrder, expectedDirection) => {
+            jest.spyOn(posthog, 'getFeatureFlag').mockImplementation((key) => flags[key as string] as any)
+            setDefaultRecordingSort({ order: 'start_time', order_direction: 'ASC' })
+
+            const result = getDefaultFilters(personUUID, undefined, urlFilters)
+
+            expect(result.order).toBe(expectedOrder)
+            expect(result.order_direction).toBe(expectedDirection)
+        })
+
+        it.each<[string, string]>([
+            ['not valid JSON', 'not-json'],
+            ['an unknown order key', JSON.stringify({ order: 'nonsense', order_direction: 'DESC' })],
+            ['an invalid direction', JSON.stringify({ order: 'start_time', order_direction: 'sideways' })],
+        ])('falls back to the standard default when the stored value is %s', (_name, storedValue) => {
+            localStorage.setItem(storageKey, storedValue)
+
+            const result = getDefaultFilters()
+
+            expect(result.order).toBe(DEFAULT_RECORDING_FILTERS_ORDER_BY)
+            expect(result.order_direction).toBe('DESC')
+        })
+
+        it('persists and clears the preference via setDefaultSort', () => {
+            logic = sessionRecordingsPlaylistLogic({ logicKey: 'default-sort-test' })
+            logic.mount()
+
+            logic.actions.setDefaultSort({ order: 'console_error_count', order_direction: 'DESC' })
+            expect(JSON.parse(localStorage.getItem(storageKey) ?? 'null')).toEqual({
+                order: 'console_error_count',
+                order_direction: 'DESC',
+            })
+            expect(logic.values.defaultSort).toEqual({ order: 'console_error_count', order_direction: 'DESC' })
+            expect(getDefaultFilters().order).toBe('console_error_count')
+
+            logic.actions.setDefaultSort(null)
+            expect(localStorage.getItem(storageKey)).toBeNull()
+            expect(logic.values.defaultSort).toBeNull()
+            expect(getDefaultFilters().order).toBe(DEFAULT_RECORDING_FILTERS_ORDER_BY)
         })
     })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -18,7 +18,7 @@ import {
 } from 'lib/components/UniversalFilters/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { getCurrentTeamId } from 'lib/utils/getAppContext'
+import { getCurrentTeamId, getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
 import { isString } from 'lib/utils/guards'
 import { objectClean, objectsEqual } from 'lib/utils/objects'
 import { toParams } from 'lib/utils/url'
@@ -26,7 +26,13 @@ import { createPlaylist } from 'scenes/session-recordings/playlist/playlistUtils
 import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 import { urls } from 'scenes/urls'
 
-import { NodeKind, RecordingOrder, RecordingsQuery, RecordingsQueryResponse } from '~/queries/schema/schema-general'
+import {
+    NodeKind,
+    RecordingOrder,
+    RecordingOrderDirection,
+    RecordingsQuery,
+    RecordingsQueryResponse,
+} from '~/queries/schema/schema-general'
 import {
     AnyPropertyFilter,
     FilterLogicalOperator,
@@ -158,6 +164,48 @@ const getDefaultFilterTestAccounts = (): boolean => {
     return stored === 'true'
 }
 
+export type RecordingSortPreference = {
+    order: RecordingOrder
+    order_direction: RecordingOrderDirection
+}
+
+const getDefaultSortStorageKey = (): string | null => {
+    const teamId = getCurrentTeamIdOrNone()
+    return teamId ? `replay_default_sort_${teamId}` : null
+}
+
+export const getDefaultRecordingSort = (): RecordingSortPreference | null => {
+    const storageKey = getDefaultSortStorageKey()
+    if (!storageKey) {
+        return null
+    }
+    try {
+        const stored = localStorage.getItem(storageKey)
+        if (!stored) {
+            return null
+        }
+        const parsed = JSON.parse(stored)
+        if (isValidRecordingOrder(parsed?.order) && ['ASC', 'DESC'].includes(parsed?.order_direction)) {
+            return { order: parsed.order, order_direction: parsed.order_direction }
+        }
+    } catch {
+        // an unreadable stored value falls back to the standard default below
+    }
+    return null
+}
+
+export const setDefaultRecordingSort = (sort: RecordingSortPreference | null): void => {
+    const storageKey = getDefaultSortStorageKey()
+    if (!storageKey) {
+        return
+    }
+    if (sort) {
+        localStorage.setItem(storageKey, JSON.stringify(sort))
+    } else {
+        localStorage.removeItem(storageKey)
+    }
+}
+
 export const DEFAULT_RECORDING_FILTERS: RecordingUniversalFilters = {
     filter_test_accounts: false,
     date_from: '-3d',
@@ -178,17 +226,22 @@ export const getDefaultFilters = (
     // (urlFilters, e.g. "View recordings" CTAs) come with a specific session in mind,
     // where recency is the better default than relevance
     const hasSpecificIntent = !!personUUID || !!pinnedFilters || !!urlFilters
+    // A sort the user explicitly saved as their default wins over the flag-driven relevance default,
+    // but only on the plain landing page, since specific-intent pages assume recency
+    const preferredSort = hasSpecificIntent ? null : getDefaultRecordingSort()
     const defaults: RecordingUniversalFilters = {
         ...DEFAULT_RECORDING_FILTERS,
         filter_test_accounts: filterTestAccounts,
         date_from: personUUID ? '-30d' : '-3d',
         // Default to sorting by relevance for the surfacing-score rollout or the relevance-sort experiment's test arm
-        order:
-            !hasSpecificIntent &&
-            (posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE) ||
-                posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT) === 'test')
-                ? 'surfacing_score'
-                : DEFAULT_RECORDING_FILTERS.order,
+        order: preferredSort
+            ? preferredSort.order
+            : !hasSpecificIntent &&
+                (posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE) ||
+                    posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT) === 'test')
+              ? 'surfacing_score'
+              : DEFAULT_RECORDING_FILTERS.order,
+        order_direction: preferredSort ? preferredSort.order_direction : DEFAULT_RECORDING_FILTERS.order_direction,
     }
     if (pinnedFilters) {
         defaults.filter_group = mergePinnedFilters(defaults.filter_group, pinnedFilters)
@@ -446,6 +499,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
 
     actions({
         setFilters: (filters: Partial<RecordingUniversalFilters>) => ({ filters }),
+        setDefaultSort: (defaultSort: RecordingSortPreference | null) => ({ defaultSort }),
         setShowFilters: (showFilters: boolean) => ({ showFilters }),
         setShowSettings: (showSettings: boolean) => ({ showSettings }),
         resetFilters: true,
@@ -691,6 +745,12 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 resetFilters: () => getDefaultFilters(props.personUUID, props.pinnedFilters),
             },
         ],
+        defaultSort: [
+            getDefaultRecordingSort() as RecordingSortPreference | null,
+            {
+                setDefaultSort: (_, { defaultSort }) => defaultSort,
+            },
+        ],
         showFilters: [
             true,
             {
@@ -823,6 +883,17 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             actions.loadSessionRecordings(undefined, filters)
             props.onFiltersChange?.(values.filters)
             actions.loadEventsHaveSessionId()
+        },
+
+        setDefaultSort: ({ defaultSort }) => {
+            setDefaultRecordingSort(defaultSort)
+            posthog.capture('session recording default sort updated', {
+                sort_key: defaultSort?.order ?? null,
+                sort_direction: defaultSort?.order_direction ?? null,
+            })
+            lemonToast.success(
+                defaultSort ? 'Default sort saved. Session replay will open with this sort.' : 'Default sort cleared.'
+            )
         },
 
         resetFilters: () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -229,19 +229,17 @@ export const getDefaultFilters = (
     // A sort the user explicitly saved as their default wins over the flag-driven relevance default,
     // but only on the plain landing page, since specific-intent pages assume recency
     const preferredSort = hasSpecificIntent ? null : getDefaultRecordingSort()
+    // Default to sorting by relevance for the surfacing-score rollout or the relevance-sort experiment's test arm
+    const flagDefaultsToRelevance =
+        !hasSpecificIntent &&
+        (posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE) ||
+            posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT) === 'test')
     const defaults: RecordingUniversalFilters = {
         ...DEFAULT_RECORDING_FILTERS,
         filter_test_accounts: filterTestAccounts,
         date_from: personUUID ? '-30d' : '-3d',
-        // Default to sorting by relevance for the surfacing-score rollout or the relevance-sort experiment's test arm
-        order: preferredSort
-            ? preferredSort.order
-            : !hasSpecificIntent &&
-                (posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE) ||
-                    posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT) === 'test')
-              ? 'surfacing_score'
-              : DEFAULT_RECORDING_FILTERS.order,
-        order_direction: preferredSort ? preferredSort.order_direction : DEFAULT_RECORDING_FILTERS.order_direction,
+        order: preferredSort?.order ?? (flagDefaultsToRelevance ? 'surfacing_score' : DEFAULT_RECORDING_FILTERS.order),
+        order_direction: preferredSort?.order_direction ?? DEFAULT_RECORDING_FILTERS.order_direction,
     }
     if (pinnedFilters) {
         defaults.filter_group = mergePinnedFilters(defaults.filter_group, pinnedFilters)


### PR DESCRIPTION
## Problem

The session replay list opens sorted by latest start time (or by relevance when the surfacing-score rollout flag is on). People who prefer a different sort, most commonly chronological "Oldest", have to re-apply it over and over, and a "Reset filters" click or a default change throws their choice away.

## Changes

- The "Sort by" menu on the recordings list gets a final item: **Set as default sort**. It saves the current sort as the default for the session replay landing page in the current project. When the current sort already is the saved default, the item becomes **Clear default sort**.
- The preference is stored per project in localStorage (`replay_default_sort_<team_id>`), following the same pattern as the existing `default_filter_test_accounts` preference. Values are validated on read, so a corrupt or stale entry falls back to the standard default instead of producing an invalid query.
- `getDefaultFilters` applies the saved sort on the plain landing page and on filter resets. It wins over the flag-driven relevance default (an explicit user choice beats the experiment default). It is deliberately not applied on specific-intent pages (person pages, pinned-filter pages, deep links with pre-applied filters), which keep their existing recency default.
- Saving or clearing shows a confirmation toast and captures a `session recording default sort updated` event.

The new menu item:

![replay-sort-menu-set-default](https://raw.githubusercontent.com/PostHog/pr-assets/6925cdf95ac026cd035ee2f05117803846567fe8/2026/07/e3b4d77b-6d80-4ade-a404-ba8245f470ca.png)

A fresh visit after saving "Oldest" as the default: the list opens chronologically and the menu offers to clear the default:

![replay-sort-menu-clear-default](https://raw.githubusercontent.com/PostHog/pr-assets/01749494faa61e7696a6b199038526bcbbf7e787/2026/07/6e0da834-ddbd-4335-b640-b4de4afb2695.png)

## How did you test this code?

Automated tests, all run locally and passing:

- 8 new parameterized jest cases in `sessionRecordingsPlaylistLogic.test.ts`:
  - saved sort applies on the landing page and wins over the surfacing-score flag (catches a refactor dropping the preference read or its precedence over the flag default)
  - ignored on person pages and deep links with pre-applied filters (catches the preference leaking past the specific-intent gate)
  - corrupt stored values (invalid JSON, unknown order key, invalid direction) fall back to the standard default (this exact bug class shipped before with sort keys in localStorage, see the comment in `recordingsQueryConversions.ts`)
  - persist/clear roundtrip through the `setDefaultSort` action (catches the listener no longer writing or clearing localStorage)
- Full `sessionRecordingsPlaylistLogic.test.ts` (83 tests) and `SessionRecordingsPlaylistSettings.test.ts` (5 tests) suites pass.

Manual verification on the local dev stack (driven by the agent via Playwright, screenshots above):

- Switched the sort to "Oldest", clicked "Set as default sort": toast shown, `replay_default_sort_1` written with `{"order":"start_time","order_direction":"ASC"}`.
- Simulated a fresh visit (cleared the persisted playlist filters, kept the preference) and reloaded: the landing page opened sorted by "Oldest".
- The menu then shows "Clear default sort". Clicking it shows the cleared toast and removes the stored key.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` cover the replay list sort behavior, so nothing to update in this repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). Skills invoked: `/writing-tests`, `/writing-kea-logics`.
- Chose localStorage per project over a backend user preference: it matches every other replay preference (playback speed, timestamp format, hide viewed) and keeps the change small and backwards compatible. A cross-device server-side preference can be layered on later if wanted.
- Placed the reactive state (`setDefaultSort` action + `defaultSort` reducer) in `sessionRecordingsPlaylistLogic` with localStorage as the source of truth, mirroring the existing `filterTestAccountsDefaultsLogic` pattern rather than inventing a new one.
