### PR TITLE
feat(impersonation): log up/downgrades to the activity log

### DIFF
--- a/ee/admin/loginas_views.py
+++ b/ee/admin/loginas_views.py
@@ -1,8 +1,11 @@
 import json
+import dataclasses
+from typing import Optional
 
 from django.http import Http404, JsonResponse
 from django.views.decorators.http import require_http_methods
 
+import structlog
 import posthoganalytics
 from loginas.utils import is_impersonated_session
 from loginas.views import user_login as loginas_user_login
@@ -14,6 +17,50 @@ from posthog.middleware import (
     is_read_only_impersonation,
 )
 from posthog.models import User
+from posthog.models.activity_logging.activity_log import ActivityContextBase, Detail, log_activity
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class ImpersonationContext(ActivityContextBase):
+    staff_user_email: str
+    target_user_email: Optional[str]
+    reason: str
+    mode: str
+
+
+def _log_impersonation_mode_change(staff_user: User, target_user: Optional[User], reason: str, activity: str) -> None:
+    """Record an impersonation upgrade/downgrade in the activity log (staff-only visibility).
+
+    Actor is the original staff user; the entry is scoped to the impersonated user's org so it
+    surfaces in the org-level activity log. Logging must never break the mode change itself.
+    """
+    if not target_user or not target_user.current_organization_id:
+        return
+    mode = "read_write" if activity == "impersonation_upgraded" else "read_only"
+    try:
+        log_activity(
+            organization_id=target_user.current_organization_id,
+            team_id=None,
+            user=staff_user,
+            item_id=target_user.id,
+            scope="User",
+            activity=activity,
+            detail=Detail(
+                name=target_user.email,
+                changes=[],
+                context=ImpersonationContext(
+                    staff_user_email=staff_user.email,
+                    target_user_email=target_user.email,
+                    reason=reason,
+                    mode=mode,
+                ),
+            ),
+            was_impersonated=True,
+        )
+    except Exception:
+        logger.exception("Failed to log impersonation mode change", activity=activity)
 
 
 def loginas_user(request, user_id):
@@ -26,7 +73,7 @@ def loginas_user(request, user_id):
             request.session[IMPERSONATION_READ_ONLY_SESSION_KEY] = True
 
         # Persist the reason server-side so it survives both Django-admin and in-app starts,
-        # and can be surfaced to the frontend (autofill).
+        # and can be surfaced to the frontend (autofill) and the activity log.
         request.session[IMPERSONATION_REASON_SESSION_KEY] = request.POST.get("reason", "")
 
         target_user = User.objects.filter(id=user_id).first()
@@ -67,19 +114,22 @@ def upgrade_impersonation(request):
 
     if IMPERSONATION_READ_ONLY_SESSION_KEY in request.session:
         del request.session[IMPERSONATION_READ_ONLY_SESSION_KEY]
+    request.session[IMPERSONATION_REASON_SESSION_KEY] = reason
     request.session.modified = True
 
+    target_user = get_impersonated_user(request)
     posthoganalytics.capture(
         distinct_id=str(staff_user.distinct_id),
         event="impersonation_upgraded",
         properties={
             "staff_user_id": staff_user.id,
             "staff_user_email": staff_user.email,
-            "target_user_id": request.user.id,
-            "target_user_email": request.user.email,
+            "target_user_id": target_user.id if target_user else None,
+            "target_user_email": target_user.email if target_user else None,
             "reason": reason,
         },
     )
+    _log_impersonation_mode_change(staff_user, target_user, reason, "impersonation_upgraded")
 
     return JsonResponse({"success": True})
 
@@ -119,5 +169,6 @@ def downgrade_impersonation(request):
             "reason": reason,
         },
     )
+    _log_impersonation_mode_change(staff_user, target_user, reason, "impersonation_downgraded")
 
     return JsonResponse({"success": True})

--- a/ee/admin/loginas_views.py
+++ b/ee/admin/loginas_views.py
@@ -7,7 +7,7 @@ import posthoganalytics
 from loginas.utils import is_impersonated_session
 from loginas.views import user_login as loginas_user_login
 
-from posthog.helpers.impersonation import get_original_user_from_session
+from posthog.helpers.impersonation import get_impersonated_user, get_original_user_from_session
 from posthog.middleware import (
     IMPERSONATION_READ_ONLY_SESSION_KEY,
     IMPERSONATION_REASON_SESSION_KEY,
@@ -77,6 +77,45 @@ def upgrade_impersonation(request):
             "staff_user_email": staff_user.email,
             "target_user_id": request.user.id,
             "target_user_email": request.user.email,
+            "reason": reason,
+        },
+    )
+
+    return JsonResponse({"success": True})
+
+
+@require_http_methods(["POST"])
+def downgrade_impersonation(request):
+    """Downgrade from read-write to read-only impersonation"""
+    if not is_impersonated_session(request) or is_read_only_impersonation(request):
+        raise Http404()
+
+    try:
+        data = json.loads(request.body)
+        reason = data.get("reason", "").strip()
+    except (json.JSONDecodeError, AttributeError):
+        reason = ""
+
+    if not reason:
+        return JsonResponse({"error": "A reason is required to downgrade impersonation"}, status=400)
+
+    staff_user = get_original_user_from_session(request)
+    if not staff_user or not staff_user.is_staff:
+        return JsonResponse({"error": "Unable to downgrade impersonation"}, status=400)
+
+    request.session[IMPERSONATION_READ_ONLY_SESSION_KEY] = True
+    request.session[IMPERSONATION_REASON_SESSION_KEY] = reason
+    request.session.modified = True
+
+    target_user = get_impersonated_user(request)
+    posthoganalytics.capture(
+        distinct_id=str(staff_user.distinct_id),
+        event="impersonation_downgraded",
+        properties={
+            "staff_user_id": staff_user.id,
+            "staff_user_email": staff_user.email,
+            "target_user_id": target_user.id if target_user else None,
+            "target_user_email": target_user.email if target_user else None,
             "reason": reason,
         },
     )

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -15,7 +15,7 @@ from posthog.views import api_key_search_view, redis_edit_ttl_view, redis_values
 
 from products.cdp.backend.api import hooks
 
-from ee.admin.loginas_views import loginas_user, upgrade_impersonation
+from ee.admin.loginas_views import downgrade_impersonation, loginas_user, upgrade_impersonation
 from ee.admin.oauth_views import admin_auth_check, admin_oauth_success
 from ee.api import integration
 from ee.api.agentic_provisioning import views as agentic_provisioning_views
@@ -241,6 +241,7 @@ if settings.ADMIN_PORTAL_ENABLED:
         ),
         path("admin/login/user/<str:user_id>/", loginas_user, name="loginas-user-login"),
         path("admin/impersonation/upgrade/", upgrade_impersonation, name="impersonation-upgrade"),
+        path("admin/impersonation/downgrade/", downgrade_impersonation, name="impersonation-downgrade"),
         path("admin/", include("loginas.urls")),
         path("admin/", admin.site.urls),
     ]

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -142,6 +142,8 @@ function ImpersonationNoticeContent(): JSX.Element {
         isReadOnly,
         isUpgradeModalOpen,
         isImpersonationUpgradeInProgress,
+        isDowngradeModalOpen,
+        isImpersonationDowngradeInProgress,
         changeableMembers,
         isChangingUser,
         membersLoading,
@@ -149,6 +151,8 @@ function ImpersonationNoticeContent(): JSX.Element {
     const {
         closeUpgradeModal,
         upgradeImpersonation,
+        closeDowngradeModal,
+        downgradeImpersonation,
         setSessionExpired,
         returnToPostHog,
         changeUser,
@@ -159,7 +163,7 @@ function ImpersonationNoticeContent(): JSX.Element {
     const [pendingUserId, setPendingUserId] = useState<number | null>(null)
 
     // The reason given when impersonation of the current user started (persisted server-side),
-    // used to pre-fill the change-user and upgrade modals.
+    // used to pre-fill the change-user and upgrade/downgrade modals.
     const storedReason = user?.is_impersonated_reason
 
     const changeUserItems =
@@ -240,7 +244,7 @@ function ImpersonationNoticeContent(): JSX.Element {
                     Log out to admin
                 </LemonButton>
             </div>
-            {isReadOnly && (
+            {isReadOnly ? (
                 <ImpersonationReasonModal
                     isOpen={isUpgradeModalOpen}
                     onClose={closeUpgradeModal}
@@ -249,6 +253,17 @@ function ImpersonationNoticeContent(): JSX.Element {
                     description="Read-write mode allows you to make changes on behalf of the user. Please provide a reason for this upgrade."
                     confirmText="Upgrade"
                     loading={isImpersonationUpgradeInProgress}
+                    initialReason={storedReason ?? ''}
+                />
+            ) : (
+                <ImpersonationReasonModal
+                    isOpen={isDowngradeModalOpen}
+                    onClose={closeDowngradeModal}
+                    onConfirm={downgradeImpersonation}
+                    title="Downgrade to read-only impersonation"
+                    description="Read-only mode prevents you from making changes on behalf of the user. Please provide a reason for this downgrade."
+                    confirmText="Downgrade"
+                    loading={isImpersonationDowngradeInProgress}
                     initialReason={storedReason ?? ''}
                 />
             )}
@@ -283,7 +298,8 @@ export function ImpersonationNotice(): JSX.Element | null {
         ticketContext,
         adminLoginUrls,
     } = useValues(impersonationNoticeLogic)
-    const { minimize, maximize, openUpgradeModal, setPageVisible } = useActions(impersonationNoticeLogic)
+    const { minimize, maximize, openUpgradeModal, openDowngradeModal, setPageVisible } =
+        useActions(impersonationNoticeLogic)
 
     const { isVisible: isPageVisible } = usePageVisibility()
 
@@ -354,13 +370,18 @@ export function ImpersonationNotice(): JSX.Element | null {
                         <div className="ImpersonationNotice__header">
                             <IconWarning className="ImpersonationNotice__warning-icon" />
                             <span className="ImpersonationNotice__title">{title}</span>
-                            {isImpersonated && isReadOnly && (
+                            {isImpersonated && (
                                 <LemonMenu
                                     items={[
-                                        {
-                                            label: 'Upgrade to read-write',
-                                            onClick: openUpgradeModal,
-                                        },
+                                        isReadOnly
+                                            ? {
+                                                  label: 'Upgrade to read-write',
+                                                  onClick: openUpgradeModal,
+                                              }
+                                            : {
+                                                  label: 'Downgrade to read-only',
+                                                  onClick: openDowngradeModal,
+                                              },
                                     ]}
                                 >
                                     <LemonButton size="xsmall" icon={<IconEllipsis />} />

--- a/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.test.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.test.ts
@@ -840,4 +840,30 @@ describe('impersonationNoticeLogic', () => {
             }
         })
     })
+
+    describe('downgrade modal', () => {
+        it('toggles isDowngradeModalOpen', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.openDowngradeModal()
+            }).toMatchValues({ isDowngradeModalOpen: true })
+
+            await expectLogic(logic, () => {
+                logic.actions.closeDowngradeModal()
+            }).toMatchValues({ isDowngradeModalOpen: false })
+        })
+
+        it('closes the modal on a successful downgrade once the user is read-only', async () => {
+            userLogic.actions.loadUserSuccess({ ...MOCK_IMPERSONATED_USER, is_impersonated_read_only: false })
+            logic.actions.openDowngradeModal()
+
+            await expectLogic(logic, () => {
+                userLogic.actions.downgradeImpersonationSuccess({
+                    ...MOCK_IMPERSONATED_USER,
+                    is_impersonated_read_only: true,
+                })
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ isDowngradeModalOpen: false })
+        })
+    })
 })

--- a/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.ts
@@ -52,10 +52,22 @@ export const impersonationNoticeLogic = kea<impersonationNoticeLogicType>([
     path(['layout', 'navigation', 'ImpersonationNotice', 'impersonationNoticeLogic']),
 
     connect(() => ({
-        values: [userLogic, ['user', 'isImpersonationUpgradeInProgress'], membersLogic, ['members', 'membersLoading']],
+        values: [
+            userLogic,
+            ['user', 'isImpersonationUpgradeInProgress', 'isImpersonationDowngradeInProgress'],
+            membersLogic,
+            ['members', 'membersLoading'],
+        ],
         actions: [
             userLogic,
-            ['upgradeImpersonation', 'upgradeImpersonationSuccess', 'loadUser', 'loadUserSuccess'],
+            [
+                'upgradeImpersonation',
+                'upgradeImpersonationSuccess',
+                'downgradeImpersonation',
+                'downgradeImpersonationSuccess',
+                'loadUser',
+                'loadUserSuccess',
+            ],
             membersLogic,
             ['ensureAllMembersLoaded'],
         ],
@@ -66,6 +78,8 @@ export const impersonationNoticeLogic = kea<impersonationNoticeLogicType>([
         maximize: true,
         openUpgradeModal: true,
         closeUpgradeModal: true,
+        openDowngradeModal: true,
+        closeDowngradeModal: true,
         setPageVisible: (visible: boolean) => ({ visible }),
         clearPageHiddenAt: true,
         setTicketContext: (context: ImpersonationTicketContext | null) => ({ context }),
@@ -90,6 +104,13 @@ export const impersonationNoticeLogic = kea<impersonationNoticeLogicType>([
             {
                 openUpgradeModal: () => true,
                 closeUpgradeModal: () => false,
+            },
+        ],
+        isDowngradeModalOpen: [
+            false,
+            {
+                openDowngradeModal: () => true,
+                closeDowngradeModal: () => false,
             },
         ],
         pageHiddenAt: [
@@ -181,6 +202,11 @@ export const impersonationNoticeLogic = kea<impersonationNoticeLogicType>([
         upgradeImpersonationSuccess: () => {
             if (values.isUpgradeModalOpen && !values.isReadOnly) {
                 actions.closeUpgradeModal()
+            }
+        },
+        downgradeImpersonationSuccess: () => {
+            if (values.isDowngradeModalOpen && values.isReadOnly) {
+                actions.closeDowngradeModal()
             }
         },
         reImpersonate: async ({ reason, readOnly }) => {

--- a/frontend/src/scenes/authentication/shared/activityDescriptions.tsx
+++ b/frontend/src/scenes/authentication/shared/activityDescriptions.tsx
@@ -37,5 +37,19 @@ export function userActivityDescriber(logItem: ActivityLogItem, asNotification?:
         }
     }
 
+    if (logItem.activity === 'impersonation_upgraded' || logItem.activity === 'impersonation_downgraded') {
+        const target = context?.target_user_email || logItem.detail?.name || 'a user'
+        const mode = logItem.activity === 'impersonation_upgraded' ? 'read-write' : 'read-only'
+        return {
+            description: (
+                <>
+                    <strong>{userNameForLogItem(logItem)}</strong> changed impersonation of <strong>{target}</strong> to{' '}
+                    {mode}
+                    {context?.reason && <> (reason: {context.reason})</>}
+                </>
+            ),
+        }
+    }
+
     return defaultDescriber(logItem, asNotification)
 }

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -71,6 +71,7 @@ export const userLogic = kea<userLogicType>([
         updateCurrentOrganization: (organizationId: string, destination?: string) => ({ organizationId, destination }),
         logout: (preserveLocation = false) => ({ preserveLocation }),
         upgradeImpersonation: (reason: string) => ({ reason }),
+        downgradeImpersonation: (reason: string) => ({ reason }),
         updateUser: (user: Partial<UserType>, successCallback?: () => void) => ({
             user,
             successCallback,
@@ -208,6 +209,21 @@ export const userLogic = kea<userLogicType>([
                         return values.user
                     }
                 },
+                downgradeImpersonation: async ({ reason }) => {
+                    try {
+                        await api.create('admin/impersonation/downgrade/', { reason })
+                        actions.loadUser()
+                        lemonToast.success('Downgraded to read-only impersonation')
+
+                        // optimistically update user to read-only rather than
+                        // waiting for `loadUser` to complete
+                        return values.user ? { ...values.user, is_impersonated_read_only: true } : null
+                    } catch (error: any) {
+                        console.error(error)
+                        lemonToast.error('Failed to downgrade impersonation')
+                        return values.user
+                    }
+                },
             },
         ],
     })),
@@ -233,6 +249,14 @@ export const userLogic = kea<userLogicType>([
                 upgradeImpersonation: () => true,
                 upgradeImpersonationSuccess: () => false,
                 upgradeImpersonationFailure: () => false,
+            },
+        ],
+        isImpersonationDowngradeInProgress: [
+            false,
+            {
+                downgradeImpersonation: () => true,
+                downgradeImpersonationSuccess: () => false,
+                downgradeImpersonationFailure: () => false,
             },
         ],
         optimisticThemeMode: [

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -361,6 +361,14 @@ activity_visibility_restrictions: list[dict[str, Any]] = [
         "allow_staff": True,
     },
     {
+        # Impersonation read-only/read-write changes are staff-only operations and must not
+        # surface to the impersonated customer's org admins.
+        "scope": "User",
+        "activities": ["impersonation_upgraded", "impersonation_downgraded"],
+        "exclude_when": {},
+        "allow_staff": True,
+    },
+    {
         "scope": "User",
         "activities": ["created", "updated"],
         "exclude_when": {},

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1540,6 +1540,121 @@ class TestUpgradeImpersonation(APIBaseTest):
         assert response.json()["error"] == "Unable to upgrade impersonation"
 
 
+class TestDowngradeImpersonation(APIBaseTest):
+    other_user: User
+
+    def setUp(self):
+        super().setUp()
+        self.other_user = User.objects.create_and_join(
+            self.organization, email="other-user@posthog.com", password="123456"
+        )
+        self.user.is_staff = True
+        self.user.save()
+
+        self.client = cast(Any, DjangoClient())
+        self.client.force_login(self.user)
+
+    def login_as_read_only(self):
+        return self.client.post(
+            reverse("loginas-user-login", kwargs={"user_id": self.other_user.id}),
+            data={"read_only": "true", "reason": "Initial read-only impersonation"},
+            follow=True,
+        )
+
+    def login_as_read_write(self):
+        return self.client.post(
+            reverse("loginas-user-login", kwargs={"user_id": self.other_user.id}),
+            data={"read_only": "false", "reason": "Initial read-write impersonation"},
+            follow=True,
+        )
+
+    def test_downgrade_succeeds_from_read_write_with_reason(self):
+        self.login_as_read_write()
+
+        # Verify we're in read-write mode
+        user_response = self.client.get("/api/users/@me/")
+        assert user_response.json()["is_impersonated_read_only"] is False
+
+        # Downgrade to read-only
+        response = self.client.post(
+            reverse("impersonation-downgrade"),
+            data=json.dumps({"reason": "Done making changes, returning to read-only"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        # Verify we're now in read-only mode
+        user_response = self.client.get("/api/users/@me/")
+        assert user_response.json()["is_impersonated_read_only"] is True
+
+    def test_downgrade_returns_404_when_not_impersonated(self):
+        response = self.client.post(
+            reverse("impersonation-downgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    def test_downgrade_returns_404_when_already_read_only(self):
+        self.login_as_read_only()
+
+        response = self.client.post(
+            reverse("impersonation-downgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    def test_downgrade_returns_400_without_reason(self):
+        self.login_as_read_write()
+
+        response = self.client.post(
+            reverse("impersonation-downgrade"),
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "reason" in response.json()["error"].lower()
+
+    def test_downgrade_returns_400_with_empty_reason(self):
+        self.login_as_read_write()
+
+        response = self.client.post(
+            reverse("impersonation-downgrade"),
+            data=json.dumps({"reason": "   "}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    @patch("ee.admin.loginas_views.get_original_user_from_session", return_value=None)
+    def test_downgrade_returns_400_when_staff_user_not_found(self, mock_get_staff):
+        self.login_as_read_write()
+
+        response = self.client.post(
+            reverse("impersonation-downgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert response.json()["error"] == "Unable to downgrade impersonation"
+
+    def test_downgrade_returns_400_when_staff_demoted_mid_session(self):
+        self.login_as_read_write()
+
+        # Revoke staff privileges mid-session
+        self.user.is_staff = False
+        self.user.save()
+
+        response = self.client.post(
+            reverse("impersonation-downgrade"),
+            data=json.dumps({"reason": "Some reason"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert response.json()["error"] == "Unable to downgrade impersonation"
+
+
 @override_settings(SESSION_COOKIE_AGE=100)
 class TestSessionAgeMiddleware(APIBaseTest):
     def setUp(self):

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -26,6 +26,7 @@ from social_core.exceptions import AuthCanceled, AuthFailed, AuthMissingParamete
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.middleware import per_request_logging_context_middleware
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.models.user import User
@@ -1473,6 +1474,29 @@ class TestUpgradeImpersonation(APIBaseTest):
         self.login_as_read_only()
         assert self.client.get("/api/users/@me/").json()["is_impersonated_reason"] == "Initial read-only impersonation"
 
+    def test_upgrade_exposes_reason_and_logs_activity(self):
+        self.login_as_read_only()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("impersonation-upgrade"),
+                data=json.dumps({"reason": "Upgrade reason for ticket #5678"}),
+                content_type="application/json",
+            )
+        assert response.status_code == 200
+
+        # Reason is surfaced to the frontend for autofill
+        assert self.client.get("/api/users/@me/").json()["is_impersonated_reason"] == "Upgrade reason for ticket #5678"
+
+        # And recorded in the activity log, attributed to the staff user, scoped to the target
+        log = ActivityLog.objects.filter(scope="User", activity="impersonation_upgraded").latest("created_at")
+        assert log.was_impersonated is True
+        assert log.user_id == self.user.id
+        assert str(log.item_id) == str(self.other_user.id)
+        assert log.detail is not None
+        assert log.detail["context"]["reason"] == "Upgrade reason for ticket #5678"
+        assert log.detail["context"]["mode"] == "read_write"
+
     def test_upgrade_returns_404_when_not_impersonated(self):
         response = self.client.post(
             reverse("impersonation-upgrade"),
@@ -1587,6 +1611,30 @@ class TestDowngradeImpersonation(APIBaseTest):
         # Verify we're now in read-only mode
         user_response = self.client.get("/api/users/@me/")
         assert user_response.json()["is_impersonated_read_only"] is True
+
+    def test_downgrade_exposes_reason_and_logs_activity(self):
+        self.login_as_read_write()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("impersonation-downgrade"),
+                data=json.dumps({"reason": "Done with changes, back to read-only"}),
+                content_type="application/json",
+            )
+        assert response.status_code == 200
+
+        assert (
+            self.client.get("/api/users/@me/").json()["is_impersonated_reason"]
+            == "Done with changes, back to read-only"
+        )
+
+        log = ActivityLog.objects.filter(scope="User", activity="impersonation_downgraded").latest("created_at")
+        assert log.was_impersonated is True
+        assert log.user_id == self.user.id
+        assert str(log.item_id) == str(self.other_user.id)
+        assert log.detail is not None
+        assert log.detail["context"]["reason"] == "Done with changes, back to read-only"
+        assert log.detail["context"]["mode"] == "read_only"
 
     def test_downgrade_returns_404_when_not_impersonated(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

Impersonation mode changes (read-only ↔ read-write) weren't recorded anywhere durable, so there was no audit trail of who changed a session's access level and why.

## Changes

Records `impersonation_upgraded` / `impersonation_downgraded` in the activity log, attributed to the original staff user and scoped to the impersonated user's org, with staff-only visibility so it never surfaces to the customer's admins. Adds a frontend describer for the two activities.

Stacks on #70455 (downgrade).

## How did you test this code?

`test_middleware.py` activity-log assertions (`test_upgrade_exposes_reason_and_logs_activity`, `test_downgrade_exposes_reason_and_logs_activity`) confirm the entry is written, attributed to the staff user, scoped to the target, and carries the reason and mode. Both pass locally. No manual browser testing was done by the agent.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Third PR in a 3-part stack split out of a larger impersonation branch. Built with Claude via PostHog Code.
