### PR TITLE
feat(admin): bulk restore actions for dashboards and insights

### DIFF
--- a/products/dashboards/backend/admin/dashboard_admin.py
+++ b/products/dashboards/backend/admin/dashboard_admin.py
@@ -66,6 +66,9 @@ class DashboardAdmin(admin.ModelAdmin):
         )
 
         dashboards = list(queryset.filter(deleted=True))
+        # Count before restoring: the changelist queryset carries the deleted=True filter, so a
+        # post-restore count() would drop the rows we just un-deleted and skew "skipped" negative.
+        skipped = queryset.count() - len(dashboards)
         with transaction.atomic():
             for dashboard in dashboards:
                 # The same path PATCH {"deleted": false} runs: un-deletes the dashboard's tiles
@@ -77,7 +80,6 @@ class DashboardAdmin(admin.ModelAdmin):
                 dashboard.deleted = False
                 dashboard.save()
 
-        skipped = queryset.count() - len(dashboards)
         message = f"Restored {len(dashboards)} dashboards."
         if skipped:
             message += f" Skipped {skipped} that were not soft-deleted."

--- a/products/dashboards/backend/admin/dashboard_admin.py
+++ b/products/dashboards/backend/admin/dashboard_admin.py
@@ -50,8 +50,7 @@ class DashboardAdmin(admin.ModelAdmin):
         return Dashboard.objects_including_soft_deleted.all()
 
     def get_actions(self, request: HttpRequest) -> dict[str, Any]:
-        # Dashboards are soft-deleted product-side; the built-in bulk action is a hard
-        # DELETE with FK cascades, so offering it invites irreversible mistakes.
+        # Drop the built-in hard-delete: dashboards are soft-deleted product-side.
         actions = super().get_actions(request)
         actions.pop("delete_selected", None)
         return actions
@@ -61,21 +60,19 @@ class DashboardAdmin(admin.ModelAdmin):
         description="Restore selected dashboards (incl. tiles and co-deleted insights)",
     )
     def restore_selected(self, request: HttpRequest, queryset: QuerySet[Dashboard]) -> None:
-        from products.dashboards.backend.api.dashboard import (  # noqa: PLC0415 — keeps the heavy API module off the django.setup() path admin modules load on
+        from products.dashboards.backend.api.dashboard import (  # noqa: PLC0415 — keeps the heavy API module off the django.setup() path
             DashboardSerializer,
         )
 
         dashboards = list(queryset.filter(deleted=True))
         # Count before restoring: the changelist queryset carries the deleted=True filter, so a
-        # post-restore count() would drop the rows we just un-deleted and skew "skipped" negative.
+        # later count() would exclude the rows we just un-deleted and skew "skipped" negative.
         skipped = queryset.count() - len(dashboards)
+        # Same path as PATCH {"deleted": false}: restores tiles, co-deleted insights, FileSystem
+        # entries, and logs the restore via ModelActivityMixin. Atomic so a mid-batch failure
+        # can't leave a dashboard back without its tiles.
         with transaction.atomic():
             for dashboard in dashboards:
-                # The same path PATCH {"deleted": false} runs: un-deletes the dashboard's tiles
-                # and any insights soft-deleted together with it, and re-syncs their FileSystem
-                # entries. save() re-syncs the dashboard's own entry and logs a "restored"
-                # activity via ModelActivityMixin. Wrapped in a transaction so a mid-batch
-                # failure can't leave a dashboard restored without its tiles (no ATOMIC_REQUESTS).
                 DashboardSerializer._undo_delete_related_tiles(dashboard)
                 dashboard.deleted = False
                 dashboard.save()

--- a/products/dashboards/backend/admin/dashboard_admin.py
+++ b/products/dashboards/backend/admin/dashboard_admin.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.contrib import admin, messages
+from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.urls import reverse
@@ -65,14 +66,16 @@ class DashboardAdmin(admin.ModelAdmin):
         )
 
         dashboards = list(queryset.filter(deleted=True))
-        for dashboard in dashboards:
-            # The same path PATCH {"deleted": false} runs: un-deletes the dashboard's tiles
-            # and any insights soft-deleted together with it, and re-syncs their FileSystem
-            # entries. save() re-syncs the dashboard's own entry and logs a "restored"
-            # activity via ModelActivityMixin.
-            DashboardSerializer._undo_delete_related_tiles(dashboard)
-            dashboard.deleted = False
-            dashboard.save()
+        with transaction.atomic():
+            for dashboard in dashboards:
+                # The same path PATCH {"deleted": false} runs: un-deletes the dashboard's tiles
+                # and any insights soft-deleted together with it, and re-syncs their FileSystem
+                # entries. save() re-syncs the dashboard's own entry and logs a "restored"
+                # activity via ModelActivityMixin. Wrapped in a transaction so a mid-batch
+                # failure can't leave a dashboard restored without its tiles (no ATOMIC_REQUESTS).
+                DashboardSerializer._undo_delete_related_tiles(dashboard)
+                dashboard.deleted = False
+                dashboard.save()
 
         skipped = queryset.count() - len(dashboards)
         message = f"Restored {len(dashboards)} dashboards."

--- a/products/dashboards/backend/admin/dashboard_admin.py
+++ b/products/dashboards/backend/admin/dashboard_admin.py
@@ -1,4 +1,8 @@
-from django.contrib import admin
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db.models import QuerySet
+from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -39,9 +43,42 @@ class DashboardAdmin(admin.ModelAdmin):
     autocomplete_fields = ("team", "created_by")
     ordering = ("-created_at", "creation_mode")
     inlines = (DashboardTileInline,)
+    actions = ["restore_selected"]
 
     def get_queryset(self, request):
         return Dashboard.objects_including_soft_deleted.all()
+
+    def get_actions(self, request: HttpRequest) -> dict[str, Any]:
+        # Dashboards are soft-deleted product-side; the built-in bulk action is a hard
+        # DELETE with FK cascades, so offering it invites irreversible mistakes.
+        actions = super().get_actions(request)
+        actions.pop("delete_selected", None)
+        return actions
+
+    @admin.action(
+        permissions=["change"],
+        description="Restore selected dashboards (incl. tiles and co-deleted insights)",
+    )
+    def restore_selected(self, request: HttpRequest, queryset: QuerySet[Dashboard]) -> None:
+        from products.dashboards.backend.api.dashboard import (  # noqa: PLC0415 — keeps the heavy API module off the django.setup() path admin modules load on
+            DashboardSerializer,
+        )
+
+        dashboards = list(queryset.filter(deleted=True))
+        for dashboard in dashboards:
+            # The same path PATCH {"deleted": false} runs: un-deletes the dashboard's tiles
+            # and any insights soft-deleted together with it, and re-syncs their FileSystem
+            # entries. save() re-syncs the dashboard's own entry and logs a "restored"
+            # activity via ModelActivityMixin.
+            DashboardSerializer._undo_delete_related_tiles(dashboard)
+            dashboard.deleted = False
+            dashboard.save()
+
+        skipped = queryset.count() - len(dashboards)
+        message = f"Restored {len(dashboards)} dashboards."
+        if skipped:
+            message += f" Skipped {skipped} that were not soft-deleted."
+        self.message_user(request, message, messages.SUCCESS)
 
     @admin.display(description="Team")
     def team_link(self, dashboard: Dashboard):

--- a/products/dashboards/backend/test/test_dashboard_admin.py
+++ b/products/dashboards/backend/test/test_dashboard_admin.py
@@ -1,4 +1,5 @@
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
@@ -57,6 +58,18 @@ class TestDashboardAdminRestore(BaseTest):
         assert deleted_tile.deleted is False
         assert co_deleted_insight.deleted is False
         assert removed_tile.deleted is True
+
+    def test_restore_reports_no_negative_skip_when_queryset_is_filtered_to_deleted(self):
+        # The admin changelist passes an action queryset already filtered to deleted=True
+        # (the "deleted: Yes" sidebar filter). Counting after the restore would then drop the
+        # just-restored rows and report a negative "Skipped" count.
+        deleted_dashboard = Dashboard.objects.create(team=self.team, name="deleted dashboard", deleted=True)
+        queryset = Dashboard.objects_including_soft_deleted.filter(id=deleted_dashboard.id, deleted=True)
+
+        with patch.object(self.admin, "message_user") as message_user:
+            self.admin.restore_selected(self._post_request(), queryset)
+
+        assert message_user.call_args[0][1] == "Restored 1 dashboards."
 
     def test_bulk_hard_delete_action_is_not_offered(self):
         actions = self.admin.get_actions(self._post_request())

--- a/products/dashboards/backend/test/test_dashboard_admin.py
+++ b/products/dashboards/backend/test/test_dashboard_admin.py
@@ -2,12 +2,20 @@ from posthog.test.base import BaseTest
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
+from django.http import HttpRequest
 from django.test import RequestFactory
 
 from products.dashboards.backend.admin.dashboard_admin import DashboardAdmin
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.product_analytics.backend.models.insight import Insight
+
+
+def _attach_messages(request) -> None:
+    # The request param is deliberately untyped: session and _messages are set by
+    # middleware at runtime, so assigning them on a typed request fails type checking.
+    request.session = {}
+    request._messages = FallbackStorage(request)
 
 
 class TestDashboardAdminRestore(BaseTest):
@@ -18,11 +26,10 @@ class TestDashboardAdminRestore(BaseTest):
         self.admin = DashboardAdmin(Dashboard, AdminSite())
         self.factory = RequestFactory()
 
-    def _post_request(self):
+    def _post_request(self) -> HttpRequest:
         request = self.factory.post("/")
         request.user = self.user
-        request.session = {}
-        request._messages = FallbackStorage(request)
+        _attach_messages(request)
         return request
 
     def test_restore_selected_restores_tiles_and_co_deleted_insights_but_skips_live_dashboards(self):

--- a/products/dashboards/backend/test/test_dashboard_admin.py
+++ b/products/dashboards/backend/test/test_dashboard_admin.py
@@ -1,0 +1,57 @@
+from posthog.test.base import BaseTest
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from products.dashboards.backend.admin.dashboard_admin import DashboardAdmin
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
+from products.product_analytics.backend.models.insight import Insight
+
+
+class TestDashboardAdminRestore(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.admin = DashboardAdmin(Dashboard, AdminSite())
+        self.factory = RequestFactory()
+
+    def _post_request(self):
+        request = self.factory.post("/")
+        request.user = self.user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    def test_restore_selected_restores_tiles_and_co_deleted_insights_but_skips_live_dashboards(self):
+        co_deleted_insight = Insight.objects.create(team=self.team, name="co-deleted insight", deleted=True)
+        deleted_dashboard = Dashboard.objects.create(team=self.team, name="deleted dashboard", deleted=True)
+        deleted_tile = DashboardTile.objects_including_soft_deleted.create(
+            dashboard=deleted_dashboard, insight=co_deleted_insight, deleted=True
+        )
+        # A live dashboard from which a tile was intentionally removed before the action:
+        # restore must not resurrect it, or the deleted=True guard has been dropped.
+        live_dashboard = Dashboard.objects.create(team=self.team, name="live dashboard")
+        removed_insight = Insight.objects.create(team=self.team, name="intentionally removed")
+        removed_tile = DashboardTile.objects_including_soft_deleted.create(
+            dashboard=live_dashboard, insight=removed_insight, deleted=True
+        )
+
+        queryset = Dashboard.objects_including_soft_deleted.filter(id__in=[deleted_dashboard.id, live_dashboard.id])
+        self.admin.restore_selected(self._post_request(), queryset)
+
+        deleted_dashboard.refresh_from_db()
+        deleted_tile.refresh_from_db()
+        co_deleted_insight.refresh_from_db()
+        removed_tile.refresh_from_db()
+        assert deleted_dashboard.deleted is False
+        assert deleted_tile.deleted is False
+        assert co_deleted_insight.deleted is False
+        assert removed_tile.deleted is True
+
+    def test_bulk_hard_delete_action_is_not_offered(self):
+        actions = self.admin.get_actions(self._post_request())
+        assert "delete_selected" not in actions
+        assert "restore_selected" in actions

--- a/products/dashboards/backend/test/test_dashboard_admin.py
+++ b/products/dashboards/backend/test/test_dashboard_admin.py
@@ -13,8 +13,7 @@ from products.product_analytics.backend.models.insight import Insight
 
 
 def _attach_messages(request) -> None:
-    # The request param is deliberately untyped: session and _messages are set by
-    # middleware at runtime, so assigning them on a typed request fails type checking.
+    # Untyped: session and _messages are set by middleware at runtime.
     request.session = {}
     request._messages = FallbackStorage(request)
 
@@ -39,8 +38,7 @@ class TestDashboardAdminRestore(BaseTest):
         deleted_tile = DashboardTile.objects_including_soft_deleted.create(
             dashboard=deleted_dashboard, insight=co_deleted_insight, deleted=True
         )
-        # A live dashboard from which a tile was intentionally removed before the action:
-        # restore must not resurrect it, or the deleted=True guard has been dropped.
+        # Live dashboard with an intentionally-removed tile: restore must not resurrect it.
         live_dashboard = Dashboard.objects.create(team=self.team, name="live dashboard")
         removed_insight = Insight.objects.create(team=self.team, name="intentionally removed")
         removed_tile = DashboardTile.objects_including_soft_deleted.create(
@@ -60,9 +58,8 @@ class TestDashboardAdminRestore(BaseTest):
         assert removed_tile.deleted is True
 
     def test_restore_reports_no_negative_skip_when_queryset_is_filtered_to_deleted(self):
-        # The admin changelist passes an action queryset already filtered to deleted=True
-        # (the "deleted: Yes" sidebar filter). Counting after the restore would then drop the
-        # just-restored rows and report a negative "Skipped" count.
+        # The changelist passes a deleted=True-filtered queryset; a post-restore count would
+        # drop the just-restored rows and report a negative skip.
         deleted_dashboard = Dashboard.objects.create(team=self.team, name="deleted dashboard", deleted=True)
         queryset = Dashboard.objects_including_soft_deleted.filter(id=deleted_dashboard.id, deleted=True)
 

--- a/products/product_analytics/backend/admin.py
+++ b/products/product_analytics/backend/admin.py
@@ -97,8 +97,7 @@ class InsightAdmin(admin.ModelAdmin):
         return Insight.objects_including_soft_deleted.all()
 
     def get_actions(self, request: HttpRequest) -> dict[str, Any]:
-        # Insights are soft-deleted product-side; the built-in bulk action is a hard
-        # DELETE with FK cascades, so offering it invites irreversible mistakes.
+        # Drop the built-in hard-delete: insights are soft-deleted product-side.
         actions = super().get_actions(request)
         actions.pop("delete_selected", None)
         return actions
@@ -110,12 +109,11 @@ class InsightAdmin(admin.ModelAdmin):
     def restore_selected(self, request: HttpRequest, queryset: QuerySet[Insight]) -> None:
         insights = list(queryset.filter(deleted=True).select_related("team"))
         # Count before restoring: the changelist queryset carries the deleted=True filter, so a
-        # post-restore count() would drop the rows we just un-deleted and skew "skipped" negative.
+        # later count() would exclude the rows we just un-deleted and skew "skipped" negative.
         skipped = queryset.count() - len(insights)
         user = cast(User, request.user)
-        # Same shape as the bulk_restore endpoint: restore, re-activate tiles, and log the
-        # audit trail as one transaction, so a mid-batch failure can't leave insights restored
-        # without their tiles or activity entries (PostHog has no ATOMIC_REQUESTS).
+        # Mirrors the bulk_restore endpoint. Atomic so a mid-batch failure can't leave insights
+        # restored without their tiles or activity entries (PostHog has no ATOMIC_REQUESTS).
         with transaction.atomic():
             for insight in insights:
                 insight.deleted = False
@@ -124,9 +122,8 @@ class InsightAdmin(admin.ModelAdmin):
                 insight.save()  # post_save signal re-creates the FileSystem entry
 
             if insights:
-                # Bring tiles back on dashboards that still exist, and leave an audit trail
-                # (Insight has no ModelActivityMixin, so nothing gets logged on save). Unnamed
-                # insights (e.g. experiment internals) are skipped in the log, matching the API.
+                # Re-activate tiles on live dashboards, and log manually since Insight has no
+                # ModelActivityMixin. Unnamed insights are skipped in the log, matching the API.
                 DashboardTile.objects_including_soft_deleted.filter(
                     insight_id__in=[insight.id for insight in insights],
                     deleted=True,

--- a/products/product_analytics/backend/admin.py
+++ b/products/product_analytics/backend/admin.py
@@ -109,6 +109,9 @@ class InsightAdmin(admin.ModelAdmin):
     )
     def restore_selected(self, request: HttpRequest, queryset: QuerySet[Insight]) -> None:
         insights = list(queryset.filter(deleted=True).select_related("team"))
+        # Count before restoring: the changelist queryset carries the deleted=True filter, so a
+        # post-restore count() would drop the rows we just un-deleted and skew "skipped" negative.
+        skipped = queryset.count() - len(insights)
         user = cast(User, request.user)
         # Same shape as the bulk_restore endpoint: restore, re-activate tiles, and log the
         # audit trail as one transaction, so a mid-batch failure can't leave insights restored
@@ -146,7 +149,6 @@ class InsightAdmin(admin.ModelAdmin):
                     ]
                 )
 
-        skipped = queryset.count() - len(insights)
         message = f"Restored {len(insights)} insights."
         if skipped:
             message += f" Skipped {skipped} that were not soft-deleted."

--- a/products/product_analytics/backend/admin.py
+++ b/products/product_analytics/backend/admin.py
@@ -2,10 +2,12 @@ from typing import Any, cast
 
 from django import forms
 from django.contrib import admin, messages
+from django.db import transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.timezone import now
 
 from posthog.admin.filters import DeletedFilter
 from posthog.models.activity_logging.activity_log import Detail, LogActivityEntry, bulk_log_activity
@@ -107,37 +109,42 @@ class InsightAdmin(admin.ModelAdmin):
     )
     def restore_selected(self, request: HttpRequest, queryset: QuerySet[Insight]) -> None:
         insights = list(queryset.filter(deleted=True).select_related("team"))
-        for insight in insights:
-            insight.deleted = False
-            insight.save()  # post_save signal re-creates the FileSystem entry
+        user = cast(User, request.user)
+        # Same shape as the bulk_restore endpoint: restore, re-activate tiles, and log the
+        # audit trail as one transaction, so a mid-batch failure can't leave insights restored
+        # without their tiles or activity entries (PostHog has no ATOMIC_REQUESTS).
+        with transaction.atomic():
+            for insight in insights:
+                insight.deleted = False
+                insight.last_modified_at = now()
+                insight.last_modified_by = user
+                insight.save()  # post_save signal re-creates the FileSystem entry
 
-        if insights:
-            # Mirror the bulk_restore endpoint: bring tiles back on dashboards that still
-            # exist, and leave an audit trail (Insight has no ModelActivityMixin, so
-            # nothing gets logged on save). Unnamed insights (e.g. experiment internals)
-            # are skipped in the log, matching the API paths.
-            DashboardTile.objects_including_soft_deleted.filter(
-                insight_id__in=[insight.id for insight in insights],
-                deleted=True,
-                dashboard__deleted=False,
-            ).update(deleted=False)
-            user = cast(User, request.user)
-            bulk_log_activity(
-                [
-                    LogActivityEntry(
-                        organization_id=insight.team.organization_id,
-                        team_id=insight.team_id,
-                        user=user,
-                        was_impersonated=False,
-                        item_id=insight.id,
-                        scope="Insight",
-                        activity="restored",
-                        detail=Detail(name=insight.name or insight.derived_name, short_id=insight.short_id),
-                    )
-                    for insight in insights
-                    if insight.name or insight.derived_name
-                ]
-            )
+            if insights:
+                # Bring tiles back on dashboards that still exist, and leave an audit trail
+                # (Insight has no ModelActivityMixin, so nothing gets logged on save). Unnamed
+                # insights (e.g. experiment internals) are skipped in the log, matching the API.
+                DashboardTile.objects_including_soft_deleted.filter(
+                    insight_id__in=[insight.id for insight in insights],
+                    deleted=True,
+                    dashboard__deleted=False,
+                ).update(deleted=False)
+                bulk_log_activity(
+                    [
+                        LogActivityEntry(
+                            organization_id=insight.team.organization_id,
+                            team_id=insight.team_id,
+                            user=user,
+                            was_impersonated=False,
+                            item_id=insight.id,
+                            scope="Insight",
+                            activity="restored",
+                            detail=Detail(name=insight.name or insight.derived_name, short_id=insight.short_id),
+                        )
+                        for insight in insights
+                        if insight.name or insight.derived_name
+                    ]
+                )
 
         skipped = queryset.count() - len(insights)
         message = f"Restored {len(insights)} insights."

--- a/products/product_analytics/backend/admin.py
+++ b/products/product_analytics/backend/admin.py
@@ -1,10 +1,17 @@
+from typing import Any, cast
+
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.db.models import QuerySet
+from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.html import format_html
 
 from posthog.admin.filters import DeletedFilter
+from posthog.models.activity_logging.activity_log import Detail, LogActivityEntry, bulk_log_activity
+from posthog.models.user import User
 
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.product_analytics.backend.models.insight import Insight
 
 
@@ -82,9 +89,61 @@ class InsightAdmin(admin.ModelAdmin):
     )
     autocomplete_fields = ("team", "dashboard", "created_by", "last_modified_by")
     ordering = ("-created_at",)
+    actions = ["restore_selected"]
 
     def get_queryset(self, request):
         return Insight.objects_including_soft_deleted.all()
+
+    def get_actions(self, request: HttpRequest) -> dict[str, Any]:
+        # Insights are soft-deleted product-side; the built-in bulk action is a hard
+        # DELETE with FK cascades, so offering it invites irreversible mistakes.
+        actions = super().get_actions(request)
+        actions.pop("delete_selected", None)
+        return actions
+
+    @admin.action(
+        permissions=["change"],
+        description="Restore selected insights (re-activates tiles on live dashboards)",
+    )
+    def restore_selected(self, request: HttpRequest, queryset: QuerySet[Insight]) -> None:
+        insights = list(queryset.filter(deleted=True).select_related("team"))
+        for insight in insights:
+            insight.deleted = False
+            insight.save()  # post_save signal re-creates the FileSystem entry
+
+        if insights:
+            # Mirror the bulk_restore endpoint: bring tiles back on dashboards that still
+            # exist, and leave an audit trail (Insight has no ModelActivityMixin, so
+            # nothing gets logged on save). Unnamed insights (e.g. experiment internals)
+            # are skipped in the log, matching the API paths.
+            DashboardTile.objects_including_soft_deleted.filter(
+                insight_id__in=[insight.id for insight in insights],
+                deleted=True,
+                dashboard__deleted=False,
+            ).update(deleted=False)
+            user = cast(User, request.user)
+            bulk_log_activity(
+                [
+                    LogActivityEntry(
+                        organization_id=insight.team.organization_id,
+                        team_id=insight.team_id,
+                        user=user,
+                        was_impersonated=False,
+                        item_id=insight.id,
+                        scope="Insight",
+                        activity="restored",
+                        detail=Detail(name=insight.name or insight.derived_name, short_id=insight.short_id),
+                    )
+                    for insight in insights
+                    if insight.name or insight.derived_name
+                ]
+            )
+
+        skipped = queryset.count() - len(insights)
+        message = f"Restored {len(insights)} insights."
+        if skipped:
+            message += f" Skipped {skipped} that were not soft-deleted."
+        self.message_user(request, message, messages.SUCCESS)
 
     fieldsets = (
         (None, {"fields": ("name", "description", "team", "short_id")}),

--- a/products/product_analytics/backend/test/test_insight_admin.py
+++ b/products/product_analytics/backend/test/test_insight_admin.py
@@ -1,0 +1,59 @@
+from posthog.test.base import BaseTest
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from posthog.models.activity_logging.activity_log import ActivityLog
+
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
+from products.product_analytics.backend.admin import InsightAdmin
+from products.product_analytics.backend.models.insight import Insight
+
+
+class TestInsightAdminRestore(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        self.admin = InsightAdmin(Insight, AdminSite())
+        self.factory = RequestFactory()
+
+    def _post_request(self):
+        request = self.factory.post("/")
+        request.user = self.user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    def test_restore_selected_reactivates_tiles_on_live_dashboards_only_and_logs_activity(self):
+        live_dashboard = Dashboard.objects.create(team=self.team, name="live dashboard")
+        deleted_dashboard = Dashboard.objects.create(team=self.team, name="deleted dashboard", deleted=True)
+        deleted_insight = Insight.objects.create(team=self.team, name="deleted insight", deleted=True)
+        tile_on_live = DashboardTile.objects_including_soft_deleted.create(
+            dashboard=live_dashboard, insight=deleted_insight, deleted=True
+        )
+        tile_on_deleted = DashboardTile.objects_including_soft_deleted.create(
+            dashboard=deleted_dashboard, insight=deleted_insight, deleted=True
+        )
+        live_insight = Insight.objects.create(team=self.team, name="live insight")
+
+        queryset = Insight.objects_including_soft_deleted.filter(id__in=[deleted_insight.id, live_insight.id])
+        self.admin.restore_selected(self._post_request(), queryset)
+
+        deleted_insight.refresh_from_db()
+        tile_on_live.refresh_from_db()
+        tile_on_deleted.refresh_from_db()
+        assert deleted_insight.deleted is False
+        assert tile_on_live.deleted is False
+        # The dashboard itself is still deleted, so its tile must stay hidden.
+        assert tile_on_deleted.deleted is True
+
+        restored_logs = ActivityLog.objects.filter(scope="Insight", activity="restored", team_id=self.team.id)
+        assert [log.item_id for log in restored_logs] == [str(deleted_insight.id)]
+
+    def test_bulk_hard_delete_action_is_not_offered(self):
+        actions = self.admin.get_actions(self._post_request())
+        assert "delete_selected" not in actions
+        assert "restore_selected" in actions

--- a/products/product_analytics/backend/test/test_insight_admin.py
+++ b/products/product_analytics/backend/test/test_insight_admin.py
@@ -15,8 +15,7 @@ from products.product_analytics.backend.models.insight import Insight
 
 
 def _attach_messages(request) -> None:
-    # The request param is deliberately untyped: session and _messages are set by
-    # middleware at runtime, so assigning them on a typed request fails type checking.
+    # Untyped: session and _messages are set by middleware at runtime.
     request.session = {}
     request._messages = FallbackStorage(request)
 
@@ -54,19 +53,18 @@ class TestInsightAdminRestore(BaseTest):
         tile_on_live.refresh_from_db()
         tile_on_deleted.refresh_from_db()
         assert deleted_insight.deleted is False
-        # Restore touches last-modified metadata, matching the bulk_restore endpoint.
+        # Last-modified touched, matching the bulk_restore endpoint.
         assert deleted_insight.last_modified_by == self.user
         assert tile_on_live.deleted is False
-        # The dashboard itself is still deleted, so its tile must stay hidden.
+        # Dashboard still deleted, so its tile stays hidden.
         assert tile_on_deleted.deleted is True
 
         restored_logs = ActivityLog.objects.filter(scope="Insight", activity="restored", team_id=self.team.id)
         assert [log.item_id for log in restored_logs] == [str(deleted_insight.id)]
 
     def test_restore_reports_no_negative_skip_when_queryset_is_filtered_to_deleted(self):
-        # The admin changelist passes an action queryset already filtered to deleted=True
-        # (the "deleted: Yes" sidebar filter). Counting after the restore would then drop the
-        # just-restored rows and report a negative "Skipped" count.
+        # The changelist passes a deleted=True-filtered queryset; a post-restore count would
+        # drop the just-restored rows and report a negative skip.
         deleted_insight = Insight.objects.create(team=self.team, name="deleted insight", deleted=True)
         queryset = Insight.objects_including_soft_deleted.filter(id=deleted_insight.id, deleted=True)
 

--- a/products/product_analytics/backend/test/test_insight_admin.py
+++ b/products/product_analytics/backend/test/test_insight_admin.py
@@ -2,6 +2,7 @@ from posthog.test.base import BaseTest
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
+from django.http import HttpRequest
 from django.test import RequestFactory
 
 from posthog.models.activity_logging.activity_log import ActivityLog
@@ -12,6 +13,13 @@ from products.product_analytics.backend.admin import InsightAdmin
 from products.product_analytics.backend.models.insight import Insight
 
 
+def _attach_messages(request) -> None:
+    # The request param is deliberately untyped: session and _messages are set by
+    # middleware at runtime, so assigning them on a typed request fails type checking.
+    request.session = {}
+    request._messages = FallbackStorage(request)
+
+
 class TestInsightAdminRestore(BaseTest):
     def setUp(self):
         super().setUp()
@@ -20,11 +28,10 @@ class TestInsightAdminRestore(BaseTest):
         self.admin = InsightAdmin(Insight, AdminSite())
         self.factory = RequestFactory()
 
-    def _post_request(self):
+    def _post_request(self) -> HttpRequest:
         request = self.factory.post("/")
         request.user = self.user
-        request.session = {}
-        request._messages = FallbackStorage(request)
+        _attach_messages(request)
         return request
 
     def test_restore_selected_reactivates_tiles_on_live_dashboards_only_and_logs_activity(self):

--- a/products/product_analytics/backend/test/test_insight_admin.py
+++ b/products/product_analytics/backend/test/test_insight_admin.py
@@ -1,4 +1,5 @@
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
@@ -61,6 +62,18 @@ class TestInsightAdminRestore(BaseTest):
 
         restored_logs = ActivityLog.objects.filter(scope="Insight", activity="restored", team_id=self.team.id)
         assert [log.item_id for log in restored_logs] == [str(deleted_insight.id)]
+
+    def test_restore_reports_no_negative_skip_when_queryset_is_filtered_to_deleted(self):
+        # The admin changelist passes an action queryset already filtered to deleted=True
+        # (the "deleted: Yes" sidebar filter). Counting after the restore would then drop the
+        # just-restored rows and report a negative "Skipped" count.
+        deleted_insight = Insight.objects.create(team=self.team, name="deleted insight", deleted=True)
+        queryset = Insight.objects_including_soft_deleted.filter(id=deleted_insight.id, deleted=True)
+
+        with patch.object(self.admin, "message_user") as message_user:
+            self.admin.restore_selected(self._post_request(), queryset)
+
+        assert message_user.call_args[0][1] == "Restored 1 insights."
 
     def test_bulk_hard_delete_action_is_not_offered(self):
         actions = self.admin.get_actions(self._post_request())

--- a/products/product_analytics/backend/test/test_insight_admin.py
+++ b/products/product_analytics/backend/test/test_insight_admin.py
@@ -53,6 +53,8 @@ class TestInsightAdminRestore(BaseTest):
         tile_on_live.refresh_from_db()
         tile_on_deleted.refresh_from_db()
         assert deleted_insight.deleted is False
+        # Restore touches last-modified metadata, matching the bulk_restore endpoint.
+        assert deleted_insight.last_modified_by == self.user
         assert tile_on_live.deleted is False
         # The dashboard itself is still deleted, so its tile must stay hidden.
         assert tile_on_deleted.deleted is True


### PR DESCRIPTION
## Problem

Accidentally deleted dashboards and insights are soft-deleted, but there is no way to restore them in bulk. Recovering from a bulk deletion currently requires a hand-written Django shell script on a prod pod, because flipping `deleted=False` isn't enough: dashboard tiles, insights co-deleted with their dashboard, FileSystem (sidebar) entries, and audit entries all hang off the product restore paths.

The Django admin already shows soft-deleted rows on both changelists (`objects_including_soft_deleted` + `DeletedFilter`), but the only bulk action it offers is Django's built-in "Delete selected" - a hard DELETE with FK cascades that bypasses soft-delete semantics, tile handling, and activity logging.

The reason I wanted to add this is a user bulk deleted a bunch of stuff I assume with AI or MCP and its much harder for me to undo that 😓 

## Changes

- `DashboardAdmin`: new "Restore selected dashboards" action. Runs the same path as `PATCH {"deleted": false}` (`DashboardSerializer._undo_delete_related_tiles` + `save()`), so tiles come back, insights co-deleted via "delete dashboard + insights" come back, FileSystem entries re-sync, and `ModelActivityMixin` logs a "restored" activity attributed to the staff user.
- `InsightAdmin`: new "Restore selected insights" action. Mirrors the `bulk_restore` endpoint: restores the insights (post_save re-syncs FileSystem), re-activates their tiles on dashboards that still exist, and writes "restored" activity entries (`Insight` has no `ModelActivityMixin`, so nothing is logged on save).
- Both admins: remove the built-in `delete_selected` bulk action. Per-object delete on the change page remains for genuinely intentional hard deletes.

> [!NOTE]
> The hard-delete removal is done by popping `delete_selected` in `get_actions` rather than `has_delete_permission = False` on purpose: Django's cascade-delete confirmation (`get_deleted_objects`) consults every registered ModelAdmin's `has_delete_permission`, so returning False here would also block deleting teams/orgs/users from other admin pages whenever the cascade includes an insight or dashboard.

## How did you test this code?

New tests, one file per admin:

- `test_restore_selected_restores_tiles_and_co_deleted_insights_but_skips_live_dashboards`: catches a restore that flips only `deleted` (tiles and co-deleted insights would stay hidden), and catches dropping the `deleted=True` guard, which would resurrect tiles intentionally removed from live dashboards.
- `test_restore_selected_reactivates_tiles_on_live_dashboards_only_and_logs_activity`: catches dropping tile re-activation, dropping the `dashboard__deleted=False` clause (tiles on still-deleted dashboards must stay hidden), and losing the "restored" audit entries.
- `test_bulk_hard_delete_action_is_not_offered` (both admins): catches removing the `get_actions` override, which would silently re-offer bulk hard delete.

All 4 pass locally via Django's test runner against a local Postgres (`Ran 4 tests in 3.025s, OK`) - the sandbox has no ClickHouse, so the pytest fixtures can't run there; CI runs them under pytest. `ruff` and `hogli ci:preflight --fix` pass. I did not manually exercise the admin UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal staff admin tooling, no docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code session, driven by a support need to restore accidentally bulk-deleted dashboards and insights without shell access. Skills invoked: `/writing-tests`.

Decisions along the way:

- Reused `DashboardSerializer._undo_delete_related_tiles` instead of reimplementing it, to keep parity with the API restore path (including FileSystem sync). The import is deferred inside the action because the API module is deliberately kept off the `django.setup()` path that admin modules load on.
- The insight action drops two endpoint behaviors that don't apply in staff context: the per-dashboard edit-permission check on tile re-activation, and nothing else - unnamed insights are still skipped in activity logging, matching the API paths.
- Local verification skipped Django system checks: importing the product admin modules directly in tests registers a partial admin registry (lazy `register_all_admin()` never runs), tripping pre-existing `admin.E039` autocomplete references unrelated to this diff.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
