### PR TITLE
fix(notebooks): hide synthetic empty title row in read-only notebooks

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -2493,6 +2493,18 @@ Intro paragraph
         expect(container.querySelectorAll('[data-placeholder="Start writing..."]')).toHaveLength(0)
     })
 
+    it('hides the synthetic empty title row in view mode', () => {
+        const { container } = render(
+            createElement(MarkdownNotebook, {
+                value: '<Query query={{"kind":"DataTableNode"}} />',
+                mode: 'view',
+            })
+        )
+
+        expect(container.querySelectorAll('[data-placeholder="Untitled notebook"]')).toHaveLength(0)
+        expect(container.querySelectorAll('.MarkdownNotebook__text-block--title')).toHaveLength(0)
+    })
+
     it('records keystrokes, mouse events, and commits into a downloadable debug log', async () => {
         const { createObjectURL, anchorClick, restore } = stubNotebookLogDownload()
 

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
@@ -76,6 +76,7 @@ import {
     setsEqual,
     textBlocksShareContinuationStyle,
     updateNotebookCodeBlockText,
+    withoutLeadingEmptyTitleGroup,
     writeSystemClipboardText,
 } from './documentModel'
 import {
@@ -5598,10 +5599,11 @@ function MarkdownNotebookEditor({
         canvasRef.current?.focus()
     }
 
-    const renderedNodeGroups = getMarkdownNotebookVisualGroups(
+    const allNodeGroups = getMarkdownNotebookVisualGroups(
         renderedNodes,
         insertMenu?.detached ? insertMenu.nodeId : undefined
     )
+    const renderedNodeGroups = mode === 'edit' ? allNodeGroups : withoutLeadingEmptyTitleGroup(allNodeGroups)
 
     // The insert menu never takes focus (typing keeps filtering), so the canvas points at the
     // selected option via aria-activedescendant.

--- a/frontend/src/lib/components/MarkdownNotebook/documentModel.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/documentModel.ts
@@ -115,6 +115,22 @@ export function getMarkdownNotebookVisualGroups(
     return groups
 }
 
+// ensureEditableNotebookDocument prepends an empty `# ` title row so editors always have a
+// title to type into. Viewers can't type, so in view mode that synthetic row would render as
+// a bare "Untitled notebook" placeholder card (e.g. profile canvases whose content starts
+// with a component) — drop it from the rendered groups instead.
+export function withoutLeadingEmptyTitleGroup(groups: MarkdownNotebookVisualGroup[]): MarkdownNotebookVisualGroup[] {
+    const firstGroup = groups[0]
+    if (!firstGroup || firstGroup.type !== 'text') {
+        return groups
+    }
+    const [firstItem, ...restItems] = firstGroup.items
+    if (!firstItem || firstItem.index !== 0 || !isTextBlockNode(firstItem.node) || nodeHasContent(firstItem.node)) {
+        return groups
+    }
+    return restItems.length ? [{ ...firstGroup, items: restItems }, ...groups.slice(1)] : groups.slice(1)
+}
+
 export function isTextBlockNode(node: NotebookBlockNode): node is NotebookTextBlockNode {
     return node.type === 'paragraph' || node.type === 'heading' || node.type === 'blockquote'
 }


### PR DESCRIPTION
## TL;DR

Person and group profile pages showed a big grey "Untitled notebook" heading above the profile panels. The profile canvas is a read-only notebook, and the markdown editor always sticks an invisible empty title line at the top so that editors have somewhere to type a title. Since the canvas content starts with a component (not text), that empty title rendered as a placeholder card nobody can edit. Now the empty title row is simply not rendered when the notebook isn't editable.

## Problem

With markdown notebooks enabled, profile canvases on person and group pages are rendered through `MarkdownNotebookV2`. `ensureEditableNotebookDocument` prepends a synthetic empty `# ` title row whenever the first node isn't a text block, and that row renders its `Untitled notebook` placeholder even in view mode — producing a large empty "Untitled notebook" card at the top of every profile canvas.

**Why:** the profile canvas is read-only, so the viewer can't act on the title placeholder — it's pure noise on a customer-facing surface.

## Changes

- `withoutLeadingEmptyTitleGroup` (documentModel): drops the leading text group item when it's the synthetic empty title at index 0.
- `MarkdownNotebook` applies it to the rendered visual groups whenever `mode !== 'edit'`; edit mode is unchanged, so the title stays typable for editors.

Before (person profile canvas):

the profile renders a bordered card containing only a grey "Untitled notebook" placeholder above the usage metrics panel.

## How did you test this code?

- New Jest test: renders a view-mode notebook whose content starts with a component and asserts no "Untitled notebook" placeholder and no title block — catches a regression where the synthetic title row leaks back into read-only rendering (the profile canvas bug); no existing test covered view-mode title rendering (the existing placeholder test is edit-mode only).
- Ran the full `MarkdownNotebook` and `MarkdownNotebookV2Renderer` suites (417 tests, all passing).
- `hogli ci:preflight --fix` clean. TypeScript errors in this environment are pre-existing (missing kea typegen output; identical count on clean master).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe this internal rendering detail.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`.
- Investigated where the title came from (synthetic title insertion in `ensureEditableNotebookDocument`, placeholder applied to row 0, CSS `:empty::before`), then chose to filter the rendered visual groups in view mode rather than change document synthesis — the document model still guarantees a title row for edit mode, and mode can flip view→edit after the document is built, so presentation-level filtering is the safer seam. Hiding only the row (not the whole text group) was rejected because the empty group still renders a bordered padded card.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
