### PR TITLE
feat: add Support to product onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -90,6 +90,8 @@ describe('onboardingLogic — flow composition', () => {
             [ProductKey.LOGS, ['install:logs', 'invite_teammates:logs']],
             // Data Warehouse has no install step — the link_data step is the entry point.
             [ProductKey.DATA_WAREHOUSE, ['link_data:data_warehouse', 'invite_teammates:data_warehouse']],
+            // Support has no product-specific step; it's enabled on completion, so only the shared step shows.
+            [ProductKey.CONVERSATIONS, ['invite_teammates:conversations']],
         ]
 
         it.each(cases)('builds the expected flow when only %s is selected', (product, expected) => {
@@ -594,6 +596,7 @@ describe('onboardingLogic — flow composition', () => {
             [ProductKey.WORKFLOWS, /workflow/i],
             [ProductKey.LOGS, /log/i],
             [ProductKey.DATA_WAREHOUSE, /sources|data-management/i],
+            [ProductKey.CONVERSATIONS, /support/i],
         ]
 
         it.each(cases)('%s lands on a product-specific page', (product, pattern) => {

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -521,6 +521,10 @@ export const onboardingLogic = kea<onboardingLogicType>([
             if (primary === ProductKey.ERROR_TRACKING) {
                 teamLogic.actions.updateCurrentTeam({ autocapture_exceptions_opt_in: true })
             }
+            // Support has no onboarding screen; enable the product on completion so it's live on arrival.
+            if (primary === ProductKey.CONVERSATIONS) {
+                teamLogic.actions.updateCurrentTeam({ conversations_enabled: true })
+            }
             // Only mark a product as fully onboarded when the user actually visited at
             // least one of its steps. Without this guard, a hand-crafted URL with an
             // arbitrary `?with=...` list would silently flip every secondary's flag on

--- a/frontend/src/scenes/onboarding/legacy/productRecommendations.ts
+++ b/frontend/src/scenes/onboarding/legacy/productRecommendations.ts
@@ -48,10 +48,15 @@ export const USE_CASE_OPTIONS: ReadonlyArray<UseCaseDefinition> = [
     {
         key: 'collect_feedback',
         title: 'Collect user feedback',
-        description: 'Collect feedback with in-app surveys and watch session recordings',
+        description: 'Collect feedback with surveys and Support tickets, and watch session recordings',
         iconKey: 'IconMessage',
         iconColor: 'rgb(243 84 84)',
-        products: [ProductKey.SURVEYS, ProductKey.PRODUCT_ANALYTICS, ProductKey.SESSION_REPLAY],
+        products: [
+            ProductKey.SURVEYS,
+            ProductKey.CONVERSATIONS,
+            ProductKey.PRODUCT_ANALYTICS,
+            ProductKey.SESSION_REPLAY,
+        ],
     },
     {
         key: 'monitor_ai',

--- a/frontend/src/scenes/onboarding/legacy/stepProviderRegistry.ts
+++ b/frontend/src/scenes/onboarding/legacy/stepProviderRegistry.ts
@@ -1,6 +1,7 @@
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { aiObservabilityOnboarding } from 'products/ai_observability/frontend/onboarding/steps'
+import { conversationsOnboarding } from 'products/conversations/frontend/onboarding/steps'
 import { dataWarehouseOnboarding } from 'products/data_warehouse/frontend/onboarding/steps'
 import { errorTrackingOnboarding } from 'products/error_tracking/frontend/onboarding/steps'
 import { experimentsOnboarding } from 'products/experiments/frontend/onboarding/steps'
@@ -38,4 +39,5 @@ export const onboardingProviderRegistry: Partial<Record<ProductKey, ProductOnboa
     [ProductKey.WORKFLOWS]: workflowsOnboarding,
     [ProductKey.LOGS]: logsOnboarding,
     [ProductKey.MCP_ANALYTICS]: mcpAnalyticsOnboarding,
+    [ProductKey.CONVERSATIONS]: conversationsOnboarding,
 }

--- a/frontend/src/scenes/onboarding/shared/utils.tsx
+++ b/frontend/src/scenes/onboarding/shared/utils.tsx
@@ -336,4 +336,21 @@ export const availableOnboardingProducts: AvailableOnboardingProducts = {
         scene: Scene.MCPAnalytics,
         setupEffort: 'low',
     },
+    [ProductKey.CONVERSATIONS]: {
+        name: 'Support',
+        description: 'Receive customer questions over web, email, Slack, and Microsoft Teams',
+        userCentricDescription: 'Triage, assign, and automate customer support in PostHog',
+        capabilities: ['In-app chat widget', 'Email, Slack & Teams channels', 'Direct conversations API'],
+        valueProps: [
+            { title: 'In-app widget', problem: 'Let customers reach you without leaving your product' },
+            { title: 'Multi-channel inbox', problem: 'Handle email, Slack, and Teams tickets in one place' },
+            { title: 'Direct API', problem: 'Build your own support UI on top of the conversations API' },
+        ],
+        hedgehog: HedgehogReporter,
+        icon: 'IconMessage',
+        iconColor: 'var(--color-product-support-light)',
+        url: urls.supportTickets(),
+        scene: Scene.SupportTickets,
+        setupEffort: 'low',
+    },
 }

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -159,6 +159,7 @@ export enum Scene {
     Survey = 'Survey',
     SurveyWizard = 'SurveyWizard',
     SurveyFormBuilder = 'SurveyFormBuilder',
+    SupportTickets = 'SupportTickets',
     Surveys = 'Surveys',
     SystemStatus = 'SystemStatus',
     ToolbarLaunch = 'ToolbarLaunch',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6920,7 +6920,8 @@ export type AvailableOnboardingProducts = Record<
     | ProductKey.AI_OBSERVABILITY
     | ProductKey.WORKFLOWS
     | ProductKey.LOGS
-    | ProductKey.MCP_ANALYTICS,
+    | ProductKey.MCP_ANALYTICS
+    | ProductKey.CONVERSATIONS,
     OnboardingProduct
 >
 

--- a/products/conversations/frontend/onboarding/steps.tsx
+++ b/products/conversations/frontend/onboarding/steps.tsx
@@ -1,0 +1,11 @@
+import { type ProductOnboardingProvider } from 'scenes/onboarding/legacy/types'
+import { urls } from 'scenes/urls'
+
+// Support has no product-specific onboarding screen worth showing: enabling the product and
+// configuring channels both live in Support settings. `conversations_enabled` is flipped on
+// onboarding completion in onboardingLogic (see ProductKey.CONVERSATIONS there), so the flow is
+// just the shared trailing steps, then a redirect into the product.
+export const conversationsOnboarding: ProductOnboardingProvider = {
+    steps: () => [],
+    completeRedirectUrl: () => urls.supportTickets(),
+}


### PR DESCRIPTION
## Problem

Support (conversations) was not selectable in signup product onboarding, so new teams picking Support had no onboarding path and never got `conversations_enabled` flipped for them.

## Changes

- Add Support to the onboarding product catalog and provider registry
- Register an empty provider: no product-specific step, just shared trailing steps (e.g. invite teammates), then redirect to `/support/tickets`
- On onboarding completion for Support as primary, set `conversations_enabled: true` (same pattern as error tracking's completion side-effect)
- Suggest Support in the "Collect user feedback" use-case recommendations
- Cover the empty flow + landing URL in `onboardingLogic` tests

