### PR TITLE
fix(taxonomic-filter): deflake component tests with fake timers

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -140,9 +140,11 @@ const config: Config = {
     // Faking queueMicrotask starves the web-streams pump that MSW v2 response bodies ride on:
     // each pump microtask lands in the fake queue and respawns the next one, so any
     // advanceTimersByTimeAsync allocates unboundedly until the worker OOMs. Keep microtasks real.
+    // setImmediate drives MSW v2's interceptor response pump the same way — faking it deadlocks
+    // any test that awaits a mocked request under fake timers (upstream stance: mswjs/msw#1830).
     // Merged into per-test `jest.useFakeTimers({...})` configs unless they pass their own doNotFake.
     fakeTimers: {
-        doNotFake: ['queueMicrotask'],
+        doNotFake: ['queueMicrotask', 'setImmediate'],
     },
 
     // Force coverage collection from ignored files using an array of glob patterns

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.component.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'kea'
 
@@ -92,8 +92,22 @@ describe('PropertyFilters recent selections', () => {
         await userEvent.click(screen.getByTestId(tabTestId))
     }
 
+    // Typing here pays taxonomicFilterLogic's real 500ms search breakpoint (plus stacked 100ms
+    // ones). Fake timers skip that wait; real timers resume immediately after so the resulting
+    // MSW round trip settles normally instead of fighting fake-timer polling. setImmediate is
+    // excluded like queueMicrotask (see jest.config.ts) — it also drives MSW v2's response pump.
     async function searchFor(query: string): Promise<void> {
-        await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), query)
+        jest.useFakeTimers({ doNotFake: ['queueMicrotask', 'setImmediate'] })
+        try {
+            await userEvent
+                .setup({ advanceTimers: jest.advanceTimersByTime })
+                .type(screen.getByTestId('taxonomic-filter-searchfield'), query)
+            await act(async () => {
+                jest.advanceTimersByTime(600)
+            })
+        } finally {
+            jest.useRealTimers()
+        }
     }
 
     async function selectItem(itemTestId: string, onChange: jest.Mock): Promise<void> {

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'kea'
 import posthog from 'posthog-js'
@@ -92,6 +92,27 @@ describe('TaxonomicFilter', () => {
         expect(screen.getByTestId(activeTestId)).toHaveClass('LemonTag--primary')
         if (inactiveTestId) {
             expect(screen.getByTestId(inactiveTestId)).not.toHaveClass('LemonTag--primary')
+        }
+    }
+
+    // Search interactions pay taxonomicFilterLogic's real 500ms breakpoint (plus stacked
+    // 100ms ones), which is what pushed these tests over CI's per-test timeout. Fake timers
+    // skip that wait; real timers resume immediately after so the resulting MSW round trip
+    // (and any waitFor built on it) settles normally instead of fighting fake-timer polling.
+    async function withoutDebounceDelay(
+        action: (user: ReturnType<typeof userEvent.setup>) => Promise<void>
+    ): Promise<void> {
+        // setImmediate also drives MSW v2's response-body pump (like queueMicrotask, see
+        // jest.config.ts) — faking it makes advanceTimersByTime re-run that pump once per
+        // virtual ms for every matched row, turning a fast search into a slow one.
+        jest.useFakeTimers({ doNotFake: ['queueMicrotask', 'setImmediate'] })
+        try {
+            await action(userEvent.setup({ advanceTimers: jest.advanceTimersByTime }))
+            await act(async () => {
+                jest.advanceTimersByTime(600)
+            })
+        } finally {
+            jest.useRealTimers()
         }
     }
 
@@ -220,7 +241,9 @@ describe('TaxonomicFilter', () => {
                 expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
             })
 
-            await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'test event')
+            await withoutDebounceDelay((user) =>
+                user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'test event')
+            )
 
             await waitFor(() => {
                 expect(screen.getAllByText('test event').length).toBeGreaterThanOrEqual(1)
@@ -270,13 +293,13 @@ describe('TaxonomicFilter', () => {
             })
 
             const searchInput = screen.getByTestId('taxonomic-filter-searchfield')
-            await userEvent.type(searchInput, 'xyznonexistent')
+            await withoutDebounceDelay((user) => user.type(searchInput, 'xyznonexistent'))
 
             await waitFor(() => {
                 expect(screen.queryByTestId('prop-filter-events-0')).not.toBeInTheDocument()
             })
 
-            await userEvent.clear(searchInput)
+            await withoutDebounceDelay((user) => user.clear(searchInput))
 
             await waitFor(() => {
                 expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
@@ -309,7 +332,11 @@ describe('TaxonomicFilter', () => {
             })
 
             await activateGroupWithResults('taxonomic-tab-person_properties')
-            // Search for something that only matches events, leaving person properties empty
+            // Search for something that only matches events, leaving person properties empty.
+            // Real timers here: this scenario includes SuggestedFilters, whose reveal-barrier
+            // state doesn't survive the fake->real timer switch withoutDebounceDelay performs
+            // (a pending fake timer is dropped rather than carried over), so the button never
+            // appears. See withoutDebounceDelay's other uses for the debounce-skip that's safe.
             await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'test event')
 
             // The empty state offers a shortcut to the aggregated all/suggested-filters section
@@ -337,6 +364,8 @@ describe('TaxonomicFilter', () => {
             })
 
             await activateGroupWithResults('taxonomic-tab-person_properties')
+            // Real timers: SuggestedFilters is present here too — see the comment in the
+            // preceding test for why withoutDebounceDelay isn't safe for this scenario.
             await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'xyznonexistent')
 
             await waitFor(() => {
@@ -354,7 +383,9 @@ describe('TaxonomicFilter', () => {
 
             await activateGroupWithResults('taxonomic-tab-events')
             // `purchase_value` exists only as a property, so the active Events tab comes up empty
-            await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'purchase_value')
+            await withoutDebounceDelay((user) =>
+                user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'purchase_value')
+            )
 
             let switchButton: HTMLElement | undefined
             await waitFor(() => {
@@ -383,7 +414,9 @@ describe('TaxonomicFilter', () => {
             })
 
             await activateGroupWithResults('taxonomic-tab-events')
-            await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'purchase_value')
+            await withoutDebounceDelay((user) =>
+                user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'purchase_value')
+            )
 
             // The genuinely-matching tab is still offered...
             await waitFor(() => {
@@ -893,12 +926,14 @@ describe('TaxonomicFilter', () => {
                 expect(screen.getByTestId('prop-filter-events-0')).toBeInTheDocument()
             })
 
-            await userEvent.type(screen.getByTestId('taxonomic-filter-searchfield'), 'zzznonexistentevent12345')
+            await withoutDebounceDelay((user) =>
+                user.type(screen.getByTestId('taxonomic-filter-searchfield'), 'zzznonexistentevent12345')
+            )
 
             await waitFor(() => {
                 expect(screen.queryAllByTestId(/^prop-filter-events-/)).toHaveLength(0)
             })
-        }, 10000)
+        })
     })
 
     it.each([
@@ -1116,7 +1151,6 @@ describe('TaxonomicFilter', () => {
         }
 
         it('collapses the matching URL list to a single "URL contains" shortcut row', async () => {
-            const user = userEvent.setup()
             useMockPageviewUrls(['https://example.com/pricing', 'https://example.com/pricing/teams'])
             renderFilter({
                 taxonomicGroupTypes: [TaxonomicFilterGroupType.PageviewUrls],
@@ -1124,7 +1158,7 @@ describe('TaxonomicFilter', () => {
             })
 
             const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
-            await user.type(searchInput, 'pricing')
+            await withoutDebounceDelay((fakeTimerUser) => fakeTimerUser.type(searchInput, 'pricing'))
 
             const firstRow = await waitFor(() => screen.getByTestId('prop-filter-pageview_urls-0'))
             // The two matching URLs collapse into one row, which is the contains shortcut.
@@ -1141,7 +1175,7 @@ describe('TaxonomicFilter', () => {
             })
 
             const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
-            await user.type(searchInput, 'pricing')
+            await withoutDebounceDelay((fakeTimerUser) => fakeTimerUser.type(searchInput, 'pricing'))
 
             const row = await waitFor(() => {
                 const el = document.querySelector('[data-attr="taxonomic-shortcut-pricing-property"]')
@@ -1167,6 +1201,11 @@ describe('TaxonomicFilter', () => {
         })
 
         it('collapses URLs in the aggregated Suggested filters tab too', async () => {
+            // Real timers: this scenario includes SuggestedFilters, whose reveal-barrier state
+            // doesn't survive the fake->real timer switch withoutDebounceDelay performs (a
+            // pending fake timer is dropped rather than carried over), so the aggregated row
+            // never appears. See withoutDebounceDelay's other uses in this describe for the
+            // debounce-skip that's safe when SuggestedFilters isn't part of the group list.
             const user = userEvent.setup()
             useMockPageviewUrls(['https://example.com/pricing', 'https://example.com/pricing/teams'])
             renderFilter({
@@ -1192,14 +1231,13 @@ describe('TaxonomicFilter', () => {
         })
 
         it('lists individual URLs (no collapse) when the prop is omitted', async () => {
-            const user = userEvent.setup()
             useMockPageviewUrls(['https://example.com/pricing'])
             renderFilter({
                 taxonomicGroupTypes: [TaxonomicFilterGroupType.PageviewUrls],
             })
 
             const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
-            await user.type(searchInput, 'pricing')
+            await withoutDebounceDelay((fakeTimerUser) => fakeTimerUser.type(searchInput, 'pricing'))
 
             await waitFor(() => {
                 expect(screen.getByTestId('prop-filter-pageview_urls-0')).toBeInTheDocument()
@@ -1208,7 +1246,6 @@ describe('TaxonomicFilter', () => {
         })
 
         it('shows no shortcut row when no URL matches the query', async () => {
-            const user = userEvent.setup()
             // Flag set when the URL values endpoint actually responds (empty), so the negative
             // assertions below aren't vacuously true before the async fetch path runs.
             let valuesFetched = false
@@ -1230,7 +1267,7 @@ describe('TaxonomicFilter', () => {
             const searchInput = await waitFor(() => screen.getByTestId('taxonomic-filter-searchfield'))
             // A query unique to this test so the module-level `apiCache` in infiniteListLogic
             // can't serve a non-empty response cached by an earlier test under the same URL.
-            await user.type(searchInput, 'nomatchquery')
+            await withoutDebounceDelay((user) => user.type(searchInput, 'nomatchquery'))
 
             await waitFor(() => expect(valuesFetched).toBe(true))
             await waitFor(() => {


### PR DESCRIPTION
## Problem

Trunk quarantined several tests in `TaxonomicFilter.test.tsx` and `PropertyFilters.component.test.tsx` as CI timeout flakes. They aren't unstable in outcome, they're just slow: each search interaction pays taxonomicFilterLogic's real `breakpoint(500)` search debounce (plus a few stacked `breakpoint(100)`s) on real timers. At ~1.3-1.4s baseline, plus MSW round trips and `waitFor` polling, they occasionally exceed jest's 5000ms per-test timeout once CI's sharded `--maxWorkers=2` runners add contention.

## Changes

Removes the wall-clock wait instead of raising the timeout or loosening assertions:

- A `withoutDebounceDelay` helper (and an equivalent inline in `PropertyFilters.component.test.tsx`'s shared `searchFor`) scopes `jest.useFakeTimers()` around just the search interaction, advances past the debounce, then calls `jest.useRealTimers()` before the test's own `waitFor` picks up the resulting MSW round trip.
- The fake-timer config excludes `setImmediate` in addition to `queueMicrotask` (already excluded globally in `jest.config.ts` for the same reason). `setImmediate` also drives MSW v2's response-body pump — faking it makes `advanceTimersByTime` re-run that pump once per virtual ms for every matched row, turning a fast search into a slow one.
- A few scenarios that also render the `SuggestedFilters` "reveal barrier" don't tolerate the fake-to-real timer switch: a pending fake timer scheduled during the fake window is dropped rather than carried over when timers switch back to real, so the barrier never opens. Those stay on real timers, each with a comment explaining why — forcing it would have hidden a real functional break behind a "passing" test.
- Dropped a couple of pre-existing `}, 10000)` per-test timeout overrides in `TaxonomicFilter.test.tsx` that are no longer needed once the debounce wait is gone.

No product code changed — this is test-only.

## How did you test this code?

Automated only, run in the branch's worktree.

**Before/after timing** (`--maxWorkers=1`, per-test):

| Test | Before | After |
|---|---|---|
| `TaxonomicFilter` › search › typing in the search field filters results | 1128ms | 611ms |
| `TaxonomicFilter` › search › returns full unfiltered results when search is cleared | 1212ms | 884ms |
| `TaxonomicFilter` › no results - switch to all › does not offer a jump to a render-backed group with no real matches | 1381ms | 1078ms |
| `TaxonomicFilter` › no results - switch to all › offers a per-category jump when matches live on another tab | 1505ms | 852ms |
| `TaxonomicFilter` › edge cases › renders correctly when search matches no items | 1531ms | 1001ms |
| `TaxonomicFilter` › collapseUrlsToContainsRow › (4 non-SuggestedFilters tests) | 590-629ms | 66-178ms |
| `PropertyFilters` › shortcut group (pageview URL / screen name / email) | 918-1168ms | 373-538ms |
| `PropertyFilters` › selecting a property and completing the value records to recents | 1725ms | 1163ms |
| `PropertyFilters` › recents show/search hint/prefix disappears/searching in recents | 932-1326ms | 385-732ms |
| `PropertyFilters` › multiple selections limited to 3 in suggested filters | 3596ms | 1354ms |

Two tests in `no results - switch to all` and one in `collapseUrlsToContainsRow` stay on real timers (see comments) since they hit the SuggestedFilters reveal-barrier incompatibility above — they're unchanged from baseline (~900-1300ms), still comfortably clear of the 5000ms timeout.

Full-file totals: `TaxonomicFilter.test.tsx` 31.2s → 25.8s (81 tests), `PropertyFilters.component.test.tsx` 16.6s → 12.5s (13 tests). All 94 tests pass.

**Stability loop**: both files together, `--maxWorkers=2`, 24/24 runs green (target was 20).

**Cross-file check**: `Combobox.test.tsx` (the file whose existing fake-timer idiom this follows) run once, 38/38 pass, unaffected.

## Docs update

N/A — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this from a pre-established diagnosis (already root-caused: real-timer search debounces pushing quarantined tests over CI's per-test timeout) and specified the fix approach (scoped fake timers, following the existing `Combobox.test.tsx`/`recentTaxonomicFiltersLogic.test.ts` idiom) plus the validation bar (before/after timing, a 20-run stability loop at `--maxWorkers=2`).

I'm Claude (Sonnet), working in the target worktree. No skills were invoked — this is a test-timing fix, not new test coverage or a DRF/migration/taxonomic-filter *behavior* change, so `/writing-tests` and `/modifying-taxonomic-filter` didn't apply.

Key decisions along the way:
- Tried whole-file and whole-describe `jest.useFakeTimers()` first, per the preferred approach — it deadlocked every test that touched MSW (jest's own per-test 5000ms watchdog killed each one, leaking fake timers into subsequent tests). Root cause: `@testing-library/dom`'s `waitFor` self-drives fake-timer advancement in a loop, and MSW v2's response pump rides `setImmediate`, which was being faked and re-entered on every virtual millisecond.
- Landed on scoping `jest.useFakeTimers()`/`jest.useRealTimers()` tightly around just the typing interaction (matching `Combobox.test.tsx`'s existing per-test idiom), excluding `setImmediate` from the fake set.
- Found empirically (not guessed) that this still breaks the `SuggestedFilters` reveal-barrier scenarios specifically — confirmed by testing with a much longer `waitFor` timeout (4000ms) and observing the assertion still never resolved, i.e. a genuine functional break rather than a timing shortfall. Left those on real timers per the task's explicit fallback instruction rather than forcing a fix that would have masked the break.