### PR TITLE
fix(cdp): store only error message, not stack, in invocation results

### DIFF
--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.test.ts
@@ -227,12 +227,12 @@ describe('HogInvocationResultsService', () => {
             expect(rows).toHaveLength(1)
             expect(rows[0].status).toBe('failed')
             expect(rows[0].error_kind).toBe('timeout')
-            // Only the message is persisted — never the stack trace. App-level
-            // executors assign the whole Error to result.error, so a regression
-            // to `error.stack` would leak Node internals (file paths, frames)
-            // into the Invocations tab.
+            // Exact match: only the message is persisted, never the stack.
+            // App-level executors assign the whole Error to result.error, so a
+            // regression to `error.stack` would make this the multi-line
+            // "Error: ...\n    at ..." string and leak Node internals into the
+            // Invocations tab.
             expect(rows[0].error_message).toBe('Request timed out after 30s')
-            expect(rows[0].error_message).not.toContain('    at ')
         })
 
         it('produces no row for an in-flight result that has not finished and has no error', async () => {

--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.test.ts
@@ -227,11 +227,7 @@ describe('HogInvocationResultsService', () => {
             expect(rows).toHaveLength(1)
             expect(rows[0].status).toBe('failed')
             expect(rows[0].error_kind).toBe('timeout')
-            // Exact match: only the message is persisted, never the stack.
-            // App-level executors assign the whole Error to result.error, so a
-            // regression to `error.stack` would make this the multi-line
-            // "Error: ...\n    at ..." string and leak Node internals into the
-            // Invocations tab.
+            // Exact match: the message only, never the stack trace.
             expect(rows[0].error_message).toBe('Request timed out after 30s')
         })
 

--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.test.ts
@@ -227,7 +227,12 @@ describe('HogInvocationResultsService', () => {
             expect(rows).toHaveLength(1)
             expect(rows[0].status).toBe('failed')
             expect(rows[0].error_kind).toBe('timeout')
-            expect(rows[0].error_message).toContain('timed out')
+            // Only the message is persisted — never the stack trace. App-level
+            // executors assign the whole Error to result.error, so a regression
+            // to `error.stack` would leak Node internals (file paths, frames)
+            // into the Invocations tab.
+            expect(rows[0].error_message).toBe('Request timed out after 30s')
+            expect(rows[0].error_message).not.toContain('    at ')
         })
 
         it('produces no row for an in-flight result that has not finished and has no error', async () => {

--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
@@ -122,7 +122,8 @@ const classifyError = (error: unknown): { kind: string; message: string } => {
         typeof error === 'string'
             ? error
             : error instanceof Error
-              ? error.message
+              ? // fall back to the error name so an empty message doesn't blank the row (without the stack)
+                error.message || error.name
               : (() => {
                     try {
                         return JSON.stringify(error)

--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
@@ -111,16 +111,9 @@ const truncate = (value: string, max: number): string => {
 }
 
 // Best-effort error classification — keeps `error_kind` low-cardinality so the
-// status_idx skipping index stays small.
-//
-// Only the error *message* lands in `error_message` — never the stack trace.
-// App-level executors (native destinations, legacy plugins, segment) assign the
-// whole caught `Error` to `result.error`, so a naive `error.stack` here would
-// persist Node internals (file paths, line numbers, interpolated values) to
-// ClickHouse for 30 days and render them unredacted in the Invocations tab.
-// This matches the message-only convention already used for `log_entries`
-// (`addLog('error', ...e.message)`). Errors thrown by the hog VM itself already
-// reach us as a message string, so their detail is preserved.
+// status_idx skipping index stays small. Only the message lands in
+// `error_message`, never the stack trace — app-level executors pass the whole
+// `Error` here, and its stack would otherwise leak into the Invocations tab.
 const classifyError = (error: unknown): { kind: string; message: string } => {
     if (!error) {
         return { kind: '', message: '' }

--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
@@ -111,8 +111,16 @@ const truncate = (value: string, max: number): string => {
 }
 
 // Best-effort error classification — keeps `error_kind` low-cardinality so the
-// status_idx skipping index stays small. The full message lands in
-// `error_message`, the full stack stays in log_entries.
+// status_idx skipping index stays small.
+//
+// Only the error *message* lands in `error_message` — never the stack trace.
+// App-level executors (native destinations, legacy plugins, segment) assign the
+// whole caught `Error` to `result.error`, so a naive `error.stack` here would
+// persist Node internals (file paths, line numbers, interpolated values) to
+// ClickHouse for 30 days and render them unredacted in the Invocations tab.
+// This matches the message-only convention already used for `log_entries`
+// (`addLog('error', ...e.message)`). Errors thrown by the hog VM itself already
+// reach us as a message string, so their detail is preserved.
 const classifyError = (error: unknown): { kind: string; message: string } => {
     if (!error) {
         return { kind: '', message: '' }
@@ -121,7 +129,7 @@ const classifyError = (error: unknown): { kind: string; message: string } => {
         typeof error === 'string'
             ? error
             : error instanceof Error
-              ? error.stack || error.message
+              ? error.message
               : (() => {
                     try {
                         return JSON.stringify(error)


### PR DESCRIPTION
## Problem

The function Invocations tab (filtered to failed) is showing full Node.js stack traces in the error detail. App-level executors — native destinations, legacy plugins, segment — assign the whole caught `Error` to `result.error`. `classifyError` then serialized `error.stack || error.message` into the `error_message` column on `hog_invocation_results`, which the tab renders unredacted in a `<pre>` block. That persists internal file paths, line numbers, and framework internals to ClickHouse for 30 days and surfaces them in the UI.

This is out of step with the "current logs" (`log_entries`), which already store message-only for these same failures (`addLog('error', ...e.message)`). The intent was already documented in a code comment on `classifyError` ("the full stack stays in log_entries") — but the implementation contradicted it, and the stack was in fact never in `log_entries`, only in `error_message`.

## Changes

`classifyError` now emits `error.message` for `Error` instances instead of falling back to `error.stack`. This is the single chokepoint both the invocation and rerun-wrapper rows route through, so it fixes every path at once.

Errors thrown by the hog VM itself already reach this code as a plain message string (the hog executor reduces to `err.message` before setting `result.error`), so hog-code error detail is unchanged — only app-level Error objects, which carried a stack, are affected. The `error_kind` classification (timeout / http_4xx / http_5xx / oom) is unchanged since it already derived from the message text.

> [!NOTE]
> The raw JS stack is now not persisted to any customer-facing surface (it was only ever in `error_message`, never in `log_entries`). That is intentional — internal file paths and framework frames belong in server logs, not the product. `error_kind` plus the message is what the tab needs.

Before / after in the function Invocations tab, same destination. The top row (fixed) stores just the message; the bottom row (old code) leaks `Error: … at HogExecutorService…`:

![Before and after in the Invocations tab](https://raw.githubusercontent.com/PostHog/pr-assets/6e8e20557d19236b96d0e6d8fa36c96f2d47ee96/2026/07/02bfde56-4a31-4975-80e1-ad4680c1713d.png)

Expanding the fixed invocation, the error detail is only the message — no stack, no internal file paths:

![After — expanded invocation detail shows message only](https://raw.githubusercontent.com/PostHog/pr-assets/f1c8b0e2ef75ae76d763f1f4973d8603bc155511/2026/07/183096b5-7607-42fa-9ae3-cae46ad9c597.png)

## How did you test this code?

Tightened the existing failed-invocation unit test to assert `error_message` is exactly the message and contains no stack-frame markers. The prior assertion (`toContain('timed out')`) passed whether the stack or the message was stored, so it did not catch this. Reverting to `error.stack` now fails that test.

I (Daniel) also verified the fix end to end on the local dev stack, driving Claude Code:

- Ran the Jest suite for `hog-invocation-results.service.test.ts` locally — 17/17 pass, including the tightened assertion.
- Drove real failing invocations through the running CDP worker and read the `hog_invocation_results` rows back from ClickHouse. Both error paths that previously stored a stack now store message-only:
  - `http_4xx` — a destination `fetch()` to a 401 endpoint.
  - `hog_error` — the self-referential ingest-loop guard tripping at max depth.
- Confirmed the same clean message renders in the Invocations (beta) tab in the UI.

Rows written before the fix are still in the table with their full stacks, so the before/after is visible side by side. Comparison of the real stored `error_message` values:

<details>
<summary>Before (old code, <code>error.stack</code>) vs after (this fix, <code>error.message</code>)</summary>

```
# http_4xx
before (~1066 chars):
  Error: HTTP fetch failed on attempt 1 with status code 405.
      at HogExecutorService.executeFetch (nodejs/src/cdp/services/hog-executor.service.ts:843:32)
      at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
      at async withSpan (nodejs/src/common/tracing/tracing-utils.ts:94:16)
      ... (full stack)
after (52 chars):
  HTTP fetch failed on attempt 1 with status code 401.

# hog_error (self-loop guard)
before (~1135 chars):
  Error: Self-referential event-forwarding loop blocked at max depth
      at HogExecutorService.executeFetch (nodejs/src/cdp/services/hog-executor.service.ts:805:40)
      ... (full stack)
after (59 chars):
  Self-referential event-forwarding loop blocked at max depth
```

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Flagged in a Slack thread: a glance at a function's Invocations tab showed failed entries including a full stack trace, with the suggestion that app-level thrown errors should store only the message (like `log_entries` already do) while hog-code errors keep more detail.

I traced the leak from the frontend (`HogInvocations.tsx` renders `error_message` raw) back through the `hog_invocation_results` write path to `classifyError` in `hog-invocation-results.service.ts`, and confirmed the hog-VM path already reduces to a message string while the app-level executors pass the whole `Error`. Fixed at the single `classifyError` chokepoint rather than at each executor. Invoked the `/writing-tests` skill before tightening the test.

Follow-up: Daniel verified the fix end to end on the local stack via Claude Code (Jest + real triggered invocations checked in ClickHouse for both `http_4xx` and `hog_error`, plus the Invocations UI) before this was marked ready. See "How did you test this code?".

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1783928582075459?thread_ts=1783928582.075459&cid=C06GG249PR6)*
