### PR TITLE
fix(devex): fail cloud deploys on unconfigured product db routes

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -48,6 +48,12 @@ class PostHogConfig(AppConfig):
         # shell) would lose them. They live in dedicated import-light modules — never wire
         # ready() through an API module, even one that looks light today.
         import posthog.storage.checks  # noqa: F401, PLC0415
+
+        # Product-DB route checks must register even when no PRODUCT_DB_* env
+        # vars are set — the unconfigured case is exactly what
+        # check_product_db_routes_configured guards — and Django only imports
+        # the router module when at least one route is configured.
+        import posthog.product_db_router  # noqa: F401, PLC0415
         import posthog.caching.organization_serializer_cache  # noqa: F401, PLC0415
         import posthog.models.activity_logging.signal_handlers  # noqa: F401, PLC0415
 

--- a/posthog/product_db_config.py
+++ b/posthog/product_db_config.py
@@ -45,12 +45,24 @@ def load_product_db_routes(base_dir: Path | str) -> tuple[ProductDBRoute, ...]:
             )
             continue
 
+        optional = route_config.get("optional", False)
+        if not isinstance(optional, bool):
+            # Fail closed: a quoted value like "false" is a truthy string, and
+            # treating it as optional would suppress the deploy-gating check.
+            logger.warning(
+                "Non-boolean 'optional' value %r for route %r in %s; treating the route as required",
+                optional,
+                app_label,
+                config_path,
+            )
+            optional = False
+
         routes.append(
             ProductDBRoute(
                 app_label=app_label,
                 database=database,
                 source=str(config_path),
-                optional=bool(route_config.get("optional", False)),
+                optional=optional,
             )
         )
 

--- a/posthog/product_db_config.py
+++ b/posthog/product_db_config.py
@@ -16,6 +16,7 @@ class ProductDBRoute:
     app_label: str
     database: str
     source: str
+    optional: bool = False
 
     def routes_model(self, model: object) -> bool:
         model_meta = getattr(model, "_meta", None)
@@ -49,6 +50,7 @@ def load_product_db_routes(base_dir: Path | str) -> tuple[ProductDBRoute, ...]:
                 app_label=app_label,
                 database=database,
                 source=str(config_path),
+                optional=bool(route_config.get("optional", False)),
             )
         )
 

--- a/posthog/product_db_router.py
+++ b/posthog/product_db_router.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from functools import lru_cache
 
 from django.conf import settings
-from django.core.checks import Error, register
+from django.core.checks import CheckMessage, Error, Warning, register
 
 from posthog.product_db_config import ProductDBRoute, load_product_db_routes
 from posthog.settings.base_variables import TEST
+from posthog.settings.utils import DEPLOYED_CLOUD_DEPLOYMENTS
 
 
 @lru_cache(maxsize=1)
@@ -85,3 +86,46 @@ def check_product_db_routes(app_configs, **kwargs):
         app_label_to_database[route.app_label] = route.database
 
     return errors
+
+
+def product_db_routes_configured_errors(routes: tuple[ProductDBRoute, ...]) -> list[CheckMessage]:
+    # Only enforced on deployed cloud environments, where charts always injects
+    # the PRODUCT_DB_* env vars. E2E (local cloud-features dev) and self-hosted
+    # (no CLOUD_DEPLOYMENT) intentionally run product models on the default
+    # database instead. DEBUG needs no guard: settings import rejects DEBUG on
+    # deployed cloud (assert_debug_not_in_production, same deployment tuple).
+    if settings.TEST:
+        return []
+    if (settings.CLOUD_DEPLOYMENT or "").upper() not in DEPLOYED_CLOUD_DEPLOYMENTS:
+        return []
+
+    messages: list[CheckMessage] = []
+    for route in routes:
+        configured = f"{route.database}_db_writer" in settings.DATABASES
+        if route.optional and configured:
+            messages.append(
+                Warning(
+                    f"Product database '{route.database}' (app '{route.app_label}') is configured but "
+                    f"still marked 'optional: true' in {route.source}.",
+                    hint="Once the database is provisioned in every environment, remove the 'optional' "
+                    "flag so a missing connection fails deploys instead of silently falling back.",
+                    id="posthog.W001",
+                )
+            )
+        elif not route.optional and not configured:
+            env_var = f"PRODUCT_DB_{route.database.upper()}_WRITER_URL"
+            messages.append(
+                Error(
+                    f"Product database '{route.database}' (app '{route.app_label}') has no connection configured, "
+                    "so its models would silently fall back to the default database.",
+                    hint=f"Set {env_var} in the deployment, or mark the route 'optional: true' in {route.source} "
+                    "while the database is still being provisioned.",
+                    id="posthog.E005",
+                )
+            )
+    return messages
+
+
+@register()
+def check_product_db_routes_configured(app_configs, **kwargs):
+    return product_db_routes_configured_errors(get_product_db_routes())

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -209,6 +209,9 @@ for route in product_routes:
         writer_url = f"postgres://{PG_USER}:{PG_PASSWORD}@{PG_HOST}:{PG_PORT}/{PG_DATABASE}_{db}"
 
     if not writer_url:
+        # Intentional fail-open outside deployed cloud: self-hosted runs product
+        # models on the default database. On cloud, check_product_db_routes_configured
+        # fails the deploy's migrate step for non-optional routes instead.
         continue
 
     PRODUCT_DB_WRITER_URLS[db] = writer_url

--- a/posthog/settings/utils.py
+++ b/posthog/settings/utils.py
@@ -7,12 +7,17 @@ from django.core.exceptions import ImproperlyConfigured
 from posthog.utils import str_to_bool
 
 __all__ = [
+    "DEPLOYED_CLOUD_DEPLOYMENTS",
     "assert_debug_not_in_production",
     "generate_rsa_private_key_pem",
     "get_from_env",
     "get_list",
     "str_to_bool",
 ]
+
+# Deployed, charts-managed cloud environments. E2E is cloud-like (is_cloud()
+# includes it) but only runs locally and in automated tests, so it's not listed.
+DEPLOYED_CLOUD_DEPLOYMENTS: tuple[str, ...] = ("US", "EU", "DEV")
 
 
 def assert_debug_not_in_production(*, debug: bool, cloud_deployment: Optional[str], test: bool) -> None:
@@ -23,7 +28,7 @@ def assert_debug_not_in_production(*, debug: bool, cloud_deployment: Optional[st
     TEST is excluded because the suite runs with DEBUG=1 (see posthog/settings/overrides.py). E2E is
     not listed: it runs only in automated tests and never sets DEBUG, so the guard can't fire there.
     """
-    if debug and not test and (cloud_deployment or "").upper() in ("US", "EU", "DEV"):
+    if debug and not test and (cloud_deployment or "").upper() in DEPLOYED_CLOUD_DEPLOYMENTS:
         raise ImproperlyConfigured(
             f"DEBUG must not be enabled on deployed cloud environments (CLOUD_DEPLOYMENT={cloud_deployment!r}). "
             "Unset DEBUG. Developing cloud-only features locally? Use CLOUD_DEPLOYMENT=E2E instead — "

--- a/posthog/test/test_product_db_router.py
+++ b/posthog/test/test_product_db_router.py
@@ -79,12 +79,17 @@ class TestProductDBRouteLoading(SimpleTestCase):
                 "    optional: true\n"
                 "  - app_label: established_product\n"
                 "    database: established_product\n"
+                "  - app_label: quoted_product\n"
+                "    database: quoted_product\n"
+                '    optional: "false"\n'
             )
 
             routes = {route.app_label: route for route in load_product_db_routes(base_dir)}
 
         self.assertTrue(routes["staged_product"].optional)
         self.assertFalse(routes["established_product"].optional)
+        # Non-boolean values fail closed: a quoted "false" is a truthy string.
+        self.assertFalse(routes["quoted_product"].optional)
 
 
 class TestProductDBRouteChecks(SimpleTestCase):

--- a/posthog/test/test_product_db_router.py
+++ b/posthog/test/test_product_db_router.py
@@ -1,10 +1,18 @@
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
 from django.test import SimpleTestCase, override_settings
 
+from parameterized import parameterized
+
 from posthog.product_db_config import ProductDBRoute, load_product_db_routes
-from posthog.product_db_router import ProductDBRouter, check_product_db_routes, get_product_db_routes
+from posthog.product_db_router import (
+    ProductDBRouter,
+    check_product_db_routes,
+    get_product_db_routes,
+    product_db_routes_configured_errors,
+)
 
 FAKE_PRODUCT_DATABASES: dict[str, dict] = {
     "default": {},
@@ -13,19 +21,20 @@ FAKE_PRODUCT_DATABASES: dict[str, dict] = {
 }
 
 
+def _visual_review_route(optional: bool = False) -> ProductDBRoute:
+    return ProductDBRoute(
+        app_label="visual_review",
+        database="visual_review",
+        source="products/db_routing.yaml",
+        optional=optional,
+    )
+
+
 @override_settings(DATABASES=FAKE_PRODUCT_DATABASES)
 class TestProductDBRouter(SimpleTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.router = ProductDBRouter(
-            routes=(
-                ProductDBRoute(
-                    app_label="visual_review",
-                    database="visual_review",
-                    source="products/db_routing.yaml",
-                ),
-            )
-        )
+        self.router = ProductDBRouter(routes=(_visual_review_route(),))
 
     def test_routes_visual_review_model_to_configured_aliases(self) -> None:
         model = SimpleNamespace(_meta=SimpleNamespace(app_label="visual_review", model_name="run"))
@@ -42,15 +51,7 @@ class TestProductDBRouter(SimpleTestCase):
 
     @override_settings(DATABASES={"default": {}})
     def test_only_enables_routes_with_configured_aliases(self) -> None:
-        router = ProductDBRouter(
-            routes=(
-                ProductDBRoute(
-                    app_label="visual_review",
-                    database="visual_review",
-                    source="products/db_routing.yaml",
-                ),
-            )
-        )
+        router = ProductDBRouter(routes=(_visual_review_route(),))
 
         model = SimpleNamespace(_meta=SimpleNamespace(app_label="visual_review", model_name="run"))
 
@@ -67,6 +68,24 @@ class TestProductDBRouteLoading(SimpleTestCase):
         self.assertEqual(visual_review_routes[0].database, "visual_review")
         self.assertTrue(visual_review_routes[0].source.endswith("products/db_routing.yaml"))
 
+    def test_parses_optional_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as base_dir:
+            config_path = Path(base_dir) / "products" / "db_routing.yaml"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text(
+                "routes:\n"
+                "  - app_label: staged_product\n"
+                "    database: staged_product\n"
+                "    optional: true\n"
+                "  - app_label: established_product\n"
+                "    database: established_product\n"
+            )
+
+            routes = {route.app_label: route for route in load_product_db_routes(base_dir)}
+
+        self.assertTrue(routes["staged_product"].optional)
+        self.assertFalse(routes["established_product"].optional)
+
 
 class TestProductDBRouteChecks(SimpleTestCase):
     @override_settings(BASE_DIR=Path(__file__).resolve().parents[2])
@@ -75,3 +94,40 @@ class TestProductDBRouteChecks(SimpleTestCase):
         self.addCleanup(get_product_db_routes.cache_clear)
 
         self.assertEqual(check_product_db_routes(None), [])
+
+
+class TestProductDBRoutesConfiguredCheck(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("enforced_on_cloud", "US", False, 1),
+            ("self_hosted_unenforced", None, False, 0),
+            ("e2e_unenforced", "E2E", False, 0),
+            ("optional_route_allowed", "US", True, 0),
+        ]
+    )
+    def test_missing_writer_alias(self, _name, cloud_deployment, optional, expected_errors) -> None:
+        route = _visual_review_route(optional=optional)
+        with override_settings(DATABASES={"default": {}}, CLOUD_DEPLOYMENT=cloud_deployment, TEST=False):
+            errors = product_db_routes_configured_errors((route,))
+
+        self.assertEqual(len(errors), expected_errors)
+        if expected_errors:
+            self.assertEqual(errors[0].id, "posthog.E005")
+
+    def test_configured_route_passes(self) -> None:
+        with override_settings(
+            DATABASES={"default": {}, "visual_review_db_writer": {}},
+            CLOUD_DEPLOYMENT="US",
+            TEST=False,
+        ):
+            self.assertEqual(product_db_routes_configured_errors((_visual_review_route(),)), [])
+
+    def test_configured_optional_route_warns_to_remove_flag(self) -> None:
+        with override_settings(
+            DATABASES={"default": {}, "visual_review_db_writer": {}},
+            CLOUD_DEPLOYMENT="US",
+            TEST=False,
+        ):
+            messages = product_db_routes_configured_errors((_visual_review_route(optional=True),))
+
+        self.assertEqual([message.id for message in messages], ["posthog.W001"])

--- a/products/README.md
+++ b/products/README.md
@@ -230,7 +230,9 @@ This automatically:
 - Runs migrations via `bin/migrate` (calls `migrate_product_databases` management command)
 - Creates the database in local Docker via the Postgres init script
 
-Locally (`DEBUG=1`), it auto-connects to `posthog_visual_review` on localhost. In prod, the infrastructure handles env vars and connections automatically. If the env var is absent, the route is silently skipped.
+Locally (`DEBUG=1`), it auto-connects to `posthog_visual_review` on localhost. Self-hosted and local setups skip a route silently if its env var is absent — the product's models just run on the default database.
+
+On PostHog Cloud (`CLOUD_DEPLOYMENT` set to a deployed environment), that silent fallback is dangerous: a misconfigured deploy would misroute writes without anyone noticing. There, a missing connection for a non-optional route fails Django's system checks, which blocks the deploy's `migrate` step. New routes are scaffolded with `optional: true` for exactly this reason — it's a staged rollout escape hatch for when code lands before infra has provisioned the database. Remove the flag once the database is up, so a missing connection fails loudly from then on — a system-check warning nags about routes that are configured but still marked optional.
 
 ### Adding a new product database
 

--- a/tools/hogli-commands/hogli_commands/product/scaffold.py
+++ b/tools/hogli-commands/hogli_commands/product/scaffold.py
@@ -140,7 +140,7 @@ def _get_existing_databases() -> list[str]:
 
 
 def _add_to_db_routing(product_name: str, database_name: str, *, dry_run: bool) -> None:
-    route_entry = f"    - app_label: {product_name}\n      database: {database_name}\n"
+    route_entry = f"    - app_label: {product_name}\n      database: {database_name}\n      optional: true\n"
 
     def write(content: str) -> str:
         return content.rstrip() + "\n" + route_entry
@@ -189,6 +189,11 @@ def _prompt_for_separate_db(name: str) -> tuple[bool, str | None]:
         "  ⚠ Adding a route here is only the Django side. The database must also "
         "be provisioned by #team-infrastructure (Terraform + charts).",
         fg="yellow",
+    )
+    click.echo(
+        "  The route starts with 'optional: true' in db_routing.yaml, so cloud deploys "
+        "won't fail before infra provisions the database. Remove that line once it's "
+        "provisioned, so cloud deploys fail loudly if the connection ever goes missing."
     )
     existing_dbs = _get_existing_databases()
     if existing_dbs:


### PR DESCRIPTION
## Problem

A route in `products/db_routing.yaml` whose `PRODUCT_DB_*_WRITER_URL` env var is missing gets silently skipped at settings load, and the product's models quietly route to the default database. That fallback is intentional for self-hosted, where everything runs on one DB anyway, but on cloud it means a typo'd or forgotten env var misroutes writes with zero signal.

## Changes

- New system check `posthog.E005`: on deployed cloud environments (US/EU/DEV), a non-optional route without a configured writer alias fails checks. Checks run on `manage.py migrate`, which gates deploys via the migration sync hook, so a bad config blocks the rollout instead of crash-looping running pods.
- Routes can set `optional: true` in `db_routing.yaml` as a staged-rollout escape hatch for when code lands before infra provisions the database. `hogli product:bootstrap` scaffolds new routes with the flag set.
- Companion warning `posthog.W001` fires once an optional route is actually configured, so the flag gets removed instead of rotting.
- The deployed-env list is now a shared constant (`DEPLOYED_CLOUD_DEPLOYMENTS`) used by both `assert_debug_not_in_production` and the new check, so the two can't drift. E2E stays excluded since it only runs locally.
- The check registers via an import in `apps.py` `ready()` because Django only imports the router module when at least one route is configured, which is exactly the failure case being guarded.

> [!NOTE]
> No behavior change for self-hosted or local dev. The silent default-DB fallback stays intact there.

## How did you test this code?

`pytest posthog/test/test_product_db_router.py` (12 tests, all passing). New coverage: the enforcement matrix for the check (cloud enforced, self-hosted and E2E skipped, optional route allowed, configured route passes, stale optional route warns) and YAML parsing of the `optional` flag. No existing test covered a route present in `db_routing.yaml` with no configured connection, which is the regression this guards.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The "Separate product databases" section of `products/README.md` documented the silent skip and is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. The work started as a design scrutiny of per-product DB credential handling across this repo and the charts repo. Conclusion there was that the credential env var scheme is fine as-is (charts generates the URLs from one per-cluster secret), and the actual sharp edge is the silent fail-open on a missing writer URL, so this PR fixes that instead. Skills invoked: /writing-tests, /simplify. Key decisions: a system check instead of raising at settings import (blocks bad deploys at the migrate sync hook without crash-looping running pods, and keeps the intentional self-hosted fallback working), and registration via `ready()` since the router module isn't imported when zero routes are configured. The /simplify pass centralized the deployed-env tuple into `DEPLOYED_CLOUD_DEPLOYMENTS`, removed a provably dead `DEBUG` guard, and added the `W001` staleness warning.
