### PR TITLE
feat(batch-exports): authenticate Snowflake exports via integrations

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -420,6 +420,30 @@ class S3CompatibleDestinationConfigSerializer(S3FamilyDestinationConfigSerialize
     )
 
 
+class SnowflakeDestinationConfigSerializer(serializers.Serializer):
+    """Typed configuration for a Snowflake batch-export destination.
+
+    Account, user, authentication type and credentials may live in a linked Integration (when one is
+    provided) or inline in this config (legacy). Mirrors the non-credential fields of
+    `SnowflakeBatchExportInputs` in `products/batch_exports/backend/service.py`.
+    """
+
+    database = serializers.CharField(help_text="Snowflake database to write to.")
+    warehouse = serializers.CharField(help_text="Snowflake compute warehouse to use.")
+    schema = serializers.CharField(help_text="Schema inside the database containing the destination table.")
+    table_name = serializers.CharField(
+        required=False,
+        default="events",
+        help_text="Destination table name.",
+    )
+    role = serializers.CharField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Optional Snowflake role to assume for the session.",
+    )
+
+
 @extend_schema_field(
     PolymorphicProxySerializer(
         component_name="BatchExportDestinationConfig",
@@ -430,6 +454,7 @@ class S3CompatibleDestinationConfigSerializer(S3FamilyDestinationConfigSerialize
             "Postgres": PostgresDestinationConfigSerializer,
             "AwsS3": AwsS3DestinationConfigSerializer,
             "S3Compatible": S3CompatibleDestinationConfigSerializer,
+            "Snowflake": SnowflakeDestinationConfigSerializer,
         },
         resource_type_field_name="type",
     )
@@ -523,6 +548,20 @@ class S3CompatibleDestinationRequestSerializer(serializers.Serializer):
     config = S3CompatibleDestinationConfigSerializer()
 
 
+class SnowflakeDestinationRequestSerializer(serializers.Serializer):
+    """Request shape for creating or updating a Snowflake batch-export destination."""
+
+    type = serializers.ChoiceField(choices=["Snowflake"])
+    integration_id = serializers.IntegerField(
+        required=False,
+        help_text=(
+            "ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over "
+            "inline credentials. Use the integrations-list MCP tool to find one."
+        ),
+    )
+    config = SnowflakeDestinationConfigSerializer()
+
+
 BatchExportDestinationRequest = PolymorphicProxySerializer(
     component_name="BatchExportDestinationRequest",
     serializers={
@@ -532,6 +571,7 @@ BatchExportDestinationRequest = PolymorphicProxySerializer(
         "Postgres": PostgresDestinationRequestSerializer,
         "AwsS3": AwsS3DestinationRequestSerializer,
         "S3Compatible": S3CompatibleDestinationRequestSerializer,
+        "Snowflake": SnowflakeDestinationRequestSerializer,
     },
     resource_type_field_name="type",
 )
@@ -542,10 +582,11 @@ class BatchExportDestinationRequestField(serializers.JSONField):
     """JSONField annotated with a polymorphic OpenAPI request schema.
 
     Only integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3,
-    S3Compatible) are exposed in the schema. integration_id is required for Databricks, AzureBlob
-    and BigQuery, and optional for the S3 family (inline credentials remain supported for the time
-    being). Existing Postgres and S3 exports created before integrations keep their inline
-    credentials. Runtime validation remains `BatchExportDestinationSerializer.validate_destination`.
+    S3Compatible, Snowflake) are exposed in the schema. integration_id is required for Databricks,
+    AzureBlob and BigQuery, and optional for the S3 family and Snowflake (inline credentials remain
+    supported for the time being). Existing Postgres, S3 and Snowflake exports created before
+    integrations keep their inline credentials. Runtime validation remains
+    `BatchExportDestinationSerializer.validate_destination`.
     """
 
     pass
@@ -621,15 +662,16 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
     The `config` field is polymorphic and typed only for destinations that keep
     credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
-    AwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed
-    OpenAPI schema. Secret fields are stripped from `config` on read.
+    AwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a
+    typed OpenAPI schema. Secret fields are stripped from `config` on read.
     """
 
     config = TypedBatchExportDestinationConfigField(
         help_text=(
             "Destination-specific configuration. Fields depend on `type`. Credentials for "
-            "integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) "
-            "are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses."
+            "integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, "
+            "Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped "
+            "from responses."
         ),
     )
     integration = TeamScopedPrimaryKeyRelatedField(
@@ -646,8 +688,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text=(
             "ID of a team-scoped Integration providing credentials. Required when creating Databricks, "
-            "AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials "
-            "remain supported); unused for other types."
+            "AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline "
+            "credentials remain supported); unused for other types."
         ),
     )
 
@@ -685,14 +727,17 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
             str_fields = ", ".join(f"'{extra_field}'" for extra_field in sorted(extra_fields))
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")
 
-        # S3-family credential fields are optional on the dataclass (integration-backed exports
+        # Some credential/connection fields are optional on the dataclass (integration-backed exports
         # resolve them at run time), so they must be required here only when no Integration is linked.
-        # TODO: remove this code once integrations for S3 are enforced
+        # TODO: remove this code once integrations for S3 and Snowflake are enforced
         conditionally_required: set[str] = set()
-        if export_type in S3_FAMILY_TYPES and attrs.get("integration") is None:
-            conditionally_required = {"aws_access_key_id", "aws_secret_access_key"}
-            if export_type == BatchExportDestination.Destination.S3_COMPATIBLE:
-                conditionally_required.add("endpoint_url")
+        if attrs.get("integration") is None:
+            if export_type in S3_FAMILY_TYPES:
+                conditionally_required = {"aws_access_key_id", "aws_secret_access_key"}
+                if export_type == BatchExportDestination.Destination.S3_COMPATIBLE:
+                    conditionally_required.add("endpoint_url")
+            elif export_type == BatchExportDestination.Destination.SNOWFLAKE:
+                conditionally_required = {"account", "user"}
 
         for destination_field in destination_fields:
             is_required = (
@@ -1142,13 +1187,29 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(f"Invalid destination URL: {url}")
 
         if destination_type == BatchExportDestination.Destination.SNOWFLAKE:
-            if config.get("authentication_type") == "password" and merged_config.get("password") is None:
-                raise serializers.ValidationError("Password is required if authentication type is password")
-            if config.get("authentication_type") == "keypair" and merged_config.get("private_key") is None:
-                raise serializers.ValidationError("Private key is required if authentication type is key pair")
+            integration: Integration | None = destination_attrs.get("integration")
+
+            # Sticky integration: an export that uses one cannot drop back to inline credentials.
+            # TODO: remove this guard once integrations are mandatory for Snowflake and inline credentials are gone.
+            if instance is not None and instance.destination.integration is not None and integration is None:
+                raise serializers.ValidationError(
+                    "Cannot remove the integration from a Snowflake batch export that uses one. "
+                    "Re-send its `integration` to keep it (or a different one to swap)."
+                )
+
+            if integration is not None:
+                # (Team ownership is already enforced by the team-scoped `integration` field.)
+                if integration.kind != Integration.IntegrationKind.SNOWFLAKE:
+                    raise serializers.ValidationError("Integration is not a Snowflake integration.")
+            else:
+                # Inline credentials: the credential field for the chosen auth type is required.
+                if config.get("authentication_type") == "password" and merged_config.get("password") is None:
+                    raise serializers.ValidationError("Password is required if authentication type is password")
+                if config.get("authentication_type") == "keypair" and merged_config.get("private_key") is None:
+                    raise serializers.ValidationError("Private key is required if authentication type is key pair")
 
         if destination_type in S3_FAMILY_TYPES:
-            integration: Integration | None = destination_attrs.get("integration")
+            integration = destination_attrs.get("integration")
 
             # TODO: remove this guard once integrations are mandatory for S3 and inline credentials are gone.
             if instance is not None and instance.destination.integration is not None and integration is None:
@@ -1518,8 +1579,9 @@ def recursive_dict_merge(
 @extend_schema(tags=["batch_exports"])
 @extend_schema_view(
     # Request bodies use a polymorphic destination schema so that integration-backed types
-    # (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) advertise integration_id up
-    # front — required for Databricks, AzureBlob and BigQuery, optional for Postgres and the S3 family.
+    # (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) advertise
+    # integration_id up front — required for Databricks, AzureBlob and BigQuery, optional for Postgres,
+    # the S3 family and Snowflake.
     # Responses continue to use BatchExportSerializer.
     create=extend_schema(request=BatchExportRequestSerializer),
     update=extend_schema(request=BatchExportRequestSerializer),

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -362,13 +362,18 @@ class FileDownloadBatchExportInputs(BaseBatchExportInputs):
 
 @dataclass(kw_only=True)
 class SnowflakeBatchExportInputs(BaseBatchExportInputs):
-    """Inputs for Snowflake export workflow."""
+    """Inputs for Snowflake export workflow.
 
-    account: str
-    user: str
+    account, user, authentication_type and the credential fields are optional here:
+    integration-backed exports resolve them from the linked Integration at run time (see
+    `integration_id`), while legacy exports carry them inline.
+    """
+
     database: str
     warehouse: str
     schema: str
+    account: str | None = None
+    user: str | None = None
     table_name: str = "events"
     authentication_type: str = "password"
     password: str | None = None

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -24,6 +24,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
+from posthog.models.integration import Integration, SnowflakeIntegration, SnowflakeIntegrationError
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -108,6 +109,10 @@ NON_RETRYABLE_ERROR_TYPES = (
     "SnowflakeQueryServerTimeoutError",
     # Raised when either the warehouse does not exist or we are missing 'USAGE' permissions on it
     "SnowflakeWarehouseUsageError",
+    # The linked Integration was deleted or doesn't belong to the team.
+    "SnowflakeIntegrationNotFoundError",
+    # The linked Integration is the wrong kind or has invalid/missing credentials.
+    "SnowflakeIntegrationError",
 )
 
 
@@ -166,6 +171,31 @@ class SnowflakeAuthenticationError(Exception):
 
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class SnowflakeIntegrationNotFoundError(Exception):
+    def __init__(self, integration_id: int, team_id: int):
+        super().__init__(f"Snowflake integration with ID '{integration_id}' not found for team '{team_id}'")
+
+
+async def _get_snowflake_integration(integration_id: int, team_id: int) -> SnowflakeIntegration:
+    """Fetch a Snowflake integration from the database.
+
+    The kind is validated on create by the batch export serializer, so the wrong-kind branch is
+    purely defensive against an integration whose kind was changed out from under the export.
+    `SnowflakeIntegration` itself raises `SnowflakeIntegrationError` if the config is malformed.
+    """
+    try:
+        integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
+    except Integration.DoesNotExist:
+        raise SnowflakeIntegrationNotFoundError(integration_id, team_id)
+
+    if integration.kind != Integration.IntegrationKind.SNOWFLAKE:
+        raise SnowflakeIntegrationError(
+            f"Integration with ID '{integration_id}' for team '{team_id}' is not a Snowflake integration "
+            f"(kind='{integration.kind}')"
+        )
+    return SnowflakeIntegration(integration)
 
 
 class InvalidPrivateKeyError(Exception):
@@ -451,12 +481,15 @@ class SnowflakeInsertInputs(BatchExportInsertInputs):
     # to keep track of where credentials are being stored and increases the
     # attach surface for credential leaks.
 
-    user: str
-    account: str
     database: str
     warehouse: str
     schema: str
     table_name: str
+    # When set, account/user/authentication_type and credentials are resolved from this Integration
+    # at run time; otherwise the inline values below are used (legacy path).
+    integration_id: int | None = None
+    user: str | None = None
+    account: str | None = None
     authentication_type: str = "password"
     password: str | None = None
     private_key: str | None = None
@@ -1346,6 +1379,18 @@ async def insert_into_snowflake_activity_from_stage(
         inputs.table_name,
     )
 
+    # Integration-backed exports resolve account, user, auth type and credentials at run time;
+    # legacy exports carry them inline.
+    # TODO: require integration
+    if inputs.integration_id is not None:
+        integration = await _get_snowflake_integration(inputs.integration_id, inputs.team_id)
+        inputs.account = integration.account
+        inputs.user = integration.user
+        inputs.authentication_type = integration.authentication_type
+        inputs.password = integration.password
+        inputs.private_key = integration.private_key
+        inputs.private_key_passphrase = integration.private_key_passphrase
+
     async with Heartbeater():
         model: BatchExportModel | BatchExportSchema | None = None
         if inputs.batch_export_schema is None:
@@ -1541,6 +1586,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
 
         insert_inputs = SnowflakeInsertInputs(
             team_id=inputs.team_id,
+            integration_id=inputs.integration_id,
             user=inputs.user,
             account=inputs.account,
             authentication_type=inputs.authentication_type,

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -24,7 +24,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
-from posthog.models.integration import Integration, SnowflakeIntegration, SnowflakeIntegrationError
+from posthog.models.integration import Integration, SnowflakeIntegration
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -181,20 +181,15 @@ class SnowflakeIntegrationNotFoundError(Exception):
 async def _get_snowflake_integration(integration_id: int, team_id: int) -> SnowflakeIntegration:
     """Fetch a Snowflake integration from the database.
 
-    The kind is validated on create by the batch export serializer, so the wrong-kind branch is
-    purely defensive against an integration whose kind was changed out from under the export.
-    `SnowflakeIntegration` itself raises `SnowflakeIntegrationError` if the config is malformed.
+    `SnowflakeIntegration` raises `SnowflakeIntegrationError` if the config is malformed.
     """
     try:
-        integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
+        integration = await Integration.objects.aget(
+            id=integration_id, team_id=team_id, kind=Integration.IntegrationKind.SNOWFLAKE
+        )
     except Integration.DoesNotExist:
         raise SnowflakeIntegrationNotFoundError(integration_id, team_id)
 
-    if integration.kind != Integration.IntegrationKind.SNOWFLAKE:
-        raise SnowflakeIntegrationError(
-            f"Integration with ID '{integration_id}' for team '{team_id}' is not a Snowflake integration "
-            f"(kind='{integration.kind}')"
-        )
     return SnowflakeIntegration(integration)
 
 
@@ -1386,19 +1381,19 @@ async def insert_into_snowflake_activity_from_stage(
         inputs.table_name,
     )
 
-    # Integration-backed exports resolve account, user, auth type and credentials at run time;
-    # legacy exports carry them inline.
-    # TODO: require integration
-    if inputs.integration_id is not None:
-        integration = await _get_snowflake_integration(inputs.integration_id, inputs.team_id)
-        inputs.account = integration.account
-        inputs.user = integration.user
-        inputs.authentication_type = integration.authentication_type
-        inputs.password = integration.password
-        inputs.private_key = integration.private_key
-        inputs.private_key_passphrase = integration.private_key_passphrase
-
     async with Heartbeater():
+        # Integration-backed exports resolve account, user, auth type and credentials at run time;
+        # legacy exports carry them inline.
+        # TODO: require integration
+        if inputs.integration_id is not None:
+            integration = await _get_snowflake_integration(inputs.integration_id, inputs.team_id)
+            inputs.account = integration.account
+            inputs.user = integration.user
+            inputs.authentication_type = integration.authentication_type
+            inputs.password = integration.password
+            inputs.private_key = integration.private_key
+            inputs.private_key_passphrase = integration.private_key_passphrase
+
         model: BatchExportModel | BatchExportSchema | None = None
         if inputs.batch_export_schema is None:
             model = inputs.batch_export_model

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -569,6 +569,13 @@ class SnowflakeClient:
     def from_inputs(cls, inputs: SnowflakeInsertInputs) -> typing.Self:
         """Initialize `SnowflakeClient` from `SnowflakeInsertInputs`."""
 
+        # account and user are optional on the inputs (integration-backed exports resolve them at run
+        # time in the activity), but they must be resolved by the time we open a connection.
+        account = inputs.account
+        user = inputs.user
+        if account is None or user is None:
+            raise SnowflakeAuthenticationError("Snowflake account and user are required")
+
         # User could have specified both password and private key in their batch export config.
         # (for example, if they've already created a batch export with password auth and are now switching to keypair auth)
         # Therefore we decide which one to use based on the authentication_type.
@@ -588,8 +595,8 @@ class SnowflakeClient:
             raise SnowflakeAuthenticationError(f"Invalid authentication type: {inputs.authentication_type}")
 
         return cls(
-            user=inputs.user,
-            account=inputs.account,
+            user=user,
+            account=account,
             warehouse=inputs.warehouse,
             database=inputs.database,
             schema=inputs.schema,

--- a/products/batch_exports/backend/tests/api/fixtures.py
+++ b/products/batch_exports/backend/tests/api/fixtures.py
@@ -1,5 +1,8 @@
+from django.test.client import Client as TestClient
+
 from posthog.api.test.test_organization import create_organization as create_organization_base
 from posthog.models import Organization, Team, User
+from posthog.models.integration import Integration
 
 from products.batch_exports.backend.models.batch_export import (
     BatchExport,
@@ -7,6 +10,7 @@ from products.batch_exports.backend.models.batch_export import (
     BatchExportDestination,
     BatchExportRun,
 )
+from products.batch_exports.backend.tests.api.operations import create_batch_export_ok
 
 
 def create_organization(name: str) -> Organization:
@@ -62,6 +66,34 @@ def create_batch_export(team, destination) -> BatchExport:
         destination=destination,
         interval="hour",
     )
+
+
+def create_integration_backed_snowflake_export(client: TestClient, team: Team, user: User) -> tuple[Integration, dict]:
+    """Create a Snowflake integration and an integration-backed batch export using it.
+
+    Returns the integration and the created batch export (as returned by the API).
+    """
+    integration = Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.SNOWFLAKE,
+        integration_id="prod-snowflake",
+        config={"name": "prod-snowflake", "account": "my-account", "user": "svc", "authentication_type": "password"},
+        sensitive_config={"password": "secret"},
+        created_by=user,
+    )
+    export_data = {
+        "name": "my-export",
+        "interval": "hour",
+        "destination": {
+            "type": "Snowflake",
+            # No account/user/credentials inline — they come from the integration.
+            "config": {"database": "my-db", "warehouse": "COMPUTE_WH", "schema": "public"},
+            "integration": integration.pk,
+        },
+    }
+    client.force_login(user)
+    batch_export = create_batch_export_ok(client, team.pk, export_data)
+    return integration, batch_export
 
 
 def create_backfill(team, batch_export, start_at, end_at, status, finished_at) -> BatchExportBackfill:

--- a/products/batch_exports/backend/tests/api/test_create.py
+++ b/products/batch_exports/backend/tests/api/test_create.py
@@ -372,6 +372,11 @@ def test_cannot_create_a_batch_export_for_another_organization(client: HttpClien
             Integration.IntegrationKind.DATABRICKS,
             {"http_path": "p", "catalog": "c", "schema": "s", "table_name": "t"},
         ),
+        (
+            "Snowflake",
+            Integration.IntegrationKind.SNOWFLAKE,
+            {"database": "d", "warehouse": "w", "schema": "s"},
+        ),
     ],
 )
 def test_cannot_create_batch_export_with_integration_from_another_team(

--- a/products/batch_exports/backend/tests/api/test_create_snowflake.py
+++ b/products/batch_exports/backend/tests/api/test_create_snowflake.py
@@ -3,7 +3,12 @@ import pytest
 from django.test.client import Client as HttpClient
 
 from rest_framework import status
+from temporalio.client import ScheduleActionStartWorkflow
 
+from posthog.models.integration import Integration
+
+from products.batch_exports.backend.tests.api.conftest import describe_schedule
+from products.batch_exports.backend.tests.api.fixtures import create_integration_backed_snowflake_export
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
 pytestmark = [
@@ -79,3 +84,44 @@ def test_create_snowflake_batch_export_validates_credentials(
             assert "Password is required if authentication type is password" in response.json()["detail"]
         else:
             assert "Private key is required if authentication type is key pair" in response.json()["detail"]
+
+
+def test_create_snowflake_batch_export_using_integration(client: HttpClient, temporal, organization, team, user):
+    """A Snowflake export authenticates via a matching integration, with no account/user/credentials in config."""
+    _, data = create_integration_backed_snowflake_export(client, team, user)
+    assert data["destination"]["type"] == "Snowflake"
+    assert "password" not in data["destination"]["config"]
+
+    schedule = describe_schedule(temporal, data["id"])
+    assert isinstance(schedule.schedule.action, ScheduleActionStartWorkflow)
+    assert schedule.schedule.action.workflow == "snowflake-export"
+
+
+def test_create_snowflake_batch_export_rejects_mismatched_integration_kind(
+    client: HttpClient, temporal, organization, team, user
+):
+    """A Snowflake export rejects an integration whose kind isn't snowflake."""
+    integration = Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
+    client.force_login(user)
+    response = create_batch_export(
+        client,
+        team.pk,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {
+                "type": "Snowflake",
+                "config": {"database": "my-db", "warehouse": "COMPUTE_WH", "schema": "public"},
+                "integration": integration.id,
+            },
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["detail"] == "Integration is not a Snowflake integration."

--- a/products/batch_exports/backend/tests/api/test_update_snowflake.py
+++ b/products/batch_exports/backend/tests/api/test_update_snowflake.py
@@ -4,6 +4,7 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
+from products.batch_exports.backend.tests.api.fixtures import create_integration_backed_snowflake_export
 from products.batch_exports.backend.tests.api.operations import (
     create_batch_export_ok,
     get_batch_export_ok,
@@ -144,3 +145,41 @@ def test_switching_snowflake_auth_type_to_keypair_requires_private_key(
     batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
     assert batch_export["destination"]["type"] == "Snowflake"
     assert batch_export["destination"]["config"]["authentication_type"] == "password"
+
+
+@pytest.mark.parametrize("integration_value", [None, "omitted"])
+def test_updating_snowflake_batch_export_rejects_removing_integration(
+    client: HttpClient, temporal, organization, team, user, integration_value
+):
+    """An integration-backed export can't drop back to inline credentials — whether the caller sends
+    `integration: null` or omits it entirely (clients re-send the full destination on update).
+    """
+    _, batch_export = create_integration_backed_snowflake_export(client, team, user)
+
+    destination: dict = {"type": "Snowflake", "config": {}}
+    if integration_value is None:
+        destination["integration"] = None
+
+    response = patch_batch_export(client, team.pk, batch_export["id"], {"destination": destination})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["detail"] == (
+        "Cannot remove the integration from a Snowflake batch export that uses one. "
+        "Re-send its `integration` to keep it (or a different one to swap)."
+    )
+
+
+def test_updating_integration_backed_snowflake_export_allows_config_patch_with_integration(
+    client: HttpClient, temporal, organization, team, user
+):
+    """Updating config while re-sending the integration succeeds and keeps it linked."""
+    integration, batch_export = create_integration_backed_snowflake_export(client, team, user)
+
+    response = patch_batch_export(
+        client,
+        team.pk,
+        batch_export["id"],
+        {"destination": {"type": "Snowflake", "config": {"schema": "new_schema"}, "integration": integration.id}},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json()["destination"]["config"]["schema"] == "new_schema"
+    assert response.json()["destination"]["integration"] == integration.id

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity.py
@@ -5,7 +5,7 @@ These don't touch a real Snowflake instance, so (unlike test_activity_e2e.py) th
 
 import pytest
 
-from posthog.models.integration import Integration, SnowflakeIntegrationError
+from posthog.models.integration import Integration
 
 from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import (
     SnowflakeIntegrationNotFoundError,
@@ -20,11 +20,11 @@ async def test_get_snowflake_integration_raises_when_not_found(ateam):
         await _get_snowflake_integration(2147483647, ateam.pk)
 
 
-async def test_get_snowflake_integration_rejects_wrong_kind(ateam):
-    """An integration whose kind isn't snowflake can't be resolved as one.
+async def test_get_snowflake_integration_ignores_wrong_kind(ateam):
+    """A non-snowflake integration doesn't match the kind-filtered lookup, so it reads as not found.
 
-    The serializer validates the kind on create/update, so this only happens if the integration's
-    kind is changed out from under an existing export.
+    Guards against the kind filter being dropped from the query, which would let an export resolve
+    an unrelated integration.
     """
     integration = await Integration.objects.acreate(
         team_id=ateam.pk,
@@ -33,7 +33,5 @@ async def test_get_snowflake_integration_rejects_wrong_kind(ateam):
         config={},
         sensitive_config={},
     )
-    with pytest.raises(SnowflakeIntegrationError) as exc_info:
+    with pytest.raises(SnowflakeIntegrationNotFoundError):
         await _get_snowflake_integration(integration.id, ateam.pk)
-    assert "not a Snowflake integration" in str(exc_info.value)
-    assert "kind='slack'" in str(exc_info.value)

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity.py
@@ -1,0 +1,39 @@
+"""Un-gated unit tests for the Snowflake insert activity's integration resolution.
+
+These don't touch a real Snowflake instance, so (unlike test_activity_e2e.py) they run in CI.
+"""
+
+import pytest
+
+from posthog.models.integration import Integration, SnowflakeIntegrationError
+
+from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import (
+    SnowflakeIntegrationNotFoundError,
+    _get_snowflake_integration,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+
+async def test_get_snowflake_integration_raises_when_not_found(ateam):
+    with pytest.raises(SnowflakeIntegrationNotFoundError):
+        await _get_snowflake_integration(2147483647, ateam.pk)
+
+
+async def test_get_snowflake_integration_rejects_wrong_kind(ateam):
+    """An integration whose kind isn't snowflake can't be resolved as one.
+
+    The serializer validates the kind on create/update, so this only happens if the integration's
+    kind is changed out from under an existing export.
+    """
+    integration = await Integration.objects.acreate(
+        team_id=ateam.pk,
+        kind=Integration.IntegrationKind.SLACK,
+        integration_id="not-snowflake",
+        config={},
+        sensitive_config={},
+    )
+    with pytest.raises(SnowflakeIntegrationError) as exc_info:
+        await _get_snowflake_integration(integration.id, ateam.pk)
+    assert "not a Snowflake integration" in str(exc_info.value)
+    assert "kind='slack'" in str(exc_info.value)

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -234,6 +234,7 @@ async def test_insert_into_snowflake_activity_resolves_credentials_from_integrat
     )
 
     table_name = f"test_integration_activity_table_{ateam.pk}"
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
 
     await _run_activity(
         activity_environment=activity_environment,
@@ -246,6 +247,7 @@ async def test_insert_into_snowflake_activity_resolves_credentials_from_integrat
         table_name=table_name,
         batch_export_model=BatchExportModel(name="events", schema=None),
         integration_id=integration.id,
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -14,6 +14,7 @@ import pytest
 
 from django.test import override_settings
 
+from posthog.models.integration import Integration
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
 from products.batch_exports.backend.service import BatchExportModel, BatchExportSchema
@@ -66,8 +67,15 @@ async def _run_activity(
     uppercase_columns: list[str] | None = None,
     extra_fields: dict[str, t.Any] | None = None,
     min_ingested_timestamp: dt.datetime | None = None,
+    integration_id: int | None = None,
 ):
     """Helper function to run insert_into_snowflake_activity_from_stage and assert records in Snowflake"""
+    config = dict(snowflake_config)
+    if integration_id is not None:
+        # Account, user and credentials come from the Integration, not inline config.
+        for key in ("account", "user", "authentication_type", "password", "private_key", "private_key_passphrase"):
+            config.pop(key, None)
+
     insert_inputs = SnowflakeInsertInputs(
         team_id=team.pk,
         table_name=table_name,
@@ -77,7 +85,8 @@ async def _run_activity(
         batch_export_schema=batch_export_schema,
         batch_export_model=batch_export_model,
         batch_export_id=str(uuid.uuid4()),
-        **snowflake_config,
+        integration_id=integration_id,
+        **config,
     )
 
     assert insert_inputs.batch_export_id is not None
@@ -187,6 +196,56 @@ async def test_insert_into_snowflake_activity_inserts_data_into_snowflake_table(
         exclude_events=exclude_events,
         sort_key=sort_key,
         min_ingested_timestamp=min_ingested_timestamp,
+    )
+
+
+async def test_insert_into_snowflake_activity_resolves_credentials_from_integration(
+    clickhouse_client,
+    activity_environment,
+    snowflake_cursor,
+    snowflake_config,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+):
+    """An integration-backed export resolves account, user and credentials from the linked Integration
+    at run time, with none of them present on the activity inputs.
+    """
+    sensitive_config: dict[str, str] = {}
+    if snowflake_config["authentication_type"] == "keypair":
+        sensitive_config["private_key"] = snowflake_config["private_key"]
+        if snowflake_config.get("private_key_passphrase"):
+            sensitive_config["private_key_passphrase"] = snowflake_config["private_key_passphrase"]
+    else:
+        sensitive_config["password"] = snowflake_config["password"]
+
+    integration = await Integration.objects.acreate(
+        team_id=ateam.pk,
+        kind=Integration.IntegrationKind.SNOWFLAKE,
+        integration_id="prod-snowflake",
+        config={
+            "name": "prod-snowflake",
+            "account": snowflake_config["account"],
+            "user": snowflake_config["user"],
+            "authentication_type": snowflake_config["authentication_type"],
+        },
+        sensitive_config=sensitive_config,
+    )
+
+    table_name = f"test_integration_activity_table_{ateam.pk}"
+
+    await _run_activity(
+        activity_environment=activity_environment,
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        snowflake_config=snowflake_config,
+        team=ateam,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        table_name=table_name,
+        batch_export_model=BatchExportModel(name="events", schema=None),
+        integration_id=integration.id,
     )
 
 

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -302,6 +302,37 @@ export interface S3CompatibleDestinationConfigApi {
     type: S3CompatibleDestinationConfigApiType
 }
 
+export type SnowflakeDestinationConfigApiType =
+    (typeof SnowflakeDestinationConfigApiType)[keyof typeof SnowflakeDestinationConfigApiType]
+
+export const SnowflakeDestinationConfigApiType = {
+    Snowflake: 'Snowflake',
+} as const
+
+/**
+ * Typed configuration for a Snowflake batch-export destination.
+ *
+ * Account, user, authentication type and credentials may live in a linked Integration (when one is
+ * provided) or inline in this config (legacy). Mirrors the non-credential fields of
+ * `SnowflakeBatchExportInputs` in `products/batch_exports/backend/service.py`.
+ */
+export interface SnowflakeDestinationConfigApi {
+    /** Snowflake database to write to. */
+    database: string
+    /** Snowflake compute warehouse to use. */
+    warehouse: string
+    /** Schema inside the database containing the destination table. */
+    schema: string
+    /** Destination table name. */
+    table_name?: string
+    /**
+     * Optional Snowflake role to assume for the session.
+     * @nullable
+     */
+    role?: string | null
+    type: SnowflakeDestinationConfigApiType
+}
+
 export type BatchExportDestinationConfigApi =
     | DatabricksDestinationConfigApi
     | AzureBlobDestinationConfigApi
@@ -309,14 +340,15 @@ export type BatchExportDestinationConfigApi =
     | PostgresDestinationConfigApi
     | AwsS3DestinationConfigApi
     | S3CompatibleDestinationConfigApi
+    | SnowflakeDestinationConfigApi
 
 /**
  * Serializer for an BatchExportDestination model.
  *
  * The `config` field is polymorphic and typed only for destinations that keep
  * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
- * AwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed
- * OpenAPI schema. Secret fields are stripped from `config` on read.
+ * AwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a
+ * typed OpenAPI schema. Secret fields are stripped from `config` on read.
  */
 export interface BatchExportDestinationApi {
     /** A choice of supported BatchExportDestination types.
@@ -335,7 +367,7 @@ export interface BatchExportDestinationApi {
      * * `NoOp` - Noop
      * * `FileDownload` - File Download */
     type: BatchExportDestinationTypeEnumApi
-    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
     config: BatchExportDestinationConfigApi
     /**
      * The integration for this destination.
@@ -343,7 +375,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.
+     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.
      * @nullable
      */
     integration_id?: number | null
@@ -1261,6 +1293,23 @@ export interface S3CompatibleDestinationRequestApi {
     config: S3CompatibleDestinationConfigApi
 }
 
+export type SnowflakeDestinationRequestApiType =
+    (typeof SnowflakeDestinationRequestApiType)[keyof typeof SnowflakeDestinationRequestApiType]
+
+export const SnowflakeDestinationRequestApiType = {
+    Snowflake: 'Snowflake',
+} as const
+
+/**
+ * Request shape for creating or updating a Snowflake batch-export destination.
+ */
+export interface SnowflakeDestinationRequestApi {
+    type: SnowflakeDestinationRequestApiType
+    /** ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+    integration_id?: number
+    config: SnowflakeDestinationConfigApi
+}
+
 export type BatchExportDestinationRequestApi =
     | DatabricksDestinationRequestApi
     | AzureBlobDestinationRequestApi
@@ -1268,6 +1317,7 @@ export type BatchExportDestinationRequestApi =
     | PostgresDestinationRequestApi
     | AwsS3DestinationRequestApi
     | S3CompatibleDestinationRequestApi
+    | SnowflakeDestinationRequestApi
 
 /**
  * Request body for create/partial_update on BatchExportViewSet.
@@ -1813,6 +1863,16 @@ export type S3CompatibleDestinationRequestTypeEnumApi =
 
 export const S3CompatibleDestinationRequestTypeEnumApi = {
     S3Compatible: 'S3Compatible',
+} as const
+
+/**
+ * * `Snowflake` - Snowflake
+ */
+export type SnowflakeDestinationRequestTypeEnumApi =
+    (typeof SnowflakeDestinationRequestTypeEnumApi)[keyof typeof SnowflakeDestinationRequestTypeEnumApi]
+
+export const SnowflakeDestinationRequestTypeEnumApi = {
+    Snowflake: 'Snowflake',
 } as const
 
 export type BatchExportsListParams = {

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -21,6 +21,7 @@ export const batchExportsCreateBodyDestinationOneFourConfigHasSelfSignedCertDefa
 export const batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
 export const batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
+export const batchExportsCreateBodyDestinationOneSevenConfigTableNameDefault = `events`
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -290,6 +291,37 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Snowflake']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneSevenConfigTableNameDefault)
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                                type: zod.enum(['Snowflake']),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -593,6 +625,7 @@ export const batchExportsUpdateBodyDestinationOneFourConfigHasSelfSignedCertDefa
 export const batchExportsUpdateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
 export const batchExportsUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
+export const batchExportsUpdateBodyDestinationOneSevenConfigTableNameDefault = `events`
 export const batchExportsUpdateBodyOffsetDayMin = 0
 export const batchExportsUpdateBodyOffsetDayMax = 6
 
@@ -862,6 +895,37 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Snowflake']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsUpdateBodyDestinationOneSevenConfigTableNameDefault)
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                                type: zod.enum(['Snowflake']),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -918,6 +982,7 @@ export const batchExportsPartialUpdateBodyDestinationOneFourConfigHasSelfSignedC
 export const batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
+export const batchExportsPartialUpdateBodyDestinationOneSevenConfigTableNameDefault = `events`
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -1189,6 +1254,37 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Snowflake']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneSevenConfigTableNameDefault)
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                                type: zod.enum(['Snowflake']),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
@@ -1250,6 +1346,7 @@ export const batchExportsPauseCreateBodyDestinationOneConfigOneFourHasSelfSigned
 export const batchExportsPauseCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
 export const batchExportsPauseCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsPauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
+export const batchExportsPauseCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
 export const batchExportsPauseCreateBodyOffsetDayMin = 0
 export const batchExportsPauseCreateBodyOffsetDayMax = 6
 
@@ -1488,20 +1585,40 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneSevenTableNameDefault)
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                                type: zod.enum(['Snowflake']),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1567,6 +1684,7 @@ export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneFourHasSelf
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
 export const batchExportsRunTestStepCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepCreateBodyOffsetDayMax = 6
 
@@ -1819,20 +1937,42 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneSevenTableNameDefault
+                                    )
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                                type: zod.enum(['Snowflake']),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1901,6 +2041,7 @@ export const batchExportsUnpauseCreateBodyDestinationOneConfigOneFourHasSelfSign
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
 export const batchExportsUnpauseCreateBodyOffsetDayMin = 0
 export const batchExportsUnpauseCreateBodyOffsetDayMax = 6
 
@@ -2143,20 +2284,40 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneSevenTableNameDefault)
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                                type: zod.enum(['Snowflake']),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -2222,6 +2383,7 @@ export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFourHasS
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSevenTableNameDefault = `events`
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMax = 6
 
@@ -2478,20 +2640,42 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSevenTableNameDefault
+                                    )
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                                type: zod.enum(['Snowflake']),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a\ntyped OpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -10774,15 +10774,46 @@ export namespace Schemas {
       type: S3CompatibleDestinationConfigType;
     }
 
-    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig | BigQueryDestinationConfig | PostgresDestinationConfig | AwsS3DestinationConfig | S3CompatibleDestinationConfig;
+    export type SnowflakeDestinationConfigType = typeof SnowflakeDestinationConfigType[keyof typeof SnowflakeDestinationConfigType];
+
+
+    export const SnowflakeDestinationConfigType = {
+      Snowflake: 'Snowflake',
+    } as const;
+
+    /**
+     * Typed configuration for a Snowflake batch-export destination.
+     *
+     * Account, user, authentication type and credentials may live in a linked Integration (when one is
+     * provided) or inline in this config (legacy). Mirrors the non-credential fields of
+     * `SnowflakeBatchExportInputs` in `products/batch_exports/backend/service.py`.
+     */
+    export interface SnowflakeDestinationConfig {
+      /** Snowflake database to write to. */
+      database: string;
+      /** Snowflake compute warehouse to use. */
+      warehouse: string;
+      /** Schema inside the database containing the destination table. */
+      schema: string;
+      /** Destination table name. */
+      table_name?: string;
+      /**
+         * Optional Snowflake role to assume for the session.
+         * @nullable
+         */
+      role?: string | null;
+      type: SnowflakeDestinationConfigType;
+    }
+
+    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig | BigQueryDestinationConfig | PostgresDestinationConfig | AwsS3DestinationConfig | S3CompatibleDestinationConfig | SnowflakeDestinationConfig;
 
     /**
      * Serializer for an BatchExportDestination model.
      *
      * The `config` field is polymorphic and typed only for destinations that keep
      * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
-     * AwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed
-     * OpenAPI schema. Secret fields are stripped from `config` on read.
+     * AwsS3, S3Compatible, Snowflake). Other destination types accept the same JSON shape but without a
+     * typed OpenAPI schema. Secret fields are stripped from `config` on read.
      */
     export interface BatchExportDestination {
       /** A choice of supported BatchExportDestination types.
@@ -10801,7 +10832,7 @@ export namespace Schemas {
        * * `NoOp` - Noop
        * * `FileDownload` - File Download */
       type: BatchExportDestinationTypeEnum;
-      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
       config: BatchExportDestinationConfig;
       /**
          * The integration for this destination.
@@ -10809,7 +10840,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.
+         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.
          * @nullable
          */
       integration_id?: number | null;
@@ -11777,7 +11808,24 @@ export namespace Schemas {
       config: S3CompatibleDestinationConfig;
     }
 
-    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest | BigQueryDestinationRequest | PostgresDestinationRequest | AwsS3DestinationRequest | S3CompatibleDestinationRequest;
+    export type SnowflakeDestinationRequestType = typeof SnowflakeDestinationRequestType[keyof typeof SnowflakeDestinationRequestType];
+
+
+    export const SnowflakeDestinationRequestType = {
+      Snowflake: 'Snowflake',
+    } as const;
+
+    /**
+     * Request shape for creating or updating a Snowflake batch-export destination.
+     */
+    export interface SnowflakeDestinationRequest {
+      type: SnowflakeDestinationRequestType;
+      /** ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+      integration_id?: number;
+      config: SnowflakeDestinationConfig;
+    }
+
+    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest | BigQueryDestinationRequest | PostgresDestinationRequest | AwsS3DestinationRequest | S3CompatibleDestinationRequest | SnowflakeDestinationRequest;
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
@@ -53916,6 +53964,16 @@ export namespace Schemas {
       /** All runs on the task, oldest first. Empty when no mapping was found. */
       runs: SlackThreadContextRun[];
     }
+
+    /**
+     * * `Snowflake` - Snowflake
+     */
+    export type SnowflakeDestinationRequestTypeEnum = typeof SnowflakeDestinationRequestTypeEnum[keyof typeof SnowflakeDestinationRequestTypeEnum];
+
+
+    export const SnowflakeDestinationRequestTypeEnum = {
+      Snowflake: 'Snowflake',
+    } as const;
 
     export interface SourceConnectLink {
       /** The source type the link is for. */

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -41,6 +41,7 @@ export const batchExportsCreateBodyDestinationOneFourConfigHasSelfSignedCertDefa
 export const batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
 export const batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
+export const batchExportsCreateBodyDestinationOneSevenConfigTableNameDefault = `events`
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -304,6 +305,36 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Snowflake']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsCreateBodyDestinationOneSevenConfigTableNameDefault)
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -368,6 +399,7 @@ export const batchExportsPartialUpdateBodyDestinationOneFourConfigHasSelfSignedC
 export const batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
 export const batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
+export const batchExportsPartialUpdateBodyDestinationOneSevenConfigTableNameDefault = `events`
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -633,6 +665,36 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['Snowflake']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                database: zod.string().describe('Snowflake database to write to.'),
+                                warehouse: zod.string().describe('Snowflake compute warehouse to use.'),
+                                schema: zod
+                                    .string()
+                                    .describe('Schema inside the database containing the destination table.'),
+                                table_name: zod
+                                    .string()
+                                    .default(batchExportsPartialUpdateBodyDestinationOneSevenConfigTableNameDefault)
+                                    .describe('Destination table name.'),
+                                role: zod
+                                    .string()
+                                    .nullish()
+                                    .describe('Optional Snowflake role to assume for the session.'),
+                            })
+                            .describe(
+                                'Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating a Snowflake batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
@@ -376,7 +376,7 @@
                                     "type": "string"
                                 },
                                 "warehouse": {
-                                    "description": "Snowflake warehouse used to run the load queries.",
+                                    "description": "Snowflake compute warehouse to use.",
                                     "type": "string"
                                 }
                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
@@ -344,6 +344,56 @@
                     },
                     "required": ["type", "config"],
                     "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating a Snowflake batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "database": {
+                                    "description": "Snowflake database to write to.",
+                                    "type": "string"
+                                },
+                                "role": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional Snowflake role to assume for the session."
+                                },
+                                "schema": {
+                                    "description": "Schema inside the database containing the destination table.",
+                                    "type": "string"
+                                },
+                                "table_name": {
+                                    "default": "events",
+                                    "description": "Destination table name.",
+                                    "type": "string"
+                                },
+                                "warehouse": {
+                                    "description": "Snowflake warehouse used to run the load queries.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["database", "warehouse", "schema"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["Snowflake"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
+                    "type": "object"
                 }
             ],
             "description": "Destination configuration. Required integration_id is enforced per destination type."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
@@ -343,6 +343,56 @@
                     },
                     "required": ["type", "config"],
                     "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating a Snowflake batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for a Snowflake batch-export destination.\n\nAccount, user, authentication type and credentials may live in a linked Integration (when one is\nprovided) or inline in this config (legacy). Mirrors the non-credential fields of\n`SnowflakeBatchExportInputs` in `products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "database": {
+                                    "description": "Snowflake database to write to.",
+                                    "type": "string"
+                                },
+                                "role": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional Snowflake role to assume for the session."
+                                },
+                                "schema": {
+                                    "description": "Schema inside the database containing the destination table.",
+                                    "type": "string"
+                                },
+                                "table_name": {
+                                    "default": "events",
+                                    "description": "Destination table name.",
+                                    "type": "string"
+                                },
+                                "warehouse": {
+                                    "description": "Snowflake warehouse used to run the load queries.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["database", "warehouse", "schema"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["Snowflake"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
+                    "type": "object"
                 }
             ],
             "description": "Destination configuration. Required integration_id is enforced per destination type."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
@@ -375,7 +375,7 @@
                                     "type": "string"
                                 },
                                 "warehouse": {
-                                    "description": "Snowflake warehouse used to run the load queries.",
+                                    "description": "Snowflake compute warehouse to use.",
                                     "type": "string"
                                 }
                             },


### PR DESCRIPTION
## Problem

Snowflake batch exports store all their credentials (`user`, `password`, `private_key`, `private_key_passphrase`) inline in each destination's encrypted config. That means credentials are duplicated per export and can't be reused, rotated, or managed independently. Databricks, Azure Blob, Postgres, and the S3 family already authenticate via the shared `Integration` model. This wires Snowflake up to do the same.

Second PR in the Snowflake migration. The first (#69642) added the `snowflake` Integration kind; this one makes batch exports actually use it.

## Changes

- **Runtime resolution (`snowflake_batch_export.py`):** when a destination has an `integration_id`, the Temporal activity resolves account, user, authentication type and the credential material from the linked Integration at run time. Otherwise it falls back to inline config (legacy path). A missing or wrong-kind integration raises a non-retryable error.
- **Serializer (`api/batch_export.py`):** typed `Snowflake` config and request serializers, `integration_id` accepted, and the integration kind validated against the destination in `validate_destination`. An export that already uses an integration can't drop back to inline credentials (matches the S3 family behaviour).
- **`service.py`:** `account` and `user` become optional on the input dataclass, since integration-backed exports resolve them at run time.

> [!NOTE]
> Inline credentials still work at runtime so existing exports keep running. It is also still possible to create Snowflake batch exports without integrations via the API for now. Enforcing integrations and backfilling existing exports is a later PR.

## How did you test this code?

Automated tests only:

- **API** (`test_create_snowflake.py`, `test_update_snowflake.py`, a shared case in `test_create.py`)
- **Temporal** (`snowflake/test_activity.py`, new): un-gated unit tests for the integration resolver — a missing integration and a wrong-kind integration each raise the expected non-retryable error. Plus a live-Snowflake activity test (`test_activity_e2e.py`) that resolves credentials from an integration, gated behind `SKIP_IF_MISSING_REQUIRED_ENV_VARS`.

## Automatic notifications

- [ ] Publish to changelog? _Not yet_
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs — backend only. The frontend create/edit flow comes with the next PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked: `/improving-drf-endpoints` (the config/request serializers and `validate_destination` branch) and `/writing-tests` (the API and temporal test additions).

Modelled closely on the S3-family equivalent (#65855)

---

_Created with [PostHog Code](https://posthog.com/code?ref=pr)_
