### PR TITLE
feat(quill): add viewportClassName to DialogBody

### DIFF
--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -427,6 +427,10 @@ Grouped items: pass `items={[{ label, items }]}` shapes, render `AutocompleteGro
 
 Hide close button: `<DialogContent showCloseButton={false}>`
 
+`DialogBody` defaults its `render` to a `ScrollArea` (scroll shadows and a pinned footer for free).
+To style the scrollable viewport (`data-slot="scroll-area-viewport"`), pass `viewportClassName`.
+For example, drop the default `1rem` viewport padding for full-bleed content: `<DialogBody viewportClassName="p-0">`.
+
 ### Alert Dialog (must-resolve confirmation)
 
 Same shell as Dialog (shared `quill-dialog__*` styles) but `role="alertdialog"`, always modal, backdrop clicks never dismiss, and no X button — the user must pick an action (or Esc). Use for destructive/irreversible confirmations; put Cancel first so it takes initial focus.

--- a/packages/quill/packages/primitives/src/dialog.stories.tsx
+++ b/packages/quill/packages/primitives/src/dialog.stories.tsx
@@ -142,3 +142,30 @@ export const ScrollableContent: Story = {
         </Dialog>
     ),
 } satisfies Story
+
+export const FullBleedBody: Story = {
+    render: () => (
+        <Dialog>
+            <DialogTrigger render={<Button variant="outline" size="sm" />}>Open dialog</DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Full-bleed body</DialogTitle>
+                    <DialogDescription>
+                        viewportClassName="p-0" drops the default 1rem viewport padding so rows run edge to edge.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogBody viewportClassName="p-0">
+                    {Array.from({ length: 20 }).map((_, index) => (
+                        <div key={index} className="px-4 py-2 odd:bg-muted">
+                            Row {index + 1}
+                        </div>
+                    ))}
+                </DialogBody>
+                <DialogFooter>
+                    <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+                    <Button variant="primary">Confirm</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/dialog.tsx
+++ b/packages/quill/packages/primitives/src/dialog.tsx
@@ -115,8 +115,17 @@ function DialogBody({
     className,
     render,
     children,
+    viewportClassName,
     ...props
-}: useRender.ComponentProps<'div'>): React.ReactElement {
+}: useRender.ComponentProps<'div'> & {
+    /**
+     * Class applied to the inner ScrollArea viewport (`data-slot="scroll-area-viewport"`),
+     * the element that actually scrolls. For example, `viewportClassName="p-0"` drops the
+     * default body padding for full-bleed content. Ignored when a custom `render` is
+     * supplied (set `viewportClassName` on your own `<ScrollArea>` there instead).
+     */
+    viewportClassName?: string
+}): React.ReactElement {
     /*
      * Default render = `<ScrollArea>` so consumers get scroll shadows
      * (and edge-overflow data attrs) for free. The scroll-area-aware
@@ -133,8 +142,13 @@ function DialogBody({
      * order stays stable (eslint-plugin-react-hooks would flag a
      * conditional call otherwise, since `useRender` starts with `use`).
      */
-    const effectiveRender =
-        render ?? <ScrollArea data-slot="dialog-body" className={cn('quill-dialog__body', className)} />
+    const effectiveRender = render ?? (
+        <ScrollArea
+            data-slot="dialog-body"
+            className={cn('quill-dialog__body', className)}
+            viewportClassName={viewportClassName}
+        />
+    )
     return useRender({
         defaultTagName: 'div',
         props: mergeProps<'div'>(


### PR DESCRIPTION
## Problem

There's no clean way to style the scrollable viewport inside a quill dialog (the element with `data-slot="scroll-area-viewport"`). `DialogBody` defaults its `render` to a `ScrollArea`, and any `className` you pass lands on the scroll-area root, not the viewport that actually scrolls. The dialog CSS also hard-codes `1rem` padding on that viewport, so opting into full-bleed content (an embedded list, a table) meant reaching for the verbose `render={<ScrollArea viewportClassName="…" />}` escape hatch.

**Why:** consumers need the dialog's scroll viewport to accept a class (for example to drop the default padding), without dropping down to a custom `render`.

## Changes

- Add an optional `viewportClassName` prop to `DialogBody`, forwarded to the `ScrollArea`'s existing `viewportClassName`. So `<DialogBody viewportClassName="p-0">` now styles the `scroll-area-viewport` directly.
- Add a `FullBleedBody` Storybook story demonstrating the padding override.
- Note it in the primitives `AGENTS.md` Dialog section.

Backward compatible: the prop is optional and defaults to `undefined`, so existing dialogs render identically. It's a pure pass-through (same name `ScrollArea` already exposes) and is ignored when a custom `render` is supplied, since those consumers already control the `ScrollArea`.

## How did you test this code?

- Built `@posthog/quill-primitives` (`vite build`, which emits `.d.ts`), so the new prop and its forwarding typecheck cleanly.
- Ran `tsc --noEmit` over the package `src`: `dialog.tsx` and `dialog.stories.tsx` are clean (the only errors are pre-existing and unrelated, in `progress.stories.tsx`).
- I (Claude, via PostHog Code) did not open Storybook to eyeball it in this environment. The `FullBleedBody` story is added so a reviewer (or the visual-regression suite) can confirm the `p-0` viewport renders edge to edge while the default stories are unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Component reference updated in-repo (`packages/quill/packages/primitives/AGENTS.md`). No posthog.com docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Adam directed this; I (Claude, via PostHog Code) implemented it.

Key decision: the prop lives on `DialogBody`, not `DialogContent`. `DialogContent` only renders its children plus the close button and never owns a scroll area, whereas `DialogBody`'s default `render` is the `ScrollArea` that produces the `scroll-area-viewport`. Named it `viewportClassName` to match the prop it forwards to on `ScrollArea`, keeping the API consistent. Both the target and the name were confirmed with the requester.

Also considered doing nothing, since `<DialogBody render={<ScrollArea viewportClassName="…" />}>` already works today. Chose to add the shorthand because the render override is verbose for what's a common need. No repo skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
