### PR TITLE
chore(insights): lemon-skin port and date range composer exploration

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateRangeComposer.stories.tsx
+++ b/frontend/src/lib/components/DateFilter/DateRangeComposer.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { type ReactNode, useState } from 'react'
+
+import {
+    Button as QuillButton,
+    composerExclusionsSummary,
+    composerSelectionLabel,
+    CUSTOM_RANGE,
+    DateRangeComposer,
+    DateTimePicker,
+    Popover as QuillPopover,
+    PopoverContent as QuillPopoverContent,
+    PopoverTrigger as QuillPopoverTrigger,
+    quickRanges,
+    type DateRangeComposerExclusions,
+    type DateRangeComposerSelection,
+    type DateTimeValue,
+} from '@posthog/quill'
+
+import { dayjs } from 'lib/dayjs'
+
+// The date filter redesign concepts, one quill implementation each, shown twice: raw quill
+// and wrapped in the lemon skin (lemon-skin.scss rebinds quill tokens under
+// `data-lemon-skin` — same code, lemon look; see InsightDateFilterNext for the production
+// pattern). No hand-rolled Lemon twins.
+
+const meta: Meta = {
+    title: 'Components/Date Range Composer',
+    parameters: {
+        mockDate: '2026-07-13',
+    },
+    tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj
+
+function ConceptColumn({ title, children }: { title: string; children: ReactNode }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-2">
+            <span className="text-xs font-semibold text-secondary">{title}</span>
+            {children}
+        </div>
+    )
+}
+
+function ComposerConcept({ lemonSkin }: { lemonSkin?: boolean }): JSX.Element {
+    const [selection, setSelection] = useState<DateRangeComposerSelection>({
+        kind: 'rolling',
+        count: 7,
+        unit: 'days',
+    })
+    const [exclusions, setExclusions] = useState<DateRangeComposerExclusions>({ days: [], incomplete: false })
+    const [open, setOpen] = useState(false)
+    const summary = composerExclusionsSummary(exclusions)
+    const skinProps = lemonSkin ? { 'data-lemon-skin': true, 'data-quill': true } : {}
+    return (
+        <QuillPopover open={open} onOpenChange={setOpen}>
+            <QuillPopoverTrigger render={<QuillButton variant="outline" {...skinProps} />}>
+                {composerSelectionLabel(selection)}
+                {summary && <span className="size-1.5 rounded-full bg-primary" aria-label={summary} />}
+            </QuillPopoverTrigger>
+            <QuillPopoverContent
+                align="start"
+                collisionAvoidance={{ side: 'flip', align: 'none', fallbackAxisSide: 'none' }}
+                className="w-auto overflow-hidden border-none p-0 shadow-none ring-0"
+                {...(lemonSkin ? { 'data-lemon-skin': true } : {})}
+            >
+                <DateRangeComposer
+                    selection={selection}
+                    onSelect={(next) => {
+                        setSelection(next)
+                        if (next.kind !== 'rolling') {
+                            setOpen(false)
+                        }
+                    }}
+                    exclusions={exclusions}
+                    onExclusionsChange={setExclusions}
+                />
+            </QuillPopoverContent>
+        </QuillPopover>
+    )
+}
+
+function PresetsFirstConcept({ lemonSkin }: { lemonSkin?: boolean }): JSX.Element {
+    const [value, setValue] = useState<DateTimeValue>({
+        start: dayjs().subtract(7, 'day').toDate(),
+        end: dayjs().toDate(),
+        range: quickRanges.find((r) => r.name === 'Last 7 days')!,
+    })
+    const [open, setOpen] = useState(false)
+    const label =
+        value.range.id !== CUSTOM_RANGE.id
+            ? value.range.name
+            : `${dayjs(value.start).format('MMM D')} – ${dayjs(value.end).format('MMM D')}`
+    const skinProps = lemonSkin ? { 'data-lemon-skin': true, 'data-quill': true } : {}
+    return (
+        <QuillPopover open={open} onOpenChange={setOpen}>
+            <QuillPopoverTrigger render={<QuillButton variant="outline" {...skinProps} />}>{label}</QuillPopoverTrigger>
+            <QuillPopoverContent
+                align="start"
+                collisionAvoidance={{ side: 'flip', align: 'none', fallbackAxisSide: 'none' }}
+                className="w-auto overflow-hidden border-none p-0 shadow-none ring-0"
+                {...(lemonSkin ? { 'data-lemon-skin': true } : {})}
+            >
+                <DateTimePicker
+                    presetsFirst
+                    showTime={false}
+                    value={value}
+                    onApply={(next) => {
+                        setValue(next)
+                        setOpen(false)
+                    }}
+                />
+            </QuillPopoverContent>
+        </QuillPopover>
+    )
+}
+
+export const AllConcepts: Story = {
+    render: () => (
+        <div className="flex flex-wrap items-start gap-8 pb-[40rem]">
+            <ConceptColumn title="Composer · quill">
+                <ComposerConcept />
+            </ConceptColumn>
+            <ConceptColumn title="Composer · lemon skin">
+                <ComposerConcept lemonSkin />
+            </ConceptColumn>
+            <ConceptColumn title="Presets-first · quill">
+                <PresetsFirstConcept />
+            </ConceptColumn>
+            <ConceptColumn title="Presets-first · lemon skin">
+                <PresetsFirstConcept lemonSkin />
+            </ConceptColumn>
+        </div>
+    ),
+}

--- a/frontend/src/lib/components/DateRangeFilter/DateRangeFilter.stories.tsx
+++ b/frontend/src/lib/components/DateRangeFilter/DateRangeFilter.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import { IconCalendar } from '@posthog/icons'
+import { Button } from '@posthog/quill'
+
+import {
+    ALL_TIME_PRESET,
+    INSIGHT_DATE_PRESETS,
+    type InsightDatePreset,
+} from 'scenes/insights/filters/InsightDateFilter/insightDateFilterNextUtils'
+
+import { DateExclusionsControl } from './DateExclusionsControl'
+import { DateRangeFilter, type DateRangePreset } from './DateRangeFilter'
+
+const PRESETS: DateRangePreset<InsightDatePreset>[] = [...INSIGHT_DATE_PRESETS, ALL_TIME_PRESET].map((preset) => ({
+    id: preset.dateFrom,
+    label: preset.name,
+    value: preset,
+    previewStart: (now: Date) => preset.rangeSetter(now, 1),
+    previewEnd: preset.endSetter ? (now: Date) => preset.endSetter!(now, 1) : undefined,
+}))
+
+function DateRangeFilterDemo({ lemonSkin }: { lemonSkin: boolean }): JSX.Element {
+    const [selectedPresetId, setSelectedPresetId] = useState<string | null>('-7d')
+    const [custom, setCustom] = useState<{ start: Date; end: Date } | null>(null)
+    const [excludedDays, setExcludedDays] = useState<number[]>([])
+    const [excludeIncomplete, setExcludeIncomplete] = useState(false)
+
+    const selected = PRESETS.find((preset) => preset.id === selectedPresetId)
+    const label = custom
+        ? `${custom.start.toLocaleDateString()} - ${custom.end.toLocaleDateString()}`
+        : (selected?.label ?? 'Last 7 days')
+
+    const skinAttrs = lemonSkin ? { 'data-lemon-skin': 'true' } : {}
+    return (
+        <div className="flex h-[600px] items-start p-4" data-quill {...skinAttrs}>
+            <DateRangeFilter
+                presets={PRESETS}
+                selectedPresetId={custom ? null : selectedPresetId}
+                onPresetSelect={(preset) => {
+                    setSelectedPresetId(preset.id)
+                    setCustom(null)
+                }}
+                onCustomApply={(start, end) => {
+                    setCustom({ start, end })
+                    setSelectedPresetId(null)
+                }}
+                customActive={!!custom}
+                customStart={custom?.start}
+                customEnd={custom?.end}
+                footerExtra={
+                    <DateExclusionsControl
+                        excludedDays={excludedDays}
+                        onExcludedDaysChange={setExcludedDays}
+                        excludeIncomplete={excludeIncomplete}
+                        onExcludeIncompleteChange={setExcludeIncomplete}
+                    />
+                }
+                contentProps={skinAttrs as unknown as React.ComponentProps<typeof DateRangeFilter>['contentProps']}
+                trigger={
+                    <Button variant="outline" size="default" data-quill {...skinAttrs}>
+                        <IconCalendar />
+                        {label}
+                    </Button>
+                }
+            />
+        </div>
+    )
+}
+
+const meta: Meta<typeof DateRangeFilterDemo> = {
+    title: 'Components/Date Range Filter',
+    parameters: {
+        viewMode: 'story',
+    },
+}
+export default meta
+type Story = StoryObj<typeof DateRangeFilterDemo>
+
+/** The insight date filter's shape with the lemon skin applied (lemon-skin.scss). */
+export const LemonSkin: Story = {
+    render: () => <DateRangeFilterDemo lemonSkin />,
+}
+
+/** The same filter with quill's native styling, for comparison. */
+export const QuillNative: Story = {
+    render: () => <DateRangeFilterDemo lemonSkin={false} />,
+}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -13,3 +13,4 @@
 @import '../../node_modules/@posthog/quill/dist/base.scoped.css';
 @import '../../node_modules/@posthog/quill/dist/primitives.css';
 @import 'quill-bridge';
+@import 'lemon-skin';

--- a/frontend/src/styles/lemon-skin.scss
+++ b/frontend/src/styles/lemon-skin.scss
@@ -1,0 +1,911 @@
+/*
+ * PROTOTYPE — Lemon skin for quill.
+ *
+ * The mirror of quill-skin.scss: restyles quill primitives to LemonUI's
+ * current visual language, so quill components can be adopted inside Lemon
+ * scenes with zero visible change. Under this strategy the code migrates
+ * Lemon → quill invisibly (migration PRs are snapshot-identical), and the new
+ * design ships in one final flip: removing this skin reveals quill's native
+ * look app-wide.
+ *
+ * Opt in with a wrapper attribute (alongside `data-quill`, which quill
+ * components need for their tokens anyway):
+ *
+ *     <div data-quill data-lemon-skin>…</div>
+ *
+ * Quill's own rules live in `@layer components`, so these unlayered overrides
+ * win the cascade without specificity hacks.
+ *
+ * Covered: Button, Input, InputGroup, Textarea, Checkbox, Switch, RadioGroup,
+ * Select, Badge (→ LemonTag), Chip (→ LemonSnack), Separator, Skeleton,
+ * Label, Kbd, Item, MenuLabel, Empty, Tooltip,
+ * Popover/DropdownMenu/ContextMenu surfaces, Tabs (line + pill variants),
+ * Dialog (→ LemonModal), Progress, ToggleGroup (→ Lemon day chips) — plus a
+ * core-token rebind that turns
+ * bespoke Tailwind in quill-based features lemony wholesale. First real
+ * consumer: the taxonomic filter rebuild
+ * (lib/components/TaxonomicFilter/menu/).
+ *
+ * PORTAL CAVEAT: overlay content (tooltip, menus, select popup, dialog)
+ * renders in portals at <body>, outside any scoped wrapper. Two ways to
+ * cover it: put the attributes on <body>/<html> (the eventual app-wide flip
+ * deployment), or pass `data-lemon-skin` to the quill *Content component so
+ * it lands on the portaled element itself — the taxonomic filter menu does
+ * the latter, and the portal-surface rules below match both placements.
+ *
+ * Known gaps, acceptable for a prototype:
+ * icon-* button sizes, Accordion/Collapsible, Card, Avatar, Table, Toast,
+ * Drawer, Slider, standalone Toggle, NumberField keep quill styling; no
+ * hover-raise/press-sink travel on buttons.
+ */
+
+/*
+ * Lemon token aliases. quill-bridge.scss rebinds several Lemon var names
+ * (`--color-border-primary`, `--color-accent`, `--color-bg-surface-primary`,
+ * `--color-text-secondary`, `--color-bg-primary`, …) to QUILL tokens inside
+ * `[data-quill]`, so referencing those names here would resolve to quill
+ * values. These aliases restore the Lemon values (mirroring base.scss) under
+ * skin-local names. `--radius`/`--radius-lg` are likewise shadowed by quill's
+ * scoped tokens, hence the literals.
+ */
+[data-lemon-skin] {
+    --lemon-skin-accent: hsl(
+        var(--color-brand-primary-hue),
+        var(--color-brand-primary-saturation),
+        var(--color-brand-primary-lightness)
+    );
+    --lemon-skin-accent-hover: hsl(
+        var(--color-brand-primary-hue),
+        var(--color-brand-primary-saturation),
+        calc(var(--color-brand-primary-lightness) + 10%)
+    );
+    --lemon-skin-border: var(--color-posthog-3000-200);
+    --lemon-skin-border-hover: var(--color-posthog-3000-400);
+    --lemon-skin-surface: var(--color-white);
+    --lemon-skin-bg-page: var(--color-posthog-3000-50);
+    --lemon-skin-text-secondary: var(--color-neutral-750);
+    --lemon-skin-radius: 0.375rem;
+    --lemon-skin-radius-lg: 0.625rem;
+}
+
+[theme='dark'] [data-lemon-skin] {
+    --lemon-skin-border: var(--color-neutral-cool-800);
+    --lemon-skin-border-hover: var(--color-neutral-cool-600);
+    --lemon-skin-surface: var(--color-neutral-cool-850);
+    --lemon-skin-bg-page: var(--color-neutral-cool-950);
+    --lemon-skin-text-secondary: var(--color-neutral-350);
+}
+
+/*
+ * Core quill semantic tokens → Lemon values. This is the broad brush: it
+ * recolors quill primitive CSS AND bespoke Tailwind in quill-based features
+ * (`bg-(--fill-hover)`, `text-muted-foreground`, `border-border`, `text-xs`)
+ * in one place, so feature code like the taxonomic filter rebuild turns
+ * lemony without per-feature rules. The per-component sections below refine
+ * geometry and typography on top.
+ *
+ * Quill primitives set `data-quill` on their own root elements, and
+ * tokens.scoped.css sets token values directly on every `[data-quill]`
+ * element — an inherited rebind from a wrapper would lose to those. The
+ * extra selectors out-specificity the scoped token sheet.
+ */
+[data-lemon-skin],
+[data-lemon-skin][data-quill],
+[data-lemon-skin] [data-quill] {
+    --foreground: var(--text-3000);
+    --muted-foreground: var(--lemon-skin-text-secondary);
+    --border: var(--lemon-skin-border);
+    --input: var(--lemon-skin-border);
+    --card: var(--color-bg-surface-popover);
+    --background: var(--lemon-skin-surface);
+    --primary: var(--lemon-skin-accent);
+    --primary-foreground: var(--lemon-skin-surface);
+    --fill-hover: var(--color-bg-fill-button-tertiary-hover);
+    --fill-selected: var(--color-bg-fill-button-tertiary-active);
+    --fill-expanded: var(--color-bg-fill-button-tertiary-active);
+    --radius-xs: 0.25rem;
+    --radius-sm: 0.375rem;
+    --radius-md: 0.375rem;
+    --radius-lg: 0.625rem;
+
+    /* Quill's base 12px text → Lemon's 14px, wherever quill CSS reads the var */
+    --text-xs: 0.875rem;
+    --shadow-md: var(--shadow-elevation-3000);
+}
+
+/* ═══ Button → LemonButton ═════════════════════════════════════════════ */
+
+/* The attribute matches an ancestor (wrapped surfaces, portaled content) or the
+   element itself, so an opted-in inline button is skinned without a wrapper. */
+
+[data-lemon-skin] .quill-button,
+.quill-button[data-lemon-skin] {
+    font-family: var(--font-button);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.5rem;
+    color: var(--text-3000);
+    border-radius: var(--lemon-skin-radius);
+}
+
+/* primary → Lemon primary (white face, brown border, single 3D frame fill below).
+   LemonButton draws that frame on a chrome pseudo-element inset -1px on the sides
+   (1px wider each side) with `0 3px 0 -1px`, so its net edge is full button width.
+   The skin's shadow sits on the button itself, so it uses 0 spread to match. */
+
+[data-lemon-skin] .quill-button--variant-primary,
+.quill-button--variant-primary[data-lemon-skin] {
+    color: var(--text-3000-light);
+    background-color: var(--primary-3000-button-bg);
+    border: 1px solid var(--primary-3000-button-border);
+    box-shadow: 0 0.1875rem 0 0 var(--primary-3000-frame-bg);
+    translate: none;
+}
+
+[data-lemon-skin] .quill-button--variant-primary:not(:disabled, [aria-disabled='true']):hover,
+.quill-button--variant-primary[data-lemon-skin]:not(:disabled, [aria-disabled='true']):hover {
+    background-color: var(--primary-3000-button-bg);
+    border-color: var(--primary-3000-button-border-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-primary:not(:disabled, [aria-disabled='true']):active,
+.quill-button--variant-primary[data-lemon-skin]:not(:disabled, [aria-disabled='true']):active {
+    box-shadow: none;
+    translate: 0 0.1875rem;
+}
+
+/* outline → Lemon secondary */
+
+[data-lemon-skin] .quill-button--variant-outline,
+.quill-button--variant-outline[data-lemon-skin] {
+    background-color: transparent;
+    border: 1px solid var(--secondary-3000-button-border);
+    box-shadow: 0 0.1875rem 0 0 var(--secondary-3000-frame-bg);
+}
+
+[data-lemon-skin] .quill-button--variant-outline:not(:disabled, [aria-disabled='true']):hover,
+.quill-button--variant-outline[data-lemon-skin]:not(:disabled, [aria-disabled='true']):hover {
+    color: var(--text-3000);
+    background-color: transparent;
+    border-color: var(--secondary-3000-button-border-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-outline:not(:disabled, [aria-disabled='true']):active,
+.quill-button--variant-outline[data-lemon-skin]:not(:disabled, [aria-disabled='true']):active {
+    box-shadow: none;
+    translate: 0 0.1875rem;
+}
+
+/* default (ghost) → Lemon tertiary */
+
+[data-lemon-skin] .quill-button--variant-default,
+.quill-button--variant-default[data-lemon-skin] {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-button--variant-default:not(:disabled, [aria-disabled='true']):hover,
+.quill-button--variant-default[data-lemon-skin]:not(:disabled, [aria-disabled='true']):hover {
+    color: var(--text-3000);
+    background-color: var(--color-bg-fill-button-tertiary-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-default:not(:disabled, [aria-disabled='true']):active,
+.quill-button--variant-default[data-lemon-skin]:not(:disabled, [aria-disabled='true']):active {
+    background-color: var(--color-bg-fill-button-tertiary-active);
+}
+
+/* destructive → Lemon secondary + status="danger" */
+
+[data-lemon-skin] .quill-button--variant-destructive,
+.quill-button--variant-destructive[data-lemon-skin] {
+    color: var(--danger-3000-button-border-hover);
+    background-color: var(--secondary-3000-button-bg);
+    border: 1px solid var(--danger-3000-button-border);
+    box-shadow: 0 0.1875rem 0 0 var(--danger-3000-frame-bg);
+}
+
+[data-lemon-skin] .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):hover,
+.quill-button--variant-destructive[data-lemon-skin]:not(:disabled, [aria-disabled='true']):hover {
+    background-color: var(--secondary-3000-button-bg);
+    border-color: var(--danger-3000-button-border-hover);
+}
+
+[data-lemon-skin] .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):active,
+.quill-button--variant-destructive[data-lemon-skin]:not(:disabled, [aria-disabled='true']):active {
+    box-shadow: none;
+    translate: 0 0.1875rem;
+}
+
+/* link / link-muted → Lemon Link (accent text, no underline) */
+
+[data-lemon-skin] .quill-button--variant-link,
+[data-lemon-skin] .quill-button--variant-link-muted,
+.quill-button--variant-link[data-lemon-skin],
+.quill-button--variant-link-muted[data-lemon-skin] {
+    height: auto;
+    padding: 0;
+    color: var(--lemon-skin-accent);
+    text-decoration-line: none;
+    background: none;
+    border: none;
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-button--variant-link-muted,
+.quill-button--variant-link-muted[data-lemon-skin] {
+    color: var(--text-3000);
+}
+
+[data-lemon-skin]
+    :is(.quill-button--variant-link, .quill-button--variant-link-muted):not(:disabled, [aria-disabled='true']):hover,
+:is(.quill-button--variant-link, .quill-button--variant-link-muted)[data-lemon-skin]:not(
+        :disabled,
+        [aria-disabled='true']
+    ):hover {
+    color: var(--lemon-skin-accent-hover);
+    text-decoration-line: none;
+    background: none;
+}
+
+/* Sizes → Lemon's scale by closest geometry: xs→xxsmall, sm→xsmall,
+   default→small, lg→medium */
+
+[data-lemon-skin] .quill-button--size-default,
+.quill-button--size-default[data-lemon-skin] {
+    gap: 0.5rem;
+    height: 2.0625rem;
+    padding-inline: 0.5rem;
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-button--size-default svg:not([class*='size-']),
+.quill-button--size-default[data-lemon-skin] svg:not([class*='size-']) {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+[data-lemon-skin] .quill-button--size-xs,
+.quill-button--size-xs[data-lemon-skin] {
+    gap: 0.1875rem;
+    height: 1.25rem;
+    padding-inline: 0.25rem;
+    font-size: 0.6875rem;
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-button--size-xs svg:not([class*='size-']),
+.quill-button--size-xs[data-lemon-skin] svg:not([class*='size-']) {
+    width: 0.8125rem;
+    height: 0.8125rem;
+}
+
+[data-lemon-skin] .quill-button--size-sm,
+.quill-button--size-sm[data-lemon-skin] {
+    gap: 0.25rem;
+    height: 1.625rem;
+    padding-inline: 0.375rem;
+    font-size: 0.75rem;
+}
+
+[data-lemon-skin] .quill-button--size-sm svg:not([class*='size-']),
+.quill-button--size-sm[data-lemon-skin] svg:not([class*='size-']) {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
+[data-lemon-skin] .quill-button--size-lg,
+.quill-button--size-lg[data-lemon-skin] {
+    gap: 0.5rem;
+    height: 2.3125rem;
+    padding-inline: 0.75rem;
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-button--size-lg svg:not([class*='size-']),
+.quill-button--size-lg[data-lemon-skin] svg:not([class*='size-']) {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+/* ═══ Input → LemonInput ═══════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-input {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    color: var(--text-3000);
+}
+
+/*
+ * Geometry and chrome only for standalone inputs — inside an InputGroup the
+ * group owns the border and the fixed 2rem height (search overlays like the
+ * taxonomic filter's input-trigger measure against it).
+ */
+[data-lemon-skin] .quill-input:not([data-slot='input-group-control']) {
+    height: calc(2.125rem + 3px);
+    padding: 0.25rem 0.5rem;
+    background-color: var(--color-bg-fill-input);
+    border: 1px solid var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-input:not([data-slot='input-group-control']):hover:not(:disabled),
+[data-lemon-skin] .quill-input:not([data-slot='input-group-control']):focus-visible {
+    /* Lemon inputs signal focus with a border-color change, not a ring */
+    border-color: var(--lemon-skin-border-hover);
+    box-shadow: none;
+}
+
+/* ═══ InputGroup (input with addons) — recolor only, keep 2rem metrics ═ */
+
+[data-lemon-skin] .quill-input-group {
+    font-family: var(--font-sans);
+    background-color: var(--color-bg-fill-input);
+    border-color: var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-input-group:has([data-slot='input-group-control']:focus-visible) {
+    border-color: var(--lemon-skin-border-hover);
+    box-shadow: none;
+}
+
+/* ═══ Textarea → LemonTextArea ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-textarea {
+    min-height: 2.5rem;
+    padding: 0.5rem;
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    line-height: 1.4;
+    color: var(--text-3000);
+    background-color: var(--color-bg-fill-input);
+    border: 1px solid var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-textarea:hover:not(:disabled),
+[data-lemon-skin] .quill-textarea:focus-visible {
+    border-color: var(--lemon-skin-border-hover);
+    box-shadow: none;
+}
+
+/* ═══ Checkbox → LemonCheckbox ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-checkbox,
+[data-lemon-skin] .quill-checkbox-indicator {
+    /* Lemon has a single 1rem box size */
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--lemon-skin-surface);
+    border: 1.5px solid var(--lemon-skin-border);
+    border-radius: 0.25rem;
+}
+
+[data-lemon-skin] .quill-checkbox:hover:not(:disabled) {
+    border-color: var(--lemon-skin-accent-hover);
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-checkbox:focus-visible {
+    border-color: var(--lemon-skin-accent-hover);
+    outline: -webkit-focus-ring-color auto 1px;
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-checkbox[data-checked],
+[data-lemon-skin] .quill-checkbox-indicator--checked {
+    color: var(--lemon-skin-surface);
+    background-color: var(--lemon-skin-accent);
+    border-color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-checkbox[data-checked]:hover:not(:disabled) {
+    background-color: var(--lemon-skin-accent-hover);
+    border-color: var(--lemon-skin-accent-hover);
+}
+
+/* ═══ Switch → LemonSwitch ═════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-switch {
+    border: none;
+    outline: 1px solid var(--lemon-skin-border);
+}
+
+/* Lemon medium: 13px handle in a 28×15 pill track */
+
+[data-lemon-skin] .quill-switch[data-size='default'] {
+    width: 28px;
+    height: 15px;
+}
+
+[data-lemon-skin] .quill-switch[data-size='default'] .quill-switch__thumb {
+    width: 13px;
+    height: 13px;
+}
+
+[data-lemon-skin] .quill-switch[data-unchecked] {
+    background-color: var(--color-bg-fill-switch);
+}
+
+[data-lemon-skin] .quill-switch[data-checked] {
+    background-color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-switch__thumb {
+    /* Lemon hardcodes a white handle in the off state */
+    background-color: #fff;
+}
+
+[data-lemon-skin] .quill-switch[data-checked] .quill-switch__thumb {
+    background-color: var(--lemon-skin-surface);
+    transform: translateX(100%);
+}
+
+/* ═══ RadioGroup — Lemon uses native radios; accent-tint is the analog ═ */
+
+[data-lemon-skin] .quill-radio {
+    background-color: var(--lemon-skin-surface);
+    border-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-radio:focus-visible {
+    border-color: var(--lemon-skin-accent-hover);
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-radio[data-checked] {
+    color: var(--lemon-skin-surface);
+    background-color: var(--lemon-skin-accent);
+    border-color: var(--lemon-skin-accent);
+}
+
+/* ═══ Badge → LemonTag (small variant — badges live in dense list rows) ═ */
+
+[data-lemon-skin] .quill-badge {
+    height: auto;
+    padding: 0 0.1875rem;
+    font-family: var(--font-sans);
+    font-size: 0.625rem;
+    font-weight: 500;
+    line-height: 0.875rem;
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-badge--variant-default {
+    color: var(--text-3000);
+    background-color: transparent;
+    border-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-badge--variant-info {
+    /* Lemon has no blue tag; its "primary" (accent outline) is the analog */
+    color: var(--lemon-skin-accent);
+    background-color: transparent;
+    border-color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-badge--variant-success {
+    color: var(--success);
+    background-color: transparent;
+    border-color: var(--success);
+}
+
+[data-lemon-skin] .quill-badge--variant-warning {
+    color: var(--warning);
+    background-color: transparent;
+    border-color: var(--warning);
+}
+
+[data-lemon-skin] .quill-badge--variant-destructive {
+    color: var(--danger);
+    background-color: transparent;
+    border-color: var(--danger);
+}
+
+/* ═══ Chip → LemonSnack ════════════════════════════════════════════════ */
+
+/*
+ * Chip composes Button (variant=outline), so this must out-order the button
+ * outline rules above to strip the secondary-button chrome.
+ */
+[data-lemon-skin] .quill-chip {
+    padding-block: 0.25rem;
+    padding-inline: 0.375rem;
+    font-size: 0.8125rem;
+    color: var(--text-3000);
+    background-color: var(--color-accent-highlight-secondary);
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    box-shadow: none;
+}
+
+[data-lemon-skin] .quill-chip:not(:disabled, [aria-disabled='true']):hover {
+    background-color: var(--color-accent-highlight-secondary);
+    border-color: transparent;
+}
+
+/* ═══ Separator → LemonDivider ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-separator {
+    background-color: var(--lemon-skin-border);
+}
+
+/* ═══ Skeleton → LemonSkeleton (shimmer, not pulse) ════════════════════ */
+
+[data-lemon-skin] .quill-skeleton {
+    background: linear-gradient(
+        90deg,
+        var(--color-skeleton-light) 25%,
+        var(--color-skeleton-dark) 45%,
+        var(--color-skeleton-light) 65%
+    );
+    background-size: 400% 100%;
+    border-radius: var(--lemon-skin-radius);
+
+    /* Reuses the global keyframes from LemonSkeleton.scss */
+    animation: LemonSkeleton__shimmer 2s ease infinite;
+}
+
+/* ═══ Label → LemonLabel ═══════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-label {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.5rem;
+}
+
+/* ═══ Kbd → KeyboardShortcut keycap ════════════════════════════════════ */
+
+[data-lemon-skin] .quill-kbd {
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0.125rem 0.25rem;
+    font-family: var(--font-title);
+    font-size: 0.75rem;
+    color: var(--text-3000);
+    background: var(--lemon-skin-surface);
+    border: 1px solid var(--secondary-3000-button-border-hover);
+
+    /* The thicker bottom edge gives Lemon's keycap bevel */
+    border-bottom-width: 2px;
+    border-radius: 0.25rem;
+}
+
+/* ═══ Item rows (ItemGroup, ItemMenuItem, combobox rows) ═══════════════ */
+
+[data-lemon-skin] .quill-item {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-item__title {
+    font-size: 0.875rem;
+}
+
+[data-lemon-skin] .quill-item__description {
+    font-size: 0.75rem;
+}
+
+/* ═══ MenuLabel → Lemon section title (no uppercase tracking) ══════════ */
+
+[data-lemon-skin] .quill-menu-label {
+    font-family: var(--font-sans);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--lemon-skin-text-secondary);
+    text-transform: none;
+    letter-spacing: normal;
+}
+
+/* ═══ Empty state — Lemon centers muted text without the dashed frame ══ */
+
+[data-lemon-skin] .quill-empty {
+    border: none;
+}
+
+/* ═══ Lemon components inside skinned surfaces ═════════════════════════ */
+
+/* trigger field: small → medium metrics */
+[data-lemon-skin] .LemonInput.LemonInput--small {
+    --lemon-input-height: calc(2.125rem + 3px);
+
+    padding: 0.25rem 0.5rem;
+}
+
+/* embedded button (the trigger's filter icon): → xsmall metrics */
+[data-lemon-skin] .LemonInput .LemonButton {
+    --lemon-button-height: 1.625rem;
+    --lemon-button-font-size: 0.75rem;
+    --lemon-button-icon-size: 0.875rem;
+    --lemon-button-padding-horizontal: 0.375rem;
+    --lemon-button-padding-adjacent-icon: 0.25rem;
+    --lemon-button-gap: 0.25rem;
+}
+
+/*
+ * Portal-mounted surfaces below (tooltip, popover, menus, select popup,
+ * dialog): the skin attribute is passed to the *Content component and lands
+ * ON the portaled element itself, so each surface rule needs a self variant
+ * alongside the descendant one.
+ */
+
+/* ═══ Tooltip → Lemon Tooltip ══════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-tooltip__content,
+.quill-tooltip__content[data-lemon-skin] {
+    font-family: var(--font-sans);
+    color: var(--color-text-primary-inverse);
+    background-color: var(--color-bg-surface-tooltip);
+    border-radius: var(--lemon-skin-radius);
+    box-shadow: var(--modal-shadow-elevation);
+}
+
+[data-lemon-skin] .quill-tooltip__arrow {
+    background-color: var(--color-bg-surface-tooltip);
+    fill: var(--color-bg-surface-tooltip);
+}
+
+/* ═══ Popover / menu / select surfaces → Lemon Popover box ═════════════ */
+
+[data-lemon-skin]
+    :is(
+        .quill-popover__content,
+        .quill-menu__content,
+        .quill-menu__sub-content,
+        .quill-select__content,
+        .quill-combobox__content
+    ),
+:is(
+    .quill-popover__content,
+    .quill-menu__content,
+    .quill-menu__sub-content,
+    .quill-select__content,
+    .quill-combobox__content
+)[data-lemon-skin] {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    background-color: var(--color-bg-surface-popover);
+    border: 1px solid var(--secondary-3000-button-border);
+    border-radius: var(--lemon-skin-radius-lg);
+    box-shadow: var(--shadow-elevation-3000);
+}
+
+[data-lemon-skin] .quill-menu__separator,
+[data-lemon-skin] .quill-select__separator {
+    background-color: var(--lemon-skin-border);
+}
+
+/* SelectTrigger sizes itself via data-size, not Button's size prop: sm → xsmall */
+[data-lemon-skin] .quill-select__trigger[data-size='sm'] {
+    gap: 0.25rem;
+    height: 1.625rem;
+    padding-inline: 0.375rem;
+    font-size: 0.75rem;
+}
+
+/* Select triggers embedded in an input go flat, border centered in the field */
+[data-lemon-skin] :is(.quill-input-group, .LemonInput) .quill-select__trigger {
+    background-color: transparent;
+    box-shadow: none;
+    translate: none;
+}
+
+[data-lemon-skin]
+    :is(.quill-input-group, .LemonInput)
+    .quill-select__trigger:not(:disabled, [aria-disabled='true']):hover {
+    background-color: transparent;
+}
+
+[data-lemon-skin]
+    :is(.quill-input-group, .LemonInput)
+    .quill-select__trigger:not(:disabled, [aria-disabled='true']):active {
+    translate: none;
+}
+
+/* Select/combobox rows sized like the small LemonButtons LemonMenu renders */
+
+[data-lemon-skin] :is(.quill-select__item, .quill-combobox__item) {
+    height: auto;
+    min-height: 2.0625rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-radius: var(--lemon-skin-radius);
+}
+
+[data-lemon-skin] .quill-select__item:focus,
+[data-lemon-skin] .quill-combobox__item[data-highlighted] {
+    background-color: var(--color-bg-fill-button-tertiary-hover);
+}
+
+[data-lemon-skin] .quill-combobox__content .quill-combobox__item,
+.quill-combobox__content[data-lemon-skin] .quill-combobox__item {
+    height: auto;
+    min-height: 2.0625rem;
+
+    /* quill's checkmark gutter, clobbered by the button-size remap above */
+    padding-inline-start: 1.875rem;
+}
+
+[data-lemon-skin] .quill-combobox__content .quill-combobox__item [data-slot='item-content'],
+.quill-combobox__content[data-lemon-skin] .quill-combobox__item [data-slot='item-content'] {
+    padding-block: 0.375rem;
+}
+
+[data-lemon-skin] .quill-select__item:not(:hover)[aria-selected='true'] {
+    background-color: var(--color-bg-fill-button-tertiary-active);
+}
+
+/* ═══ Tabs (line variant) → LemonTabs ══════════════════════════════════ */
+
+[data-lemon-skin] .quill-tabs__trigger {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-tertiary);
+}
+
+[data-lemon-skin] .quill-tabs__trigger:hover {
+    color: var(--text-3000);
+    background-color: transparent;
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-line {
+    gap: 1rem;
+    height: auto;
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-line .quill-tabs__trigger {
+    flex: 0 0 auto;
+    padding-block: 0.5rem;
+    padding-inline: 0;
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-line .quill-tabs__trigger[data-active] {
+    /*
+     * Quill paints the active tab `var(--background) !important`; a layered
+     * !important can't be out-cascaded from here, but rebinding the var it
+     * resolves can.
+     */
+    --background: transparent;
+
+    color: var(--lemon-skin-accent);
+}
+
+[data-lemon-skin] .quill-tabs__indicator--variant-line {
+    background-color: var(--lemon-skin-accent);
+}
+
+/* ═══ Tabs (pill variant) → Lemon segmented look ═══════════════════════ */
+
+[data-lemon-skin] .quill-tabs__list--variant-default {
+    /* here `bg-muted` resolves to --muted-3000, Lemon's muted TEXT color
+       (the quill/Lemon token collision quill-bridge.scss documents) */
+    --muted-3000: var(--lemon-skin-bg-page);
+
+    background-color: var(--lemon-skin-bg-page);
+    border-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-default .quill-tabs__trigger {
+    font-size: 0.8125rem;
+    color: var(--lemon-skin-text-secondary);
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-default .quill-tabs__trigger:hover {
+    color: var(--text-3000);
+}
+
+[data-lemon-skin] .quill-tabs__list--variant-default .quill-tabs__trigger[data-active] {
+    --background: var(--lemon-skin-surface);
+
+    color: var(--text-3000);
+}
+
+[data-lemon-skin] .quill-tabs__indicator--variant-default {
+    background-color: var(--lemon-skin-surface);
+    border-color: var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+}
+
+/* ═══ Progress → LemonProgress ═════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-progress__track {
+    height: 0.375rem;
+    background-color: var(--lemon-skin-bg-page);
+    border-radius: 9999px;
+}
+
+[data-lemon-skin] .quill-progress__indicator {
+    border-radius: 9999px;
+}
+
+[data-lemon-skin] .quill-progress__indicator--variant-default {
+    background-color: var(--brand-blue);
+}
+
+/* ═══ Dialog → LemonModal ══════════════════════════════════════════════ */
+
+[data-lemon-skin] .quill-dialog__content,
+.quill-dialog__content[data-lemon-skin] {
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    background-color: var(--lemon-skin-surface);
+    border: 1px solid var(--border-bold);
+    border-radius: var(--lemon-skin-radius);
+    box-shadow: var(--modal-shadow-elevation);
+}
+
+[data-lemon-skin] .quill-dialog__title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    line-height: 1.5rem;
+}
+
+[data-lemon-skin] .quill-dialog__header:has(~ [data-slot='dialog-body']) {
+    border-bottom-color: var(--lemon-skin-border);
+}
+
+[data-lemon-skin] .quill-dialog__footer {
+    background-color: transparent;
+    border-top-color: var(--lemon-skin-border);
+}
+
+/* ═══ ToggleGroup → Lemon day chips ════════════════════════════════════ */
+
+/* Items render as outline Buttons but carry quill's toggle classes, whose
+   grey pressed styling leaks through. Give each a pressable white face with
+   an accent bottom edge (unselected), sinking onto it when pressed on. */
+
+[data-lemon-skin] .quill-toggle-group__item {
+    font-size: 0.75rem;
+    color: var(--text-3000);
+    background-color: var(--lemon-skin-surface);
+    border: 1px solid var(--lemon-skin-border);
+    border-radius: var(--lemon-skin-radius);
+    box-shadow: 0 0.1875rem 0 0 var(--lemon-skin-accent);
+    translate: none;
+}
+
+[data-lemon-skin] .quill-toggle-group__item:not(:disabled, [aria-disabled='true']):hover {
+    color: var(--text-3000);
+    background-color: var(--lemon-skin-surface);
+    border-color: var(--lemon-skin-border-hover);
+}
+
+/* Selected → pressed: sink onto the accent edge and tint the face */
+
+[data-lemon-skin] .quill-toggle-group__item:is([aria-pressed='true'], [data-pressed], [data-state='on']) {
+    color: var(--lemon-skin-accent);
+    background-color: color-mix(in oklab, var(--lemon-skin-accent) 12%, var(--lemon-skin-surface));
+    border-color: var(--lemon-skin-accent);
+    box-shadow: none;
+    translate: 0 0.1875rem;
+}
+
+/* ═══ DateTimePicker quick-range presets → Lemon menu rows ══════════════ */
+
+/* Quill hardcodes the rail's preset buttons to size=sm (0.75rem); bump them
+   toward a Lemon menu row so the list reads at a comfortable size. The
+   .quill-button class lifts specificity over the base size-sm rule. */
+
+[data-lemon-skin]
+    .quill-button:is([data-attr^='date-time-picker-quick-range-'], [data-attr='date-time-picker-custom-range']) {
+    font-size: 0.875rem;
+}
+
+/* ═══ DateTimePicker actions footer → small Lemon buttons ══════════════ */
+
+/* The Cancel/Apply buttons are quill size=sm (xsmall); bump them to small Lemon
+   metrics. The footer band's flat surface + readout size come from quill itself
+   (its bg-muted/30 and text-[10px] are !important Tailwind utilities the skin
+   can't override from an unlayered rule). */
+
+[data-lemon-skin]
+    .quill-button:is([data-attr='date-time-picker-cancel'], [data-attr='date-time-picker-apply-date-range']) {
+    height: 2.0625rem;
+    padding-inline: 0.75rem;
+    font-size: 0.8125rem;
+}

--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -8,6 +8,8 @@ Quick-reference for AI agents using `@posthog/quill-components` — composed com
 - `DateTimePicker` — calendar range picker with quick-range presets (`quickRanges`, `CUSTOM_RANGE`)
 - `DatePicker` — single-date picker (one calendar, optional time, no quick ranges)
 - `useCalendar` — headless calendar grid hook (`Day`, `Month` enums)
+- `RelativeRangeInput` — "N units" duration control (count stepper + unit dropdown)
+- `DateRangeComposer` — CONCEPT (unstable): date filter redesign exploration — chips + `RelativeRangeInput` + calendar + exclusions; kept as a component so the app storybook can render it next to its Lemon twin
 - `Metric` — composable stat tile (`Card` + `Badge` pill + `Sparkline`); marries primitives with `@posthog/quill-charts`. Import from the `@posthog/quill-components/metric` subpath (not the main barrel)
 
 ## DataTable
@@ -100,6 +102,26 @@ Rules:
 ## useCalendar
 
 Headless month-grid state for building custom calendar UIs: returns `calendar` (months > weeks > days), view navigation (`viewNextMonth`, `viewToday`, ...), and selection helpers (`select`, `selectRange`, `isSelected`, `toggle`). Selected dates are normalized to midnight. Reach for this only when DateTimePicker doesn't fit.
+
+## RelativeRangeInput
+
+A "N units" duration control: count stepper (type, scrub, or ±) plus a unit `Select`.
+Controlled via `value: { count, unit }` / `onChange`; `units` narrows the dropdown (default hours→months), `min`/`max` clamp the count.
+The component is vocabulary-free: the host renders surrounding words ("Last …") and maps the value to its own range model.
+Unit labels singularize when count is 1.
+See the `Components/DateRangeComposer` stories for the intended composition — a presets-as-chips date filter panel where this control is the primary input and `DateTimePicker` (embedded, `ranges={[]}`) covers custom ranges.
+
+```tsx
+import { RelativeRangeInput, type RelativeRangeValue } from '@posthog/quill-components'
+
+const [value, setValue] = useState<RelativeRangeValue>({ count: 30, unit: 'days' })
+;<div className="flex items-center gap-2">
+  <Text size="sm" weight="semibold" render={<span />}>
+    Last
+  </Text>
+  <RelativeRangeInput value={value} onChange={setValue} />
+</div>
+```
 
 ## Metric
 

--- a/packages/quill/packages/components/src/date-range-composer.stories.tsx
+++ b/packages/quill/packages/components/src/date-range-composer.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import * as React from 'react'
+
+import { Button, Popover, PopoverContent, PopoverTrigger, Text } from '@posthog/quill-primitives'
+
+import {
+    composerExclusionsSummary,
+    composerSelectionLabel,
+    DateRangeComposer,
+    type DateRangeComposerExclusions,
+    type DateRangeComposerSelection,
+} from './date-range-composer'
+import { RelativeRangeInput, type RelativeRangeValue } from './relative-range-input'
+
+const meta = {
+    title: 'Components/DateRangeComposer',
+    component: DateRangeComposer,
+    tags: ['autodocs'],
+} satisfies Meta<typeof DateRangeComposer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const baseArgs = {
+    selection: { kind: 'rolling', count: 7, unit: 'days' } as DateRangeComposerSelection,
+    onSelect: () => undefined,
+    exclusions: { days: [], incomplete: false },
+    onExclusionsChange: () => undefined,
+}
+
+export const Composer: Story = {
+    args: baseArgs,
+    render: () => {
+        const [selection, setSelection] = React.useState<DateRangeComposerSelection>({
+            kind: 'rolling',
+            count: 7,
+            unit: 'days',
+        })
+        const [exclusions, setExclusions] = React.useState<DateRangeComposerExclusions>({
+            days: [],
+            incomplete: false,
+        })
+        return (
+            <DateRangeComposer
+                selection={selection}
+                onSelect={setSelection}
+                exclusions={exclusions}
+                onExclusionsChange={setExclusions}
+            />
+        )
+    },
+}
+
+export const ComposerInPopover: Story = {
+    args: baseArgs,
+    render: () => {
+        const [selection, setSelection] = React.useState<DateRangeComposerSelection>({
+            kind: 'rolling',
+            count: 7,
+            unit: 'days',
+        })
+        const [exclusions, setExclusions] = React.useState<DateRangeComposerExclusions>({
+            days: [],
+            incomplete: false,
+        })
+        const [open, setOpen] = React.useState(false)
+        const summary = composerExclusionsSummary(exclusions)
+        return (
+            <div className="h-140">
+                <Popover open={open} onOpenChange={setOpen}>
+                    <PopoverTrigger render={<Button variant="outline" />}>
+                        {composerSelectionLabel(selection)}
+                        {summary && <span className="size-1.5 rounded-full bg-primary" aria-label={summary} />}
+                    </PopoverTrigger>
+                    <PopoverContent
+                        align="start"
+                        collisionAvoidance={{ side: 'flip', align: 'none', fallbackAxisSide: 'none' }}
+                        className="w-auto overflow-hidden border-none p-0 shadow-none ring-0"
+                    >
+                        <DateRangeComposer
+                            selection={selection}
+                            onSelect={(next) => {
+                                setSelection(next)
+                                if (next.kind !== 'rolling') {
+                                    setOpen(false)
+                                }
+                            }}
+                            exclusions={exclusions}
+                            onExclusionsChange={setExclusions}
+                        />
+                    </PopoverContent>
+                </Popover>
+            </div>
+        )
+    },
+}
+
+export const StandaloneInput: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<RelativeRangeValue>({
+            count: 30,
+            unit: 'days',
+        })
+        return (
+            <div className="flex items-center gap-2">
+                <Text size="sm" weight="semibold" render={<span />}>
+                    Last
+                </Text>
+                <RelativeRangeInput value={value} onChange={setValue} />
+            </div>
+        )
+    },
+}

--- a/packages/quill/packages/components/src/date-range-composer.tsx
+++ b/packages/quill/packages/components/src/date-range-composer.tsx
@@ -1,0 +1,313 @@
+import {
+    endOfMonth,
+    format,
+    startOfDay,
+    startOfMonth,
+    startOfYear,
+    subDays,
+    subHours,
+    subMonths,
+    subWeeks,
+    subYears,
+} from 'date-fns'
+import * as React from 'react'
+
+import { Button, Separator, Switch, Text, ToggleGroup, ToggleGroupItem } from '@posthog/quill-primitives'
+
+import { DateTimePicker, type DateTimeValue } from './date-time-picker'
+import { CUSTOM_RANGE } from './date-time-ranges'
+import { RelativeRangeInput, type RelativeRangeUnit, type RelativeRangeValue } from './relative-range-input'
+
+/** CONCEPT — date filter redesign exploration ("the composer"), not a stable API.
+ * Rolling shortcuts and fixed presets as chips, `RelativeRangeInput` as the generalization,
+ * with a custom-range calendar and an exclusions drawer behind footer links.
+ * Lives here (rather than in the stories) so the app storybook can render it next to the
+ * Lemon-skin twin. Chip vocabulary is overridable via props; hosts map selections to their
+ * own range model. */
+
+export type DateRangeComposerSelection =
+    | { kind: 'rolling'; count: number; unit: RelativeRangeUnit }
+    | { kind: 'fixed'; name: string }
+    | { kind: 'custom'; start: Date; end: Date }
+
+export interface DateRangeComposerExclusions {
+    days: string[]
+    incomplete: boolean
+}
+
+// Rolling shortcuts sorted by duration, counts ranked by production click share.
+const DEFAULT_ROLLING_CHIPS: { count: number; unit: RelativeRangeUnit }[] = [
+    { count: 1, unit: 'hours' },
+    { count: 24, unit: 'hours' },
+    { count: 7, unit: 'days' },
+    { count: 14, unit: 'days' },
+    { count: 30, unit: 'days' },
+    { count: 90, unit: 'days' },
+    { count: 180, unit: 'days' },
+    { count: 12, unit: 'months' },
+]
+const DEFAULT_FIXED_CHIPS = ['Today', 'Yesterday', 'This month', 'Last month', 'Year to date', 'All time']
+
+export function composerSelectionLabel(selection: DateRangeComposerSelection): string {
+    if (selection.kind === 'rolling') {
+        const unit = selection.count === 1 ? selection.unit.slice(0, -1) : selection.unit
+        return `Last ${selection.count} ${unit}`
+    }
+    if (selection.kind === 'fixed') {
+        return selection.name
+    }
+    return `${format(selection.start, 'MMM d')} – ${format(selection.end, 'MMM d')}`
+}
+
+export function composerExclusionsSummary({ days, incomplete }: DateRangeComposerExclusions): string {
+    const parts: string[] = []
+    if (days.length > 0) {
+        const sorted = [...days].sort().join(',')
+        parts.push(sorted === '6,7' ? 'weekends' : sorted === '1,2,3,4,5' ? 'weekdays' : `${days.length} days`)
+    }
+    if (incomplete) {
+        parts.push('incomplete')
+    }
+    return parts.length > 0 ? `Excluding ${parts.join(', ')}` : ''
+}
+
+function rollingStart(count: number, unit: RelativeRangeUnit, now: Date): Date {
+    switch (unit) {
+        case 'minutes':
+            return new Date(now.getTime() - count * 60_000)
+        case 'hours':
+            return subHours(now, count)
+        case 'days':
+            return subDays(now, count)
+        case 'weeks':
+            return subWeeks(now, count)
+        case 'months':
+            return subMonths(now, count)
+        case 'years':
+            return subYears(now, count)
+    }
+}
+
+function fixedRange(name: string, now: Date): { start: Date; end: Date } {
+    switch (name) {
+        case 'Today':
+            return { start: startOfDay(now), end: now }
+        case 'Yesterday':
+            return { start: startOfDay(subDays(now, 1)), end: startOfDay(now) }
+        case 'This month':
+            return { start: startOfMonth(now), end: now }
+        case 'Last month':
+            return { start: startOfMonth(subMonths(now, 1)), end: endOfMonth(subMonths(now, 1)) }
+        case 'Year to date':
+            return { start: startOfYear(now), end: now }
+        default:
+            return { start: subYears(now, 10), end: now }
+    }
+}
+
+function ExclusionsDrawer({
+    exclusions,
+    onChange,
+}: {
+    exclusions: DateRangeComposerExclusions
+    onChange: (exclusions: DateRangeComposerExclusions) => void
+}): React.ReactElement {
+    const labels: Record<string, string> = {
+        1: 'M',
+        2: 'T',
+        3: 'W',
+        4: 'T',
+        5: 'F',
+        6: 'S',
+        7: 'S',
+    }
+    return (
+        <div className="flex flex-col gap-2 border-t border-border bg-foreground/[0.03] px-3 py-2.5">
+            <div className="flex items-center justify-between gap-2">
+                <Text size="xs" className="whitespace-nowrap" render={<label htmlFor="composer-exclude-incomplete" />}>
+                    Skip incomplete period
+                </Text>
+                <Switch
+                    id="composer-exclude-incomplete"
+                    size="sm"
+                    checked={exclusions.incomplete}
+                    onCheckedChange={(incomplete) => onChange({ ...exclusions, incomplete })}
+                />
+            </div>
+            <div className="flex items-center justify-between gap-2">
+                <Text size="xs" className="whitespace-nowrap" render={<span />}>
+                    Exclude days
+                </Text>
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="link-muted"
+                        size="xs"
+                        onClick={() => onChange({ ...exclusions, days: ['6', '7'] })}
+                    >
+                        Weekends
+                    </Button>
+                    <Button
+                        variant="link-muted"
+                        size="xs"
+                        onClick={() => onChange({ ...exclusions, days: ['1', '2', '3', '4', '5'] })}
+                    >
+                        Weekdays
+                    </Button>
+                    <Button variant="link-muted" size="xs" onClick={() => onChange({ ...exclusions, days: [] })}>
+                        Clear
+                    </Button>
+                </div>
+            </div>
+            <ToggleGroup
+                multiple
+                size="sm"
+                spacing={1}
+                className="w-full"
+                value={exclusions.days}
+                onValueChange={(days) => onChange({ ...exclusions, days })}
+            >
+                {Object.keys(labels).map((day) => (
+                    <ToggleGroupItem
+                        key={day}
+                        value={day}
+                        className="flex-1 data-[pressed]:border-primary data-[pressed]:bg-primary/10 data-[pressed]:text-primary"
+                        aria-label={`Exclude day ${day}`}
+                    >
+                        {labels[day]}
+                    </ToggleGroupItem>
+                ))}
+            </ToggleGroup>
+        </div>
+    )
+}
+
+const CHIP_CLASSES =
+    'border-border bg-transparent aria-selected:border-primary aria-selected:bg-primary/10 aria-selected:font-semibold aria-selected:text-primary'
+
+export interface DateRangeComposerProps {
+    selection: DateRangeComposerSelection
+    onSelect: (selection: DateRangeComposerSelection) => void
+    exclusions: DateRangeComposerExclusions
+    onExclusionsChange: (exclusions: DateRangeComposerExclusions) => void
+    rollingChips?: { count: number; unit: RelativeRangeUnit }[]
+    fixedChips?: string[]
+}
+
+export function DateRangeComposer({
+    selection,
+    onSelect,
+    exclusions,
+    onExclusionsChange,
+    rollingChips = DEFAULT_ROLLING_CHIPS,
+    fixedChips = DEFAULT_FIXED_CHIPS,
+}: DateRangeComposerProps): React.ReactElement {
+    const [calendarOpen, setCalendarOpen] = React.useState(false)
+    const [excludeOpen, setExcludeOpen] = React.useState(false)
+    const rolling: RelativeRangeValue =
+        selection.kind === 'rolling' ? { count: selection.count, unit: selection.unit } : { count: 7, unit: 'days' }
+    const summary = composerExclusionsSummary(exclusions)
+    const now = new Date()
+
+    const calendarValue: DateTimeValue =
+        selection.kind === 'custom'
+            ? {
+                  start: selection.start,
+                  end: selection.end,
+                  range: CUSTOM_RANGE,
+              }
+            : selection.kind === 'rolling'
+              ? {
+                    start: rollingStart(selection.count, selection.unit, now),
+                    end: now,
+                    range: CUSTOM_RANGE,
+                }
+              : { ...fixedRange(selection.name, now), range: CUSTOM_RANGE }
+
+    return (
+        <div className="w-72 overflow-hidden rounded-lg bg-card text-foreground shadow-md ring-1 ring-foreground/10">
+            <div className="flex flex-col">
+                <div className="flex flex-wrap gap-1 px-3 pt-3 pb-2">
+                    {rollingChips.map(({ count, unit }) => (
+                        <Button
+                            key={`${count}-${unit}`}
+                            variant="outline"
+                            size="sm"
+                            className={CHIP_CLASSES}
+                            aria-selected={
+                                selection.kind === 'rolling' && selection.count === count && selection.unit === unit
+                            }
+                            onClick={() => onSelect({ kind: 'rolling', count, unit })}
+                            data-attr={`date-composer-rolling-${count}-${unit}`}
+                        >
+                            {count} {unit.slice(0, 1)}
+                        </Button>
+                    ))}
+                </div>
+                <Separator />
+                <div className="flex items-center gap-2 px-3 py-2">
+                    <Text size="sm" weight="semibold" render={<span />}>
+                        Last
+                    </Text>
+                    <RelativeRangeInput
+                        value={rolling}
+                        onChange={({ count, unit }) => onSelect({ kind: 'rolling', count, unit })}
+                    />
+                </div>
+                <Separator />
+                <div className="flex flex-wrap gap-1 px-3 py-2">
+                    {fixedChips.map((name) => (
+                        <Button
+                            key={name}
+                            variant="outline"
+                            size="sm"
+                            className={CHIP_CLASSES}
+                            aria-selected={selection.kind === 'fixed' && selection.name === name}
+                            onClick={() => onSelect({ kind: 'fixed', name })}
+                            data-attr={`date-composer-fixed-${name.toLowerCase().replace(/\s+/g, '-')}`}
+                        >
+                            {name}
+                        </Button>
+                    ))}
+                </div>
+                <div className="mt-auto flex items-center justify-between border-t border-border px-3 py-1.5">
+                    <Button
+                        variant="link"
+                        size="xs"
+                        aria-expanded={calendarOpen}
+                        onClick={() => setCalendarOpen((prev) => !prev)}
+                        data-attr="date-composer-custom-range"
+                    >
+                        Custom range…
+                    </Button>
+                    <Button
+                        variant="link"
+                        size="xs"
+                        aria-expanded={excludeOpen}
+                        onClick={() => setExcludeOpen((prev) => !prev)}
+                        data-attr="date-composer-exclusions"
+                    >
+                        {summary || '+ Exclude'}
+                    </Button>
+                </div>
+                {excludeOpen && <ExclusionsDrawer exclusions={exclusions} onChange={onExclusionsChange} />}
+                {calendarOpen && (
+                    <div className="border-t border-border">
+                        <DateTimePicker
+                            compact
+                            showHeader={false}
+                            showTime={false}
+                            ranges={[]}
+                            value={calendarValue}
+                            onApply={({ start, end }) => {
+                                onSelect({ kind: 'custom', start, end })
+                                setCalendarOpen(false)
+                            }}
+                            onCancel={() => setCalendarOpen(false)}
+                            className="w-full rounded-none shadow-none ring-0"
+                        />
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/packages/quill/packages/components/src/index.ts
+++ b/packages/quill/packages/components/src/index.ts
@@ -13,6 +13,21 @@ export { DateTimePicker, type DateTimePickerProps, type DateTimeValue, type Date
 export { DatePicker, type DatePickerProps } from './date-picker'
 export { quickRanges, CUSTOM_RANGE, type DateTimeRange, type DateTimeRangeName } from './date-time-ranges'
 export { useCalendar, Day, Month, type UseCalendarOptions, type UseCalendarReturn } from './use-calendar'
+export {
+    RelativeRangeInput,
+    type RelativeRangeInputProps,
+    type RelativeRangeUnit,
+    type RelativeRangeValue,
+} from './relative-range-input'
+// CONCEPT — date filter redesign exploration, not a stable API (see date-range-composer.tsx).
+export {
+    DateRangeComposer,
+    composerExclusionsSummary,
+    composerSelectionLabel,
+    type DateRangeComposerExclusions,
+    type DateRangeComposerProps,
+    type DateRangeComposerSelection,
+} from './date-range-composer'
 // `Metric` is intentionally NOT re-exported here: it pulls `@posthog/quill-charts` (d3), and this
 // barrel is inlined into the always-eager `@posthog/quill` bundle. Import it from its own entry —
 // `@posthog/quill-components/metric` — so charts only loads where a metric tile is actually used.

--- a/packages/quill/packages/components/src/relative-range-input.tsx
+++ b/packages/quill/packages/components/src/relative-range-input.tsx
@@ -1,0 +1,105 @@
+import { Minus, Plus } from 'lucide-react'
+import * as React from 'react'
+
+import {
+    InputGroup,
+    InputGroupAddon,
+    InputGroupButton,
+    InputGroupNumberInput,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    cn,
+} from '@posthog/quill-primitives'
+
+export type RelativeRangeUnit = 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'years'
+
+export interface RelativeRangeValue {
+    count: number
+    unit: RelativeRangeUnit
+}
+
+export interface RelativeRangeInputProps {
+    value: RelativeRangeValue
+    onChange: (value: RelativeRangeValue) => void
+    /** Units offered in the dropdown. Defaults to hours through months. */
+    units?: RelativeRangeUnit[]
+    min?: number
+    max?: number
+    className?: string
+}
+
+const DEFAULT_UNITS: RelativeRangeUnit[] = ['hours', 'days', 'weeks', 'months']
+
+function unitLabel(unit: RelativeRangeUnit, count: number): string {
+    return count === 1 ? unit.slice(0, -1) : unit
+}
+
+/** A "N units" duration control: stepper + unit dropdown. The host provides surrounding
+ * words ("Last …") and maps the value to its own range vocabulary. */
+export function RelativeRangeInput({
+    value,
+    onChange,
+    units = DEFAULT_UNITS,
+    min = 1,
+    max = 999,
+    className,
+}: RelativeRangeInputProps): React.ReactElement {
+    const clamp = (n: number): number => Math.min(max, Math.max(min, n))
+    const setCount = (count: number | null): void => {
+        if (count !== null && !Number.isNaN(count)) {
+            onChange({ ...value, count: clamp(count) })
+        }
+    }
+
+    return (
+        <div className={cn('flex items-center gap-2', className)}>
+            <InputGroup className="w-24">
+                <InputGroupAddon align="inline-start">
+                    <InputGroupButton
+                        size="icon-xs"
+                        aria-label="Decrease"
+                        disabled={value.count <= min}
+                        onClick={() => setCount(value.count - 1)}
+                    >
+                        <Minus />
+                    </InputGroupButton>
+                </InputGroupAddon>
+                <InputGroupNumberInput
+                    aria-label="Count"
+                    value={value.count}
+                    min={min}
+                    max={max}
+                    onValueChange={setCount}
+                />
+                <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                        size="icon-xs"
+                        aria-label="Increase"
+                        disabled={value.count >= max}
+                        onClick={() => setCount(value.count + 1)}
+                    >
+                        <Plus />
+                    </InputGroupButton>
+                </InputGroupAddon>
+            </InputGroup>
+            <Select
+                value={value.unit}
+                onValueChange={(unit) => onChange({ ...value, unit: unit as RelativeRangeUnit })}
+            >
+                <SelectTrigger size="sm" className="w-auto gap-1" aria-label="Unit">
+                    <SelectValue>{(unit: RelativeRangeUnit) => unitLabel(unit, value.count)}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                    {units.map((unit) => (
+                        <SelectItem key={unit} value={unit}>
+                            {unitLabel(unit, value.count)}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    )
+}


### PR DESCRIPTION
## Problem

The insight date filter is moving to quill's presets-first `DateTimePicker` (#70304 adds the picker mode, #68359 swaps it in behind the `product-analytics-quill-date-filter` flag). Two design questions remained open, and this PR is the exploration surface for both:

1. **Skin or no skin?** The migration strategy said: restyle quill to Lemon's visual language (a "lemon skin") so the swap is visually invisible, then flip to quill's native look app-wide later. The skin prototype existed on an archived branch and needed porting onto the new filter architecture to be judged.
2. **Is presets-first even the right shape?** A competing concept for the filter panel: quick chips + a "Last N units" stepper + named presets, with the calendar embedded for custom ranges.

## Changes

Stacked on #68359. Everything here is exploratory and flag/storybook-scoped; nothing ships to users.

- **`lemon-skin.scss` port** (910 lines): restyles quill primitives to Lemon's language under a `data-lemon-skin` opt-in attribute, unlayered so it wins over quill's `@layer components` rules. Ported from the pre-restack prototype; the date-filter rules now also cover the picker's new "Custom range…" row.
- **`RelativeRangeInput`** (quill components): a vocabulary-free "N units" duration control (count stepper + unit select). Stable enough to keep regardless of the composer's fate.
- **`DateRangeComposer`** (quill components, exported with a CONCEPT marker): the chips + stepper + presets panel, with embedded calendar and exclusions row. Kept as a component so the app storybook can render it beside its Lemon-skinned twin.
- **Comparison stories** in the app storybook (which loads the full Lemon token sheet the skin needs, unlike quill's own storybook):
  - `Components/Date Range Filter` – the real presets-first filter shape, lemon-skinned vs quill-native
  - `Components/DateRangeComposer` – the composer concept, same comparison

### Where we got to

Side-by-side verdict so far: the skin works for 1:1 control swaps (trigger button, calendar), but it turns dense chip grids clunky. Lemon's raised 3D button chrome repeated across ~16 chips drowns the selection state and flattens hierarchy; quill's flat chips read better. Working hypothesis: skin the surfaces that replace existing Lemon controls, let genuinely new patterns (like the composer) ship quill-native.

## How did you test this code?

- Viewed both story sets in the app storybook, light and dark, and exercised the filter and composer interactions manually.
- Existing automated coverage on the stack: 7 picker tests (quill), 2 `DateRangeFilter` wrapper tests. This PR adds stories and a concept component, no behavior change to shipped code paths, so no new tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`packages/quill/packages/components/AGENTS.md` documents `RelativeRangeInput` and marks `DateRangeComposer` as an unstable concept.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored in a PostHog Code session directed by Sam. The lemon skin was ported from the archived pre-restack branch after the filter architecture settled; the composer concept and `RelativeRangeInput` came out of Sam's design iteration in storybook.
- Skills invoked: /writing-tests (earlier in the stack; no new tests here).
- Decisions: comparison stories live in the app storybook because the skin depends on ~45 Lemon app tokens that quill's isolated storybook doesn't load, and stubbing them would fork the token sheet. The exclusions panel on the stack was also reworked to a portaled nested Popover after the skin review surfaced it being clipped by the popover's overflow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
