### PR TITLE
feat(logs): push consumer lag, producer queue, and process metrics to posthog

### DIFF
--- a/nodejs/src/common/kafka/consumer/consumer-v1.ts
+++ b/nodejs/src/common/kafka/consumer/consumer-v1.ts
@@ -46,6 +46,7 @@ import {
     consumerBatchSizeKb as histogramKafkaBatchSizeKb,
     kafkaConsumerAssignment,
 } from './metrics'
+import { recordBatchConsumed, recordConsumedBatchBackpressure, recordConsumedBatchDuration } from './otel-metrics'
 
 const DEFAULT_BATCH_TIMEOUT_MS = 500
 const SLOW_BATCH_PROCESSING_LOG_THRESHOLD_MS = 10000
@@ -675,6 +676,7 @@ export class KafkaConsumer {
                     histogramKafkaBatchSizeKb.observe(
                         messages.reduce((acc, m) => (m.value?.length ?? 0) + acc, 0) / 1024
                     )
+                    recordBatchConsumed(topic, groupId, messages, Date.now())
 
                     if (!messages.length && !callEachBatchWhenEmpty) {
                         logger.debug('🔁', 'main_loop_empty_batch', { cause: 'empty' })
@@ -686,6 +688,7 @@ export class KafkaConsumer {
 
                     const processingTimeMs = new Date().valueOf() - startProcessingTimeMs
                     consumedBatchDuration.labels({ topic, groupId }).observe(processingTimeMs)
+                    recordConsumedBatchDuration(processingTimeMs, topic, groupId)
 
                     const logSummary = `Processed ${messages.length} events in ${
                         Math.round(processingTimeMs / 10) / 100
@@ -758,12 +761,14 @@ export class KafkaConsumer {
                             topic: this.config.topic,
                             groupId: this.config.groupId,
                         })
+                        const backpressureStartMs = Date.now()
                         // If we have more than the max, we need to await one
                         await instrumentFn(
                             { key: 'consumer_backpressure_wait', timeoutMs: 30_000, sendException: false },
                             () => this.backgroundTask[0].promise
                         )
                         stopTimer()
+                        recordConsumedBatchBackpressure(Date.now() - backpressureStartMs, topic, groupId)
                     }
                 }
 

--- a/nodejs/src/common/kafka/consumer/consumer-v2.ts
+++ b/nodejs/src/common/kafka/consumer/consumer-v2.ts
@@ -34,6 +34,7 @@ import {
     consumerStaleStoreOffsetsSkipped,
     kafkaConsumerAssignment,
 } from './metrics'
+import { recordBatchConsumed, recordConsumedBatchBackpressure, recordConsumedBatchDuration } from './otel-metrics'
 
 const DEFAULT_BATCH_TIMEOUT_MS = 500
 const STATISTICS_INTERVAL_MS = 5000
@@ -285,6 +286,7 @@ export class KafkaConsumerV2 {
         consumerBatchSize.observe(messages.length)
         consumerBatchSizeKb.observe(messages.reduce((acc, m) => (m.value?.length ?? 0) + acc, 0) / 1024)
         consumerBatchUtilization.labels({ groupId: this.config.groupId }).set(messages.length / this.fetchBatchSize)
+        recordBatchConsumed(this.config.topic, this.config.groupId, messages, Date.now())
 
         if (messages.length === 0 && !this.config.callEachBatchWhenEmpty) {
             return
@@ -300,7 +302,9 @@ export class KafkaConsumerV2 {
         // crash the process. At-least-once is preserved (uncommitted offsets get re-read
         // on restart) and any logic bug surfaces loudly rather than silently dropping.
         const result: EachBatchResult = await eachBatch(messages)
-        consumedBatchDuration.labels(this.config.topic, this.config.groupId).observe(Date.now() - startMs)
+        const batchDurationMs = Date.now() - startMs
+        consumedBatchDuration.labels(this.config.topic, this.config.groupId).observe(batchDurationMs)
+        recordConsumedBatchDuration(batchDurationMs, this.config.topic, this.config.groupId)
 
         // We always track. If a REVOKE arrived while eachBatch ran, the generation tag in
         // trackTask makes the storeOffsets a no-op, but inFlight still holds the entry so
@@ -376,12 +380,14 @@ export class KafkaConsumerV2 {
             topic: this.config.topic,
             groupId: this.config.groupId,
         })
+        const backpressureStartMs = Date.now()
         try {
             // Wait for the OLDEST task's settled chain. Using settled (not raw) means we don't
             // release backpressure until storeOffsets has been attempted.
             await this.inFlight[0].settled
         } finally {
             stop()
+            recordConsumedBatchBackpressure(Date.now() - backpressureStartMs, this.config.topic, this.config.groupId)
         }
     }
 

--- a/nodejs/src/common/kafka/consumer/metrics.ts
+++ b/nodejs/src/common/kafka/consumer/metrics.ts
@@ -15,6 +15,13 @@ export const kafkaConsumerAssignment = new Gauge({
     labelNames: ['topic_name', 'partition_id', 'pod', 'group_id'],
 })
 
+export const kafkaConsumerMessageAgeSeconds = new Histogram({
+    name: 'kafka_consumer_message_age_seconds',
+    help: 'Age of the oldest message in each consumed batch — consumer lag in seconds',
+    labelNames: ['topic', 'groupId'],
+    buckets: [1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600, Infinity],
+})
+
 export const consumedBatchDuration = new Histogram({
     name: 'consumed_batch_duration_ms',
     help: 'Main loop consumer batch processing duration in ms',

--- a/nodejs/src/common/kafka/consumer/otel-metrics.test.ts
+++ b/nodejs/src/common/kafka/consumer/otel-metrics.test.ts
@@ -1,0 +1,139 @@
+import { metrics as metricsApi } from '@opentelemetry/api'
+import {
+    type DataPoint,
+    type Histogram as HistogramDataPointValue,
+    InMemoryMetricExporter,
+    MeterProvider,
+    PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics'
+
+import { kafkaConsumerMessageAgeSeconds } from './metrics'
+import {
+    recordBatchConsumed,
+    recordConsumedBatchBackpressure,
+    recordConsumedBatchDuration,
+    resetConsumerOtelInstrumentsForTests,
+} from './otel-metrics'
+
+describe('consumer otel-metrics', () => {
+    let exporter: InMemoryMetricExporter
+    let provider: MeterProvider
+    let reader: PeriodicExportingMetricReader
+
+    beforeEach(() => {
+        // Simulate the real startup-order hazard: a record call may run before a
+        // provider exists (bound to the noop meter), with the provider registered
+        // afterwards. Lazily acquired instruments must still deliver data recorded
+        // after registration.
+        resetConsumerOtelInstrumentsForTests()
+        recordConsumedBatchDuration(1, 'warmup', 'warmup')
+
+        exporter = new InMemoryMetricExporter(0)
+        reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 60_000 })
+        provider = new MeterProvider({ readers: [reader] })
+        metricsApi.setGlobalMeterProvider(provider)
+        resetConsumerOtelInstrumentsForTests()
+        kafkaConsumerMessageAgeSeconds.reset()
+    })
+
+    afterEach(async () => {
+        await provider.shutdown()
+        metricsApi.disable()
+    })
+
+    const dataPointsFor = (name: string): readonly DataPoint<HistogramDataPointValue>[] =>
+        exporter
+            .getMetrics()
+            .flatMap((rm) => rm.scopeMetrics)
+            .flatMap((sm) => sm.metrics)
+            .filter((m) => m.descriptor.name === name)
+            .flatMap((m) => m.dataPoints as unknown as readonly DataPoint<HistogramDataPointValue>[])
+
+    it('records the age of the OLDEST message in seconds, to both the OTel and prom sinks', async () => {
+        const nowMs = 1_700_000_060_000
+        // Oldest message is 60s old; a ms/seconds mix-up or an oldest/newest flip changes the value.
+        recordBatchConsumed(
+            'clickhouse_logs',
+            'group-1',
+            [{ timestamp: nowMs - 60_000 }, { timestamp: nowMs - 5_000 }],
+            nowMs
+        )
+
+        await reader.forceFlush()
+
+        const points = dataPointsFor('kafka_consumer_message_age_seconds')
+        expect(points).toHaveLength(1)
+        expect(points[0].attributes).toEqual({ topic: 'clickhouse_logs', groupId: 'group-1' })
+        expect(points[0].value.count).toEqual(1)
+        expect(points[0].value.sum).toBeCloseTo(60)
+
+        const promSnapshot = await kafkaConsumerMessageAgeSeconds.get()
+        const promSum = promSnapshot.values.find(
+            (v) =>
+                v.metricName === 'kafka_consumer_message_age_seconds_sum' &&
+                v.labels.topic === 'clickhouse_logs' &&
+                v.labels.groupId === 'group-1'
+        )
+        expect(promSum?.value).toBeCloseTo(60)
+    })
+
+    it('clamps clock skew to zero and still records batch size for empty or untimestamped batches', async () => {
+        const nowMs = 1_700_000_060_000
+        recordBatchConsumed('t', 'g', [{ timestamp: nowMs + 30_000 }], nowMs) // producer clock ahead
+        recordBatchConsumed('t', 'g', [{}, {}], nowMs) // no timestamps
+        recordBatchConsumed('t', 'g', [], nowMs) // empty poll
+
+        await reader.forceFlush()
+
+        const agePoints = dataPointsFor('kafka_consumer_message_age_seconds')
+        expect(agePoints).toHaveLength(1)
+        expect(agePoints[0].value.count).toEqual(1)
+        expect(agePoints[0].value.sum).toEqual(0)
+
+        const sizePoints = dataPointsFor('consumer_batch_size')
+        expect(sizePoints).toHaveLength(1)
+        expect(sizePoints[0].attributes).toEqual({})
+        expect(sizePoints[0].value.count).toEqual(3)
+        expect(sizePoints[0].value.sum).toEqual(3)
+    })
+
+    it.each([
+        ['recordConsumedBatchDuration', 'consumed_batch_duration_ms', () => recordConsumedBatchDuration(250, 't', 'g')],
+        [
+            'recordConsumedBatchBackpressure',
+            'consumed_batch_backpressure_duration_ms',
+            () => recordConsumedBatchBackpressure(250, 't', 'g'),
+        ],
+    ] as const)('%s emits %s with prom label parity', async (_name, metricName, record) => {
+        record()
+
+        await reader.forceFlush()
+
+        const points = dataPointsFor(metricName)
+        expect(points).toHaveLength(1)
+        expect(points[0].attributes).toEqual({ topic: 't', groupId: 'g' })
+        expect(points[0].value.count).toEqual(1)
+        expect(points[0].value.sum).toEqual(250)
+    })
+
+    it.each([
+        ['recordBatchConsumed', () => recordBatchConsumed('t', 'g', [{ timestamp: 1 }], 2)],
+        ['recordConsumedBatchDuration', () => recordConsumedBatchDuration(1, 't', 'g')],
+        ['recordConsumedBatchBackpressure', () => recordConsumedBatchBackpressure(1, 't', 'g')],
+    ] as const)('%s swallows a throwing OTel SDK so the consumer loop never dies on telemetry', (_name, record) => {
+        const throwing = () => {
+            throw new Error('otel exploded')
+        }
+        metricsApi.disable() // the API ignores a second setGlobalMeterProvider without this
+        metricsApi.setGlobalMeterProvider({
+            getMeter: () =>
+                ({
+                    createCounter: () => ({ add: throwing }),
+                    createHistogram: () => ({ record: throwing }),
+                }) as any,
+        } as any)
+        resetConsumerOtelInstrumentsForTests()
+
+        expect(record).not.toThrow()
+    })
+})

--- a/nodejs/src/common/kafka/consumer/otel-metrics.ts
+++ b/nodejs/src/common/kafka/consumer/otel-metrics.ts
@@ -1,0 +1,109 @@
+import { Histogram, Meter, MetricOptions, metrics as metricsApi } from '@opentelemetry/api'
+
+import { histogramWithExemplars } from '~/common/metrics/exemplars'
+import { swallowing } from '~/common/metrics/swallow'
+
+import { kafkaConsumerMessageAgeSeconds } from './metrics'
+
+/**
+ * OTLP-pushed twins of the consumer-loop prom metrics, plus the message-age (lag
+ * in seconds) recorder that feeds both sinks. The prom side keeps feeding the
+ * scrape/VictoriaMetrics dashboards; these land in the PostHog metrics product
+ * through the exporter installed by initMetrics (common/metrics/otel-metrics.ts).
+ *
+ * Names and label sets deliberately match the prom metrics so dashboards translate 1:1.
+ *
+ * Instruments are acquired lazily on first record: the OTel metrics API has no proxy
+ * provider, so instruments created at module load (before initMetrics runs) would be
+ * bound to the noop meter forever.
+ */
+
+interface ConsumerInstruments {
+    messageAge: Histogram
+    batchSize: Histogram
+    batchDuration: Histogram
+    batchBackpressureDuration: Histogram
+}
+
+/** Keep in lockstep with the kafka_consumer_message_age_seconds prom buckets. */
+export const MESSAGE_AGE_SECONDS_BOUNDARIES = [1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600]
+/** Keep in lockstep with the consumer_batch_size prom buckets. */
+const BATCH_SIZE_BOUNDARIES = [0, 50, 100, 250, 500, 750, 1000, 1500, 2000, 3000]
+const BATCH_DURATION_MS_BOUNDARIES = [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000]
+
+let instruments: ConsumerInstruments | null = null
+
+const createHistogram = (meter: Meter, name: string, options?: MetricOptions): Histogram =>
+    histogramWithExemplars(name, meter.createHistogram(name, options))
+
+function getInstruments(): ConsumerInstruments {
+    if (instruments === null) {
+        const meter = metricsApi.getMeter('kafka-consumer')
+        instruments = {
+            messageAge: createHistogram(meter, 'kafka_consumer_message_age_seconds', {
+                description: 'Age of the oldest message in each consumed batch — consumer lag in seconds',
+                unit: 's',
+                advice: { explicitBucketBoundaries: MESSAGE_AGE_SECONDS_BOUNDARIES },
+            }),
+            batchSize: createHistogram(meter, 'consumer_batch_size', {
+                description: 'The size of the batches we are receiving from Kafka',
+                advice: { explicitBucketBoundaries: BATCH_SIZE_BOUNDARIES },
+            }),
+            batchDuration: createHistogram(meter, 'consumed_batch_duration_ms', {
+                description: 'Main loop consumer batch processing duration in ms',
+                unit: 'ms',
+                advice: { explicitBucketBoundaries: BATCH_DURATION_MS_BOUNDARIES },
+            }),
+            batchBackpressureDuration: createHistogram(meter, 'consumed_batch_backpressure_duration_ms', {
+                description: 'Time spent waiting for background work to finish due to backpressure',
+                unit: 'ms',
+                advice: { explicitBucketBoundaries: BATCH_DURATION_MS_BOUNDARIES },
+            }),
+        }
+    }
+    return instruments
+}
+
+/**
+ * Batch-level consume telemetry: batch size, and the age of the oldest message as the
+ * consumer's lag-in-seconds signal. Age goes to BOTH sinks (the prom histogram and the
+ * OTel twin); a batch with no broker timestamps records no age.
+ */
+export const recordBatchConsumed = swallowing(
+    (topic: string, groupId: string, messages: ReadonlyArray<{ timestamp?: number }>, nowMs: number): void => {
+        const { messageAge, batchSize } = getInstruments()
+        batchSize.record(messages.length)
+
+        let oldestTimestamp: number | undefined
+        for (const message of messages) {
+            if (
+                message.timestamp !== undefined &&
+                (oldestTimestamp === undefined || message.timestamp < oldestTimestamp)
+            ) {
+                oldestTimestamp = message.timestamp
+            }
+        }
+        if (oldestTimestamp === undefined) {
+            return
+        }
+        // Clamped: a producer clock slightly ahead of ours must not record negative age.
+        const ageSeconds = Math.max(0, (nowMs - oldestTimestamp) / 1000)
+        kafkaConsumerMessageAgeSeconds.labels(topic, groupId).observe(ageSeconds)
+        messageAge.record(ageSeconds, { topic, groupId })
+    }
+)
+
+export const recordConsumedBatchDuration = swallowing((durationMs: number, topic: string, groupId: string): void => {
+    getInstruments().batchDuration.record(durationMs, { topic, groupId })
+})
+
+export const recordConsumedBatchBackpressure = swallowing(
+    (durationMs: number, topic: string, groupId: string): void => {
+        getInstruments().batchBackpressureDuration.record(durationMs, { topic, groupId })
+    }
+)
+
+/** Test seam: forget cached instruments so a test-installed provider is picked up. */
+export function resetConsumerOtelInstrumentsForTests(): void {
+    instruments = null
+}

--- a/nodejs/src/common/kafka/kafka-producer-metrics.ts
+++ b/nodejs/src/common/kafka/kafka-producer-metrics.ts
@@ -3,6 +3,7 @@ import { Gauge } from 'prom-client'
 import { parseJSON } from '../utils/json-parse'
 import { logger } from '../utils/logger'
 import { producerStatsSchema } from './kafka-producer-stats-schema'
+import { recordProducerQueueStats } from './producer-otel-metrics'
 
 export const kafkaProducerQueueMessages = new Gauge({
     name: 'kafka_producer_queue_messages',
@@ -106,13 +107,20 @@ export class ProducerStatsTracker {
             kafkaProducerCallbackQueueDepth.set(labels, stats.replyq)
         }
 
+        let anyBrokersDown: boolean | undefined
         if (stats.brokers) {
             const brokers = Object.values(stats.brokers)
             if (brokers.length > 0) {
-                const anyDown = brokers.some((b) => b.state !== 'UP')
-                kafkaProducerAnyBrokersDown.set(labels, anyDown ? 1 : 0)
+                anyBrokersDown = brokers.some((b) => b.state !== 'UP')
+                kafkaProducerAnyBrokersDown.set(labels, anyBrokersDown ? 1 : 0)
             }
         }
+
+        recordProducerQueueStats(this.producerName, {
+            queueMessages: stats.msg_cnt,
+            queueBytes: stats.msg_size,
+            anyBrokersDown,
+        })
 
         if (stats.topics) {
             for (const [topic, topicStats] of Object.entries(stats.topics)) {

--- a/nodejs/src/common/kafka/producer-otel-metrics.test.ts
+++ b/nodejs/src/common/kafka/producer-otel-metrics.test.ts
@@ -1,0 +1,92 @@
+import { metrics as metricsApi } from '@opentelemetry/api'
+import {
+    type DataPoint,
+    InMemoryMetricExporter,
+    MeterProvider,
+    PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics'
+
+import { ProducerStatsTracker } from './kafka-producer-metrics'
+import { resetProducerOtelInstrumentsForTests } from './producer-otel-metrics'
+
+const makeStats = (overrides: Record<string, any> = {}): string =>
+    JSON.stringify({
+        msg_cnt: 10,
+        msg_size: 1024,
+        msg_max: 100_000,
+        msg_size_max: 1_073_741_824,
+        replyq: 0,
+        brokers: {},
+        topics: {},
+        ...overrides,
+    })
+
+describe('producer otel-metrics', () => {
+    let exporter: InMemoryMetricExporter
+    let provider: MeterProvider
+    let reader: PeriodicExportingMetricReader
+
+    beforeEach(() => {
+        exporter = new InMemoryMetricExporter(0)
+        reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 60_000 })
+        provider = new MeterProvider({ readers: [reader] })
+        metricsApi.setGlobalMeterProvider(provider)
+        resetProducerOtelInstrumentsForTests()
+    })
+
+    afterEach(async () => {
+        await provider.shutdown()
+        metricsApi.disable()
+    })
+
+    const dataPointsFor = (name: string): readonly DataPoint<number>[] =>
+        exporter
+            .getMetrics()
+            .flatMap((rm) => rm.scopeMetrics)
+            .flatMap((sm) => sm.metrics)
+            .filter((m) => m.descriptor.name === name)
+            .flatMap((m) => m.dataPoints as unknown as readonly DataPoint<number>[])
+
+    it('mirrors queue depth and broker health gauges from a tracked librdkafka stats payload', async () => {
+        const tracker = new ProducerStatsTracker('LOGS')
+
+        tracker.track(
+            makeStats({
+                msg_cnt: 42,
+                msg_size: 9000,
+                brokers: {
+                    'kafka-1:9092/1': { state: 'UP' },
+                    'kafka-2:9092/2': { state: 'DOWN' },
+                },
+            })
+        )
+
+        await reader.forceFlush()
+
+        const attributes = { producer_name: 'LOGS' }
+        const expectations: [string, number][] = [
+            ['kafka_producer_queue_messages', 42],
+            ['kafka_producer_queue_bytes', 9000],
+            ['kafka_producer_any_brokers_down', 1],
+        ]
+        for (const [name, value] of expectations) {
+            const points = dataPointsFor(name)
+            expect(points).toHaveLength(1)
+            expect(points[0].attributes).toEqual(attributes)
+            expect(points[0].value).toEqual(value)
+        }
+    })
+
+    it('swallows a throwing OTel SDK so stats callbacks never break the producer', () => {
+        const throwing = () => {
+            throw new Error('otel exploded')
+        }
+        metricsApi.disable() // the API ignores a second setGlobalMeterProvider without this
+        metricsApi.setGlobalMeterProvider({
+            getMeter: () => ({ createGauge: () => ({ record: throwing }) }) as any,
+        } as any)
+        resetProducerOtelInstrumentsForTests()
+
+        expect(() => new ProducerStatsTracker('LOGS').track(makeStats())).not.toThrow()
+    })
+})

--- a/nodejs/src/common/kafka/producer-otel-metrics.ts
+++ b/nodejs/src/common/kafka/producer-otel-metrics.ts
@@ -1,0 +1,63 @@
+import { Gauge, metrics as metricsApi } from '@opentelemetry/api'
+
+import { swallowing } from '~/common/metrics/swallow'
+
+/**
+ * OTLP-pushed twins of the producer-queue prom gauges set by ProducerStatsTracker.
+ * A growing produce queue is the earliest backpressure signal when downstream Kafka
+ * slows, so these need to be visible in the PostHog metrics product during incidents.
+ *
+ * Names and label sets deliberately match the prom gauges so dashboards translate 1:1.
+ *
+ * Instruments are acquired lazily on first record: the OTel metrics API has no proxy
+ * provider, so instruments created at module load (before initMetrics runs) would be
+ * bound to the noop meter forever.
+ */
+
+interface ProducerInstruments {
+    queueMessages: Gauge
+    queueBytes: Gauge
+    anyBrokersDown: Gauge
+}
+
+let instruments: ProducerInstruments | null = null
+
+function getInstruments(): ProducerInstruments {
+    if (instruments === null) {
+        const meter = metricsApi.getMeter('kafka-producer')
+        instruments = {
+            queueMessages: meter.createGauge('kafka_producer_queue_messages', {
+                description: 'Current number of messages in the producer queue.',
+            }),
+            queueBytes: meter.createGauge('kafka_producer_queue_bytes', {
+                description: 'Current size in bytes of messages in the producer queue.',
+                unit: 'By',
+            }),
+            anyBrokersDown: meter.createGauge('kafka_producer_any_brokers_down', {
+                description: '1 if any broker the producer knows about is not in the UP state, 0 otherwise.',
+            }),
+        }
+    }
+    return instruments
+}
+
+export const recordProducerQueueStats = swallowing(
+    (producerName: string, stats: { queueMessages?: number; queueBytes?: number; anyBrokersDown?: boolean }): void => {
+        const { queueMessages, queueBytes, anyBrokersDown } = getInstruments()
+        const attributes = { producer_name: producerName }
+        if (stats.queueMessages !== undefined) {
+            queueMessages.record(stats.queueMessages, attributes)
+        }
+        if (stats.queueBytes !== undefined) {
+            queueBytes.record(stats.queueBytes, attributes)
+        }
+        if (stats.anyBrokersDown !== undefined) {
+            anyBrokersDown.record(stats.anyBrokersDown ? 1 : 0, attributes)
+        }
+    }
+)
+
+/** Test seam: forget cached instruments so a test-installed provider is picked up. */
+export function resetProducerOtelInstrumentsForTests(): void {
+    instruments = null
+}

--- a/nodejs/src/common/metrics/otel-metrics.ts
+++ b/nodejs/src/common/metrics/otel-metrics.ts
@@ -10,6 +10,7 @@ import { registerShutdownHandler } from '~/lifecycle'
 
 import { counterWithExemplars } from './exemplars'
 import { OtlpJsonMetricExporter } from './otlp-json-exporter'
+import { registerProcessOtelMetrics } from './process-otel-metrics'
 
 /**
  * OTLP metrics push — the same OTel-SDK path customers use, pointed at our own
@@ -57,6 +58,8 @@ export const initMetrics = (): void => {
         ],
     })
     metricsApi.setGlobalMeterProvider(provider)
+    // CPU / RSS / event-loop-utilization observables — only sampled when push is on.
+    registerProcessOtelMetrics()
 
     registerShutdownHandler(async () => {
         await provider?.shutdown()

--- a/nodejs/src/common/metrics/process-otel-metrics.test.ts
+++ b/nodejs/src/common/metrics/process-otel-metrics.test.ts
@@ -1,0 +1,74 @@
+import { metrics as metricsApi } from '@opentelemetry/api'
+import {
+    DataPointType,
+    InMemoryMetricExporter,
+    MeterProvider,
+    type MetricData,
+    PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics'
+
+import { cpuUsageSeconds, registerProcessOtelMetrics, resetProcessOtelMetricsForTests } from './process-otel-metrics'
+
+describe('process-otel-metrics', () => {
+    it('converts cumulative microsecond CPU usage to seconds', () => {
+        expect(cpuUsageSeconds({ user: 2_500_000, system: 500_000 })).toEqual(3)
+    })
+
+    describe('registered observables', () => {
+        let exporter: InMemoryMetricExporter
+        let provider: MeterProvider
+        let reader: PeriodicExportingMetricReader
+
+        beforeEach(() => {
+            exporter = new InMemoryMetricExporter(0)
+            reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 60_000 })
+            provider = new MeterProvider({ readers: [reader] })
+            metricsApi.setGlobalMeterProvider(provider)
+            resetProcessOtelMetricsForTests()
+        })
+
+        afterEach(async () => {
+            await provider.shutdown()
+            metricsApi.disable()
+        })
+
+        const metricFor = (name: string): MetricData | undefined =>
+            exporter
+                .getMetrics()
+                .flatMap((rm) => rm.scopeMetrics)
+                .flatMap((sm) => sm.metrics)
+                .find((m) => m.descriptor.name === name)
+
+        it('observes CPU seconds as a monotonic sum and RSS / event loop utilization as gauges', async () => {
+            registerProcessOtelMetrics()
+
+            await reader.forceFlush()
+
+            const cpu = metricFor('process_cpu_seconds_total')
+            expect(cpu?.dataPointType).toEqual(DataPointType.SUM)
+            expect(cpu && 'isMonotonic' in cpu && cpu.isMonotonic).toBe(true)
+            expect(cpu?.dataPoints[0].value as number).toBeGreaterThan(0)
+            // A µs→s conversion slip reads as ~1e6× the process's real CPU time.
+            expect(cpu?.dataPoints[0].value as number).toBeLessThan(process.uptime() * 64)
+
+            const rss = metricFor('process_resident_memory_bytes')
+            expect(rss?.dataPointType).toEqual(DataPointType.GAUGE)
+            expect(rss?.dataPoints[0].value as number).toBeGreaterThan(0)
+
+            const elu = metricFor('event_loop_utilization')
+            expect(elu?.dataPointType).toEqual(DataPointType.GAUGE)
+            expect(elu?.dataPoints[0].value as number).toBeGreaterThanOrEqual(0)
+            expect(elu?.dataPoints[0].value as number).toBeLessThanOrEqual(1)
+        })
+
+        it('is idempotent: re-registering does not create duplicate series', async () => {
+            registerProcessOtelMetrics()
+            registerProcessOtelMetrics()
+
+            await reader.forceFlush()
+
+            const cpu = metricFor('process_cpu_seconds_total')
+            expect(cpu?.dataPoints).toHaveLength(1)
+        })
+    })
+})

--- a/nodejs/src/common/metrics/process-otel-metrics.ts
+++ b/nodejs/src/common/metrics/process-otel-metrics.ts
@@ -1,0 +1,63 @@
+import { metrics as metricsApi } from '@opentelemetry/api'
+import { EventLoopUtilization, performance } from 'perf_hooks'
+
+/**
+ * Process resource usage pushed to the PostHog metrics product. The prom side of
+ * these already exists (prom-client collectDefaultMetrics + event_loop_utilization
+ * in node-instrumentation.ts) and keeps feeding the scrape/VictoriaMetrics
+ * dashboards; names match so a CPU/memory panel translates 1:1.
+ *
+ * Registered from initMetrics only when OTLP export is enabled, so nothing is
+ * observed (or even sampled) for deployments that don't opt in.
+ */
+
+export const cpuUsageSeconds = (usage: { user: number; system: number }): number => (usage.user + usage.system) / 1e6
+
+let registered = false
+let lastEventLoopUtilization: EventLoopUtilization | null = null
+
+export function registerProcessOtelMetrics(): void {
+    if (registered) {
+        return
+    }
+    registered = true
+
+    const meter = metricsApi.getMeter('nodejs-process')
+
+    meter
+        .createObservableCounter('process_cpu_seconds_total', {
+            description: 'Total user and system CPU time spent by the process in seconds.',
+            unit: 's',
+        })
+        .addCallback((result) => {
+            result.observe(cpuUsageSeconds(process.cpuUsage()))
+        })
+
+    meter
+        .createObservableGauge('process_resident_memory_bytes', {
+            description: 'Resident memory size of the process in bytes.',
+            unit: 'By',
+        })
+        .addCallback((result) => {
+            result.observe(process.memoryUsage.rss())
+        })
+
+    meter
+        .createObservableGauge('event_loop_utilization', {
+            description: 'Proportion of time the event loop was busy since the previous export.',
+        })
+        .addCallback((result) => {
+            const current = performance.eventLoopUtilization()
+            const delta = lastEventLoopUtilization
+                ? performance.eventLoopUtilization(current, lastEventLoopUtilization)
+                : current
+            lastEventLoopUtilization = current
+            result.observe(delta.utilization)
+        })
+}
+
+/** Test seam: allow re-registration against a test-installed provider. */
+export function resetProcessOtelMetricsForTests(): void {
+    registered = false
+    lastEventLoopUtilization = null
+}

--- a/nodejs/src/common/metrics/swallow.ts
+++ b/nodejs/src/common/metrics/swallow.ts
@@ -1,0 +1,14 @@
+/**
+ * Telemetry recorders run in finally blocks, error handlers, and stats callbacks of
+ * hot paths — a throw there would mask the real error (or DLQ a message with the
+ * wrong reason), so recording failures are swallowed.
+ */
+export function swallowing<Args extends unknown[]>(record: (...args: Args) => void): (...args: Args) => void {
+    return (...args: Args): void => {
+        try {
+            record(...args)
+        } catch {
+            // never let telemetry break the caller
+        }
+    }
+}

--- a/nodejs/src/logs/ingestion-otel-metrics.ts
+++ b/nodejs/src/logs/ingestion-otel-metrics.ts
@@ -1,6 +1,7 @@
 import { Attributes, Counter, Histogram, Meter, MetricOptions, metrics as metricsApi } from '@opentelemetry/api'
 
 import { counterWithExemplars, histogramWithExemplars } from '~/common/metrics/exemplars'
+import { swallowing } from '~/common/metrics/swallow'
 
 /**
  * OTLP-pushed twins of the core logs-ingestion prom counters. The prom side keeps
@@ -83,21 +84,6 @@ function getInstruments(): LogsIngestionInstruments {
 function addPositive(counter: Counter, value: number, attributes?: Attributes): void {
     if (value > 0) {
         counter.add(value, attributes)
-    }
-}
-
-/**
- * These run in finally blocks and error handlers of the ingestion hot path — a throw
- * here would mask the real processing error and DLQ the message with the wrong reason,
- * so recording failures are swallowed.
- */
-function swallowing<Args extends unknown[]>(record: (...args: Args) => void): (...args: Args) => void {
-    return (...args: Args): void => {
-        try {
-            record(...args)
-        } catch {
-            // never let telemetry break ingestion
-        }
     }
 }
 


### PR DESCRIPTION
## Problem

When investigating a logs/traces pipeline incident (lag, drops, a stalled consumer), the ingestion-stage signals live only in the Prometheus/VictoriaMetrics scrape stack. The PostHog metrics product already receives OTLP-pushed twins of the core logs-ingestion counters, but the signals you actually reach for first in a lag incident are missing from it:

- how far behind the consumer is (no lag-in-seconds metric exists in either sink today, only a 0/1 assignment gauge)
- whether the producer queue is backing up (earliest backpressure signal)
- whether the pod is CPU-bound (process metrics are scrape-only)

## Changes

Extends the existing twin pattern (`nodejs/src/logs/ingestion-otel-metrics.ts`) to the consumer/producer/process layers. Prom series are untouched, everything dual-emits, and nothing is recorded unless `OTEL_METRICS_EXPORT_URL`/`OTEL_METRICS_EXPORT_TOKEN` are set.

- **New metric in both sinks**: `kafka_consumer_message_age_seconds{topic, groupId}` — age of the oldest message in each consumed batch, recorded in consumer v1 and v2. This is the consumer's lag-in-seconds signal.
- **OTel twins of existing prom metrics**: `consumer_batch_size`, `consumed_batch_duration_ms`, `consumed_batch_backpressure_duration_ms` (matching label sets, prom bucket parity where prom has explicit buckets).
- **Producer queue gauges**: `kafka_producer_queue_messages`, `kafka_producer_queue_bytes`, `kafka_producer_any_brokers_down` twins recorded from the librdkafka stats callback.
- **Process resources**: `process_cpu_seconds_total`, `process_resident_memory_bytes`, `event_loop_utilization` observables registered by `initMetrics` (names match the prom-client defaults so panels translate 1:1).
- Extracted the shared `swallowing` helper — telemetry must never break the consumer loop or mask a hot-path error.

Since the traces ingestion consumer subclasses the logs one and all server modes share `initMetrics`, this covers both logs and traces deployments through the same env gating.

## How did you test this code?

Automated only (no manual testing):

- `nodejs/src/common/kafka/consumer/otel-metrics.test.ts` — catches silent loss from broken lazy-instrument binding, an oldest/newest flip or ms/s error in the age computation, clock-skew going negative, and a throwing OTel SDK escaping into the consumer loop.
- `nodejs/src/common/kafka/producer-otel-metrics.test.ts` — catches the stats-callback wiring breaking (gauges not mirrored through `ProducerStatsTracker.track`) and telemetry errors escaping into the producer poll loop.
- `nodejs/src/common/metrics/process-otel-metrics.test.ts` — catches µs→s conversion slips in CPU seconds, wrong instrument kinds (counter vs gauge), and duplicate-series registration.
- Existing suites for touched files pass: `consumer-v1.test.ts`, `consumer-v2.test.ts`, `kafka-producer-metrics.test.ts`, `ingestion-otel-metrics.test.ts`. Typecheck and eslint clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal observability only; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) directed by Daniel. Skills invoked: /writing-tests. Approach follows the established OTLP-twin convention from #70106: lazy instrument binding, swallowed recording errors, name/label parity with the prom side. Considered twinning every consumer/producer metric but kept scope to the signals used first in lag incidents; the batch-utilization and drain metrics can follow if we miss them. The message-age metric is new in both sinks because no lag-in-seconds signal existed anywhere.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*