### PR TITLE
feat(cli): configure sourcemap upload concurrency

### DIFF
--- a/cli/.sampo/changesets/flexible-sourcemap-upload-concurrency.md
+++ b/cli/.sampo/changesets/flexible-sourcemap-upload-concurrency.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Sourcemap upload concurrency can now be configured with `--concurrency` or `POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY`, while keeping the existing default of 10 uploads at a time.

--- a/cli/README.md
+++ b/cli/README.md
@@ -72,6 +72,22 @@ Pass `--include-source` to bundle the referenced source files for richer context
 
 The standalone `posthog-cli dsym upload` command is unchanged and still recommended for dSYM-only Xcode build phases, where it also reads release and version metadata from each bundle's `Info.plist`.
 
+## Configuring sourcemap upload concurrency
+
+Sourcemap uploads run up to 10 file uploads at a time by default. Set a different positive value with `--concurrency` on `sourcemap upload` or `sourcemap process`:
+
+```bash
+posthog-cli sourcemap process --directory ./dist --concurrency 32
+```
+
+For build integrations such as `@posthog/nextjs-config`, set `POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY` in the build environment instead:
+
+```bash
+POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY=32 npm run build
+```
+
+The CLI flag takes precedence over the environment variable. Both require a value greater than zero. This setting applies only to plain sourcemap uploads; other CLI concurrency remains unchanged.
+
 ## Skipping uploads (dry run)
 
 Pass `--dry-run` before the subcommand (`posthog-cli --dry-run hermes upload ...`), or set `POSTHOG_CLI_DRY_RUN=true`, to turn the upload commands — `sourcemap`, `dsym`, `hermes`, and `proguard` — into a no-op.

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -1,8 +1,13 @@
 use anyhow::{anyhow, Context, Result};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::{
+    iter::{IntoParallelIterator, ParallelIterator},
+    ThreadPool, ThreadPoolBuilder,
+};
 use reqwest::blocking::multipart::{Form, Part};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Debug, iter, thread::sleep, time::Duration};
+use std::{
+    collections::HashMap, fmt::Debug, iter, num::NonZeroUsize, thread::sleep, time::Duration,
+};
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
@@ -14,6 +19,7 @@ use crate::{
 const MAX_FILE_SIZE: usize = 100 * 1024 * 1024; // 100 MB
 const FINISH_UPLOAD_ERROR_MESSAGE: &str =
     "Failed to finalize symbol upload; maps were not attached";
+pub const DEFAULT_UPLOAD_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(10).unwrap();
 
 #[derive(Error, Debug)]
 pub enum UploadError {
@@ -78,7 +84,32 @@ pub fn upload_with_retry(
     force: bool,
     skip_on_conflict: bool,
 ) -> Result<()> {
-    let res = upload_inner(&input_sets, batch_size, force, skip_on_conflict);
+    upload_with_retry_and_concurrency(
+        input_sets,
+        batch_size,
+        skip_release_on_fail,
+        force,
+        skip_on_conflict,
+        DEFAULT_UPLOAD_CONCURRENCY,
+    )
+}
+
+pub fn upload_with_retry_and_concurrency(
+    input_sets: Vec<SymbolSetUpload>,
+    batch_size: usize,
+    skip_release_on_fail: bool,
+    force: bool,
+    skip_on_conflict: bool,
+    concurrency: NonZeroUsize,
+) -> Result<()> {
+    let thread_pool = build_upload_thread_pool(concurrency)?;
+    let res = upload_inner(
+        &input_sets,
+        batch_size,
+        force,
+        skip_on_conflict,
+        &thread_pool,
+    );
     match res {
         Ok(()) => Ok(()),
         Err(UploadError::ReleaseIdMismatch) if skip_release_on_fail => {
@@ -91,11 +122,24 @@ pub fn upload_with_retry(
                     data: s.data,
                 })
                 .collect();
-            upload_inner(&sets_without_release, batch_size, force, skip_on_conflict)
-                .map_err(|e| e.into())
+            upload_inner(
+                &sets_without_release,
+                batch_size,
+                force,
+                skip_on_conflict,
+                &thread_pool,
+            )
+            .map_err(|e| e.into())
         }
         Err(e) => Err(e.into()),
     }
+}
+
+fn build_upload_thread_pool(concurrency: NonZeroUsize) -> Result<ThreadPool> {
+    ThreadPoolBuilder::new()
+        .num_threads(concurrency.get())
+        .build()
+        .context("Failed to initialize symbol set upload thread pool")
 }
 
 fn upload_inner(
@@ -103,6 +147,7 @@ fn upload_inner(
     batch_size: usize,
     force: bool,
     skip_on_conflict: bool,
+    thread_pool: &ThreadPool,
 ) -> Result<(), UploadError> {
     let upload_requests: Vec<_> = input_sets
         .iter()
@@ -129,20 +174,22 @@ fn upload_inner(
             batch.len() - start_response.id_map.len()
         );
 
-        let res: Result<HashMap<String, String>> = start_response
-            .id_map
-            .into_par_iter()
-            .map(|(chunk_id, data)| {
-                debug!("uploading chunk {}", chunk_id);
-                let upload = id_map.get(chunk_id.as_str()).ok_or(anyhow!(
-                    "Got a chunk ID back from posthog that we didn't expect!"
-                ))?;
+        let res: Result<HashMap<String, String>> = thread_pool.install(|| {
+            start_response
+                .id_map
+                .into_par_iter()
+                .map(|(chunk_id, data)| {
+                    debug!("uploading chunk {}", chunk_id);
+                    let upload = id_map.get(chunk_id.as_str()).ok_or(anyhow!(
+                        "Got a chunk ID back from posthog that we didn't expect!"
+                    ))?;
 
-                let content_hash = content_hash([&upload.data]);
-                upload_to_s3(data.presigned_url.clone(), &upload.data)?;
-                Ok((data.symbol_set_id, content_hash))
-            })
-            .collect();
+                    let content_hash = content_hash([&upload.data]);
+                    upload_to_s3(data.presigned_url.clone(), &upload.data)?;
+                    Ok((data.symbol_set_id, content_hash))
+                })
+                .collect()
+        });
 
         let content_hashes = res?;
 
@@ -440,6 +487,13 @@ mod tests {
             .count();
 
         assert_eq!(retry_logs, 2);
+    }
+
+    #[test]
+    fn upload_thread_pool_uses_configured_concurrency() {
+        let thread_pool = build_upload_thread_pool(NonZeroUsize::new(3).unwrap()).unwrap();
+
+        assert_eq!(thread_pool.current_num_threads(), 3);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,4 @@
 use posthog_cli::{cmd, invocation_context::init_posthog_telemetry};
-use rayon::ThreadPoolBuilder;
 
 fn main() {
     let subscriber = tracing_subscriber::fmt()
@@ -10,12 +9,6 @@ fn main() {
                 .from_env_lossy(),
         )
         .finish();
-
-    // Init the rayon thread pool
-    ThreadPoolBuilder::new()
-        .num_threads(10)
-        .build_global()
-        .expect("We successfully install a global thread pool");
 
     tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
     init_posthog_telemetry();

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -1,12 +1,29 @@
 use std::{
     fmt::Display,
     io::{self, BufRead},
+    num::NonZeroUsize,
     path::PathBuf,
 };
 
 use anyhow::{bail, Result};
 
-use crate::{api::releases::ReleaseBuilder, utils::files::FileSelection};
+use crate::{
+    api::{releases::ReleaseBuilder, symbol_sets::DEFAULT_UPLOAD_CONCURRENCY},
+    utils::files::FileSelection,
+};
+
+pub const SOURCEMAP_UPLOAD_CONCURRENCY_ENV: &str = "POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY";
+
+#[derive(clap::Args, Clone, Debug)]
+pub struct UploadConcurrencyArgs {
+    /// The number of sourcemap files to upload concurrently
+    #[arg(
+        long,
+        env = SOURCEMAP_UPLOAD_CONCURRENCY_ENV,
+        default_value_t = DEFAULT_UPLOAD_CONCURRENCY
+    )]
+    pub concurrency: NonZeroUsize,
+}
 
 #[derive(clap::Args, Clone)]
 pub struct FileSelectionArgs {
@@ -141,6 +158,35 @@ impl From<ReleaseArgs> for ReleaseBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+    use std::sync::Mutex;
+
+    static CONCURRENCY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[derive(Debug, Parser)]
+    struct ConcurrencyCli {
+        #[command(flatten)]
+        upload: UploadConcurrencyArgs,
+    }
+
+    fn parse_concurrency(args: &[&str], env: Option<&str>) -> clap::error::Result<ConcurrencyCli> {
+        let _guard = CONCURRENCY_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(SOURCEMAP_UPLOAD_CONCURRENCY_ENV);
+
+        match env {
+            Some(value) => std::env::set_var(SOURCEMAP_UPLOAD_CONCURRENCY_ENV, value),
+            None => std::env::remove_var(SOURCEMAP_UPLOAD_CONCURRENCY_ENV),
+        }
+
+        let parsed = ConcurrencyCli::try_parse_from(args);
+
+        match original {
+            Some(value) => std::env::set_var(SOURCEMAP_UPLOAD_CONCURRENCY_ENV, value),
+            None => std::env::remove_var(SOURCEMAP_UPLOAD_CONCURRENCY_ENV),
+        }
+
+        parsed
+    }
 
     fn make_args(name: Option<&str>, version: Option<&str>, build: Option<&str>) -> ReleaseArgs {
         ReleaseArgs {
@@ -168,6 +214,54 @@ mod tests {
                 builder.has_version(),
                 expect_version,
                 "version={version:?} build={build:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn upload_concurrency_defaults_to_ten() {
+        let parsed = parse_concurrency(&["test"], None).unwrap();
+
+        assert_eq!(parsed.upload.concurrency.get(), 10);
+    }
+
+    #[test]
+    fn upload_concurrency_accepts_cli_override() {
+        let parsed = parse_concurrency(&["test", "--concurrency", "32"], None).unwrap();
+
+        assert_eq!(parsed.upload.concurrency.get(), 32);
+    }
+
+    #[test]
+    fn upload_concurrency_accepts_environment_override() {
+        let parsed = parse_concurrency(&["test"], Some("48")).unwrap();
+
+        assert_eq!(parsed.upload.concurrency.get(), 48);
+    }
+
+    #[test]
+    fn upload_concurrency_prefers_cli_override() {
+        let parsed = parse_concurrency(&["test", "--concurrency", "32"], Some("48")).unwrap();
+
+        assert_eq!(parsed.upload.concurrency.get(), 32);
+    }
+
+    #[test]
+    fn upload_concurrency_rejects_zero_cli_value() {
+        let error = parse_concurrency(&["test", "--concurrency", "0"], None).unwrap_err();
+
+        assert!(error.to_string().contains("invalid value '0'"));
+    }
+
+    #[test]
+    fn upload_concurrency_rejects_invalid_environment_values() {
+        for value in ["0", "many"] {
+            let error = parse_concurrency(&["test"], Some(value)).unwrap_err();
+            let message = error.to_string();
+            assert!(
+                message.contains(&format!("invalid value '{value}'"))
+                    && message.contains("--concurrency"),
+                "unexpected error for {value:?}: {message}"
             );
         }
     }

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Subcommand;
 
 use crate::sourcemaps::{
-    args::{FileSelectionArgs, ReleaseArgs, UploadConflictArgs},
+    args::{FileSelectionArgs, ReleaseArgs, UploadConcurrencyArgs, UploadConflictArgs},
     inject::InjectArgs,
 };
 
@@ -44,6 +44,9 @@ pub struct ProcessArgs {
 
     #[clap(flatten)]
     pub conflict: UploadConflictArgs,
+
+    #[clap(flatten)]
+    pub upload_concurrency: UploadConcurrencyArgs,
 }
 
 impl ProcessArgs {
@@ -69,8 +72,50 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             batch_size: args.batch_size,
             release: args.release,
             conflict: args.conflict,
+            upload_concurrency: args.upload_concurrency,
         };
 
         (inject_args, upload_args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct SourcemapCli {
+        #[command(subcommand)]
+        command: SourcemapCommand,
+    }
+
+    #[test]
+    fn process_concurrency_defaults_to_ten() {
+        let parsed = SourcemapCli::try_parse_from(["test", "process", "--directory", "."])
+            .expect("process args should parse");
+        let SourcemapCommand::Process(args) = parsed.command else {
+            panic!("expected process command");
+        };
+
+        assert_eq!(args.upload_concurrency.concurrency.get(), 10);
+    }
+
+    #[test]
+    fn upload_accepts_concurrency_override() {
+        let parsed = SourcemapCli::try_parse_from([
+            "test",
+            "upload",
+            "--directory",
+            ".",
+            "--concurrency",
+            "24",
+        ])
+        .expect("upload args should parse");
+        let SourcemapCommand::Upload(args) = parsed.command else {
+            panic!("expected upload command");
+        };
+
+        assert_eq!(args.upload_concurrency.concurrency.get(), 24);
     }
 }

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -91,14 +91,21 @@ mod tests {
     }
 
     #[test]
-    fn process_concurrency_defaults_to_ten() {
-        let parsed = SourcemapCli::try_parse_from(["test", "process", "--directory", "."])
-            .expect("process args should parse");
+    fn process_accepts_concurrency_override() {
+        let parsed = SourcemapCli::try_parse_from([
+            "test",
+            "process",
+            "--directory",
+            ".",
+            "--concurrency",
+            "18",
+        ])
+        .expect("process args should parse");
         let SourcemapCommand::Process(args) = parsed.command else {
             panic!("expected process command");
         };
 
-        assert_eq!(args.upload_concurrency.concurrency.get(), 10);
+        assert_eq!(args.upload_concurrency.concurrency.get(), 18);
     }
 
     #[test]

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     invocation_context::context,
     sourcemaps::{
-        args::{FileSelectionArgs, ReleaseArgs, UploadConflictArgs},
+        args::{FileSelectionArgs, ReleaseArgs, UploadConcurrencyArgs, UploadConflictArgs},
         content::MinifiedSourceFile,
         inject::get_release_for_maps,
         plain::inject::is_javascript_file,
@@ -52,6 +52,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub conflict: UploadConflictArgs,
+
+    #[clap(flatten)]
+    pub upload_concurrency: UploadConcurrencyArgs,
 
     /// DEPRECATED - this flag is a no-op. Use top-level `--skip-ssl-verification` instead.
     #[arg(long)]
@@ -147,12 +150,13 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
     );
 
     let started_at = Instant::now();
-    let upload_result = symbol_sets::upload_with_retry(
+    let upload_result = symbol_sets::upload_with_retry_and_concurrency(
         uploads,
         args.batch_size,
         args.release.skip_release_on_fail,
         args.conflict.force,
         args.conflict.skip_on_conflict,
+        args.upload_concurrency.concurrency,
     );
     let duration_ms = started_at.elapsed().as_millis();
 


### PR DESCRIPTION
## Problem

Closes #70238

Sourcemap S3 uploads use a process-wide Rayon pool hardcoded to 10 threads, so large builds cannot tune upload concurrency.

## Changes

- Add `--concurrency` and `POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY` to `sourcemap upload` and `sourcemap process`.
- Replace the global Rayon pool with a local symbol-set upload pool.
- Keep 10 as the default for all existing upload paths, and reject zero or malformed values.

## How did you test this code?

- `cargo +1.91.1 test concurrency --lib` – 9 concurrency tests pass.
- `cargo +1.91.1 test --all-features -- --skip test_pair_inject` – 136 tests pass. On this Windows checkout, the skipped fixture test has the same CRLF/LF mismatch on unmodified `master`.
- `cargo +1.91.1 clippy --all-targets --all-features -- -D warnings -A clippy::needless-borrows-for-generic-args` – clean; the allowed lint is an unchanged Windows-only finding in `login.rs`.
- `cargo +1.91.1 fmt --all -- --check`, release build, and Rustdoc with warnings denied – clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `cli/README.md` with the default, precedence, direct CLI usage, and build-environment usage for `@posthog/nextjs-config`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made the changes and ran the checks using the public `contribute` skill. I chose a PostHog-specific setting and a local pool so sourcemap builds can tune their upload workload without changing unrelated global Rayon behavior.
