### PR TITLE
fix(warehouse): finalize zero-batch data-import jobs via workflow_run_id

### DIFF
--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -416,10 +416,8 @@ async def test_update_external_job_activity(activity_environment, team, **kwargs
 async def test_update_external_job_activity_resolves_job_by_workflow_run_id_when_job_id_missing(
     activity_environment, team, **kwargs
 ):
-    # Zero-batch runs (e.g. quiet Slack channels) finalize in the workflow's finally block with
-    # job_id=None. Finalization must resolve *this run's* job by workflow_run_id, not the newest
-    # RUNNING job for the schema: a schema routinely carries several stranded RUNNING rows, so the
-    # positional heuristic completes the wrong job and strands this run in RUNNING forever.
+    # A schema can carry several stranded RUNNING rows, so finalizing a zero-batch run (job_id=None)
+    # must resolve this run's job by workflow_run_id, not the newest RUNNING job for the schema.
     new_source = await sync_to_async(ExternalDataSource.objects.create)(
         source_id=str(uuid.uuid4()),
         connection_id=str(uuid.uuid4()),

--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -413,6 +413,66 @@ async def test_update_external_job_activity(activity_environment, team, **kwargs
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
+async def test_update_external_job_activity_resolves_job_by_workflow_run_id_when_job_id_missing(
+    activity_environment, team, **kwargs
+):
+    # Zero-batch runs (e.g. quiet Slack channels) finalize in the workflow's finally block with
+    # job_id=None. Finalization must resolve *this run's* job by workflow_run_id, not the newest
+    # RUNNING job for the schema: a schema routinely carries several stranded RUNNING rows, so the
+    # positional heuristic completes the wrong job and strands this run in RUNNING forever.
+    new_source = await sync_to_async(ExternalDataSource.objects.create)(
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        team=team,
+        status="running",
+        source_type="Slack",
+    )
+    schema = await sync_to_async(ExternalDataSchema.objects.create)(
+        name="C09M2GF0M8R",
+        team_id=team.id,
+        source_id=new_source.pk,
+        should_sync=True,
+    )
+
+    # This run's job, created first so it is NOT the newest RUNNING row for the schema.
+    this_run_job = await _create_external_data_job(
+        team_id=team.id,
+        external_data_source_id=new_source.pk,
+        workflow_id=activity_environment.info.workflow_id,
+        workflow_run_id=activity_environment.info.workflow_run_id,
+        external_data_schema_id=schema.id,
+    )
+    # A newer, unrelated RUNNING job for the same schema — what the positional heuristic would pick.
+    other_run_job = await _create_external_data_job(
+        team_id=team.id,
+        external_data_source_id=new_source.pk,
+        workflow_id=str(uuid.uuid4()),
+        workflow_run_id=str(uuid.uuid4()),
+        external_data_schema_id=schema.id,
+    )
+
+    inputs = UpdateExternalDataJobStatusInputs(
+        job_id=None,
+        status=ExternalDataJob.Status.COMPLETED,
+        latest_error=None,
+        internal_error=None,
+        schema_id=str(schema.pk),
+        source_id=str(new_source.pk),
+        team_id=team.id,
+        workflow_run_id=activity_environment.info.workflow_run_id,
+    )
+
+    await activity_environment.run(update_external_data_job_model, inputs)
+    await sync_to_async(this_run_job.refresh_from_db)()
+    await sync_to_async(other_run_job.refresh_from_db)()
+
+    assert this_run_job.status == ExternalDataJob.Status.COMPLETED
+    assert other_run_job.status == ExternalDataJob.Status.RUNNING
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
 async def test_update_external_job_activity_with_retryable_error(activity_environment, team, **kwargs):
     new_source = await sync_to_async(ExternalDataSource.objects.create)(
         source_id=str(uuid.uuid4()),

--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -121,10 +121,8 @@ class UpdateExternalDataJobStatusInputs:
     status: str
     internal_error: str | None
     latest_error: str | None
-    # Temporal run id of the workflow that owns this job. The create-job activity stamps the
-    # same value on the ExternalDataJob row, so finalization can resolve *this* run's job even
-    # when job_id never made it back to the workflow (create-activity result lost to a restart).
-    # Optional so mixed-version workers during a rollout stay compatible.
+    # Run id stamped on the job row by the create-job activity, so finalization can resolve this
+    # run's own job when job_id never made it back. Optional for mixed-version workers mid-rollout.
     workflow_run_id: str | None = None
 
     @property
@@ -155,11 +153,8 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
     if inputs.job_id is None:
 
         def _resolve_job() -> ExternalDataJob | None:
-            # Prefer the deterministic run id. The create-job activity stamps workflow_run_id on the
-            # row, so this resolves this run's own job even when the create-activity result was lost
-            # (worker restart) and job_id never made it back to the workflow. This is what strands
-            # zero-batch runs (e.g. quiet Slack channels) in RUNNING: with no batch the loader never
-            # finalizes the job, so the finally-block update is the only finalizer.
+            # Resolve this run's own job by run id; the finally-block update is the only finalizer for
+            # zero-batch runs (e.g. quiet Slack channels) that never send a batch to complete the job.
             if inputs.workflow_run_id is not None:
                 job = (
                     ExternalDataJob.objects.filter(team_id=inputs.team_id, workflow_run_id=inputs.workflow_run_id)
@@ -168,8 +163,7 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
                 )
                 if job is not None:
                     return job
-            # Legacy fallback for runs started before workflow_run_id was threaded through. Racy when a
-            # schema has concurrent runs, but preserved so in-flight jobs mid-rollout still finalize.
+            # Legacy fallback for runs started before workflow_run_id existed; racy under concurrent runs.
             return (
                 ExternalDataJob.objects.filter(schema_id=inputs.schema_id, status=ExternalDataJob.Status.RUNNING)
                 .order_by("-created_at")
@@ -178,9 +172,7 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
 
         job: ExternalDataJob | None = await database_sync_to_async_pool(_resolve_job)()
         if job is None:
-            # A job row almost always exists (create-job commits it before extraction); reaching here
-            # means we could not resolve it and it would be stranded in RUNNING. Surface it loudly
-            # instead of the previous silent info log.
+            # Unresolvable job would be stranded in RUNNING — surface it loudly, not a silent info log.
             logger.warning("No job to update status on", workflow_run_id=inputs.workflow_run_id)
             capture_exception(Exception("V3 job finalization could not resolve a job to update"))
             return
@@ -326,8 +318,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             team_id=inputs.team_id,
             schema_id=str(inputs.external_data_schema_id),
             source_id=str(inputs.external_data_source_id),
-            # Deterministic and available immediately; lets the finalizer resolve this run's job
-            # even if the create-job activity's result is lost and job_id never gets set below.
+            # Deterministic and available immediately, so the finalizer can resolve this run's job.
             workflow_run_id=workflow.info().run_id,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -121,6 +121,11 @@ class UpdateExternalDataJobStatusInputs:
     status: str
     internal_error: str | None
     latest_error: str | None
+    # Temporal run id of the workflow that owns this job. The create-job activity stamps the
+    # same value on the ExternalDataJob row, so finalization can resolve *this* run's job even
+    # when job_id never made it back to the workflow (create-activity result lost to a restart).
+    # Optional so mixed-version workers during a rollout stay compatible.
+    workflow_run_id: str | None = None
 
     @property
     def properties_to_log(self) -> dict[str, typing.Any]:
@@ -130,6 +135,7 @@ class UpdateExternalDataJobStatusInputs:
             "schema_id": self.schema_id,
             "source_id": self.source_id,
             "status": self.status,
+            "workflow_run_id": self.workflow_run_id,
         }
 
 
@@ -147,15 +153,36 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
     await finish_row_tracking(inputs.team_id, inputs.schema_id)
 
     if inputs.job_id is None:
-        job: ExternalDataJob | None = await database_sync_to_async_pool(
-            lambda: (
+
+        def _resolve_job() -> ExternalDataJob | None:
+            # Prefer the deterministic run id. The create-job activity stamps workflow_run_id on the
+            # row, so this resolves this run's own job even when the create-activity result was lost
+            # (worker restart) and job_id never made it back to the workflow. This is what strands
+            # zero-batch runs (e.g. quiet Slack channels) in RUNNING: with no batch the loader never
+            # finalizes the job, so the finally-block update is the only finalizer.
+            if inputs.workflow_run_id is not None:
+                job = (
+                    ExternalDataJob.objects.filter(team_id=inputs.team_id, workflow_run_id=inputs.workflow_run_id)
+                    .order_by("-created_at")
+                    .first()
+                )
+                if job is not None:
+                    return job
+            # Legacy fallback for runs started before workflow_run_id was threaded through. Racy when a
+            # schema has concurrent runs, but preserved so in-flight jobs mid-rollout still finalize.
+            return (
                 ExternalDataJob.objects.filter(schema_id=inputs.schema_id, status=ExternalDataJob.Status.RUNNING)
                 .order_by("-created_at")
                 .first()
             )
-        )()
+
+        job: ExternalDataJob | None = await database_sync_to_async_pool(_resolve_job)()
         if job is None:
-            logger.info("No job to update status on")
+            # A job row almost always exists (create-job commits it before extraction); reaching here
+            # means we could not resolve it and it would be stranded in RUNNING. Surface it loudly
+            # instead of the previous silent info log.
+            logger.warning("No job to update status on", workflow_run_id=inputs.workflow_run_id)
+            capture_exception(Exception("V3 job finalization could not resolve a job to update"))
             return
 
         job_id = str(job.pk)
@@ -299,6 +326,9 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             team_id=inputs.team_id,
             schema_id=str(inputs.external_data_schema_id),
             source_id=str(inputs.external_data_source_id),
+            # Deterministic and available immediately; lets the finalizer resolve this run's job
+            # even if the create-job activity's result is lost and job_id never gets set below.
+            workflow_run_id=workflow.info().run_id,
         )
 
         source_type = None

--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -172,9 +172,13 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
 
         job: ExternalDataJob | None = await database_sync_to_async_pool(_resolve_job)()
         if job is None:
-            # Unresolvable job would be stranded in RUNNING — surface it loudly, not a silent info log.
+            # A FAILED finalization with no resolvable job means an early activity (e.g. create-job)
+            # failed before a row was committed — nothing is stranded and that failure is already
+            # reported on its own, so don't double-alarm. A non-FAILED finalization that can't find
+            # its job is a real anomaly (work we think succeeded has nowhere to record it) — surface it.
             logger.warning("No job to update status on", workflow_run_id=inputs.workflow_run_id)
-            capture_exception(Exception("V3 job finalization could not resolve a job to update"))
+            if inputs.status != ExternalDataJob.Status.FAILED:
+                capture_exception(Exception("Data import finalization could not resolve a job to update"))
             return
 
         job_id = str(job.pk)


### PR DESCRIPTION
## Problem

Some data-warehouse import jobs get stuck in `status='Running'` forever with `finished_at=NULL` and `rows_synced=0`. Investigating the last two days of pipeline runs surfaced a slow accumulation of these phantom `Running` rows, concentrated on Slack sources (one project alone was leaking ~3-4/day).

Root cause is a finalization gap for zero-batch runs:

1. Slack per-channel schemas are webhook-only. A quiet channel yields **0 rows**, so `PipelineV3._finalize()` hits `total_batches == 0` and returns without enqueuing a final batch. That is the expected steady state for a quiet channel, not an edge case.
2. With no batch, the loader (which normally marks a job `Completed` on the final batch) never runs for that job. Completion falls to the workflow's `finally` block.
3. The `finally` block calls `update_external_data_job_model`, and when `job_id` never made it back to the workflow (the create-job activity committed the row but its result was lost to a worker restart), it fell back to "newest RUNNING job for the schema". That lookup races with concurrent and already-stranded runs and silently no-ops, logging `No job to update status on`. The job is left in `Running`.
4. Nothing else reaps it: the loader only completes jobs with a final batch, the consumer's reconcile path only ever moves jobs to `Failed`, and the old lock-takeover sweep that used to force-fail stale `Running` jobs was retired.

This is a bookkeeping bug, not data loss. The schema row still shows `Completed`/`last_synced_at`, and real data lands via the webhook path when messages arrive. The harm is the growing pile of phantom `Running` rows and the misleading state in the UI.

## Changes

The `ExternalDataJob` row is already stamped with `workflow_run_id` by the create-job activity, so the row exists and carries that id even when the activity result is lost. This change threads the run's own `workflow_run_id` through `UpdateExternalDataJobStatusInputs` so the finalizer resolves **this run's** job deterministically instead of guessing.

- Added `workflow_run_id: str | None = None` to `UpdateExternalDataJobStatusInputs` (optional default keeps mixed-version workers compatible mid-rollout).
- `ExternalDataJobWorkflow.run()` sets `workflow_run_id=workflow.info().run_id` when building `update_inputs` — deterministic and available before any activity runs.
- `update_external_data_job_model` resolves the `job_id is None` case by `(team_id, workflow_run_id)` first. The legacy schema+RUNNING lookup stays as a fallback for jobs in flight during rollout. An unresolved finalization now emits `capture_exception` instead of a silent info log, so any future strand is visible.

> [!NOTE]
> This path is shared by both V2 (`v2-non-dlt`) and V3 (`v3-kafka-s3`) and is not behind a feature flag. V2 always finalizes through this `finally` block (its `consumer_manages_job_status` is always false), so it benefits from the same deterministic resolution. The change is additive and backward compatible: the happy path (`job_id` set) is untouched, `workflow_run_id` is stamped on V2 rows too, and Temporal run ids are unique so the lookup matches at most one row.

This does not retroactively clean the already-stranded rows — those need a one-off backfill/force-complete, tracked separately.

## How did you test this code?

Added one regression test in `test_external_data_job.py`: `test_update_external_job_activity_resolves_job_by_workflow_run_id_when_job_id_missing`.

It catches the specific regression: with `job_id=None` and two RUNNING jobs for the same schema (the observed production state — stranded rows accumulate), the finalizer must complete the job matching this run's `workflow_run_id` and leave the other untouched. Reverting to the "newest RUNNING for schema" heuristic completes the wrong job and fails this test. A naive single-job test would not distinguish the two, so it would not be worth keeping.

I (Claude) could **not** run the DB-backed test locally — this environment has no Docker/Postgres, so `@pytest.mark.django_db(transaction=True)` can't connect. It will run in CI. Locally I verified: `ruff check`, `ruff format`, and the pre-commit `ty` type check all pass, and `hogli ci:preflight --strict` reports 0 failures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation and fix produced with PostHog Code (Claude). Started from a two-day health review of pipeline V3 runs using the `investigating-warehouse-sources-load` skill, which surfaced the phantom `Running` accumulation. Traced it through Loki (extractor + loader logs — the loader had no logs for the affected schema, and the extractor logged `No job to update status on`) and the federated queue tables, then through the code to the zero-batch finalization gap.

Considered gating the new lookup behind `is_v3` to shrink the blast radius, but rejected it: the change is additive and backward compatible, and it fixes the same latent gap for V2. Invoked the `/writing-tests` skill before adding the test to keep it to a single case that maps to a real regression.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
