### PR TITLE
feat(conversations): mailgun proof of delivery for email replies

### DIFF
--- a/.semgrep/rules/security/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/security/idor-team-scoped-models.yaml
@@ -117,6 +117,7 @@ rules:
                               |DeploymentEvent
                               |DeploymentProject
                               |EarlyAccessFeature
+                              |EmailDeliveryEvent
                               |EmailMessageMapping
                               |EvaluationContext
                               |Edge
@@ -404,6 +405,7 @@ rules:
                         |DeploymentEvent
                         |DeploymentProject
                         |EarlyAccessFeature
+                        |EmailDeliveryEvent
                         |EmailMessageMapping
                         |EvaluationContext
                         |Edge

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -207,12 +207,12 @@ CONSTANCE_CONFIG = {
     ),
     "CONVERSATIONS_EMAIL_WEBHOOK_SIGNING_KEY": (
         get_from_env("CONVERSATIONS_EMAIL_WEBHOOK_SIGNING_KEY", default=""),
-        "HMAC signing key for validating inbound Mailgun webhook authenticity.",
+        "HMAC signing key for validating Mailgun webhook authenticity (inbound email and delivery events).",
         str,
     ),
     "CONVERSATIONS_EMAIL_MAILGUN_API_KEY": (
         get_from_env("CONVERSATIONS_EMAIL_MAILGUN_API_KEY", default=""),
-        "Mailgun API key for domain management (add/verify/delete sending domains).",
+        "Mailgun API key for domain management (add/verify/delete sending domains) and delivery webhook registration.",
         str,
     ),
     "GITHUB_WEBHOOK_SECRET": (

--- a/products/conversations/backend/api/email_delivery_events.py
+++ b/products/conversations/backend/api/email_delivery_events.py
@@ -128,7 +128,7 @@ def email_delivery_event_handler(request: HttpRequest) -> HttpResponse:
         headers = {}
     message_id = _normalize_message_id(str(headers.get("message-id") or ""))
     if not provider_event_id or not message_id:
-        logger.warning("email_delivery_event_missing_identifiers", event=event)
+        logger.warning("email_delivery_event_missing_identifiers", event_type=event)
         return HttpResponse(status=200)
 
     outbox = (
@@ -136,7 +136,7 @@ def email_delivery_event_handler(request: HttpRequest) -> HttpResponse:
     )
     if outbox is None:
         # Not an outbound ticket reply (e.g. a settings test email) — nothing to attach to.
-        logger.info("email_delivery_event_unmatched", event=event, provider_event_id=provider_event_id)
+        logger.info("email_delivery_event_unmatched", event_type=event, provider_event_id=provider_event_id)
         return HttpResponse(status=200)
 
     recipient = str(event_data.get("recipient") or "")[:254]
@@ -168,7 +168,7 @@ def email_delivery_event_handler(request: HttpRequest) -> HttpResponse:
         "email_delivery_event_recorded",
         team_id=outbox.team_id,
         ticket_id=str(outbox.ticket_id),
-        event=event,
+        event_type=event,
         severity=severity,
         provider_event_id=provider_event_id,
     )

--- a/products/conversations/backend/api/email_delivery_events.py
+++ b/products/conversations/backend/api/email_delivery_events.py
@@ -1,0 +1,175 @@
+"""Mailgun delivery-event webhook endpoint — proof of delivery for outbound replies.
+
+Mailgun POSTs one JSON body per event:
+
+    {
+        "signature": {"timestamp": "...", "token": "...", "signature": "..."},
+        "event-data": {"event": "delivered", "id": "...", "recipient": "...", ...}
+    }
+
+Authenticity is checked the way Mailgun's FAQ prescribes: HMAC-SHA256 over
+timestamp+token with the account's webhook signing key, constant-time compared,
+plus a freshness window (validate_webhook_signature). Tokens are deliberately
+not cached for replay detection: events are idempotent on Mailgun's globally
+unique event id, so a replay inside the freshness window is a no-op, while a
+token cache would drop Mailgun's legitimate retries of a request we failed.
+"""
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from django.db import IntegrityError, transaction
+from django.http import HttpRequest, HttpResponse
+from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
+
+import structlog
+
+from products.conversations.backend.mailgun import validate_webhook_signature
+from products.conversations.backend.models import EmailDeliveryEvent, EmailOutboxMessage
+from products.conversations.backend.services.delivery_status import set_comment_delivery_status
+
+logger = structlog.get_logger(__name__)
+
+# Only delivery outcomes are recorded; opens/clicks are force-disabled at send time.
+ACCEPTED_EVENTS = {choice.value for choice in EmailDeliveryEvent.Event}
+MAX_REASON_LENGTH = 2000
+
+
+def _normalize_message_id(raw: str) -> str:
+    """Mailgun strips the RFC 5322 angle brackets from message-id in event payloads;
+    EmailOutboxMessage stores make_msgid() output with them."""
+    raw = raw.strip()
+    if raw and not raw.startswith("<"):
+        return f"<{raw}>"
+    return raw
+
+
+def _compose_reason(event_data: dict[str, Any]) -> str:
+    """Human-readable failure context from the event's reason and SMTP delivery status."""
+    delivery_status = event_data.get("delivery-status")
+    if not isinstance(delivery_status, dict):
+        delivery_status = {}
+
+    parts = [
+        str(event_data.get("reason") or ""),
+        str(delivery_status.get("description") or delivery_status.get("message") or ""),
+    ]
+    code = delivery_status.get("code")
+    if code:
+        parts.append(f"code={code}")
+    return "; ".join(p for p in parts if p)[:MAX_REASON_LENGTH]
+
+
+def _parse_occurred_at(event_data: dict[str, Any]) -> datetime:
+    try:
+        return datetime.fromtimestamp(float(event_data["timestamp"]), tz=UTC)
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return timezone.now()
+
+
+def _update_primary_recipient_badge(outbox: EmailOutboxMessage, event: str, severity: str, recipient: str) -> None:
+    """Reflect the primary (To:) recipient's delivery outcome on the reply comment.
+
+    Cc recipients don't drive the badge — the agent-facing question it answers is
+    "did the customer get this?". Temporary failures keep the "sent" badge since
+    Mailgun is still retrying; a permanent failure after acceptance is shown with
+    the same "failed" badge as a send failure.
+    """
+    email_from = outbox.ticket.email_from or ""
+    if not recipient or recipient.lower() != email_from.lower():
+        return
+
+    if event == EmailDeliveryEvent.Event.DELIVERED:
+        set_comment_delivery_status(outbox.team_id, outbox.comment_id, "delivered")
+    elif event == EmailDeliveryEvent.Event.FAILED and severity == EmailDeliveryEvent.Severity.PERMANENT:
+        set_comment_delivery_status(outbox.team_id, outbox.comment_id, "failed")
+
+
+@csrf_exempt
+def email_delivery_event_handler(request: HttpRequest) -> HttpResponse:
+    if request.method != "POST":
+        return HttpResponse(status=405)
+
+    try:
+        payload = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return HttpResponse("Invalid JSON", status=400)
+    if not isinstance(payload, dict):
+        return HttpResponse("Invalid JSON", status=400)
+
+    signature = payload.get("signature")
+    if not isinstance(signature, dict):
+        signature = {}
+    if not validate_webhook_signature(
+        str(signature.get("token") or ""),
+        str(signature.get("timestamp") or ""),
+        str(signature.get("signature") or ""),
+    ):
+        logger.warning("email_delivery_event_invalid_signature")
+        return HttpResponse("Invalid signature", status=403)
+
+    # Past this point the request is authenticated as Mailgun's, so unusable
+    # payloads get a 200: a non-2xx would only make Mailgun retry them forever.
+    event_data = payload.get("event-data")
+    if not isinstance(event_data, dict):
+        logger.warning("email_delivery_event_missing_event_data")
+        return HttpResponse(status=200)
+
+    event = event_data.get("event")
+    if event not in ACCEPTED_EVENTS:
+        return HttpResponse(status=200)
+
+    provider_event_id = str(event_data.get("id") or "")[:128]
+    message = event_data.get("message")
+    headers = message.get("headers") if isinstance(message, dict) else None
+    if not isinstance(headers, dict):
+        headers = {}
+    message_id = _normalize_message_id(str(headers.get("message-id") or ""))
+    if not provider_event_id or not message_id:
+        logger.warning("email_delivery_event_missing_identifiers", event=event)
+        return HttpResponse(status=200)
+
+    outbox = (
+        EmailOutboxMessage.objects.select_related("ticket").filter(message_id=message_id).order_by("created_at").first()
+    )
+    if outbox is None:
+        # Not an outbound ticket reply (e.g. a settings test email) — nothing to attach to.
+        logger.info("email_delivery_event_unmatched", event=event, provider_event_id=provider_event_id)
+        return HttpResponse(status=200)
+
+    recipient = str(event_data.get("recipient") or "")[:254]
+    severity = str(event_data.get("severity") or "")[:20] if event == EmailDeliveryEvent.Event.FAILED else ""
+
+    row = EmailDeliveryEvent(
+        team_id=outbox.team_id,
+        ticket_id=outbox.ticket_id,
+        comment_id=outbox.comment_id,
+        message_id=message_id,
+        recipient=recipient,
+        event=event,
+        severity=severity,
+        reason=_compose_reason(event_data),
+        provider_event_id=provider_event_id,
+        occurred_at=_parse_occurred_at(event_data),
+    )
+    try:
+        with transaction.atomic():
+            row.save()
+    except IntegrityError:
+        # Mailgun retry or replay of an event we already stored.
+        logger.info("email_delivery_event_duplicate", provider_event_id=provider_event_id)
+        return HttpResponse(status=200)
+
+    _update_primary_recipient_badge(outbox, event, severity, recipient)
+
+    logger.info(
+        "email_delivery_event_recorded",
+        team_id=outbox.team_id,
+        ticket_id=str(outbox.ticket_id),
+        event=event,
+        severity=severity,
+        provider_event_id=provider_event_id,
+    )
+    return HttpResponse(status=200)

--- a/products/conversations/backend/api/email_settings.py
+++ b/products/conversations/backend/api/email_settings.py
@@ -26,8 +26,10 @@ from products.conversations.backend.mailgun import (
     MailgunNotConfigured,
     add_domain as mailgun_add_domain,
     delete_domain as mailgun_delete_domain,
+    delivery_webhook_url,
     get_domain as mailgun_get_domain,
     send_mime,
+    sync_delivery_webhooks as mailgun_sync_delivery_webhooks,
     verify_domain as mailgun_verify_domain,
 )
 from products.conversations.backend.models import EmailChannel
@@ -90,6 +92,18 @@ def _config_to_dict(config: EmailChannel, inbound_domain: str | None = None) -> 
         "domain_verified": config.domain_verified,
         "dns_records": config.dns_records,
     }
+
+
+def _sync_delivery_webhooks_best_effort(team: Team, domain: str) -> None:
+    """Point the domain's Mailgun delivery webhooks (proof of delivery) at this instance.
+
+    Best-effort by design: delivery events enrich already-sent mail, so a Mailgun
+    hiccup here must not fail the connect/verify request that triggered the sync.
+    """
+    try:
+        mailgun_sync_delivery_webhooks(domain, delivery_webhook_url())
+    except Exception:
+        logger.exception("email_delivery_webhook_sync_failed", team_id=team.id, domain=domain)
 
 
 def _release_domain_if_unused(team: Team, domain: str) -> None:
@@ -298,6 +312,8 @@ class EmailConnectView(APIView):
             assert failure is not None
             return failure
 
+        _sync_delivery_webhooks_best_effort(team, domain)
+
         logger.info(
             "email_channel_connected",
             team_id=team.id,
@@ -338,6 +354,9 @@ class EmailVerifyDomainView(APIView):
             domain_verified=is_active,
             dns_records=dns_records,
         )
+
+        if is_active:
+            _sync_delivery_webhooks_best_effort(team, config.domain)
 
         logger.info(
             "email_domain_verified",

--- a/products/conversations/backend/api/tests/test_email_delivery_events.py
+++ b/products/conversations/backend/api/tests/test_email_delivery_events.py
@@ -1,0 +1,203 @@
+import hmac
+import json
+import time
+import hashlib
+from typing import Any
+from uuid import uuid4
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from posthog.models.comment import Comment
+
+from products.conversations.backend.models import Channel, EmailChannel, EmailDeliveryEvent, EmailOutboxMessage, Status
+from products.conversations.backend.models.ticket import Ticket
+from products.conversations.backend.services.delivery_status import set_comment_delivery_status
+
+SIGNING_KEY = "test-webhook-signing-key"
+ENDPOINT = "/api/conversations/v1/email/events"
+
+PATCH_SIGNING_KEY = patch(
+    "products.conversations.backend.mailgun.get_instance_setting",
+    return_value=SIGNING_KEY,
+)
+
+
+def _sign(timestamp: str, token: str, key: str = SIGNING_KEY) -> str:
+    return hmac.new(key=key.encode(), msg=f"{timestamp}{token}".encode(), digestmod=hashlib.sha256).hexdigest()
+
+
+def _payload(
+    message_id: str,
+    event: str = "delivered",
+    recipient: str = "customer@example.com",
+    event_id: str | None = None,
+    key: str = SIGNING_KEY,
+    **event_fields: Any,
+) -> dict:
+    timestamp = str(int(time.time()))
+    token = uuid4().hex
+    event_data: dict[str, Any] = {
+        "event": event,
+        "id": event_id or uuid4().hex[:22],
+        "timestamp": time.time(),
+        "recipient": recipient,
+        "message": {"headers": {"message-id": message_id}},
+        **event_fields,
+    }
+    return {
+        "signature": {"timestamp": timestamp, "token": token, "signature": _sign(timestamp, token, key)},
+        "event-data": event_data,
+    }
+
+
+class TestEmailDeliveryEventsWebhook(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.config = EmailChannel.objects.create(
+            team=self.team,
+            inbound_token="a" * 32,
+            from_email="support@example.com",
+            from_name="Support",
+            domain="example.com",
+            domain_verified=True,
+        )
+        self.ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.EMAIL,
+            email_config=self.config,
+            widget_session_id="",
+            distinct_id="customer@example.com",
+            status=Status.NEW,
+            email_from="customer@example.com",
+            cc_participants=["cc@example.com"],
+            email_subject="Help",
+        )
+        self.comment = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="On it!",
+            item_context={"author_type": "support", "is_private": False},
+        )
+        # The reply signal created the outbox row; simulate the state after a
+        # successful send, which is when Mailgun starts emitting delivery events.
+        self.outbox = EmailOutboxMessage.objects.get(comment=self.comment)
+        set_comment_delivery_status(self.team.id, self.comment.id, "sent")
+
+    def _post(self, payload: dict) -> Any:
+        return self.client.post(ENDPOINT, data=json.dumps(payload), content_type="application/json")
+
+    def _bare_message_id(self) -> str:
+        # Mailgun's event payloads carry message-id without the RFC 5322 angle
+        # brackets the outbox stores, so posting the bare form also covers
+        # normalization on every test.
+        return self.outbox.message_id.strip("<>")
+
+    def _badge(self) -> str | None:
+        self.comment.refresh_from_db()
+        return (self.comment.item_context or {}).get("email_delivery_status")
+
+    def _rows(self) -> Any:
+        return EmailDeliveryEvent.objects.for_team(self.team.id)
+
+    @PATCH_SIGNING_KEY
+    def test_rejects_forged_signature(self, _mock_key: MagicMock):
+        response = self._post(_payload(self._bare_message_id(), key="attacker-key"))
+
+        assert response.status_code == 403
+        assert self._rows().count() == 0
+        assert self._badge() == "sent"
+
+    @PATCH_SIGNING_KEY
+    def test_rejects_replay_outside_freshness_window(self, _mock_key: MagicMock):
+        payload = _payload(self._bare_message_id())
+        stale = str(int(time.time()) - 3600)
+        payload["signature"] = {"timestamp": stale, "token": "tok", "signature": _sign(stale, "tok")}
+
+        response = self._post(payload)
+
+        assert response.status_code == 403
+        assert self._rows().count() == 0
+
+    @parameterized.expand(
+        [
+            ("delivered_primary", "delivered", None, "customer@example.com", "delivered"),
+            ("permanent_fail_primary", "failed", "permanent", "customer@example.com", "failed"),
+            ("temporary_fail_primary", "failed", "temporary", "customer@example.com", "sent"),
+            ("complained_primary", "complained", None, "customer@example.com", "sent"),
+            ("delivered_cc_only", "delivered", None, "cc@example.com", "sent"),
+        ]
+    )
+    @PATCH_SIGNING_KEY
+    def test_event_recorded_and_badge_updated(
+        self,
+        _name: str,
+        event: str,
+        severity: str | None,
+        recipient: str,
+        expected_badge: str,
+        _mock_key: MagicMock,
+    ):
+        extra = {"severity": severity} if severity else {}
+        response = self._post(_payload(self._bare_message_id(), event=event, recipient=recipient, **extra))
+
+        assert response.status_code == 200
+        row = self._rows().get()
+        assert row.event == event
+        assert row.severity == (severity or "")
+        assert row.recipient == recipient
+        assert row.message_id == self.outbox.message_id
+        assert row.ticket_id == self.ticket.id
+        assert row.comment_id == self.comment.id
+        assert self._badge() == expected_badge
+
+    @PATCH_SIGNING_KEY
+    def test_failure_reason_captured(self, _mock_key: MagicMock):
+        response = self._post(
+            _payload(
+                self._bare_message_id(),
+                event="failed",
+                severity="permanent",
+                reason="bounce",
+                **{"delivery-status": {"code": 550, "description": "mailbox unavailable"}},
+            )
+        )
+
+        assert response.status_code == 200
+        row = self._rows().get()
+        assert "bounce" in row.reason
+        assert "mailbox unavailable" in row.reason
+        assert "code=550" in row.reason
+
+    @PATCH_SIGNING_KEY
+    def test_duplicate_event_id_stored_once(self, _mock_key: MagicMock):
+        payload = _payload(self._bare_message_id(), event_id="evt-dup-1")
+
+        assert self._post(payload).status_code == 200
+        assert self._post(payload).status_code == 200
+        assert self._rows().count() == 1
+
+    @PATCH_SIGNING_KEY
+    def test_unmatched_message_id_returns_200_without_row(self, _mock_key: MagicMock):
+        response = self._post(_payload(f"{uuid4().hex}@unknown.example.com"))
+
+        assert response.status_code == 200
+        assert self._rows().count() == 0
+
+    @PATCH_SIGNING_KEY
+    def test_untracked_event_type_ignored(self, _mock_key: MagicMock):
+        response = self._post(_payload(self._bare_message_id(), event="opened"))
+
+        assert response.status_code == 200
+        assert self._rows().count() == 0
+
+    @PATCH_SIGNING_KEY
+    def test_malformed_json_returns_400(self, _mock_key: MagicMock):
+        response = self.client.post(ENDPOINT, data="not-json", content_type="application/json")
+
+        assert response.status_code == 400
+        assert self._rows().count() == 0

--- a/products/conversations/backend/api/tests/test_email_delivery_events.py
+++ b/products/conversations/backend/api/tests/test_email_delivery_events.py
@@ -35,6 +35,7 @@ def _payload(
     recipient: str = "customer@example.com",
     event_id: str | None = None,
     key: str = SIGNING_KEY,
+    delivery_status: dict[str, Any] | None = None,
     **event_fields: Any,
 ) -> dict:
     timestamp = str(int(time.time()))
@@ -47,6 +48,8 @@ def _payload(
         "message": {"headers": {"message-id": message_id}},
         **event_fields,
     }
+    if delivery_status is not None:
+        event_data["delivery-status"] = delivery_status
     return {
         "signature": {"timestamp": timestamp, "token": token, "signature": _sign(timestamp, token, key)},
         "event-data": event_data,
@@ -163,7 +166,7 @@ class TestEmailDeliveryEventsWebhook(BaseTest):
                 event="failed",
                 severity="permanent",
                 reason="bounce",
-                **{"delivery-status": {"code": 550, "description": "mailbox unavailable"}},
+                delivery_status={"code": 550, "description": "mailbox unavailable"},
             )
         )
 

--- a/products/conversations/backend/api/tests/test_email_delivery_events.py
+++ b/products/conversations/backend/api/tests/test_email_delivery_events.py
@@ -35,8 +35,9 @@ def _payload(
     recipient: str = "customer@example.com",
     event_id: str | None = None,
     key: str = SIGNING_KEY,
+    severity: str | None = None,
+    reason: str | None = None,
     delivery_status: dict[str, Any] | None = None,
-    **event_fields: Any,
 ) -> dict:
     timestamp = str(int(time.time()))
     token = uuid4().hex
@@ -46,8 +47,11 @@ def _payload(
         "timestamp": time.time(),
         "recipient": recipient,
         "message": {"headers": {"message-id": message_id}},
-        **event_fields,
     }
+    if severity is not None:
+        event_data["severity"] = severity
+    if reason is not None:
+        event_data["reason"] = reason
     if delivery_status is not None:
         event_data["delivery-status"] = delivery_status
     return {
@@ -145,8 +149,7 @@ class TestEmailDeliveryEventsWebhook(BaseTest):
         expected_badge: str,
         _mock_key: MagicMock,
     ):
-        extra = {"severity": severity} if severity else {}
-        response = self._post(_payload(self._bare_message_id(), event=event, recipient=recipient, **extra))
+        response = self._post(_payload(self._bare_message_id(), event=event, recipient=recipient, severity=severity))
 
         assert response.status_code == 200
         row = self._rows().get()

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -1808,3 +1808,91 @@ class TestEmailSendTestView(BaseTest):
 
         self.config.refresh_from_db()
         assert self.config.domain_verified is False
+
+
+class TestEmailDeliveryWebhookRegistration(BaseTest):
+    """Delivery webhooks (proof of delivery) must be registered whenever a domain
+    becomes usable, and their registration must never break connect/verify."""
+
+    def setUp(self):
+        super().setUp()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        self.client.force_login(self.user)
+        self.config = EmailChannel.objects.create(
+            team=self.team,
+            inbound_token="b" * 32,
+            from_email="support@ex.com",
+            from_name="Support",
+            domain="ex.com",
+            domain_verified=False,
+        )
+
+    def _verify(self):
+        return self.client.post(
+            "/api/conversations/v1/email/verify-domain",
+            {"config_id": str(self.config.id)},
+            content_type="application/json",
+        )
+
+    @parameterized.expand(
+        [
+            ("active_domain_syncs", "active", 1),
+            ("unverified_domain_skips", "unverified", 0),
+        ]
+    )
+    @patch("products.conversations.backend.api.email_settings.mailgun_sync_delivery_webhooks")
+    @patch("products.conversations.backend.api.email_settings.mailgun_verify_domain")
+    def test_verify_domain_syncs_webhooks_only_when_active(
+        self,
+        _name: str,
+        state: str,
+        expected_sync_calls: int,
+        mock_verify: MagicMock,
+        mock_sync: MagicMock,
+    ):
+        mock_verify.return_value = {"state": state, "sending_dns_records": []}
+
+        response = self._verify()
+
+        assert response.status_code == 200
+        assert mock_sync.call_count == expected_sync_calls
+        if expected_sync_calls:
+            domain_arg, url_arg = mock_sync.call_args.args
+            assert domain_arg == "ex.com"
+            assert url_arg.endswith("/api/conversations/v1/email/events")
+
+    @patch(
+        "products.conversations.backend.api.email_settings.mailgun_sync_delivery_webhooks",
+        side_effect=Exception("mailgun down"),
+    )
+    @patch(
+        "products.conversations.backend.api.email_settings.mailgun_verify_domain",
+        return_value={"state": "active", "sending_dns_records": []},
+    )
+    def test_verify_domain_survives_webhook_sync_failure(self, _mock_verify: MagicMock, _mock_sync: MagicMock):
+        response = self._verify()
+
+        assert response.status_code == 200
+        assert response.json()["domain_verified"] is True
+        self.config.refresh_from_db()
+        assert self.config.domain_verified is True
+
+    @patch("products.conversations.backend.api.email_settings.mailgun_sync_delivery_webhooks")
+    @patch("products.conversations.backend.api.email_settings.mailgun_add_domain", return_value={})
+    @patch(
+        "products.conversations.backend.api.email_settings.get_instance_setting",
+        return_value="mg.posthog.com",
+    )
+    def test_connect_syncs_webhooks_for_new_domain(
+        self, _mock_setting: MagicMock, _mock_add: MagicMock, mock_sync: MagicMock
+    ):
+        response = self.client.post(
+            "/api/conversations/v1/email/connect",
+            {"from_email": "help@newdomain.com", "from_name": "Help"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        mock_sync.assert_called_once()
+        assert mock_sync.call_args.args[0] == "newdomain.com"

--- a/products/conversations/backend/api/tests/test_mailgun.py
+++ b/products/conversations/backend/api/tests/test_mailgun.py
@@ -211,7 +211,7 @@ class TestSyncDeliveryWebhooks:
         assert all(call.kwargs["data"]["url"] == WEBHOOK_URL for call in mock_post.call_args_list)
         mock_put.assert_not_called()
 
-    def test_updates_webhook_pointing_elsewhere(
+    def test_appends_to_webhook_pointing_elsewhere(
         self, mock_get: MagicMock, mock_post: MagicMock, mock_put: MagicMock, _mock_key: MagicMock
     ):
         mock_get.return_value = _mailgun_response(
@@ -224,7 +224,8 @@ class TestSyncDeliveryWebhooks:
 
         assert mock_put.call_count == 1
         assert "/domains/example.com/webhooks/delivered" in mock_put.call_args.args[0]
-        assert mock_put.call_args.kwargs["data"] == {"url": WEBHOOK_URL}
+        # Existing callbacks are preserved — ours is appended, not substituted.
+        assert mock_put.call_args.kwargs["data"] == [("url", "https://old.example.com/hook"), ("url", WEBHOOK_URL)]
         posted = {call.kwargs["data"]["id"] for call in mock_post.call_args_list}
         assert posted == set(DELIVERY_WEBHOOK_TYPES) - {"delivered"}
 

--- a/products/conversations/backend/api/tests/test_mailgun.py
+++ b/products/conversations/backend/api/tests/test_mailgun.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import requests
 
 from products.conversations.backend.mailgun import (
+    DELIVERY_WEBHOOK_TYPES,
     MailgunDomainConflict,
     MailgunDomainNotRegistered,
     MailgunNotConfigured,
@@ -12,6 +13,7 @@ from products.conversations.backend.mailgun import (
     add_domain,
     get_domain,
     send_mime,
+    sync_delivery_webhooks,
 )
 
 
@@ -186,3 +188,54 @@ class TestSendMime:
 
         with pytest.raises(MailgunTransientError):
             send_mime("example.com", self.MIME, recipients=self.RECIPIENTS)
+
+
+WEBHOOK_URL = "https://us.posthog.com/api/conversations/v1/email/events"
+
+
+@patch("products.conversations.backend.mailgun.get_instance_setting", return_value="fake-api-key")
+@patch("products.conversations.backend.mailgun.requests.put")
+@patch("products.conversations.backend.mailgun.requests.post")
+@patch("products.conversations.backend.mailgun.requests.get")
+class TestSyncDeliveryWebhooks:
+    def test_registers_all_missing_webhooks(
+        self, mock_get: MagicMock, mock_post: MagicMock, mock_put: MagicMock, _mock_key: MagicMock
+    ):
+        mock_get.return_value = _mailgun_response(200, {"webhooks": {}})
+        mock_post.return_value = _mailgun_response(200, {})
+
+        sync_delivery_webhooks("example.com", WEBHOOK_URL)
+
+        posted = {call.kwargs["data"]["id"] for call in mock_post.call_args_list}
+        assert posted == set(DELIVERY_WEBHOOK_TYPES)
+        assert all(call.kwargs["data"]["url"] == WEBHOOK_URL for call in mock_post.call_args_list)
+        mock_put.assert_not_called()
+
+    def test_updates_webhook_pointing_elsewhere(
+        self, mock_get: MagicMock, mock_post: MagicMock, mock_put: MagicMock, _mock_key: MagicMock
+    ):
+        mock_get.return_value = _mailgun_response(
+            200, {"webhooks": {"delivered": {"urls": ["https://old.example.com/hook"]}}}
+        )
+        mock_post.return_value = _mailgun_response(200, {})
+        mock_put.return_value = _mailgun_response(200, {})
+
+        sync_delivery_webhooks("example.com", WEBHOOK_URL)
+
+        assert mock_put.call_count == 1
+        assert "/domains/example.com/webhooks/delivered" in mock_put.call_args.args[0]
+        assert mock_put.call_args.kwargs["data"] == {"url": WEBHOOK_URL}
+        posted = {call.kwargs["data"]["id"] for call in mock_post.call_args_list}
+        assert posted == set(DELIVERY_WEBHOOK_TYPES) - {"delivered"}
+
+    def test_skips_webhooks_already_aligned(
+        self, mock_get: MagicMock, mock_post: MagicMock, mock_put: MagicMock, _mock_key: MagicMock
+    ):
+        mock_get.return_value = _mailgun_response(
+            200, {"webhooks": {name: {"urls": [WEBHOOK_URL]} for name in DELIVERY_WEBHOOK_TYPES}}
+        )
+
+        sync_delivery_webhooks("example.com", WEBHOOK_URL)
+
+        mock_post.assert_not_called()
+        mock_put.assert_not_called()

--- a/products/conversations/backend/api/urls.py
+++ b/products/conversations/backend/api/urls.py
@@ -2,6 +2,7 @@
 
 from django.urls import path, re_path
 
+from .email_delivery_events import email_delivery_event_handler
 from .email_events import email_inbound_handler
 from .email_settings import (
     EmailConnectView,
@@ -54,6 +55,7 @@ urlpatterns = [
     re_path(r"^v1/teams/select-channel/?$", TeamsSelectChannelView.as_view(), name="teams-select-channel"),
     # Email channel
     re_path(r"^v1/email/inbound/?$", email_inbound_handler, name="email-inbound"),
+    re_path(r"^v1/email/events/?$", email_delivery_event_handler, name="email-delivery-events"),
     re_path(r"^v1/email/status/?$", EmailStatusView.as_view(), name="email-status"),
     re_path(r"^v1/email/connect/?$", EmailConnectView.as_view(), name="email-connect"),
     re_path(r"^v1/email/disconnect/?$", EmailDisconnectView.as_view(), name="email-disconnect"),

--- a/products/conversations/backend/mailgun.py
+++ b/products/conversations/backend/mailgun.py
@@ -5,6 +5,8 @@ import time
 import hashlib
 from typing import Any
 
+from django.conf import settings
+
 import requests
 import structlog
 
@@ -17,6 +19,11 @@ MAILGUN_API_BASE = "https://api.mailgun.net/v3"
 WEBHOOK_TIMESTAMP_MAX_AGE_SECONDS = 300  # 5 minutes
 
 MAILGUN_SEND_TIMEOUT = 30  # seconds
+
+# Webhook names in Mailgun's registration API. permanent_fail/temporary_fail both
+# arrive as event "failed", distinguished by event-data.severity. Opens/clicks are
+# force-disabled at send time, so only delivery-outcome webhooks are registered.
+DELIVERY_WEBHOOK_TYPES = ("delivered", "permanent_fail", "temporary_fail", "complained")
 
 
 class MailgunError(Exception):
@@ -276,3 +283,58 @@ def send_mime(domain: str, mime_bytes: bytes, recipients: list[str]) -> str:
         body=body_snippet,
     )
     raise MailgunPermanentError(f"Mailgun {status}: {body_snippet}")
+
+
+def delivery_webhook_url() -> str:
+    """Where Mailgun should POST delivery events for domains owned by this instance.
+
+    Delivery webhooks are per-domain (unlike the account-global inbound route), so
+    each region registers its own domains against its own SITE_URL and events land
+    in the region that owns the sending team.
+    """
+    return f"{settings.SITE_URL}/api/conversations/v1/email/events"
+
+
+def get_webhooks(domain: str) -> dict[str, Any]:
+    """Fetch the webhooks registered for a domain, keyed by webhook name."""
+    resp = requests.get(
+        f"{MAILGUN_API_BASE}/domains/{domain}/webhooks",
+        auth=("api", _get_api_key()),
+        timeout=15,
+    )
+    resp.raise_for_status()
+    return resp.json().get("webhooks") or {}
+
+
+def sync_delivery_webhooks(domain: str, webhook_url: str) -> None:
+    """Idempotently point the domain's delivery webhooks at webhook_url.
+
+    Mailgun signs every webhook POST with the account's HTTP webhook signing key
+    (HMAC-SHA256 over timestamp+token, validated by validate_webhook_signature),
+    so registering these is what completes the proof-of-delivery loop for
+    outbound ticket replies. Safe to call repeatedly: already-aligned webhooks
+    are left untouched, ones pointing elsewhere are updated in place.
+    """
+    api_key = _get_api_key()
+    existing = get_webhooks(domain)
+
+    for name in DELIVERY_WEBHOOK_TYPES:
+        urls = (existing.get(name) or {}).get("urls") or []
+        if webhook_url in urls:
+            continue
+        if urls:
+            resp = requests.put(
+                f"{MAILGUN_API_BASE}/domains/{domain}/webhooks/{name}",
+                auth=("api", api_key),
+                data={"url": webhook_url},
+                timeout=15,
+            )
+        else:
+            resp = requests.post(
+                f"{MAILGUN_API_BASE}/domains/{domain}/webhooks",
+                auth=("api", api_key),
+                data={"id": name, "url": webhook_url},
+                timeout=15,
+            )
+        resp.raise_for_status()
+        logger.info("mailgun_delivery_webhook_synced", domain=domain, webhook=name)

--- a/products/conversations/backend/mailgun.py
+++ b/products/conversations/backend/mailgun.py
@@ -313,7 +313,8 @@ def sync_delivery_webhooks(domain: str, webhook_url: str) -> None:
     (HMAC-SHA256 over timestamp+token, validated by validate_webhook_signature),
     so registering these is what completes the proof-of-delivery loop for
     outbound ticket replies. Safe to call repeatedly: already-aligned webhooks
-    are left untouched, ones pointing elsewhere are updated in place.
+    are left untouched. Mailgun supports multiple URLs per webhook, so a webhook
+    pointing elsewhere gets ours appended rather than replacing existing callbacks.
     """
     api_key = _get_api_key()
     existing = get_webhooks(domain)
@@ -326,7 +327,7 @@ def sync_delivery_webhooks(domain: str, webhook_url: str) -> None:
             resp = requests.put(
                 f"{MAILGUN_API_BASE}/domains/{domain}/webhooks/{name}",
                 auth=("api", api_key),
-                data={"url": webhook_url},
+                data=[("url", u) for u in [*urls, webhook_url]],
                 timeout=15,
             )
         else:

--- a/products/conversations/backend/management/commands/sync_email_delivery_webhooks.py
+++ b/products/conversations/backend/management/commands/sync_email_delivery_webhooks.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from products.conversations.backend.mailgun import delivery_webhook_url, sync_delivery_webhooks
+from products.conversations.backend.models import EmailChannel
+
+
+class Command(BaseCommand):
+    help = (
+        "Register Mailgun delivery-event webhooks (proof of delivery) for every verified "
+        "conversations email domain. Connect/verify flows sync webhooks going forward; "
+        "this backfills domains verified before delivery tracking existed."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--dry-run", action="store_true", help="List domains without calling Mailgun")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        webhook_url = delivery_webhook_url()
+        domains = (
+            EmailChannel.objects.filter(domain_verified=True)
+            .order_by("domain")
+            .values_list("domain", flat=True)
+            .distinct()
+        )
+
+        self.stdout.write(f"Syncing delivery webhooks for {len(domains)} domain(s) -> {webhook_url}")
+        for domain in domains:
+            if options["dry_run"]:
+                self.stdout.write(f"would sync {domain}")
+                continue
+            try:
+                sync_delivery_webhooks(domain, webhook_url)
+                self.stdout.write(self.style.SUCCESS(f"synced {domain}"))
+            except Exception as e:
+                self.stderr.write(self.style.ERROR(f"failed {domain}: {e}"))

--- a/products/conversations/backend/migrations/0047_email_delivery_event.py
+++ b/products/conversations/backend/migrations/0047_email_delivery_event.py
@@ -1,0 +1,72 @@
+import django.utils.timezone
+import django.db.models.deletion
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("conversations", "0046_ticket_org_id_indexes"),
+        ("posthog", "1251_alter_integration_kind"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EmailDeliveryEvent",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                ("message_id", models.CharField(max_length=255)),
+                ("recipient", models.CharField(max_length=254)),
+                (
+                    "event",
+                    models.CharField(
+                        choices=[
+                            ("delivered", "Delivered"),
+                            ("failed", "Failed"),
+                            ("complained", "Complained"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "severity",
+                    models.CharField(
+                        blank=True,
+                        choices=[("permanent", "Permanent"), ("temporary", "Temporary")],
+                        default="",
+                        max_length=20,
+                    ),
+                ),
+                ("reason", models.TextField(blank=True, default="")),
+                ("provider_event_id", models.CharField(max_length=128, unique=True)),
+                ("occurred_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "comment",
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="posthog.comment"),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        db_constraint=False, on_delete=django.db.models.deletion.CASCADE, to="posthog.team"
+                    ),
+                ),
+                (
+                    "ticket",
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="conversations.ticket"),
+                ),
+            ],
+            options={
+                "db_table": "posthog_conversations_email_delivery_event",
+                "indexes": [
+                    models.Index(fields=["team", "ticket", "-created_at"], name="posthog_con_delivery_tkt_idx")
+                ],
+            },
+        ),
+    ]

--- a/products/conversations/backend/migrations/0048_outbox_message_id_index.py
+++ b/products/conversations/backend/migrations/0048_outbox_message_id_index.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [("conversations", "0047_email_delivery_event")]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="emailoutboxmessage",
+            index=models.Index(fields=["message_id"], name="posthog_con_outbox_msgid_idx"),
+        ),
+    ]

--- a/products/conversations/backend/migrations/max_migration.txt
+++ b/products/conversations/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0046_ticket_org_id_indexes
+0048_outbox_message_id_index

--- a/products/conversations/backend/models/__init__.py
+++ b/products/conversations/backend/models/__init__.py
@@ -1,5 +1,6 @@
 from .assignment import TicketAssignment
 from .constants import Channel, ChannelDetail, Priority, RuleType, Status
+from .email_delivery_event import EmailDeliveryEvent
 from .email_message_mapping import EmailMessageMapping
 from .email_outbox_message import EmailOutboxMessage
 from .github_comment_mapping import GithubCommentMapping
@@ -17,6 +18,7 @@ __all__ = [
     "ChannelDetail",
     "ConversationRestoreToken",
     "EmailChannel",
+    "EmailDeliveryEvent",
     "EmailMessageMapping",
     "EmailOutboxMessage",
     "GithubCommentMapping",

--- a/products/conversations/backend/models/email_delivery_event.py
+++ b/products/conversations/backend/models/email_delivery_event.py
@@ -1,0 +1,57 @@
+from django.db import models
+from django.utils import timezone
+
+from posthog.models.scoping.root_mixin import TeamScopedRootMixin
+from posthog.models.utils import UUIDModel
+
+from .ticket import Ticket
+
+
+class EmailDeliveryEvent(TeamScopedRootMixin, UUIDModel):
+    """Per-recipient delivery outcome for an outbound ticket email, as reported
+    by Mailgun's delivery webhooks.
+
+    ``EmailOutboxMessage.status = sent`` only proves Mailgun's API accepted the
+    message; rows here are the proof of what happened to each envelope recipient
+    after acceptance. One row per Mailgun event, deduplicated on Mailgun's
+    globally unique event id so webhook retries and replays are idempotent.
+    """
+
+    class Event(models.TextChoices):
+        DELIVERED = "delivered", "Delivered"
+        FAILED = "failed", "Failed"
+        COMPLAINED = "complained", "Complained"
+
+    class Severity(models.TextChoices):
+        PERMANENT = "permanent", "Permanent"
+        TEMPORARY = "temporary", "Temporary"
+
+    # db_constraint=False: a real FK constraint would take SHARE ROW EXCLUSIVE on the
+    # hot posthog_team table on CreateModel. App-level enforcement is enough here.
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, db_constraint=False)
+    ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE)
+    comment = models.ForeignKey("posthog.Comment", on_delete=models.CASCADE)
+
+    # Message-ID of the outbound email, normalized to the angle-bracketed form
+    # stored on EmailOutboxMessage.message_id.
+    message_id = models.CharField(max_length=255)
+    recipient = models.CharField(max_length=254)
+    event = models.CharField(max_length=20, choices=Event.choices)
+    # Only set for failed events: permanent (bounce) vs temporary (still retrying).
+    severity = models.CharField(max_length=20, choices=Severity.choices, blank=True, default="")
+    reason = models.TextField(blank=True, default="")
+
+    # Mailgun's globally unique event id — the idempotency key across webhook retries.
+    provider_event_id = models.CharField(max_length=128, unique=True)
+    occurred_at = models.DateTimeField(default=timezone.now)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        app_label = "conversations"
+        db_table = "posthog_conversations_email_delivery_event"
+        indexes = [
+            models.Index(fields=["team", "ticket", "-created_at"], name="posthog_con_delivery_tkt_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"EmailDeliveryEvent({self.event} -> {self.recipient}, message_id={self.message_id})"

--- a/products/conversations/backend/models/email_outbox_message.py
+++ b/products/conversations/backend/models/email_outbox_message.py
@@ -49,6 +49,8 @@ class EmailOutboxMessage(UUIDModel):
         indexes = [
             # Sweeper query: pending rows due for an attempt, oldest first.
             models.Index(fields=["status", "next_attempt_at"], name="posthog_con_outbox_due_idx"),
+            # Delivery-event webhook lookup by Message-ID.
+            models.Index(fields=["message_id"], name="posthog_con_outbox_msgid_idx"),
         ]
 
     def __str__(self) -> str:

--- a/products/conversations/backend/services/delivery_status.py
+++ b/products/conversations/backend/services/delivery_status.py
@@ -1,0 +1,26 @@
+from uuid import UUID
+
+from django.db import models
+from django.db.models.fields.json import JSONField
+from django.db.models.functions import Coalesce
+
+from posthog.models.comment import Comment
+
+
+def set_comment_delivery_status(team_id: int, comment_id: UUID, status_value: str) -> None:
+    """Denormalize delivery status onto the comment's item_context so the agent UI can
+    show a sending/delivered/failed badge. Uses a queryset update to avoid re-firing
+    Comment signals.
+
+    Merges at the DB level (JSONB ``||``) rather than read-modify-write: a concurrent
+    edit to another key (e.g. an agent flipping ``is_private``) must not be clobbered.
+    The dict values flow through ORM ``Value`` params, so this is fully parameterized.
+    """
+    merged = models.Func(
+        Coalesce("item_context", models.Value({}, output_field=JSONField())),
+        models.Value({"email_delivery_status": status_value}, output_field=JSONField()),
+        template="%(expressions)s",
+        arg_joiner=" || ",
+        output_field=JSONField(),
+    )
+    Comment.objects.filter(id=comment_id, team_id=team_id).update(item_context=merged)

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -12,8 +12,6 @@ from django.core import mail
 from django.core.cache import cache
 from django.db import IntegrityError, models, transaction
 from django.db.models import F
-from django.db.models.fields.json import JSONField
-from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 import requests
@@ -56,6 +54,7 @@ from products.conversations.backend.models import (
 from products.conversations.backend.models.constants import Channel, ChannelDetail, Status
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
+from products.conversations.backend.services.delivery_status import set_comment_delivery_status
 from products.conversations.backend.slack import (
     TICKET_CONFIRM_ACTION_DISMISS,
     TICKET_CONFIRM_ACTION_OPEN,
@@ -620,24 +619,6 @@ EMAIL_OUTBOX_MAX_AGE = timedelta(days=5)  # give up past this (comfortably > a F
 EMAIL_OUTBOX_FLUSH_BATCH_SIZE = 100
 
 
-def _set_comment_delivery_status(team_id: int, comment_id: UUID, status_value: str) -> None:
-    """Denormalize delivery status onto the comment's item_context so the agent UI can
-    show a sending/failed badge. Uses a queryset update to avoid re-firing Comment signals.
-
-    Merges at the DB level (JSONB ``||``) rather than read-modify-write: a concurrent
-    edit to another key (e.g. an agent flipping ``is_private``) must not be clobbered.
-    The dict values flow through ORM ``Value`` params, so this is fully parameterized.
-    """
-    merged = models.Func(
-        Coalesce("item_context", models.Value({}, output_field=JSONField())),
-        models.Value({"email_delivery_status": status_value}, output_field=JSONField()),
-        template="%(expressions)s",
-        arg_joiner=" || ",
-        output_field=JSONField(),
-    )
-    CommentModel.objects.filter(id=comment_id, team_id=team_id).update(item_context=merged)
-
-
 def _mark_outbox_sent(outbox: EmailOutboxMessage) -> None:
     outbox.status = EmailOutboxMessage.Status.SENT
     outbox.sent_at = timezone.now()
@@ -653,7 +634,7 @@ def _mark_outbox_sent(outbox: EmailOutboxMessage) -> None:
         )
     except Exception:
         logger.exception("email_reply_mapping_failed", outbox_id=str(outbox.id), message_id=outbox.message_id)
-    _set_comment_delivery_status(outbox.team_id, outbox.comment_id, "sent")
+    set_comment_delivery_status(outbox.team_id, outbox.comment_id, "sent")
 
 
 def _mark_outbox_failed(outbox: EmailOutboxMessage, error: str) -> None:
@@ -661,7 +642,7 @@ def _mark_outbox_failed(outbox: EmailOutboxMessage, error: str) -> None:
     outbox.last_error = error[:2000]
     outbox.locked_until = None
     outbox.save(update_fields=["status", "last_error", "locked_until", "updated_at"])
-    _set_comment_delivery_status(outbox.team_id, outbox.comment_id, "failed")
+    set_comment_delivery_status(outbox.team_id, outbox.comment_id, "failed")
 
 
 def _schedule_outbox_retry(outbox: EmailOutboxMessage, error: str) -> None:
@@ -674,7 +655,7 @@ def _schedule_outbox_retry(outbox: EmailOutboxMessage, error: str) -> None:
     outbox.last_error = error[:2000]
     outbox.locked_until = None
     outbox.save(update_fields=["attempts", "next_attempt_at", "last_error", "locked_until", "updated_at"])
-    _set_comment_delivery_status(outbox.team_id, outbox.comment_id, "sending")
+    set_comment_delivery_status(outbox.team_id, outbox.comment_id, "sending")
 
 
 def _process_outbox_row(outbox: EmailOutboxMessage) -> None:

--- a/products/conversations/frontend/components/Chat/Message.tsx
+++ b/products/conversations/frontend/components/Chat/Message.tsx
@@ -197,6 +197,10 @@ export function Message({
                                 </Tooltip>
                             ) : message.emailDeliveryStatus === 'sending' ? (
                                 <span className="text-xs text-muted-alt">Sending…</span>
+                            ) : message.emailDeliveryStatus === 'delivered' ? (
+                                <Tooltip title="Mailgun confirmed delivery to the recipient's mail server.">
+                                    <span className="text-xs text-muted-alt">Delivered</span>
+                                </Tooltip>
                             ) : (
                                 deliveryStatus && (
                                     <span className="text-xs text-muted-alt">

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -188,8 +188,10 @@ export interface MessageAuthor {
     email?: string
 }
 
-/** Delivery state of an outbound email reply, denormalized from the backend outbox. */
-export type EmailDeliveryStatus = 'sending' | 'sent' | 'failed'
+/** Delivery state of an outbound email reply, denormalized from the backend outbox.
+ * 'sent' means Mailgun accepted the message; 'delivered' means Mailgun confirmed
+ * delivery to the customer's mailbox via webhook. */
+export type EmailDeliveryStatus = 'sending' | 'sent' | 'delivered' | 'failed'
 
 export interface ChatMessage {
     id: string


### PR DESCRIPTION
## Problem

For email tickets, an outbound reply's "Sent" state only means Mailgun's API accepted the message — we had no record of whether it actually reached the customer's mailbox. A hard bounce, a spam complaint, or a silently-retrying deferral all looked identical to a successful delivery, both in the DB and in the agent UI. Support agents couldn't answer "did the customer get my reply?".

## Changes

- New `/api/conversations/v1/email/events` webhook consumes Mailgun delivery events (`delivered`, `failed` permanent/temporary, `complained`), authenticated exactly per [Mailgun's webhook security FAQ](https://documentation.mailgun.com/docs/mailgun/faq/receiving#how-do-i-know-if-http-post-callbacks-are-coming-from-mailgun-and-not-forged): HMAC-SHA256 over `timestamp+token` with the signing key, constant-time compare, 5-minute freshness window. Replays are handled by idempotency on Mailgun's globally unique event id rather than a token cache, so Mailgun's legitimate retries aren't dropped.
- New `EmailDeliveryEvent` model stores one row per recipient outcome, joined back to the ticket/comment via the outbound `Message-ID` already stored on `EmailOutboxMessage`.
- Delivery webhooks are registered per sending domain: automatically on email channel connect and on successful domain verify (best-effort, never fails the request), plus a `sync_email_delivery_webhooks` management command to backfill already-verified domains.
- The primary recipient's outcome updates the reply badge in the ticket UI: `sent` → `delivered` on confirmation, → `failed` on a permanent bounce. Cc outcomes are recorded but don't drive the badge.

```mermaid
flowchart LR
    A[Agent reply] --> O[Outbox] --> M{{Mailgun API}} --> S[badge: Sent]
    S -.->|mailbox outcome unknown| X[?]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,O phBlue; class M phRed; class S,X phGray;
```

```mermaid
flowchart LR
    M{{Mailgun}} -->|delivery webhook| V[HMAC verify] --> E[EmailDeliveryEvent] --> B[badge: Delivered / Failed]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class V phBlue; class M phRed; class B phYellow; class E phGray;
```

> [!NOTE]
> Migrations: `0047` creates the new table (`db_constraint=False` on the team FK, so no lock on `posthog_team`); `0048` adds the `message_id` lookup index on the outbox via `SafeAddIndexConcurrently`.

## How did you test this code?

Automated tests only — no manual testing against a live Mailgun account was done.

- `test_mailgun.py` (27 passed locally): includes 3 new tests for idempotent webhook registration (register missing, update stale URL, skip aligned).
- `test_email_delivery_events.py` (new, 11 tests): forged-signature and stale-timestamp rejection using the real HMAC scheme (not mocked), per-event badge transitions (delivered / permanent / temporary / complained / cc-only), event-id dedup across webhook retries, bare-vs-bracketed `Message-ID` normalization, unmatched message ids, malformed JSON.
- `test_email_endpoints.py` (+4 tests): webhooks sync on connect and on active verify, skip on unverified, and connect/verify surviving a Mailgun outage during sync.
- `makemigrations --check` clean; migration SQL inspected (`CREATE INDEX CONCURRENTLY`, no team-table FK constraint).

All three suites are green locally (full stack: Postgres, Redis, ClickHouse + Keeper): `test_mailgun.py` 27 passed, `test_email_endpoints.py` 92 passed, `test_email_delivery_events.py` 12 passed. The endpoint tests caught one real bug before merge — a structlog `event=` kwarg collision that 500'd the webhook — fixed in the second commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No existing docs page covers the conversations email channel's delivery internals; instance-setting descriptions (`CONVERSATIONS_EMAIL_WEBHOOK_SIGNING_KEY`, `CONVERSATIONS_EMAIL_MAILGUN_API_KEY`) were updated in place.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by Claude (PostHog Code session) from Luke's request to add proof of delivery based on Mailgun's webhook-verification FAQ. Skills invoked: `/django-migrations`, `/writing-tests`, `/improving-drf-endpoints`.

Decisions along the way: matched events to replies via the stable `Message-ID` already on `EmailOutboxMessage` (no schema change to the send path); chose event-id idempotency over a token replay-cache since a cache would drop Mailgun's legitimate retries of requests we 5xx'd; kept `opened`/`clicked` out of scope because sends force-disable tracking rewrites; made webhook registration best-effort so a Mailgun hiccup can't fail connect/verify; badge reflects only the primary (To:) recipient because the agent-facing question is "did the customer get it".


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

