### PR TITLE
fix(frontend): rethrow chunk-load errors from nested error boundaries

### DIFF
--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -5,6 +5,8 @@ import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
 import { BeforeSendFn, CapturedNetworkRequest } from 'posthog-js'
 import { createRoot } from 'react-dom/client'
 
+import { ChunkLoadErrorBoundary } from 'scenes/ChunkLoadErrorBoundary'
+
 import { Exporter } from '~/exporter/Exporter'
 import { ExportType, ExportedData } from '~/exporter/types'
 import { initKea } from '~/initKea'
@@ -81,7 +83,12 @@ function renderApp(): void {
     if (root) {
         createRoot(root).render(
             <ErrorBoundary>
-                <Exporter {...exportedData} />
+                {/* Inside ErrorBoundary: chunk-load failures reload once (embeds outlive many deploys,
+                    so stale chunk references are routine); if the reload guard trips, the error surfaces
+                    to the ErrorBoundary above instead of escaping to the React root. */}
+                <ChunkLoadErrorBoundary>
+                    <Exporter {...exportedData} />
+                </ChunkLoadErrorBoundary>
             </ErrorBoundary>
         )
     } else {

--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import posthog from 'posthog-js'
+
+import { ChunkLoadErrorBoundary } from 'scenes/ChunkLoadErrorBoundary'
+
+import { initKeaTests } from '~/test/init'
+
+import { ErrorBoundary, LightErrorBoundary } from './ErrorBoundary'
+
+function ThrowChunkError(): JSX.Element {
+    throw new TypeError('Failed to fetch dynamically imported module: /static/react-json-view.js')
+}
+
+function ThrowRegularError(): JSX.Element {
+    throw new Error('regular render failure')
+}
+
+describe('ErrorBoundary chunk-load recovery', () => {
+    let consoleErrorSpy: jest.SpyInstance
+    let consoleWarnSpy: jest.SpyInstance
+    let captureExceptionSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        window.localStorage.clear()
+        initKeaTests()
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+        consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        captureExceptionSpy = jest.spyOn(posthog, 'captureException').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore()
+        consoleWarnSpy.mockRestore()
+        captureExceptionSpy.mockRestore()
+        cleanup()
+    })
+
+    it.each([
+        ['ErrorBoundary', ErrorBoundary],
+        ['LightErrorBoundary', LightErrorBoundary],
+    ])('%s rethrows chunk-load errors to the ChunkLoadErrorBoundary above, after capturing', (_name, Boundary) => {
+        const reload = jest.fn()
+
+        render(
+            <ChunkLoadErrorBoundary reload={reload}>
+                <Boundary>
+                    <ThrowChunkError />
+                </Boundary>
+            </ChunkLoadErrorBoundary>
+        )
+
+        expect(reload).toHaveBeenCalledTimes(1)
+        expect(captureExceptionSpy).toHaveBeenCalledTimes(1)
+        expect(screen.queryByText(/Failed to fetch dynamically imported module/)).not.toBeInTheDocument()
+    })
+
+    it.each([
+        ['ErrorBoundary', ErrorBoundary],
+        ['LightErrorBoundary', LightErrorBoundary],
+    ])('%s renders its error UI for chunk-load errors when no ChunkLoadErrorBoundary is above', (_name, Boundary) => {
+        render(
+            <Boundary>
+                <ThrowChunkError />
+            </Boundary>
+        )
+
+        expect(screen.getByText(/Failed to fetch dynamically imported module/)).toBeInTheDocument()
+    })
+
+    it('renders the error UI for non-chunk errors instead of rethrowing', () => {
+        const reload = jest.fn()
+
+        render(
+            <ChunkLoadErrorBoundary reload={reload}>
+                <ErrorBoundary>
+                    <ThrowRegularError />
+                </ErrorBoundary>
+            </ChunkLoadErrorBoundary>
+        )
+
+        expect(reload).not.toHaveBeenCalled()
+        expect(screen.getByText('An error has occurred')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import './ErrorBoundary.scss'
 
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { useContext } from 'react'
 
 import { IconCopy } from '@posthog/icons'
 import { PostHogErrorBoundary, type PostHogErrorBoundaryFallbackProps } from '@posthog/react'
@@ -10,6 +11,8 @@ import { SupportTicketExceptionEvent, supportLogic } from 'lib/components/Suppor
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { isChunkLoadError } from 'lib/utils/isChunkLoadError'
+import { ChunkLoadRecoveryContext } from 'scenes/ChunkLoadErrorBoundary'
 import { teamLogic } from 'scenes/teamLogic'
 
 const DOM_MUTATION_PATTERNS = [
@@ -32,6 +35,7 @@ interface ErrorBoundaryProps {
 export function ErrorBoundary({ children, exceptionProps = {}, className }: ErrorBoundaryProps): JSX.Element {
     const { currentTeamId } = useValues(teamLogic)
     const { openSupportForm } = useActions(supportLogic)
+    const chunkLoadRecoveryAvailable = useContext(ChunkLoadRecoveryContext)
 
     const additionalProperties = { ...exceptionProps }
 
@@ -44,6 +48,12 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
             additionalProperties={additionalProperties}
             fallback={(props: PostHogErrorBoundaryFallbackProps) => {
                 const rawError = props.error
+                if (chunkLoadRecoveryAvailable && isChunkLoadError(rawError)) {
+                    // Rethrow chunk-load failures (PostHogErrorBoundary has already captured them) so the
+                    // ChunkLoadErrorBoundary above reloads once and a stale deploy heals with fresh assets,
+                    // instead of dead-ending in this error UI on every lazy component that failed to load.
+                    throw rawError
+                }
                 const normalizedError =
                     rawError instanceof Error
                         ? rawError
@@ -146,6 +156,7 @@ export function ErrorBoundary({ children, exceptionProps = {}, className }: Erro
 
 export function LightErrorBoundary({ children, exceptionProps = {}, className }: ErrorBoundaryProps): JSX.Element {
     const { currentTeamId } = useValues(teamLogic)
+    const chunkLoadRecoveryAvailable = useContext(ChunkLoadRecoveryContext)
     const additionalProperties = { ...exceptionProps }
     if (currentTeamId !== undefined) {
         additionalProperties.team_id = currentTeamId
@@ -155,6 +166,10 @@ export function LightErrorBoundary({ children, exceptionProps = {}, className }:
             additionalProperties={additionalProperties}
             fallback={(props: PostHogErrorBoundaryFallbackProps) => {
                 const rawError = props.error
+                if (chunkLoadRecoveryAvailable && isChunkLoadError(rawError)) {
+                    // Same recovery as ErrorBoundary: let the ChunkLoadErrorBoundary above reload once.
+                    throw rawError
+                }
                 const normalizedError =
                     rawError instanceof Error
                         ? rawError

--- a/frontend/src/lib/utils/dedupeChunkLoadExceptions.test.ts
+++ b/frontend/src/lib/utils/dedupeChunkLoadExceptions.test.ts
@@ -1,0 +1,60 @@
+import { type CaptureResult } from 'posthog-js'
+
+import { dedupeChunkLoadExceptions } from './dedupeChunkLoadExceptions'
+
+function exceptionEvent(type: string, value: string): CaptureResult {
+    return {
+        event: '$exception',
+        properties: { $exception_list: [{ type, value }] },
+    } as unknown as CaptureResult
+}
+
+describe('dedupeChunkLoadExceptions', () => {
+    const CHUNK_MESSAGE = 'Failed to fetch dynamically imported module: /static/foo.js'
+
+    it('keeps the first chunk-load exception but drops synchronous repeats of the same error', () => {
+        const beforeSend = dedupeChunkLoadExceptions()
+        const first = exceptionEvent('TypeError', CHUNK_MESSAGE)
+        const second = exceptionEvent('TypeError', CHUNK_MESSAGE)
+
+        // One chunk failure rethrown through two nested boundaries → two identical captures in one task.
+        expect(beforeSend(first)).toBe(first)
+        expect(beforeSend(second)).toBeNull()
+    })
+
+    it('keeps distinct chunk-load failures (different messages) even in the same task', () => {
+        const beforeSend = dedupeChunkLoadExceptions()
+        const a = exceptionEvent('TypeError', 'Failed to fetch dynamically imported module: /static/a.js')
+        const b = exceptionEvent('TypeError', 'Failed to fetch dynamically imported module: /static/b.js')
+
+        expect(beforeSend(a)).toBe(a)
+        expect(beforeSend(b)).toBe(b)
+    })
+
+    it('re-reports the same chunk error once the task settles', async () => {
+        const beforeSend = dedupeChunkLoadExceptions()
+        const first = exceptionEvent('TypeError', CHUNK_MESSAGE)
+        const later = exceptionEvent('TypeError', CHUNK_MESSAGE)
+
+        expect(beforeSend(first)).toBe(first)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(beforeSend(later)).toBe(later)
+    })
+
+    it('passes through non-chunk exceptions untouched, including repeats', () => {
+        const beforeSend = dedupeChunkLoadExceptions()
+        const a = exceptionEvent('Error', 'regular render failure')
+        const b = exceptionEvent('Error', 'regular render failure')
+
+        expect(beforeSend(a)).toBe(a)
+        expect(beforeSend(b)).toBe(b)
+    })
+
+    it('passes through non-exception events and null', () => {
+        const beforeSend = dedupeChunkLoadExceptions()
+        const pageview = { event: '$pageview', properties: {} } as unknown as CaptureResult
+
+        expect(beforeSend(pageview)).toBe(pageview)
+        expect(beforeSend(null)).toBeNull()
+    })
+})

--- a/frontend/src/lib/utils/dedupeChunkLoadExceptions.ts
+++ b/frontend/src/lib/utils/dedupeChunkLoadExceptions.ts
@@ -1,0 +1,42 @@
+import { type BeforeSendFn, type CaptureResult } from 'posthog-js'
+
+import { isChunkLoadError } from './isChunkLoadError'
+
+interface ExceptionListItem {
+    type?: string
+    value?: string
+}
+
+// A single chunk-load failure is caught and captured by every nested ErrorBoundary it rethrows
+// through on the way to the ChunkLoadErrorBoundary (see layout/ErrorBoundary). Those captures all
+// fire synchronously during one React error-propagation pass, so one stale-deploy failure turns
+// into N identical `$exception` events. Keep the first and drop the synchronous repeats.
+//
+// Distinct failures (a different chunk, so a different message) and non-chunk exceptions are never
+// touched — only exact repeats of the same chunk error within the current task are dropped.
+export function dedupeChunkLoadExceptions(): BeforeSendFn {
+    const seenThisTask = new Set<string>()
+
+    return (event: CaptureResult | null): CaptureResult | null => {
+        if (!event || event.event !== '$exception') {
+            return event
+        }
+
+        const list = event.properties?.$exception_list as ExceptionListItem[] | undefined
+        const chunkError = Array.isArray(list)
+            ? list.find((item) => isChunkLoadError({ name: item?.type, message: item?.value }))
+            : undefined
+        if (!chunkError) {
+            return event
+        }
+
+        const key = `${chunkError.type ?? ''}:${chunkError.value ?? ''}`
+        if (seenThisTask.has(key)) {
+            return null
+        }
+        seenThisTask.add(key)
+        // Clear once the synchronous burst settles so a genuinely new failure later still reports.
+        setTimeout(() => seenThisTask.delete(key), 0)
+        return event
+    }
+}

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -3,6 +3,7 @@ import { sampleOnProperty } from 'posthog-js/lib/src/extensions/sampling'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { isOAuthMode } from 'lib/oauth/oauthClient'
+import { dedupeChunkLoadExceptions } from 'lib/utils/dedupeChunkLoadExceptions'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
 
 import { startDetachedElementTracking } from './detachedElementTracker'
@@ -56,7 +57,16 @@ export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
             error_tracking: {
                 __capturePostHogExceptions: true,
             },
-            before_send: options.beforeSend,
+            // Drop the duplicate `$exception` events a chunk-load failure produces as it rethrows
+            // up through nested ErrorBoundaries, then run any caller-provided hooks.
+            before_send: [
+                dedupeChunkLoadExceptions(),
+                ...(Array.isArray(options.beforeSend)
+                    ? options.beforeSend
+                    : options.beforeSend
+                      ? [options.beforeSend]
+                      : []),
+            ],
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true

--- a/frontend/src/scenes/ChunkLoadErrorBoundary.tsx
+++ b/frontend/src/scenes/ChunkLoadErrorBoundary.tsx
@@ -1,9 +1,16 @@
-import { Component, type ReactNode } from 'react'
+import { Component, createContext, type ReactNode } from 'react'
 
 import { isChunkLoadError } from 'lib/utils/isChunkLoadError'
 
 const RELOAD_GUARD_KEY = 'posthog-chunk-reload-at'
 const RELOAD_GUARD_WINDOW_MS = 20_000
+
+/**
+ * True wherever a ChunkLoadErrorBoundary is mounted above, i.e. a rethrown chunk-load error
+ * gets recovered with a one-time reload instead of escaping to the React root. Nested error
+ * boundaries (layout/ErrorBoundary) check this before rethrowing chunk-load errors upward.
+ */
+export const ChunkLoadRecoveryContext = createContext(false)
 
 interface State {
     error: unknown
@@ -67,6 +74,6 @@ export class ChunkLoadErrorBoundary extends Component<ChunkLoadErrorBoundaryProp
         if (error && isChunkLoadError(error)) {
             return null
         }
-        return this.props.children
+        return <ChunkLoadRecoveryContext.Provider value={true}>{this.props.children}</ChunkLoadRecoveryContext.Provider>
     }
 }


### PR DESCRIPTION
## Problem

**Why:** a customer bug report showed a dashboard replaced by the raw "An error has occurred" card with `TypeError: Failed to fetch dynamically imported module` after a deploy, and error tracking shows this class firing steadily across many chunk hashes, clustering around deploys.

We already have a recovery pipeline for stale-deploy chunk failures. `retryImport` retries transient fetch failures (#68897), and if the chunk is really gone `ChunkLoadErrorBoundary` reloads the page once so the tab picks up fresh assets (guarded against loops). The scene loader and root `App` import are wired into it, and `App.tsx` even orders its boundaries so scene-level chunk errors reach `ChunkLoadErrorBoundary` before the scene's `ErrorBoundary`.

But any `ErrorBoundary` mounted deeper in the tree preempts that. Dashboard tiles (`InsightCard`/`QueryCard`) and a dozen other surfaces wrap their content in the shared `ErrorBoundary`, which catches the chunk error first and renders the raw stack trace with an "Email an engineer" button. The reload recovery never runs. Because `React.lazy` caches the rejected import, the component stays broken for the rest of the SPA session, so the user hits the same error card on every dashboard they navigate to until they manually reload. This is the same UX described in #55535, surviving through the nested-boundary path.

Refs #55535

**Before**

```mermaid
flowchart LR
    A{{lazy chunk fetch fails}} --> R[retryImport retries]
    R --> B[nested ErrorBoundary]
    B --> C[raw stack + email an engineer card]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
    class C phRed;
```

**After**

```mermaid
flowchart LR
    A{{lazy chunk fetch fails}} --> R[retryImport retries]
    R --> B[nested ErrorBoundary captures then rethrows]
    B --> D[ChunkLoadErrorBoundary]
    D --> E[one-time reload with fresh assets]
    D --> F[reload guard tripped - error card]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,D phBlue;
    class E phYellow;
    class F phRed;
```

## Changes

- `ChunkLoadErrorBoundary` now provides `ChunkLoadRecoveryContext` (default `false`) around its children, signalling that a rethrown chunk-load error will be recovered with a reload instead of escaping to the React root.
- `ErrorBoundary` and `LightErrorBoundary` rethrow chunk-load errors from their fallback when that context is set. `PostHogErrorBoundary.componentDidCatch` has already captured the exception by the time the fallback renders, so error tracking visibility is unchanged. React's already-failed-boundary handling propagates the rethrow to the next boundary above rather than looping.
- The exporter entry point (shared dashboards and embeds, which outlive many deploys) gets a `ChunkLoadErrorBoundary` inside its existing `ErrorBoundary`, so stale embeds heal the same way and a guard-tripped error still lands in the error UI.
- Trees with no `ChunkLoadErrorBoundary` above (e.g. the toolbar) keep today's behavior, the context gate means nothing rethrows into a dead end.

> [!NOTE]
> Behavior change: a chunk-load failure inside a nested boundary now triggers the same guarded one-time page reload that scene-level failures already do, instead of rendering a broken tile. Repeated failures within the 20s guard window still surface the error card.

Not covered here: `NotebookComponentShell` and `NotebookNodePlaylist` use `PostHogErrorBoundary` directly with custom fallbacks and still swallow chunk errors, left for a follow-up.

## How did you test this code?

Automated only, no manual browser testing (agent-authored change):

- New `frontend/src/layout/ErrorBoundary/ErrorBoundary.test.tsx` (5 tests). Regressions each group catches, none covered by existing tests since `ErrorBoundary` had no test file:
  - rethrow-to-reload for both boundary variants, including capture-before-rethrow: catches removing the rethrow or the provider, which would silently restore the dead-end error card on every dashboard tile
  - chunk error with no `ChunkLoadErrorBoundary` above renders the normal error UI: catches ungating the rethrow, which would let chunk errors escape to the React root and blank exporter or toolbar pages
  - non-chunk errors still render the error UI and never trigger a reload: catches an inverted or over-eager condition
- Existing `ChunkLoadErrorBoundary.test.tsx` (3 tests) still passes with the provider change, and the `HogQLX/render.test.tsx` suite (11 tests, consumes `LightErrorBoundary`, snapshots) is unchanged.
- `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected, this is internal frontend failure recovery.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) from a customer bug report, directed by @darkopia. Skills invoked: `/writing-tests`. Investigation: queried error tracking for this failure class (steady occurrence across many chunk hashes, clustered around deploy annotations), reconstructed the reporting user's session (repeated failures across dashboards with no reload in between, confirming the boundary never fired), and read `@posthog/react`'s `PostHogErrorBoundary` source to confirm capture happens in `componentDidCatch` before the fallback renders, so a fallback rethrow keeps capture intact. Considered an unconditional rethrow but rejected it because trees without a `ChunkLoadErrorBoundary` (exporter, toolbar) would dead-end at the React root, hence the context gate. Checked for overlapping work first: #68897 (merged) covers retries, #67294 / #68503 / #70227 (open) only extend `isChunkLoadError` message patterns, none touch the nested-boundary path.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
