### PR TITLE
chore(ci): bump lagging third-party action pins

### DIFF
--- a/.depot/actions/setup-sqlx-cli/action.yml
+++ b/.depot/actions/setup-sqlx-cli/action.yml
@@ -15,7 +15,7 @@ runs:
     steps:
         - name: Restore sqlx-cli binary from cache
           id: cache-sqlx-cli
-          uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/sqlx-cli
               key: sqlx-cli-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -40,7 +40,7 @@ runs:
 
         - name: Save sqlx-cli binary to cache
           if: steps.cache-sqlx-cli.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
-          uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/sqlx-cli
               key: sqlx-cli-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/actions/rust-compute-affected/action.yml
+++ b/.github/actions/rust-compute-affected/action.yml
@@ -36,7 +36,7 @@ runs:
     steps:
         - name: Restore cached binary
           id: cache
-          uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: rust/target/release/affected-services
               key: affected-services-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust/affected-services/**', 'rust/Cargo.lock') }}
@@ -52,7 +52,7 @@ runs:
           # just evicts the shared one. PRs restore master's binary; PRs that touch
           # affected-services rebuild without saving. Matches setup-sccache/sqlx-cli.
           if: steps.cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
-          uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: rust/target/release/affected-services
               key: affected-services-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust/affected-services/**', 'rust/Cargo.lock') }}

--- a/.github/actions/setup-emsdk/action.yml
+++ b/.github/actions/setup-emsdk/action.yml
@@ -19,7 +19,7 @@ runs:
     steps:
         - name: Restore emsdk tarball from cache
           id: cache-emsdk
-          uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/emsdk-pinned.tar.gz
               key: emsdk-tarball-${{ inputs.emsdk-tag }}
@@ -44,7 +44,7 @@ runs:
 
         - name: Save emsdk tarball to cache
           if: steps.cache-emsdk.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
-          uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/emsdk-pinned.tar.gz
               key: emsdk-tarball-${{ inputs.emsdk-tag }}

--- a/.github/actions/setup-protoc/action.yml
+++ b/.github/actions/setup-protoc/action.yml
@@ -15,7 +15,7 @@ runs:
     steps:
         - name: Restore protoc binary from cache
           id: cache-protoc
-          uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/protoc
               key: protoc-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -55,7 +55,7 @@ runs:
 
         - name: Save protoc binary to cache
           if: steps.cache-protoc.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
-          uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/protoc
               key: protoc-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -15,7 +15,7 @@ runs:
     steps:
         - name: Restore sccache binary from cache
           id: cache-sccache
-          uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/sccache
               key: sccache-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -60,7 +60,7 @@ runs:
 
         - name: Save sccache binary to cache
           if: steps.cache-sccache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
-          uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/sccache
               key: sccache-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/actions/setup-sqlx-cli/action.yml
+++ b/.github/actions/setup-sqlx-cli/action.yml
@@ -15,7 +15,7 @@ runs:
     steps:
         - name: Restore sqlx-cli binary from cache
           id: cache-sqlx-cli
-          uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/sqlx-cli
               key: sqlx-cli-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -40,7 +40,7 @@ runs:
 
         - name: Save sqlx-cli binary to cache
           if: steps.cache-sqlx-cli.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
-          uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ${{ runner.temp }}/sqlx-cli
               key: sqlx-cli-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/build-hogql-parser-rs.yml
+++ b/.github/workflows/build-hogql-parser-rs.yml
@@ -210,7 +210,7 @@ jobs:
 
             - name: Install uv
               id: setup-uv
-              uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.14'
                   enable-cache: true

--- a/.github/workflows/build-hogql-parser-rs.yml
+++ b/.github/workflows/build-hogql-parser-rs.yml
@@ -130,7 +130,7 @@ jobs:
                   python-version: '3.12.10' # 3.12.11/.12 binaries lag on macOS
 
             - name: Build wheel via maturin
-              uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.3
+              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               with:
                   command: build
                   target: ${{ matrix.target }}
@@ -146,7 +146,7 @@ jobs:
 
             - name: Build sdist (linux x86_64 manylinux only)
               if: matrix.os == 'ubuntu-22.04' && matrix.target == 'x86_64' && matrix.manylinux == '2_28'
-              uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.3
+              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               with:
                   command: sdist
                   args: --out dist --manifest-path rust/hogql/parser/Cargo.toml

--- a/.github/workflows/cd-agent-proxy-image.yml
+++ b/.github/workflows/cd-agent-proxy-image.yml
@@ -80,7 +80,7 @@ jobs:
 
             - name: Get PR labels
               id: labels
-              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({

--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -96,7 +96,7 @@ jobs:
 
             - name: Get PR labels
               id: labels
-              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({

--- a/.github/workflows/ci-clickhouse-hcl-schema.yml
+++ b/.github/workflows/ci-clickhouse-hcl-schema.yml
@@ -44,7 +44,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Log in to ghcr.io
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -134,7 +134,7 @@ jobs:
                       posthog-schema-master-
 
             - name: Log in to ghcr.io
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -153,7 +153,7 @@ jobs:
 
             - name: Upload compose logs on failure
               if: failure()
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: multinode-compose-logs
                   path: multinode-compose.log

--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -26,7 +26,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Set up Go
-              uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
               with:
                   go-version: '1.25.5'
 

--- a/.github/workflows/ci-phrocs.yml
+++ b/.github/workflows/ci-phrocs.yml
@@ -26,7 +26,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Set up Go
-              uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
               with:
                   go-version: '1.25.5'
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -260,7 +260,7 @@ jobs:
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
               with:
                   shared-key: 'v2-rust-ci'
                   workspaces: rust
@@ -518,7 +518,7 @@ jobs:
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
               with:
                   shared-key: 'v2-rust-ci'
                   workspaces: rust

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -905,7 +905,7 @@ jobs:
                   fetch-depth: 1
                   persist-credentials: false
             - name: Download JUnit artifacts
-              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v6.0.0
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               continue-on-error: true
               with:
                   path: ./junit-artifacts

--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -119,7 +119,7 @@ jobs:
         steps:
             - name: Decide build vs teardown vs skip
               id: decide
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const base = `${context.repo.owner}/${context.repo.repo}`;
@@ -221,7 +221,7 @@ jobs:
         steps:
             - name: Announce (deployment + building comment)
               id: start
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const pr = Number(process.env.PR);
@@ -294,7 +294,7 @@ jobs:
             # sensitive comes online.
             - name: Guard dispatch against fork PRs
               if: github.event_name == 'workflow_dispatch'
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const pr = Number(process.env.PR);
@@ -318,7 +318,7 @@ jobs:
             # PRs skip all of this and keep the ~1-min preview.
             - name: Detect frontend changes
               id: fe
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const pr = Number(process.env.PR);
@@ -412,7 +412,7 @@ jobs:
             # sensitive comes online.
             - name: Guard dispatch against fork PRs
               if: github.event_name == 'workflow_dispatch'
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const pr = Number(process.env.PR);
@@ -501,7 +501,7 @@ jobs:
             # FE build has usually long finished, so this returns near-instantly.
             - name: Wait for the PR frontend build
               id: fe
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const jobName = 'build PR frontend';
@@ -560,7 +560,7 @@ jobs:
 
             - name: Report ready (deployment + comment)
               if: success()
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               # SHA + DEP come from the job env (announce job outputs).
               env:
                   URL: ${{ steps.build.outputs.url }}
@@ -623,7 +623,7 @@ jobs:
 
             - name: Report failure (deployment + comment)
               if: failure()
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const pr = Number(process.env.PR);
@@ -712,7 +712,7 @@ jobs:
             # gets the same treatment from pr-cleanup.yml's deployment reaper.)
             - name: Deactivate deployment + update comment
               if: always()
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const pr = Number(process.env.PR);

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -54,7 +54,7 @@ jobs:
             # or auto) proceed to the tailnet join + token mint below.
             - name: Check whether this PR had a preview
               id: gate
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               with:
                   script: |
                       const pr = Number(process.env.PR);


### PR DESCRIPTION
## Problem

- Third-party action pins had drifted: several actions resolved to 2-3 different SHAs, with pockets 1-2 majors behind their repo-majority pin
- Renovate's github-actions bumps are dashboard-gated, so lagging callsites accumulate silently
- GitHub removes Node 20 from runners on September 16, 2026 (forced to Node 24 since June 2), so node20-only pins are on borrowed time

## Changes

Consistency (converge on the SHA the repo already uses most, no version churn):

- Bump 31 callsites across 16 files to the majority SHA (upload-artifact v4.6.2 to v6, download-artifact v6 to v7, github-script v7.x to v8, docker/login-action v3.4 to v4.1, rust-cache, setup-go, setup-uv, cache restore/save v5.0.1 to v5.0.3 in five composites)
- Sync the `.depot/actions/setup-sqlx-cli` mirror (byte-equivalent again)

Runtime deprecation (only bump where a node24-ready release exists):

- `PyO3/maturin-action` v1.49.3 (node20) to v1.51.0 (node24), 2 callsites

Deliberately excluded:

- `ci-backend.yml`'s three download-artifact v6 callsites (reporting blocks the depot shadow strips; touching canonical alone trips the shadow-drift check). After this PR they are the only inconsistent pins repo-wide

## How did you test this code?

- Repo-wide census (all trees incl. `.depot`): every third-party action pins one SHA except the excluded ci-backend.yml callsites; zero tag pins
- Advisory scan of all 45 third-party action repos via the GitHub advisory DB: 2 advisories exist, both pins already on patched versions (download-artifact v6/v7 vs patched 4.1.3; pypi-publish at patched v1.13.0)
- Runtime census of every pinned SHA's `runs.using`: no node16 anywhere
- `bin/hogli lint:workflows` and actionlint pass

> [!NOTE]
> Three actions remain node20 with no node24 release available upstream: `iFaxity/wait-on-action` v1.2.1, `tlambert03/setup-qt-libs` v1.8, `inkeep/inkeep-agents-action` (head of main). They already run forced on node24 and keep working after Sept 16, but they're unmaintained-watch candidates for replacement.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, with /authoring-ci-workflows invoked; bump targets are trust-by-majority (each SHA already runs at 7-54 callsites here), except maturin-action where the node20 deprecation justified moving to latest
- Verified every changed line is a pure `uses:` SHA + version-comment swap
