### PR TITLE
fix(braze): stop sending offset=0 which Braze rejects with 400

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braze/braze.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braze/braze.py
@@ -77,7 +77,11 @@ def _build_params(config: BrazeEndpointConfig, cursor: int, modified_after: str 
     if config.pagination == "page":
         params = {"page": cursor}
     else:
-        params = {"limit": config.page_size, "offset": cursor}
+        # Braze's offset endpoints reject offset=0 (offset must be a positive integer),
+        # so omit it on the first page — equivalent to skipping nothing.
+        params = {"limit": config.page_size}
+        if cursor:
+            params["offset"] = cursor
 
     if modified_after and config.modified_after_param:
         params[config.modified_after_param] = modified_after

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braze/tests/test_braze.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braze/tests/test_braze.py
@@ -78,6 +78,11 @@ class TestBuildParams:
         params = _build_params(BRAZE_ENDPOINTS["email_templates"], cursor=200, modified_after=None)
         assert params == {"limit": 100, "offset": 200}
 
+    def test_offset_omitted_on_first_page(self):
+        # Braze 400s on offset=0, so the first page must not carry an offset param.
+        params = _build_params(BRAZE_ENDPOINTS["email_templates"], cursor=0, modified_after=None)
+        assert params == {"limit": 100}
+
     def test_modified_after_added_only_for_incremental_endpoint(self):
         params = _build_params(BRAZE_ENDPOINTS["email_templates"], cursor=0, modified_after="2026-01-01T00:00:00+00:00")
         assert params["modified_after"] == "2026-01-01T00:00:00+00:00"
@@ -189,7 +194,8 @@ class TestGetRows:
         list(get_rows("key", BASE_URL, "email_templates", mock.MagicMock(), manager, team_id=1))
 
         urls = [call.args[0] for call in mock_session.return_value.get.call_args_list]
-        assert "offset=0" in urls[0]
+        # First page omits offset (Braze rejects offset=0); later pages advance by page size.
+        assert "offset=" not in urls[0]
         assert "limit=100" in urls[0]
         assert "offset=100" in urls[1]
 


### PR DESCRIPTION
## Problem

Braze imports of the offset-paginated endpoints (`email_templates` → `/templates/email/list`, `content_blocks` → `/content_blocks/list`) fail on the very first page with:

```
HTTPError: 400 Client Error: Bad Request for url: .../templates/email/list?limit=100&offset=0
```

Surfaced by error tracking: [issue 019f5a8f-3c4c-75a1-89ee-05f3da48d0a6](https://us.posthog.com/project/2/error_tracking/019f5a8f-3c4c-75a1-89ee-05f3da48d0a6). The failing frame is `fetch_page` in `braze.py` (`response.raise_for_status()`), reached through the normal import pipeline (`import_data_activity_sync` → `pipeline.run` → `braze.get_rows` → `fetch_page`).

Braze documents the `offset` param on these endpoints as a "Positive number", and its API rejects `offset=0` with a 400. Our pagination always started at `offset=0`, so the first request of every sync of those two endpoints was rejected. This is our bug, not a credential or account problem: the page-paginated endpoints (0-indexed `page`) are accepted and never showed up in the error.

> [!NOTE]
> Only the offset endpoints are affected. Page-paginated endpoints (campaigns, canvases, segments, events) send `page=0`, which Braze accepts.

## Changes

Omit `offset` on the first page of offset pagination (equivalent to skipping nothing), matching Braze's own guidance to leave `offset` off the first call. Later pages continue to advance by page size (`offset=100`, `200`, …).

```diff
-        params = {"limit": config.page_size, "offset": cursor}
+        params = {"limit": config.page_size}
+        if cursor:
+            params["offset"] = cursor
```

## How did you test this code?

I (Claude) couldn't run the suite in this environment — the local venv has no dependencies installed. The change is covered by unit tests, which CI will run:

- `TestBuildParams.test_offset_omitted_on_first_page` — new. Locks in that `cursor=0` produces `{"limit": 100}` with no `offset`. This is the exact regression that caused the 400; no existing test covered the first-page offset value.
- `TestGetRows.test_offset_pagination_advances_by_page_size` — updated. The first request no longer carries `offset=`, and later pages still advance (`offset=100`). Previously this asserted `offset=0` was present, which was the bug.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the Braze warehouse source. I (Claude) pulled the issue and a representative stack trace via the PostHog error-tracking tools, confirmed the failure originated in `braze.py`, cross-checked the Braze API docs for the offset endpoints, and concluded it was a fixable request-construction bug rather than a user/upstream error — so I fixed the code instead of extending `NonRetryableErrors` (which would have left the endpoints permanently broken). Invoked the `/writing-tests` skill before touching tests. Scoped strictly to the offset-pagination path; retry policy is unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
