### PR TITLE
chore(mcp): roll out agent-feedback tool to everyone

### DIFF
--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -932,7 +932,6 @@
         "title": "Submit PostHog feedback",
         "required_scopes": [],
         "always_available": true,
-        "feature_flag": "mcp-feedback-tool",
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": false,

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -21,7 +21,6 @@
         "title": "Submit PostHog feedback",
         "required_scopes": [],
         "always_available": true,
-        "feature_flag": "mcp-feedback-tool",
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": false,

--- a/services/mcp/src/hono/instructions.ts
+++ b/services/mcp/src/hono/instructions.ts
@@ -58,7 +58,6 @@ export class InstructionsBuilder {
                         ...(def.system_prompt_hint ? { systemPromptHint: def.system_prompt_hint } : {}),
                     } as QueryToolInfo
                 }),
-            featureFlags: state.toolFeatureFlags,
             renderUiEnabled: state.renderUiEnabled,
             metadata: state.metadata,
             groupTypes: state.groupTypes,

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -7,7 +7,6 @@ import {
     type QueryToolInfo,
     type ToolInfo,
 } from '@/lib/instructions'
-import type { EvaluatedFlags } from '@/lib/posthog/flags'
 import { formatPrompt } from '@/lib/utils'
 import AGENT_FEEDBACK from '@/templates/sections/agent-feedback.md'
 import BASIC_FUNCTIONALITY from '@/templates/sections/basic-functionality.md'
@@ -33,9 +32,6 @@ export interface InstructionsContext {
     metadata?: string | undefined
     tools?: ToolInfo[] | undefined
     queryTools?: QueryToolInfo[] | undefined
-    /** Resolved tool feature flags from `resolveToolFeatureFlags`. Used to gate
-     *  prompt sections whose corresponding tool is flag-gated. */
-    featureFlags?: EvaluatedFlags | undefined
     /** Whether `render-ui` is actually available to this client (i.e. the client is
      *  an MCP Apps host). Gates the CLI rendering section so it never reaches clients —
      *  like Claude Code — that can't mount the iframe. */
@@ -59,7 +55,7 @@ export class InstructionsFormatter {
                 SCHEMA_WORKFLOW,
                 ENV_CONTEXT,
                 URL_PATTERNS,
-                ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK] : []),
+                AGENT_FEEDBACK,
                 EXAMPLES,
             ],
             ctx,
@@ -114,14 +110,13 @@ export class InstructionsFormatter {
             SCHEMA_WORKFLOW,
             ENV_CONTEXT,
             URL_PATTERNS,
-            ...(this.agentFeedbackEnabled(ctx.featureFlags) ? [AGENT_FEEDBACK] : []),
+            AGENT_FEEDBACK,
             EXAMPLES,
         ]
         const renderCtx: InstructionsContext = opts.stripEnvContext
             ? {
                   guidelines: ctx.guidelines,
                   queryTools: ctx.queryTools,
-                  featureFlags: ctx.featureFlags,
                   ...(opts.keepEnvContext ? { metadata: ctx.metadata, groupTypes: ctx.groupTypes } : {}),
               }
             : { ...ctx, tools: undefined }
@@ -130,13 +125,6 @@ export class InstructionsFormatter {
         // agents still discover domains at runtime via the `search` command, and
         // `instructions`-honoring clients keep the compact domain index there.
         return this.compose(sections, renderCtx, { compact: false })
-    }
-
-    /** The agent-feedback section is only useful when the `agent-feedback` tool
-     *  is reachable, which is governed by the `mcp-feedback-tool` flag evaluated
-     *  in `resolveToolFeatureFlags`. */
-    private agentFeedbackEnabled(featureFlags: EvaluatedFlags | undefined): boolean {
-        return featureFlags?.['mcp-feedback-tool'] === true
     }
 
     private compose(sections: string[], ctx: InstructionsContext, opts: { compact: boolean }): string {

--- a/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
@@ -46,7 +46,6 @@ const STATIC_CTX: InstructionsContext = {
     metadata: STATIC_METADATA,
     tools: STATIC_TOOLS,
     queryTools: STATIC_QUERY_TOOLS,
-    featureFlags: { 'mcp-feedback-tool': true },
     renderUiEnabled: true,
 }
 
@@ -142,7 +141,7 @@ describe('InstructionsFormatter prompt snapshots', () => {
         const state = {
             allTools: Object.keys(getToolDefinitions()).map((name) => ({ name })),
             clientProfile: new MCPClientProfile({ vendorClient: 'ClaudeAI', userAgent: 'Claude-User' }),
-            toolFeatureFlags: { 'mcp-feedback-tool': true },
+            toolFeatureFlags: {},
             renderUiEnabled: true,
             metadata: worstCaseMetadata,
             groupTypes: worstCaseGroupTypes,

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -34,7 +34,6 @@ const fullCtx: InstructionsContext = {
     metadata: realisticMetadata,
     tools: realisticTools,
     queryTools: realisticQueryTools,
-    featureFlags: { 'mcp-feedback-tool': true },
     renderUiEnabled: true,
 }
 
@@ -82,15 +81,12 @@ describe('InstructionsFormatter', () => {
             expect(result).not.toContain('{metadata}')
         })
 
-        it('includes the agent-feedback section only when the mcp-feedback-tool flag is on', () => {
+        it('always includes the agent-feedback section', () => {
             const formatter = new InstructionsFormatter()
-            const withFeedback = formatter.buildToolsInstructions(fullCtx)
-            expect(withFeedback).toContain('### Sharing feedback on PostHog')
-
-            for (const featureFlags of [undefined, { 'mcp-feedback-tool': false }, {}]) {
-                const result = formatter.buildToolsInstructions({ ...fullCtx, featureFlags })
-                expect(result).not.toContain('### Sharing feedback on PostHog')
-            }
+            expect(formatter.buildToolsInstructions(fullCtx)).toContain('### Sharing feedback on PostHog')
+            expect(formatter.buildToolsInstructions({ guidelines: 'rules' })).toContain(
+                '### Sharing feedback on PostHog'
+            )
         })
     })
 
@@ -205,17 +201,11 @@ describe('InstructionsFormatter', () => {
             expect(result).toContain('Defined group types: organization')
         })
 
-        it('includes the agent-feedback section only when the mcp-feedback-tool flag is on', () => {
+        it('always includes the agent-feedback section', () => {
             const formatter = new InstructionsFormatter()
             for (const stripEnvContext of [true, false]) {
                 const withFeedback = formatter.buildExecCommandReference(fullCtx, { stripEnvContext })
                 expect(withFeedback).toContain('### Sharing feedback on PostHog')
-
-                const withoutFeedback = formatter.buildExecCommandReference(
-                    { ...fullCtx, featureFlags: { 'mcp-feedback-tool': false } },
-                    { stripEnvContext }
-                )
-                expect(withoutFeedback).not.toContain('### Sharing feedback on PostHog')
             }
         })
 

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -140,16 +140,14 @@ describe('Tool Filtering - Tools Allowlist', () => {
             expect(withEmptyTools).toEqual(allTools)
         })
 
-        it('should return only specified tools (plus always_available tools when enabled)', () => {
+        it('should return only specified tools (plus always_available tools)', () => {
             const tools = getToolsForFeatures({
                 tools: ['dashboard-get', 'dashboard-create'],
-                featureFlags: { 'mcp-feedback-tool': true },
             })
             expect(tools).toContain('dashboard-get')
             expect(tools).toContain('dashboard-create')
 
-            // always_available tools are included alongside the allowlist regardless of order
-            // (when their gating feature flag is enabled).
+            // always_available tools are included alongside the allowlist regardless of order.
             const alwaysAvailableTools = collectAlwaysAvailableToolNames()
             expect(tools).toContain('agent-feedback')
 
@@ -163,7 +161,6 @@ describe('Tool Filtering - Tools Allowlist', () => {
         it('should return only always_available tools for nonexistent tool names', () => {
             const tools = getToolsForFeatures({
                 tools: ['nonexistent-tool'],
-                featureFlags: { 'mcp-feedback-tool': true },
             })
             const alwaysAvailableTools = collectAlwaysAvailableToolNames()
 
@@ -175,19 +172,15 @@ describe('Tool Filtering - Tools Allowlist', () => {
         it('should always include agent-feedback even when feature filter matches no tools', () => {
             const tools = getToolsForFeatures({
                 features: ['nonexistent-feature'],
-                featureFlags: { 'mcp-feedback-tool': true },
             })
             expect(tools).toContain('agent-feedback')
         })
 
-        it('should hide agent-feedback when its gating feature flag is off', () => {
-            // Flag explicitly off — tool is hidden even though it's always_available.
-            const toolsWithFlagOff = getToolsForFeatures({ featureFlags: { 'mcp-feedback-tool': false } })
-            expect(toolsWithFlagOff).not.toContain('agent-feedback')
-
-            // No flags evaluated at all — also hidden (default behavior is `enable`).
-            const toolsWithoutFlags = getToolsForFeatures({})
-            expect(toolsWithoutFlags).not.toContain('agent-feedback')
+        it('should include agent-feedback regardless of feature flags', () => {
+            // agent-feedback is always_available and no longer flag-gated — it is
+            // present whether or not any feature flags are evaluated.
+            expect(getToolsForFeatures({})).toContain('agent-feedback')
+            expect(getToolsForFeatures({ featureFlags: {} })).toContain('agent-feedback')
         })
 
         it('should union with features (OR) when both are provided', () => {
@@ -327,7 +320,7 @@ describe('Tool Filtering - API Scopes', () => {
 
     it('should return only tools with no required scopes when user has no matching scopes', async () => {
         const context = createMockContext(['some:unknown'])
-        const tools = await getToolsFromContext(context, { featureFlags: { 'mcp-feedback-tool': true } })
+        const tools = await getToolsFromContext(context)
         const toolNames = tools.map((t) => t.name)
 
         // Only tools with no required scopes (or that bypass scope checks) should be available.
@@ -338,7 +331,7 @@ describe('Tool Filtering - API Scopes', () => {
 
     it('should return only tools with no required scopes when user has empty scopes', async () => {
         const context = createMockContext([])
-        const tools = await getToolsFromContext(context, { featureFlags: { 'mcp-feedback-tool': true } })
+        const tools = await getToolsFromContext(context)
         const toolNames = tools.map((t) => t.name)
 
         expect(toolNames).toContain('debug-mcp-ui-apps')
@@ -734,7 +727,6 @@ describe('Tool Filtering - Feature Flags', () => {
 
     it('getRequiredFeatureFlags should return flags used by current definitions', () => {
         const flags = getRequiredFeatureFlags()
-        // Includes the gating flag for agent-feedback alongside the other gated tools.
         expect(flags).toEqual(
             expect.arrayContaining([
                 'agent-platform',
@@ -743,7 +735,6 @@ describe('Tool Filtering - Feature Flags', () => {
                 'replay-video-based-summarization',
                 'tracing',
                 'visual-review',
-                'mcp-feedback-tool',
                 'user-interviews',
                 'customer-analytics-csp',
                 'notebooks-collaboration',
@@ -760,7 +751,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'engineering-analytics',
             ])
         )
-        expect(flags).toHaveLength(21)
+        expect(flags).toHaveLength(20)
     })
 
     // Exercise the real predicate (toolPassesFlagGate) over hand-rolled entries

--- a/services/mcp/tests/unit/tool-schema-snapshots.test.ts
+++ b/services/mcp/tests/unit/tool-schema-snapshots.test.ts
@@ -84,10 +84,10 @@ describe('Tool schema snapshots', () => {
     it('snapshots runtime tool schemas', async () => {
         const shouldUpdateSnapshots = isSnapshotUpdateAll()
         const root = path.resolve(__dirname, '__snapshots__', 'tool-schemas')
-        // Enable flag-gated tools we snapshot here: agent-feedback, tracing (APM spans), tasks,
+        // Enable flag-gated tools we snapshot here: tracing (APM spans), tasks,
         // dashboard-widgets. Other flag-gated tools (logs-alerts, visual-review, etc.) stay off to keep the surface stable.
+        // agent-feedback is always_available and no longer flag-gated, so it appears regardless.
         const featureFlags = {
-            'mcp-feedback-tool': true,
             tracing: true,
             tasks: true,
             'dashboard-widgets': true,


### PR DESCRIPTION
## Problem

The MCP `agent-feedback` tool (and its instructions section) was gated behind the `mcp-feedback-tool` feature flag, so only clients whose evaluated flags included it could see or use it. We want feedback collection on for every MCP client.

## Changes

Remove the `mcp-feedback-tool` flag entirely so the tool ships to all clients:

- Drop `feature_flag` from the `agent-feedback` definition in `tool-definitions.json` (and the combined `tool-definitions-all.json`). The tool stays `always_available`, read-only, and requires no scopes, so it now passes the filter for everyone.
- `InstructionsFormatter` always renders the "Sharing feedback on PostHog" section. Removed the dead `agentFeedbackEnabled` gate and the `featureFlags` field it was the only consumer of (also dropped the corresponding pass-through in `instructions.ts`).
- Updated tool-filtering, instructions, and snapshot tests to reflect that the tool is unconditionally present.

> [!NOTE]
> `getRequiredFeatureFlags()` no longer emits `mcp-feedback-tool`, so it stops being evaluated per request. The underlying PostHog flag can be retired separately once no other surface reads it.

## How did you test this code?

I (the PostHog Slack app agent) could not install the monorepo toolchain in the sandbox, so I did not run the vitest suite or typecheck here. Verification was static: confirmed the flag key, the removed method, and the removed context field have no remaining references in `services/mcp`, and that both JSON definition files still parse. The updated tests (`tool-filtering`, `instructions-formatter`, `instructions-formatter-snapshot`, `tool-schema-snapshots`) should be run in CI. Snapshots are unchanged because the feedback section was already enabled in their fixtures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy asked (via Slack) to remove the agentic-feedback feature flag in `services/mcp` and roll the tool out for all. I traced the gate to two places: the `feature_flag: mcp-feedback-tool` on the tool definition (drives tool registration via `toolPassesFlagGate`) and a direct flag read in `InstructionsFormatter` that gated the prompt section. Rolling out "for all" meant both had to change — just dropping the tool flag would have silently removed the instructions section, since the flag would no longer be evaluated. I chose to delete the now-unused `featureFlags` field from `InstructionsContext` rather than leave dead plumbing. No skills were invoked. Tests were updated but not executed locally (see testing section).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1783946357122479)*
