### PR TITLE
feat(notebooks): expose cell run, result, and interrupt as MCP tools

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -538,6 +538,8 @@ SPECTACULAR_SETTINGS = {
         "BatchExportRunStatusEnum": "products.batch_exports.backend.models.batch_export.BatchExportRun.Status",
         "HeatmapType": "products.web_analytics.backend.models.heatmap_saved.SavedHeatmap.Type",
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
+        "NotebookCellRunNodeTypeEnum": ["hogql", "python"],
+        "NotebookCellRunRefKindEnum": ["hogql", "local"],
         "PropertyGroupOperator": ["AND", "OR"],
         # bulk_update_tags exposes an identical add/remove/set `action` ChoiceField on both
         # BulkUpdateTagsRequest and its UUID subclass, so the shared enum can't be component-prefixed

--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -74,8 +74,11 @@ from products.notebooks.backend.sql_v2_references import (
     resolve_sql_node_run,
 )
 from products.notebooks.backend.sql_v2_serializers import (
+    NotebookSQLV2InterruptResponseSerializer,
     NotebookSQLV2PageRequestSerializer,
     NotebookSQLV2RunRequestSerializer,
+    NotebookSQLV2RunResponseSerializer,
+    NotebookSQLV2RunStatusResponseSerializer,
 )
 from products.notebooks.backend.temporal.client import start_sql_v2_run_workflow
 from products.notebooks.backend.temporal.sql_v2 import SQLV2RunInput
@@ -917,8 +920,16 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
 
         return Response(data)
 
-    # Experimental, flag-gated slice — kept out of the public OpenAPI schema (no generated FE/MCP types yet).
-    @extend_schema(exclude=True)
+    @extend_schema(
+        request=NotebookSQLV2RunRequestSerializer,
+        responses=NotebookSQLV2RunResponseSerializer,
+        summary="Run a notebook cell",
+        description=(
+            "Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. "
+            "Returns a run_id immediately; poll the run result endpoint until the status is terminal. "
+            "Requires the notebook's kernel to be running and the revamped-py-notebooks feature."
+        ),
+    )
     @action(methods=["POST"], url_path="sql_v2/run", detail=True, required_scopes=["notebook:write", "query:read"])
     def sql_v2_run(self, request: Request, **kwargs):
         user = self._current_user()
@@ -1013,7 +1024,23 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
 
         return Response({"run_id": str(run.id)})
 
-    @extend_schema(exclude=True)
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "run_id",
+                type=OpenApiTypes.UUID,
+                location=OpenApiParameter.PATH,
+                description="The run_id returned by the run endpoint.",
+            )
+        ],
+        responses=NotebookSQLV2RunStatusResponseSerializer,
+        summary="Get a notebook cell run's status and result",
+        description=(
+            "Read a dispatched run's state. Poll until status is 'done', 'failed', or 'interrupted'; "
+            "done and interrupted runs carry the result envelope (columns, first rows, and for python "
+            "cells the captured stdout/stderr and figures)."
+        ),
+    )
     @action(
         methods=["GET"],
         url_path="sql_v2/runs/(?P<run_id>[^/.]+)",
@@ -1136,7 +1163,23 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
 
         return Response(page)
 
-    @extend_schema(exclude=True)
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "run_id",
+                type=OpenApiTypes.UUID,
+                location=OpenApiParameter.PATH,
+                description="The run_id returned by the run endpoint.",
+            )
+        ],
+        request=None,
+        responses=NotebookSQLV2InterruptResponseSerializer,
+        summary="Interrupt a running notebook cell",
+        description=(
+            "Stop a running cell. The terminal 'interrupted' state (with any captured output) arrives "
+            "via the run result endpoint; when no kernel is reachable the run is marked interrupted directly."
+        ),
+    )
     @action(
         methods=["POST"],
         url_path="sql_v2/runs/(?P<run_id>[^/.]+)/interrupt",

--- a/products/notebooks/backend/sql_v2_serializers.py
+++ b/products/notebooks/backend/sql_v2_serializers.py
@@ -153,3 +153,45 @@ class NotebookSQLV2EnvelopeSerializer(serializers.Serializer):
 
 class NotebookSQLV2CallbackRequestSerializer(serializers.Serializer):
     envelope = NotebookSQLV2EnvelopeSerializer(help_text="The result envelope produced by the sandbox run.")
+
+
+class NotebookSQLV2RunResponseSerializer(serializers.Serializer):
+    run_id = serializers.UUIDField(
+        help_text="Identifier of the dispatched run. Poll the run result endpoint with it until the status is terminal."
+    )
+
+
+class NotebookSQLV2RunStatusResponseSerializer(serializers.Serializer):
+    status = serializers.CharField(
+        help_text=(
+            "Run state: 'running' while executing (keep polling), or terminal 'done', 'failed', or "
+            "'interrupted' (user-requested stop)."
+        )
+    )
+    result = NotebookSQLV2EnvelopeSerializer(
+        required=False,
+        allow_null=True,
+        help_text=(
+            "The result envelope once the run is done or interrupted: columns, a bounded first_page of rows, "
+            "row_count, and for python cells the captured stdout/stderr and any figures. Null while running or failed."
+        ),
+    )
+    error = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="Error message when the run failed or was interrupted; null otherwise.",
+    )
+
+
+class NotebookSQLV2InterruptResponseSerializer(serializers.Serializer):
+    status = serializers.CharField(
+        help_text=(
+            "The run's status after the interrupt request: usually still 'running' (the terminal 'interrupted' "
+            "state arrives via the run result endpoint), or already-terminal state when nothing was stopped."
+        )
+    )
+    detail = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="Set when nothing was stopped, e.g. the run has not reached the kernel yet; retry shortly.",
+    )

--- a/products/notebooks/frontend/generated/api.schemas.ts
+++ b/products/notebooks/frontend/generated/api.schemas.ts
@@ -272,6 +272,126 @@ export interface NotebookCollabSaveApi {
     cursor_head?: number | null
 }
 
+/**
+ * * `hogql` - hogql
+ * * `local` - local
+ */
+export type NotebookCellRunRefKindEnumApi =
+    (typeof NotebookCellRunRefKindEnumApi)[keyof typeof NotebookCellRunRefKindEnumApi]
+
+export const NotebookCellRunRefKindEnumApi = {
+    Hogql: 'hogql',
+    Local: 'local',
+} as const
+
+export interface NotebookSQLV2RefApi {
+    /** ProseMirror node id of the upstream node this name points at. */
+    node_id: string
+    /** What the name resolves to: 'hogql' is a SQL node's query definition (resolved to its last-run HogQL); 'local' is a dataframe a Python node bound in the kernel namespace.
+     *
+     * * `hogql` - hogql
+     * * `local` - local */
+    kind?: NotebookCellRunRefKindEnumApi
+}
+
+/**
+ * Available upstream nodes, keyed by dataframe name. A SQL node inlines referenced hogql refs as CTEs — unless it references a local ref, which reroutes the run to the sandbox's DuckDB; a python node materializes the hogql refs its code reads as pandas frames.
+ */
+export type NotebookSQLV2RunRequestApiRefs = { [key: string]: NotebookSQLV2RefApi }
+
+/**
+ * * `hogql` - hogql
+ * * `python` - python
+ */
+export type NotebookCellRunNodeTypeEnumApi =
+    (typeof NotebookCellRunNodeTypeEnumApi)[keyof typeof NotebookCellRunNodeTypeEnumApi]
+
+export const NotebookCellRunNodeTypeEnumApi = {
+    Hogql: 'hogql',
+    Python: 'python',
+} as const
+
+export interface NotebookSQLV2RunRequestApi {
+    /** ProseMirror node id of the SQLV2 node being run. */
+    node_id: string
+    /** Execution kind. 'hogql' is a SQL node — pushed to ClickHouse, or rerouted to the sandbox's DuckDB when it references a local frame; 'python' runs the code in the sandbox kernel, materializing referenced upstream nodes as pandas frames first.
+     *
+     * * `hogql` - hogql
+     * * `python` - python */
+    node_type?: NotebookCellRunNodeTypeEnumApi
+    /** The node's source — SQL for a hogql node, Python for a python node. Must not be blank. */
+    code: string
+    /** Kernel nodes only: the dataframe variable to bind the result to in the kernel namespace (a python node falls back to the last expression for its preview). */
+    output_name?: string
+    /** Available upstream nodes, keyed by dataframe name. A SQL node inlines referenced hogql refs as CTEs — unless it references a local ref, which reroutes the run to the sandbox's DuckDB; a python node materializes the hogql refs its code reads as pandas frames. */
+    refs?: NotebookSQLV2RunRequestApiRefs
+}
+
+export interface NotebookSQLV2RunResponseApi {
+    /** Identifier of the dispatched run. Poll the run result endpoint with it until the status is terminal. */
+    run_id: string
+}
+
+export interface NotebookSQLV2MediaApi {
+    /** MIME type of the media, e.g. 'image/png' for a matplotlib figure. */
+    mime_type: string
+    /** Base64-encoded media bytes. */
+    data: string
+}
+
+export interface NotebookSQLV2EnvelopeApi {
+    /** Run outcome: 'ok', 'error', or 'interrupted' (user-requested stop). */
+    status: string
+    /** Captured stdout from a Python node run. */
+    stdout?: string
+    /** Captured stderr (including tracebacks) from a Python node run. */
+    stderr?: string
+    /** Rich outputs from a Python node run, e.g. matplotlib figures as PNGs. */
+    media?: NotebookSQLV2MediaApi[]
+    /** Result column names. */
+    columns?: string[]
+    /** ClickHouse type per column, as [name, type] pairs; used by the visualization tab. */
+    types?: string[][]
+    /** Number of rows in the result. */
+    row_count?: number
+    /** Whether ClickHouse has more rows beyond first_page (detected by fetching limit+1). */
+    has_more?: boolean
+    /** First page of result rows for display; each row is a list of cell values. */
+    first_page?: unknown[][]
+    /**
+     * Identifier of the materialized result, used as the paging key.
+     * @nullable
+     */
+    result_id?: string | null
+    /**
+     * Error message when status is 'error'.
+     * @nullable
+     */
+    error?: string | null
+}
+
+export interface NotebookSQLV2RunStatusResponseApi {
+    /** Run state: 'running' while executing (keep polling), or terminal 'done', 'failed', or 'interrupted' (user-requested stop). */
+    status: string
+    /** The result envelope once the run is done or interrupted: columns, a bounded first_page of rows, row_count, and for python cells the captured stdout/stderr and any figures. Null while running or failed. */
+    result?: NotebookSQLV2EnvelopeApi | null
+    /**
+     * Error message when the run failed or was interrupted; null otherwise.
+     * @nullable
+     */
+    error?: string | null
+}
+
+export interface NotebookSQLV2InterruptResponseApi {
+    /** The run's status after the interrupt request: usually still 'running' (the terminal 'interrupted' state arrives via the run result endpoint), or already-terminal state when nothing was stopped. */
+    status: string
+    /**
+     * Set when nothing was stopped, e.g. the run has not reached the kernel yet; retry shortly.
+     * @nullable
+     */
+    detail?: string | null
+}
+
 export type NotebooksListParams = {
     /**
      * Filter for notebooks that match a provided filter.

--- a/products/notebooks/frontend/generated/api.ts
+++ b/products/notebooks/frontend/generated/api.ts
@@ -13,6 +13,10 @@ import type {
     NotebookCollabPresenceApi,
     NotebookCollabSaveApi,
     NotebookMarkdownSaveApi,
+    NotebookSQLV2InterruptResponseApi,
+    NotebookSQLV2RunRequestApi,
+    NotebookSQLV2RunResponseApi,
+    NotebookSQLV2RunStatusResponseApi,
     NotebooksListParams,
     PaginatedNotebookMinimalListApi,
     PatchedNotebookApi,
@@ -439,6 +443,71 @@ export const notebooksKernelStopCreate = async (
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(notebookApi),
     })
+}
+
+export const getNotebooksSqlV2RunCreateUrl = (projectId: string, shortId: string) => {
+    return `/api/projects/${projectId}/notebooks/${shortId}/sql_v2/run/`
+}
+
+/**
+ * Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. Returns a run_id immediately; poll the run result endpoint until the status is terminal. Requires the notebook's kernel to be running and the revamped-py-notebooks feature.
+ * @summary Run a notebook cell
+ */
+export const notebooksSqlV2RunCreate = async (
+    projectId: string,
+    shortId: string,
+    notebookSQLV2RunRequestApi: NotebookSQLV2RunRequestApi,
+    options?: RequestInit
+): Promise<NotebookSQLV2RunResponseApi> => {
+    return apiMutator<NotebookSQLV2RunResponseApi>(getNotebooksSqlV2RunCreateUrl(projectId, shortId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(notebookSQLV2RunRequestApi),
+    })
+}
+
+export const getNotebooksSqlV2RunsRetrieveUrl = (projectId: string, shortId: string, runId: string) => {
+    return `/api/projects/${projectId}/notebooks/${shortId}/sql_v2/runs/${runId}/`
+}
+
+/**
+ * Read a dispatched run's state. Poll until status is 'done', 'failed', or 'interrupted'; done and interrupted runs carry the result envelope (columns, first rows, and for python cells the captured stdout/stderr and figures).
+ * @summary Get a notebook cell run's status and result
+ */
+export const notebooksSqlV2RunsRetrieve = async (
+    projectId: string,
+    shortId: string,
+    runId: string,
+    options?: RequestInit
+): Promise<NotebookSQLV2RunStatusResponseApi> => {
+    return apiMutator<NotebookSQLV2RunStatusResponseApi>(getNotebooksSqlV2RunsRetrieveUrl(projectId, shortId, runId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getNotebooksSqlV2RunsInterruptCreateUrl = (projectId: string, shortId: string, runId: string) => {
+    return `/api/projects/${projectId}/notebooks/${shortId}/sql_v2/runs/${runId}/interrupt/`
+}
+
+/**
+ * Stop a running cell. The terminal 'interrupted' state (with any captured output) arrives via the run result endpoint; when no kernel is reachable the run is marked interrupted directly.
+ * @summary Interrupt a running notebook cell
+ */
+export const notebooksSqlV2RunsInterruptCreate = async (
+    projectId: string,
+    shortId: string,
+    runId: string,
+    options?: RequestInit
+): Promise<NotebookSQLV2InterruptResponseApi> => {
+    return apiMutator<NotebookSQLV2InterruptResponseApi>(
+        getNotebooksSqlV2RunsInterruptCreateUrl(projectId, shortId, runId),
+        {
+            ...options,
+            method: 'POST',
+        }
+    )
 }
 
 export const getNotebooksAllActivityRetrieveUrl = (projectId: string) => {

--- a/products/notebooks/frontend/generated/api.zod.ts
+++ b/products/notebooks/frontend/generated/api.zod.ts
@@ -376,3 +376,49 @@ export const NotebooksKernelStopCreateBody = /* @__PURE__ */ zod.object({
     deleted: zod.boolean().optional().describe('Whether the notebook has been soft-deleted.'),
     _create_in_folder: zod.string().optional(),
 })
+
+/**
+ * Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. Returns a run_id immediately; poll the run result endpoint until the status is terminal. Requires the notebook's kernel to be running and the revamped-py-notebooks feature.
+ * @summary Run a notebook cell
+ */
+export const notebooksSqlV2RunCreateBodyNodeTypeDefault = `hogql`
+export const notebooksSqlV2RunCreateBodyOutputNameDefault = ``
+export const notebooksSqlV2RunCreateBodyRefsKindDefault = `hogql`
+
+export const NotebooksSqlV2RunCreateBody = /* @__PURE__ */ zod.object({
+    node_id: zod.string().describe('ProseMirror node id of the SQLV2 node being run.'),
+    node_type: zod
+        .enum(['hogql', 'python'])
+        .describe('\* `hogql` - hogql\n\* `python` - python')
+        .default(notebooksSqlV2RunCreateBodyNodeTypeDefault)
+        .describe(
+            "Execution kind. 'hogql' is a SQL node — pushed to ClickHouse, or rerouted to the sandbox's DuckDB when it references a local frame; 'python' runs the code in the sandbox kernel, materializing referenced upstream nodes as pandas frames first.\n\n\* `hogql` - hogql\n\* `python` - python"
+        ),
+    code: zod
+        .string()
+        .describe("The node's source — SQL for a hogql node, Python for a python node. Must not be blank."),
+    output_name: zod
+        .string()
+        .default(notebooksSqlV2RunCreateBodyOutputNameDefault)
+        .describe(
+            'Kernel nodes only: the dataframe variable to bind the result to in the kernel namespace (a python node falls back to the last expression for its preview).'
+        ),
+    refs: zod
+        .record(
+            zod.string(),
+            zod.object({
+                node_id: zod.string().describe('ProseMirror node id of the upstream node this name points at.'),
+                kind: zod
+                    .enum(['hogql', 'local'])
+                    .describe('\* `hogql` - hogql\n\* `local` - local')
+                    .default(notebooksSqlV2RunCreateBodyRefsKindDefault)
+                    .describe(
+                        "What the name resolves to: 'hogql' is a SQL node's query definition (resolved to its last-run HogQL); 'local' is a dataframe a Python node bound in the kernel namespace.\n\n\* `hogql` - hogql\n\* `local` - local"
+                    ),
+            })
+        )
+        .optional()
+        .describe(
+            "Available upstream nodes, keyed by dataframe name. A SQL node inlines referenced hogql refs as CTEs — unless it references a local ref, which reroutes the run to the sandbox's DuckDB; a python node materializes the hogql refs its code reads as pandas frames."
+        ),
+})

--- a/products/notebooks/mcp/tools.yaml
+++ b/products/notebooks/mcp/tools.yaml
@@ -146,6 +146,55 @@ tools:
         description: >
             Get a specific notebook by its short_id. Returns the full notebook including title, content, version, and
             creation/modification metadata.
+    notebooks-run-cell:
+        operation: notebooks_sql_v2_run_create
+        enabled: true
+        feature_flag: revamped-py-notebooks
+        scopes:
+            - notebook:write
+            - query:read
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Run a notebook cell
+        description: >
+            Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. Set node_type to
+            'python' for python code (with output_name naming the dataframe it produces) and 'hogql' for SQL. Pass
+            refs mapping each upstream dataframe name the code reads to its cell's node_id. Returns a run_id
+            immediately; poll notebooks-run-cell-result until the status is terminal. The notebook's kernel must be
+            running, and cells are the component tags (<SQLV2 .../>, <PythonV2 .../>) inside the notebook's
+            markdown content.
+    notebooks-run-cell-interrupt:
+        operation: notebooks_sql_v2_runs_interrupt_create
+        enabled: true
+        feature_flag: revamped-py-notebooks
+        scopes:
+            - notebook:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Interrupt a running notebook cell
+        description: >
+            Stop a running cell by its run_id. The terminal 'interrupted' state (with any output captured before the
+            stop) arrives via notebooks-run-cell-result.
+    notebooks-run-cell-result:
+        operation: notebooks_sql_v2_runs_retrieve
+        enabled: true
+        feature_flag: revamped-py-notebooks
+        scopes:
+            - notebook:read
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get a notebook cell run's result
+        description: >
+            Read a dispatched run's state by run_id. Poll every few seconds until status is 'done', 'failed', or
+            'interrupted'. Done and interrupted runs carry the result envelope: columns, a bounded first_page of
+            rows, row_count, and for python cells the captured stdout/stderr (the run's logs) and any figures.
     notebooks-update:
         operation: notebooks_update
         enabled: false

--- a/products/notebooks/mcp/tools.yaml
+++ b/products/notebooks/mcp/tools.yaml
@@ -149,7 +149,6 @@ tools:
     notebooks-run-cell:
         operation: notebooks_sql_v2_run_create
         enabled: true
-        feature_flag: revamped-py-notebooks
         scopes:
             - notebook:write
             - query:read
@@ -160,15 +159,14 @@ tools:
         title: Run a notebook cell
         description: >
             Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. Set node_type to
-            'python' for python code (with output_name naming the dataframe it produces) and 'hogql' for SQL. Pass
-            refs mapping each upstream dataframe name the code reads to its cell's node_id. Returns a run_id
-            immediately; poll notebooks-run-cell-result until the status is terminal. The notebook's kernel must be
-            running, and cells are the component tags (<SQLV2 .../>, <PythonV2 .../>) inside the notebook's
-            markdown content.
+            'python' for python code (with output_name naming the dataframe it produces) and 'hogql' for SQL. Pass refs
+            mapping each upstream dataframe name the code reads to its cell's node_id. Returns a run_id immediately;
+            poll notebooks-run-cell-result until the status is terminal. The notebook's kernel must be running, and
+            cells are the component tags (<SQLV2 .../>, <PythonV2 .../>) inside the notebook's markdown content.
+        feature_flag: revamped-py-notebooks
     notebooks-run-cell-interrupt:
         operation: notebooks_sql_v2_runs_interrupt_create
         enabled: true
-        feature_flag: revamped-py-notebooks
         scopes:
             - notebook:write
         annotations:
@@ -179,10 +177,10 @@ tools:
         description: >
             Stop a running cell by its run_id. The terminal 'interrupted' state (with any output captured before the
             stop) arrives via notebooks-run-cell-result.
+        feature_flag: revamped-py-notebooks
     notebooks-run-cell-result:
         operation: notebooks_sql_v2_runs_retrieve
         enabled: true
-        feature_flag: revamped-py-notebooks
         scopes:
             - notebook:read
             - query:read
@@ -193,8 +191,9 @@ tools:
         title: Get a notebook cell run's result
         description: >
             Read a dispatched run's state by run_id. Poll every few seconds until status is 'done', 'failed', or
-            'interrupted'. Done and interrupted runs carry the result envelope: columns, a bounded first_page of
-            rows, row_count, and for python cells the captured stdout/stderr (the run's logs) and any figures.
+            'interrupted'. Done and interrupted runs carry the result envelope: columns, a bounded first_page of rows,
+            row_count, and for python cells the captured stdout/stderr (the run's logs) and any figures.
+        feature_flag: revamped-py-notebooks
     notebooks-update:
         operation: notebooks_update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5845,6 +5845,51 @@
             "readOnlyHint": true
         }
     },
+    "notebooks-run-cell": {
+        "description": "Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. Set node_type to 'python' for python code (with output_name naming the dataframe it produces) and 'hogql' for SQL. Pass refs mapping each upstream dataframe name the code reads to its cell's node_id. Returns a run_id immediately; poll notebooks-run-cell-result until the status is terminal. The notebook's kernel must be running, and cells are the component tags (<SQLV2 .../>, <PythonV2 .../>) inside the notebook's markdown content.",
+        "category": "Notebooks",
+        "feature": "notebooks",
+        "summary": "Run a notebook cell",
+        "title": "Run a notebook cell",
+        "required_scopes": ["notebook:write", "query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "revamped-py-notebooks"
+    },
+    "notebooks-run-cell-interrupt": {
+        "description": "Stop a running cell by its run_id. The terminal 'interrupted' state (with any output captured before the stop) arrives via notebooks-run-cell-result.",
+        "category": "Notebooks",
+        "feature": "notebooks",
+        "summary": "Interrupt a running notebook cell",
+        "title": "Interrupt a running notebook cell",
+        "required_scopes": ["notebook:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "revamped-py-notebooks"
+    },
+    "notebooks-run-cell-result": {
+        "description": "Read a dispatched run's state by run_id. Poll every few seconds until status is 'done', 'failed', or 'interrupted'. Done and interrupted runs carry the result envelope: columns, a bounded first_page of rows, row_count, and for python cells the captured stdout/stderr (the run's logs) and any figures.",
+        "category": "Notebooks",
+        "feature": "notebooks",
+        "summary": "Get a notebook cell run's result",
+        "title": "Get a notebook cell run's result",
+        "required_scopes": ["notebook:read", "query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "revamped-py-notebooks"
+    },
     "org-member-get-github-login": {
         "description": "Resolve the GitHub username (login) for a single organization member, given their PostHog user UUID (obtainable from org-members-list, or \"@me\" for the current user). Returns null if the member has no GitHub identity linked. Use this when you know which member you want and need their GitHub handle — for example to set suggested reviewers.",
         "category": "Platform Features",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6296,6 +6296,51 @@
             "readOnlyHint": true
         }
     },
+    "notebooks-run-cell": {
+        "description": "Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. Set node_type to 'python' for python code (with output_name naming the dataframe it produces) and 'hogql' for SQL. Pass refs mapping each upstream dataframe name the code reads to its cell's node_id. Returns a run_id immediately; poll notebooks-run-cell-result until the status is terminal. The notebook's kernel must be running, and cells are the component tags (<SQLV2 .../>, <PythonV2 .../>) inside the notebook's markdown content.",
+        "category": "Notebooks",
+        "feature": "notebooks",
+        "summary": "Run a notebook cell",
+        "title": "Run a notebook cell",
+        "required_scopes": ["notebook:write", "query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "revamped-py-notebooks"
+    },
+    "notebooks-run-cell-interrupt": {
+        "description": "Stop a running cell by its run_id. The terminal 'interrupted' state (with any output captured before the stop) arrives via notebooks-run-cell-result.",
+        "category": "Notebooks",
+        "feature": "notebooks",
+        "summary": "Interrupt a running notebook cell",
+        "title": "Interrupt a running notebook cell",
+        "required_scopes": ["notebook:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "revamped-py-notebooks"
+    },
+    "notebooks-run-cell-result": {
+        "description": "Read a dispatched run's state by run_id. Poll every few seconds until status is 'done', 'failed', or 'interrupted'. Done and interrupted runs carry the result envelope: columns, a bounded first_page of rows, row_count, and for python cells the captured stdout/stderr (the run's logs) and any figures.",
+        "category": "Notebooks",
+        "feature": "notebooks",
+        "summary": "Get a notebook cell run's result",
+        "title": "Get a notebook cell run's result",
+        "required_scopes": ["notebook:read", "query:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "revamped-py-notebooks"
+    },
     "org-member-get-github-login": {
         "description": "Resolve the GitHub username (login) for a single organization member, given their PostHog user UUID (obtainable from org-members-list, or \"@me\" for the current user). Returns null if the member has no GitHub identity linked. Use this when you know which member you want and need their GitHub handle — for example to set suggested reviewers.",
         "category": "Platform Features",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -31043,6 +31043,30 @@ export namespace Schemas {
       _create_in_folder?: string;
     }
 
+    /**
+     * * `hogql` - hogql
+     * * `python` - python
+     */
+    export type NotebookCellRunNodeTypeEnum = typeof NotebookCellRunNodeTypeEnum[keyof typeof NotebookCellRunNodeTypeEnum];
+
+
+    export const NotebookCellRunNodeTypeEnum = {
+      Hogql: 'hogql',
+      Python: 'python',
+    } as const;
+
+    /**
+     * * `hogql` - hogql
+     * * `local` - local
+     */
+    export type NotebookCellRunRefKindEnum = typeof NotebookCellRunRefKindEnum[keyof typeof NotebookCellRunRefKindEnum];
+
+
+    export const NotebookCellRunRefKindEnum = {
+      Hogql: 'hogql',
+      Local: 'local',
+    } as const;
+
     export interface NotebookCollabCursor {
       /**
          * ProseMirror selection head position (rich v1 notebooks).
@@ -31138,6 +31162,102 @@ export namespace Schemas {
          */
       readonly user_access_level: string | null;
       _create_in_folder?: string;
+    }
+
+    export interface NotebookSQLV2Media {
+      /** MIME type of the media, e.g. 'image/png' for a matplotlib figure. */
+      mime_type: string;
+      /** Base64-encoded media bytes. */
+      data: string;
+    }
+
+    export interface NotebookSQLV2Envelope {
+      /** Run outcome: 'ok', 'error', or 'interrupted' (user-requested stop). */
+      status: string;
+      /** Captured stdout from a Python node run. */
+      stdout?: string;
+      /** Captured stderr (including tracebacks) from a Python node run. */
+      stderr?: string;
+      /** Rich outputs from a Python node run, e.g. matplotlib figures as PNGs. */
+      media?: NotebookSQLV2Media[];
+      /** Result column names. */
+      columns?: string[];
+      /** ClickHouse type per column, as [name, type] pairs; used by the visualization tab. */
+      types?: string[][];
+      /** Number of rows in the result. */
+      row_count?: number;
+      /** Whether ClickHouse has more rows beyond first_page (detected by fetching limit+1). */
+      has_more?: boolean;
+      /** First page of result rows for display; each row is a list of cell values. */
+      first_page?: unknown[][];
+      /**
+         * Identifier of the materialized result, used as the paging key.
+         * @nullable
+         */
+      result_id?: string | null;
+      /**
+         * Error message when status is 'error'.
+         * @nullable
+         */
+      error?: string | null;
+    }
+
+    export interface NotebookSQLV2InterruptResponse {
+      /** The run's status after the interrupt request: usually still 'running' (the terminal 'interrupted' state arrives via the run result endpoint), or already-terminal state when nothing was stopped. */
+      status: string;
+      /**
+         * Set when nothing was stopped, e.g. the run has not reached the kernel yet; retry shortly.
+         * @nullable
+         */
+      detail?: string | null;
+    }
+
+    export interface NotebookSQLV2Ref {
+      /** ProseMirror node id of the upstream node this name points at. */
+      node_id: string;
+      /** What the name resolves to: 'hogql' is a SQL node's query definition (resolved to its last-run HogQL); 'local' is a dataframe a Python node bound in the kernel namespace.
+       *
+       * * `hogql` - hogql
+       * * `local` - local */
+      kind?: NotebookCellRunRefKindEnum;
+    }
+
+    /**
+     * Available upstream nodes, keyed by dataframe name. A SQL node inlines referenced hogql refs as CTEs — unless it references a local ref, which reroutes the run to the sandbox's DuckDB; a python node materializes the hogql refs its code reads as pandas frames.
+     */
+    export type NotebookSQLV2RunRequestRefs = {[key: string]: NotebookSQLV2Ref};
+
+    export interface NotebookSQLV2RunRequest {
+      /** ProseMirror node id of the SQLV2 node being run. */
+      node_id: string;
+      /** Execution kind. 'hogql' is a SQL node — pushed to ClickHouse, or rerouted to the sandbox's DuckDB when it references a local frame; 'python' runs the code in the sandbox kernel, materializing referenced upstream nodes as pandas frames first.
+       *
+       * * `hogql` - hogql
+       * * `python` - python */
+      node_type?: NotebookCellRunNodeTypeEnum;
+      /** The node's source — SQL for a hogql node, Python for a python node. Must not be blank. */
+      code: string;
+      /** Kernel nodes only: the dataframe variable to bind the result to in the kernel namespace (a python node falls back to the last expression for its preview). */
+      output_name?: string;
+      /** Available upstream nodes, keyed by dataframe name. A SQL node inlines referenced hogql refs as CTEs — unless it references a local ref, which reroutes the run to the sandbox's DuckDB; a python node materializes the hogql refs its code reads as pandas frames. */
+      refs?: NotebookSQLV2RunRequestRefs;
+    }
+
+    export interface NotebookSQLV2RunResponse {
+      /** Identifier of the dispatched run. Poll the run result endpoint with it until the status is terminal. */
+      run_id: string;
+    }
+
+    export interface NotebookSQLV2RunStatusResponse {
+      /** Run state: 'running' while executing (keep polling), or terminal 'done', 'failed', or 'interrupted' (user-requested stop). */
+      status: string;
+      /** The result envelope once the run is done or interrupted: columns, a bounded first_page of rows, row_count, and for python cells the captured stdout/stderr and any figures. Null while running or failed. */
+      result?: NotebookSQLV2Envelope | null;
+      /**
+         * Error message when the run failed or was interrupted; null otherwise.
+         * @nullable
+         */
+      error?: string | null;
     }
 
     /**

--- a/services/mcp/src/generated/notebooks/api.ts
+++ b/services/mcp/src/generated/notebooks/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 5 enabled ops
+ * PostHog API - MCP 8 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -127,5 +127,88 @@ export const NotebooksDestroyParams = /* @__PURE__ */ zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
+    short_id: zod.string(),
+})
+
+/**
+ * Dispatch a SQL (HogQL) or Python cell of a revamped notebook to its sandbox kernel. Returns a run_id immediately; poll the run result endpoint until the status is terminal. Requires the notebook's kernel to be running and the revamped-py-notebooks feature.
+ * @summary Run a notebook cell
+ */
+export const NotebooksSqlV2RunCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    short_id: zod.string(),
+})
+
+export const notebooksSqlV2RunCreateBodyNodeTypeDefault = `hogql`
+export const notebooksSqlV2RunCreateBodyOutputNameDefault = ``
+export const notebooksSqlV2RunCreateBodyRefsKindDefault = `hogql`
+
+export const NotebooksSqlV2RunCreateBody = /* @__PURE__ */ zod.object({
+    node_id: zod.string().describe('ProseMirror node id of the SQLV2 node being run.'),
+    node_type: zod
+        .enum(['hogql', 'python'])
+        .describe('* `hogql` - hogql\n* `python` - python')
+        .default(notebooksSqlV2RunCreateBodyNodeTypeDefault)
+        .describe(
+            "Execution kind. 'hogql' is a SQL node — pushed to ClickHouse, or rerouted to the sandbox's DuckDB when it references a local frame; 'python' runs the code in the sandbox kernel, materializing referenced upstream nodes as pandas frames first.\n\n* `hogql` - hogql\n* `python` - python"
+        ),
+    code: zod
+        .string()
+        .describe("The node's source — SQL for a hogql node, Python for a python node. Must not be blank."),
+    output_name: zod
+        .string()
+        .default(notebooksSqlV2RunCreateBodyOutputNameDefault)
+        .describe(
+            'Kernel nodes only: the dataframe variable to bind the result to in the kernel namespace (a python node falls back to the last expression for its preview).'
+        ),
+    refs: zod
+        .record(
+            zod.string(),
+            zod.object({
+                node_id: zod.string().describe('ProseMirror node id of the upstream node this name points at.'),
+                kind: zod
+                    .enum(['hogql', 'local'])
+                    .describe('* `hogql` - hogql\n* `local` - local')
+                    .default(notebooksSqlV2RunCreateBodyRefsKindDefault)
+                    .describe(
+                        "What the name resolves to: 'hogql' is a SQL node's query definition (resolved to its last-run HogQL); 'local' is a dataframe a Python node bound in the kernel namespace.\n\n* `hogql` - hogql\n* `local` - local"
+                    ),
+            })
+        )
+        .optional()
+        .describe(
+            "Available upstream nodes, keyed by dataframe name. A SQL node inlines referenced hogql refs as CTEs — unless it references a local ref, which reroutes the run to the sandbox's DuckDB; a python node materializes the hogql refs its code reads as pandas frames."
+        ),
+})
+
+/**
+ * Read a dispatched run's state. Poll until status is 'done', 'failed', or 'interrupted'; done and interrupted runs carry the result envelope (columns, first rows, and for python cells the captured stdout/stderr and figures).
+ * @summary Get a notebook cell run's status and result
+ */
+export const NotebooksSqlV2RunsRetrieveParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    run_id: zod.string().describe('The run_id returned by the run endpoint.'),
+    short_id: zod.string(),
+})
+
+/**
+ * Stop a running cell. The terminal 'interrupted' state (with any captured output) arrives via the run result endpoint; when no kernel is reachable the run is marked interrupted directly.
+ * @summary Interrupt a running notebook cell
+ */
+export const NotebooksSqlV2RunsInterruptCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    run_id: zod.string().describe('The run_id returned by the run endpoint.'),
     short_id: zod.string(),
 })

--- a/services/mcp/src/tools/generated/notebooks.ts
+++ b/services/mcp/src/tools/generated/notebooks.ts
@@ -9,6 +9,10 @@ import {
     NotebooksPartialUpdateBody,
     NotebooksPartialUpdateParams,
     NotebooksRetrieveParams,
+    NotebooksSqlV2RunCreateBody,
+    NotebooksSqlV2RunCreateParams,
+    NotebooksSqlV2RunsInterruptCreateParams,
+    NotebooksSqlV2RunsRetrieveParams,
 } from '@/generated/notebooks/api'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -137,10 +141,83 @@ const notebooksRetrieve = (): ToolBase<typeof NotebooksRetrieveSchema, WithPostH
     },
 })
 
+const NotebooksRunCellSchema = NotebooksSqlV2RunCreateParams.omit({ project_id: true }).extend(
+    NotebooksSqlV2RunCreateBody.shape
+)
+
+const notebooksRunCell = (): ToolBase<typeof NotebooksRunCellSchema, Schemas.NotebookSQLV2RunResponse> => ({
+    name: 'notebooks-run-cell',
+    schema: NotebooksRunCellSchema,
+    handler: async (context: Context, params: z.infer<typeof NotebooksRunCellSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.node_id !== undefined) {
+            body['node_id'] = params.node_id
+        }
+        if (params.node_type !== undefined) {
+            body['node_type'] = params.node_type
+        }
+        if (params.code !== undefined) {
+            body['code'] = params.code
+        }
+        if (params.output_name !== undefined) {
+            body['output_name'] = params.output_name
+        }
+        if (params.refs !== undefined) {
+            body['refs'] = params.refs
+        }
+        const result = await context.api.request<Schemas.NotebookSQLV2RunResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/notebooks/${encodeURIComponent(String(params.short_id))}/sql_v2/run/`,
+            body,
+        })
+        return result
+    },
+})
+
+const NotebooksRunCellInterruptSchema = NotebooksSqlV2RunsInterruptCreateParams.omit({ project_id: true })
+
+const notebooksRunCellInterrupt = (): ToolBase<
+    typeof NotebooksRunCellInterruptSchema,
+    Schemas.NotebookSQLV2InterruptResponse
+> => ({
+    name: 'notebooks-run-cell-interrupt',
+    schema: NotebooksRunCellInterruptSchema,
+    handler: async (context: Context, params: z.infer<typeof NotebooksRunCellInterruptSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.NotebookSQLV2InterruptResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/notebooks/${encodeURIComponent(String(params.short_id))}/sql_v2/runs/${encodeURIComponent(String(params.run_id))}/interrupt/`,
+        })
+        return result
+    },
+})
+
+const NotebooksRunCellResultSchema = NotebooksSqlV2RunsRetrieveParams.omit({ project_id: true })
+
+const notebooksRunCellResult = (): ToolBase<
+    typeof NotebooksRunCellResultSchema,
+    Schemas.NotebookSQLV2RunStatusResponse
+> => ({
+    name: 'notebooks-run-cell-result',
+    schema: NotebooksRunCellResultSchema,
+    handler: async (context: Context, params: z.infer<typeof NotebooksRunCellResultSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.NotebookSQLV2RunStatusResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/notebooks/${encodeURIComponent(String(params.short_id))}/sql_v2/runs/${encodeURIComponent(String(params.run_id))}/`,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'notebooks-create': notebooksCreate,
     'notebooks-destroy': notebooksDestroy,
     'notebooks-list': notebooksList,
     'notebooks-partial-update': notebooksPartialUpdate,
     'notebooks-retrieve': notebooksRetrieve,
+    'notebooks-run-cell': notebooksRunCell,
+    'notebooks-run-cell-interrupt': notebooksRunCellInterrupt,
+    'notebooks-run-cell-result': notebooksRunCellResult,
 }

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -777,9 +777,10 @@ describe('Tool Filtering - Feature Flags', () => {
                 'metrics',
                 'mcp-sql-schema-discovery',
                 'endpoints-ai-materialization-fix',
+                'revamped-py-notebooks',
             ])
         )
-        expect(flags).toHaveLength(21)
+        expect(flags).toHaveLength(22)
     })
 
     // Exercise the real predicate (toolPassesFlagGate) over hand-rolled entries


### PR DESCRIPTION
## Problem

Journey 13 of the revamped notebooks plan: an agent talking to the MCP should create a notebook, add a Python/SQL cell, run it, wait for the output, read the logs, and decide its next step. The notebook CRUD tools already exist (and already teach agents to author cells as `<SQLV2 …/>` / `<PythonV2 …/>` component tags in markdown content), but the run endpoints were invisible to the OpenAPI → Zod → MCP pipeline: the run action carried a stale `@extend_schema(exclude=True)` and validated manually, and the result/interrupt actions were excluded. Agents could author cells but never execute them.

## Changes

Stacks on #70202 (Journeys 14/15).

- Response serializers with full `help_text` for run dispatch (`run_id`), run status (documented `status` values plus the nullable result envelope and error), and interrupt; `@extend_schema` annotations on all three actions with typed `run_id` path parameters. `status` stays a described CharField rather than a ChoiceField to avoid the enum-collision trap.
- The run request's `node_type`/`kind` choices did collide with data warehouse's `node_type` enum (schema build failed with `default='hogql' is not a member of enum=['table','view','matview','endpoint']`), fixed with inline-list `ENUM_NAME_OVERRIDES` entries.
- Three MCP tools in `products/notebooks/mcp/tools.yaml`, gated on the same `revamped-py-notebooks` flag as the endpoints: `notebooks-run-cell` (dispatch, `notebook:write` + `query:read`), `notebooks-run-cell-result` (read-only poll; the envelope carries columns/row preview and python stdout/stderr, the walkthrough's "logs"), and `notebooks-run-cell-interrupt`. Waiting is the agent polling the result tool — tools stay atomic per the MCP design guidance.
- Regenerated OpenAPI artifacts and MCP handlers.

> [!NOTE]
> No new capability surface: the tools call the same endpoints with the same scopes, per-notebook access control, RBAC query gate, and feature flag as the UI. Page/collab/kernel-lifecycle endpoints stay unexposed.

## How did you test this code?

Automated tests only:

- `test_sql_v2.py` (108 passed): the run/result/interrupt behavior these tools call is already covered by the endpoint tests from Journeys 9-15; the annotations changed no runtime behavior.
- `hogli build:openapi` clean (zero warnings under `--fail-on-warn`, which is what caught the enum collision); `pnpm --filter=@posthog/mcp run lint-tool-names` passes; `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

MCP tool descriptions are the user-facing docs here and are included; no separate docs page covers notebook MCP tools yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5) as part of the stacked revamped-notebooks journey series (stacks on #70202). Skills invoked: /implementing-mcp-tools, /improving-drf-endpoints (earlier in the series), /writing-tests.

Decisions: polling stays client-side (no blocking wait endpoint) to keep tools atomic; the interactive page endpoint stays unexposed since agents get the envelope preview; tool names follow the 52-char kebab constraint and the flag gate mirrors the endpoints' own gating so the tools appear exactly when the feature does.
