### PR TITLE
feat(data-warehouse): cross-run claim ordering + CDC backpressure valve

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -722,6 +722,7 @@ class CDCExtractActivity:
             self.reader.connect()
 
             self._load_pk_columns()
+            self._flush_pending_deferred_runs()
             self._read_wal_loop()
 
             self.log.info("wal_changes_read", event_count=self.event_count, tables=list(self.all_table_names))
@@ -733,7 +734,6 @@ class CDCExtractActivity:
                 self._handle_no_changes(truncated_tables)
                 return
 
-            self._flush_pending_deferred_runs()
             final_flushed = self._final_flush()
             self._finalize_trackers(final_flushed)
             self._advance_slot_after_run()
@@ -1226,7 +1226,13 @@ class CDCExtractActivity:
     # Flush + finalization
     # ------------------------------------------------------------------
     def _flush_pending_deferred_runs(self) -> None:
-        """Flush deferred runs for schemas that transitioned to streaming."""
+        """Flush deferred runs for schemas that transitioned to streaming.
+
+        Must run before the read loop can enqueue any of this tick's
+        micro-batches: deferred runs carry strictly older WAL windows, and the
+        loader applies a schema's runs in enqueue (created_at) order — flushing
+        them after this run's batches would apply the older data last.
+        """
         assert self.source is not None
         for schema in self.cdc_schemas:
             if schema.cdc_mode == "streaming" and schema.sync_type_config.get("cdc_deferred_runs"):

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -104,6 +104,15 @@ CDC_ORPHAN_JOB_MIN_AGE = dt.timedelta(minutes=30)
 # tell an abandoned run from one whose batches simply aged out.
 CDC_ORPHAN_JOB_MAX_AGE = dt.timedelta(days=14)
 
+# Backpressure valve: skip the extraction tick only once the oldest non-terminal batch is older
+# than this. Cross-run apply ordering is enforced by the loader's claim gate, so coexisting runs
+# are safe — this valve only bounds how much queue backlog (and therefore WAL, which accumulates
+# while ticks are skipped) a slow loader can build up. 30 min is well past the loader's
+# recovery-sweep grace (300s) and retry backoffs, so a healthy-but-busy loader never trips it,
+# while WAL growth stays bounded far below the 2048 MB slot-drop safety net for any source whose
+# steady-state WAL rate the slot could survive anyway.
+CDC_BACKPRESSURE_MAX_PENDING_AGE = dt.timedelta(minutes=30)
+
 # Backpressure guard: past this age a skipped tick is a stuck load, not a slow one — well beyond
 # the loader's recovery-sweep grace (300s) and retry backoffs, so it only trips when a run needs
 # operator attention. Skips past it log at error level; the tick is still skipped (see
@@ -788,18 +797,21 @@ class CDCExtractActivity:
             self.log.exception("failed_to_delete_own_schedule")
 
     def _previous_load_still_pending(self) -> bool:
-        """Backpressure guard: skip this tick while a previous run's batches are still loading.
+        """Backpressure valve: skip this tick only when the load backlog is older than
+        CDC_BACKPRESSURE_MAX_PENDING_AGE.
 
-        CDC ticks don't hold the per-schema pipeline lock the way external-data-job runs do,
-        so without this check every tick enqueues a fresh run regardless of whether the
-        previous one landed. Coexisting runs of one schema can then be claimed out of order
-        by the loader (its head-of-line gate is run-scoped), and an incremental merge applied
-        out of order silently overwrites newer rows with older ones. Skipping keeps at most
-        one active run per schema; nothing has been peeked and the slot is untouched, so WAL
-        accumulates and the next tick catches up.
+        Correctness no longer lives here: the loader's claim-side cross-run ordering gate
+        (see jobs_db._state_claim_candidates_sql) guarantees a schema's runs apply in
+        enqueue order, so coexisting runs of one schema can no longer be merged out of
+        order. That decouples slot advance from load completion — the S3/queue backlog is
+        the elastic buffer — and leaves this guard as a queue-depth valve: while the oldest
+        non-terminal batch is younger than the valve, keep extracting; past it, skip the
+        tick so a persistently slow loader converts into bounded queue backlog instead of
+        unbounded WAL buildup (nothing is peeked on a skipped tick, so the slot is
+        untouched and WAL accumulates until the backlog drains).
 
         Per-source, not per-schema: the slot is read once for all tables, so one table's
-        pending load must hold back the whole source's tick.
+        aged backlog must hold back the whole source's tick.
 
         Deliberately no auto-remediation past CDC_BACKPRESSURE_STUCK_AGE: the slot already
         advanced past the pending runs' events, so failing their batches would leave a
@@ -824,7 +836,7 @@ class CDCExtractActivity:
         finally:
             conn.close()
 
-        if age is None:
+        if age is None or age < CDC_BACKPRESSURE_MAX_PENDING_AGE.total_seconds():
             return False
 
         stuck = age >= CDC_BACKPRESSURE_STUCK_AGE.total_seconds()

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -14,6 +14,7 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.cdc.activities import (
+    CDC_BACKPRESSURE_MAX_PENDING_AGE,
     CDC_BACKPRESSURE_STUCK_AGE,
     CDC_MAX_CHANGES_PER_READ,
     CDC_ORPHAN_JOB_MIN_AGE,
@@ -327,13 +328,17 @@ class TestBackpressureGuard:
         "age_seconds,expect_skip,expect_stuck",
         [
             (None, False, None),
-            (30.0, True, False),
+            # Below the valve the tick proceeds even with a pending backlog — the
+            # loader's claim-side ordering gate owns cross-run correctness now.
+            (30.0, False, None),
+            (CDC_BACKPRESSURE_MAX_PENDING_AGE.total_seconds() - 1, False, None),
+            (CDC_BACKPRESSURE_MAX_PENDING_AGE.total_seconds() + 1, True, False),
             (CDC_BACKPRESSURE_STUCK_AGE.total_seconds() + 1, True, True),
         ],
     )
     @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.metrics.get_tick_skipped_metric")
     @patch("psycopg.Connection.connect")
-    def test_skips_only_while_previous_batches_pend(
+    def test_skips_only_when_backlog_age_exceeds_valve(
         self, mock_connect, mock_metric, age_seconds, expect_skip, expect_stuck
     ):
         act = self._activity()
@@ -359,7 +364,11 @@ class TestBackpressureGuard:
         with (
             patch.object(act, "_setup", return_value=True),
             patch.object(act, "_mark_schemas_running") as mark_running,
-            patch.object(BatchQueue, "get_oldest_non_terminal_batch_age_seconds", return_value=42.0),
+            patch.object(
+                BatchQueue,
+                "get_oldest_non_terminal_batch_age_seconds",
+                return_value=CDC_BACKPRESSURE_MAX_PENDING_AGE.total_seconds() + 1,
+            ),
         ):
             act.run()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -25,6 +25,7 @@ from products.warehouse_sources.backend.temporal.data_imports.cdc.activities imp
     cdc_extract_activity,
     cleanup_orphan_slots_activity,
 )
+from products.warehouse_sources.backend.temporal.data_imports.cdc.batcher import ChangeEventBatcher
 from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import CDCErrorCategory, cdc_error_info
 from products.warehouse_sources.backend.temporal.data_imports.cdc.types import ChangeEvent
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
@@ -585,6 +586,80 @@ class TestCDCExtractActivity:
         mock_producer.flush.assert_called_once()
         mock_reader.confirm_position.assert_called_once_with("0/200")
         mock_reader.close.assert_called_once()
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.PostgresProducer")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.S3BatchWriter")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataJob")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_deferred_runs_enqueue_before_current_run_batches(
+        self,
+        mock_close_conns,
+        MockJob,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        MockS3Writer,
+        MockProducer,
+        mock_activity,
+    ):
+        # The loader applies a schema's runs in enqueue (created_at) order, so the
+        # deferred (older-WAL) snapshot-era runs must hit the queue before any of
+        # this tick's micro-batches — a mid-loop flush enqueued first would make
+        # the older data apply last and overwrite newer rows.
+        source = _make_source()
+        schema = _make_schema("users", cdc_mode="streaming", source=source)
+        schema.sync_type_config["cdc_deferred_runs"] = [
+            {
+                "job_id": "job-deferred",
+                "run_uuid": "deferred-run-1",
+                "data_folder": "s3://bucket/deferred/",
+                "schema_path": "s3://bucket/deferred-schema.json",
+                "total_batches": 1,
+                "total_rows": 10,
+                "batch_results": [
+                    {
+                        "s3_path": "s3://bucket/deferred/part-0000.parquet",
+                        "row_count": 10,
+                        "byte_size": 1024,
+                        "batch_index": 0,
+                        "timestamp_ns": 1,
+                    }
+                ],
+            }
+        ]
+        events = [
+            _make_event(op="I", position="0/100", columns={"id": 1, "name": "Alice"}),
+            _make_event(op="U", position="0/200", columns={"id": 1, "name": "Bob"}),
+        ]
+        _setup_mocks(
+            mock_activity,
+            MockProducer,
+            MockS3Writer,
+            mock_get_adapter,
+            mock_get_schemas,
+            MockSourceModel,
+            MockJob,
+            mock_close_conns,
+            source,
+            [schema],
+            events,
+        )
+
+        # Force a mid-loop micro-batch flush so this run's first batch is enqueued
+        # while the read loop is still draining.
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ChangeEventBatcher",
+            lambda: ChangeEventBatcher(max_events=1),
+        ):
+            cdc_extract_activity(CDCExtractInput(team_id=1, source_id=source.id))
+
+        producer_run_uuids = [c.kwargs["run_uuid"] for c in MockProducer.call_args_list]
+        assert len(producer_run_uuids) >= 2, "expected both the deferred run and a mid-loop batch to enqueue"
+        assert producer_run_uuids[0] == "deferred-run-1"
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
     @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.PostgresProducer")
@@ -2036,13 +2111,22 @@ class TestSlotInvalidationRecovery:
     """When the replication slot is invalidated/dropped on the source DB, the activity
     must recreate it and reset all CDC schemas to snapshot mode instead of failing forever."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_producer(self):
+        # Deferred runs flush before the read loop (enqueue order = apply order), so
+        # these run()-level tests reach the producer before the slot error fires.
+        with patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.PostgresProducer"):
+            yield
+
     def _setup(self, mock_get_schemas, mock_get_adapter, MockSourceModel, mock_activity):
         source = _make_source()
         MockSourceModel.objects.get.return_value = source
 
         schema = _make_schema("users", cdc_mode="streaming", source=source)
         schema.sync_type_config["cdc_last_log_position"] = "0/OLD"
-        schema.sync_type_config["cdc_deferred_runs"] = [{"run_uuid": "stale"}]
+        schema.sync_type_config["cdc_deferred_runs"] = [
+            {"job_id": "job-stale", "run_uuid": "stale", "batch_results": []}
+        ]
         mock_get_schemas.return_value = [schema]
 
         invalidation_error = psycopg.errors.ObjectNotInPrerequisiteState(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -178,9 +178,23 @@ def _state_claim_candidates_sql() -> str:
     """Claimable-batch candidates read from the denormalized state columns.
 
     The claimable scan and every NOT EXISTS gate are answered by the partial
-    indexes (sb_claimable_idx, sb_run_gate_idx, sb_schema_busy_idx), so the
-    work tracks the claimable set instead of everything retained. 'pending'
-    means no status row yet; 'waiting' is deliberately not claimable.
+    indexes (sb_claimable_idx, sb_run_gate_idx, sb_schema_busy_idx,
+    sb_schema_order_idx), so the work tracks the claimable set instead of
+    everything retained. 'pending' means no status row yet; 'waiting' is
+    deliberately not claimable.
+
+    Cross-run schema ordering (the last gate): a batch is claimable only when
+    no batch of a *different* run of the same (team_id, schema_id) with a
+    strictly earlier ``created_at`` is still non-terminal. ``created_at`` is a
+    valid cross-run apply order because it is assigned server-side by the
+    single queue DB clock at enqueue, source ticks are serialized by the
+    Temporal schedule's SKIP overlap policy, and retry attempts re-read the
+    same WAL window (older-attempt batches are a prefix). Blockers whose run
+    contains a 'failed' batch are ignored — their remaining batches can never
+    be claimed (failed-run gate above), so counting them would deadlock the
+    schema forever. No id tiebreak: batch ids are ``gen_random_uuid()`` (not
+    time-ordered), so equal-timestamp batches in different runs simply don't
+    block each other — the schema-busy gate still serializes execution.
     """
     return f"""
         SELECT
@@ -233,6 +247,25 @@ def _state_claim_candidates_sql() -> str:
                     AND b_busy.schema_id = b.schema_id
                     AND b_busy.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                     AND b_busy.latest_state = 'executing'
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                FROM {BATCH_TABLE} b_older
+                WHERE b_older.team_id = b.team_id
+                    AND b_older.schema_id = b.schema_id
+                    AND b_older.run_uuid != b.run_uuid
+                    AND b_older.created_at < b.created_at
+                    AND b_older.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                    AND b_older.latest_state IN ('pending', 'waiting', 'waiting_retry', 'executing')
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM {BATCH_TABLE} b_older_failed
+                        WHERE b_older_failed.run_uuid = b_older.run_uuid
+                            AND b_older_failed.team_id = b_older.team_id
+                            AND b_older_failed.schema_id = b_older.schema_id
+                            AND b_older_failed.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                            AND b_older_failed.latest_state = 'failed'
+                    )
             )
     """
 
@@ -513,6 +546,17 @@ class BatchQueue:
         group is being processed by its lease holder). This keeps a schema's
         other queued runs from consuming the ``LIMIT`` window ahead of the lease
         claim and starving other schemas' claimable work.
+
+        Cross-run schema ordering: only the schema's oldest non-failed run has
+        claimable batches — a batch is excluded while any *different* run of
+        the same ``(team_id, schema_id)`` still has a non-terminal batch with
+        a strictly earlier ``created_at``. Runs therefore apply in enqueue
+        order even when several coexist in the queue (a ``waiting_retry``
+        batch whose backoff elapsed can no longer be raced by a newer run's
+        batches), which is what makes it safe for the CDC producer to keep
+        extracting while a backlog drains. Applies to every v3 sync type; the
+        blocked batches are exactly the out-of-order ones, and the oldest
+        run's batches stay claimable, so the queue self-drains.
 
         Per-team fairness: candidates are interleaved round-robin across teams so one
         team's deep backlog cannot monopolize the ``LIMIT`` window; within a team,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -96,6 +96,25 @@ def pending_batch_predicate(status_alias: str) -> str:
     return f"({status_alias}.batch_id IS NULL OR {status_alias}.job_state IN ('waiting', 'waiting_retry', 'executing'))"
 
 
+def _no_failed_batch_in_run_sql(outer_alias: str, failed_alias: str) -> str:
+    """NOT EXISTS guard: ``outer_alias``'s run contains no 'failed' batch.
+
+    Scoped by run_uuid + team_id + schema_id (guards against cross-group
+    run_uuid collisions and keeps the probe on the run-gate partial index).
+    Shared by the claim gate's cross-run blocker and the CDC producer's
+    backpressure probe, which must agree on which runs count as dead.
+    """
+    return f"""NOT EXISTS (
+        SELECT 1
+        FROM {BATCH_TABLE} {failed_alias}
+        WHERE {failed_alias}.run_uuid = {outer_alias}.run_uuid
+            AND {failed_alias}.team_id = {outer_alias}.team_id
+            AND {failed_alias}.schema_id = {outer_alias}.schema_id
+            AND {failed_alias}.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+            AND {failed_alias}.latest_state = 'failed'
+    )"""
+
+
 def build_status_dual_write_sql(*, with_batch_created_at: bool) -> str:
     """Single-statement status INSERT + denormalized-state UPDATE (atomic under autocommit).
 
@@ -184,17 +203,19 @@ def _state_claim_candidates_sql() -> str:
     deliberately not claimable.
 
     Cross-run schema ordering (the last gate): a batch is claimable only when
-    no batch of a *different* run of the same (team_id, schema_id) with a
-    strictly earlier ``created_at`` is still non-terminal. ``created_at`` is a
-    valid cross-run apply order because it is assigned server-side by the
-    single queue DB clock at enqueue, source ticks are serialized by the
+    no batch of a *different* run of the same (team_id, schema_id) with an
+    earlier ``(created_at, run_uuid)`` is still non-terminal. ``created_at``
+    is a valid cross-run apply order because it is assigned server-side by
+    the single queue DB clock at enqueue, source ticks are serialized by the
     Temporal schedule's SKIP overlap policy, and retry attempts re-read the
     same WAL window (older-attempt batches are a prefix). Blockers whose run
     contains a 'failed' batch are ignored — their remaining batches can never
     be claimed (failed-run gate above), so counting them would deadlock the
-    schema forever. No id tiebreak: batch ids are ``gen_random_uuid()`` (not
-    time-ordered), so equal-timestamp batches in different runs simply don't
-    block each other — the schema-busy gate still serializes execution.
+    schema forever. Equal timestamps (theoretically possible across producer
+    connections — ``created_at`` is per-statement ``now()`` at microsecond
+    resolution) break by ``run_uuid`` so the ordering stays total; batch ids
+    are ``gen_random_uuid()`` and useless as a tiebreak. Mirrors the duckgres
+    sink's ``(started_at, run_uuid)`` cross-run ordering.
     """
     return f"""
         SELECT
@@ -254,18 +275,13 @@ def _state_claim_candidates_sql() -> str:
                 WHERE b_older.team_id = b.team_id
                     AND b_older.schema_id = b.schema_id
                     AND b_older.run_uuid != b.run_uuid
-                    AND b_older.created_at < b.created_at
+                    AND (
+                        b_older.created_at < b.created_at
+                        OR (b_older.created_at = b.created_at AND b_older.run_uuid < b.run_uuid)
+                    )
                     AND b_older.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                     AND b_older.latest_state IN ('pending', 'waiting', 'waiting_retry', 'executing')
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM {BATCH_TABLE} b_older_failed
-                        WHERE b_older_failed.run_uuid = b_older.run_uuid
-                            AND b_older_failed.team_id = b_older.team_id
-                            AND b_older_failed.schema_id = b_older.schema_id
-                            AND b_older_failed.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
-                            AND b_older_failed.latest_state = 'failed'
-                    )
+                    AND {_no_failed_batch_in_run_sql("b_older", "b_older_failed")}
             )
     """
 
@@ -939,15 +955,7 @@ class BatchQueue:
                   AND b.team_id = %(team_id)s
                   AND b.schema_id = ANY(%(schema_ids)s)
                   AND b.latest_state IN ('pending', 'waiting', 'waiting_retry', 'executing')
-                  AND NOT EXISTS (
-                      SELECT 1
-                      FROM {BATCH_TABLE} b_failed
-                      WHERE b_failed.run_uuid = b.run_uuid
-                          AND b_failed.team_id = b.team_id
-                          AND b_failed.schema_id = b.schema_id
-                          AND b_failed.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
-                          AND b_failed.latest_state = 'failed'
-                  )
+                  AND {_no_failed_batch_in_run_sql("b", "b_failed")}
                 """,
                 {"team_id": team_id, "schema_ids": schema_ids},
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -389,6 +389,23 @@ class TestBatchQueueCrossRunOrdering:
         await _release(conn, batches=batches)
 
     @pytest.mark.asyncio
+    async def test_equal_created_at_ties_break_by_run_uuid(self, conn):
+        # created_at can theoretically tie across producer connections; the run_uuid
+        # tiebreak keeps the ordering total, so tied runs still apply one at a time
+        # instead of both claiming into the same window in arbitrary order.
+        first = await _insert_batch(conn, run_uuid="run-a", batch_index=0)
+        tied = await _insert_batch(conn, run_uuid="run-b", batch_index=0)
+        await conn.execute(
+            f"UPDATE {BATCH_TABLE} SET created_at = (SELECT created_at FROM {BATCH_TABLE} WHERE id = %s) WHERE id = %s",
+            (first, tied),
+        )
+
+        batches = await _claim(conn)
+
+        assert [str(b.id) for b in batches] == [first]
+        await _release(conn, batches=batches)
+
+    @pytest.mark.asyncio
     async def test_backoff_pending_retry_still_blocks_newer_runs(self, conn):
         # The gate must hold even while the older run's retry sits inside its backoff
         # window: claiming the newer run there is exactly the out-of-order apply the

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -84,6 +84,10 @@ def _ensure_tables(conn: psycopg.Connection[Any]) -> None:
             WHERE latest_state = 'executing'
     """)
     conn.execute(f"""
+        CREATE INDEX IF NOT EXISTS sb_schema_order_idx ON {BATCH_TABLE} (team_id, schema_id, created_at)
+            WHERE latest_state IN ('pending', 'waiting', 'waiting_retry', 'executing')
+    """)
+    conn.execute(f"""
         CREATE TABLE IF NOT EXISTS {STATUS_TABLE} (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             batch_id UUID NOT NULL REFERENCES {BATCH_TABLE}(id) ON DELETE CASCADE,
@@ -144,6 +148,15 @@ _BATCH_DEFAULTS: dict[str, Any] = {
 async def _insert_batch(conn: psycopg.AsyncConnection[Any], **overrides: Any) -> str:
     params = {**_BATCH_DEFAULTS, **overrides}
     return await BatchQueue.insert(conn, **params)
+
+
+async def _backdate_batch(conn: psycopg.AsyncConnection[Any], batch_id: str, seconds: int) -> None:
+    # BatchQueue.insert stamps created_at server-side; backdate after the fact to
+    # build deterministic cross-run enqueue orderings.
+    await conn.execute(
+        f"UPDATE {BATCH_TABLE} SET created_at = created_at - make_interval(secs => %s) WHERE id = %s",
+        (seconds, batch_id),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -313,6 +326,101 @@ class TestBatchQueueGetUnprocessed:
 
         assert [b.run_uuid for b in batches] == ["run-2"]
         await _release(conn, batches=batches)
+
+
+@pytest.mark.django_db(transaction=True)
+class TestBatchQueueCrossRunOrdering:
+    @pytest.mark.parametrize("sync_type", ["cdc", "full_refresh"])
+    @pytest.mark.asyncio
+    async def test_older_run_blocks_newer_run_same_schema(self, conn, sync_type):
+        # Regression guard for the ordering gate itself: without it both runs'
+        # batches are claimable together and a newer run's merge can apply before
+        # the older run's (silent overwrite of newer rows). Applies to every v3
+        # sync type, not just CDC.
+        old = await _insert_batch(conn, run_uuid="run-old", batch_index=0, sync_type=sync_type)
+        await _backdate_batch(conn, old, 60)
+        await _insert_batch(conn, run_uuid="run-new", batch_index=0, sync_type=sync_type)
+
+        batches = await _claim(conn)
+
+        assert [str(b.id) for b in batches] == [old]
+        await _release(conn, batches=batches)
+
+    @pytest.mark.asyncio
+    async def test_older_run_does_not_block_other_schema(self, conn):
+        # The gate is schema-scoped; one schema's backlog must not stall another's.
+        old = await _insert_batch(conn, schema_id="A", run_uuid="run-old", batch_index=0)
+        await _backdate_batch(conn, old, 60)
+        other = await _insert_batch(conn, schema_id="B", run_uuid="run-other", batch_index=0)
+
+        batches = await _claim(conn)
+
+        assert {str(b.id) for b in batches} == {old, other}
+        await _release(conn, batches=batches)
+
+    @pytest.mark.asyncio
+    async def test_failed_older_run_does_not_block_newer_run(self, conn):
+        # A failed old run's leftover pending batches can never be claimed; if they
+        # still counted as blockers the schema would deadlock forever.
+        old_pending = await _insert_batch(conn, run_uuid="run-old", batch_index=0)
+        old_failed = await _insert_batch(conn, run_uuid="run-old", batch_index=1)
+        await BatchQueue.update_status(conn, batch_id=old_failed, job_state="failed", attempt=1)
+        for bid in (old_pending, old_failed):
+            await _backdate_batch(conn, bid, 60)
+        new = await _insert_batch(conn, run_uuid="run-new", batch_index=0)
+
+        batches = await _claim(conn)
+
+        assert [str(b.id) for b in batches] == [new]
+        await _release(conn, batches=batches)
+
+    @pytest.mark.asyncio
+    async def test_elapsed_retry_in_oldest_run_claims_before_newer_runs(self, conn):
+        # Starvation regression: a waiting_retry batch whose backoff elapsed used to
+        # race newer runs' batches for the claim window; the oldest run claims alone.
+        retry = await _insert_batch(conn, run_uuid="run-old", batch_index=0)
+        await BatchQueue.update_status(conn, batch_id=retry, job_state="waiting_retry", attempt=1)
+        await _backdate_batch(conn, retry, 60)
+        await _insert_batch(conn, run_uuid="run-new", batch_index=0)
+
+        batches = await _claim(conn, retry_backoff_base_seconds=0)
+
+        assert [str(b.id) for b in batches] == [retry]
+        await _release(conn, batches=batches)
+
+    @pytest.mark.asyncio
+    async def test_backoff_pending_retry_still_blocks_newer_runs(self, conn):
+        # The gate must hold even while the older run's retry sits inside its backoff
+        # window: claiming the newer run there is exactly the out-of-order apply the
+        # gate exists to prevent.
+        retry = await _insert_batch(conn, run_uuid="run-old", batch_index=0)
+        await BatchQueue.update_status(conn, batch_id=retry, job_state="waiting_retry", attempt=1)
+        await _backdate_batch(conn, retry, 60)
+        await _insert_batch(conn, run_uuid="run-new", batch_index=0)
+
+        assert await _claim(conn, retry_backoff_base_seconds=3600) == []
+
+    @pytest.mark.asyncio
+    async def test_interleaved_runs_drain_in_created_at_order(self, conn):
+        # cdc_table_mode='both' enqueues two runs per schema with interleaved
+        # created_at. The gate must serialize them globally by enqueue time and
+        # keep draining — a unique oldest always exists, so no deadlock.
+        a0 = await _insert_batch(conn, run_uuid="run-a", batch_index=0)
+        b0 = await _insert_batch(conn, run_uuid="run-b", batch_index=0)
+        a1 = await _insert_batch(conn, run_uuid="run-a", batch_index=1)
+        b1 = await _insert_batch(conn, run_uuid="run-b", batch_index=1)
+        for bid, age in ((a0, 40), (b0, 30), (a1, 20), (b1, 10)):
+            await _backdate_batch(conn, bid, age)
+
+        drained = []
+        for _ in range(4):
+            batches = await _claim(conn)
+            assert len(batches) == 1, "only the globally oldest non-terminal batch may be claimable"
+            drained.append(str(batches[0].id))
+            await BatchQueue.update_status(conn, batch_id=str(batches[0].id), job_state="succeeded", attempt=1)
+
+        assert drained == [a0, b0, a1, b1]
+        assert await _claim(conn) == []
 
 
 @pytest.mark.django_db(transaction=True)

--- a/products/warehouse_sources_queue/backend/migrations/0007_sourcebatch_schema_order_idx.py
+++ b/products/warehouse_sources_queue/backend/migrations/0007_sourcebatch_schema_order_idx.py
@@ -1,0 +1,65 @@
+from django.db import migrations, models
+
+# Serves the claim query's cross-run schema-ordering gate: "is there an older
+# non-terminal batch of a different run for this (team_id, schema_id)?" The
+# predicate mirrors the gate's non-terminal state list exactly so the planner
+# can use the partial index.
+#
+# sourcebatch is a partitioned parent, so CREATE INDEX CONCURRENTLY is not
+# possible — plain creation follows this app's 0006 precedent (and the queue's
+# low volume); lock_timeout keeps a blocked attempt from queueing behind long
+# claim queries (bin/migrate retries). Guarded with to_regclass so the
+# migration no-ops on DBs without the sourcebatch table. One statement per
+# execute() and no PL/pgSQL, so it applies against Postgres-wire targets that
+# parse a single statement at a time.
+
+_INDEX_NAME = "sb_schema_order_idx"
+_CREATE_INDEX_SQL = f"""
+    CREATE INDEX IF NOT EXISTS {_INDEX_NAME}
+        ON sourcebatch (team_id, schema_id, created_at)
+        WHERE latest_state IN ('pending', 'waiting', 'waiting_retry', 'executing')
+"""
+
+
+def _sourcebatch_exists(schema_editor) -> bool:
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute("SELECT to_regclass('public.sourcebatch')")
+        row = cursor.fetchone()
+    return row is not None and row[0] is not None
+
+
+def _create_index(apps, schema_editor):
+    if not _sourcebatch_exists(schema_editor):
+        return
+    schema_editor.execute("SET LOCAL lock_timeout = '5s'")
+    schema_editor.execute(_CREATE_INDEX_SQL)
+
+
+def _drop_index(apps, schema_editor):
+    if not _sourcebatch_exists(schema_editor):
+        return
+    schema_editor.execute(f"DROP INDEX IF EXISTS {_INDEX_NAME}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources_queue", "0006_sourcebatch_latest_state"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="sourcebatch",
+                    index=models.Index(
+                        condition=models.Q(("latest_state__in", ["pending", "waiting", "waiting_retry", "executing"])),
+                        fields=["team_id", "schema_id", "created_at"],
+                        name="sb_schema_order_idx",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunPython(_create_index, _drop_index),
+            ],
+        ),
+    ]

--- a/products/warehouse_sources_queue/backend/migrations/0007_sourcebatch_schema_order_idx.py
+++ b/products/warehouse_sources_queue/backend/migrations/0007_sourcebatch_schema_order_idx.py
@@ -38,6 +38,7 @@ def _create_index(apps, schema_editor):
 def _drop_index(apps, schema_editor):
     if not _sourcebatch_exists(schema_editor):
         return
+    schema_editor.execute("SET LOCAL lock_timeout = '5s'")
     schema_editor.execute(f"DROP INDEX IF EXISTS {_INDEX_NAME}")
 
 

--- a/products/warehouse_sources_queue/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources_queue/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0006_sourcebatch_latest_state
+0007_sourcebatch_schema_order_idx

--- a/products/warehouse_sources_queue/backend/models.py
+++ b/products/warehouse_sources_queue/backend/models.py
@@ -82,6 +82,11 @@ class SourceBatch(UUIDModel):
                 name="sb_schema_busy_idx",
                 condition=models.Q(latest_state="executing"),
             ),
+            models.Index(
+                fields=["team_id", "schema_id", "created_at"],
+                name="sb_schema_order_idx",
+                condition=models.Q(latest_state__in=["pending", "waiting", "waiting_retry", "executing"]),
+            ),
         ]
 
 


### PR DESCRIPTION
## Problem

The v3 warehouse-sources queue guarantees apply ordering only *within* a run (the `batch_index` head-of-line gate). Cross-run ordering for a schema was unguaranteed, so #70226 made the CDC producer skip its extraction tick while ANY previous batch of the source was still non-terminal. That prevents out-of-order merges (data corruption), but it couples replication-slot advance to load completion: one slow-loading schema holds back extraction for the whole source, sustained load backlog converts into WAL buildup, and eventually the WAL safety net drops the replication slot — forcing a full re-sync of every CDC schema on the source. This recently played out on a large CDC source.

North star: slot advance must depend only on extract+persist (S3), never on load. The queue backlog is the elastic buffer, and ordering is enforced where it belongs — at claim time.

## Changes

```mermaid
flowchart LR
    subgraph before [Before]
        T1{{CDC tick}} --> P1{any batch of source non-terminal?}
        P1 -- yes --> S1[skip tick, WAL accumulates]
        P1 -- no --> E1[extract + enqueue]
    end
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class T1 phYellow;
    class P1 phBlue;
    class S1,E1 phGray;
```

```mermaid
flowchart LR
    subgraph after [After]
        T2{{CDC tick}} --> P2{oldest non-terminal batch older than 30 min?}
        P2 -- yes --> S2[skip tick - queue-depth valve]
        P2 -- no --> E2[extract + enqueue]
        L2{{Loader claim}} --> G2{older non-terminal batch of a different run, same schema?}
        G2 -- yes --> B2[not claimable yet]
        G2 -- no --> C2[claim in enqueue order]
    end
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class T2,L2 phYellow;
    class P2,G2 phBlue;
    class S2,E2,B2,C2 phGray;
```

Both parts ship in one PR because the producer relaxation is only safe with the claim gate in place.

### 1. Claim-side cross-run ordering gate (`jobs_db.py`)

A batch is claimable only when no batch of a *different* `run_uuid` for the same `(team_id, schema_id)` with an earlier `(created_at, run_uuid)` is still non-terminal (`pending`, `waiting`, `waiting_retry`, `executing`). Blockers whose run contains a `failed` batch are ignored — their remaining batches can never be claimed (the existing failed-run gate skips them), so counting them would deadlock the schema forever. The failed-run probe is scoped by `run_uuid + team_id + schema_id` and shared (as an extracted SQL fragment) with the CDC producer's backpressure probe, which must agree on which runs count as dead; it is served by the existing `sb_run_gate_idx`.

Why `created_at` is a valid cross-run order: it's assigned server-side (`now()`) by the single queue DB clock at enqueue, source ticks are serialized by the Temporal schedule's `ScheduleOverlapPolicy.SKIP`, and retry attempts re-read the same WAL window (older-attempt batches are a prefix of the newer attempt). Equal timestamps are theoretically possible across producer connections (per-statement `now()` at microsecond resolution), so ties break by `run_uuid` — mirroring the duckgres sink's `(started_at, run_uuid)` cross-run ordering — keeping the order total instead of letting tied runs claim into the same window in arbitrary order. Batch ids are `gen_random_uuid()` and useless as a tiebreak.

> [!NOTE]
> **Blast radius: the gate applies to ALL v3 sync types**, not just CDC — `get_unprocessed_and_lock` serves full_refresh/incremental/append too. This is fail-safe in direction: it only ever claims strictly fewer things, the blocked batches are exactly the out-of-order ones, and the oldest run's batches stay claimable so the queue self-drains. Covered by a non-CDC parameterized test.

This also fixes a starvation race: a `waiting_retry` batch whose backoff elapsed can no longer be raced by newer runs' batches — only the schema's oldest non-failed run is claimable.

`cdc_table_mode='both'` note: one tick creates two runs per schema (snapshot run + `_cdc` companion run) with interleaved `created_at`. The gate serializes the two runs' batches globally by enqueue time — no deadlock (there is always a unique oldest batch; covered by the interleaved-drain test), just serialization, which the schema-busy gate imposes anyway.

### 2. Partial index + migration 0007

`sb_schema_order_idx` on `(team_id, schema_id, created_at) WHERE latest_state IN ('pending', 'waiting', 'waiting_retry', 'executing')` — the predicate mirrors the gate exactly so the planner can use it.

`sourcebatch` is a partitioned parent (`PARTITION BY RANGE (created_at)`), so `CREATE INDEX CONCURRENTLY` is not possible — the migration follows this app's 0006 precedent: `SeparateDatabaseAndState` with a state-side `AddIndex` and a database-side `RunPython` doing plain `CREATE INDEX IF NOT EXISTS` under a `to_regclass` guard with `lock_timeout = '5s'` (both directions). Per #70472, the migration issues one statement per `execute()` and uses no PL/pgSQL (the `to_regclass` guard runs from Python).

Verified locally: applied, reversed, and re-applied against the dev DB's real partitioned `sourcebatch`; `makemigrations --check` reports no drift.

**EXPLAIN evidence** (local Postgres, scratch DB mirroring the prod DDL — partitioned parent, all partial indexes, synthetic data of 445 schemas x 8 runs x 25 batches ≈ 89k rows; timings include the run_uuid tiebreak):

| scenario | claimable batches | execution time | plan shape |
|---|---|---|---|
| steady state: 23 of 445 schemas have a 2-run pending backlog | 1,145 | 4.4 ms (139 buffers) | gate answered from `sb_schema_order_idx` partition children (bitmap index scan on the low-density partitions) |
| worst case: every schema has 2 fully-pending runs | 22,241 | 52 ms | planner switches to hash anti-joins over the claimable set — no nested-loop blowup |

<details>
<summary>Steady-state plan excerpt (the new gate's arm)</summary>

```
->  Hash Anti Join  (actual time=0.534..3.117 rows=570 loops=1)
      Hash Cond: ((b.team_id = b_older.team_id) AND ((b.schema_id)::text = (b_older.schema_id)::text))
      Join Filter: (((b_older.run_uuid)::text <> (b.run_uuid)::text) AND (b_older.created_at < b.created_at))
      ...
      ->  Hash Anti Join  (actual time=0.067..0.372 rows=1150 loops=1)  -- failed-run exclusion
            Hash Cond: (((b_older.run_uuid)::text = (b_older_failed.run_uuid)::text) AND ...)
            ->  Append
                  ->  Bitmap Heap Scan on sourcebatch_20260713 b_older_6
                        Recheck Cond: ((created_at > (now() - '14 days'::interval)) AND ((latest_state)::text = ANY ('{pending,waiting,waiting_retry,executing}'::text[])))
```

</details>

### 3. Producer guard relaxed into a queue-depth valve (`cdc/activities.py`)

`_previous_load_still_pending` now skips the tick only when the oldest non-terminal batch age exceeds `CDC_BACKPRESSURE_MAX_PENDING_AGE` (new constant, 30 min). Correctness lives in the claim gate; the guard's remaining job is bounding how much backlog (and therefore WAL, which accumulates while ticks are skipped) a persistently slow loader can build.

Sizing: 30 min is well past the loader's recovery-sweep grace (300s) and retry backoffs, so a healthy-but-busy loader never trips it. WAL only accumulates while ticks are actually skipped, and the 2048 MB slot-drop threshold corresponds to hours of WAL at rates any healthy source sustains — the valve engages long before the safety net is at risk for sources the slot could survive at all. The 2h `CDC_BACKPRESSURE_STUCK_AGE` error escalation, the fail-open contract on probe errors, and the skip metric are unchanged.

### 4. Deferred snapshot-era runs flush before the read loop (`cdc/activities.py`)

Surfaced by review: on a schema's first streaming tick, deferred (snapshot-era) runs — which hold strictly older WAL windows — were flushed to the queue *after* the read loop, so a mid-loop micro-batch flush could enqueue this tick's newer data first. Since the loader now applies a schema's runs strictly in enqueue order, that would apply the older deferred data last and overwrite newer rows. The flush now runs before the read loop. This mis-ordering predates this PR (the claim window was already `created_at`-ordered), but the ordering gate makes enqueue order load-bearing, so it must be right.

> [!NOTE]
> Two small behavior deltas from the reorder: deferred runs now also flush on a no-changes tick (previously they waited for a tick with events), and a tick that dies on slot invalidation now enqueues the pending deferred runs before recovery resets schemas to snapshot (previously recovery discarded them). Both are safe — deferred runs hold valid committed data, and the post-recovery re-snapshot supersedes whatever they applied.

> [!WARNING]
> Honest scope note: this PR decouples slot advance from load completion only while the backlog age stays under the valve. A load-bound source additionally needs the grouped-partition-merge and batch-coalescing work (separate PRs) for sustained decoupling; a per-source backlog-age alert (also a separate PR) is the signal that should fire before the valve engages. The 2048 MB safety net remains the backstop.

## How did you test this code?

- `pytest .../postgres_queue/test_jobs_db.py` — 70 passed locally. New `TestBatchQueueCrossRunOrdering` class:
  - `test_older_run_blocks_newer_run_same_schema` (parameterized cdc + full_refresh): catches removal/weakening of the gate — without it both runs claim together and a newer run's merge can apply before the older run's (the silent-corruption case), for any v3 sync type.
  - `test_older_run_does_not_block_other_schema`: catches the gate over-blocking across schemas (would stall unrelated schemas fleet-wide).
  - `test_failed_older_run_does_not_block_newer_run`: catches the schema-deadlocks-forever failure if failed runs counted as blockers.
  - `test_elapsed_retry_in_oldest_run_claims_before_newer_runs`: the starvation regression — a backoff-elapsed retry must claim alone, not race newer runs.
  - `test_backoff_pending_retry_still_blocks_newer_runs`: newer runs must stay blocked while the older run's retry waits out backoff — exactly the out-of-order window #70226 closed producer-side.
  - `test_equal_created_at_ties_break_by_run_uuid`: without the tiebreak, tied runs both claim into the same window in arbitrary order.
  - `test_interleaved_runs_drain_in_created_at_order`: both-mode interleaved runs drain one batch at a time in enqueue order with no deadlock.
- `pytest .../cdc/tests/test_extract_activity.py` — 69 passed. Guard tests re-parameterized around the new valve (below-valve ages no longer skip; above-valve skips; 2h still escalates to stuck). New `test_deferred_runs_enqueue_before_current_run_batches` forces a mid-loop micro-batch flush and asserts the deferred run hits the queue first — catches a revert of the change-4 reorder. Slot-invalidation recovery tests updated for the reorder (producer stubbed; the stale deferred-run fixture made complete). 1 pre-existing order-dependent failure (`test_run_skips_tick_without_touching_schemas_or_reader`) reproduces identically on clean master in my local env only (passes in isolation and in CI) — flagged separately, unrelated to this change.
- `pytest .../postgres_queue/test_consumer.py test_producer.py` — 74 passed (shared module, no behavior assertions on the claim SQL).
- Migration: applied + reversed + re-applied against the local dev DB's real partitioned `sourcebatch`; index verified via `pg_indexes`; `makemigrations --check` clean.
- EXPLAIN benchmarks above run against a scratch DB mirroring prod DDL.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal pipeline behavior; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a reviewed implementation plan (PR C of a CDC reliability series). Skills invoked: `/django-migrations`, `/writing-tests`, plus the `dc-review-pr` skill from the PostHog skill store for a post-authoring review pass.
- Decisions: the migration deliberately avoids `AddIndexConcurrently`/`SafeAddIndexConcurrently` (impossible on a partitioned parent) and follows the app's 0006 `SeparateDatabaseAndState` precedent, updated to the one-statement-per-execute rule from #70472 (the `to_regclass` guard moved from PL/pgSQL into Python). The new gate's non-terminal state list and the index predicate are kept byte-identical so the partial index always matches.
- The review pass produced four findings, all addressed in the second commit: the deferred-run flush reorder (change 4 — the review's must-fix, a pre-existing counterexample to the "claim gate carries correctness" contract), the equal-timestamp `run_uuid` tiebreak (the plan originally called for no tiebreak, reasoning the schema-busy gate serializes ties — but serialization is not ordering, so the tiebreak replaces that), the shared failed-run SQL fragment, and `lock_timeout` on the reverse migration.
