### PR TITLE
chore(ci): isolate mcp checks from frontend

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -79,7 +79,6 @@ jobs:
                         - 'products/**/*.tsx'
                         - 'products/**/*.json'
                         - 'playwright/**'
-                        - 'services/mcp/**'
                         - 'docs/**/*.tsx'
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-frontend.yml
@@ -99,6 +98,8 @@ jobs:
                         - '**/*.yaml'
                         - '**/*.yml'
                         - .config/.markdownlint-cli2.jsonc
+                        # MCP owns its code-quality checks in ci-mcp.yml.
+                        - '!services/mcp/**'
                       # Like `frontend` but excludes doc/config-only files that don't affect
                       # compiled output — used to skip Jest, bundle-size, and TypeScript checks
                       # when only markdown or YAML files change.
@@ -112,7 +113,6 @@ jobs:
                         - 'products/**/*.tsx'
                         - 'products/**/*.json'
                         - 'playwright/**'
-                        - 'services/mcp/**'
                         - .github/workflows/ci-frontend.yml
                         - .oxlintrc.json
                         - .oxfmtrc*
@@ -124,6 +124,7 @@ jobs:
                         - tsconfig.*.json
                         - webpack.config.js
                         - stylelint*
+                        - '!services/mcp/**'
                       # The @posthog/replay-shared package's own jest suite (the
                       # jest-replay-shared job). posthog-js bumps land via the catalog +
                       # lockfile and have broken it before (rrweb subpath entries switching

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -134,7 +134,14 @@ jobs:
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
               with:
-                  install-command: pnpm --filter=@posthog/mcp... --filter='./products/*' install --frozen-lockfile
+                  install-command: pnpm --filter=@posthog/root --filter=@posthog/mcp... --filter='./products/*' install --frozen-lockfile
+
+            - name: Check MCP code quality
+              run: |
+                  pnpm exec oxlint --quiet services/mcp
+                  pnpm exec oxfmt --check "services/mcp/**/*.{md,mdx}"
+                  pnpm exec oxfmt --check "services/mcp/**/*.{yaml,yml}"
+                  pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc "services/mcp/**/*.{md,mdx}"
 
             - name: Build package
               run: cd services/mcp && pnpm build

--- a/services/mcp/AGENTS.md
+++ b/services/mcp/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Commands
 
-Run these commands from `services/mcp`:
+Run these commands from the repository root:
 
-- Run `pnpm typecheck` after changing TypeScript or TSX files. It checks types without emitting files.
-- Run `pnpm format` before committing JavaScript, TypeScript, JSON, YAML, CSS, or SCSS changes. It applies Oxlint fixes and Oxfmt formatting, so it may rewrite files.
+- Run `pnpm --filter=@posthog/mcp run typecheck` after changing TypeScript or TSX files. It checks types without emitting files.
+- Run `pnpm --filter=@posthog/mcp run format` before committing JavaScript, TypeScript, JSON, YAML, CSS, or SCSS changes. It applies Oxlint fixes and Oxfmt formatting, so it may rewrite files.

--- a/services/mcp/AGENTS.md
+++ b/services/mcp/AGENTS.md
@@ -1,0 +1,8 @@
+# MCP development guide
+
+## Commands
+
+Run these commands from `services/mcp`:
+
+- Run `pnpm typecheck` after changing TypeScript or TSX files. It checks types without emitting files.
+- Run `pnpm format` before committing JavaScript, TypeScript, JSON, YAML, CSS, or SCSS changes. It applies Oxlint fixes and Oxfmt formatting, so it may rewrite files.

--- a/services/mcp/CLAUDE.md
+++ b/services/mcp/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Problem

Changes limited to `services/mcp/**` currently select Frontend CI. This runs frontend formatting, bundle-size checks, typechecking, and the full Jest matrix even though the frontend does not consume the MCP service. The path was added only to provide Oxlint coverage.

```mermaid
flowchart LR
    Change[MCP service change] --> MCP[MCP CI]
    Change --> Frontend[Frontend CI]
    Frontend --> Matrix[Format, bundle, types, Jest]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Change phYellow;
    class MCP,Frontend phBlue;
    class Matrix phGray;
```

## Changes

- Exclude `services/mcp/**` from the frontend and frontend-code path filters.
- Run the existing Oxlint, Markdown, and YAML checks inside MCP CI.
- Keep MCP UI app coverage in Storybook and MCP UI Apps CI unchanged.
- Document the existing `pnpm typecheck` and `pnpm format` package scripts in `services/mcp/AGENTS.md`.

```mermaid
flowchart LR
    Change[MCP service change] --> MCP[MCP CI]
    MCP --> Checks[Build, tests, code quality]
    UI[MCP UI app change] --> Visual[Storybook and UI Apps CI]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Change,UI phYellow;
    class MCP,Visual phBlue;
    class Checks phGray;
```

## How did you test this code?

- `bin/hogli ci:preflight --fix`
- `bin/hogli lint:workflows`
- `pnpm --dir services/mcp typecheck`
- Targeted MCP Oxlint, Markdown formatting, YAML formatting, and markdownlint checks
- `.github/scripts/check-agents-md-symlinks.sh`
- `git diff --check`

`actionlint` was unavailable both directly and through flox, so I could not run that additional syntax check. The repository workflow linter passed all six checks across 99 workflows.

No tests were added because this only changes workflow routing and developer instructions.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Added `services/mcp/AGENTS.md` with the MCP typecheck and formatting commands. The required sibling `CLAUDE.md` symlink points to the same canonical instructions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change using `/authoring-ci-workflows`, `/running-ci-preflight`, and `/submit-pr`. The existing code-quality coverage was moved into MCP CI so MCP-only changes can skip the unrelated frontend matrix without weakening validation. The MCP package already exposed `typecheck` and `format`, so I documented those commands instead of adding duplicate aliases.