### PR TITLE
fix(conversations): Enable flag events for Slack nudge

### DIFF
--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -815,7 +815,7 @@ def _is_nudge_classifier_flag_enabled(team: Team) -> bool:
                     "project": {"id": str(team.id), "uuid": str(team.uuid)},
                 },
                 only_evaluate_locally=False,
-                send_feature_flag_events=False,
+                send_feature_flag_events=True,
             )
         )
     except Exception as e:


### PR DESCRIPTION
## Problem

We want feature flag called events when evaluating the `product-support-nudge-llm-classifier` flag.

## Changes

Enable `send_feature_flag_events`.