### PR TITLE
fix(replay-vision): break the quota/temporal circular import

### DIFF
--- a/products/replay_vision/backend/prompt_evaluation.py
+++ b/products/replay_vision/backend/prompt_evaluation.py
@@ -12,7 +12,6 @@ from products.replay_vision.backend.billing import observation_credits_for_model
 from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerType
 from products.replay_vision.backend.models.replay_scanner_prompt_suggestion import ReplayScannerPromptSuggestion
-from products.replay_vision.backend.temporal.constants import EVALUATE_PROMPT_SUGGESTION_EXECUTION_TIMEOUT
 
 # Each evaluated session is a full scanner run, so keep the bill bounded.
 EVALUATION_SESSION_CAP = 100
@@ -84,6 +83,12 @@ _EVALUATION_RUNNING_GRACE = dt.timedelta(minutes=5)
 
 def evaluation_in_flight(evaluation: Any) -> bool:
     """True while a running evaluation's workflow can still be alive. Past the timeout nothing is left to finalize it."""
+    # Deferred: importing anything under temporal.* runs the package __init__, whose activity
+    # imports circle back into quota.py -> this module, breaking import at module level.
+    from products.replay_vision.backend.temporal.constants import (  # noqa: PLC0415
+        EVALUATE_PROMPT_SUGGESTION_EXECUTION_TIMEOUT,
+    )
+
     if not isinstance(evaluation, dict) or evaluation.get("status") != "running":
         return False
     try:


### PR DESCRIPTION
## Problem

`hogli build:openapi` (and any process that imports `products.replay_vision.backend.quota` before the temporal package) fails on master:

```
ImportError: cannot import name 'compute_quota_snapshot' from partially initialized module 'products.replay_vision.backend.quota' (most likely due to a circular import)
```

The cycle: `quota.py` imports `prompt_evaluation.py`, whose module-level import of `temporal.constants` runs the `temporal` package `__init__` (which aggregates every activity), and `activities/create_observation.py` imports back into the still-initializing `quota.py`.

The CI job that regenerates OpenAPI types only runs when serializers change, so this sat unnoticed on master until the next replay-vision serializer PR hit it.

## Changes

Defer the single `EVALUATE_PROMPT_SUGGESTION_EXECUTION_TIMEOUT` import in `prompt_evaluation.py` into the one function that uses it, with a `# noqa: PLC0415` justified by the cycle. The constant stays defined in `temporal/constants.py` (single source of truth).

## How did you test this code?

- `hogli build:openapi-schema` fails on master with the ImportError above and succeeds on this branch.
- `python -c 'django.setup(); import products.replay_vision.backend.quota; import products.replay_vision.backend.temporal'` succeeds in both import orders.
- No new tests: this is an import-order fix with no behavior change, and the schema build itself is the regression check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal import-order fix only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) while rebasing the replay-vision alert-engine branch, where a local `hogli build:openapi` run surfaced the failure. Verified the failure reproduces on unmodified master before fixing. Considered moving the constant out of `temporal/constants.py` instead, but that would give the constants module Django model imports via `prompt_evaluation`; the deferred import is the smaller, safer change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
