### PR TITLE
fix(product-analytics): deflake retention spec week-header assertion

### DIFF
--- a/playwright/e2e/product-analytics/retention.spec.ts
+++ b/playwright/e2e/product-analytics/retention.spec.ts
@@ -62,8 +62,12 @@ test.describe('Retention', () => {
 
         await test.step('change period from Day to Week', async () => {
             await insight.retention.selectPeriod('weeks')
-            const headerTexts = await insight.retention.getColumnHeaderTexts()
-            expect(headerTexts.filter(isWeekHeader).length).toBe(8)
+            // The period change refetches the query; poll until the weekly headers render
+            // instead of reading the (possibly still daily/loading) table immediately.
+            await expect(async () => {
+                const headerTexts = await insight.retention.getColumnHeaderTexts()
+                expect(headerTexts.filter(isWeekHeader).length).toBe(8)
+            }).toPass({ timeout: 15000 })
         })
 
         await test.step('toggle to cumulative retention', async () => {


### PR DESCRIPTION
## Problem

`Retention › Retention calculations, period, breakdown, and chart` is Trunk-quarantined and failing at ~14%/day with "expected 8 week headers but found 0" (27 occurrences in the current window).

The "change period from Day to Week" step calls `selectPeriod('weeks')` — which refetches the retention query — and then reads the column headers immediately. On a slow response the table still shows the daily/loading state, `isWeekHeader` matches nothing, and the assertion sees 0.

## Changes

Poll the header read with `expect(...).toPass({ timeout: 15000 })` until the weekly headers render, exactly matching the pattern the same spec already uses for its custom-range headers step (which carries a comment explaining the same wait-for-refetch reasoning).

## How did you test this code?

Analytical fix validated by pattern-match against the working sibling step in the same file; playwright needs the full app stack, which isn't available in the authoring environment — this PR's own playwright CI run exercises the spec. The failure mode (instant DOM read racing a query refetch) is fully explained by the diff, and the fix waits on the exact condition the assertion checks rather than a fixed sleep.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code during a flaky-test backlog triage; skill invoked: `/fixing-flaky-tests`.
- Identified from Trunk failure data (quarantined, persistent at ~14%/day since July 10, uniform "found 0 headers" summary); the race was located statically and the fix reuses the file's own established polling idiom rather than introducing a new pattern.
