### PR TITLE
feat(subscriptions): attribute insight query type on subscription analytics events

### DIFF
--- a/posthog/models/test/test_subscription_model.py
+++ b/posthog/models/test/test_subscription_model.py
@@ -101,6 +101,25 @@ class TestSubscription(BaseTest):
         with self.assertRaises(ValueError):
             _ = subscription.resource_type
 
+    def test_analytics_metadata_includes_insight_query_kind(self):
+        insight = Insight.objects.create(
+            team=self.team,
+            query={"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}},
+        )
+        metadata = self._create_subscription(insight=insight).get_analytics_metadata()
+
+        assert metadata["query_kind"] == "InsightVizNode"
+        assert metadata["query_source_kind"] == "TrendsQuery"
+
+    def test_analytics_metadata_omits_query_kind_for_non_insight_subscription(self):
+        # Query-kind attribution is insight-only; dashboard/prompt subs must not carry stale keys.
+        metadata = self._create_subscription(
+            dashboard=Dashboard.objects.create(team=self.team)
+        ).get_analytics_metadata()
+
+        assert "query_kind" not in metadata
+        assert "query_source_kind" not in metadata
+
     @parameterized.expand(
         [
             ("insight", 1, None, None, Subscription.ResourceType.INSIGHT),

--- a/products/exports/backend/models/subscription.py
+++ b/products/exports/backend/models/subscription.py
@@ -467,7 +467,7 @@ class Subscription(ModelActivityMixin, models.Model):
         """
         Returns serialized information about the object for analytics reporting.
         """
-        return {
+        metadata: dict[str, Any] = {
             "id": self.id,
             "resource_type": self.resource_type,
             "target_type": self.target_type,
@@ -479,6 +479,12 @@ class Subscription(ModelActivityMixin, models.Model):
             "prompt_length": len(self.prompt or ""),
             "ai_window_mode": self.ai_window_mode if self.resource_type == self.ResourceType.AI_PROMPT else None,
         }
+        # For insight subscriptions, attribute the subscribed insight's query type (e.g. TrendsQuery,
+        # FunnelsQuery) using the same keys as the "insight created/updated" events, so subscriptions
+        # can be sliced by which kinds of insights people subscribe to.
+        if self.resource_type == self.ResourceType.INSIGHT and self.insight:
+            metadata.update(self.insight.get_analytics_query_kinds())
+        return metadata
 
 
 @receiver(post_save, sender=Subscription, dispatch_uid="hook-subscription-saved")


### PR DESCRIPTION
## Problem

Insight subscription analytics events (`insight subscription created` / `insight subscription updated`) captured the resource type, delivery target, and schedule — but nothing about the insight itself. That means we can't answer a basic product question: **which kinds of insights (trends, funnels, retention, paths, …) do people actually subscribe to?** The only insight reference on the event was the short_id buried in `$current_url`, and the insight itself lives in each customer's own project, so there was no way to slice subscriptions by insight type.

## Changes

Enrich `Subscription.get_analytics_metadata()` so that for **insight** subscriptions it includes the subscribed insight's query type via the existing `Insight.get_analytics_query_kinds()` helper — adding `query_kind` (e.g. `InsightVizNode`) and `query_source_kind` (e.g. `TrendsQuery`, `FunnelsQuery`, `RetentionQuery`).

These are the same keys the `insight created` / `insight updated` events already emit, so subscription events become sliceable by insight type using a consistent taxonomy. Dashboard and AI-prompt subscriptions are unaffected (the keys are only added when a real insight is attached). No new events, no schema/migration changes — this only adds properties to an existing analytics event.

## How did you test this code?

Added two focused unit tests to `posthog/models/test/test_subscription_model.py`:
- `test_analytics_metadata_includes_insight_query_kind` — an insight subscription whose insight has a `TrendsQuery` emits `query_kind`/`query_source_kind`. Catches a regression where insight-type attribution is dropped or wired to the wrong keys.
- `test_analytics_metadata_omits_query_kind_for_non_insight_subscription` — a dashboard subscription does **not** carry those keys, guarding the insight-only gating.

Note: this environment has no dev stack (no `hogli`/`pytest`), so I could not execute the suite locally — please rely on CI. The change mirrors the already-tested `insight created`/`insight updated` attribution pattern.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with the PostHog Slack app, following a thread investigating June's subscription growth. The question "what type of insights are users subscribing to?" turned out to be unanswerable from current instrumentation — this closes that gap. Chose to reuse `Insight.get_analytics_query_kinds()` and its exact key names (rather than invent new ones) so subscription events share the insight taxonomy and existing dashboards/queries keep working. Scoped to insight subs to keep the surface minimal; dashboard tile-type attribution could be a follow-up. Skill invoked: `/writing-tests` (to gate the added tests).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1783526285712029?thread_ts=1783526285.712029&cid=C09BDQLM8KA)*
