### PR TITLE
fix(insights): show compare tag in breakdown detailed results table

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.stories.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.stories.tsx
@@ -162,6 +162,16 @@ export const ComparePrevious: Story = {
     },
 }
 
+// The "Detailed results" table below an insight renders as a legend (not isMainInsightView).
+// With a single series + breakdown, the breakdown value replaces the series column, so the
+// current/previous compare tag must still appear on each row.
+export const CompareLegend: Story = {
+    render: renderCompareInsightsTable,
+    args: {
+        isLegend: true,
+    },
+}
+
 // A HogQL breakdown expression that is far too long to fit in a column. The header should be clipped
 // with an ellipsis rather than overflowing into neighbouring columns.
 const LONG_SQL_BREAKDOWN =

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -30,7 +30,7 @@ import {
 import { BreakdownColumnItem, BreakdownColumnTitle, MultipleBreakdownColumnTitle } from './columns/BreakdownColumn'
 import { ColorCustomizationColumnItem, ColorCustomizationColumnTitle } from './columns/ColorCustomizationColumn'
 import { SeriesCheckColumnItem, SeriesCheckColumnTitle } from './columns/SeriesCheckColumn'
-import { SeriesColumnItem } from './columns/SeriesColumn'
+import { formatCompareLabel, SeriesColumnItem } from './columns/SeriesColumn'
 import { ValueColumnItem, ValueColumnTitle } from './columns/ValueColumn'
 import { WorldMapColumnItem, WorldMapColumnTitle } from './columns/WorldMapColumn'
 import { AggregationType, insightsTableDataLogic } from './insightsTableDataLogic'
@@ -185,6 +185,7 @@ export function InsightsTable({
                     item={item}
                     formatItemBreakdownLabel={formatItemBreakdownLabel!}
                     breakdownFilter={breakdownFilter}
+                    compareValue={item.compare && !isCompareTable ? formatCompareLabel(item) : undefined}
                 />
             ) : (
                 <SeriesColumnItem

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/BreakdownColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/BreakdownColumn.tsx
@@ -1,5 +1,5 @@
 import { IconPin, IconPinFilled } from '@posthog/icons'
-import { Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { parseAliasToReadable } from 'lib/components/PathCleanFilters/PathCleanFilterItem'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
@@ -81,12 +81,15 @@ type BreakdownColumnItemProps = {
     item: IndexedTrendResult
     formatItemBreakdownLabel: (item: IndexedTrendResult) => string
     breakdownFilter?: BreakdownFilter
+    /** Compare-to-previous-period tag (e.g. "Current"/"Previous"), shown when the breakdown value replaces the series column. */
+    compareValue?: string
 }
 
 export function BreakdownColumnItem({
     item,
     formatItemBreakdownLabel,
     breakdownFilter,
+    compareValue,
 }: BreakdownColumnItemProps): JSX.Element {
     const breakdownLabel = formatItemBreakdownLabel(item)
     const showPathCleaningHighlight = breakdownFilter?.breakdown_path_cleaning && typeof breakdownLabel === 'string'
@@ -96,7 +99,7 @@ export function BreakdownColumnItem({
 
     // Clipped with CSS only, so the full value stays in the DOM — copying the cell copies everything
     return (
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-center gap-2">
             {breakdownLabel && (
                 <>
                     {isURL(breakdownLabel) ? (
@@ -115,6 +118,11 @@ export function BreakdownColumnItem({
                         </div>
                     )}
                 </>
+            )}
+            {compareValue && (
+                <Tooltip title={compareValue}>
+                    <LemonTag className="shrink-0">{compareValue}</LemonTag>
+                </Tooltip>
             )}
         </div>
     )


### PR DESCRIPTION
## TL;DR

The little "Current" / "Previous" tags you get on a trends "Detailed results" table when you turn on "compare to previous period" went missing whenever the insight had a breakdown. This puts them back.

## Problem

The "Detailed results" table under a trends insight shows each row's period as a tag ("Current" / "Previous") when compare-to-previous-period is on. This worked for plain insights but silently dropped the tag for insights with a breakdown.

Root cause: when an insight has a single series **and** a breakdown, the table merges the breakdown value into the first column and renders it with `BreakdownColumnItem` instead of `SeriesColumnItem`. The compare tag is produced by `SeriesColumnItem` (via `InsightLabel`'s pills). `BreakdownColumnItem` had no notion of compare at all, so the tag never rendered. Multi-series or multi-breakdown insights keep `SeriesColumnItem`, which is why they were unaffected.

## Changes

- `BreakdownColumnItem` gains an optional `compareValue` and renders it as a `LemonTag`.
- `InsightsTable` passes the compare label to the merged first column, guarded so the main-insight compare view keeps using its dedicated "Previous" aggregation columns instead of a pill.
- Added a `CompareLegend` story covering the legend / "Detailed results" path where the bug lived (the existing `ComparePrevious` story only exercised `isMainInsightView`).

## How did you test this code?

Added the `CompareLegend` Storybook story that reproduces the exact scenario (single series + single breakdown + compare, rendered as a legend). I (Claude) could not run the frontend typecheck, lint, or Storybook in this environment (`node_modules` not installed). The change is small and type-safe; please rely on CI for typecheck and visual-regression snapshots.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and authored by Claude (PostHog Code). Traced the missing tag to the `isSingleSeriesWithBreakdown` shortcut in `InsightsTable.tsx` that swaps `SeriesColumnItem` for `BreakdownColumnItem`. Considered instead dropping the shortcut when compare is on and falling back to `SeriesColumnItem`, but that would show a redundant event name on every row and lose the breakdown-value-as-first-column behavior, so I taught `BreakdownColumnItem` to render the compare pill directly.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
