### PR TITLE
perf(devex): raise whitenoise max-age for non-hashed static

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -419,6 +419,14 @@ def static_varies_origin(headers, path, url):
 
 WHITENOISE_ADD_HEADERS_FUNCTION = static_varies_origin
 
+# Non-hashed static files (notably the posthog-js SDK bundles served to
+# end-user browsers) otherwise fall back to whitenoise's 60s default and
+# generate constant 304 revalidation churn (~a third of /static traffic).
+# Hashed manifest assets are unaffected — whitenoise already serves those
+# with far-future caching. One hour bounds how long a client that does not
+# cache-bust can hold a stale SDK bundle after a release.
+WHITENOISE_MAX_AGE = get_from_env("WHITENOISE_MAX_AGE", 3600, type_cast=int)
+
 # Per-IP signup throttle rate (see posthog.rate_limit.SignupIPThrottle). Overridable per-env so
 # non-prod (e.g. dev deploy smoke-tests) can raise it without weakening the prod default.
 SIGNUP_IP_THROTTLE_RATE = get_from_env("SIGNUP_IP_THROTTLE_RATE", "5/day")


### PR DESCRIPTION
**Problem** — whitenoise's default 60s max-age on non-hashed static means the posthog-js SDK bundles served from /static generate constant 304 revalidation churn (~a third of /static requests on the web pods). Since the Granian WSGI cutover that serving is pure-Python and GIL-bound, so the churn now costs tail latency too, not just requests.

**Changes** — set WHITENOISE_MAX_AGE to 3600, env-overridable. Hashed manifest assets are untouched (already far-future). Bounded staleness: a non-cache-busting client can hold an SDK bundle at most 1h after a release.

**How did you test** — settings module compiles; no other WHITENOISE_MAX_AGE definition in the repo; rollback is env var or revert.