### PR TITLE
fix(hogql): scope materialized-column printer tests to unique event names

### DIFF
--- a/posthog/hogql/printer/test/__snapshots__/test_printer.ambr
+++ b/posthog/hogql/printer/test/__snapshots__/test_printer.ambr
@@ -23,7 +23,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.mat_test_prop, 'foo'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_force_index_test'), equals(events.mat_test_prop, 'foo'))
   LIMIT 100 SETTINGS force_data_skipping_indices='bloom_filter_mat_test_prop',
                      readonly=2,
                      max_execution_time=60,
@@ -43,7 +43,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%@posthog.com'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%@posthog.com'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -63,7 +63,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%@posthog.com'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%@posthog.com'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -83,7 +83,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', '')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', '')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -103,7 +103,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', '')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', '')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -123,7 +123,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), 'hello@posthog.com'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), 'hello@posthog.com'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -143,7 +143,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), 'hello@posthog.com'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), 'hello@posthog.com'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -163,7 +163,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%null%'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%null%'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -183,7 +183,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%null%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%null%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -203,7 +203,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -223,7 +223,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), '%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -243,7 +243,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), ''), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), ''), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -263,7 +263,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), ''), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), ''), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -283,7 +283,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(ilike(events.mat_test_prop, '%@posthog.com'), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(ilike(events.mat_test_prop, '%@posthog.com'), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -303,7 +303,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, '%@posthog.com'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, '%@posthog.com'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -323,7 +323,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNull(events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNull(events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -343,7 +343,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNotNull(events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNotNull(events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -363,7 +363,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(ilike(events.mat_test_prop, 'hello@posthog.com'), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(ilike(events.mat_test_prop, 'hello@posthog.com'), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -383,7 +383,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, 'hello@posthog.com'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, 'hello@posthog.com'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -403,7 +403,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(ilike(events.mat_test_prop, '%null%'), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(ilike(events.mat_test_prop, '%null%'), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -423,7 +423,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, '%null%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, '%null%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -443,7 +443,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(ilike(events.mat_test_prop, '%'), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(ilike(events.mat_test_prop, '%'), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -463,7 +463,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, '%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, '%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -483,7 +483,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(ilike(events.mat_test_prop, ''), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(ilike(events.mat_test_prop, ''), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -503,7 +503,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, ''), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, ''), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -523,7 +523,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ilike(events.mat_test_prop, '%@posthog.com'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ilike(events.mat_test_prop, '%@posthog.com'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -543,7 +543,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notILike(events.mat_test_prop, '%@posthog.com'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), notILike(events.mat_test_prop, '%@posthog.com'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -563,7 +563,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -583,7 +583,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNotNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNotNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -603,7 +603,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ilike(events.mat_test_prop, 'hello@posthog.com'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ilike(events.mat_test_prop, 'hello@posthog.com'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -623,7 +623,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notILike(events.mat_test_prop, 'hello@posthog.com'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), notILike(events.mat_test_prop, 'hello@posthog.com'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -643,7 +643,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -663,7 +663,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -683,7 +683,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -703,7 +703,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -723,7 +723,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -743,7 +743,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -763,7 +763,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(like(lower(coalesce(events.mat_test_prop, '')), lower('%@posthog.com')), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(like(lower(coalesce(events.mat_test_prop, '')), lower('%@posthog.com')), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -783,7 +783,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, '%@posthog.com'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, '%@posthog.com'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -803,7 +803,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNull(events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNull(events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -823,7 +823,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNotNull(events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNotNull(events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -843,7 +843,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(like(lower(coalesce(events.mat_test_prop, '')), lower('hello@posthog.com')), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(like(lower(coalesce(events.mat_test_prop, '')), lower('hello@posthog.com')), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -863,7 +863,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, 'hello@posthog.com'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, 'hello@posthog.com'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -883,7 +883,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(like(lower(coalesce(events.mat_test_prop, '')), lower('%null%')), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(like(lower(coalesce(events.mat_test_prop, '')), lower('%null%')), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -903,7 +903,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, '%null%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, '%null%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -923,7 +923,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(like(lower(coalesce(events.mat_test_prop, '')), lower('%')), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(like(lower(coalesce(events.mat_test_prop, '')), lower('%')), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -943,7 +943,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, '%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, '%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -963,7 +963,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(like(lower(coalesce(events.mat_test_prop, '')), lower('')), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), and(like(lower(coalesce(events.mat_test_prop, '')), lower('')), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -983,7 +983,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(events.mat_test_prop, ''), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(events.mat_test_prop, ''), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1003,7 +1003,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), like(lower(events.mat_test_prop), lower('%@posthog.com')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), like(lower(events.mat_test_prop), lower('%@posthog.com')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1023,7 +1023,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notILike(events.mat_test_prop, '%@posthog.com'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), notILike(events.mat_test_prop, '%@posthog.com'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1043,7 +1043,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1063,7 +1063,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), isNotNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), isNotNull(nullIf(nullIf(events.mat_test_prop, ''), 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1083,7 +1083,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), like(lower(events.mat_test_prop), lower('hello@posthog.com')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), like(lower(events.mat_test_prop), lower('hello@posthog.com')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1103,7 +1103,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notILike(events.mat_test_prop, 'hello@posthog.com'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), notILike(events.mat_test_prop, 'hello@posthog.com'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1123,7 +1123,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1143,7 +1143,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%null%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1163,7 +1163,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1183,7 +1183,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), '%'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1203,7 +1203,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 0))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(ilike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 0))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1223,7 +1223,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_ilike_test'), ifNull(notILike(nullIf(nullIf(events.mat_test_prop, ''), 'null'), ''), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1243,7 +1243,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1263,7 +1263,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1283,7 +1283,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1303,7 +1303,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1323,7 +1323,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1343,7 +1343,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1363,7 +1363,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', '')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', '')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1383,7 +1383,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', '')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', '')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1403,7 +1403,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'other_value')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'other_value')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1423,7 +1423,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'other_value')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('hello@posthog.com', 'other_value')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1443,7 +1443,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1463,7 +1463,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1483,7 +1483,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('NULL')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('NULL')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1503,7 +1503,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1523,7 +1523,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null', 'NULL')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null', 'NULL')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1543,7 +1543,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null', 'NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'test_prop'), ''), 'null'), '^"|"$', ''), tuple('null', 'NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1563,7 +1563,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1583,7 +1583,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1603,7 +1603,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has([''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has([''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1623,7 +1623,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1643,7 +1643,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com', 'null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com', 'null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1663,7 +1663,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1683,7 +1683,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com', ''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com', ''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1703,7 +1703,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', '')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', '')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1723,7 +1723,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com', 'other_value'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com', 'other_value'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1743,7 +1743,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1763,7 +1763,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1783,7 +1783,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1803,7 +1803,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1823,7 +1823,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1843,7 +1843,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['null', 'NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['null', 'NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1863,7 +1863,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('null', 'NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('null', 'NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1883,7 +1883,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['hello@posthog.com'], events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), has(['hello@posthog.com'], events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1903,7 +1903,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(events.mat_test_prop, tuple('hello@posthog.com')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), notIn(events.mat_test_prop, tuple('hello@posthog.com')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1923,7 +1923,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1943,7 +1943,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1963,7 +1963,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -1983,7 +1983,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2003,7 +2003,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2023,7 +2023,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2043,7 +2043,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['hello@posthog.com', 'other_value'], events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), has(['hello@posthog.com', 'other_value'], events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2063,7 +2063,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2083,7 +2083,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2103,7 +2103,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2123,7 +2123,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['NULL'], events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), has(['NULL'], events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2143,7 +2143,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(events.mat_test_prop, tuple('NULL')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), notIn(events.mat_test_prop, tuple('NULL')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2163,7 +2163,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2183,7 +2183,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2203,7 +2203,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2223,7 +2223,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2243,7 +2243,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has([''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has([''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2263,7 +2263,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2283,7 +2283,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com', 'null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com', 'null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2303,7 +2303,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2323,7 +2323,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com', ''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com', ''], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2343,7 +2343,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', '')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', '')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2363,7 +2363,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['hello@posthog.com', 'other_value'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['hello@posthog.com', 'other_value'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2383,7 +2383,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2403,7 +2403,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['null'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2423,7 +2423,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2443,7 +2443,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2463,7 +2463,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2483,7 +2483,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(has(['null', 'NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), and(has(['null', 'NULL'], events.mat_test_prop), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2503,7 +2503,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(events.mat_test_prop, tuple('null', 'NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(events.mat_test_prop, tuple('null', 'NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2523,7 +2523,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['hello@posthog.com'], events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), has(['hello@posthog.com'], events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2543,7 +2543,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(events.mat_test_prop, tuple('hello@posthog.com')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), notIn(events.mat_test_prop, tuple('hello@posthog.com')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2563,7 +2563,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2583,7 +2583,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2603,7 +2603,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2623,7 +2623,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', 'null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2643,7 +2643,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2663,7 +2663,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('hello@posthog.com', '')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2683,7 +2683,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['hello@posthog.com', 'other_value'], events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), has(['hello@posthog.com', 'other_value'], events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2703,7 +2703,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), notIn(events.mat_test_prop, tuple('hello@posthog.com', 'other_value')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2723,7 +2723,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2743,7 +2743,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2763,7 +2763,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['NULL'], events.mat_test_prop))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), has(['NULL'], events.mat_test_prop))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2783,7 +2783,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(events.mat_test_prop, tuple('NULL')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), notIn(events.mat_test_prop, tuple('NULL')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2803,7 +2803,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), in(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2823,7 +2823,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_in_test'), ifNull(notIn(nullIf(nullIf(events.mat_test_prop, ''), 'null'), tuple('null', 'NULL')), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2843,7 +2843,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['hello@posthog.com'], lower(coalesce(events.mat_test_prop, ''))))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_lower_in_test'), has(['hello@posthog.com'], lower(coalesce(events.mat_test_prop, ''))))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2863,7 +2863,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(lower(coalesce(events.mat_test_prop, '')), tuple('hello@posthog.com')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_lower_in_test'), notIn(lower(coalesce(events.mat_test_prop, '')), tuple('hello@posthog.com')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2883,7 +2883,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['hello@posthog.com'], lower(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_lower_in_test'), has(['hello@posthog.com'], lower(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2903,7 +2903,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notIn(lower(events.mat_test_prop), tuple('hello@posthog.com')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_lower_in_test'), notIn(lower(events.mat_test_prop), tuple('hello@posthog.com')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -2954,7 +2954,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['foo@example.com', 'bar@example.com'], lower(coalesce(events.mat_email, ''))))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_lower_bloom_events_test'), has(['foo@example.com', 'bar@example.com'], lower(coalesce(events.mat_email, ''))))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2973,7 +2973,7 @@
   '''
   SELECT count() AS `count()`
   FROM events
-  WHERE and(equals(events.team_id, 99999), has(['foo@example.com', 'bar@example.com'], lower(coalesce(events.mat_email, ''))))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_lower_ngram_events_test'), has(['foo@example.com', 'bar@example.com'], lower(coalesce(events.mat_email, ''))))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2992,7 +2992,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(equals(events.mat_test_prop, 'target_value'), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_eq_test'), and(equals(events.mat_test_prop, 'target_value'), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -3012,7 +3012,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), ifNull(notEquals(events.mat_test_prop, 'target_value'), 1))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_eq_test'), ifNull(notEquals(events.mat_test_prop, 'target_value'), 1))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -3032,7 +3032,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), equals(events.mat_test_prop, 'target_value'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_eq_test'), equals(events.mat_test_prop, 'target_value'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -3052,7 +3052,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), notEquals(events.mat_test_prop, 'target_value'))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_eq_test'), notEquals(events.mat_test_prop, 'target_value'))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -3072,7 +3072,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(less(events.mat_test_prop, 'mango'), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_range_test'), and(less(events.mat_test_prop, 'mango'), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -3092,7 +3092,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.mat_test_prop, 'mango'), isNotNull(events.mat_test_prop)))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_range_test'), and(greaterOrEquals(events.mat_test_prop, 'mango'), isNotNull(events.mat_test_prop)))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -3112,7 +3112,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(less(events.mat_test_prop, 'mango'), notEquals(events.mat_test_prop, ''), notEquals(events.mat_test_prop, 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_range_test'), and(less(events.mat_test_prop, 'mango'), notEquals(events.mat_test_prop, ''), notEquals(events.mat_test_prop, 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
@@ -3132,7 +3132,7 @@
   '''
   SELECT events.distinct_id AS distinct_id
   FROM events
-  WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.mat_test_prop, 'mango'), notEquals(events.mat_test_prop, ''), notEquals(events.mat_test_prop, 'null')))
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'mat_col_opt_range_test'), and(greaterOrEquals(events.mat_test_prop, 'mango'), notEquals(events.mat_test_prop, ''), notEquals(events.mat_test_prop, 'null')))
   ORDER BY events.distinct_id ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4784,22 +4784,24 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
         expected_gte_mango: list[tuple[str]],
     ) -> None:
         # End-to-end: rewrite preserves the printer's prior semantics for both nullability flavors AND ClickHouse picks up the minmax index. Companion to ``test_materialized_column_optimization_returns_correct_results`` below.
+        # Unique event name so the queries below see only this test's events. Postgres teams roll back
+        # between tests but ClickHouse events don't, so a reused team_id can carry foreign events from
+        # another test class into an un-scoped `FROM events` query.
+        event_name = "mat_col_opt_range_test"
         with materialized("events", "test_prop", create_minmax_index=True, is_nullable=is_nullable) as mat_col:
-            _create_event(team=self.team, distinct_id="d_low", event="test_event", properties={"test_prop": "apple"})
-            _create_event(team=self.team, distinct_id="d_mid", event="test_event", properties={"test_prop": "mango"})
-            _create_event(team=self.team, distinct_id="d_high", event="test_event", properties={"test_prop": "zebra"})
-            _create_event(team=self.team, distinct_id="d_empty", event="test_event", properties={"test_prop": ""})
-            _create_event(
-                team=self.team, distinct_id="d_null_str", event="test_event", properties={"test_prop": "null"}
-            )
-            _create_event(team=self.team, distinct_id="d_missing", event="test_event", properties={})
-            _create_event(team=self.team, distinct_id="d_null", event="test_event", properties={"test_prop": None})
+            _create_event(team=self.team, distinct_id="d_low", event=event_name, properties={"test_prop": "apple"})
+            _create_event(team=self.team, distinct_id="d_mid", event=event_name, properties={"test_prop": "mango"})
+            _create_event(team=self.team, distinct_id="d_high", event=event_name, properties={"test_prop": "zebra"})
+            _create_event(team=self.team, distinct_id="d_empty", event=event_name, properties={"test_prop": ""})
+            _create_event(team=self.team, distinct_id="d_null_str", event=event_name, properties={"test_prop": "null"})
+            _create_event(team=self.team, distinct_id="d_missing", event=event_name, properties={})
+            _create_event(team=self.team, distinct_id="d_null", event=event_name, properties={"test_prop": None})
 
             index_name = get_minmax_index_name(mat_col.name)
 
             lt_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE properties.test_prop < 'mango' ORDER BY distinct_id",
+                query=f"SELECT distinct_id FROM events WHERE event = '{event_name}' AND properties.test_prop < 'mango' ORDER BY distinct_id",
             )
             self.assertEqual(lt_result.results, expected_lt_mango)
             assert lt_result.clickhouse is not None
@@ -4809,7 +4811,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
 
             gte_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE properties.test_prop >= 'mango' ORDER BY distinct_id",
+                query=f"SELECT distinct_id FROM events WHERE event = '{event_name}' AND properties.test_prop >= 'mango' ORDER BY distinct_id",
             )
             self.assertEqual(gte_result.results, expected_gte_mango)
             assert gte_result.clickhouse is not None
@@ -4824,47 +4826,48 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
         ]
     )
     def test_materialized_column_optimization_returns_correct_results(self, _, is_nullable) -> None:
+        event_name = "mat_col_opt_eq_test"
         with materialized("events", "test_prop", create_minmax_index=True, is_nullable=is_nullable) as mat_col:
             _create_event(
                 team=self.team,
                 distinct_id="d1",
-                event="test_event",
+                event=event_name,
                 properties={"test_prop": "target_value"},
             )
             _create_event(
                 team=self.team,
                 distinct_id="d2",
-                event="test_event",
+                event=event_name,
                 properties={"test_prop": "other_value"},
             )
             _create_event(
                 team=self.team,
                 distinct_id="d3",
-                event="test_event",
+                event=event_name,
                 properties={"test_prop": ""},
             )
             _create_event(
                 team=self.team,
                 distinct_id="d4",
-                event="test_event",
+                event=event_name,
                 properties={"test_prop": "null"},
             )
             _create_event(
                 team=self.team,
                 distinct_id="d5",
-                event="test_event",
+                event=event_name,
                 properties={},
             )
             _create_event(
                 team=self.team,
                 distinct_id="d6",
-                event="test_event",
+                event=event_name,
                 properties={"test_prop": None},
             )
 
             eq_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE properties.test_prop = 'target_value' ORDER BY distinct_id",
+                query=f"SELECT distinct_id FROM events WHERE event = '{event_name}' AND properties.test_prop = 'target_value' ORDER BY distinct_id",
             )
             self.assertEqual(eq_result.results, [("d1",)])
             assert eq_result.clickhouse is not None
@@ -4875,7 +4878,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
 
             neq_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE properties.test_prop != 'target_value' ORDER BY distinct_id",
+                query=f"SELECT distinct_id FROM events WHERE event = '{event_name}' AND properties.test_prop != 'target_value' ORDER BY distinct_id",
             )
             self.assertEqual(neq_result.results, [("d2",), ("d3",), ("d4",), ("d5",), ("d6",)])
 
@@ -5266,13 +5269,14 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
             assert "has(" not in self._expr("lower(properties.test_prop) in ('', 'value2')")
 
     def test_force_data_skipping_indices_works_with_simple_equality(self) -> None:
+        event_name = "mat_col_opt_force_index_test"
         with materialized("events", "test_prop", is_nullable=False, create_bloom_filter_index=True) as mat_col:
-            _create_event(team=self.team, distinct_id="test", event="test", properties={"test_prop": "foo"})
+            _create_event(team=self.team, distinct_id="test", event=event_name, properties={"test_prop": "foo"})
 
             index_name = get_bloom_filter_index_name(mat_col.name)
             result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE properties.test_prop = 'foo'",
+                query=f"SELECT distinct_id FROM events WHERE event = '{event_name}' AND properties.test_prop = 'foo'",
                 modifiers=HogQLQueryModifiers(
                     materializationMode=MaterializationMode.AUTO,
                     forceClickhouseDataSkippingIndexes=[index_name],
@@ -5334,13 +5338,17 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
 
     def test_lower_in_uses_bloom_filter_lower_index_on_events(self) -> None:
         # Events are a single direct scan, so EXPLAIN of the executed query exposes the skip index directly
+        event_name = "mat_col_lower_bloom_events_test"
         with materialized("events", "email", is_nullable=True, create_bloom_filter_lower_index=True) as mat_col:
-            _create_event(team=self.team, distinct_id="u1", event="e", properties={"email": "Foo@Example.com"})
+            _create_event(team=self.team, distinct_id="u1", event=event_name, properties={"email": "Foo@Example.com"})
 
             result = execute_hogql_query(
                 team=self.team,
-                query="SELECT count() FROM events WHERE lower(properties.email) IN {emails}",
-                placeholders={"emails": ast.Constant(value=["foo@example.com", "bar@example.com"])},
+                query="SELECT count() FROM events WHERE event = {event} AND lower(properties.email) IN {emails}",
+                placeholders={
+                    "event": ast.Constant(value=event_name),
+                    "emails": ast.Constant(value=["foo@example.com", "bar@example.com"]),
+                },
                 modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.AUTO),
             )
             assert result.results == [(1,)]
@@ -5354,13 +5362,17 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
 
     def test_lower_in_uses_ngram_lower_index_on_events(self) -> None:
         # The rewrite must also let an ngram_lower index serve the IN lookup end to end.
+        event_name = "mat_col_lower_ngram_events_test"
         with materialized("events", "email", is_nullable=True, create_ngram_lower_index=True) as mat_col:
-            _create_event(team=self.team, distinct_id="u1", event="e", properties={"email": "Foo@Example.com"})
+            _create_event(team=self.team, distinct_id="u1", event=event_name, properties={"email": "Foo@Example.com"})
 
             result = execute_hogql_query(
                 team=self.team,
-                query="SELECT count() FROM events WHERE lower(properties.email) IN {emails}",
-                placeholders={"emails": ast.Constant(value=["foo@example.com", "bar@example.com"])},
+                query="SELECT count() FROM events WHERE event = {event} AND lower(properties.email) IN {emails}",
+                placeholders={
+                    "event": ast.Constant(value=event_name),
+                    "emails": ast.Constant(value=["foo@example.com", "bar@example.com"]),
+                },
                 modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.AUTO),
             )
             assert result.results == [(1,)]
@@ -5384,6 +5396,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
     def test_ilike_and_not_ilike_optimization_gives_correct_results(
         self, _, is_nullable, create_ngram_lower_index
     ) -> None:
+        event_name = "mat_col_opt_ilike_test"
         if is_nullable is not None:
             mat_col = materialize(
                 "events", "test_prop", is_nullable=is_nullable, create_ngram_lower_index=create_ngram_lower_index
@@ -5447,7 +5460,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
             _create_event(
                 team=self.team,
                 distinct_id=case,
-                event="test_event",
+                event=event_name,
                 properties={"test_prop": case if case != "None" else None},
             )
         flush_persons_and_events()
@@ -5458,8 +5471,8 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
             pattern_expr = ast.Constant(value=pattern if pattern != "None" else None)
             ilike_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE ilike(properties.test_prop, {pattern}) ORDER BY distinct_id",
-                placeholders={"pattern": pattern_expr},
+                query="SELECT distinct_id FROM events WHERE event = {event} AND ilike(properties.test_prop, {pattern}) ORDER BY distinct_id",
+                placeholders={"pattern": pattern_expr, "event": ast.Constant(value=event_name)},
             )
             ilike_matches = {d for (d,) in ilike_result.results}
             assert ilike_matches == ilike_expected, "ilike " + str(pattern)
@@ -5480,8 +5493,8 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
             not_ilike_expected = cases.difference(ilike_expected)
             not_ilike_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE notILike(properties.test_prop, {pattern}) ORDER BY distinct_id",
-                placeholders={"pattern": pattern_expr},
+                query="SELECT distinct_id FROM events WHERE event = {event} AND notILike(properties.test_prop, {pattern}) ORDER BY distinct_id",
+                placeholders={"pattern": pattern_expr, "event": ast.Constant(value=event_name)},
             )
             not_ilike_matches = {d for (d,) in not_ilike_result.results}
             assert not_ilike_matches == not_ilike_expected, "not_ilike " + str(pattern)
@@ -5496,6 +5509,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
         ]
     )
     def test_in_and_not_in_optimization_gives_correct_results(self, _, is_nullable, create_bloom_filter_index) -> None:
+        event_name = "mat_col_opt_in_test"
         if is_nullable is not None:
             mat_col = materialize(
                 "events", "test_prop", is_nullable=is_nullable, create_bloom_filter_index=create_bloom_filter_index
@@ -5534,7 +5548,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
             _create_event(
                 team=self.team,
                 distinct_id=case,
-                event="test_event",
+                event=event_name,
                 properties={"test_prop": case if case != "None" else None},
             )
 
@@ -5547,8 +5561,8 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
 
             in_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE properties.test_prop IN {in_values} ORDER BY distinct_id",
-                placeholders={"in_values": in_tuple},
+                query="SELECT distinct_id FROM events WHERE event = {event} AND properties.test_prop IN {in_values} ORDER BY distinct_id",
+                placeholders={"in_values": in_tuple, "event": ast.Constant(value=event_name)},
             )
             in_matches = {d for (d,) in in_result.results}
             assert in_matches == in_expected, f"IN {in_values}"
@@ -5566,8 +5580,8 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
             not_in_expected = cases.difference(in_expected)
             not_in_result = execute_hogql_query(
                 team=self.team,
-                query="SELECT distinct_id FROM events WHERE properties.test_prop NOT IN {in_values} ORDER BY distinct_id",
-                placeholders={"in_values": in_tuple},
+                query="SELECT distinct_id FROM events WHERE event = {event} AND properties.test_prop NOT IN {in_values} ORDER BY distinct_id",
+                placeholders={"in_values": in_tuple, "event": ast.Constant(value=event_name)},
             )
             not_in_matches = {d for (d,) in not_in_result.results}
             assert not_in_matches == not_in_expected, f"NOT IN {in_values}"
@@ -5575,6 +5589,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
     @parameterized.expand([("nullable", True), ("non_nullable", False)])
     def test_lower_in_optimization_handles_null_and_sentinel_rows(self, _, is_nullable) -> None:
         # The rewrite must stay correct for NULL/missing, empty-string, and literal-"null" property rows
+        event_name = "mat_col_opt_lower_in_test"
         with materialized("events", "test_prop", is_nullable=is_nullable, create_bloom_filter_lower_index=True):
             events: list[tuple[str, dict]] = [
                 ("mixed_case", {"test_prop": "Hello@PostHog.com"}),
@@ -5586,7 +5601,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
                 ("json_null", {"test_prop": None}),
             ]
             for distinct_id, properties in events:
-                _create_event(team=self.team, distinct_id=distinct_id, event="e", properties=properties)
+                _create_event(team=self.team, distinct_id=distinct_id, event=event_name, properties=properties)
             all_ids = {distinct_id for distinct_id, _ in events}
 
             def run(op: str) -> tuple[set[str], str]:
@@ -5594,7 +5609,7 @@ class TestMaterializedColumnOptimization(ClickhouseTestMixin, APIBaseTest):
                     team=self.team,
                     query=(
                         f"SELECT distinct_id FROM events "
-                        f"WHERE lower(properties.test_prop) {op} ('hello@posthog.com') ORDER BY distinct_id"
+                        f"WHERE event = '{event_name}' AND lower(properties.test_prop) {op} ('hello@posthog.com') ORDER BY distinct_id"
                     ),
                     modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.AUTO),
                 )


### PR DESCRIPTION
## Problem

`posthog/hogql/printer/test/test_printer.py::TestMaterializedColumnOptimization` redded master three consecutive times today on shard 6/18 (runs 29198300893/29199249292/29200181975, ~15:30-16:30 UTC), then healed with no relevant commit landing. The failure mode was extra/duplicate rows in result sets, which points at cross-test ClickHouse pollution rather than a real regression.

ClickHouse events created by a test persist for the life of the pytest process, but Postgres team ids get reused across test classes. Several tests in this class run queries like `SELECT distinct_id FROM events WHERE properties.test_prop = 'x'` with no `event =` predicate, and use generic distinct_ids (`d1`, `d2`, `test`, `u1`, ...). When a later test reuses a team_id that an earlier test class also used, its leftover events (and colliding distinct_ids) leak into the unscoped query and inflate the result set.

This is the same mechanism already diagnosed and fixed for the sibling `TestPrinter` class in 68fa5cbb7c0 (`test_event_property_groups_optimized_in_query_results`).

## Changes

Applied the same fix pattern used in 68fa5cbb7c0: give each test a unique event name and add an `event = '<name>'` predicate to every query it runs against `events`, so each test only ever sees its own rows.

Fixed the four methods most directly implicated in today's reds:
- `test_materialized_column_optimization_returns_correct_results`
- `test_ilike_and_not_ilike_optimization_gives_correct_results`
- `test_in_and_not_in_optimization_gives_correct_results`
- `test_lower_in_optimization_handles_null_and_sentinel_rows`

While auditing the rest of the class for the same unscoped-query shape, I found and fixed four more with an identical pattern (unscoped `FROM events` query on property values, generic distinct_ids):
- `test_materialized_column_range_optimization_returns_correct_results`
- `test_force_data_skipping_indices_works_with_simple_equality`
- `test_lower_in_uses_bloom_filter_lower_index_on_events`
- `test_lower_in_uses_ngram_lower_index_on_events`

Left `test_person_property_is_not_set_behavior` and the persons-table tests alone (already event-scoped, or not querying `events` directly). Also reviewed `test_force_data_skipping_indices_fails_when_index_cannot_be_used`, which only asserts an exception is raised regardless of row content, so pollution can't affect it; left unscoped.

No assertion semantics changed. The `equals(events.event, '<name>')` predicate is additive to each WHERE clause, so the printer's materialized-column / skip-index rewrite output is unchanged apart from that extra AND term. Updated `__snapshots__/test_printer.ambr` to match.

## How did you test this code?

Ran on the shared devbox worktree (`~/flake-hunt`, master-based checkout with ClickHouse containing real leftover events from many prior test runs, i.e. the authentic polluted condition):

- `pytest posthog/hogql/printer/test/test_printer.py::TestMaterializedColumnOptimization --reuse-db --snapshot-update -q` → 72 passed, snapshots updated
- Same command without `--snapshot-update`, run twice more for stability → 72 passed both times
- Full file: `pytest posthog/hogql/printer/test/test_printer.py --reuse-db -q` → 824 passed, 1 xfailed, no fallout in `TestPrinter` or `TestMaterializedColumnOptimization`

Diffed the regenerated snapshot file against the pre-fix version to confirm the only changes are the added `equals(events.event, '<name>')` terms, nothing else in the printed SQL moved.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) picked this up from a flaky-test backlog triage: the unquarantined members of `TestMaterializedColumnOptimization` redded master three times today on shard 6, and the diagnosis (reused team_id + persistent ClickHouse events + unscoped `FROM events` queries) had already been established and proven correct for the sibling `TestPrinter` class in 68fa5cbb7c0. I applied the identical fix pattern here rather than re-deriving the root cause, then audited the rest of the class for the same shape and fixed four additional methods that weren't in the original red set but shared the vulnerability. Validated end-to-end against a devbox ClickHouse instance carrying real accumulated pollution from prior runs, including three consecutive clean runs of the fixed class to rule out remaining flakiness.