### PR TITLE
feat(customer-analytics): 404 announcements route when flag off

### DIFF
--- a/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
+++ b/products/customer_analytics/frontend/CustomerAnalyticsScene.tsx
@@ -85,6 +85,12 @@ function CustomerAnalyticsSceneContent(): JSX.Element {
         return <NotFound object="page" />
     }
 
+    // Same for Announcements: a direct `/customer_analytics/announcements` visit with the flag
+    // off must 404 rather than silently fall through to the dashboard.
+    if (activeTab === 'announcements' && !featureFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS_ANNOUNCEMENTS]) {
+        return <NotFound object="page" />
+    }
+
     const dashboardContent =
         businessType === 'b2b' && shouldShowGroupsIntroduction ? (
             <>


### PR DESCRIPTION
> [!NOTE]
> Last in the stack, on top of [#70377](https://github.com/PostHog/posthog/pull/70377) → [#70370](https://github.com/PostHog/posthog/pull/70370) → [#70366](https://github.com/PostHog/posthog/pull/70366) → [#70358](https://github.com/PostHog/posthog/pull/70358).

## Problem

The announcements tab is gated by the `customer-analytics-announcements` flag in the scene, but the route is registered unconditionally. Without a guard, hitting `/customer_analytics/announcements` directly while the flag is off resolves the scene, sets the active tab to `announcements`, finds no matching tab in the (flag-gated) tab list, and silently falls through to dashboard content. That's the exact footgun the accounts/notes tabs already guard against.

## Changes

One guard in `CustomerAnalyticsScene`, mirroring the existing accounts/notes one: if the active tab is `announcements` and the flag is off, render `NotFound`. With the flag on, the route resolves normally even when announcements isn't the visually-active tab.

The connect-banner the original plan slotted here already shipped with the tab in [#70377](https://github.com/PostHog/posthog/pull/70377) — a composer with no not-connected handling would have been broken on its own, so it belonged there. This PR is just the routing guard, which closes out the stack.

## How did you test this code?

I'm an agent (Claude, via PostHog Code), directed by @ceyniustranberg. The change is a one-line render guard that reuses the `NotFound` + flag pattern already present for accounts/notes in the same file; it type-checks (the `activeTab` union already includes `announcements` from the previous PR, and the flag constant exists) and `pnpm format` is clean. I didn't add a test — the sibling accounts/notes guard has none, and a full scene render for a one-line guard isn't worth the cost. I didn't drive the live UI this session.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @ceyniustranberg directed the work and is the DRI.

Built with Claude (PostHog Code). Trivial follow-up PR; labeled `skip-agent-review`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
