### PR TITLE
fix(metabase): handle non-JSON session responses without crashing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
@@ -22,6 +22,10 @@ MAX_RETRIES = 5
 
 HOST_NOT_ALLOWED_ERROR = "Metabase host is not allowed"
 
+# Stable substring matched by MetabaseSource.get_non_retryable_errors when the session endpoint
+# returns a 2xx that isn't JSON (the Instance URL isn't a Metabase API).
+SESSION_RESPONSE_NOT_JSON_ERROR = "Metabase session response was not valid JSON"
+
 API_KEY_AUTH = "api_key"
 SESSION_AUTH = "session"
 
@@ -137,7 +141,12 @@ def _resolve_auth_headers(base_url: str, auth: MetabaseAuth, logger: FilteringBo
         logger.error(f"Metabase session error: status={response.status_code}, body={response.text}")
         raise MetabaseRetryableError(f"Metabase session error (retryable): status={response.status_code}")
 
-    token = response.json().get("id")
+    try:
+        token = response.json().get("id")
+    except requests.exceptions.JSONDecodeError as e:
+        # A 2xx with a non-JSON body means the Instance URL isn't Metabase's session API (e.g. an
+        # SSO/login page or a proxy). Deterministic, so surface it as a non-retryable auth error.
+        raise MetabaseAuthError(SESSION_RESPONSE_NOT_JSON_ERROR) from e
     if not token:
         raise MetabaseAuthError("Metabase session response did not contain a token")
     return {"X-Metabase-Session": token, "Accept": "application/json"}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
@@ -146,7 +146,11 @@ def _resolve_auth_headers(base_url: str, auth: MetabaseAuth, logger: FilteringBo
     except requests.exceptions.JSONDecodeError as e:
         # A 2xx with a non-JSON body means the Instance URL isn't Metabase's session API (e.g. an
         # SSO/login page or a proxy). Deterministic, so surface it as a non-retryable auth error.
-        raise MetabaseAuthError(SESSION_RESPONSE_NOT_JSON_ERROR) from e
+        # Keep the stable substring first so both the non-retryable classifier and validate_credentials
+        # (which returns this message straight to the user) carry the guidance.
+        raise MetabaseAuthError(
+            f"{SESSION_RESPONSE_NOT_JSON_ERROR}. Check that the Instance URL points to your Metabase instance."
+        ) from e
     if not token:
         raise MetabaseAuthError("Metabase session response did not contain a token")
     return {"X-Metabase-Session": token, "Accept": "application/json"}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/source.py
@@ -26,6 +26,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.metabase.m
     API_KEY_AUTH,
     HOST_NOT_ALLOWED_ERROR,
     SESSION_AUTH,
+    SESSION_RESPONSE_NOT_JSON_ERROR,
     MetabaseAuth,
     metabase_source,
     validate_credentials as validate_metabase_credentials,
@@ -127,6 +128,7 @@ The API key (or user) needs read access to the data you want to sync.""",
             "401 Client Error": "Your Metabase credentials are invalid or expired. Update them and reconnect.",
             "403 Client Error": "Your Metabase credentials lack the permissions needed to sync this data. Grant read access and reconnect.",
             HOST_NOT_ALLOWED_ERROR: "The Metabase host is not allowed. Please use your instance's public URL.",
+            SESSION_RESPONSE_NOT_JSON_ERROR: "Metabase didn't return a valid session response. Check that the Instance URL points to your Metabase instance, then reconnect.",
         }
 
     def _build_auth(self, config: MetabaseSourceConfig) -> MetabaseAuth:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
@@ -3,10 +3,13 @@ from typing import Any, Optional
 import pytest
 from unittest import mock
 
+import requests
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.metabase import metabase as metabase_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.metabase.metabase import (
     API_KEY_AUTH,
     SESSION_AUTH,
+    SESSION_RESPONSE_NOT_JSON_ERROR,
     MetabaseAuth,
     MetabaseAuthError,
     MetabaseHostNotAllowedError,
@@ -122,6 +125,16 @@ class TestResolveAuthHeaders:
         session, patch = self._patch_mint(_response(json_data={}))
         with patch, pytest.raises(MetabaseAuthError):
             _resolve_auth_headers("https://x.metabaseapp.com", _session_auth(), mock.MagicMock())
+
+    def test_session_non_json_body_raises_auth_error(self):
+        # A 2xx whose body isn't JSON (host isn't a Metabase API) must surface as a non-retryable
+        # MetabaseAuthError, not a raw JSONDecodeError bubbling out of the activity.
+        response = _response(status_code=200)
+        response.json.side_effect = requests.exceptions.JSONDecodeError("Expecting value", "", 0)
+        session, patch = self._patch_mint(response)
+        with patch, pytest.raises(MetabaseAuthError) as exc:
+            _resolve_auth_headers("https://x.metabaseapp.com", _session_auth(), mock.MagicMock())
+        assert SESSION_RESPONSE_NOT_JSON_ERROR in str(exc.value)
 
     @pytest.mark.parametrize("status_code", [404, 422, 500])
     def test_session_unexpected_status_raises_retryable_not_httperror(self, status_code):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase_source.py
@@ -12,6 +12,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.metabase.metabase import (
     API_KEY_AUTH,
     SESSION_AUTH,
+    SESSION_RESPONSE_NOT_JSON_ERROR,
     MetabaseAuth,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.metabase.settings import ENDPOINTS
@@ -64,7 +65,10 @@ class TestMetabaseSource:
         }
         assert secret_field_names == {"api_key", "password"}
 
-    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error", "Invalid Metabase credentials"])
+    @pytest.mark.parametrize(
+        "expected_key",
+        ["401 Client Error", "403 Client Error", "Invalid Metabase credentials", SESSION_RESPONSE_NOT_JSON_ERROR],
+    )
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` originating in the Metabase data-warehouse import source, in `_resolve_auth_headers` (`metabase.py`).

When authenticating with username/password, the source mints a session token via `POST /api/session` and then calls `response.json()` on the result. The code assumed a 2xx response body is always JSON. If the configured Instance URL points at something that returns a 2xx with an empty or non-JSON body — an SSO/login page, a proxy, or a host that isn't actually a Metabase API — `response.json()` raised an unhandled `JSONDecodeError`. That escaped the intended typed-error handling (`MetabaseAuthError` / `MetabaseRetryableError`) and crashed the import activity, and because it wasn't recognized, it kept getting retried pointlessly.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f5bd1-5a83-7b51-b848-5c8b1efa42e2

## Changes

- Wrap the session-response JSON parse in `_resolve_auth_headers` and, on a decode failure, raise a typed `MetabaseAuthError` with an actionable message pointing the user back at their Instance URL.
- Treat that condition as non-retryable via `get_non_retryable_errors` (mirrors the Stripe pattern). It's deterministic — retrying an identical malformed 2xx never succeeds; the fix is a correct Instance URL — so there's nothing to gain from retrying.
- Share the match string as a module-level constant so the raised message and the non-retryable key can't drift apart.

**Decision (bug vs. user/upstream):** primarily a fixable bug — our code was fragile on a response shape it should handle, so it now fails cleanly instead of throwing a raw decode error. The underlying condition is a misconfigured/non-Metabase host (user/upstream), which is why it's also classified non-retryable with guidance rather than left to retry.

## How did you test this code?

Automated unit tests (run locally, all green — 72 passed):

- `test_metabase.py::TestResolveAuthHeaders::test_session_non_json_body_raises_auth_error` — a 2xx whose `.json()` raises `JSONDecodeError` now surfaces as a `MetabaseAuthError` carrying the stable substring, instead of a raw decode error bubbling out of the activity. No existing test exercised a non-JSON 2xx session body.
- `test_metabase_source.py::test_non_retryable_errors` — extended to assert the new message is recognized as non-retryable, guarding the substring match used by the retry classifier.

I (the agent) did not perform manual end-to-end testing against a live Metabase instance.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the failure originated in this source (top in-app frame `_resolve_auth_headers` at `metabase.py:140`, the `response.json()` call), read the source and its retry/auth handling, and checked open PRs (including the maintainer's) to rule out a duplicate. Considered treating it purely as a retryable transient vs. a config error; landed on fixing the fragile parse and classifying the deterministic result as non-retryable, since an identical malformed 2xx will never succeed on retry.

Skills invoked: `/writing-tests` (before adding the regression tests).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
