### PR TITLE
feat(quill): presets-first mode and footerExtra slot for DateTimePicker

### DIFF
--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -66,6 +66,9 @@ Rules:
 - `minDate`/`maxDate` are day-granular; time inputs are independent of those bounds.
 - `weekStartsOn` affects the calendar grid only, not quick-range math.
 - Embedding in a host surface (e.g. inside a popover with the host's own sections): `showHeader={false}` drops the caps header band, `showTime={false}` switches to day-granular mode (no time segments, no "Now", date-only footer readout) — pair with a `className` that strips the card chrome (`shadow-none ring-0`).
+- `presetsFirst` renders the quick ranges as a left-hand vertical list that applies immediately on click (`onApply` fires with the computed range — no staging); the calendar with its staged Apply flow is revealed in place by a built-in "Custom range…" row (Cancel collapses back). Opens on the calendar when `value.range` is `CUSTOM_RANGE`. Ignored in `compact`. The picker never interprets what a preset means — hosts map the applied `range` back to their own vocabulary (e.g. relative date strings) by its `id`.
+- `footerExtra` pins host content in the actions bar next to the readout (e.g. an exclusions control); in collapsed `presetsFirst` it renders as the sole footer row. The footer's date readout hides at `lg` where the inputs row shows the same staged range.
+- When hosting the picker in a quill `Popover` in `presetsFirst` mode, pass `collisionAvoidance={{ align: 'none' }}` on the `PopoverContent` so the surface stays pinned when the calendar expands instead of re-shifting (which would move the preset list under the user's cursor).
 
 ## DatePicker
 

--- a/packages/quill/packages/components/src/date-time-picker.stories.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.stories.tsx
@@ -13,7 +13,7 @@ import {
 import { Clock } from 'lucide-react'
 import * as React from 'react'
 
-import { Button, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill-primitives'
+import { Button, Label, Popover, PopoverContent, PopoverTrigger, Separator, Switch, ToggleGroup, ToggleGroupItem } from '@posthog/quill-primitives'
 
 import { CUSTOM_RANGE, type DateTimeRange } from './date-time-ranges'
 import { DateTimePicker, type DateTimeValue } from './date-time-picker'
@@ -214,5 +214,161 @@ export const NarrowContainer: Story = {
     render: () => {
         const [value, setValue] = React.useState<DateTimeValue>(initialValue)
         return <DateTimePicker value={value} onApply={setValue} compact />
+    },
+}
+
+const analyticsRanges: DateTimeRange[] = [
+    { id: 1, name: 'Today', rangeSetter: (d) => d },
+    { id: 2, name: 'Last 7 days', rangeSetter: (d) => subDays(d, 7) },
+    { id: 3, name: 'Last 30 days', rangeSetter: (d) => subDays(d, 30) },
+    { id: 4, name: 'Last 90 days', rangeSetter: (d) => subDays(d, 90) },
+    { id: 5, name: 'This month', rangeSetter: (d) => startOfMonth(d) },
+    { id: 6, name: 'Last month', rangeSetter: (d) => startOfMonth(subMonths(d, 1)), endSetter: (d) => endOfMonth(subMonths(d, 1)) },
+    { id: 7, name: 'Year to date', rangeSetter: (d) => startOfYear(d) },
+]
+
+// An exclusions control for the footerExtra slot: a small link opening a panel with an
+// incomplete-period toggle and exclude-day chips. Host-supplied; the picker only provides the slot.
+function ExcludeControlDemo(): React.ReactElement {
+    const [excludedDays, setExcludedDays] = React.useState<string[]>([])
+    const [excludeIncomplete, setExcludeIncomplete] = React.useState(false)
+    const [openPanel, setOpenPanel] = React.useState(false)
+    const rootRef = React.useRef<HTMLDivElement>(null)
+    React.useEffect(() => {
+        if (!openPanel) {
+            return
+        }
+        const onPointerDown = (event: PointerEvent): void => {
+            if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+                setOpenPanel(false)
+            }
+        }
+        document.addEventListener('pointerdown', onPointerDown)
+        return () => document.removeEventListener('pointerdown', onPointerDown)
+    }, [openPanel])
+    const labels: Record<string, string> = { 1: 'M', 2: 'T', 3: 'W', 4: 'T', 5: 'F', 6: 'S', 7: 'S' }
+    const sorted = [...excludedDays].sort().join(',')
+    const parts: string[] = []
+    if (excludedDays.length > 0) {
+        parts.push(sorted === '6,7' ? 'weekends' : sorted === '1,2,3,4,5' ? 'weekdays' : `${excludedDays.length} days`)
+    }
+    if (excludeIncomplete) {
+        parts.push('incomplete')
+    }
+    return (
+        <div className="relative" ref={rootRef}>
+            <Button variant="link" size="xs" aria-expanded={openPanel} onClick={() => setOpenPanel((prev) => !prev)}>
+                {parts.length > 0 ? `Excluding ${parts.join(', ')}` : '+ Exclude'}
+            </Button>
+            {openPanel && (
+                <div className="bg-card absolute bottom-full left-0 z-10 mb-1 flex w-64 flex-col rounded-md border shadow-md">
+                    <div className="flex items-center justify-between gap-2 px-3 py-2.5">
+                        <Label htmlFor="story-exclude-incomplete">Incomplete period</Label>
+                        <Switch
+                            id="story-exclude-incomplete"
+                            size="sm"
+                            checked={excludeIncomplete}
+                            onCheckedChange={setExcludeIncomplete}
+                        />
+                    </div>
+                    <Separator />
+                    <div className="flex flex-col gap-2 px-3 py-2.5">
+                        <ToggleGroup
+                            multiple
+                            size="sm"
+                            className="w-full"
+                            value={excludedDays}
+                            onValueChange={setExcludedDays}
+                        >
+                            {Object.keys(labels).map((day) => (
+                                <ToggleGroupItem key={day} value={day} className="flex-1">
+                                    {labels[day]}
+                                </ToggleGroupItem>
+                            ))}
+                        </ToggleGroup>
+                        <div className="flex items-center justify-center gap-3">
+                            <Button variant="link" size="xs" onClick={() => setExcludedDays(['6', '7'])}>
+                                Weekends
+                            </Button>
+                            <Button variant="link" size="xs" onClick={() => setExcludedDays(['1', '2', '3', '4', '5'])}>
+                                Weekdays
+                            </Button>
+                            <Button variant="link" size="xs" onClick={() => setExcludedDays([])}>
+                                Clear
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+export const PresetsFirst: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<DateTimeValue>({
+            start: subDays(new Date(), 7),
+            end: new Date(),
+            range: analyticsRanges.find((r) => r.name === 'Last 7 days')!,
+        })
+        return <DateTimePicker value={value} onApply={setValue} ranges={analyticsRanges} presetsFirst showTime={false} />
+    },
+}
+
+export const PresetsFirstWithExclusions: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<DateTimeValue>({
+            start: subDays(new Date(), 7),
+            end: new Date(),
+            range: analyticsRanges.find((r) => r.name === 'Last 7 days')!,
+        })
+        return (
+            <DateTimePicker
+                value={value}
+                onApply={setValue}
+                ranges={analyticsRanges}
+                presetsFirst
+                showTime={false}
+                footerExtra={<ExcludeControlDemo />}
+            />
+        )
+    },
+}
+
+export const PresetsFirstInPopover: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<DateTimeValue>({
+            start: subDays(new Date(), 7),
+            end: new Date(),
+            range: analyticsRanges.find((r) => r.name === 'Last 7 days')!,
+        })
+        const [open, setOpen] = React.useState(false)
+        return (
+            <div className="h-120">
+                <Popover open={open} onOpenChange={setOpen}>
+                    <PopoverTrigger render={<Button variant="outline">{formatTriggerLabel(value)}</Button>} />
+                    <PopoverContent
+                        align="start"
+                        collisionAvoidance={{ align: 'none' }}
+                        className="w-auto overflow-hidden border-none p-0 shadow-none ring-0"
+                    >
+                        <DateTimePicker
+                            value={value}
+                            onApply={(next) => {
+                                setValue(next)
+                                setOpen(false)
+                            }}
+                            ranges={analyticsRanges}
+                            presetsFirst
+                            showTime={false}
+                            footerExtra={<ExcludeControlDemo />}
+                        />
+                    </PopoverContent>
+                </Popover>
+            </div>
+        )
     },
 }

--- a/packages/quill/packages/components/src/date-time-picker.stories.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.stories.tsx
@@ -229,23 +229,10 @@ const analyticsRanges: DateTimeRange[] = [
 
 // An exclusions control for the footerExtra slot: a small link opening a panel with an
 // incomplete-period toggle and exclude-day chips. Host-supplied; the picker only provides the slot.
+// A nested Popover portals the panel out, so it can't be clipped by the picker or a host popover.
 function ExcludeControlDemo(): React.ReactElement {
     const [excludedDays, setExcludedDays] = React.useState<string[]>([])
     const [excludeIncomplete, setExcludeIncomplete] = React.useState(false)
-    const [openPanel, setOpenPanel] = React.useState(false)
-    const rootRef = React.useRef<HTMLDivElement>(null)
-    React.useEffect(() => {
-        if (!openPanel) {
-            return
-        }
-        const onPointerDown = (event: PointerEvent): void => {
-            if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
-                setOpenPanel(false)
-            }
-        }
-        document.addEventListener('pointerdown', onPointerDown)
-        return () => document.removeEventListener('pointerdown', onPointerDown)
-    }, [openPanel])
     const labels: Record<string, string> = { 1: 'M', 2: 'T', 3: 'W', 4: 'T', 5: 'F', 6: 'S', 7: 'S' }
     const sorted = [...excludedDays].sort().join(',')
     const parts: string[] = []
@@ -256,51 +243,49 @@ function ExcludeControlDemo(): React.ReactElement {
         parts.push('incomplete')
     }
     return (
-        <div className="relative" ref={rootRef}>
-            <Button variant="link" size="xs" aria-expanded={openPanel} onClick={() => setOpenPanel((prev) => !prev)}>
+        <Popover>
+            <PopoverTrigger render={<Button variant="link" size="xs" />}>
                 {parts.length > 0 ? `Excluding ${parts.join(', ')}` : '+ Exclude'}
-            </Button>
-            {openPanel && (
-                <div className="bg-card absolute bottom-full left-0 z-10 mb-1 flex w-64 flex-col rounded-md border shadow-md">
-                    <div className="flex items-center justify-between gap-2 px-3 py-2.5">
-                        <Label htmlFor="story-exclude-incomplete">Incomplete period</Label>
-                        <Switch
-                            id="story-exclude-incomplete"
-                            size="sm"
-                            checked={excludeIncomplete}
-                            onCheckedChange={setExcludeIncomplete}
-                        />
-                    </div>
-                    <Separator />
-                    <div className="flex flex-col gap-2 px-3 py-2.5">
-                        <ToggleGroup
-                            multiple
-                            size="sm"
-                            className="w-full"
-                            value={excludedDays}
-                            onValueChange={setExcludedDays}
-                        >
-                            {Object.keys(labels).map((day) => (
-                                <ToggleGroupItem key={day} value={day} className="flex-1">
-                                    {labels[day]}
-                                </ToggleGroupItem>
-                            ))}
-                        </ToggleGroup>
-                        <div className="flex items-center justify-center gap-3">
-                            <Button variant="link" size="xs" onClick={() => setExcludedDays(['6', '7'])}>
-                                Weekends
-                            </Button>
-                            <Button variant="link" size="xs" onClick={() => setExcludedDays(['1', '2', '3', '4', '5'])}>
-                                Weekdays
-                            </Button>
-                            <Button variant="link" size="xs" onClick={() => setExcludedDays([])}>
-                                Clear
-                            </Button>
-                        </div>
+            </PopoverTrigger>
+            <PopoverContent side="top" align="start" className="w-64 gap-0 p-0">
+                <div className="flex items-center justify-between gap-2 px-3 py-2.5">
+                    <Label htmlFor="story-exclude-incomplete">Incomplete period</Label>
+                    <Switch
+                        id="story-exclude-incomplete"
+                        size="sm"
+                        checked={excludeIncomplete}
+                        onCheckedChange={setExcludeIncomplete}
+                    />
+                </div>
+                <Separator />
+                <div className="flex flex-col gap-2 px-3 py-2.5">
+                    <ToggleGroup
+                        multiple
+                        size="sm"
+                        className="w-full"
+                        value={excludedDays}
+                        onValueChange={setExcludedDays}
+                    >
+                        {Object.keys(labels).map((day) => (
+                            <ToggleGroupItem key={day} value={day} className="flex-1">
+                                {labels[day]}
+                            </ToggleGroupItem>
+                        ))}
+                    </ToggleGroup>
+                    <div className="flex items-center justify-center gap-3">
+                        <Button variant="link" size="xs" onClick={() => setExcludedDays(['6', '7'])}>
+                            Weekends
+                        </Button>
+                        <Button variant="link" size="xs" onClick={() => setExcludedDays(['1', '2', '3', '4', '5'])}>
+                            Weekdays
+                        </Button>
+                        <Button variant="link" size="xs" onClick={() => setExcludedDays([])}>
+                            Clear
+                        </Button>
                     </div>
                 </div>
-            )}
-        </div>
+            </PopoverContent>
+        </Popover>
     )
 }
 

--- a/packages/quill/packages/components/src/date-time-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.test.tsx
@@ -76,4 +76,62 @@ describe('DateTimePicker', () => {
         expect(applied.end).toEqual(new Date(2022, 11, 31, 23, 59, 59))
         expect(applied.range).toBe(lastMonth)
     })
+
+    it('presetsFirst: a preset click applies immediately without the Apply button', async () => {
+        const onApply = jest.fn()
+        const lastMonth: DateTimeRange = {
+            id: 1,
+            name: 'Last month',
+            rangeSetter: () => new Date(2022, 11, 1),
+            endSetter: () => new Date(2022, 11, 31, 23, 59, 59),
+        }
+        render(<DateTimePicker value={VALUE} maxDate={MAX} onApply={onApply} ranges={[lastMonth]} presetsFirst />)
+
+        await userEvent.click(screen.getByTitle('Last month'))
+
+        expect(onApply).toHaveBeenCalledTimes(1)
+        const applied = onApply.mock.calls[0][0]
+        expect(applied.start).toEqual(new Date(2022, 11, 1))
+        expect(applied.end).toEqual(new Date(2022, 11, 31, 23, 59, 59))
+        expect(applied.range).toBe(lastMonth)
+    })
+
+    it('presetsFirst: the calendar is collapsed until Custom range, Cancel collapses it back, footerExtra persists', async () => {
+        const ranges: DateTimeRange[] = [{ id: 1, name: 'This month', rangeSetter: (d) => d }]
+        const presetValue = { start: VALUE.start, end: VALUE.end, range: ranges[0] }
+        render(
+            <DateTimePicker
+                value={presetValue}
+                maxDate={MAX}
+                onApply={jest.fn()}
+                ranges={ranges}
+                presetsFirst
+                footerExtra={<span>Exclusions</span>}
+            />
+        )
+
+        expect(screen.queryByLabelText('Apply date range')).toBeNull()
+        expect(screen.getByText('Exclusions')).toBeTruthy()
+
+        await userEvent.click(screen.getByText('Custom range…'))
+        expect(screen.getByLabelText('Apply date range')).toBeTruthy()
+        expect(screen.getByText('Exclusions')).toBeTruthy()
+
+        await userEvent.click(screen.getByLabelText('Cancel'))
+        expect(screen.queryByLabelText('Apply date range')).toBeNull()
+    })
+
+    it('presetsFirst: opens expanded when the value is a custom range', () => {
+        render(
+            <DateTimePicker
+                value={VALUE}
+                maxDate={MAX}
+                onApply={jest.fn()}
+                ranges={[{ id: 1, name: 'This month', rangeSetter: (d) => d }]}
+                presetsFirst
+            />
+        )
+
+        expect(screen.getByLabelText('Apply date range')).toBeTruthy()
+    })
 })

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -59,8 +59,15 @@ export interface DateTimePickerProps {
     ranges?: DateTimeRange[]
     /** Hide the "Choose date range / Quick ranges" header band when embedding in a host surface. */
     showHeader?: boolean
+    /** Host content in the actions bar, next to the range readout (e.g. an exclusions control). */
+    footerExtra?: React.ReactNode
     /** Day-granular mode: hides the time segments and "Now", and drops time from the footer readout. */
     showTime?: boolean
+    /** Presets-first mode: quick ranges render as a left-hand list and apply immediately on click
+     * (`onApply` fires with the computed range); the calendar, with its staged Apply flow, is
+     * revealed in place by a "Custom range…" row. Opens on the calendar when `value.range` is
+     * `CUSTOM_RANGE`. Ignored in `compact`. */
+    presetsFirst?: boolean
     className?: string
 }
 
@@ -77,11 +84,16 @@ export function DateTimePicker({
     compact = false,
     ranges = quickRanges,
     showHeader = true,
+    footerExtra,
     showTime = true,
+    presetsFirst = false,
     className,
 }: DateTimePickerProps): React.ReactElement {
     const presetRanges = ranges.filter((r) => r.id !== CUSTOM_RANGE.id)
-    const hasPresets = presetRanges.length > 0
+    const presetsFirstMode = presetsFirst && !compact
+    const hasPresets = presetRanges.length > 0 && !presetsFirstMode
+    const [customExpanded, setCustomExpanded] = React.useState(value.range.id === CUSTOM_RANGE.id)
+    const showCalendarArea = !presetsFirstMode || customExpanded
     const maxDate = maxDateProp ?? new Date()
     const hasExplicitMaxDate = maxDateProp !== undefined
     // The second calendar only renders at `lg`; below it (and in compact) there's
@@ -192,6 +204,12 @@ export function DateTimePicker({
         setLeftViewing(subMonths(nextEnd, 1))
     }
 
+    const applyQuickRange = (next: DateTimeRange): void => {
+        const now = new Date()
+        handleQuickRange(next)
+        onApply({ start: next.rangeSetter(now), end: next.endSetter?.(now) ?? now, range: next })
+    }
+
     const dateTimeFormat = showTime ? DATE_TIME_FORMATS[dateFormat] : DATE_FORMATS[dateFormat]
     const presentationalStart = format(start, dateTimeFormat)
     const presentationalEnd = format(end, dateTimeFormat)
@@ -200,7 +218,13 @@ export function DateTimePicker({
         <div
             className={cn(
                 'bg-card text-foreground rounded-lg shadow-md ring-1 ring-foreground/10 overflow-hidden',
-                compact ? 'w-[15rem]' : 'w-[15rem] lg:w-full max-w-[42rem]',
+                compact
+                    ? 'w-[15rem]'
+                    : presetsFirstMode && !customExpanded
+                      ? 'w-max'
+                      : presetsFirstMode
+                        ? 'w-[15rem] lg:w-full max-w-[53rem]'
+                        : 'w-[15rem] lg:w-full max-w-[42rem]',
                 className
             )}
         >
@@ -226,11 +250,48 @@ export function DateTimePicker({
             )}
 
             {/* Body */}
-            <div className={compact || !hasPresets
-                ? 'flex flex-col'
-                : 'flex flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]'
-            }>
+            <div className={cn(
+                compact || !hasPresets ? 'flex flex-col' : 'flex flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_9rem]',
+                presetsFirstMode && customExpanded && 'flex-row'
+            )}>
+                {/* Presets-first list column */}
+                {presetsFirstMode && (
+                    <div className={cn('flex flex-col', customExpanded && 'shrink-0 border-r border-border')}>
+                        <ul className="flex max-h-[400px] flex-col gap-px overflow-y-auto p-1">
+                            {presetRanges.map((quick) => (
+                                <li key={quick.id} className="w-full">
+                                    <Button
+                                        variant="default"
+                                        left
+                                        className="w-full justify-start whitespace-nowrap"
+                                        aria-selected={range.id === quick.id}
+                                        aria-label={`Choose ${quick.name.toLowerCase()}`}
+                                        title={quick.name}
+                                        onClick={() => applyQuickRange(quick)}
+                                        data-attr={`date-time-picker-quick-range-${quick.name.toLowerCase().replace(/\s+/g, '-')}`}
+                                    >
+                                        {quick.name}
+                                    </Button>
+                                </li>
+                            ))}
+                            <li className="w-full">
+                                <Button
+                                    variant="default"
+                                    left
+                                    className="w-full justify-start whitespace-nowrap"
+                                    aria-selected={customExpanded || range.id === CUSTOM_RANGE.id}
+                                    onClick={() => setCustomExpanded((prev) => !prev)}
+                                    data-attr="date-time-picker-custom-range"
+                                >
+                                    Custom range…
+                                </Button>
+                            </li>
+                        </ul>
+                    </div>
+                )}
+
                 {/* Calendars column */}
+                {showCalendarArea && (
                 <div className={compact ? 'order-1' : 'order-1 lg:order-none'}>
                     {/* Inputs */}
                     {!compact && (
@@ -300,6 +361,7 @@ export function DateTimePicker({
                         </div>
                     </div>
                 </div>
+                )}
 
                 {/* Quick ranges column */}
                 {hasPresets && (
@@ -338,15 +400,34 @@ export function DateTimePicker({
                 )}
             </div>
 
-            <Separator />
+            {(showCalendarArea || footerExtra) && <Separator />}
 
             {/* Actions */}
+            {!showCalendarArea && footerExtra && (
+                <div className="flex items-center px-3 py-2 bg-muted/30">{footerExtra}</div>
+            )}
+            {showCalendarArea && (
             <div className="flex justify-end px-3 py-2 items-center gap-2 bg-muted/30">
-                <span className="text-[10px] text-muted-foreground flex items-center gap-1 tabular-nums mr-auto">
-                    {range.id === CUSTOM_RANGE.id ? <>{presentationalStart} <ArrowRight className="size-3" /> {presentationalEnd}</> : range.name}
-                </span>
-                {onCancel ? (
-                    <Button variant="outline" size="sm" onClick={onCancel} aria-label="Cancel" data-attr="date-time-picker-cancel">
+                <div className="mr-auto flex items-center gap-2">
+                    {/* The lg inputs row shows the same staged range, so the readout yields to it */}
+                    <span
+                        className={cn(
+                            'text-[10px] text-muted-foreground flex items-center gap-1 tabular-nums',
+                            !compact && 'lg:hidden'
+                        )}
+                    >
+                        {range.id === CUSTOM_RANGE.id ? <>{presentationalStart} <ArrowRight className="size-3" /> {presentationalEnd}</> : range.name}
+                    </span>
+                    {footerExtra}
+                </div>
+                {onCancel || presetsFirstMode ? (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={presetsFirstMode ? () => setCustomExpanded(false) : onCancel}
+                        aria-label="Cancel"
+                        data-attr="date-time-picker-cancel"
+                    >
                         Cancel
                     </Button>
                 ) : null}
@@ -361,6 +442,7 @@ export function DateTimePicker({
                     Apply
                 </Button>
             </div>
+            )}
         </div>
     )
 }

--- a/packages/quill/packages/components/src/date-time-picker.tsx
+++ b/packages/quill/packages/components/src/date-time-picker.tsx
@@ -256,8 +256,13 @@ export function DateTimePicker({
             )}>
                 {/* Presets-first list column */}
                 {presetsFirstMode && (
-                    <div className={cn('flex flex-col', customExpanded && 'shrink-0 border-r border-border')}>
-                        <ul className="flex max-h-[400px] flex-col gap-px overflow-y-auto p-1">
+                    <div className={cn('flex flex-col', customExpanded && 'relative w-36 shrink-0 border-r border-border')}>
+                        <ul
+                            className={cn(
+                                'flex flex-col gap-px overflow-y-auto p-1',
+                                customExpanded ? 'absolute inset-0' : 'max-h-[400px]'
+                            )}
+                        >
                             {presetRanges.map((quick) => (
                                 <li key={quick.id} className="w-full">
                                     <Button
@@ -404,10 +409,10 @@ export function DateTimePicker({
 
             {/* Actions */}
             {!showCalendarArea && footerExtra && (
-                <div className="flex items-center px-3 py-2 bg-muted/30">{footerExtra}</div>
+                <div className="flex items-center px-3 py-2">{footerExtra}</div>
             )}
             {showCalendarArea && (
-            <div className="flex justify-end px-3 py-2 items-center gap-2 bg-muted/30">
+            <div className={cn('flex justify-end px-3 py-2 items-center gap-2', !presetsFirstMode && 'bg-muted/30')}>
                 <div className="mr-auto flex items-center gap-2">
                     {/* The lg inputs row shows the same staged range, so the readout yields to it */}
                     <span


### PR DESCRIPTION
## Problem

The insight date filter rebuild converged on a presets-first interaction: a quick-range list applies instantly, and a calendar is revealed in place for custom ranges — one fused surface. We prototyped hosting that interaction outside the picker twice (mode props were tried and closed in #69870; a `DateRangeFilter` block was prototyped in #70284), and both ended up re-rendering the picker's quick-ranges rail next to it. The list and the calendar want to share one surface, and the picker already owns that surface.

## Changes

Two additions to `DateTimePicker`, both backward compatible:

- `presetsFirst` — the quick ranges render as a left-hand vertical list that applies immediately on click (`onApply` fires with the computed range; no staging). A built-in "Custom range…" row reveals the calendar in place with the normal staged Apply flow; Cancel collapses back. Opens on the calendar when `value.range` is `CUSTOM_RANGE`. Ignored in `compact`. The boundary holds: the picker never interprets what a preset means — hosts map the applied `range` back to their own vocabulary (e.g. relative date strings) by its `id`.
- `footerExtra` — host content pinned in the actions bar next to the range readout (e.g. an exclusions control). In collapsed `presetsFirst` it renders as the sole footer row, so host controls stay reachable from the list view.

Plus one dedupe: the footer's date readout now hides at `lg`, where the inputs row shows the same staged range (it remains the only readout below `lg` and in `compact`).

Stories: `PresetsFirst`, `PresetsFirstWithExclusions` (a demo exclusions panel in `footerExtra`), and `PresetsFirstInPopover` (the full filter shape: trigger + pinned popover — `collisionAvoidance={{ align: 'none' }}` so the surface doesn't shift when the calendar expands).

First consumer: the insight date filter (#68359), via a `lib/components` wrapper that adds PostHog's relative-date vocabulary.

## How did you test this code?

- 3 new jest tests, each guarding a distinct contract: instant apply on a rail preset (catches the mode silently reverting to staging), collapsed-until-custom with Cancel collapsing back and `footerExtra` persisting across both states (catches the view toggle and the collapsed footer being dropped), and opening expanded when the value is a custom range (catches the jump-to-calendar logic). All 18 existing picker/date-picker tests pass unchanged — default mode is untouched.
- Stories cover the three presets-first states for visual review, light and dark.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`packages/quill/packages/components/AGENTS.md` updated (presetsFirst, footerExtra, popover pinning guidance).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session), directed by Sam through live Storybook iteration on the filter interaction (list placement, expansion behavior, exclusions placement — header row vs footer, fused panel vs flyout). The converged design put the whole surface in the picker, superseding the block approach (#70284, closed) and reversing the earlier decision to keep mode props out of the picker (#69870) now that the alternatives were prototyped and both duplicated the rail.
- Skills invoked: /writing-tests.
- Decisions: `presetsFirst` is one opinionated mode prop rather than separate rail-position/instant-apply/collapse flags — the combination is the pattern, and à-la-carte flags would recreate #69870's API sprawl; exclusions ship as a `footerExtra` slot, not a picker feature, keeping day-of-week/incomplete-period semantics host-side.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
