### PR TITLE
fix(notebooks): release destroyed editor references

### DIFF
--- a/frontend/src/lib/components/RichContentEditor/index.tsx
+++ b/frontend/src/lib/components/RichContentEditor/index.tsx
@@ -12,6 +12,7 @@ import { JSONContent, TTEditor } from './types'
 type RichContentEditorProps = {
     initialContent?: JSONContent
     onCreate?: (editor: TTEditor) => void
+    onDestroy?: (editor: TTEditor) => void
     onUpdate?: (content: JSONContent) => void
     onSelectionUpdate?: () => void
     extensions: Extensions
@@ -60,6 +61,7 @@ export const useRichContentEditor = ({
     disabled,
     initialContent,
     onCreate = () => {},
+    onDestroy = () => {},
     onUpdate = () => {},
     onSelectionUpdate = () => {},
 }: RichContentEditorProps): TTEditor => {
@@ -71,6 +73,7 @@ export const useRichContentEditor = ({
         onSelectionUpdate: onSelectionUpdate,
         onUpdate: ({ editor }) => onUpdate(editor.getJSON()),
         onCreate: ({ editor }) => onCreate(editor),
+        onDestroy: ({ editor }) => onDestroy(editor),
     })
 
     useEffect(() => {

--- a/frontend/src/lib/components/RichContentEditor/index.tsx
+++ b/frontend/src/lib/components/RichContentEditor/index.tsx
@@ -73,7 +73,9 @@ export const useRichContentEditor = ({
         onSelectionUpdate: onSelectionUpdate,
         onUpdate: ({ editor }) => onUpdate(editor.getJSON()),
         onCreate: ({ editor }) => onCreate(editor),
-        onDestroy: ({ editor }) => onDestroy(editor),
+        // TipTap emits the `destroy` event with no payload (unlike create/update),
+        // so close over the editor instance rather than destructuring undefined.
+        onDestroy: () => onDestroy(editor),
     })
 
     useEffect(() => {

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -8,6 +8,7 @@ import { Placeholder } from '@tiptap/extensions'
 import { collab } from '@tiptap/pm/collab'
 import StarterKit, { StarterKitOptions } from '@tiptap/starter-kit'
 import { useActions, useValues } from 'kea'
+import { useRef } from 'react'
 import { useThrottledCallback } from 'use-debounce'
 
 import { IconComment } from '@posthog/icons'
@@ -76,8 +77,9 @@ const CustomDocument = ExtensionDocument.extend({
 
 export function Editor(): JSX.Element {
     const { shortId, mode, isEditable, content, collabEnabled, notebook, previewContent } = useValues(notebookLogic)
-    const { setEditor, onEditorUpdate, onEditorSelectionUpdate, setTableOfContents, insertComment } =
+    const { setEditor, releaseEditor, onEditorUpdate, onEditorSelectionUpdate, setTableOfContents, insertComment } =
         useActions(notebookLogic)
+    const notebookEditorRef = useRef<NotebookEditor | null>(null)
     const hasCollapsibleSections = useFeatureFlag('NOTEBOOKS_COLLAPSIBLE_SECTIONS')
     const { bindEditor, unbindEditor } = useActions(notebookCollabLogic({ shortId }))
     const { clientID } = useValues(notebookCollabLogic({ shortId }))
@@ -214,12 +216,19 @@ export function Editor(): JSX.Element {
                     getText: () => textContent(editor.state.doc),
                 }
 
+                notebookEditorRef.current = notebookEditor
                 setEditor(notebookEditor)
 
                 if (useCollab) {
                     bindEditor(editor)
                 } else {
                     unbindEditor()
+                }
+            }}
+            onDestroy={() => {
+                if (notebookEditorRef.current) {
+                    releaseEditor(notebookEditorRef.current)
+                    notebookEditorRef.current = null
                 }
             }}
         >

--- a/frontend/src/scenes/notebooks/Notebook/notebookEditorLifecycle.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookEditorLifecycle.test.ts
@@ -1,0 +1,33 @@
+import { initKeaTests } from '~/test/init'
+
+import { NotebookEditor } from '../types'
+import { notebookLogic } from './notebookLogic'
+
+describe('notebook editor lifecycle', () => {
+    let logic: ReturnType<typeof notebookLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = notebookLogic({ shortId: 'canvas-person-id', mode: 'canvas' })
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('releases only the editor instance that was destroyed', () => {
+        const firstEditor = {} as NotebookEditor
+        const replacementEditor = {} as NotebookEditor
+
+        logic.actions.setEditor(firstEditor)
+        logic.actions.setEditor(replacementEditor)
+        logic.actions.releaseEditor(firstEditor)
+
+        expect(logic.values.editor).toBe(replacementEditor)
+
+        logic.actions.releaseEditor(replacementEditor)
+
+        expect(logic.values.editor).toBeNull()
+    })
+})

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -338,6 +338,7 @@ export const notebookLogic = kea<notebookLogicType>([
     })),
     actions({
         setEditor: (editor: NotebookEditor) => ({ editor }),
+        releaseEditor: (editor: NotebookEditor) => ({ editor }),
         editorIsReady: true,
         onEditorUpdate: true,
         onEditorSelectionUpdate: true,
@@ -480,6 +481,7 @@ export const notebookLogic = kea<notebookLogicType>([
             null as NotebookEditor | null,
             {
                 setEditor: (_, { editor }) => editor,
+                releaseEditor: (currentEditor, { editor }) => (currentEditor === editor ? null : currentEditor),
             },
         ],
         ready: [


### PR DESCRIPTION
## Problem

Notebook-backed customer profiles keep notebook logic mounted for the scene. When TipTap destroys the visible editor, the logic can retain its wrapper and the node-view tree it references, increasing detached DOM retention on profile pages.

**Why:** Detached element monitoring shows profile routes remain among the worst affected pages. Releasing the destroyed editor reference removes an avoidable retention path shared by person and group profiles.

## Changes

- Forward TipTap's editor destroy lifecycle through the shared rich content editor.
- Release the matching editor from notebook logic without clearing a newer replacement editor.

## How did you test this code?

- Added `notebookEditorLifecycle.test.ts` to catch destroyed editors remaining retained and stale teardown clearing a replacement editor.
- Ran `git diff --check` successfully.
- Could not run Jest, typegen, or frontend formatting because this runner has no `node_modules`, `hogli`, or `flox` installation.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex investigated the saved detached-elements insight with the PostHog MCP, then traced the shared profile canvas lifecycle in the repository. Skills invoked: `/investigate-metric`, `/querying-posthog-data`, `/writing-kea-logics`, and `/writing-tests`.

The change targets the shared notebook editor retention boundary rather than adding route-specific cleanup. The release action uses editor identity so an older TipTap destroy event cannot clear a newer editor mounted for the same notebook logic.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
