### PR TITLE
fix(error-tracking): allowlist in-app crates in rust captures

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2267,7 +2267,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4900,7 +4900,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -7887,9 +7887,9 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bcf2bdf6c269ff65ff9d4f360bc5f42d560afff96a589d873326594d473bd6"
+checksum = "9b19b9f71d36b4f2bd5c6b4db79a1d62c11b7ecf6772294aa5128711ca961f0b"
 dependencies = [
  "backtrace",
  "brotli 7.0.0",
@@ -8609,7 +8609,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8647,7 +8647,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -12248,7 +12248,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -200,7 +200,7 @@ aws-smithy-runtime-api = { version = "1.11.5", features = ["client"] }
 aws-smithy-http-client = { version = "1.1.11", features = ["rustls-aws-lc"] }
 mockall = "0.13.0"
 moka = { version = "0.12.15", features = ["sync", "future"] }
-posthog-rs = { version = "0.18.0", features = ["async-client", "capture-v1"] }
+posthog-rs = { version = "0.19.1", features = ["async-client", "capture-v1"] }
 redis = { version = "0.32.7", features = [
   "tokio-comp",
   "cluster",

--- a/rust/common/posthog/src/lib.rs
+++ b/rust/common/posthog/src/lib.rs
@@ -44,10 +44,18 @@ struct ServiceContext {
 ///
 /// Without an API key the global client is disabled and every capture is a
 /// no-op.
+///
+/// `in_app_include_paths` are substring patterns matched against each captured
+/// frame's file path and function symbol; when non-empty, only matching frames
+/// are classified in-app. The SDK's built-in default is a small crate denylist
+/// that leaves most third-party crates (hyper, axum, tower, ...) marked in-app,
+/// so services should pass their own crate prefixes plus `"common_"` for the
+/// shared workspace crates, e.g. `&["cymbal::", "common_"]`.
 pub async fn init(
     service: &'static str,
     api_key: Option<&str>,
     endpoint: &str,
+    in_app_include_paths: &[&str],
 ) -> Result<(), posthog_rs::Error> {
     let context = SERVICE
         .get_or_init(|| ServiceContext {
@@ -67,8 +75,10 @@ pub async fn init(
 
     // Exclude this crate's own frames from in-app classification so captured
     // stacks lead with the real service call site, not the shared wrapper.
+    // Excludes take precedence, so they win even over an explicit include.
     let error_tracking = posthog_rs::ErrorTrackingOptionsBuilder::default()
         .capture_panics(true)
+        .in_app_include_paths(in_app_include_paths.iter().map(|p| p.to_string()).collect())
         .in_app_exclude_paths(vec!["common_posthog::".to_string()])
         .build()
         .expect("all error tracking options have defaults");

--- a/rust/common/posthog/tests/on_error_hook.rs
+++ b/rust/common/posthog/tests/on_error_hook.rs
@@ -30,7 +30,7 @@ async fn init_hook_emits_delivery_failure_metric_on_terminal_reject() {
         })
         .await;
 
-    common_posthog::init("test-svc", Some("test-key"), &server.base_url())
+    common_posthog::init("test-svc", Some("test-key"), &server.base_url(), &[])
         .await
         .expect("init should succeed when an api key is provided");
 

--- a/rust/common/posthog/tests/panic_capture.rs
+++ b/rust/common/posthog/tests/panic_capture.rs
@@ -89,7 +89,7 @@ async fn init_enables_panic_capture() {
         })
         .await;
     std::panic::set_hook(Box::new(|_| {}));
-    common_posthog::init("panic-test", Some("test-api-key"), &posthog.base_url())
+    common_posthog::init("panic-test", Some("test-api-key"), &posthog.base_url(), &[])
         .await
         .expect("posthog init");
 

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -86,7 +86,14 @@ fn start_profiling(
 }
 
 async fn init_posthog(service_name: &'static str, api_key: &Option<String>, endpoint: &str) {
-    common_posthog::init(service_name, api_key.as_deref(), endpoint)
-        .await
-        .unwrap();
+    // All cymbal modes run this crate's code, so only cymbal and the shared
+    // workspace crates count as in-app in captured stacks.
+    common_posthog::init(
+        service_name,
+        api_key.as_deref(),
+        endpoint,
+        &["cymbal::", "common_"],
+    )
+    .await
+    .unwrap();
 }

--- a/rust/cymbal/tests/posthog_capture.rs
+++ b/rust/cymbal/tests/posthog_capture.rs
@@ -41,9 +41,14 @@ async fn pipeline_failure_is_captured_as_posthog_exception(db: PgPool) {
         })
         .await;
 
-    common_posthog::init("cymbal-test", Some("test-api-key"), &posthog.base_url())
-        .await
-        .expect("posthog init");
+    common_posthog::init(
+        "cymbal-test",
+        Some("test-api-key"),
+        &posthog.base_url(),
+        &["cymbal::", "common_"],
+    )
+    .await
+    .expect("posthog init");
 
     let mut config = ProcessingConfig::init_with_defaults().unwrap();
     config.resolver.object_storage_bucket = STORAGE_BUCKET.to_string();

--- a/rust/embedding-worker/src/main.rs
+++ b/rust/embedding-worker/src/main.rs
@@ -95,6 +95,7 @@ async fn main() {
         "embedding-worker",
         config.posthog_api_key.as_deref(),
         &config.posthog_endpoint,
+        &["embedding_worker::", "common_"],
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Problem

Exceptions captured by our internal Rust services (cymbal, embedding-worker) arrive with almost every third-party frame classified as in-app. In a [sample cymbal issue](https://us.posthog.com/project/2/error_tracking/019f5ad2-cd5d-78e3-ad9c-7cf060f0cad7) the vast majority of frames marked in-app were tokio, hyper, axum, tower and futures machinery, and the issue's "top in-app frame" was the SDK's own capture function. This makes stacks unreadable and pollutes fingerprinting, which selects frames by in-app.

Root cause: posthog-rs classifies in-app with a small crate *denylist*, so any crate not on it (hyper, axum, tower, ...) defaults to in-app, and stripped release binaries carry no file paths for the SDK's path rules to act on.

## Changes

- `common_posthog::init` now takes `in_app_include_paths` and wires it to the SDK's `in_app_include_paths`, flipping classification to an allowlist. Cymbal passes `["cymbal::", "common_"]`, embedding-worker passes `["embedding_worker::", "common_"]`. The existing `common_posthog::` exclude still wins over includes, so stacks keep leading with the real service call site.
- Bump posthog-rs 0.18.0 → 0.19.1. This picks up two upstream fixes: SDK capture frames (`posthog_rs::global::capture_exception_with`) no longer survive stripping under newer demangler renderings, and stack frames now ship in canonical bottom-up wire order (matching the server-side native symbolication contract).

batch-import-worker also depends on posthog-rs but only uses the capture API, which is unchanged in 0.19.

> [!NOTE]
> Fingerprinting selects frames by in-app, so once this deploys, new events on existing internal-service issues may mint new fingerprints (one-time churn).

Server-side companion (demoting library frames after symbolication in cymbal): #70427

## How did you test this code?

Automated tests run locally by the agent:

- `cargo test -p common-posthog` (unit + `on_error_hook` + `panic_capture` integration tests)
- `cargo test -p cymbal --lib --tests` (203 lib tests + all integration suites, including `posthog_capture`, which exercises the new init signature end-to-end against a mock capture server on the bumped SDK)
- `cargo test -p batch-import-worker -p embedding-worker`
- clippy and rustfmt clean

No new tests were added: the change is configuration wiring, and the existing `posthog_capture` end-to-end test already covers the init-to-capture path on the new SDK version. No manual testing beyond that was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal service telemetry only, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) investigated the linked error tracking issue via the PostHog MCP, traced the misclassification to the SDK's denylist defaults plus missing include-path config, and applied the fix. Considered baking the `common_` include into `common_posthog` itself but kept it explicit at each call site so services declare their own crates and empty-list callers keep SDK default behavior. `hogli ci:preflight` could not run in this checkout (jj workspace without a `.git` dir); clippy, rustfmt and the test suites above were run instead.

