### PR TITLE
feat(integrations): track integration usage explicitly and show counts

### DIFF
--- a/.github/scripts/check-idor-model-coverage.py
+++ b/.github/scripts/check-idor-model-coverage.py
@@ -321,6 +321,8 @@ def get_scoped_models() -> tuple[dict[str, set[str]], set[str], set[str], set[st
         "FeatureFlagEvaluationContext",  # via FeatureFlag
         "FeatureFlagRoleAccess",  # via FeatureFlag
         "HeatmapSnapshot",  # via SavedHeatmap
+        "HogFlowIntegration",  # via HogFlow
+        "HogFunctionIntegration",  # via HogFunction
         "LLMSkillFile",  # via LLMSkill
         "LogsAlertCheck",  # via LogsAlertConfiguration
         "LogsAlertEvent",  # via LogsAlertConfiguration

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -12,6 +12,7 @@ import { TeamMembershipLevel } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { GitHubRepoSummary } from 'lib/integrations/GitHubRepoSummary'
 import { IntegrationScopesWarning } from 'lib/integrations/IntegrationScopesWarning'
+import { pluralize } from 'lib/utils/strings'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -19,6 +20,22 @@ import { IntegrationType } from '~/types'
 
 import { integrationsLogic } from './integrationsLogic'
 import { getIntegrationNameFromKind } from './utils'
+
+function integrationUsageSummary(integration: IntegrationType): string | null {
+    if (!integration.usage) {
+        return null
+    }
+    const { destinations, workflows, sources } = integration.usage
+    const parts = [
+        destinations > 0 ? pluralize(destinations, 'destination') : null,
+        workflows > 0 ? pluralize(workflows, 'workflow') : null,
+        sources > 0 ? pluralize(sources, 'source') : null,
+    ].filter(Boolean)
+    if (parts.length === 0) {
+        return 'Not used by any destinations, workflows or sources'
+    }
+    return `Used by ${parts.join(', ')}`
+}
 
 export function IntegrationView({
     integration,
@@ -65,6 +82,7 @@ export function IntegrationView({
     )
 
     const integrationName = getIntegrationNameFromKind(integration.kind)
+    const usageSummary = integrationUsageSummary(integration)
 
     return (
         <div className="rounded border bg-surface-primary">
@@ -105,6 +123,7 @@ export function IntegrationView({
                                 />
                             </div>
                         ) : null}
+                        {usageSummary ? <div className="text-secondary text-xs">{usageSummary}</div> : null}
                         {isGitHub && (
                             <GitHubRepoSummary
                                 repoNames={repositories}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -80,6 +80,7 @@ import { QueryContext } from '~/queries/types'
 
 import { AlertType } from 'products/alerts/frontend/types'
 import type { ExperimentFeatureFlagInputApi } from 'products/experiments/frontend/generated/api.schemas'
+import type { IntegrationUsageApi } from 'products/integrations/frontend/generated/api.schemas'
 import type { AIPromptConfigApi } from 'products/subscriptions/frontend/generated/api.schemas'
 import { CyclotronInputType } from 'products/workflows/frontend/Workflows/hogflows/steps/types'
 import type { HogFlow } from 'products/workflows/frontend/Workflows/hogflows/types'
@@ -5478,6 +5479,8 @@ export interface IntegrationType {
     created_by?: UserBasicType | null
     created_at: string
     errors?: string
+    /** Usage counts, only present on list/retrieve responses */
+    usage?: IntegrationUsageApi | null
 }
 
 export interface EmailIntegrationDomainGroupedType {

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 
 import structlog
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema, extend_schema_serializer
+from drf_spectacular.utils import extend_schema, extend_schema_field, extend_schema_serializer
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
@@ -92,9 +92,19 @@ from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.tasks.email import send_integration_access_request
 from posthog.utils import is_relative_url
 
-from products.cdp.backend.services.integration_usage import get_enabled_hog_functions_using_integration
+from products.cdp.backend.services.integration_usage import (
+    count_hog_functions_using_integrations,
+    get_enabled_hog_functions_using_integration,
+)
 from products.tasks.backend.facade.api import count_in_progress_runs_for_github_integration
-from products.workflows.backend.services.integration_usage import get_active_hog_flows_using_integration
+from products.warehouse_sources.backend.facade.api import (
+    count_sources_using_integrations,
+    list_source_labels_using_integration,
+)
+from products.workflows.backend.services.integration_usage import (
+    count_hog_flows_using_integrations,
+    get_active_hog_flows_using_integration,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -372,16 +382,38 @@ class IntegrationAccessRequestResponseSerializer(serializers.Serializer):
     )
 
 
+@extend_schema_serializer(component_name="IntegrationUsage")
+class IntegrationUsageSerializer(serializers.Serializer):
+    """Counts of pipeline entities configured to use an integration."""
+
+    destinations = serializers.IntegerField(
+        help_text="Number of non-deleted pipeline functions (destinations, transformations, etc.) using this integration."
+    )
+    workflows = serializers.IntegerField(help_text="Number of non-archived workflows using this integration.")
+    sources = serializers.IntegerField(help_text="Number of non-deleted data warehouse sources using this integration.")
+
+
 @extend_schema_serializer(component_name="IntegrationConfig")
 class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
     """Standard Integration serializer."""
 
     created_by = UserBasicSerializer(read_only=True)
+    usage = serializers.SerializerMethodField(
+        help_text="Counts of destinations, workflows and data warehouse sources using this integration. "
+        "Only computed when listing or retrieving integrations; null otherwise."
+    )
 
     class Meta:
         model = Integration
-        fields = ["id", "kind", "config", "created_at", "created_by", "errors", "display_name"]
-        read_only_fields = ["id", "created_at", "created_by", "errors", "display_name"]
+        fields = ["id", "kind", "config", "created_at", "created_by", "errors", "display_name", "usage"]
+        read_only_fields = ["id", "created_at", "created_by", "errors", "display_name", "usage"]
+
+    @extend_schema_field(IntegrationUsageSerializer(allow_null=True))
+    def get_usage(self, integration: Integration) -> dict[str, int] | None:
+        usage_by_integration_id = self.context.get("integration_usage")
+        if usage_by_integration_id is None:
+            return None
+        return usage_by_integration_id.get(integration.id, {"destinations": 0, "workflows": 0, "sources": 0})
 
     def validate_kind(self, value: str) -> str:
         if value == Integration.IntegrationKind.SLACK_POSTHOG_CODE.value:
@@ -931,11 +963,35 @@ class IntegrationViewSet(
             return [GitHubRepositoryRefreshThrottle(), *super().get_throttles()]
         return super().get_throttles()
 
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        # Usage counts take three aggregate queries, so only pay for them where they're shown.
+        if getattr(self, "action", None) in ("list", "retrieve") and not getattr(self, "swagger_fake_view", False):
+            context["integration_usage"] = self._build_integration_usage_map()
+        return context
+
+    def _build_integration_usage_map(self) -> dict[int, dict[str, int]]:
+        integration_ids = list(Integration.objects.filter(team_id=self.team_id).values_list("id", flat=True))
+        destination_counts = count_hog_functions_using_integrations(self.team_id, integration_ids)
+        workflow_counts = count_hog_flows_using_integrations(self.team_id, integration_ids)
+        source_counts = count_sources_using_integrations(self.team_id, integration_ids)
+        return {
+            integration_id: {
+                "destinations": destination_counts.get(integration_id, 0),
+                "workflows": workflow_counts.get(integration_id, 0),
+                "sources": source_counts.get(integration_id, 0),
+            }
+            for integration_id in integration_ids
+        }
+
     def perform_destroy(self, instance) -> None:
         flows_using_integration = get_active_hog_flows_using_integration(
             team_id=instance.team_id, integration_id=instance.id
         )
         functions_using_integration = get_enabled_hog_functions_using_integration(
+            team_id=instance.team_id, integration_id=instance.id
+        )
+        source_labels_using_integration = list_source_labels_using_integration(
             team_id=instance.team_id, integration_id=instance.id
         )
         used_by = []
@@ -947,6 +1003,8 @@ class IntegrationViewSet(
                 sorted(function.name or str(function.id) for function in functions_using_integration)
             )
             used_by.append(f"enabled data pipelines: {function_names}")
+        if source_labels_using_integration:
+            used_by.append(f"data warehouse sources: {', '.join(source_labels_using_integration)}")
         if used_by:
             raise ValidationError(
                 f"This integration is used by {' and '.join(used_by)}. "

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1,6 +1,7 @@
 import hmac
 import json
 import time
+import uuid
 import hashlib
 from datetime import timedelta
 from urllib.parse import quote, urlencode
@@ -44,6 +45,7 @@ from posthog.rate_limit import GitHubRepositoryRefreshThrottle
 
 from products.cdp.backend.models import HogFunction
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.workflows.backend.models import HogFlow
 
 
@@ -4478,6 +4480,119 @@ class TestIntegrationDeletionHogFunctionGuard:
         assert "Slack flow" in content
         assert "Slack notifier" in content
         assert Integration.objects.filter(id=self.integration.id).exists()
+
+
+class TestIntegrationDeletionExternalDataSourceGuard:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="salesforce",
+            integration_id="sf-123",
+            config={"instance_url": "https://example.my.salesforce.com"},
+            created_by=self.user,
+        )
+
+    def _create_source(self, *, deleted: bool = False, prefix: str | None = None) -> ExternalDataSource:
+        return ExternalDataSource.objects.create(
+            team=self.team,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Salesforce",
+            prefix=prefix,
+            deleted=deleted,
+            job_inputs={"salesforce_integration_id": self.integration.id},
+        )
+
+    def _delete(self, client: HttpClient):
+        client.force_login(self.user)
+        return client.delete(f"/api/environments/{self.team.pk}/integrations/{self.integration.id}/")
+
+    def test_destroy_blocked_when_source_references_integration(self, client: HttpClient):
+        self._create_source(prefix="sf_")
+
+        response = self._delete(client)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Salesforce (sf_)" in response.content.decode()
+        assert Integration.objects.filter(id=self.integration.id).exists()
+
+    def test_destroy_allowed_when_source_deleted(self, client: HttpClient):
+        self._create_source(deleted=True)
+
+        response = self._delete(client)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not Integration.objects.filter(id=self.integration.id).exists()
+
+
+class TestIntegrationUsageCounts:
+    @pytest.fixture(autouse=True)
+    def setup_integrations(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            config={"team": {"id": "T123", "name": "Test workspace"}},
+            created_by=self.user,
+        )
+        self.unused_integration = Integration.objects.create(
+            team=self.team,
+            kind="hubspot",
+            integration_id="hs-1",
+            config={},
+            created_by=self.user,
+        )
+
+    def test_list_includes_usage_counts(self, client: HttpClient):
+        HogFunction.objects.create(
+            team=self.team,
+            name="Slack notifier",
+            type="destination",
+            hog="return event",
+            enabled=True,
+            inputs_schema=[{"key": "slack_workspace", "type": "integration"}],
+            inputs={"slack_workspace": {"value": self.integration.id}},
+        )
+        HogFlow.objects.create(
+            team=self.team,
+            name="Slack flow",
+            status="draft",
+            actions=[
+                {
+                    "id": "action_function_1",
+                    "type": "function",
+                    "config": {"inputs": {"slack_workspace": {"value": {"integrationId": self.integration.id}}}},
+                }
+            ],
+            edges=[],
+        )
+        ExternalDataSource.objects.create(
+            team=self.team,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Slack",
+            job_inputs={"slack_integration_id": self.integration.id},
+        )
+
+        client.force_login(self.user)
+        response = client.get(f"/api/environments/{self.team.pk}/integrations/")
+
+        assert response.status_code == status.HTTP_200_OK
+        usage_by_id = {row["id"]: row["usage"] for row in response.json()["results"]}
+        assert usage_by_id[self.integration.id] == {"destinations": 1, "workflows": 1, "sources": 1}
+        assert usage_by_id[self.unused_integration.id] == {"destinations": 0, "workflows": 0, "sources": 0}
 
 
 class TestIntegrationRequestAccessAPI(APIBaseTest):

--- a/products/cdp/backend/migrations/0003_hogfunctionintegration.py
+++ b/products/cdp/backend/migrations/0003_hogfunctionintegration.py
@@ -1,0 +1,40 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cdp", "0002_alter_hogfunction_batch_export"),
+        ("posthog", "1251_alter_integration_kind"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="HogFunctionIntegration",
+            fields=[
+                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                (
+                    "hog_function",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="integration_links",
+                        to="cdp.hogfunction",
+                    ),
+                ),
+                (
+                    "integration",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="hog_function_links",
+                        to="posthog.integration",
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="hogfunctionintegration",
+            constraint=models.UniqueConstraint(
+                fields=("hog_function", "integration"), name="unique_hog_function_integration"
+            ),
+        ),
+    ]

--- a/products/cdp/backend/migrations/0003_hogfunctionintegration.py
+++ b/products/cdp/backend/migrations/0003_hogfunctionintegration.py
@@ -1,6 +1,8 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
+import posthog.models.utils
+
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -12,7 +14,12 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="HogFunctionIntegration",
             fields=[
-                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
                 (
                     "hog_function",
                     models.ForeignKey(

--- a/products/cdp/backend/migrations/0004_backfill_hogfunctionintegration.py
+++ b/products/cdp/backend/migrations/0004_backfill_hogfunctionintegration.py
@@ -1,0 +1,76 @@
+from django.db import migrations
+
+BATCH_SIZE = 1000
+
+
+def _extract_integration_ids(inputs, inputs_schema):
+    # Snapshot of products/cdp/backend/services/integration_usage.py extract_integration_ids —
+    # migrations must stay self-contained as live code evolves.
+    ids = set()
+    inputs = inputs if isinstance(inputs, dict) else {}
+    for schema in inputs_schema or []:
+        if not isinstance(schema, dict) or schema.get("type") != "integration":
+            continue
+        entry = inputs.get(schema.get("key"))
+        if not isinstance(entry, dict):
+            continue
+        value = entry.get("value")
+        if isinstance(value, dict):
+            value = value.get("integrationId")
+        try:
+            ids.add(int(str(value)))
+        except (TypeError, ValueError):
+            continue
+    return ids
+
+
+def backfill(apps, schema_editor):
+    HogFunction = apps.get_model("cdp", "HogFunction")
+    HogFunctionIntegration = apps.get_model("cdp", "HogFunctionIntegration")
+    Integration = apps.get_model("posthog", "Integration")
+
+    # (function_id, team_id) -> referenced integration ids; only functions with
+    # integration-typed inputs are scanned, which keeps the pass small.
+    pending: list[tuple] = []
+
+    def flush():
+        if not pending:
+            return
+        referenced_ids = {integration_id for _, _, ids in pending for integration_id in ids}
+        # Only link integrations that exist in the function's team — job JSON is user-controlled.
+        team_by_integration = dict(Integration.objects.filter(id__in=referenced_ids).values_list("id", "team_id"))
+        rows = [
+            HogFunctionIntegration(hog_function_id=function_id, integration_id=integration_id)
+            for function_id, team_id, ids in pending
+            for integration_id in ids
+            if team_by_integration.get(integration_id) == team_id
+        ]
+        HogFunctionIntegration.objects.bulk_create(rows, batch_size=BATCH_SIZE, ignore_conflicts=True)
+        pending.clear()
+
+    functions = (
+        HogFunction.objects.filter(deleted=False, inputs_schema__contains=[{"type": "integration"}])
+        .values_list("id", "team_id", "inputs", "inputs_schema")
+        .iterator(chunk_size=BATCH_SIZE)
+    )
+    for function_id, team_id, inputs, inputs_schema in functions:
+        ids = _extract_integration_ids(inputs, inputs_schema)
+        if ids:
+            pending.append((function_id, team_id, ids))
+        if len(pending) >= BATCH_SIZE:
+            flush()
+    flush()
+
+
+def reverse(apps, schema_editor):
+    apps.get_model("cdp", "HogFunctionIntegration").objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cdp", "0003_hogfunctionintegration"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill, reverse),
+    ]

--- a/products/cdp/backend/migrations/max_migration.txt
+++ b/products/cdp/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0002_alter_hogfunction_batch_export
+0004_backfill_hogfunctionintegration

--- a/products/cdp/backend/models/__init__.py
+++ b/products/cdp/backend/models/__init__.py
@@ -1,6 +1,6 @@
 from .hog_function_template import HogFunctionTemplate
 from .hog_functions import HogFunction
-from .hog_functions.hog_function import HogFunctionState
+from .hog_functions.hog_function import HogFunctionIntegration, HogFunctionState
 from .hook import Hook
 from .plugin import (
     Plugin,
@@ -15,6 +15,7 @@ from .plugin import (
 
 __all__ = [
     "HogFunction",
+    "HogFunctionIntegration",
     "HogFunctionState",
     "HogFunctionTemplate",
     "Hook",

--- a/products/cdp/backend/models/hog_functions/hog_function.py
+++ b/products/cdp/backend/models/hog_functions/hog_function.py
@@ -252,10 +252,39 @@ class HogFunction(FileSystemSyncMixin, UUIDTModel):
         return f"HogFunction {self.id}: {self.name}"
 
 
+class HogFunctionIntegration(models.Model):
+    """Join row recording that a hog function's inputs reference an integration.
+
+    Derived from the function's JSON inputs (which stay the runtime source of truth) and kept
+    in sync on save — see products/cdp/backend/services/integration_usage.py. Exists so
+    reverse lookups ("what uses this integration?") don't need to scan JSON blobs.
+    """
+
+    id = models.BigAutoField(primary_key=True)
+    hog_function = models.ForeignKey("cdp.HogFunction", on_delete=models.CASCADE, related_name="integration_links")
+    integration = models.ForeignKey("posthog.Integration", on_delete=models.CASCADE, related_name="hog_function_links")
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["hog_function", "integration"], name="unique_hog_function_integration"),
+        ]
+
+    def __str__(self):
+        return f"HogFunctionIntegration {self.hog_function_id} -> {self.integration_id}"
+
+
 @receiver(post_save, sender=HogFunction)
 def hog_function_saved(sender, instance: HogFunction, created, **kwargs):
     if instance.type is None or instance.type in TYPES_THAT_RELOAD_PLUGIN_SERVER:
         reload_hog_functions_on_workers(team_id=instance.team_id, hog_function_ids=[str(instance.id)])
+
+
+@receiver(post_save, sender=HogFunction)
+def hog_function_integration_links_synced(sender, instance: HogFunction, created, **kwargs):
+    # The service imports this module's models — import at call time to break the cycle.
+    from products.cdp.backend.services.integration_usage import sync_hog_function_integrations  # noqa: PLC0415
+
+    sync_hog_function_integrations(instance)
 
 
 @receiver(post_save, sender=Action)

--- a/products/cdp/backend/models/hog_functions/hog_function.py
+++ b/products/cdp/backend/models/hog_functions/hog_function.py
@@ -17,7 +17,7 @@ from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.signals import mutable_receiver
 from posthog.models.team.team import Team
-from posthog.models.utils import UUIDTModel
+from posthog.models.utils import UUIDModel, UUIDTModel
 from posthog.plugins.plugin_server_api import (
     get_hog_function_status,
     patch_hog_function_status,
@@ -252,7 +252,7 @@ class HogFunction(FileSystemSyncMixin, UUIDTModel):
         return f"HogFunction {self.id}: {self.name}"
 
 
-class HogFunctionIntegration(models.Model):
+class HogFunctionIntegration(UUIDModel):
     """Join row recording that a hog function's inputs reference an integration.
 
     Derived from the function's JSON inputs (which stay the runtime source of truth) and kept
@@ -260,7 +260,6 @@ class HogFunctionIntegration(models.Model):
     reverse lookups ("what uses this integration?") don't need to scan JSON blobs.
     """
 
-    id = models.BigAutoField(primary_key=True)
     hog_function = models.ForeignKey("cdp.HogFunction", on_delete=models.CASCADE, related_name="integration_links")
     integration = models.ForeignKey("posthog.Integration", on_delete=models.CASCADE, related_name="hog_function_links")
 

--- a/products/cdp/backend/services/integration_usage.py
+++ b/products/cdp/backend/services/integration_usage.py
@@ -1,36 +1,51 @@
 from typing import Any
 
+from django.db.models import Count
+
+from posthog.models.integration import Integration
+
 from products.cdp.backend.models import HogFunction
+from products.cdp.backend.models.hog_functions.hog_function import HogFunctionIntegration
 
 
-def _input_references_integration(input_entry: Any, integration_id: int) -> bool:
+def _integration_id_from_input(input_entry: Any) -> int | None:
     if not isinstance(input_entry, dict):
-        return False
+        return None
     # Mirrors the runtime's resolution: input?.value?.integrationId ?? input?.value
     # (see nodejs/src/cdp/services/hog-inputs.service.ts loadIntegrationInputs)
     value = input_entry.get("value")
     if isinstance(value, dict):
         value = value.get("integrationId")
-    return value is not None and str(value) == str(integration_id)
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_integration_ids(inputs: Any, inputs_schema: Any) -> set[int]:
+    """Integration IDs referenced by a hog function's integration-typed inputs.
+
+    Only inputs declared as type "integration" in the inputs_schema are considered —
+    that is the only surface the runtime resolves integrations from, so a matching ID
+    planted anywhere else is not a reference.
+    """
+    ids: set[int] = set()
+    inputs = inputs if isinstance(inputs, dict) else {}
+    for schema in inputs_schema or []:
+        if not isinstance(schema, dict) or schema.get("type") != "integration":
+            continue
+        integration_id = _integration_id_from_input(inputs.get(schema.get("key")))
+        if integration_id is not None:
+            ids.add(integration_id)
+    return ids
 
 
 def _function_references_integration(function: HogFunction, integration_id: int) -> bool:
-    inputs = function.inputs if isinstance(function.inputs, dict) else {}
-    for schema in function.inputs_schema or []:
-        if not isinstance(schema, dict) or schema.get("type") != "integration":
-            continue
-        if _input_references_integration(inputs.get(schema.get("key")), integration_id):
-            return True
-    return False
+    return integration_id in extract_integration_ids(function.inputs, function.inputs_schema)
 
 
 def get_enabled_hog_functions_using_integration(team_id: int, integration_id: int) -> list[HogFunction]:
-    """Enabled, non-deleted hog functions whose integration-typed inputs reference the integration.
-
-    Only inputs declared as type "integration" in the function's inputs_schema are considered —
-    that is the only surface the runtime resolves integrations from, so a matching ID planted
-    anywhere else cannot block deletion.
-    """
+    """Enabled, non-deleted hog functions whose integration-typed inputs reference the integration."""
     functions = HogFunction.objects.filter(
         team_id=team_id,
         enabled=True,
@@ -38,3 +53,49 @@ def get_enabled_hog_functions_using_integration(team_id: int, integration_id: in
         inputs_schema__contains=[{"type": "integration"}],
     ).only("id", "name", "inputs", "inputs_schema")
     return [function for function in functions if _function_references_integration(function, integration_id)]
+
+
+def sync_hog_function_integrations(function: HogFunction) -> None:
+    """Mirror the function's JSON integration references into HogFunctionIntegration rows.
+
+    The JSON inputs stay the runtime source of truth; the join rows exist for cheap reverse
+    lookups (usage counts, deletion guards). Only integrations that exist in the function's
+    team are linked, so dangling or cross-team IDs in user-controlled JSON never create rows.
+    Note: bulk_create/bulk_update writes bypass post_save and therefore this sync — rows
+    catch up on the next regular save.
+    """
+    referenced_ids = extract_integration_ids(function.inputs, function.inputs_schema)
+    desired_ids: set[int] = set()
+    if referenced_ids:
+        desired_ids = set(
+            Integration.objects.filter(team_id=function.team_id, id__in=referenced_ids).values_list("id", flat=True)
+        )
+    existing_ids = set(
+        HogFunctionIntegration.objects.filter(hog_function=function).values_list("integration_id", flat=True)
+    )
+    if removed_ids := existing_ids - desired_ids:
+        HogFunctionIntegration.objects.filter(hog_function=function, integration_id__in=removed_ids).delete()
+    if added_ids := desired_ids - existing_ids:
+        HogFunctionIntegration.objects.bulk_create(
+            [
+                HogFunctionIntegration(hog_function=function, integration_id=integration_id)
+                for integration_id in added_ids
+            ],
+            ignore_conflicts=True,
+        )
+
+
+def count_hog_functions_using_integrations(team_id: int, integration_ids: list[int]) -> dict[int, int]:
+    """Number of non-deleted hog functions referencing each integration, keyed by integration ID."""
+    if not integration_ids:
+        return {}
+    rows = (
+        HogFunctionIntegration.objects.filter(
+            integration_id__in=integration_ids,
+            hog_function__team_id=team_id,
+            hog_function__deleted=False,
+        )
+        .values("integration_id")
+        .annotate(count=Count("id"))
+    )
+    return {row["integration_id"]: row["count"] for row in rows}

--- a/products/cdp/backend/test/test_integration_usage.py
+++ b/products/cdp/backend/test/test_integration_usage.py
@@ -1,0 +1,75 @@
+from posthog.test.base import BaseTest
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.models import Team
+from posthog.models.integration import Integration
+
+from products.cdp.backend.models import HogFunction
+from products.cdp.backend.services.integration_usage import (
+    count_hog_functions_using_integrations,
+    extract_integration_ids,
+)
+
+INTEGRATION_SCHEMA = [{"key": "slack", "type": "integration"}]
+
+
+class TestExtractIntegrationIds(SimpleTestCase):
+    # The runtime resolves input.value.integrationId ?? input.value — both the deletion guard
+    # and the usage sync depend on this extraction handling every stored shape.
+    @parameterized.expand(
+        [
+            ("dict_value", {"slack": {"value": {"integrationId": 7}}}, INTEGRATION_SCHEMA, {7}),
+            ("bare_value", {"slack": {"value": 7}}, INTEGRATION_SCHEMA, {7}),
+            ("numeric_string_value", {"slack": {"value": "7"}}, INTEGRATION_SCHEMA, {7}),
+            ("non_integration_input_ignored", {"slack": {"value": 7}}, [{"key": "slack", "type": "string"}], set()),
+            ("non_numeric_value_ignored", {"slack": {"value": "not-an-id"}}, INTEGRATION_SCHEMA, set()),
+        ]
+    )
+    def test_extract_integration_ids(self, _name, inputs, inputs_schema, expected):
+        assert extract_integration_ids(inputs, inputs_schema) == expected
+
+
+class TestHogFunctionIntegrationUsage(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.integration = Integration.objects.create(team=self.team, kind="slack", config={"team": {"id": "T123"}})
+
+    def _create_function(self, integration_value: object, **kwargs) -> HogFunction:
+        return HogFunction.objects.create(
+            team=self.team,
+            name="Slack notifier",
+            type="destination",
+            hog="return event",
+            enabled=True,
+            inputs_schema=INTEGRATION_SCHEMA,
+            inputs={"slack": {"value": integration_value}},
+            **kwargs,
+        )
+
+    def test_save_links_and_unlinks_integrations(self):
+        function = self._create_function(self.integration.id)
+        assert count_hog_functions_using_integrations(self.team.id, [self.integration.id]) == {self.integration.id: 1}
+
+        function.inputs = {"slack": {"value": None}}
+        function.save()
+        assert count_hog_functions_using_integrations(self.team.id, [self.integration.id]) == {}
+
+    def test_deleted_functions_are_not_counted(self):
+        function = self._create_function(self.integration.id)
+        function.deleted = True
+        function.save()
+
+        assert count_hog_functions_using_integrations(self.team.id, [self.integration.id]) == {}
+
+    def test_dangling_and_cross_team_references_are_not_linked(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        other_team_integration = Integration.objects.create(team=other_team, kind="slack", config={})
+        self._create_function(other_team_integration.id)
+        self._create_function(self.integration.id + other_team_integration.id)  # no such integration
+
+        assert (
+            count_hog_functions_using_integrations(self.team.id, [self.integration.id, other_team_integration.id]) == {}
+        )

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -236,6 +236,18 @@ export const IntegrationKindEnumApi = {
 } as const
 
 /**
+ * Counts of pipeline entities configured to use an integration.
+ */
+export interface IntegrationUsageApi {
+    /** Number of non-deleted pipeline functions (destinations, transformations, etc.) using this integration. */
+    destinations: number
+    /** Number of non-archived workflows using this integration. */
+    workflows: number
+    /** Number of non-deleted data warehouse sources using this integration. */
+    sources: number
+}
+
+/**
  * Standard Integration serializer.
  */
 export interface IntegrationConfigApi {
@@ -246,6 +258,8 @@ export interface IntegrationConfigApi {
     readonly created_by: UserBasicApi
     readonly errors: string
     readonly display_name: string
+    /** Counts of destinations, workflows and data warehouse sources using this integration. Only computed when listing or retrieving integrations; null otherwise. */
+    readonly usage: IntegrationUsageApi | null
 }
 
 export interface PaginatedIntegrationConfigListApi {
@@ -295,6 +309,8 @@ export interface PatchedIntegrationConfigApi {
     readonly created_by?: UserBasicApi
     readonly errors?: string
     readonly display_name?: string
+    /** Counts of destinations, workflows and data warehouse sources using this integration. Only computed when listing or retrieving integrations; null otherwise. */
+    readonly usage?: IntegrationUsageApi | null
 }
 
 export interface GitHubBranchesResponseApi {

--- a/products/warehouse_sources/backend/facade/api.py
+++ b/products/warehouse_sources/backend/facade/api.py
@@ -18,6 +18,8 @@ first facade serves the read consumers and the framework-free helpers.
 
 from uuid import UUID
 
+from django.db.models import Count
+
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob as _ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema as _ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource as _ExternalDataSource
@@ -45,6 +47,8 @@ __all__ = [
     "get_table",
     "list_tables_for_source",
     "list_jobs_for_source",
+    "count_sources_using_integrations",
+    "list_source_labels_using_integration",
     # framework-free helper transforms
     "mysql_column_to_dwh_column",
     "mysql_columns_to_dwh_columns",
@@ -179,3 +183,24 @@ def list_jobs_for_source(source_id: UUID, team_id: int) -> list[contracts.Extern
         .order_by("-created_at")
     )
     return [_to_job(j) for j in qs]
+
+
+def count_sources_using_integrations(team_id: int, integration_ids: list[int]) -> dict[int, int]:
+    """Number of non-deleted sources whose credentials come from each integration, keyed by integration ID."""
+    if not integration_ids:
+        return {}
+    rows = (
+        _ExternalDataSource.objects.filter(team_id=team_id, integration_id__in=integration_ids)
+        .exclude(deleted=True)
+        .values("integration_id")
+        .annotate(count=Count("id"))
+    )
+    return {row["integration_id"]: row["count"] for row in rows}
+
+
+def list_source_labels_using_integration(team_id: int, integration_id: int) -> list[str]:
+    """Human-readable labels of non-deleted sources whose credentials come from the integration."""
+    sources = _ExternalDataSource.objects.filter(team_id=team_id, integration_id=integration_id).exclude(deleted=True)
+    return sorted(
+        f"{source.source_type} ({source.prefix})" if source.prefix else source.source_type for source in sources
+    )

--- a/products/warehouse_sources/backend/migrations/0063_externaldatasource_integration.py
+++ b/products/warehouse_sources/backend/migrations/0063_externaldatasource_integration.py
@@ -1,0 +1,23 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources", "0062_alter_externaldatasource_source_type_and_more"),
+        ("posthog", "1251_alter_integration_kind"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="externaldatasource",
+            name="integration",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="external_data_sources",
+                to="posthog.integration",
+            ),
+        ),
+    ]

--- a/products/warehouse_sources/backend/migrations/0064_backfill_externaldatasource_integration.py
+++ b/products/warehouse_sources/backend/migrations/0064_backfill_externaldatasource_integration.py
@@ -1,0 +1,70 @@
+from django.db import migrations
+
+BATCH_SIZE = 500
+
+# Snapshot of integration_id_from_job_inputs from models/external_data_source.py —
+# migrations must stay self-contained as live code evolves.
+_NON_POSTHOG_INTEGRATION_JOB_INPUT_KEYS = frozenset({"auth_oauth2_integration_id"})
+
+
+def _integration_id_from_job_inputs(job_inputs):
+    if not isinstance(job_inputs, dict):
+        return None
+    for key in sorted(job_inputs):
+        if not key.endswith("_integration_id") or key in _NON_POSTHOG_INTEGRATION_JOB_INPUT_KEYS:
+            continue
+        try:
+            return int(str(job_inputs[key]))
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def backfill(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+    Integration = apps.get_model("posthog", "Integration")
+
+    pending = []
+
+    def flush():
+        if not pending:
+            return
+        referenced_ids = {integration_id for _, _, integration_id in pending}
+        # Only link integrations that exist in the source's team — job_inputs is user-controlled.
+        team_by_integration = dict(Integration.objects.filter(id__in=referenced_ids).values_list("id", "team_id"))
+        updates = [
+            ExternalDataSource(id=source_id, integration_id=integration_id)
+            for source_id, team_id, integration_id in pending
+            if team_by_integration.get(integration_id) == team_id
+        ]
+        ExternalDataSource.objects.bulk_update(updates, ["integration"], batch_size=BATCH_SIZE)
+        pending.clear()
+
+    # job_inputs is encrypted, so the reference can't be filtered in SQL — decrypt and scan in Python.
+    sources = (
+        ExternalDataSource.objects.exclude(deleted=True)
+        .values_list("id", "team_id", "job_inputs")
+        .iterator(chunk_size=BATCH_SIZE)
+    )
+    for source_id, team_id, job_inputs in sources:
+        integration_id = _integration_id_from_job_inputs(job_inputs)
+        if integration_id is not None:
+            pending.append((source_id, team_id, integration_id))
+        if len(pending) >= BATCH_SIZE:
+            flush()
+    flush()
+
+
+def reverse(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+    ExternalDataSource.objects.exclude(integration_id=None).update(integration_id=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources", "0063_externaldatasource_integration"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill, reverse),
+    ]

--- a/products/warehouse_sources/backend/migrations/0064_backfill_externaldatasource_integration.py
+++ b/products/warehouse_sources/backend/migrations/0064_backfill_externaldatasource_integration.py
@@ -24,7 +24,7 @@ def backfill(apps, schema_editor):
     ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
     Integration = apps.get_model("posthog", "Integration")
 
-    pending = []
+    pending: list[tuple] = []
 
     def flush():
         if not pending:

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0062_alter_externaldatasource_source_type_and_more
+0064_backfill_externaldatasource_integration

--- a/products/warehouse_sources/backend/models/external_data_source.py
+++ b/products/warehouse_sources/backend/models/external_data_source.py
@@ -7,12 +7,34 @@ import structlog
 
 from posthog.helpers.encrypted_fields import EncryptedJSONField
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
+from posthog.models.integration import Integration
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 from posthog.sync import database_sync_to_async
 
 from products.warehouse_sources.backend.types import DIRECT_ENGINE_BY_SOURCE_TYPE, ExternalDataSourceType
 
 logger = structlog.get_logger(__name__)
+
+# References CustomOAuth2Integration, a different model from posthog.Integration.
+_NON_POSTHOG_INTEGRATION_JOB_INPUT_KEYS = frozenset({"auth_oauth2_integration_id"})
+
+
+def integration_id_from_job_inputs(job_inputs: object) -> int | None:
+    """The posthog.Integration ID a source's job_inputs reference, if any.
+
+    OAuth-backed source configs store their credentials reference as a single
+    `<source>_integration_id` key in job_inputs.
+    """
+    if not isinstance(job_inputs, dict):
+        return None
+    for key in sorted(job_inputs):
+        if not key.endswith("_integration_id") or key in _NON_POSTHOG_INTEGRATION_JOB_INPUT_KEYS:
+            continue
+        try:
+            return int(str(job_inputs[key]))
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 class ExternalDataSourceManager(models.Manager):
@@ -56,6 +78,15 @@ class ExternalDataSource(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
     status = models.CharField(max_length=400)
     source_type = models.CharField(max_length=128, choices=ExternalDataSourceType)
     job_inputs = EncryptedJSONField(null=True, blank=True)
+    # Derived from job_inputs on save — job_inputs stays the runtime source of truth. Exists so
+    # reverse lookups ("what uses this integration?") don't need to decrypt and scan job_inputs.
+    integration = models.ForeignKey(
+        "posthog.Integration",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="external_data_sources",
+    )
     connection_metadata = models.JSONField(default=dict, blank=True, null=True)
     are_tables_created = models.BooleanField(default=False)
     prefix = models.CharField(max_length=100, null=True, blank=True)
@@ -76,6 +107,24 @@ class ExternalDataSource(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
 
     class Meta:
         db_table = "posthog_externaldatasource"
+
+    def save(self, *args, **kwargs):
+        if "job_inputs" not in self.get_deferred_fields():
+            self._derive_integration_link(kwargs)
+        super().save(*args, **kwargs)
+
+    def _derive_integration_link(self, save_kwargs: dict) -> None:
+        derived_id = integration_id_from_job_inputs(self.job_inputs)
+        if derived_id is not None and derived_id != self.integration_id:
+            # job_inputs is user-controlled — never link a dangling or cross-team integration ID.
+            if not Integration.objects.filter(id=derived_id, team_id=self.team_id).exists():
+                derived_id = None
+        if derived_id == self.integration_id:
+            return
+        self.integration_id = derived_id
+        update_fields = save_kwargs.get("update_fields")
+        if update_fields is not None:
+            save_kwargs["update_fields"] = [*update_fields, "integration"]
 
     @property
     def is_direct_query(self) -> bool:

--- a/products/warehouse_sources/backend/tests/test_integration_link.py
+++ b/products/warehouse_sources/backend/tests/test_integration_link.py
@@ -1,0 +1,87 @@
+import uuid
+
+from posthog.test.base import BaseTest
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.models import Team
+from posthog.models.integration import Integration
+
+from products.warehouse_sources.backend.facade import api as facade_api
+from products.warehouse_sources.backend.models.external_data_source import (
+    ExternalDataSource,
+    integration_id_from_job_inputs,
+)
+
+
+class TestIntegrationIdFromJobInputs(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("int_value", {"salesforce_integration_id": 3}, 3),
+            ("string_value", {"google_ads_integration_id": "3"}, 3),
+            ("custom_oauth2_excluded", {"auth_oauth2_integration_id": str(uuid.uuid4())}, None),
+            ("non_numeric_ignored", {"hubspot_integration_id": "garbage"}, None),
+            ("no_integration_key", {"api_key": "secret"}, None),
+        ]
+    )
+    def test_integration_id_from_job_inputs(self, _name, job_inputs, expected):
+        assert integration_id_from_job_inputs(job_inputs) == expected
+
+
+class TestExternalDataSourceIntegrationLink(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.integration = Integration.objects.create(
+            team=self.team, kind="salesforce", integration_id="sf-1", config={}
+        )
+
+    def _create_source(self, job_inputs: dict | None, **kwargs) -> ExternalDataSource:
+        return ExternalDataSource.objects.create(
+            team=self.team,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            status="Completed",
+            source_type="Salesforce",
+            job_inputs=job_inputs,
+            **kwargs,
+        )
+
+    def test_save_derives_and_clears_integration_link(self):
+        source = self._create_source({"salesforce_integration_id": self.integration.id})
+        assert source.integration_id == self.integration.id
+
+        source.job_inputs = {"salesforce_api_key": "secret"}
+        source.save()
+        source.refresh_from_db()
+        assert source.integration_id is None
+
+    def test_save_with_update_fields_persists_derived_link(self):
+        # Temporal token-refresh paths save with update_fields=["job_inputs"] — the derived
+        # link must be added to update_fields or it would silently never persist there.
+        source = self._create_source(None)
+        source.job_inputs = {"salesforce_integration_id": self.integration.id}
+        source.save(update_fields=["job_inputs"])
+
+        source.refresh_from_db()
+        assert source.integration_id == self.integration.id
+
+    def test_dangling_and_cross_team_references_are_not_linked(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        other_team_integration = Integration.objects.create(team=other_team, kind="salesforce", config={})
+
+        dangling = self._create_source({"salesforce_integration_id": self.integration.id + 1000})
+        cross_team = self._create_source({"salesforce_integration_id": other_team_integration.id})
+
+        assert dangling.integration_id is None
+        assert cross_team.integration_id is None
+
+    def test_counts_exclude_deleted_sources(self):
+        self._create_source({"salesforce_integration_id": self.integration.id})
+        self._create_source({"salesforce_integration_id": self.integration.id}, deleted=True)
+
+        assert facade_api.count_sources_using_integrations(self.team.pk, [self.integration.id]) == {
+            self.integration.id: 1
+        }
+        assert facade_api.list_source_labels_using_integration(self.team.pk, self.integration.id) == ["Salesforce"]

--- a/products/workflows/backend/migrations/0009_hogflowintegration.py
+++ b/products/workflows/backend/migrations/0009_hogflowintegration.py
@@ -1,0 +1,38 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflows", "0008_teamworkflowsconfig"),
+        ("posthog", "1251_alter_integration_kind"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="HogFlowIntegration",
+            fields=[
+                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                (
+                    "hog_flow",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="integration_links",
+                        to="workflows.hogflow",
+                    ),
+                ),
+                (
+                    "integration",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="hog_flow_links",
+                        to="posthog.integration",
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="hogflowintegration",
+            constraint=models.UniqueConstraint(fields=("hog_flow", "integration"), name="unique_hog_flow_integration"),
+        ),
+    ]

--- a/products/workflows/backend/migrations/0009_hogflowintegration.py
+++ b/products/workflows/backend/migrations/0009_hogflowintegration.py
@@ -1,6 +1,8 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
+import posthog.models.utils
+
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -12,7 +14,12 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name="HogFlowIntegration",
             fields=[
-                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
                 (
                     "hog_flow",
                     models.ForeignKey(

--- a/products/workflows/backend/migrations/0010_backfill_hogflowintegration.py
+++ b/products/workflows/backend/migrations/0010_backfill_hogflowintegration.py
@@ -29,7 +29,7 @@ def _collect_integration_ids(node, ids, depth=0):
 
 
 def _extract_integration_ids(actions, get_template_inputs_schema):
-    ids = set()
+    ids: set[int] = set()
     for action in actions or []:
         if not isinstance(action, dict) or "function" not in (action.get("type") or ""):
             continue
@@ -68,7 +68,7 @@ def backfill(apps, schema_editor):
             template_schema_cache[template_id] = template.inputs_schema if template else None
         return template_schema_cache[template_id]
 
-    pending = []
+    pending: list[tuple] = []
 
     def flush():
         if not pending:

--- a/products/workflows/backend/migrations/0010_backfill_hogflowintegration.py
+++ b/products/workflows/backend/migrations/0010_backfill_hogflowintegration.py
@@ -1,0 +1,114 @@
+from django.db import migrations
+
+BATCH_SIZE = 1000
+
+# Snapshot of products/workflows/backend/services/integration_usage.py extraction logic —
+# migrations must stay self-contained as live code evolves.
+_MAX_CONFIG_DEPTH = 20
+
+
+def _coerce_integration_id(value):
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _collect_integration_ids(node, ids, depth=0):
+    if depth > _MAX_CONFIG_DEPTH:
+        return
+    if isinstance(node, dict):
+        integration_id = _coerce_integration_id(node.get("integrationId"))
+        if integration_id is not None:
+            ids.add(integration_id)
+        for child in node.values():
+            _collect_integration_ids(child, ids, depth + 1)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_integration_ids(item, ids, depth + 1)
+
+
+def _extract_integration_ids(actions, get_template_inputs_schema):
+    ids = set()
+    for action in actions or []:
+        if not isinstance(action, dict) or "function" not in (action.get("type") or ""):
+            continue
+        config = action.get("config") or {}
+        _collect_integration_ids(config.get("inputs"), ids)
+        # Function actions store integration inputs as bare IDs; only the template's
+        # inputs_schema knows which inputs are integration-typed.
+        template_id = config.get("template_id")
+        if not template_id:
+            continue
+        inputs = config.get("inputs") or {}
+        for schema_item in get_template_inputs_schema(template_id) or []:
+            if not isinstance(schema_item, dict) or schema_item.get("type") != "integration":
+                continue
+            value = (inputs.get(schema_item.get("key")) or {}).get("value")
+            if isinstance(value, dict):
+                value = value.get("integrationId")
+            integration_id = _coerce_integration_id(value)
+            if integration_id is not None:
+                ids.add(integration_id)
+    return ids
+
+
+def backfill(apps, schema_editor):
+    HogFlow = apps.get_model("workflows", "HogFlow")
+    HogFlowIntegration = apps.get_model("workflows", "HogFlowIntegration")
+    HogFunctionTemplate = apps.get_model("cdp", "HogFunctionTemplate")
+    Integration = apps.get_model("posthog", "Integration")
+
+    template_schema_cache = {}
+
+    def get_template_inputs_schema(template_id):
+        # Latest sha by created_at, mirroring HogFunctionTemplate.get_template.
+        if template_id not in template_schema_cache:
+            template = HogFunctionTemplate.objects.filter(template_id=template_id).order_by("-created_at").first()
+            template_schema_cache[template_id] = template.inputs_schema if template else None
+        return template_schema_cache[template_id]
+
+    pending = []
+
+    def flush():
+        if not pending:
+            return
+        referenced_ids = {integration_id for _, _, ids in pending for integration_id in ids}
+        # Only link integrations that exist in the flow's team — action JSON is user-controlled.
+        team_by_integration = dict(Integration.objects.filter(id__in=referenced_ids).values_list("id", "team_id"))
+        rows = [
+            HogFlowIntegration(hog_flow_id=flow_id, integration_id=integration_id)
+            for flow_id, team_id, ids in pending
+            for integration_id in ids
+            if team_by_integration.get(integration_id) == team_id
+        ]
+        HogFlowIntegration.objects.bulk_create(rows, batch_size=BATCH_SIZE, ignore_conflicts=True)
+        pending.clear()
+
+    flows = (
+        HogFlow.objects.exclude(status="archived")
+        .values_list("id", "team_id", "actions")
+        .iterator(chunk_size=BATCH_SIZE)
+    )
+    for flow_id, team_id, actions in flows:
+        ids = _extract_integration_ids(actions, get_template_inputs_schema)
+        if ids:
+            pending.append((flow_id, team_id, ids))
+        if len(pending) >= BATCH_SIZE:
+            flush()
+    flush()
+
+
+def reverse(apps, schema_editor):
+    apps.get_model("workflows", "HogFlowIntegration").objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflows", "0009_hogflowintegration"),
+        ("cdp", "0001_migrate_cdp_models"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill, reverse),
+    ]

--- a/products/workflows/backend/migrations/max_migration.txt
+++ b/products/workflows/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0008_teamworkflowsconfig
+0010_backfill_hogflowintegration

--- a/products/workflows/backend/models/__init__.py
+++ b/products/workflows/backend/models/__init__.py
@@ -1,7 +1,14 @@
-from .hog_flow.hog_flow import HogFlow
+from .hog_flow.hog_flow import HogFlow, HogFlowIntegration
 from .hog_flow.hog_flow_template import HogFlowTemplate
 from .hog_flow_batch_job import HogFlowBatchJob
 from .hog_flow_schedule.hog_flow_schedule import HogFlowSchedule
 from .team_workflows_config import TeamWorkflowsConfig
 
-__all__ = ["HogFlow", "HogFlowBatchJob", "HogFlowSchedule", "HogFlowTemplate", "TeamWorkflowsConfig"]
+__all__ = [
+    "HogFlow",
+    "HogFlowBatchJob",
+    "HogFlowIntegration",
+    "HogFlowSchedule",
+    "HogFlowTemplate",
+    "TeamWorkflowsConfig",
+]

--- a/products/workflows/backend/models/hog_flow/hog_flow.py
+++ b/products/workflows/backend/models/hog_flow/hog_flow.py
@@ -7,7 +7,7 @@ from django.dispatch.dispatcher import receiver
 import structlog
 
 from posthog.models.team.team import Team
-from posthog.models.utils import UUIDTModel
+from posthog.models.utils import UUIDModel, UUIDTModel
 from posthog.plugins.plugin_server_api import reload_hog_flows_on_workers
 
 from products.actions.backend.models.action import Action
@@ -94,7 +94,7 @@ class HogFlow(UUIDTModel):
         return f"HogFlow {self.id}/{self.version}: {self.name}"
 
 
-class HogFlowIntegration(models.Model):
+class HogFlowIntegration(UUIDModel):
     """Join row recording that a hog flow's live action config references an integration.
 
     Derived from the flow's JSON actions (which stay the runtime source of truth) and kept
@@ -102,7 +102,6 @@ class HogFlowIntegration(models.Model):
     reverse lookups ("what uses this integration?") don't need to scan JSON blobs.
     """
 
-    id = models.BigAutoField(primary_key=True)
     hog_flow = models.ForeignKey("workflows.HogFlow", on_delete=models.CASCADE, related_name="integration_links")
     integration = models.ForeignKey("posthog.Integration", on_delete=models.CASCADE, related_name="hog_flow_links")
 

--- a/products/workflows/backend/models/hog_flow/hog_flow.py
+++ b/products/workflows/backend/models/hog_flow/hog_flow.py
@@ -94,9 +94,38 @@ class HogFlow(UUIDTModel):
         return f"HogFlow {self.id}/{self.version}: {self.name}"
 
 
+class HogFlowIntegration(models.Model):
+    """Join row recording that a hog flow's live action config references an integration.
+
+    Derived from the flow's JSON actions (which stay the runtime source of truth) and kept
+    in sync on save — see products/workflows/backend/services/integration_usage.py. Exists so
+    reverse lookups ("what uses this integration?") don't need to scan JSON blobs.
+    """
+
+    id = models.BigAutoField(primary_key=True)
+    hog_flow = models.ForeignKey("workflows.HogFlow", on_delete=models.CASCADE, related_name="integration_links")
+    integration = models.ForeignKey("posthog.Integration", on_delete=models.CASCADE, related_name="hog_flow_links")
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["hog_flow", "integration"], name="unique_hog_flow_integration"),
+        ]
+
+    def __str__(self):
+        return f"HogFlowIntegration {self.hog_flow_id} -> {self.integration_id}"
+
+
 @receiver(post_save, sender=HogFlow)
 def hog_flow_saved(sender, instance: HogFlow, created, **kwargs):
     reload_hog_flows_on_workers(team_id=instance.team_id, hog_flow_ids=[str(instance.id)])
+
+
+@receiver(post_save, sender=HogFlow)
+def hog_flow_integration_links_synced(sender, instance: HogFlow, created, **kwargs):
+    # The service imports this module's models — import at call time to break the cycle.
+    from products.workflows.backend.services.integration_usage import sync_hog_flow_integrations  # noqa: PLC0415
+
+    sync_hog_flow_integrations(instance)
 
 
 @receiver(post_delete, sender=HogFlow)

--- a/products/workflows/backend/services/integration_usage.py
+++ b/products/workflows/backend/services/integration_usage.py
@@ -1,7 +1,12 @@
 from typing import Any
 
+from django.db.models import Count
+
+from posthog.models.integration import Integration
+
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.workflows.backend.models import HogFlow
+from products.workflows.backend.models.hog_flow.hog_flow import HogFlowIntegration
 
 # Action configs are user-controlled JSON; cap traversal depth so a crafted deeply-nested
 # config can't RecursionError the deletion guard (legitimate configs nest ~5 levels).
@@ -10,31 +15,40 @@ _MAX_CONFIG_DEPTH = 20
 _TemplateCache = dict[str, HogFunctionTemplate | None]
 
 
-def _node_references_integration(node: Any, integration_id: int, depth: int = 0) -> bool:
+def _coerce_integration_id(value: Any) -> int | None:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _collect_integration_ids(node: Any, ids: set[int], depth: int = 0) -> None:
     if depth > _MAX_CONFIG_DEPTH:
-        return False
+        return
     if isinstance(node, dict):
-        value = node.get("integrationId")
-        if value is not None and str(value) == str(integration_id):
-            return True
-        return any(_node_references_integration(child, integration_id, depth + 1) for child in node.values())
-    if isinstance(node, list):
-        return any(_node_references_integration(item, integration_id, depth + 1) for item in node)
-    return False
+        integration_id = _coerce_integration_id(node.get("integrationId"))
+        if integration_id is not None:
+            ids.add(integration_id)
+        for child in node.values():
+            _collect_integration_ids(child, ids, depth + 1)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_integration_ids(item, ids, depth + 1)
 
 
-def _function_action_references_integration(action: dict, integration_id: int, template_cache: _TemplateCache) -> bool:
+def _function_action_integration_ids(action: dict, template_cache: _TemplateCache) -> set[int]:
     # Function actions store integration inputs as bare IDs; only the template's
     # inputs_schema knows which inputs are integration-typed.
     config = action.get("config") or {}
     template_id = config.get("template_id")
     if not template_id:
-        return False
+        return set()
     if template_id not in template_cache:
         template_cache[template_id] = HogFunctionTemplate.get_template(template_id)
     template = template_cache[template_id]
     if not template:
-        return False
+        return set()
+    ids: set[int] = set()
     inputs = config.get("inputs") or {}
     for schema_item in template.inputs_schema or []:
         if schema_item.get("type") != "integration":
@@ -42,19 +56,26 @@ def _function_action_references_integration(action: dict, integration_id: int, t
         value = (inputs.get(schema_item.get("key")) or {}).get("value")
         if isinstance(value, dict):
             value = value.get("integrationId")
-        if value is not None and str(value) == str(integration_id):
-            return True
-    return False
+        integration_id = _coerce_integration_id(value)
+        if integration_id is not None:
+            ids.add(integration_id)
+    return ids
 
 
-def _action_references_integration(action: dict, integration_id: int, template_cache: _TemplateCache) -> bool:
-    # Integrations are only consumed by function-style actions, via config.inputs — scanning
-    # wider would let a planted integrationId in an unused field block deletion.
-    if "function" not in (action.get("type") or ""):
-        return False
-    if _node_references_integration((action.get("config") or {}).get("inputs"), integration_id):
-        return True
-    return _function_action_references_integration(action, integration_id, template_cache)
+def extract_integration_ids(actions: Any, template_cache: _TemplateCache | None = None) -> set[int]:
+    """Integration IDs referenced by a hog flow's live action configs.
+
+    Integrations are only consumed by function-style actions, via config.inputs — scanning
+    wider would let a planted integrationId in an unused field count as a reference.
+    """
+    template_cache = template_cache if template_cache is not None else {}
+    ids: set[int] = set()
+    for action in actions or []:
+        if not isinstance(action, dict) or "function" not in (action.get("type") or ""):
+            continue
+        _collect_integration_ids((action.get("config") or {}).get("inputs"), ids)
+        ids |= _function_action_integration_ids(action, template_cache)
+    return ids
 
 
 def get_active_hog_flows_using_integration(team_id: int, integration_id: int) -> list[HogFlow]:
@@ -63,7 +84,46 @@ def get_active_hog_flows_using_integration(team_id: int, integration_id: int) ->
     return [
         flow
         for flow in HogFlow.objects.filter(team_id=team_id, status=HogFlow.State.ACTIVE)
-        if any(
-            _action_references_integration(action, integration_id, template_cache) for action in (flow.actions or [])
-        )
+        if integration_id in extract_integration_ids(flow.actions, template_cache)
     ]
+
+
+def sync_hog_flow_integrations(flow: HogFlow) -> None:
+    """Mirror the flow's JSON integration references into HogFlowIntegration rows.
+
+    The JSON actions stay the runtime source of truth; the join rows exist for cheap reverse
+    lookups (usage counts, deletion guards). Only integrations that exist in the flow's team
+    are linked, so dangling or cross-team IDs in user-controlled JSON never create rows.
+    Note: bulk_create/bulk_update writes bypass post_save and therefore this sync — rows
+    catch up on the next regular save.
+    """
+    referenced_ids = extract_integration_ids(flow.actions)
+    desired_ids: set[int] = set()
+    if referenced_ids:
+        desired_ids = set(
+            Integration.objects.filter(team_id=flow.team_id, id__in=referenced_ids).values_list("id", flat=True)
+        )
+    existing_ids = set(HogFlowIntegration.objects.filter(hog_flow=flow).values_list("integration_id", flat=True))
+    if removed_ids := existing_ids - desired_ids:
+        HogFlowIntegration.objects.filter(hog_flow=flow, integration_id__in=removed_ids).delete()
+    if added_ids := desired_ids - existing_ids:
+        HogFlowIntegration.objects.bulk_create(
+            [HogFlowIntegration(hog_flow=flow, integration_id=integration_id) for integration_id in added_ids],
+            ignore_conflicts=True,
+        )
+
+
+def count_hog_flows_using_integrations(team_id: int, integration_ids: list[int]) -> dict[int, int]:
+    """Number of non-archived hog flows referencing each integration, keyed by integration ID."""
+    if not integration_ids:
+        return {}
+    rows = (
+        HogFlowIntegration.objects.filter(
+            integration_id__in=integration_ids,
+            hog_flow__team_id=team_id,
+        )
+        .exclude(hog_flow__status=HogFlow.State.ARCHIVED)
+        .values("integration_id")
+        .annotate(count=Count("id"))
+    )
+    return {row["integration_id"]: row["count"] for row in rows}

--- a/products/workflows/backend/test/test_integration_usage.py
+++ b/products/workflows/backend/test/test_integration_usage.py
@@ -1,0 +1,74 @@
+from posthog.test.base import BaseTest
+
+from posthog.models.integration import Integration
+
+from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
+from products.workflows.backend.models import HogFlow
+from products.workflows.backend.services.integration_usage import count_hog_flows_using_integrations
+
+
+class TestHogFlowIntegrationUsage(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.integration = Integration.objects.create(team=self.team, kind="slack", config={"team": {"id": "T123"}})
+
+    def _create_flow(self, actions: list[dict], status: str = "active") -> HogFlow:
+        return HogFlow.objects.create(team=self.team, name="Flow", status=status, actions=actions, edges=[])
+
+    def _inline_action(self, integration_id: int) -> dict:
+        return {
+            "id": "action_1",
+            "type": "function",
+            "config": {"inputs": {"slack_workspace": {"value": {"integrationId": integration_id}}}},
+        }
+
+    def test_save_links_and_unlinks_integrations(self):
+        flow = self._create_flow([self._inline_action(self.integration.id)])
+        assert count_hog_flows_using_integrations(self.team.id, [self.integration.id]) == {self.integration.id: 1}
+
+        flow.actions = [{"id": "action_1", "type": "delay", "config": {"duration": "5m"}}]
+        flow.save()
+        assert count_hog_flows_using_integrations(self.team.id, [self.integration.id]) == {}
+
+    def test_archived_flows_are_not_counted(self):
+        flow = self._create_flow([self._inline_action(self.integration.id)])
+        flow.status = HogFlow.State.ARCHIVED
+        flow.save()
+
+        assert count_hog_flows_using_integrations(self.team.id, [self.integration.id]) == {}
+
+    def test_template_typed_bare_id_inputs_are_linked(self):
+        # Function actions built from a template store integration inputs as bare IDs; only the
+        # template's inputs_schema marks them as integration-typed.
+        HogFunctionTemplate.objects.create(
+            template_id="template-slack-test",
+            sha="1.0.0",
+            name="Slack",
+            description="",
+            code="return event",
+            code_language="hog",
+            inputs_schema=[{"key": "slack_workspace", "type": "integration"}],
+            type="destination",
+            status="stable",
+            category=["Integrations"],
+            free=True,
+        )
+        self._create_flow(
+            [
+                {
+                    "id": "action_1",
+                    "type": "function",
+                    "config": {
+                        "template_id": "template-slack-test",
+                        "inputs": {"slack_workspace": {"value": self.integration.id}},
+                    },
+                }
+            ]
+        )
+
+        assert count_hog_flows_using_integrations(self.team.id, [self.integration.id]) == {self.integration.id: 1}
+
+    def test_dangling_references_are_not_linked(self):
+        self._create_flow([self._inline_action(self.integration.id + 1)])
+
+        assert count_hog_flows_using_integrations(self.team.id, [self.integration.id + 1]) == {}

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -29869,6 +29869,18 @@ export namespace Schemas {
     }
 
     /**
+     * Counts of pipeline entities configured to use an integration.
+     */
+    export interface IntegrationUsage {
+      /** Number of non-deleted pipeline functions (destinations, transformations, etc.) using this integration. */
+      destinations: number;
+      /** Number of non-archived workflows using this integration. */
+      workflows: number;
+      /** Number of non-deleted data warehouse sources using this integration. */
+      sources: number;
+    }
+
+    /**
      * Standard Integration serializer.
      */
     export interface IntegrationConfig {
@@ -29879,6 +29891,8 @@ export namespace Schemas {
       readonly created_by: UserBasic;
       readonly errors: string;
       readonly display_name: string;
+      /** Counts of destinations, workflows and data warehouse sources using this integration. Only computed when listing or retrieving integrations; null otherwise. */
+      readonly usage: IntegrationUsage | null;
     }
 
     export interface RecommendedAction {
@@ -41253,6 +41267,8 @@ export namespace Schemas {
       readonly created_by?: UserBasic;
       readonly errors?: string;
       readonly display_name?: string;
+      /** Counts of destinations, workflows and data warehouse sources using this integration. Only computed when listing or retrieving integrations; null otherwise. */
+      readonly usage?: IntegrationUsage | null;
     }
 
     export interface PatchedIntervieweeContext {


### PR DESCRIPTION
## Problem

The integrations settings page ("Other integrations") shows connected integrations with no signal of whether anything depends on them, so it's hard to tell which are safe to disconnect. Under the hood every consumer stores the integration ID inside a JSON blob (`HogFunction.inputs`, `HogFlow.actions`, `ExternalDataSource.job_inputs`), so answering "what uses this?" means decrypting and scanning JSON. Worse, nothing stopped deleting an integration a data warehouse source depends on, silently breaking its syncs.

## Changes

Reference resolution before and after:

```mermaid
flowchart LR
    HF[HogFunction.inputs JSON] -.scan.-> I[Integration]
    HFl[HogFlow.actions JSON] -.scan.-> I
    EDS[ExternalDataSource.job_inputs encrypted JSON] -.no link at all.-> I
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class HF,HFl,EDS phGray;
    class I phRed;
```

```mermaid
flowchart LR
    HF[HogFunction] --> J1[HogFunctionIntegration] --> I[Integration]
    HFl[HogFlow] --> J2[HogFlowIntegration] --> I
    EDS[ExternalDataSource] -->|integration FK, SET_NULL| I
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class HF,HFl,EDS phGray;
    class J1,J2 phBlue;
    class I phRed;
```

- New join tables `HogFunctionIntegration` (cdp) and `HogFlowIntegration` (workflows), plus a nullable `ExternalDataSource.integration` FK (warehouse_sources). The JSON config stays the runtime source of truth; the relations are derived on save (post_save sync for functions/flows, `save()` derivation for sources) and only link integrations that exist in the same team. Batched backfill migrations populate existing rows.
- The integrations API now returns a `usage` object (`destinations`, `workflows`, `sources`) per integration, computed with three grouped queries on list/retrieve, and the settings UI shows "Used by 2 destinations, 1 source" (or "Not used by any destinations, workflows or sources") on each integration card.
- The existing deletion guard gains a data warehouse source check, closing the gap where deleting an integration silently orphaned a source's credentials.

> [!NOTE]
> Deleting an integration referenced by a non-deleted warehouse source is now rejected with a 400 naming the sources, matching the existing behavior for enabled destinations and active workflows. Paused sources also block, since resuming them needs the credentials.

The extraction logic used by the existing deletion guards was refactored into shared `extract_integration_ids` helpers that both the guards and the new sync use, so the two can't drift.

No screenshots: this session had no runnable stack, so I couldn't capture the settings page. The UI change is one muted line per integration card in `IntegrationView`.

## How did you test this code?

Automated tests added (each catches a regression nothing covered before):

- `products/cdp/backend/test/test_integration_usage.py`: pure extraction matrix (dict-style vs bare vs string IDs, non-integration inputs ignored) now that guard and sync share it, plus sync lifecycle (link on save, unlink on update, deleted functions and dangling/cross-team IDs excluded from counts)
- `products/workflows/backend/test/test_integration_usage.py`: sync lifecycle, archived flows excluded, and the template-typed bare-ID path, which only resolves through the template's `inputs_schema` and would undercount silently if dropped
- `products/warehouse_sources/backend/tests/test_integration_link.py`: job_inputs derivation matrix (incl. `auth_oauth2_integration_id` exclusion, it references a different model), the `update_fields` save path Temporal uses (the derived FK must be appended or it never persists there), and deleted-source exclusion from facade counts
- `posthog/api/test/test_integration.py`: destroy blocked by a referencing source / allowed once deleted, and a list-endpoint wiring test asserting the `usage` payload for used and unused integrations

This environment has no Postgres server, so I could not execute the pytest suites locally; CI runs them. What I did run locally: `makemigrations --check --dry-run` (no drift against the hand-written migrations), the migration risk analyzer, the IDOR model coverage check, `manage.py spectacular` (schema builds, `IntegrationUsage` component correct), ruff, oxlint/oxfmt, tsgo (no new errors in touched files), and `hogli ci:preflight --fix` (0 failures; regenerated OpenAPI types are committed). Existing destroy-guard tests also exercise the new sync incidentally, including the deeply-nested-config depth cap.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No matching doc under `docs/` covers the integrations settings page or the integrations API, so none updated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) directed by Luke Belton, starting from "can settings show how many sources/destinations use an integration?" and the follow-up decision to model the relation explicitly rather than compute counts by scanning JSON on demand.

Skills invoked: `/django-migrations`, `/improving-drf-endpoints`, `/adopting-generated-api-types`, `/writing-tests`.

Decisions worth knowing at review time:

- Per-consumer relations (two join tables + one FK) over a single generic usage table: real FKs give automatic cleanup when consumers are deleted, and cardinality differs (sources reference at most one integration, functions/flows can reference several). `ExternalDataSource` gets a plain FK following the `github_sync_config` precedent.
- The join tables carry no `team` column, following the existing junction-table pattern (`DashboardTile`, `ExperimentToSavedMetric`); both are registered in the IDOR check's parent-scoped baseline. This also avoids a hot-table FK to `posthog_team` and canonical-team rewrite mismatches.
- JSON stays authoritative and the relations are derived, so a stale row can't break runtime resolution; sync validates team ownership so user-controlled JSON can't link cross-team or dangling IDs. Known gap: `bulk_create`/`bulk_update` writes bypass the sync (noted in docstrings); rows catch up on the next save, and the backfills cover existing data.
- The delete guard for functions/flows keeps the battle-tested JSON scan (now via the shared extractors); the sources guard and the counts use the new relations.
- Warehouse helpers are exposed through the product facade (`count_sources_using_integrations`, `list_source_labels_using_integration`) since `warehouse_sources` is an isolated product.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*