### PR TITLE
fix(max): guard scene-context reads against unmounted scene logic

### DIFF
--- a/frontend/src/scenes/max/maxContextLogic.ts
+++ b/frontend/src/scenes/max/maxContextLogic.ts
@@ -37,6 +37,7 @@ import {
 } from './maxTypes'
 import {
     actionToMaxContextPayload,
+    activeSceneLogicHasMaxContext,
     dashboardToMaxContext,
     errorTrackingIssueToMaxContextPayload,
     evaluationToMaxContextPayload,
@@ -525,16 +526,7 @@ export const maxContextLogic = kea<maxContextLogicType>([
                 (state): MaxContextInput[] => {
                     const activeSceneLogic = sceneLogic.selectors.activeSceneLogic(state, {})
 
-                    // During a scene transition, sceneLogic can still resolve the outgoing scene's
-                    // (keyed) logic reference after kea has already unmounted it. Reading its
-                    // maxContext then walks into a store path that no longer exists and throws
-                    // "Can not find path". Skip the read while unmounted — the next recompute after
-                    // the new scene mounts returns fresh context.
-                    if (
-                        activeSceneLogic &&
-                        activeSceneLogic.isMounted() &&
-                        'maxContext' in activeSceneLogic.selectors
-                    ) {
+                    if (activeSceneLogicHasMaxContext(activeSceneLogic)) {
                         try {
                             const activeLoadedScene = sceneLogic.selectors.activeLoadedScene(state, {})
                             return activeSceneLogic.selectors.maxContext(

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -591,6 +591,31 @@ describe('maxThreadLogic', () => {
             }
         })
 
+        it('sends promptly instead of waiting for the cap when the dashboard scene logic cannot be built', async () => {
+            jest.useFakeTimers()
+            const captureSpy = jest.spyOn(posthog, 'capture')
+            try {
+                const streamSpy = mockStream()
+                // On the dashboard scene, but its logic key hasn't resolved / can't be built, so there
+                // is no logic to wait on. The gate must not hold for the full cap in this state.
+                jest.spyOn(sceneLogic.selectors, 'activeSceneId').mockReturnValue(Scene.Dashboard)
+                jest.spyOn(sceneLogic.selectors, 'activeSceneLogic').mockReturnValue(null as any)
+
+                maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
+                logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, panelId: 'test' })
+                logic.mount()
+
+                logic.actions.askMax('what am I seeing on this dashboard?')
+
+                await jest.advanceTimersByTimeAsync(300)
+
+                expect(streamSpy).toHaveBeenCalledTimes(1)
+                expect(captureSpy).not.toHaveBeenCalledWith('max dashboard context wait timed out', expect.anything())
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
         it('sends form_answers in ui_context when provided', async () => {
             const streamSpy = mockStream()
 

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -1293,10 +1293,16 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     return false
                 }
                 const activeSceneLogic = sceneLogic.values.activeSceneLogic
+                if (!activeSceneLogic) {
+                    // No dashboard scene logic to wait on — its key hasn't resolved or it can't be
+                    // built. Nothing will land, so don't block: send now rather than stalling for the
+                    // full cap and shipping without context anyway.
+                    return false
+                }
                 if (!activeSceneLogicHasMaxContext(activeSceneLogic)) {
-                    // Still on the dashboard scene but its logic isn't ready to read yet — building,
-                    // or briefly unmounted mid dashboard→dashboard navigation. Keep waiting (the cap
-                    // above bounds it) so context collection picks up the dashboard once it mounts.
+                    // The logic exists but isn't mounted yet — building, or briefly unmounted mid
+                    // dashboard→dashboard navigation. Keep waiting (bounded by the cap) so context
+                    // collection picks up the dashboard once it mounts.
                     return true
                 }
                 return !(activeSceneLogic.values as { dashboard?: unknown }).dashboard

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -91,6 +91,7 @@ import { posthogAiContextLogic } from './posthogAiContextLogic'
 import { MAX_SLASH_COMMANDS, SlashCommand } from './slash-commands'
 import { getToolCallDescriptionAndWidgetDef } from './toolCallDisplay'
 import {
+    activeSceneLogicHasMaxContext,
     findPendingClientToolCall,
     getAgentModeForScene,
     isAssistantMessage,
@@ -1292,8 +1293,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     return false
                 }
                 const activeSceneLogic = sceneLogic.values.activeSceneLogic
-                if (!activeSceneLogic || !('maxContext' in activeSceneLogic.selectors)) {
-                    return false
+                if (!activeSceneLogicHasMaxContext(activeSceneLogic)) {
+                    // Still on the dashboard scene but its logic isn't ready to read yet — building,
+                    // or briefly unmounted mid dashboard→dashboard navigation. Keep waiting (the cap
+                    // above bounds it) so context collection picks up the dashboard once it mounts.
+                    return true
                 }
                 return !(activeSceneLogic.values as { dashboard?: unknown }).dashboard
             }

--- a/frontend/src/scenes/max/posthogAiContextLogic.tsx
+++ b/frontend/src/scenes/max/posthogAiContextLogic.tsx
@@ -9,6 +9,7 @@ import { sceneLogic } from 'scenes/sceneLogic'
 
 import { AttachedContext, MaxContextInput, MaxContextType } from './maxTypes'
 import type { posthogAiContextLogicType } from './posthogAiContextLogicType'
+import { activeSceneLogicHasMaxContext } from './utils'
 
 export interface PosthogAiContextLogicProps {
     conversationId: string
@@ -131,7 +132,7 @@ export const posthogAiContextLogic = kea<posthogAiContextLogicType>([
     listeners(({ values, actions }) => ({
         syncSceneAttachments: () => {
             const activeSceneLogic = values.activeSceneLogic
-            if (!activeSceneLogic || !('maxContext' in activeSceneLogic.selectors)) {
+            if (!activeSceneLogicHasMaxContext(activeSceneLogic)) {
                 return
             }
             let sceneItems: MaxContextInput[] = []

--- a/frontend/src/scenes/max/utils.test.ts
+++ b/frontend/src/scenes/max/utils.test.ts
@@ -1,3 +1,5 @@
+import type { BuiltLogic } from 'kea'
+
 import {
     AssistantMessage,
     AssistantMessageType,
@@ -6,7 +8,12 @@ import {
 } from '~/queries/schema/schema-assistant-messages'
 
 import { EnhancedToolCall } from './max-constants'
-import { findPendingClientToolCall, isMultiQuestionFormMessage, threadEndsWithMultiQuestionForm } from './utils'
+import {
+    activeSceneLogicHasMaxContext,
+    findPendingClientToolCall,
+    isMultiQuestionFormMessage,
+    threadEndsWithMultiQuestionForm,
+} from './utils'
 
 describe('max/utils', () => {
     describe('isMultiQuestionFormMessage()', () => {
@@ -279,6 +286,28 @@ describe('max/utils', () => {
         it('returns null for an empty thread or a thread ending with a human message', () => {
             expect(findPendingClientToolCall([], clientToolNames)).toBeNull()
             expect(findPendingClientToolCall([humanMessage('Hello')], clientToolNames)).toBeNull()
+        })
+    })
+
+    describe('activeSceneLogicHasMaxContext()', () => {
+        it('returns false for null or undefined scene logic', () => {
+            expect(activeSceneLogicHasMaxContext(null)).toBe(false)
+            expect(activeSceneLogicHasMaxContext(undefined)).toBe(false)
+        })
+
+        it.each([
+            { mounted: true, hasMaxContext: true, expected: true },
+            { mounted: true, hasMaxContext: false, expected: false },
+            // The crux of the fix: a built-but-unmounted scene logic must be rejected, since reading
+            // its selectors/values throws `[KEA] Can not find path` once its reducer path is gone.
+            { mounted: false, hasMaxContext: true, expected: false },
+            { mounted: false, hasMaxContext: false, expected: false },
+        ])('mounted=$mounted hasMaxContext=$hasMaxContext -> $expected', ({ mounted, hasMaxContext, expected }) => {
+            const logic = {
+                isMounted: () => mounted,
+                selectors: hasMaxContext ? { maxContext: () => [] } : {},
+            } as unknown as BuiltLogic
+            expect(activeSceneLogicHasMaxContext(logic)).toBe(expected)
         })
     })
 })

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -1,3 +1,4 @@
+import type { BuiltLogic } from 'kea'
 import posthog from 'posthog-js'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -375,4 +376,17 @@ export const visualizationTypeToQuery = (
         return { kind: NodeKind.InsightVizNode, source, showHeader: true } satisfies InsightVizNode
     }
     return source
+}
+
+/**
+ * Whether it's safe to read auto-context from the active scene logic. `sceneLogic`'s
+ * `activeSceneLogic` is built but may already be unmounted mid scene-transition (e.g. navigating
+ * away from a dashboard); reading its selectors/values then throws `[KEA] Can not find path`
+ * because the reducer path is gone from the store. Check this at read time — mounted state changes
+ * without a selector-input change, so it can't be memoized upstream.
+ */
+export function activeSceneLogicHasMaxContext(
+    activeSceneLogic: BuiltLogic | null | undefined
+): activeSceneLogic is BuiltLogic {
+    return !!activeSceneLogic?.isMounted() && 'maxContext' in activeSceneLogic.selectors
 }


### PR DESCRIPTION
## Problem

PostHog AI's auto-context collection reads the active scene's kea logic to attach the open dashboard/insight/etc. to the conversation. It read that logic without checking it was still mounted. Mid scene-transition (for example navigating away from a dashboard, or between two dashboards) the logic is built but its reducer path has already been removed from the Redux store, so reading its selectors or `.values` threw a caught `[KEA] Can not find path ... dashboardLogic` error. That both blanked the auto-collected context and flooded error tracking on dashboard navigation.

Raised from a Slack thread in #team-max — see the footer link.

## Changes

- Added a shared `activeSceneLogicHasMaxContext` type guard in `scenes/max/utils.ts` that requires `isMounted()` before treating the active scene logic as readable, with a docstring explaining the KEA gotcha and why the check has to happen at read time (mounted state changes without a selector-input change, so it can't be memoized upstream).
- Applied it at all three read sites that previously checked only `activeSceneLogic && 'maxContext' in selectors`: `maxContextLogic` (`rawSceneContext` selector), `posthogAiContextLogic` (`syncSceneAttachments` listener), and `maxThreadLogic` (`isDashboardSceneLoading`). The third site was reading `.values.dashboard` on a possibly-unmounted logic with no guard at all — same latent bug.
- In the dashboard-wait loop, a not-yet-ready scene logic (building, or briefly unmounted during dashboard→dashboard navigation) now counts as "still loading" so the loop keeps waiting for the remount, bounded by the existing wait cap, instead of bailing early and shipping empty context.

Frontend logic-only change, no UI.

## How did you test this code?

Added automated tests; I (the PostHog Slack app agent) did not run the app or do manual testing.

- New parameterized unit tests for `activeSceneLogicHasMaxContext` in `utils.test.ts` covering null/undefined and the mounted × has-maxContext matrix. The regression they catch that nothing else did: if the `isMounted()` check is dropped, a built-but-unmounted logic would again pass the guard and callers would read a torn-down reducer path, reintroducing the `[KEA] Can not find path` flood.
- Updated the existing `activeSceneLogic` mocks in `maxContextLogic.test.ts` and `maxThreadLogic.test.ts` to expose `isMounted: () => true` (they represent a mounted dashboard scene) so they stay valid under the new guard.

> [!NOTE]
> I could not run Jest or the TypeScript check in this environment (no `node_modules` install). Please rely on CI for the frontend test + typecheck run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed (internal behavior fix).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by the requester in a Slack thread who asked to fix the caught KEA scene-context error and then to run `/simplify` and `/code-review` until quality reached at least A-. Authored by the PostHog Slack app agent.

- Skills invoked: `/simplify`, `/code-review`, and `/writing-tests` (the repo's mandatory test gate) before adding the unit tests.
- Key decision: I considered pushing the mount check down into `sceneLogic.selectors.activeSceneLogic` itself so no consumer ever receives an unmounted logic. I rejected that — that selector is memoized on `[activeExportedScene, activeSceneLogicProps]`, while mount state flips without an input change (the scene component mounts the logic after the selector last recomputed), so baking it in would cache a stale `null` and could hide a genuinely-mounted logic from other consumers (breadcrumbs, side panel). Read-time guards are the correct altitude, matching the existing `insightSceneLogic` precedent.
- Code review surfaced two issues that were fixed before this PR: the `maxThreadLogic` wait loop bailing early (now keeps waiting), and existing mocks lacking `isMounted()` (would have thrown under the new guard). The error-reporting paths were deliberately left in place — they still catch a distinct failure (a scene's own `maxContext` selector throwing on still-loading state); only the unmounted-path noise is eliminated, which is the point.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ALCCKESZ/p1783858875224219?thread_ts=1783858875.224219&cid=C09ALCCKESZ)*
