### PR TITLE
fix(mcp_store): add db_default to MCPServerTemplate category column

### DIFF
--- a/products/mcp_store/backend/migrations/0013_alter_mcpservertemplate_category_db_default.py
+++ b/products/mcp_store/backend/migrations/0013_alter_mcpservertemplate_category_db_default.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("mcp_store", "0012_alter_mcpserverinstallation_unique_together_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="mcpservertemplate",
+            name="category",
+            field=models.CharField(
+                choices=[
+                    ("business", "Business Operations"),
+                    ("data", "Data & Analytics"),
+                    ("design", "Design & Content"),
+                    ("dev", "Developer Tools & APIs"),
+                    ("infra", "Infrastructure"),
+                    ("productivity", "Productivity & Collaboration"),
+                ],
+                db_default="dev",
+                default="dev",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/products/mcp_store/backend/migrations/max_migration.txt
+++ b/products/mcp_store/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0012_alter_mcpserverinstallation_unique_together_and_more
+0013_alter_mcpservertemplate_category_db_default

--- a/products/mcp_store/backend/models.py
+++ b/products/mcp_store/backend/models.py
@@ -80,7 +80,7 @@ class MCPServerTemplate(CreatedMetaFields, UpdatedMetaFields, UUIDModel):
     description = models.TextField(blank=True, default="")
     auth_type = models.CharField(max_length=20, choices=AUTH_TYPE_CHOICES, default="oauth")
     icon_key = models.CharField(max_length=100, blank=True, default="")
-    category = models.CharField(max_length=20, choices=CATEGORY_CHOICES, default="dev")
+    category = models.CharField(max_length=20, choices=CATEGORY_CHOICES, default="dev", db_default="dev")
     oauth_issuer_url = models.URLField(max_length=2048, blank=True, default="")
     oauth_metadata = models.JSONField(default=dict, blank=True)
     oauth_credentials = EncryptedJSONField(default=dict, blank=True)


### PR DESCRIPTION
## Problem

The `MCPServerTemplate.category` column was added `NOT NULL` with a Python-only `default="dev"` and no Postgres-level default. Django's `default=` is applied at `Model.__init__`, so it is invisible to any path that doesn't go through the ORM: raw `INSERT`s, and the model-driven test schema build in `setup_test_environment.py` (which calls `disable_migrations()` and skips migrations entirely). Those paths hit a `NotNullViolation` on `category`.

## Changes

Add `db_default="dev"` to the `category` field so Postgres carries a real column `DEFAULT`. New migration `0013` emits a single `ALTER COLUMN ... SET DEFAULT 'dev'` with no `DROP DEFAULT` follow-up. This matches the sibling `scope` column added in `0012`, which already uses `db_default`.

## How did you test this code?

I (the PostHog Slack app agent) could not run `makemigrations` or the test suite in this environment (no Django installed), so I hand-wrote migration `0013` to match exactly what `makemigrations` emits when `db_default` is added to the field's model state, and updated `max_migration.txt`. Please let CI run the migration and parity checks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread as a P2 inbox item. Invoked the `/django-migrations` skill, which flags exactly this cross-language `NOT NULL` hazard: a scalar Django `default=` does not create a Postgres column default, so non-ORM writers and the model-driven test schema build break. Followed its guidance to add both `default=` and `db_default=`. I chose an `AlterField` migration over a raw `RunSQL` so the migration reflects the model state and `makemigrations` reports no drift.
