### PR TITLE
fix(tasks): allow max reasoning for gpt-5.6

### DIFF
--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -148,7 +148,12 @@ CODEX_XHIGH_REASONING_EFFORTS: tuple[ReasoningEffort, ...] = (
     *CODEX_REASONING_EFFORTS,
     ReasoningEffort.XHIGH,
 )
-CODEX_XHIGH_REASONING_MODELS: frozenset[str] = frozenset({"gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"})
+CODEX_MAX_REASONING_EFFORTS: tuple[ReasoningEffort, ...] = (
+    *CODEX_XHIGH_REASONING_EFFORTS,
+    ReasoningEffort.MAX,
+)
+CODEX_XHIGH_REASONING_MODELS: frozenset[str] = frozenset({"gpt-5.5"})
+CODEX_MAX_REASONING_MODELS: frozenset[str] = frozenset({"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"})
 
 # Canonical list of Codex models. The runtime technically accepts any
 # `gpt-*` identifier passed through, but only models on this list are
@@ -198,7 +203,10 @@ def get_supported_reasoning_efforts(
     if adapter_value == RuntimeAdapter.CLAUDE.value:
         return CLAUDE_REASONING_EFFORTS_BY_MODEL.get(model, ())
     if adapter_value == RuntimeAdapter.CODEX.value:
-        if model.lower() in CODEX_XHIGH_REASONING_MODELS:
+        normalized_model = model.lower()
+        if normalized_model in CODEX_MAX_REASONING_MODELS:
+            return CODEX_MAX_REASONING_EFFORTS
+        if normalized_model in CODEX_XHIGH_REASONING_MODELS:
             return CODEX_XHIGH_REASONING_EFFORTS
         return CODEX_REASONING_EFFORTS
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -2061,7 +2061,9 @@ class TestTaskAPI(BaseTaskAPITest):
             ("gpt_5_3_high", "gpt-5.3-codex", "high"),
             ("gpt_5_5_xhigh", "gpt-5.5", "xhigh"),
             ("gpt_5_6_sol_xhigh", "gpt-5.6-sol", "xhigh"),
+            ("gpt_5_6_sol_max", "gpt-5.6-sol", "max"),
             ("gpt_5_6_luna_xhigh", "gpt-5.6-luna", "xhigh"),
+            ("gpt_5_6_luna_max", "gpt-5.6-luna", "max"),
         ]
     )
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
@@ -2289,7 +2291,6 @@ class TestTaskAPI(BaseTaskAPITest):
             ("gpt_5_4_xhigh", "gpt-5.4", "xhigh", "low, medium, high"),
             ("gpt_5_4_max", "gpt-5.4", "max", "low, medium, high"),
             ("gpt_5_5_max", "gpt-5.5", "max", "low, medium, high, xhigh"),
-            ("gpt_5_6_sol_max", "gpt-5.6-sol", "max", "low, medium, high, xhigh"),
         ]
     )
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")


### PR DESCRIPTION
## Problem

GPT-5.6 supports the `max` reasoning level, but the task API rejected it for Codex cloud runs. The companion model-picker change is https://github.com/PostHog/code/pull/3376