### PR TITLE
feat(workflows): search invocations by person email

### DIFF
--- a/frontend/src/scenes/hog-functions/invocations/HogInvocations.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/HogInvocations.tsx
@@ -476,7 +476,7 @@ export function HogInvocations({ id, functionKind, renderLogMessage }: HogInvoca
                     <LemonInput
                         type="search"
                         size="small"
-                        placeholder="Search by invocation, event, distinct, or person ID…"
+                        placeholder="Search by invocation, event, distinct ID, person ID, or email…"
                         fullWidth
                         value={filters.search ?? ''}
                         onChange={(value) => setFilters({ search: value || undefined })}

--- a/frontend/src/scenes/hog-functions/invocations/hogInvocationsLogic.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/hogInvocationsLogic.tsx
@@ -386,9 +386,11 @@ async function fetchSparkline(props: HogInvocationsLogicProps, filters: HogInvoc
         : hogql.raw('')
     const trimmedSearch = filters.search?.trim()
     // Email is stored on `persons.properties.email`, not on `hog_invocation_results` —
-    // resolve to person_ids via a subquery when the search string looks like an email.
-    const emailSearchClause = trimmedSearch?.includes('@')
-        ? `OR person_id IN (SELECT id FROM persons WHERE properties.email = ${escapeHogQLString(trimmedSearch)})`
+    // resolve to person_ids via an `ILIKE %value%` subquery on `persons`. Runs on every
+    // non-empty search so partial matches (`meikel`, `@company.com`) work without the user
+    // having to type a full email.
+    const emailSearchClause = trimmedSearch
+        ? `OR person_id IN (SELECT id FROM persons WHERE properties.email ILIKE ${escapeHogQLString(`%${trimmedSearch}%`)})`
         : ''
     const optionalSearchClause = trimmedSearch
         ? hogql.raw(
@@ -483,9 +485,11 @@ async function fetchRunsPage(
         : hogql.raw('')
     const trimmedSearch = filters.search?.trim()
     // Email is stored on `persons.properties.email`, not on `hog_invocation_results` —
-    // resolve to person_ids via a subquery when the search string looks like an email.
-    const emailSearchClause = trimmedSearch?.includes('@')
-        ? `OR person_id IN (SELECT id FROM persons WHERE properties.email = ${escapeHogQLString(trimmedSearch)})`
+    // resolve to person_ids via an `ILIKE %value%` subquery on `persons`. Runs on every
+    // non-empty search so partial matches (`meikel`, `@company.com`) work without the user
+    // having to type a full email.
+    const emailSearchClause = trimmedSearch
+        ? `OR person_id IN (SELECT id FROM persons WHERE properties.email ILIKE ${escapeHogQLString(`%${trimmedSearch}%`)})`
         : ''
     const optionalSearchClause = trimmedSearch
         ? hogql.raw(

--- a/frontend/src/scenes/hog-functions/invocations/hogInvocationsLogic.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/hogInvocationsLogic.tsx
@@ -385,6 +385,11 @@ async function fetchSparkline(props: HogInvocationsLogicProps, filters: HogInvoc
         ? hogql.raw(`AND error_kind IN (${filters.error_kind.map(escapeHogQLString).join(',')})`)
         : hogql.raw('')
     const trimmedSearch = filters.search?.trim()
+    // Email is stored on `persons.properties.email`, not on `hog_invocation_results` —
+    // resolve to person_ids via a subquery when the search string looks like an email.
+    const emailSearchClause = trimmedSearch?.includes('@')
+        ? `OR person_id IN (SELECT id FROM persons WHERE properties.email = ${escapeHogQLString(trimmedSearch)})`
+        : ''
     const optionalSearchClause = trimmedSearch
         ? hogql.raw(
               `AND (
@@ -392,6 +397,7 @@ async function fetchSparkline(props: HogInvocationsLogicProps, filters: HogInvoc
                   OR event_uuid = ${escapeHogQLString(trimmedSearch)}
                   OR distinct_id = ${escapeHogQLString(trimmedSearch)}
                   OR person_id = ${escapeHogQLString(trimmedSearch)}
+                  ${emailSearchClause}
               )`
           )
         : hogql.raw('')
@@ -476,6 +482,11 @@ async function fetchRunsPage(
         ? hogql.raw(`AND error_kind IN (${filters.error_kind.map(escapeHogQLString).join(', ')})`)
         : hogql.raw('')
     const trimmedSearch = filters.search?.trim()
+    // Email is stored on `persons.properties.email`, not on `hog_invocation_results` —
+    // resolve to person_ids via a subquery when the search string looks like an email.
+    const emailSearchClause = trimmedSearch?.includes('@')
+        ? `OR person_id IN (SELECT id FROM persons WHERE properties.email = ${escapeHogQLString(trimmedSearch)})`
+        : ''
     const optionalSearchClause = trimmedSearch
         ? hogql.raw(
               `AND (
@@ -483,6 +494,7 @@ async function fetchRunsPage(
                   OR event_uuid = ${escapeHogQLString(trimmedSearch)}
                   OR distinct_id = ${escapeHogQLString(trimmedSearch)}
                   OR person_id = ${escapeHogQLString(trimmedSearch)}
+                  ${emailSearchClause}
               )`
           )
         : hogql.raw('')


### PR DESCRIPTION
## Problem

The invocations tab search only matches on `invocation_id`, `event_uuid`, `distinct_id`, and `person_id`, all exact-match UUIDs.
People rarely have those on hand; they usually know a user by email.

## Changes

Adds an email match to the existing OR chain, as a subquery over `persons.properties.email`.

- Case-insensitive substring: `properties.email ILIKE '%<search>%'`.
  So `meikel`, `Meikel`, `meikel@posthog.com`, and `@company.com` all work.
- Runs on every non-empty search, no `@` heuristic.
  First cut had one but it silently ate partial-name searches like `meikel`.
- Applied to both `fetchRunsPage` and `fetchSparkline` so the list and the sparkline stay in sync.
- Placeholder updated to mention email.

## How did you test this code?

manual testing on dev

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Meikel asked for email search on the workflows invocations tab.
First iteration used exact match gated on `@` in the search string, which Meikel then flagged as too narrow (`meikel` didn't match his own `meikel@posthog.com`).
Switched to `ILIKE '%…%'` and dropped the `@` guard.

Change lives in the shared `hog-functions/invocations` component so it also benefits CDP destinations.

Tool: Claude Code (Opus 4.7).
