### PR TITLE
fix(sentry): skip org-gated tag values 403 instead of failing sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -404,8 +404,7 @@ def _iter_issue_tag_values_rows(
                     # (issue, tag) values endpoint — seen on tags with unusual
                     # keys/values. Retries are already exhausted by
                     # _request_with_retry, so skip this tag's remaining values
-                    # rather than failing the whole sync. Non-server errors
-                    # (auth, etc.) still propagate to the job-level handler.
+                    # rather than failing the whole sync.
                     if response.status_code >= 500:
                         logger.warning(
                             "sentry_source.issue_tag_values_server_error_skipped",
@@ -415,6 +414,21 @@ def _iter_issue_tag_values_rows(
                             status_code=response.status_code,
                         )
                         break
+                    # Sentry gates individual tag values endpoints at the org level
+                    # (data-scrubbing/privacy settings, restricted tags), returning
+                    # 403 even for tokens that just listed the issue's tags. Skip the
+                    # tag rather than failing the sync — a genuine scope problem would
+                    # already have surfaced on the issues/tags listing above.
+                    if response.status_code == 403:
+                        logger.warning(
+                            "sentry_source.issue_tag_values_forbidden_skipped",
+                            organization_slug=organization_slug,
+                            issue_id=issue_id,
+                            tag_key=tag_key,
+                            status_code=response.status_code,
+                        )
+                        break
+                    # Other client errors (401, etc.) still propagate to the job-level handler.
                     raise
 
                 try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -591,15 +591,45 @@ class TestSentrySourceValidation:
         assert rows == [{"value": "Chrome", "issue_id": "100", "tag_key": "browser"}]
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
-    def test_issue_tag_values_propagates_client_error(self, mock_request) -> None:
+    def test_issue_tag_values_skips_tag_on_forbidden(self, mock_request) -> None:
+        def side_effect(url, headers=None, params=None, timeout=None):
+            if url.endswith("/organizations/acme/issues/"):
+                return _response([{"id": "100"}])
+            if url.endswith("/organizations/acme/issues/100/tags/"):
+                return _response([{"key": "dart.name"}, {"key": "browser"}])
+            if url.endswith("/organizations/acme/issues/100/tags/dart.name/values/"):
+                # Sentry gates this tag's values at the org level (data scrubbing).
+                return _response(None, status_code=403)
+            if url.endswith("/organizations/acme/issues/100/tags/browser/values/"):
+                return _response([{"value": "Chrome"}])
+            return _response([])
+
+        mock_request.side_effect = side_effect
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="issue_tag_values",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        # The 403 on the gated tag is skipped; the healthy "browser" tag still
+        # yields its values instead of the whole sync failing.
+        rows = list(cast(Any, resp.items()))
+        assert rows == [{"value": "Chrome", "issue_id": "100", "tag_key": "browser"}]
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_issue_tag_values_propagates_non_forbidden_client_error(self, mock_request) -> None:
         def side_effect(url, headers=None, params=None, timeout=None):
             if url.endswith("/organizations/acme/issues/"):
                 return _response([{"id": "100"}])
             if url.endswith("/organizations/acme/issues/100/tags/"):
                 return _response([{"key": "browser"}])
             if url.endswith("/organizations/acme/issues/100/tags/browser/values/"):
-                # A 4xx is not a transient upstream blip — it must still propagate.
-                return _response(None, status_code=403)
+                # A revoked token (401) is a genuine failure — it must still propagate.
+                return _response(None, status_code=401)
             return _response([])
 
         mock_request.side_effect = side_effect


### PR DESCRIPTION
## Problem

The `sentry` data-warehouse import can fail its whole sync on a single tag. When Sentry returns `403 Forbidden` for one issue's tag-values endpoint (e.g. `.../issues/<id>/tags/<tag>/values/`), the error propagated out of `_iter_issue_tag_values_rows` and killed the sync. Worse, the source's `get_non_retryable_errors` maps any `403 Client Error` to a "your token is missing scopes" message, so the customer got sent chasing a scope problem that isn't real.

By the time we hit that values endpoint we've already listed the org's issues and that issue's tags with the same token, so the token clearly has the scopes it needs. A per-tag 403 is Sentry gating that specific resource at the org level (data scrubbing / privacy settings, restricted tags), not a credential problem. A genuine missing scope would 403 the issues or tags listing first and never reach the values endpoint.

Surfaced by error tracking: [issue `019f5b6a-afee-7f82-8cc8-e5a91509971f`](https://us.posthog.com/project/2/error_tracking/019f5b6a-afee-7f82-8cc8-e5a91509971f) (`HTTPError`, raised at `sentry.py:_iter_issue_tag_values_rows`).

## Changes

Treat a 403 on the per-tag values endpoint the same way the code already treats a persistent 5xx there: log a warning and skip that tag's remaining values, letting the rest of the sync complete. This mirrors the existing org-gated 403 skip for `project_service_hooks` elsewhere in the same file.

Scope is deliberately narrow:

- Only the `issue_tag_values` fan-out's per-tag values pages are affected.
- Other client errors (401 revoked token, etc.) still propagate.
- `403 Client Error` stays in `get_non_retryable_errors`, so a real missing-scope 403 on the issues/tags listing or any other endpoint still stops the sync with the scopes message.

> [!NOTE]
> This reverses a prior deliberate choice to propagate 4xx here. The earlier reasoning ("a 4xx is not a transient blip, so fail") missed the org-gating case that `project_service_hooks` already handles: a non-transient 403 that should be skipped, not fatal.

## How did you test this code?

Automated only (I'm Claude; I did not run a live Sentry sync). In `products/warehouse_sources/.../sentry/tests/test_sentry.py`:

- Added `test_issue_tag_values_skips_tag_on_forbidden` — a 403 on one tag's values is skipped and a sibling healthy tag still yields its values. Catches a regression where a per-tag 403 again aborts the whole sync.
- Reworked the old `test_issue_tag_values_propagates_client_error` into `test_issue_tag_values_propagates_non_forbidden_client_error` (now uses 401) — guards that genuine auth failures still propagate rather than being swallowed by the new skip.

`pytest` on the full `test_sentry.py` (61 passed); `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the stack frame is genuinely in `sentry.py:_iter_issue_tag_values_rows`, read the source and its tests, and judged this an upstream org-gating case rather than a credential error (the token already read issues and tags before the values 403). Chose the code fix over widening `NonRetryableErrors` because failing the sync on one gated tag is the wrong outcome and the "missing scopes" message would mislead. Invoked `/writing-tests` before changing tests. Checked open PRs (including the maintainer's) for a duplicate — none address this path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
