### PR TITLE
feat(posthog-code/tasks): truncate_log endpoint for checkpoint restore

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1489,6 +1489,21 @@ def append_task_run_log(
     return _task_run_detail_to_dto(run)
 
 
+def truncate_task_run_log(
+    run_id: str | UUID,
+    task_id: str | UUID,
+    team_id: int,
+    *,
+    checkpoint_id: str,
+    prompt_id: int | None = None,
+) -> dict | None:
+    """Truncate a run's S3 log at a checkpoint boundary. ``None`` if the run isn't found."""
+    run = _get_visible_run(run_id, task_id, team_id)
+    if run is None:
+        return None
+    return run.truncate_log(checkpoint_id, prompt_id=prompt_id)
+
+
 def task_run_has_slack_mapping(run_id: str | UUID, task_id: str | UUID, team_id: int) -> bool | None:
     """Whether a run is mapped to a Slack thread. ``None`` if the run isn't found."""
     from products.slack_app.backend.models import (  # noqa: PLC0415 — cross-product import kept off the api import path

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1158,6 +1158,188 @@ class TaskRun(models.Model):
             return round((self.completed_at - self.created_at).total_seconds(), 1)
         return 0.0
 
+    def truncate_log(self, checkpoint_id: str, prompt_id: int | None = None) -> dict:
+        """Truncate the S3 log at the turn containing the given checkpoint.
+
+        Keeps all lines up to (but not including) the start of the next turn after the
+        checkpoint. If the checkpoint notification is not found in the log (e.g. it was
+        appended out-of-band after the turn completed), falls back to locating the turn
+        by prompt_id: finds the session/prompt request with that id, then uses the next
+        session/prompt as the cutoff.
+
+        Returns metadata including orphaned checkpoint IDs from discarded lines.
+        """
+        content = object_storage.read(self.log_url, missing_ok=True) or ""
+        if not content.strip():
+            logger.info(
+                "task_run.truncate_log.empty_log",
+                task_run_id=str(self.id),
+                checkpoint_id=checkpoint_id,
+            )
+            return {
+                "truncated": False,
+                "original_line_count": 0,
+                "truncated_line_count": 0,
+                "orphaned_checkpoint_ids": [],
+            }
+
+        lines = [line for line in content.split("\n") if line.strip()]
+        original_count = len(lines)
+
+        def _is_session_prompt_request(entry: dict) -> bool:
+            # Claude adapter: outgoing prompts logged as type="request"
+            if entry.get("type") == "request":
+                req = entry.get("request", {})
+                return isinstance(req, dict) and req.get("method") == "session/prompt"
+            # Codex adapter: all events logged as type="notification", including outgoing prompts
+            if entry.get("type") == "notification":
+                notif = entry.get("notification", {})
+                return isinstance(notif, dict) and notif.get("method") == "session/prompt"
+            return False
+
+        def _next_turn_cutoff(search_from: int) -> int:
+            """Return the index of the next session/prompt after search_from, or len(lines)."""
+            in_user_message = False
+            passed_non_user = False
+            for i in range(search_from, len(lines)):
+                try:
+                    entry = json.loads(lines[i])
+                    if _is_session_prompt_request(entry):
+                        return i
+                    notification = entry.get("notification", {})
+                    if isinstance(notification, dict) and notification.get("method") == "session/update":
+                        params = notification.get("params", {})
+                        update = params.get("update", {}) if isinstance(params, dict) else {}
+                        is_user_chunk = isinstance(update, dict) and update.get("sessionUpdate") in (
+                            "user_message",
+                            "user_message_chunk",
+                        )
+                        if is_user_chunk:
+                            if passed_non_user:
+                                return i
+                            in_user_message = True
+                        else:
+                            if in_user_message:
+                                passed_non_user = True
+                            in_user_message = False
+                    else:
+                        if in_user_message:
+                            passed_non_user = True
+                        in_user_message = False
+                except json.JSONDecodeError:
+                    continue
+            return len(lines)
+
+        def _find_cutoff_by_prompt_id() -> int:
+            """Locate the session/prompt with id==prompt_id, return index of the next one."""
+            for j, line in enumerate(lines):
+                try:
+                    entry = json.loads(line)
+                    # Claude adapter: type="request"
+                    if entry.get("type") == "request":
+                        req = entry.get("request", {})
+                        if (
+                            isinstance(req, dict)
+                            and req.get("method") == "session/prompt"
+                            and req.get("id") == prompt_id
+                        ):
+                            return _next_turn_cutoff(j + 1)
+                    # Codex adapter: type="notification" with method="session/prompt"
+                    elif entry.get("type") == "notification":
+                        notif = entry.get("notification", {})
+                        if (
+                            isinstance(notif, dict)
+                            and notif.get("method") == "session/prompt"
+                            and notif.get("id") == prompt_id
+                        ):
+                            return _next_turn_cutoff(j + 1)
+                except json.JSONDecodeError:
+                    continue
+            return len(lines)
+
+        # Try to find the checkpoint notification in the log first.
+        checkpoint_line_idx = -1
+        for i, line in enumerate(lines):
+            try:
+                entry = json.loads(line)
+                notification = entry.get("notification", {})
+                if isinstance(notification, dict) and notification.get("method") == "_posthog/git_checkpoint":
+                    if notification.get("params", {}).get("checkpointId") == checkpoint_id:
+                        checkpoint_line_idx = i
+                        break
+            except json.JSONDecodeError:
+                continue
+
+        if checkpoint_line_idx != -1:
+            cutoff = _next_turn_cutoff(checkpoint_line_idx + 1)
+            # If no next turn found (checkpoint is at the tail), fall back to prompt_id search.
+            if cutoff == len(lines) and prompt_id is not None:
+                fallback_cutoff = _find_cutoff_by_prompt_id()
+                if fallback_cutoff < len(lines):
+                    cutoff = fallback_cutoff
+        elif prompt_id is not None:
+            cutoff = _find_cutoff_by_prompt_id()
+            if cutoff == len(lines):
+                logger.info(
+                    "task_run.truncate_log.checkpoint_not_found",
+                    task_run_id=str(self.id),
+                    checkpoint_id=checkpoint_id,
+                    prompt_id=prompt_id,
+                )
+                return {
+                    "truncated": False,
+                    "original_line_count": original_count,
+                    "truncated_line_count": original_count,
+                    "orphaned_checkpoint_ids": [],
+                }
+        else:
+            logger.info(
+                "task_run.truncate_log.checkpoint_not_found",
+                task_run_id=str(self.id),
+                checkpoint_id=checkpoint_id,
+            )
+            return {
+                "truncated": False,
+                "original_line_count": original_count,
+                "truncated_line_count": original_count,
+                "orphaned_checkpoint_ids": [],
+            }
+
+        # Collect orphaned checkpoint IDs from discarded lines
+        orphaned_checkpoint_ids: list[str] = []
+        for i in range(cutoff, len(lines)):
+            try:
+                entry = json.loads(lines[i])
+                notification = entry.get("notification", {})
+                if isinstance(notification, dict) and notification.get("method") == "_posthog/git_checkpoint":
+                    cp_id = notification.get("params", {}).get("checkpointId")
+                    if cp_id:
+                        orphaned_checkpoint_ids.append(cp_id)
+            except json.JSONDecodeError:
+                continue
+
+        truncated_lines = lines[:cutoff]
+        truncated_content = "\n".join(truncated_lines)
+        object_storage.write(self.log_url, truncated_content)
+
+        logger.info(
+            "task_run.truncate_log.done",
+            task_run_id=str(self.id),
+            checkpoint_id=checkpoint_id,
+            prompt_id=prompt_id,
+            original_line_count=original_count,
+            truncated_line_count=len(truncated_lines),
+            cutoff_line=cutoff,
+            orphaned_checkpoint_count=len(orphaned_checkpoint_ids),
+        )
+
+        return {
+            "truncated": True,
+            "original_line_count": original_count,
+            "truncated_line_count": len(truncated_lines),
+            "orphaned_checkpoint_ids": orphaned_checkpoint_ids,
+        }
+
     def mark_completed(self):
         """Mark the progress as completed."""
         self.status = self.Status.COMPLETED

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1603,6 +1603,26 @@ class CodeInviteRedeemRequestSerializer(serializers.Serializer):
     code = serializers.CharField(max_length=50)
 
 
+class TaskRunTruncateLogRequestSerializer(serializers.Serializer):
+    checkpoint_id = serializers.CharField(help_text="Checkpoint ID to truncate the log at")
+
+    prompt_id = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="Optional JSON-RPC prompt ID for the turn (fallback when checkpoint not in S3)",
+    )
+
+
+class TaskRunTruncateLogResponseSerializer(serializers.Serializer):
+    truncated = serializers.BooleanField(help_text="Whether the log was truncated")
+    original_line_count = serializers.IntegerField(help_text="Number of lines before truncation")
+    truncated_line_count = serializers.IntegerField(help_text="Number of lines after truncation")
+    orphaned_checkpoint_ids = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Checkpoint IDs that were in the discarded lines",
+    )
+
+
 class TaskRunSessionLogsQuerySerializer(serializers.Serializer):
     """Query parameters for filtering task run log events"""
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -93,6 +93,8 @@ from products.tasks.backend.presentation.serializers import (
     TaskRunSessionLogsQuerySerializer,
     TaskRunSetOutputRequestSerializer,
     TaskRunStartRequestSerializer,
+    TaskRunTruncateLogRequestSerializer,
+    TaskRunTruncateLogResponseSerializer,
     TaskRunUpdateSerializer,
     TaskSerializer,
     TaskStagedArtifactsFinalizeUploadRequestSerializer,
@@ -1039,6 +1041,38 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if relay_status == "accepted":
             return Response({"status": "accepted", "relay_id": relay_id})
         return Response({"status": "skipped"})
+
+    @validated_request(
+        request_serializer=TaskRunTruncateLogRequestSerializer,
+        responses={
+            200: OpenApiResponse(
+                response=TaskRunTruncateLogResponseSerializer,
+                description="Truncation result",
+            ),
+            404: OpenApiResponse(description="Run not found"),
+        },
+        summary="Truncate task run log at a checkpoint",
+        description="Truncates the S3 log at the turn containing the given checkpoint ID, discarding all subsequent turns. Used by checkpoint restore.",
+        strict_request_validation=True,
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="truncate_log",
+        required_scopes=["task:write"],
+    )
+    def truncate_log(self, request, pk=None, **kwargs):
+        task_id = self._ensure_task_accessible()
+        result = tasks_facade.truncate_task_run_log(
+            pk,
+            task_id,
+            self.team_id,
+            checkpoint_id=str(request.validated_data["checkpoint_id"]),
+            prompt_id=request.validated_data.get("prompt_id"),
+        )
+        if result is None:
+            raise NotFound()
+        return Response(result)
 
     @validated_request(
         request_serializer=TaskRunArtifactsUploadRequestSerializer,

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from parameterized import parameterized
 
@@ -1585,3 +1585,154 @@ class TestCodeInvite(TestCase):
         with patch("products.tasks.backend.models.secrets.choice", return_value="B"):
             with self.assertRaises(IntegrityError):
                 CodeInvite.objects.create()
+
+
+class TestTaskRunTruncateLog(SimpleTestCase):
+    """Unit coverage for TaskRun.truncate_log (checkpoint-restore S3 log truncation).
+
+    truncate_log is pure log-manipulation: it only reads the *_id fields (via log_url)
+    and object_storage (mocked here), never the DB — so these run without Postgres or
+    ClickHouse on unsaved instances.
+    """
+
+    def _run(self) -> TaskRun:
+        # Unsaved instance: log_url derives solely from id/team_id/task_id.
+        return TaskRun(id=uuid.uuid4(), team_id=1, task_id=1, status=TaskRun.Status.COMPLETED)
+
+    # --- log line builders -------------------------------------------------
+    @staticmethod
+    def _prompt_claude(prompt_id: int) -> str:
+        # Claude adapter logs outgoing prompts as type="request".
+        return json.dumps({"type": "request", "request": {"method": "session/prompt", "id": prompt_id}})
+
+    @staticmethod
+    def _prompt_codex(prompt_id: int) -> str:
+        # Codex adapter logs everything (incl. prompts) as type="notification".
+        return json.dumps({"type": "notification", "notification": {"method": "session/prompt", "id": prompt_id}})
+
+    @staticmethod
+    def _agent_chunk() -> str:
+        return json.dumps(
+            {
+                "type": "notification",
+                "notification": {
+                    "method": "session/update",
+                    "params": {"update": {"sessionUpdate": "agent_message_chunk"}},
+                },
+            }
+        )
+
+    @staticmethod
+    def _checkpoint(checkpoint_id: str) -> str:
+        return json.dumps(
+            {
+                "type": "notification",
+                "notification": {"method": "_posthog/git_checkpoint", "params": {"checkpointId": checkpoint_id}},
+            }
+        )
+
+    def _three_turn_log(self, codex: bool = False) -> list[str]:
+        """3 turns, each: prompt -> agent chunk -> checkpoint (cp1/cp2/cp3). 9 lines."""
+        prompt = self._prompt_codex if codex else self._prompt_claude
+        return [
+            prompt(1),
+            self._agent_chunk(),
+            self._checkpoint("cp1"),
+            prompt(2),
+            self._agent_chunk(),
+            self._checkpoint("cp2"),
+            prompt(3),
+            self._agent_chunk(),
+            self._checkpoint("cp3"),
+        ]
+
+    # --- tests -------------------------------------------------------------
+    @patch("products.tasks.backend.models.object_storage")
+    def test_truncates_at_checkpoint_midlog(self, mock_storage):
+        lines = self._three_turn_log()
+        mock_storage.read.return_value = "\n".join(lines)
+        run = self._run()
+
+        result = run.truncate_log("cp1")
+
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["original_line_count"], 9)
+        self.assertEqual(result["truncated_line_count"], 3)
+        self.assertEqual(result["orphaned_checkpoint_ids"], ["cp2", "cp3"])
+        mock_storage.write.assert_called_once_with(run.log_url, "\n".join(lines[:3]))
+
+    @patch("products.tasks.backend.models.object_storage")
+    def test_truncates_codex_style_log(self, mock_storage):
+        lines = self._three_turn_log(codex=True)
+        mock_storage.read.return_value = "\n".join(lines)
+        run = self._run()
+
+        result = run.truncate_log("cp2")
+
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["truncated_line_count"], 6)
+        self.assertEqual(result["orphaned_checkpoint_ids"], ["cp3"])
+        mock_storage.write.assert_called_once_with(run.log_url, "\n".join(lines[:6]))
+
+    @patch("products.tasks.backend.models.object_storage")
+    def test_prompt_id_fallback_when_checkpoint_missing(self, mock_storage):
+        lines = self._three_turn_log()
+        mock_storage.read.return_value = "\n".join(lines)
+        run = self._run()
+
+        result = run.truncate_log("cp-does-not-exist", prompt_id=2)
+
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["truncated_line_count"], 6)
+        self.assertEqual(result["orphaned_checkpoint_ids"], ["cp3"])
+        mock_storage.write.assert_called_once_with(run.log_url, "\n".join(lines[:6]))
+
+    @patch("products.tasks.backend.models.object_storage")
+    def test_tail_checkpoint_falls_back_to_prompt_id(self, mock_storage):
+        # cp3 is on the final turn (no next turn to cut at); prompt_id points earlier,
+        # so the fallback kicks in and truncates before turn 3.
+        lines = self._three_turn_log()
+        mock_storage.read.return_value = "\n".join(lines)
+        run = self._run()
+
+        result = run.truncate_log("cp3", prompt_id=2)
+
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["truncated_line_count"], 6)
+        mock_storage.write.assert_called_once_with(run.log_url, "\n".join(lines[:6]))
+
+    @patch("products.tasks.backend.models.object_storage")
+    def test_restore_to_latest_checkpoint_keeps_all(self, mock_storage):
+        # Restoring to the most recent checkpoint has no following turn to drop.
+        lines = self._three_turn_log()
+        mock_storage.read.return_value = "\n".join(lines)
+        run = self._run()
+
+        result = run.truncate_log("cp3")
+
+        self.assertEqual(result["truncated_line_count"], result["original_line_count"])
+        self.assertEqual(result["orphaned_checkpoint_ids"], [])
+
+    @patch("products.tasks.backend.models.object_storage")
+    def test_no_truncation_when_checkpoint_and_prompt_missing(self, mock_storage):
+        lines = self._three_turn_log()
+        mock_storage.read.return_value = "\n".join(lines)
+        run = self._run()
+
+        result = run.truncate_log("cp-does-not-exist")
+
+        self.assertFalse(result["truncated"])
+        self.assertEqual(result["original_line_count"], 9)
+        self.assertEqual(result["truncated_line_count"], 9)
+        mock_storage.write.assert_not_called()
+
+    @patch("products.tasks.backend.models.object_storage")
+    def test_empty_log_is_noop(self, mock_storage):
+        mock_storage.read.return_value = ""
+        run = self._run()
+
+        result = run.truncate_log("cp1")
+
+        self.assertFalse(result["truncated"])
+        self.assertEqual(result["original_line_count"], 0)
+        mock_storage.write.assert_not_called()


### PR DESCRIPTION
# feat(tasks): truncate_log endpoint for checkpoint restore

> Repo: **PostHog/posthog** · Branch: `worktree-checkpoint-s3-truncate`
> Closes https://github.com/PostHog/posthog/issues/70430
> Backend half of the checkpoint-restore feature — see frontend **https://github.com/PostHog/code/pull/3390**
> (issue PostHog/posthog#76314).

---

## Summary

Adds a **`truncate_log`** capability to `TaskRun` so a cloud run's durable conversation log (the S3
JSONL) can be trimmed at a **checkpoint boundary**. This is what lets the desktop app's "restore to
this checkpoint" also roll back the agent's *memory* for a cloud run: after the working tree is
reverted, the backend truncates the run log so post-checkpoint turns no longer re-hydrate into the
agent on resume.

Without this, a restore would revert files but the agent (which resumes from the S3 log) would still
"remember" the undone turns.

---

## Context

A cloud run's conversation is persisted as JSONL in S3 and replayed to rebuild agent state on resume.
The frontend already truncates the **local** cache and the git working tree on restore; this PR gives
it the matching server-side operation for the **authoritative** S3 log. The frontend calls this during
its restore/reconnect flow (see the frontend PR's restore diagram).

---

## Flow — where the backend sits

The backend's whole job here is to be the **durable memory** the desktop feature leans on: the run
log in S3, plus three actions over it. Only **`truncate_log`** is new; `append_log`, `session_logs`,
and `runtime_adapter` already exist and are consumed as-is.

```mermaid
---
title: "Backend contract — capture / handoff-read / restore-truncate"
config:
  theme: base
  themeVariables:
    darkMode: true
    background: "#0f1430"
    primaryColor: "#232a52"
    primaryTextColor: "#eef1ff"
    primaryBorderColor: "#5661a8"
    lineColor: "#8b94dd"
    secondaryColor: "#2c2350"
    tertiaryColor: "#1b2340"
    noteBkgColor: "#2c3566"
    noteTextColor: "#eef1ff"
    noteBorderColor: "#5661a8"
    actorBkg: "#2a3160"
    actorTextColor: "#eef1ff"
    actorBorder: "#5661a8"
    actorLineColor: "#8b94dd"
    signalColor: "#cdd4ff"
    signalTextColor: "#eef1ff"
    labelBoxBkgColor: "#2a3160"
    labelBoxBorderColor: "#5661a8"
    labelTextColor: "#eef1ff"
    loopTextColor: "#eef1ff"
    sequenceNumberColor: "#0f1430"
---
sequenceDiagram
    autonumber
    participant Sandbox as sandbox · agent-server.ts
    participant Client as desktop · api-client
    participant WS as host · workspace-server
    participant API as BACKEND · posthog (Django)
    participant S3 as S3 log store

    rect rgb(28, 35, 66)
    Note over Sandbox,S3: CAPTURE writes to the run log
    Sandbox->>API: append GIT_CHECKPOINT {checkpointId, prompt_id, turnCompletedAt, artifactPath}
    API->>S3: append_log (pre-existing) persist entry
    end

    rect rgb(43, 30, 63)
    Note over WS,S3: HANDOFF reads the log to sync cloud checkpoints
    WS->>Client: handoff/service.ts » syncCloudCheckpoints()
    Client->>API: getTaskRunSessionLogs(taskId, runId)
    API->>S3: session_logs (pre-existing) read
    API-->>Client: stored entries (incl. prompt_id, artifactPath)
    end

    rect rgb(48, 27, 52)
    Note over WS,S3: RESTORE truncates memory to the checkpoint
    WS->>Client: checkpoint/service.ts » runRestore()
    Client->>API: truncateTaskRunLog(taskId, runId, checkpointId)<br/>POST …/truncate_log/ { checkpoint_id }
    API->>S3: truncate_log (NEW)<br/>rewrite log, drop entries after the checkpoint turn
    API-->>Client: { truncated, original_line_count,<br/>truncated_line_count, orphaned_checkpoint_ids }
    Client-->>WS: desktop trims local cache + rebuilds agent memory
    end
```

- **Capture:** the sandbox appends a `GIT_CHECKPOINT` entry per turn — with `prompt_id` (turn index)
  and `turnCompletedAt` — so the log records not just *that* a checkpoint exists but *which turn* it
  belongs to.
- **Handoff:** the desktop reads the log back (`getTaskRunSessionLogs`) to discover the cloud
  checkpoints it materializes locally. Pure source-of-truth here — no compute.
- **Restore:** `truncate_log` rewrites the stored JSONL, drops every entry after the target turn, and
  returns `orphaned_checkpoint_ids` (checkpoints that no longer exist once the tail is gone) so the
  desktop can prune their icons. **This truncation is what makes the agent's memory match the reverted
  code** — without it, a resumed run replays turns that "happened after" the point you rolled back to.

```mermaid
---
title: "Backend endpoints ← desktop callers"
config:
  theme: base
  themeVariables:
    darkMode: true
    background: "#0f1430"
    primaryColor: "#232a52"
    primaryTextColor: "#eef1ff"
    primaryBorderColor: "#5661a8"
    lineColor: "#8b94dd"
    clusterBkg: "#161c38"
    clusterBorder: "#5661a8"
    edgeLabelBackground: "#161c38"
    titleColor: "#eef1ff"
---
flowchart LR
    subgraph fe["Desktop (this monorepo)"]
        A["api-client » truncateTaskRunLog()"]
        B["api-client » appendTaskRunLog()"]
        C["api-client » getTaskRunSessionLogs()"]
    end
    subgraph be["Backend (posthog repo)"]
        V1["api.py » truncate_log (NEW)<br/>rewrite log + orphaned_checkpoint_ids"]
        V2["append_log (pre-existing)"]
        V3["session_logs read (pre-existing)"]
        M["TaskRun.runtime_adapter (pre-existing)<br/>prompt_id round-trips in log entries — no migration"]
    end
    A --> V1
    B --> V2
    C --> V3
    V1 -.reads/writes.-> S3[(S3 run log)]
    V2 -.writes.-> S3
    V3 -.reads.-> S3
    M -.persisted with run.-> S3

    classDef blue fill:#232a52,stroke:#5661a8,color:#eef1ff;
    classDef purple fill:#2c2350,stroke:#6a4f9e,color:#eef1ff;
    classDef store fill:#1d3a49,stroke:#4a8fb0,color:#eaffff;
    class A,B,C blue;
    class V1,V2,V3,M purple;
    class S3 store;
```

The whole PR reduces to **one new mutating view (`truncate_log`)** + its method/serializer; the two
log views and `runtime_adapter` already exist, and everything else in the feature lives desktop-side.

---

## What this PR does

- **`models.py`** — `TaskRun.truncate_log(checkpoint_id: str, prompt_id: int | None = None) -> dict`
  plus two private helpers:
  - `_next_turn_cutoff(search_from)` — walks forward to the **next turn boundary** so truncation keeps
    whole `session/prompt` turns rather than slicing mid-turn.
  - `_find_cutoff_by_prompt_id()` — locates the `session/prompt` request/notification with the given
    `id` and returns the index of the following turn.
  - **Fallback logic:** primary cutoff is by `checkpoint_id`; if the checkpoint sits at the **tail**
    of the log (no next turn to cut at) *or* the checkpoint id isn't found, it falls back to the
    `prompt_id` search. Returns a status dict —
    `{ truncated, original_line_count, truncated_line_count, orphaned_checkpoint_ids }` — so the caller
    can log/verify and prune icons for checkpoints the truncation orphaned.
  - **HTTP contract:** the endpoint body is just `{ checkpoint_id }`; `prompt_id` is derived
    server-side for the tail/fallback cases, **not** sent by the client.
- **`presentation/views/api.py`** (+34) + **`facade/api.py`** (+15) — expose the `truncate_log` DRF
  action on the TaskRun API surface and wire it through the facade.
- **`presentation/serializers.py`** (+20) — request/response fields for the endpoint.

### No migration
This is **method + endpoint only** — no model fields added, no schema change, so **no Django
migration** is required. (The log lives in S3, not the DB.)

---

## Design decisions & trade-offs

- **Turn-boundary truncation.** We never cut inside a turn; cutoffs snap to the next
  `session/prompt` boundary so a resumed agent always sees coherent turns.
- **`prompt_id` as a fallback, not the primary key.** `checkpoint_id` is the natural key, but a
  checkpoint captured on the *last* turn has no "next turn" to cut before, and cross-handoff logs can
  make a bare checkpoint-id lookup ambiguous. `prompt_id` disambiguates those tail/edge cases.
- **Idempotent / non-destructive shape.** Truncating an already-truncated log is a no-op; the return
  dict makes that observable (before == after) rather than silently succeeding.

---

## Testing

### Automated (added in this PR)
A focused unit test class `TestTaskRunTruncateLog` in `products/tasks/backend/tests/test_models.py`
(infra-free) covers:
- cutoff by `checkpoint_id` mid-log — post-checkpoint turns removed, pre-checkpoint kept whole;
- **tail checkpoint** → `prompt_id` fallback path;
- unknown `checkpoint_id` → `prompt_id` fallback;
- no-op when the checkpoint is already at the log tail (before == after);
- turn-boundary integrity (never cuts mid-turn).

Run: `pytest products/tasks/backend/tests/ -k truncate_log`.

### Manual / integration
End-to-end behavior is exercised by the **frontend handoff matrix** (frontend PR, scenarios A–D on
both Claude and Codex): after a cloud checkpoint restore, the resumed agent's memory no longer
references undone turns — which is precisely this endpoint doing its job. All four scenarios pass on
both adapters.

---

## Roadmap / planned follow-ups
This endpoint is the server-side primitive behind the frontend restore roadmap (edit-a-turn
PostHog/posthog#76232, retry PostHog/posthog#76231, and a restore-modes menu). No further backend work is required for
those — a future "restore-modes" picker may pass an extra flag (e.g. keep-memory → skip truncation),
but the truncation primitive itself is unchanged.

## Risk / blast radius
Additive endpoint + method; no schema change; failures are surfaced in the return dict and treated as
non-fatal by the caller. No behavior change for runs that never call it.
