### PR TITLE
feat(insights): add incomplete period toggle to slope graphs

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -12,6 +12,7 @@ import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { DEFAULT_DECIMAL_PLACES } from 'lib/utils/numbers'
 import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
 import { HideIncompleteConversionWindowPeriodsFilter } from 'scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter'
+import { HideIncompletePeriodsFilter } from 'scenes/insights/EditorFilters/HideIncompletePeriodsFilter'
 import { HideWeekendsFilter } from 'scenes/insights/EditorFilters/HideWeekendsFilter'
 import { LegendOptionsFilter } from 'scenes/insights/EditorFilters/LegendOptionsFilter'
 import { LifecyclePercentagesFilter } from 'scenes/insights/EditorFilters/LifecyclePercentagesFilter'
@@ -271,6 +272,7 @@ export const DisplayOptions = {
     AlertAnomalyPoints: { label: () => <ShowAlertAnomalyPointsFilter /> },
     MultipleYAxes: { label: () => <ShowMultipleYAxesFilter /> },
     TrendLines: { label: () => <ShowTrendLinesFilter /> },
+    HideIncompletePeriods: { label: () => <HideIncompletePeriodsFilter /> },
     HideIncompleteFunnelPeriods: { label: () => <HideIncompleteConversionWindowPeriodsFilter /> },
     HideWeekends: { label: () => <HideWeekendsFilter /> },
     Annotations: { label: () => <ShowAnnotationsFilter /> },

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -216,7 +216,7 @@ describe('InsightDisplayConfig', () => {
             [
                 'slope graph',
                 makeTrendsQuery(ChartDisplayType.SlopeGraph),
-                { sections: ['Display', 'Unit'], displayItems: ['Show legend'] },
+                { sections: ['Display', 'Unit'], displayItems: ['Show legend', 'Hide incomplete periods'] },
             ],
             [
                 'retention',
@@ -300,18 +300,31 @@ describe('InsightDisplayConfig', () => {
             expect(screen.queryByText(/Compare to|Previous period/i)).not.toBeInTheDocument()
         })
 
-        it('shows only the legend in the Display section', async () => {
+        it('shows only the legend and incomplete period toggle in the Display section', async () => {
             setupAndRender(makeTrendsQuery(ChartDisplayType.SlopeGraph))
             await openOptionsMenu()
 
             const items = getDisplaySectionItems()
-            expect(items).toEqual(['Show legend'])
+            expect(items).toEqual(['Show legend', 'Hide incomplete periods'])
             // None of the time-series-only options should leak in.
             expect(items).not.toContain('Show values on series')
             expect(items).not.toContain('Show trend lines')
             expect(items).not.toContain('Show alert threshold lines')
             expect(items).not.toContain('Show multiple Y-axes')
             expect(items).not.toContain('Show annotations')
+        })
+
+        it('toggles incomplete period clipping on the query date range', async () => {
+            setupAndRender(makeTrendsQuery(ChartDisplayType.SlopeGraph))
+            await openOptionsMenu()
+
+            await userEvent.click(screen.getByText('Hide incomplete periods'))
+
+            await waitFor(() => {
+                expect(insightVizDataLogic(insightProps).values.querySource?.dateRange?.excludeIncompletePeriods).toBe(
+                    true
+                )
+            })
         })
 
         it('hides the Y-axis scale and statistical analysis sections', async () => {

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -50,6 +50,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         showAnnotations,
         isNonTimeSeriesDisplay,
         interval,
+        dateRange,
         usesInChartLegend,
         insightFilter,
     } = useValues(insightVizDataLogic(insightProps))
@@ -71,6 +72,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     const isSlopeGraph = display === ChartDisplayType.SlopeGraph
     const isMetric = display === ChartDisplayType.Metric
     const hideContinuousChartOptions = isNonTimeSeriesDisplay || isMetric || isSlopeGraph
+    const showExcludeIncompletePeriodsConfig = isTrends && isSlopeGraph
     const showSmoothing =
         isTrends &&
         !hasBreakdownFilter(breakdownFilter) &&
@@ -122,11 +124,11 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         }
 
         if (isSlopeGraph) {
-            // A slope only shows the first vs last interval of each series — the legend (when there
-            // are multiple series) is the only display option that applies.
+            // A slope only shows the first vs last interval of each series.
             if (hasLegend) {
                 displayItems.push(DisplayOptions.Legend)
             }
+            displayItems.push(DisplayOptions.HideIncompletePeriods)
             return displayItems
         }
 
@@ -268,6 +270,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         (showMultipleYAxes ? 1 : 0) +
         (trendsFilter?.hideWeekends && hideWeekendsEnabled ? 1 : 0) +
         (showAnnotationsConfig && showAnnotations === false ? 1 : 0) +
+        (showExcludeIncompletePeriodsConfig && dateRange?.excludeIncompletePeriods ? 1 : 0) +
         (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
         (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0) +
         (isMetric && !!trendsFilter?.metricSummary && trendsFilter.metricSummary !== 'total' ? 1 : 0)

--- a/frontend/src/scenes/insights/EditorFilters/HideIncompletePeriodsFilter.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/HideIncompletePeriodsFilter.tsx
@@ -1,0 +1,39 @@
+import { useActions, useValues } from 'kea'
+
+import { IconInfo } from '@posthog/icons'
+import { LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+export function HideIncompletePeriodsFilter(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { dateRange } = useValues(insightVizDataLogic(insightProps))
+    const { updateDateRange } = useActions(insightVizDataLogic(insightProps))
+
+    const excludeIncompletePeriods = dateRange?.excludeIncompletePeriods ?? false
+
+    return (
+        <LemonCheckbox
+            className="p-1 px-2"
+            onChange={() =>
+                updateDateRange(
+                    {
+                        excludeIncompletePeriods: !excludeIncompletePeriods,
+                    },
+                    true
+                )
+            }
+            checked={excludeIncompletePeriods}
+            label={
+                <span className="font-normal inline-flex items-center gap-1">
+                    Hide incomplete periods
+                    <Tooltip title="Hides the current incomplete period from the trend.">
+                        <IconInfo className="relative top-0.5 text-base text-secondary" />
+                    </Tooltip>
+                </span>
+            }
+            size="small"
+        />
+    )
+}


### PR DESCRIPTION
## Problem

Slope graphs use the first and last trend buckets, so users need a way to hide the current incomplete period when it would make the ending point misleading.

## Changes

Adds a `Hide incomplete periods` display option for trends slope graphs that writes to the existing `dateRange.excludeIncompletePeriods` query flag.

## How did you test this code?

- `pnpm --filter=@posthog/frontend format`
- `pnpm --filter=@posthog/frontend jest frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx --runInBand`

Added coverage for the slope graph display-options branch so a future regression that drops the incomplete-period toggle from slope graphs fails while other trend chart options remain unchanged.

`pnpm --filter=@posthog/frontend typescript:check` did not complete successfully in this checkout because generated Kea `*Type` files are missing across unrelated frontend areas. `hogli ci:preflight --fix` was also unavailable because `hogli` was not on PATH, `flox` was not installed, and `bin/hogli` could not import the `hogli` Python module.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This exposes an existing insight query option in the slope graph display menu.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made the change. Skills invoked: `/writing-tests` for the focused Jest coverage decision.

I reused the existing `DateRange.excludeIncompletePeriods` query field instead of adding a new trends filter. The new checkbox is scoped to slope graphs because that chart type had a custom early return that previously allowed only the legend option.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
