### PR TITLE
fix(aio): validate eval report trigger threshold before save

### DIFF
--- a/products/ai_observability/frontend/evaluations/components/EvaluationReportConfig.tsx
+++ b/products/ai_observability/frontend/evaluations/components/EvaluationReportConfig.tsx
@@ -81,7 +81,15 @@ export function ScheduleConfig({
 }
 
 /** Threshold config shown when frequency is 'every_n' */
-function ThresholdConfig({ value, onChange }: { value: number; onChange: (value: number) => void }): JSX.Element {
+function ThresholdConfig({
+    value,
+    onChange,
+    error,
+}: {
+    value: number
+    onChange: (value: number) => void
+    error: string | null
+}): JSX.Element {
     return (
         <div>
             <label className="font-semibold text-sm">Evaluation count threshold</label>
@@ -91,12 +99,17 @@ function ThresholdConfig({ value, onChange }: { value: number; onChange: (value:
                 max={TRIGGER_THRESHOLD_MAX}
                 value={value}
                 onChange={(val) => onChange(Number(val))}
+                status={error ? 'danger' : undefined}
                 fullWidth
             />
-            <p className="text-xs text-muted mt-1">
-                A report will be generated after this many new evaluation results arrive. Checked every 5 minutes. Min{' '}
-                {TRIGGER_THRESHOLD_MIN}, max {TRIGGER_THRESHOLD_MAX.toLocaleString()}.
-            </p>
+            {error ? (
+                <p className="text-xs text-danger mt-1">{error}</p>
+            ) : (
+                <p className="text-xs text-muted mt-1">
+                    A report will be generated after this many new evaluation results arrive. Checked every 5 minutes.
+                    Min {TRIGGER_THRESHOLD_MIN}, max {TRIGGER_THRESHOLD_MAX.toLocaleString()}.
+                </p>
+            )}
         </div>
     )
 }
@@ -187,7 +200,7 @@ function DeliveryTargetsConfig({
 /** Shared form body used by both the create-evaluation and edit-existing-evaluation paths.
  * All state is backed by `evaluationReportLogic.configDraft` keyed by evaluationId. */
 function ReportFormFields({ evaluationId }: { evaluationId: string }): JSX.Element {
-    const { configDraft } = useValues(evaluationReportLogic({ evaluationId }))
+    const { configDraft, triggerThresholdError } = useValues(evaluationReportLogic({ evaluationId }))
     const {
         setDraftFrequency,
         setDraftScheduleCadence,
@@ -213,7 +226,11 @@ function ReportFormFields({ evaluationId }: { evaluationId: string }): JSX.Eleme
             </div>
             {configDraft.frequency === 'every_n' && (
                 <>
-                    <ThresholdConfig value={configDraft.triggerThreshold} onChange={setDraftTriggerThreshold} />
+                    <ThresholdConfig
+                        value={configDraft.triggerThreshold}
+                        onChange={setDraftTriggerThreshold}
+                        error={triggerThresholdError}
+                    />
                     <CooldownConfig value={configDraft.cooldownHours} onChange={setDraftCooldownHours} />
                 </>
             )}

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -415,6 +415,22 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                 return reports.find((r: EvaluationReport) => !r.deleted) || null
             },
         ],
+        triggerThresholdError: [
+            (s) => [s.configDraft],
+            (draft): string | null => {
+                // Only the every_n mode sends trigger_threshold to the backend, which
+                // rejects anything outside [MIN, MAX]. Catch it here so the save shows a
+                // clear message instead of failing silently on the API response.
+                if (draft.frequency !== 'every_n') {
+                    return null
+                }
+                const value = draft.triggerThreshold
+                if (!Number.isInteger(value) || value < TRIGGER_THRESHOLD_MIN || value > TRIGGER_THRESHOLD_MAX) {
+                    return `Enter a whole number between ${TRIGGER_THRESHOLD_MIN} and ${TRIGGER_THRESHOLD_MAX.toLocaleString()}.`
+                }
+                return null
+            },
+        ],
         isConfigDirty: [
             (s) => [s.activeReport, s.configDraft],
             (activeReport, draft): boolean => {

--- a/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/ai_observability/frontend/evaluations/evaluationReportLogic.ts
@@ -418,9 +418,6 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
         triggerThresholdError: [
             (s) => [s.configDraft],
             (draft): string | null => {
-                // Only the every_n mode sends trigger_threshold to the backend, which
-                // rejects anything outside [MIN, MAX]. Catch it here so the save shows a
-                // clear message instead of failing silently on the API response.
                 if (draft.frequency !== 'every_n') {
                     return null
                 }

--- a/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
@@ -691,6 +691,24 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 }
 
                 const isNew = props.evaluationId === 'new'
+
+                // Validate the (optional) scheduled-report draft before saving anything —
+                // an out-of-range trigger threshold would otherwise be rejected by the
+                // backend after the eval had already saved, so the report change appeared
+                // to fail silently.
+                const reportLogicKey = isNew ? 'new' : props.evaluationId
+                const reportLogic = evaluationReportLogic({ evaluationId: reportLogicKey })
+                if (
+                    evaluationSupportsReports(values.evaluation!) &&
+                    reportLogic.isMounted() &&
+                    reportLogic.values.triggerThresholdError
+                ) {
+                    const message = reportLogic.values.triggerThresholdError
+                    lemonToast.error(message)
+                    actions.saveEvaluationFailure(message)
+                    return
+                }
+
                 const response = isNew
                     ? // nosemgrep: prefer-codegen-api
                       await api.create(`/api/environments/${teamId}/evaluations/`, values.evaluation!)
@@ -706,8 +724,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 // evaluationReportLogic is only mounted when EvaluationReportConfig is
                 // rendered (gated on the reports feature flag), so skip when it isn't —
                 // reading .values on an unmounted keyed logic would throw.
-                const reportLogicKey = isNew ? 'new' : props.evaluationId
-                const reportLogic = evaluationReportLogic({ evaluationId: reportLogicKey })
                 if (response?.id && evaluationSupportsReports(response) && reportLogic.isMounted()) {
                     const reportConfigStillLoading =
                         !isNew && reportLogic.values.reportsLoading && !reportLogic.values.activeReport

--- a/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
@@ -692,10 +692,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
 
                 const isNew = props.evaluationId === 'new'
 
-                // Validate the (optional) scheduled-report draft before saving anything —
-                // an out-of-range trigger threshold would otherwise be rejected by the
-                // backend after the eval had already saved, so the report change appeared
-                // to fail silently.
                 const reportLogicKey = isNew ? 'new' : props.evaluationId
                 const reportLogic = evaluationReportLogic({ evaluationId: reportLogicKey })
                 if (


### PR DESCRIPTION
## Problem

When setting up a count-triggered (every N evaluations) AI observability eval report, a user could enter a trigger threshold below the allowed minimum. The backend rejects out-of-range thresholds, but on the report-create path that 400 was never surfaced, so the save appeared to fail silently — the user got no feedback about what went wrong.

## Changes

- Add a `triggerThresholdError` selector to `evaluationReportLogic` that flags a threshold outside the allowed range (only relevant in `every_n` mode).
- Show the error inline under the threshold input (red helper text + danger status) so it's visible as the user types.
- Block the shared "Save changes" / "Create evaluation" flow with a clear toast when the threshold is invalid, instead of letting the request reach the backend and fail quietly.

The bounds already live as shared constants used by both the input and the backend serializer, so the client-side check mirrors the server rule.

## How did you test this code?

I could not run the frontend typecheck or Jest in this environment (`node_modules` not installed). The change is pure frontend (no serializer/OpenAPI impact) and type-safe once kea typegen regenerates the logic type. No automated tests were added — the fix is small and there's no existing test file for `evaluationReportLogic`; happy to add a selector test if reviewers want one.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The reviewer's hunch — "quick UI minimum value" — matched the root cause: the input's `min` attribute isn't a hard gate on typed input, and the create-path save had no failure handler to surface the backend validation error. Chose to validate in the kea logic (single source of truth via the existing shared bound constants) and surface it both inline and as a pre-save guard, rather than clamping keystrokes (bad UX while typing) or only catching the API error after the fact.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1783696889177879?thread_ts=1783696889.177879&cid=C0B8ZE81ZT7)*
