### PR TITLE
chore(warehouse): drop duplicate statement_timeout RLS test

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -6463,20 +6463,6 @@ class TestRlsActiveFromConnErrorHandling:
         assert result == {}
         capture_mock.assert_not_called()
 
-    def test_unsupported_statement_timeout_error_is_not_captured(self):
-        # A Postgres-wire engine that rejects the best-effort `SET statement_timeout` (CrateDB,
-        # Materialize, etc.) is an expected shape: degrade to no RLS warnings without flooding
-        # error tracking.
-        conn = self._conn_raising(
-            psycopg.errors.FeatureNotSupported('setting configuration parameter "statement_timeout" not supported')
-        )
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.capture_exception"
-        ) as capture_mock:
-            result = _rls_active_from_conn(cast(Any, conn), "public", ["t"])
-        assert result == {}
-        capture_mock.assert_not_called()
-
     def test_unexpected_error_is_still_captured(self):
         conn = self._conn_raising(Exception("connection reset by peer"))
         with patch(


### PR DESCRIPTION
## Problem

Master's `ruff check` (the "Python code quality" CI check) is red, which blocks CI on every open PR that merges master. Two PRs landed the same "quiet unsupported `statement_timeout`" fix within minutes of each other — [#70309](https://github.com/PostHog/posthog/pull/70309) and [#70310](https://github.com/PostHog/posthog/pull/70310) — and each appended a `test_unsupported_statement_timeout_error_is_not_captured` method to `TestRlsActiveFromConnErrorHandling`. Two identically-named methods in one class trips ruff `F811` (redefinition of unused method).

## Changes

Remove the duplicated test method, keeping a single copy. The two bodies were identical (same `_conn_raising(FeatureNotSupported('...statement_timeout not supported'))` setup and the same `result == {}` / `assert_not_called()` assertions), differing only in a comment — so coverage is unchanged. The copy removed was the shadowed one (Python keeps the last definition in a class body), so the test that actually runs is untouched.

No production code changes: `postgres.py` already has a single `_is_unsupported_statement_timeout_error` helper, and the unique sibling tests added by these PRs (`TestIsUnsupportedStatementTimeoutError`, `test_feature_not_supported_after_timeout_guard_is_still_captured`) are kept.

## How did you test this code?

- `ruff check` on the file now passes (the `F811` is gone); `ruff format --check` reports it already formatted; `hogli ci:preflight` is green (0 failures).
- I did not execute the test itself — it exercises the RLS path and the suite needs infrastructure not available in this environment. The surviving test is a byte-for-byte copy of the removed one, so its behavior is unchanged; CI runs the real suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — test-only cleanup.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code. Surfaced while investigating red CI on an unrelated PR ([#69416](https://github.com/PostHog/posthog/pull/69416)) — the failing "Python code quality" check traced to this `F811` on master, not to that PR.
- No repo skills were needed; this is a mechanical de-duplication verified with `ruff check`/`ci:preflight`.
- Heads-up for triage: this "quiet statement_timeout" fix produced four `posthog-code` PRs on the same files. #70309 and #70310 both merged (the source of this duplication); #70312 and #70313 are still open and touch the same `postgres.py` / `test_postgres.py` and are likely now redundant — worth a look to close or reconcile.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
