### PR TITLE
fix(mcp): render query results through render-ui

### DIFF
--- a/.agents/skills/implementing-mcp-ui-apps/SKILL.md
+++ b/.agents/skills/implementing-mcp-ui-apps/SKILL.md
@@ -265,7 +265,9 @@ ui_apps:
 
 For apps that need fully custom logic (e.g. `debug.tsx`, `query-results.tsx`).
 The generator does NOT create an entry point — you maintain it manually at
-`services/mcp/src/ui-apps/apps/{key}.tsx`. Only the registry entry is generated.
+`services/mcp/src/ui-apps/apps/{key}.tsx`. The registry entry is always generated.
+If the custom app exposes a reusable view component, an optional `render_ui`
+configuration also adds it to the `render-ui` umbrella tool.
 
 **Required fields:**
 
@@ -275,6 +277,15 @@ The generator does NOT create an entry point — you maintain it manually at
 | `app_name`    | Display name. Required because there's no convention to derive it from (custom apps may not follow naming patterns). |
 | `description` | Short description. Required for the same reason.                                                                     |
 
+**Optional `render_ui` fields:**
+
+| Field              | Description                                                                       |
+| ------------------ | --------------------------------------------------------------------------------- |
+| `component_import` | Import path for the reusable view component, relative to `src/ui-apps/generated`. |
+| `view_component`   | React component name that renders the tool result.                                |
+| `view_prop`        | Prop name that receives the tool result.                                          |
+| `data_type`        | TypeScript type for the tool result. Omit when the component accepts `unknown`.   |
+
 **Example:**
 
 ```yaml
@@ -283,6 +294,10 @@ ui_apps:
     type: custom
     app_name: Query Results
     description: Interactive visualization for PostHog query results
+    render_ui:
+      component_import: ../components/Component
+      view_component: Component
+      view_prop: data
 ```
 
 ### Where the schemas live
@@ -295,9 +310,9 @@ To add a new field to an app type:
 
 1. Add it to the relevant Zod schema (`DetailUiAppSchema`, `ListUiAppSchema`, or `CustomUiAppSchema`)
    with `.optional()` if it has a default
-2. Add it to the matching `Resolved*` interface (`ResolvedDetailUiApp` or `ResolvedListUiApp`)
-3. Add the default derivation in `resolveDetailApp()` or `resolveListApp()` in `generate-ui-apps.ts`
-4. Use the resolved value in `generateDetailApp()` or `generateListApp()`
+2. Add it to the matching `Resolved*` interface (`ResolvedDetailUiApp`, `ResolvedListUiApp`, or `ResolvedCustomUiApp`)
+3. Add the default derivation in `resolveDetailApp()`, `resolveListApp()`, or `resolveCustomApp()` in `generate-ui-apps.ts`
+4. Use the resolved value in the entry-point or dispatch generator
 
 All schemas use `.strict()` — unknown keys are rejected at build time, catching typos.
 

--- a/services/mcp/CONTRIBUTING.md
+++ b/services/mcp/CONTRIBUTING.md
@@ -304,7 +304,7 @@ pnpm run build               # builds all apps
 
 For apps that need fully custom logic (like `debug.tsx` or `query-results.tsx`):
 
-1. **Add a `type: custom` entry** in the YAML to register the URI and app name:
+1. **Add a `type: custom` entry** in the YAML to register the URI and app name. If the app has a reusable view component, add `render_ui` so the umbrella tool can render it too:
 
    ```yaml
    ui_apps:
@@ -312,6 +312,10 @@ For apps that need fully custom logic (like `debug.tsx` or `query-results.tsx`):
        type: custom
        app_name: My Custom App
        description: Custom visualization for X
+       render_ui:
+         component_import: ../components/MyCustomView
+         view_component: MyCustomView
+         view_prop: data
    ```
 
 2. **Create the entry point** manually at `src/ui-apps/apps/my-custom-app.tsx`.

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -16,6 +16,10 @@ ui_apps:
         type: custom
         app_name: Query Results
         description: Interactive visualization for PostHog query results
+        render_ui:
+            component_import: ../components/Component
+            view_component: Component
+            view_prop: data
     render-ui:
         type: custom
         app_name: PostHog Render UI

--- a/services/mcp/scripts/generate-ui-apps.ts
+++ b/services/mcp/scripts/generate-ui-apps.ts
@@ -24,6 +24,7 @@ import { MCP_ROOT_DIR, ROOT_DIR } from './utils'
 import {
     type CategoryConfig,
     CategoryConfigSchema,
+    type ResolvedCustomUiApp,
     type ResolvedDetailUiApp,
     type ResolvedListUiApp,
     type UiAppConfig,
@@ -112,6 +113,15 @@ function resolveListApp(
         list_data_type: raw.list_data_type ?? `${singularPascal}ListData`,
         item_data_type: raw.item_data_type ?? `${singularPascal}Data`,
         view_component: raw.view_component ?? `${pascal}View`,
+    }
+}
+
+function resolveCustomApp(raw: Extract<UiAppConfig, { type: 'custom' }>): ResolvedCustomUiApp {
+    return {
+        type: 'custom',
+        app_name: raw.app_name,
+        description: raw.description,
+        ...(raw.render_ui ? { render_ui: raw.render_ui } : {}),
     }
 }
 
@@ -230,12 +240,17 @@ if (container) {
 type DispatchApp =
     | { appKey: string; type: 'detail'; config: ResolvedDetailUiApp }
     | { appKey: string; type: 'list'; config: ResolvedListUiApp }
+    | {
+          appKey: string
+          type: 'custom'
+          config: ResolvedCustomUiApp & { render_ui: NonNullable<ResolvedCustomUiApp['render_ui']> }
+      }
 
 /**
  * Generates the dispatch module consumed by the `render-ui` umbrella app. It maps
- * each detail/list app key to a render function so `render-ui` can fetch a tool
- * result and mount the matching view. Custom apps are excluded — they have no
- * convention view component to dispatch to.
+ * each app key with a reusable view to a render function so `render-ui` can fetch
+ * a tool result and mount the matching view. Custom apps opt in by declaring
+ * `render_ui` because their entry points have no convention view component.
  */
 function generateDispatchModule(apps: DispatchApp[]): string {
     // Merge named imports per component_import path (multiple apps from the same
@@ -250,10 +265,16 @@ function generateDispatchModule(apps: DispatchApp[]): string {
         if (app.type === 'detail') {
             addImport(app.config.component_import, `type ${app.config.data_type}`)
             addImport(app.config.component_import, app.config.view_component)
-        } else {
+        } else if (app.type === 'list') {
             addImport(app.config.component_import, `type ${app.config.item_data_type}`)
             addImport(app.config.component_import, `type ${app.config.list_data_type}`)
             addImport(app.config.component_import, app.config.view_component)
+        } else {
+            const { component_import, data_type, view_component } = app.config.render_ui
+            if (data_type) {
+                addImport(component_import, `type ${data_type}`)
+            }
+            addImport(component_import, view_component)
         }
     }
 
@@ -277,6 +298,11 @@ function generateDispatchModule(apps: DispatchApp[]): string {
                     return `    '${app.appKey}': ({ data, openLink }) => <${view_component} ${view_prop}={data as ${data_type}} ${link_prop}={openLink} />,`
                 }
                 return `    '${app.appKey}': ({ data }) => <${view_component} ${view_prop}={data as ${data_type}} />,`
+            }
+            if (app.type === 'custom') {
+                const { data_type, view_component, view_prop } = app.config.render_ui
+                const dataExpression = data_type ? `data as ${data_type}` : 'data'
+                return `    '${app.appKey}': ({ data }) => <${view_component} ${view_prop}={${dataExpression}} />,`
             }
             const pascalName = kebabToPascal(app.appKey)
             return `    '${app.appKey}': ({ data, app }) => <${pascalName}Content data={data as ${app.config.list_data_type}} app={app} />,`
@@ -353,8 +379,8 @@ ${uriMapEntries},
 }
 
 /**
- * App keys with a generated detail/list view that the \`render-ui\` umbrella tool
- * can render. Excludes custom apps, which have no convention view component.
+ * App keys with a reusable view that the \`render-ui\` umbrella tool can render.
+ * Custom apps are included only when they explicitly configure \`render_ui\`.
  */
 export const DISPATCHABLE_APP_KEYS: UiAppKey[] = [
 ${dispatchableEntries},
@@ -464,6 +490,14 @@ function main(): void {
                 })
             } else {
                 // type: custom — entry point is handwritten, appDir matches appKey directly
+                const resolved = resolveCustomApp(appConfig)
+                if (resolved.render_ui) {
+                    dispatchApps.push({
+                        appKey,
+                        type: 'custom',
+                        config: { ...resolved, render_ui: resolved.render_ui },
+                    })
+                }
                 registryEntries.push({
                     appKey,
                     appDir: appKey,
@@ -551,6 +585,7 @@ export {
     generateListApp,
     generateRegistry,
     kebabToPascal,
+    resolveCustomApp,
     resolveDetailApp,
     resolveListApp,
     toConstName,

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -339,7 +339,7 @@ const ListUiAppSchema = z
     .strict()
 
 /**
- * Custom UI app — handwritten entry point, only gets a registry entry.
+ * Custom UI app — handwritten entry point with optional render-ui dispatch.
  *
  * Use for apps that need fully custom logic (e.g. debug.tsx, query-results.tsx).
  * The generator does NOT create an entry point file — you maintain it manually at
@@ -353,6 +353,20 @@ const CustomUiAppSchema = z
         app_name: z.string(),
         /** Short description for the MCP resource. Required for custom apps. */
         description: z.string(),
+        /** Reusable view component that lets the render-ui umbrella app mount this custom app. */
+        render_ui: z
+            .object({
+                /** Import path for the reusable view component, relative to src/ui-apps/generated. */
+                component_import: z.string(),
+                /** React component name that renders the tool result. */
+                view_component: z.string(),
+                /** Prop name that receives the tool result. */
+                view_prop: z.string(),
+                /** TypeScript type for the tool result. Omit when the component accepts unknown. */
+                data_type: z.string().optional(),
+            })
+            .strict()
+            .optional(),
     })
     .strict()
 
@@ -386,6 +400,19 @@ export interface ResolvedListUiApp {
     list_data_type: string
     item_data_type: string
     view_component: string
+}
+
+/** Custom config, including an optional reusable view for render-ui dispatch. */
+export interface ResolvedCustomUiApp {
+    type: 'custom'
+    app_name: string
+    description: string
+    render_ui?: {
+        component_import: string
+        view_component: string
+        view_prop: string
+        data_type?: string
+    }
 }
 
 /**

--- a/services/mcp/src/resources/ui-apps.generated.ts
+++ b/services/mcp/src/resources/ui-apps.generated.ts
@@ -100,8 +100,8 @@ export const URI_MAP: Record<UiAppKey, string> = {
 }
 
 /**
- * App keys with a generated detail/list view that the `render-ui` umbrella tool
- * can render. Excludes custom apps, which have no convention view component.
+ * App keys with a reusable view that the `render-ui` umbrella tool can render.
+ * Custom apps are included only when they explicitly configure `render_ui`.
  */
 export const DISPATCHABLE_APP_KEYS: UiAppKey[] = [
     'action',
@@ -121,6 +121,7 @@ export const DISPATCHABLE_APP_KEYS: UiAppKey[] = [
     'insight-actors',
     'invite-email-preview',
     'llm-costs',
+    'query-results',
     'session-recording',
     'session-summary',
     'survey',

--- a/services/mcp/src/templates/render-ui-prompt.md
+++ b/services/mcp/src/templates/render-ui-prompt.md
@@ -1,8 +1,8 @@
-Render an interactive, explorable visualization of a PostHog entity for the user. Strongly prefer rendering whenever your answer centers on a specific entity or list that has a UI app — an experiment (or its results), survey (or its stats), cohort, action, error-tracking issue, session recording, trace, or workflow, plus the list view for most — so the user can see and verify it, not just read a text summary. Render in addition to your written summary, not instead of it, and not only when the user explicitly asks to "see" something.
+Render an interactive, explorable PostHog visualization for the user. Strongly prefer rendering whenever your answer centers on an analytics query, specific entity, or list that has a UI app — a trends or funnel result, experiment (or its results), survey (or its stats), cohort, action, error-tracking issue, session recording, trace, or workflow, plus the list view for most — so the user can see and verify it, not just read a text summary. Render in addition to your written summary, not instead of it, and not only when the user explicitly asks to "see" something.
 
 ALWAYS run `exec` first — `render-ui` is the final presentation step, never a discovery step. Use `exec` (`search` → `info` → `schema` → `call`) to resolve the entity (look up its real ID), confirm the data exists, and gather what you need for your written summary; only then render. Never render with a guessed `tool_input`.
 
-`tool_name` must be a tool from the enum; `tool_input` is the same input you would `call` it with — which you already know from your exec work. The widget fetches its own data, so you may skip a *redundant* `call` of that same UI-app tool purely to populate the widget — but that is the only `call` you may skip, never the discovery/verification workflow. Never invent a `tool_name`. Results from `query-*` tools render through their own app automatically — do not route those through `render-ui`.
+`tool_name` must be a tool from the enum; `tool_input` is the same input you would `call` it with — which you already know from your exec work. The widget fetches its own data, so you may skip a *redundant* `call` of that same UI-app tool purely to populate the widget — but that is the only `call` you may skip, never the discovery/verification workflow. Never invent a `tool_name`.
 
 When to render (always after exec, alongside your written answer):
 
@@ -10,6 +10,7 @@ When to render (always after exec, alongside your written answer):
 - Status, "how is X going" → `render-ui({ "tool_name": "experiment-get", "tool_input": { "id": 2 } })`
 - Lists / inventory, "what do we have" → the `*-list` tool, e.g. `render-ui({ "tool_name": "experiment-list", "tool_input": {} })`
 - Results / stats, "is it significant", "response rate" → the results tool, e.g. `render-ui({ "tool_name": "survey-stats", "tool_input": { "survey_id": "abc123" } })`
+- Analytics queries → run the query with `exec` for your analysis, then render the same tool with the same input, e.g. `render-ui({ "tool_name": "query-trends", "tool_input": { ... } })`
 - After a mutation (create/launch/pause/end/resolve) → the entity's detail tool, to confirm the change landed
 - Evidence mid-investigation (a recording, error issue, trace) → render it inline, e.g. `render-ui({ "tool_name": "query-error-tracking-issue", "tool_input": { "issueId": "0190-..." } })`
 
@@ -42,6 +43,6 @@ WRONG — the answer centers on a single experiment that has a UI app (`experime
 
 <bad-example>
 User: Show me a trends chart of weekly signups
-Assistant: [Calls render-ui({ "tool_name": "query-trends", ... })]
-WRONG — `query-*` results render through their own app automatically and are not in `render-ui`'s enum. Run the query directly; do not route it through `render-ui`.
+Assistant: [Runs query-trends through exec, then replies with a text-only summary]
+WRONG — after running the query for analysis, render `query-trends` with the same validated input so the user can explore the chart.
 </bad-example>

--- a/services/mcp/src/tools/render-ui.ts
+++ b/services/mcp/src/tools/render-ui.ts
@@ -29,7 +29,7 @@ function toDispatchableAppKey(tool: Tool<ZodObjectAny>): UiAppKey | undefined {
 }
 
 /**
- * Names of the tools `render-ui` can render — those whose UI app has a generated view.
+ * Names of the tools `render-ui` can render — those whose UI app exposes a reusable view.
  * Restricted to read-only tools: `render-ui` is annotated read-only, so it must not be a
  * back door for dispatching state-changing tools (e.g. `survey-launch`, `workflows-create`).
  */

--- a/services/mcp/src/ui-apps/generated/render-dispatch.generated.tsx
+++ b/services/mcp/src/ui-apps/generated/render-dispatch.generated.tsx
@@ -56,6 +56,7 @@ import {
 } from 'products/workflows/mcp/apps'
 
 import type { UiAppKey } from '../../resources/ui-apps.generated'
+import { Component } from '../components/Component'
 
 export interface RenderDispatchProps {
     data: unknown
@@ -387,6 +388,7 @@ export const RENDER_DISPATCH: Partial<Record<UiAppKey, (props: RenderDispatchPro
     ),
     'invite-email-preview': ({ data }) => <InviteEmailPreviewView data={data as InviteEmailPreviewData} />,
     'llm-costs': ({ data }) => <LLMCostsView data={data as LLMCostsData} />,
+    'query-results': ({ data }) => <Component data={data} />,
     'session-recording': ({ data }) => <SessionRecordingView recording={data as SessionRecordingData} />,
     'session-summary': ({ data }) => <SessionSummaryView data={data as SessionSummaryData} />,
     survey: ({ data }) => <SurveyView survey={data as SurveyData} />,

--- a/services/mcp/tests/unit/render-ui.test.ts
+++ b/services/mcp/tests/unit/render-ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
+import { toMcpInputSchema } from '@/hono/tool-catalog'
 import { isToolCallPayload, type ToolResultPayload } from '@/lib/build-tool-result'
 import { RENDER_UI_RESOURCE_URI, URI_MAP } from '@/resources/ui-apps.generated'
 import { createRenderUiTool, getRenderableToolNames, RENDER_UI_TOOL_NAME } from '@/tools/render-ui'
@@ -23,14 +24,18 @@ function makeTool(name: string, resourceUri?: string): Tool<ZodObjectAny> {
     }
 }
 
-// A detail app (`survey`) is dispatchable; a custom app (`debug`) is not.
+// Generated and opted-in custom apps are dispatchable; other custom apps are not.
 const surveyTool = makeTool('survey-get', URI_MAP['survey'])
+const queryTrendsTool = makeTool('query-trends', URI_MAP['query-results'])
 const debugTool = makeTool('debug-tool', URI_MAP['debug'])
 const plainTool = makeTool('plain-tool')
 
 describe('render-ui tool', () => {
-    it('only counts tools whose UI app has a generated view as renderable', () => {
-        expect(getRenderableToolNames([surveyTool, debugTool, plainTool])).toEqual(['survey-get'])
+    it('only counts tools whose UI app has a reusable view as renderable', () => {
+        expect(getRenderableToolNames([surveyTool, queryTrendsTool, debugTool, plainTool])).toEqual([
+            'survey-get',
+            'query-trends',
+        ])
     })
 
     it('excludes non-read-only tools so render-ui cannot dispatch mutating tools', () => {
@@ -44,14 +49,47 @@ describe('render-ui tool', () => {
     })
 
     it('restricts tool_name to the renderable tools', () => {
-        const tool = createRenderUiTool([surveyTool, debugTool, plainTool], mockContext)
+        const tool = createRenderUiTool([surveyTool, queryTrendsTool, debugTool, plainTool], mockContext)
         expect(tool).not.toBeNull()
         const schema = tool!.schema
 
         expect(schema.safeParse({ tool_name: 'survey-get', tool_input: { surveyId: 'abc' } }).success).toBe(true)
-        // Non-UI and custom-app tools are not valid enum members.
+        expect(schema.safeParse({ tool_name: 'query-trends', tool_input: { kind: 'TrendsQuery' } }).success).toBe(true)
+        // Non-UI and non-dispatchable custom-app tools are not valid enum members.
         expect(schema.safeParse({ tool_name: 'plain-tool' }).success).toBe(false)
         expect(schema.safeParse({ tool_name: 'debug-tool' }).success).toBe(false)
+    })
+
+    it('advertises the render-ui input schema', () => {
+        const tool = createRenderUiTool([surveyTool, queryTrendsTool, debugTool, plainTool], mockContext)
+        expect(tool).not.toBeNull()
+
+        expect(toMcpInputSchema(tool!.schema)).toMatchInlineSnapshot(`
+          {
+            "properties": {
+              "tool_input": {
+                "additionalProperties": {},
+                "description": "The generated input for that tool. The UI app uses it to fetch and render the visualization.",
+                "propertyNames": {
+                  "type": "string",
+                },
+                "type": "object",
+              },
+              "tool_name": {
+                "description": "A tool that has a UI app — its visualization will be rendered for the user.",
+                "enum": [
+                  "survey-get",
+                  "query-trends",
+                ],
+                "type": "string",
+              },
+            },
+            "required": [
+              "tool_name",
+            ],
+            "type": "object",
+          }
+        `)
     })
 
     it('emits a render directive payload with the envelope and render-ui resourceUri', async () => {

--- a/services/mcp/tests/unit/ui-apps.test.ts
+++ b/services/mcp/tests/unit/ui-apps.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi } from 'vitest'
 import { buildAppStubHtml } from '@/resources/ui-apps'
 import { DISPATCHABLE_APP_KEYS, UI_APPS, URI_MAP } from '@/resources/ui-apps.generated'
 
-import { generateDispatchModule, resolveDetailApp, resolveListApp } from '../../scripts/generate-ui-apps'
+import {
+    generateDispatchModule,
+    resolveCustomApp,
+    resolveDetailApp,
+    resolveListApp,
+} from '../../scripts/generate-ui-apps'
 
 describe('ui-apps', () => {
     describe('buildAppStubHtml', () => {
@@ -209,15 +214,30 @@ describe('ui-apps', () => {
     })
 
     describe('render-ui dispatch', () => {
-        it('DISPATCHABLE_APP_KEYS excludes custom apps', () => {
+        it('DISPATCHABLE_APP_KEYS includes opted-in custom apps', () => {
             expect(DISPATCHABLE_APP_KEYS).toContain('survey')
             expect(DISPATCHABLE_APP_KEYS).toContain('survey-list')
-            for (const customKey of ['debug', 'query-results', 'render-ui', 'visual-review-snapshots']) {
+            expect(DISPATCHABLE_APP_KEYS).toContain('query-results')
+            for (const customKey of ['debug', 'render-ui', 'visual-review-snapshots']) {
                 expect(DISPATCHABLE_APP_KEYS).not.toContain(customKey)
             }
         })
 
-        it('generates a dispatch entry per detail/list app and a Content component for list apps', () => {
+        it('generates dispatch entries for reusable views and a Content component for list apps', () => {
+            const queryResultsConfig = resolveCustomApp({
+                type: 'custom',
+                app_name: 'Query Results',
+                description: 'Interactive query results',
+                render_ui: {
+                    component_import: '../components/Component',
+                    view_component: 'Component',
+                    view_prop: 'data',
+                },
+            })
+            if (!queryResultsConfig.render_ui) {
+                throw new Error('Expected query results to configure render-ui dispatch')
+            }
+
             const code = generateDispatchModule([
                 {
                     appKey: 'survey',
@@ -227,6 +247,11 @@ describe('ui-apps', () => {
                         { type: 'detail', view_prop: 'survey' },
                         'products/surveys/mcp/apps'
                     ),
+                },
+                {
+                    appKey: 'query-results',
+                    type: 'custom',
+                    config: { ...queryResultsConfig, render_ui: queryResultsConfig.render_ui },
                 },
                 {
                     appKey: 'survey-list',
@@ -240,6 +265,8 @@ describe('ui-apps', () => {
             ])
 
             expect(code).toContain("'survey': ({ data }) => <SurveyView survey={data as SurveyData} />")
+            expect(code).toContain("import { Component } from '../components/Component'")
+            expect(code).toContain("'query-results': ({ data }) => <Component data={data} />")
             expect(code).toContain(
                 "'survey-list': ({ data, app }) => <SurveyListContent data={data as SurveyListData} app={app} />"
             )


### PR DESCRIPTION
## Problem

Query tools already attach the custom `query-results` UI app, but `render-ui` only registered generated detail and list views. That kept `query-trends` out of the advertised `render-ui` schema for clients that depend on the umbrella renderer.

## Changes

- let custom UI apps opt into `render-ui` with a reusable view component
- opt `query-results` into generated dispatch and update the render prompt
- add an inline snapshot of the advertised schema plus dispatch regression coverage
- document the custom-app configuration

Before:

```mermaid
flowchart LR
    Q[query-trends] --> U[query-results custom app]
    R[render-ui] --> G[generated detail and list views]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Q,R phYellow;
    class U phBlue;
    class G phGray;
```

After:

```mermaid
flowchart LR
    Q[query-trends] --> U[query-results reusable view]
    R[render-ui] --> D[generated dispatch]
    D --> U
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Q,R phYellow;
    class U phBlue;
    class D phGray;
```

## How did you test this code?

- `./node_modules/.bin/vitest run tests/unit/render-ui.test.ts tests/unit/ui-apps.test.ts` (23 tests passed)
- `../../node_modules/.bin/tsgo --noEmit`
- targeted `oxlint --deny-warnings`
- `pnpm --filter=@posthog/mcp run build`
- `bin/hogli ci:preflight --strict` (zero failures)

The schema snapshot catches `query-trends` disappearing from the advertised wire schema. The dispatch test catches an opted-in custom app being registered without a render function.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated the MCP contribution guide and UI app skill with the custom `render_ui` configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used Codex in the local repository; there is no shareable session link. I invoked the repo-provided `/implementing-mcp-ui-apps`, `/writing-tests`, and `/writing-skills` skills, plus `/submit-pr`.

I chose an explicit opt-in for custom apps so only apps that expose a reusable view enter the umbrella tool schema. The advertised JSON Schema and the generated render dispatch have separate regression coverage.