### PR TITLE
chore(marketing-analytics): time the precompute ensure calls in the conversion-goal path

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -1,7 +1,10 @@
 import math
 import uuid
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import (
+    dataclass,
+    field as dataclass_field,
+)
 from datetime import datetime, timedelta
 from typing import ClassVar, Optional, Union
 
@@ -21,6 +24,7 @@ from posthog.hogql import ast
 from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_channel_type_expr
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.property import action_to_expr, property_to_expr
+from posthog.hogql.timings import HogQLTimings
 
 from posthog.models import PropertyDefinition, Team, User
 
@@ -167,6 +171,10 @@ class ConversionGoalProcessor:
     config: MarketingAnalyticsConfig
     # Requesting user, threaded through to enforce per-user property access on the precompute path.
     user: Optional[User] = None
+    # Per-goal timings. HogQLTimings is not thread safe and goals are built in parallel, so each
+    # processor owns a clone (see HogQLTimings.clone_for_subquery); the runner merges them back once
+    # the pool has joined. Defaults to a standalone instance for callers outside the read path.
+    timings: HogQLTimings = dataclass_field(default_factory=HogQLTimings)
 
     _UTM_LEVEL_FIELD_MAP: ClassVar[dict[MarketingAnalyticsDrillDownLevel, str]] = {
         MarketingAnalyticsDrillDownLevel.MEDIUM: "medium",
@@ -352,8 +360,10 @@ class ConversionGoalProcessor:
                     team_id=self.team.pk,
                 )
 
-        array_collection = self.build_array_collection_query(additional_conditions)
-        return self.build_attribution_pipeline(array_collection)
+        # Live events scan. Reaching here means the precompute did not serve this goal.
+        with self.timings.measure("ma_goal_events_fallback"):
+            array_collection = self.build_array_collection_query(additional_conditions)
+            return self.build_attribution_pipeline(array_collection)
 
     def is_goal_precomputable(self) -> bool:
         """Goal-level precompute eligibility, independent of the requesting user, date range, or flag.
@@ -487,32 +497,37 @@ class ConversionGoalProcessor:
         window = timedelta(days=self.config.attribution_window_days)
 
         # Touchpoints extend back by the attribution window; conversions only span the query range.
-        touchpoints_result = ensure_precomputed(
-            team=self.team,
-            insert_query=build_touchpoints_precompute_query(),
-            time_range_start=date_from - window,
-            time_range_end=date_to,
-            ttl_seconds=PRECOMPUTE_TTL_SECONDS,
-            table=LazyComputationTable.MARKETING_TOUCHPOINTS_PREAGGREGATED,
-        )
+        # Both ensure_precomputed calls can materialize inline (PG + Redis + ClickHouse) when a slice
+        # is stale, so they are timed separately from the AST work that follows.
+        with self.timings.measure("ma_ensure_touchpoints"):
+            touchpoints_result = ensure_precomputed(
+                team=self.team,
+                insert_query=build_touchpoints_precompute_query(),
+                time_range_start=date_from - window,
+                time_range_end=date_to,
+                ttl_seconds=PRECOMPUTE_TTL_SECONDS,
+                table=LazyComputationTable.MARKETING_TOUCHPOINTS_PREAGGREGATED,
+            )
         if not touchpoints_result.ready:
             return None
 
-        conversions_result = ensure_precomputed(
-            team=self.team,
-            insert_query=self.build_conversions_precompute_query(),
-            time_range_start=date_from,
-            time_range_end=date_to,
-            ttl_seconds=PRECOMPUTE_TTL_SECONDS,
-            table=LazyComputationTable.MARKETING_CONVERSIONS_PREAGGREGATED,
-        )
+        with self.timings.measure("ma_ensure_conversions"):
+            conversions_result = ensure_precomputed(
+                team=self.team,
+                insert_query=self.build_conversions_precompute_query(),
+                time_range_start=date_from,
+                time_range_end=date_to,
+                ttl_seconds=PRECOMPUTE_TTL_SECONDS,
+                table=LazyComputationTable.MARKETING_CONVERSIONS_PREAGGREGATED,
+            )
         if not conversions_result.ready:
             return None
 
-        array_collection = self._build_array_collection_from_precomputes(
-            touchpoints_result.job_ids, conversions_result.job_ids, date_from, date_to, window
-        )
-        return self.build_attribution_pipeline(array_collection)
+        with self.timings.measure("ma_attribution_pipeline_precomputed"):
+            array_collection = self._build_array_collection_from_precomputes(
+                touchpoints_result.job_ids, conversions_result.job_ids, date_from, date_to, window
+            )
+            return self.build_attribution_pipeline(array_collection)
 
     def _build_array_collection_from_precomputes(
         self,

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -721,7 +721,14 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             )
             if should_create:
                 processor = ConversionGoalProcessor(
-                    goal=conversion_goal, index=index, team=self.team, config=self.config, user=self.user
+                    goal=conversion_goal,
+                    index=index,
+                    team=self.team,
+                    config=self.config,
+                    user=self.user,
+                    # Goals are built in parallel and HogQLTimings is not thread safe, so hand each
+                    # processor its own clone. Merged back in _build_complete_query_ast once joined.
+                    timings=self.timings.clone_for_subquery(index),
                 )
                 processors.append(processor)
         return processors
@@ -817,16 +824,18 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         conversion_aggregator = ConversionGoalsAggregator(processors, self.config) if processors else None
 
         # Build the main SELECT query
-        main_query = self._build_main_select_query(conversion_aggregator)
+        with self.timings.measure("ma_main_select"):
+            main_query = self._build_main_select_query(conversion_aggregator)
 
         # Build CTEs as a dictionary
         ctes: dict[str, ast.CTE] = {}
 
         # Add campaign_costs CTE
-        campaign_cost_select = self._build_campaign_cost_select(union_subquery)
-        campaign_cost_cte = ast.CTE(
-            name=self.config.campaign_costs_cte_name, expr=campaign_cost_select, cte_type="subquery"
-        )
+        with self.timings.measure("ma_campaign_cost_cte"):
+            campaign_cost_select = self._build_campaign_cost_select(union_subquery)
+            campaign_cost_cte = ast.CTE(
+                name=self.config.campaign_costs_cte_name, expr=campaign_cost_select, cte_type="subquery"
+            )
         ctes[self.config.campaign_costs_cte_name] = campaign_cost_cte
 
         # Add unified conversion goal CTE if any. Skip building it entirely at levels
@@ -836,14 +845,19 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         # win at hierarchy levels.
         level_config = DRILL_DOWN_LEVEL_CONFIG.get(self.config.drill_down_level, {})
         if conversion_aggregator and not level_config.get("excludes_conversion_goals"):
-            # Check if this is an aggregated query (no GROUP BY)
-            group_by_exprs = self._get_group_by_expressions()
-            if not group_by_exprs:
-                # For aggregated queries, create aggregated conversion goals CTE
-                unified_cte = self._generate_aggregated_conversion_goals_cte(conversion_aggregator, date_range)
-            else:
-                # For table queries, use the normal conversion goals CTE
-                unified_cte = conversion_aggregator.generate_unified_cte(date_range, self._get_where_conditions)
+            with self.timings.measure("ma_unified_conversion_cte"):
+                # Check if this is an aggregated query (no GROUP BY)
+                group_by_exprs = self._get_group_by_expressions()
+                if not group_by_exprs:
+                    # For aggregated queries, create aggregated conversion goals CTE
+                    unified_cte = self._generate_aggregated_conversion_goals_cte(conversion_aggregator, date_range)
+                else:
+                    # For table queries, use the normal conversion goals CTE
+                    unified_cte = conversion_aggregator.generate_unified_cte(date_range, self._get_where_conditions)
+
+            # The per-goal pool has joined, so folding each processor's cloned timings back in is safe here.
+            for processor in processors:
+                self.timings.timings.update(processor.timings.timings)
 
             if unified_cte:
                 ctes[UNIFIED_CONVERSION_GOALS_CTE_ALIAS] = unified_cte


### PR DESCRIPTION
## Problem

Follow-up to #70256, which split `marketing_analytics_base_query` and found that `ma_build_complete_query` is ~90% of it (14.6s of 16.3s on one load, 18.3s of 20.0s on another).
That span is still a black box.

It is also not what its name suggests.
Building the conversion-goal CTE calls `ensure_precomputed` twice per goal (touchpoints and conversions), and each one can materialize inline: Postgres, Redis, and a synchronous ClickHouse INSERT on the request thread.
So the time attributed to "query build" is very likely I/O, not AST construction. Meanwhile `clickhouse_execute` is only ~1.2s, so the read itself is cheap.

This PR adds the spans to prove or kill that theory.

## Changes

In `conversion_goal_processor.py`, time the precompute path directly:

- `ma_ensure_touchpoints` - the touchpoints `ensure_precomputed`
- `ma_ensure_conversions` - the conversions `ensure_precomputed`
- `ma_attribution_pipeline_precomputed` - the AST work after both land
- `ma_goal_events_fallback` - the live events scan. If this shows up, the precompute did not serve the goal

In `marketing_analytics_base_query_runner.py`, break `ma_build_complete_query` into its parts:

- `ma_main_select`, `ma_campaign_cost_cte`, `ma_unified_conversion_cte`

> [!NOTE]
> `HogQLTimings` is explicitly not thread safe, and goals are built in parallel in `ConversionGoalsAggregator.generate_unified_cte`.
> Each processor now owns a clone via `clone_for_subquery` (the same pattern `trends_query_runner` uses), and the runner folds them back into the parent once the pool has joined.
> Writing to a shared timings object from the pool would have produced garbage.

The new `timings` dataclass field defaults to a standalone `HogQLTimings`, so the Dagster warmer and tests keep constructing processors unchanged.

No behavior change, timings only.

## How did you test this code?

ruff, ty, and 532 existing tests (`products/marketing_analytics/backend/hogql_queries/` plus `products/marketing_analytics/dags/`) all pass, including the 72 snapshots.
The dags run matters here: the warmer constructs `ConversionGoalProcessor` directly, so it exercises the new default field.

I (Claude) did not drive the dashboard against this branch.
No tests added: this wraps existing calls in timing spans and adds no behavior to pin.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Javier is chasing a slow marketing analytics dashboard. #70256 narrowed the cost to `ma_build_complete_query`; this PR opens that box.

While tracing the call chain I (Claude Code) found `generate_unified_cte` -> `generate_cte_query` -> `_build_attribution_from_precomputes` -> two `ensure_precomputed` calls, which do real I/O and can run the materialization INSERT synchronously on the request thread. The working theory is that the today-slice keeps expiring: its TTL is 15 minutes (`PRECOMPUTE_TTL_SECONDS["0d"]`) while the Dagster warmer only runs hourly, so for most of every hour a dashboard load re-materializes it inline. These spans are the measurement that confirms or refutes that before anyone changes the read path.

The thread-safety detail was the one real design decision: I checked `HogQLTimings`, saw the "not thread safe" note, and followed the existing `clone_for_subquery` + merge-after-join pattern rather than inventing a lock.
