### PR TITLE
fix(new-tab): run onSelect action items from the launcher

### DIFF
--- a/frontend/src/scenes/new-tab/NewTabScene.test.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.test.tsx
@@ -1,0 +1,94 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { NewTabScene } from './NewTabScene'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useValues: jest.fn(),
+}))
+
+jest.mock('kea-router', () => ({
+    ...jest.requireActual('kea-router'),
+    router: { actions: { push: jest.fn() } },
+}))
+
+const mockActionOnSelect = jest.fn()
+
+// Stand in for the Search launcher: expose one button per item kind that calls
+// the `onItemSelect` NewTabScene wires up, exactly as a real click in the list would.
+jest.mock('lib/components/Search/Search', () => ({
+    Search: {
+        Root: ({
+            children,
+            onItemSelect,
+        }: {
+            children: React.ReactNode
+            onItemSelect: (item: {
+                id: string
+                name: string
+                category: string
+                href?: string
+                onSelect?: () => void
+            }) => void
+        }) => (
+            <div>
+                <button
+                    onClick={() =>
+                        onItemSelect({ id: 'sql', name: 'SQL editor', category: 'suggested', href: '/sql-editor' })
+                    }
+                >
+                    select-href-item
+                </button>
+                <button
+                    onClick={() =>
+                        onItemSelect({ id: 'logout', name: 'Log out', category: 'misc', onSelect: mockActionOnSelect })
+                    }
+                >
+                    select-action-item
+                </button>
+                {children}
+            </div>
+        ),
+        Input: () => <div />,
+        Status: () => <div />,
+        Separator: () => <div />,
+        Results: () => <div />,
+    },
+}))
+
+const mockedUseValues = useValues as jest.Mock
+const mockedRouterPush = router.actions.push as jest.Mock
+
+describe('NewTabScene', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockedUseValues.mockReturnValue({ searchParams: {} })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('navigates to the item href when a link item is selected', async () => {
+        render(<NewTabScene />)
+
+        await userEvent.click(screen.getByText('select-href-item'))
+
+        expect(mockedRouterPush).toHaveBeenCalledWith('/sql-editor')
+        expect(mockActionOnSelect).not.toHaveBeenCalled()
+    })
+
+    it('invokes onSelect when an action item without an href is selected', async () => {
+        render(<NewTabScene />)
+
+        await userEvent.click(screen.getByText('select-action-item'))
+
+        expect(mockActionOnSelect).toHaveBeenCalledTimes(1)
+        expect(mockedRouterPush).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/scenes/new-tab/NewTabScene.tsx
+++ b/frontend/src/scenes/new-tab/NewTabScene.tsx
@@ -14,6 +14,10 @@ export const scene: SceneExport = {
 export function NewTabScene(): JSX.Element {
     const { searchParams } = useValues(router)
     const handleItemSelect = useCallback((item: SearchItem) => {
+        if (item.onSelect) {
+            item.onSelect()
+            return
+        }
         if (item.href) {
             router.actions.push(item.href)
         }


### PR DESCRIPTION
## Problem

The new-tab launcher (the `/search` "new tab" page) was dropping any result that isn't a plain link. Its item-select handler only ran `router.push(item.href)`, so items that carry an `onSelect` action instead of an `href` did nothing when picked. Today that means "Log out" (and any future action item) is a dead entry from the new-tab page, even though the same list works from the command palette.

## Changes

`NewTabScene`'s `handleItemSelect` now runs `item.onSelect()` when present and falls back to `item.href` otherwise, matching how `Command.tsx` already dispatches the identical `SearchItem` list.

Also adds a React Testing Library test for `NewTabScene` (there was none). It stands in for the `Search` launcher and selects two item kinds:
- a link item, asserting it navigates via `router.push`
- an action item with no `href`, asserting its `onSelect` fires and no navigation happens

The action-item case fails on `master` (the bug) and passes with the fix.

## How did you test this code?

Automated only. I (Claude, via the PostHog Slack app) ran the new Jest test locally: it fails against the unmodified handler (action item's `onSelect` never called) and passes after the fix. I did not manually exercise the running app.

The test catches this specific regression: if the launcher's select handler ever stops honoring `onSelect`, action items silently no-op again. No existing test covered `NewTabScene`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread: the new-tab page couldn't get you to certain destinations. Traced it to `handleItemSelect` handling only `href` while the shared `SearchItem` type documents `onSelect` as the preferred field for non-navigation actions, and `Command.tsx` already handles it. Went with the minimal fix (mirror the command palette) rather than extracting a shared helper, to keep risk low. Invoked the `/writing-tests` skill before adding the test.

> [!NOTE]
> If "terminal" in the original report meant a specific destination rather than an action item, this fix restores `onSelect` dispatch generally but may not be the exact target - happy to adjust.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783933949246609?thread_ts=1783933949.246609&cid=C09G8Q32R6F)*
