### PR TITLE
fix(llma): guard humanize_breakdown_label against None series label

### DIFF
--- a/ee/hogai/context/insight/format/test/test_trends.py
+++ b/ee/hogai/context/insight/format/test/test_trends.py
@@ -119,6 +119,25 @@ class TestTrendsResultsFormatter(BaseTest):
         series.pop("action")
         self.assertEqual(formatter._extract_series_label(series), "$pageview breakdown for the value `0`")
 
+    def test_trends_labelless_series(self):
+        # A series with no label, custom_name, or breakdown_value used to crash the formatter with
+        # `AttributeError: 'NoneType' object has no attribute 'replace'`. It should render as an
+        # empty label instead.
+        results = [
+            {
+                "data": [242, 46, 0],
+                "labels": ["23-Jan-2025", "24-Jan-2025", "25-Jan-2025"],
+                "days": ["2025-01-23", "2025-01-24", "2025-01-25"],
+                "count": 288,
+                "label": None,
+            }
+        ]
+
+        self.assertEqual(
+            TrendsResultsFormatter(AssistantTrendsQuery(series=[]), results).format(),
+            "Date|\n2025-01-23|242\n2025-01-24|46\n2025-01-25|0",
+        )
+
     def test_trends_aggregated_value(self):
         results = [
             {

--- a/ee/hogai/context/insight/format/test/test_trends.py
+++ b/ee/hogai/context/insight/format/test/test_trends.py
@@ -188,6 +188,25 @@ class TestTrendsResultsFormatter(BaseTest):
             "so their values are incomplete. Timezone: UTC.",
         )
 
+    def test_trends_labelless_series(self):
+        # A series with no label, custom_name, or breakdown_value used to crash the formatter with
+        # `AttributeError: 'NoneType' object has no attribute 'replace'`. It should render as an
+        # empty label instead.
+        results = [
+            {
+                "data": [242, 46, 0],
+                "labels": ["23-Jan-2025", "24-Jan-2025", "25-Jan-2025"],
+                "days": ["2025-01-23", "2025-01-24", "2025-01-25"],
+                "count": 288,
+                "label": None,
+            }
+        ]
+
+        self.assertEqual(
+            TrendsResultsFormatter(AssistantTrendsQuery(series=[]), results).format(),
+            "Date|\n2025-01-23|242\n2025-01-24|46\n2025-01-25|0",
+        )
+
     def test_trends_aggregated_value(self):
         results = [
             {

--- a/posthog/hogql_queries/insights/utils/breakdowns.py
+++ b/posthog/hogql_queries/insights/utils/breakdowns.py
@@ -17,10 +17,15 @@ ALL_USERS_COHORT_ID = 0
 NOT_IN_COHORT_ID = 2**52
 
 
-def humanize_breakdown_label(label: str) -> str:
+def humanize_breakdown_label(label: str | None) -> str:
     """Swap the internal breakdown sentinels for their display strings. The sentinels are globally
     unique tokens, so a substring replace covers every label shape — standalone, action-prefixed
-    ("signed_up - <sentinel>"), and "::"-joined multi-breakdown values — without fragile splitting."""
+    ("signed_up - <sentinel>"), and "::"-joined multi-breakdown values — without fragile splitting.
+
+    A series can reach here with no label at all (no name, custom_name, or breakdown_value), so coerce
+    a missing label to an empty string rather than crashing on `None.replace(...)`."""
+    if label is None:
+        return ""
     return label.replace(BREAKDOWN_OTHER_STRING_LABEL, BREAKDOWN_OTHER_DISPLAY).replace(
         BREAKDOWN_NULL_STRING_LABEL, BREAKDOWN_NULL_DISPLAY
     )

--- a/posthog/hogql_queries/insights/utils/test/test_breakdowns.py
+++ b/posthog/hogql_queries/insights/utils/test/test_breakdowns.py
@@ -63,7 +63,9 @@ def test_breakdown_presence_helpers(
         ("Chrome", "Chrome"),
         # a normal label containing " - " must pass through untouched (no fragile splitting)
         ("Signed up - paid", "Signed up - paid"),
+        # a labelless series (no name, custom_name, or breakdown_value) must not crash
+        (None, ""),
     ],
 )
-def test_humanize_breakdown_label(label: str, expected: str) -> None:
+def test_humanize_breakdown_label(label: str | None, expected: str) -> None:
     assert humanize_breakdown_label(label) == expected


### PR DESCRIPTION
## Problem

`humanize_breakdown_label` swaps internal breakdown sentinels for display strings by calling `label.replace(...)`, with no guard against `None`. When a trends series arrives with no label, no `custom_name`, and no `breakdown_value`, the series name stays `None` and gets passed straight in, raising `AttributeError: 'NoneType' object has no attribute 'replace'`.

This is a real crash on the AI insight/alert breakdown formatting path, surfaced by an error-tracking signal. It's a regression from the change that wrapped the previously-safe `return name` in a `humanize_breakdown_label(...)` call.

**Why:** the crash recurs whenever a labelless series flows through the formatter, so it needs a guard rather than a one-off.

## Changes

- Guard `humanize_breakdown_label` so a `None` label coerces to an empty string instead of crashing.
- This covers both callers that pass a label through unchanged: the AI insight formatter (`ee/hogai/context/insight/format/trends.py`) and the alerts trends evaluator (`products/alerts/backend/evaluation/trends.py`). The funnels caller already wraps its value in `str()`.

## How did you test this code?

- Added a `None` → `""` case to the parametrized `test_humanize_breakdown_label`. Ran `test_breakdowns.py` locally: all 14 cases pass.
- Added `test_trends_labelless_series` reproducing the reported crash path (a series with `label=None` and no `custom_name`/`breakdown_value`).
- That formatter test needs a Postgres-backed Django test DB that wasn't reachable in my sandbox, so I couldn't run it there. I did exercise the formatter directly on the labelless input outside the harness and confirmed it returns `Date|\n2025-01-23|242\n...` (empty label column, no crash). CI runs the full suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Prompted by an error-tracking signal report in the PostHog inbox: https://us.posthog.com/project/2/inbox/019f4331-196d-7ab1-a80b-c7ee16bc25dc

I (Claude) traced the crash to the missing `None` guard, confirmed which callers can pass a `None` label (the AI formatter and the alerts evaluator) versus the funnels caller that already coerces with `str()`, and chose to guard the shared helper so both paths are fixed in one place. Invoked the `/writing-tests` skill to keep the added coverage to a tight regression pair: one utility-level case at the fix site, one formatter-level reproduction of the reported path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
