### PR TITLE
feat(logs): export clickhouse kafka-engine lag to the posthog metrics product

### DIFF
--- a/posthog/settings/metrics.py
+++ b/posthog/settings/metrics.py
@@ -1,3 +1,9 @@
 import os
 
 PROMETHEUS_METRICS_EXPORT_PORT = os.getenv("PROMETHEUS_METRICS_EXPORT_PORT", "8001")
+
+# OTLP/HTTP push of internal pipeline metrics into the PostHog metrics product
+# (the capture-logs /i/v1/metrics ingest, authenticated with a project token).
+# Same env contract as the capture-logs and Node.js services; off unless both are set.
+OTEL_METRICS_EXPORT_URL = os.getenv("OTEL_METRICS_EXPORT_URL", "")
+OTEL_METRICS_EXPORT_TOKEN = os.getenv("OTEL_METRICS_EXPORT_TOKEN", "")

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -91,7 +91,7 @@ from products.feature_flags.backend.tasks import (
     refresh_expiring_flag_definitions_cache_entries,
     refresh_expiring_flags_cache_entries,
 )
-from products.logs.backend.facade.tasks import logs_alert_events_cleanup_task
+from products.logs.backend.facade.tasks import logs_alert_events_cleanup_task, logs_clickhouse_lag_metrics_task
 from products.reminders.backend.tasks import process_due_reminders
 from products.streamlit_apps.backend.facade.api import (
     auto_restart_crashed_streamlit_sandboxes,
@@ -604,6 +604,14 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="8", minute="15"),
         logs_alert_events_cleanup_task.s(),
         name="clean up old logs alert events",
+    )
+
+    # Self-gated: a no-op unless OTEL_METRICS_EXPORT_URL/TOKEN are configured.
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(),  # every minute
+        logs_clickhouse_lag_metrics_task.s(),
+        name="export logs pipeline clickhouse lag metrics",
     )
 
     if settings.EE_AVAILABLE:

--- a/products/logs/backend/facade/tasks.py
+++ b/products/logs/backend/facade/tasks.py
@@ -1,11 +1,12 @@
-"""Facade re-export for the logs Celery task.
+"""Facade re-exports for the logs Celery tasks.
 
-Core's beat schedule (``posthog/tasks/scheduled.py``) imports the task object and calls
-``.s()`` on it, so the wiring crosses the boundary as an object, not data. Re-exporting
-the task keeps that coupling at the facade boundary. Its ``name=`` is pinned in
-``tasks/tasks.py``, so the registered task identity is independent of the import path.
+Core's beat schedule (``posthog/tasks/scheduled.py``) imports the task objects and calls
+``.s()`` on them, so the wiring crosses the boundary as objects, not data. Re-exporting
+the tasks keeps that coupling at the facade boundary. Each ``name=`` is pinned in its
+defining module, so the registered task identity is independent of the import path.
 """
 
+from products.logs.backend.tasks.clickhouse_lag_metrics import logs_clickhouse_lag_metrics_task
 from products.logs.backend.tasks.tasks import logs_alert_events_cleanup_task
 
-__all__ = ["logs_alert_events_cleanup_task"]
+__all__ = ["logs_alert_events_cleanup_task", "logs_clickhouse_lag_metrics_task"]

--- a/products/logs/backend/tasks/clickhouse_lag_metrics.py
+++ b/products/logs/backend/tasks/clickhouse_lag_metrics.py
@@ -1,0 +1,154 @@
+"""Export ClickHouse-stage Kafka-engine consumption lag for the logs/traces pipeline.
+
+The Kafka engine tables consume ``clickhouse_logs``/``clickhouse_traces`` directly, so
+the final pipeline stage has no app-side process to instrument. Its freshness lives
+only in the ``logs_kafka_metrics``/``trace_spans_kafka_metrics`` MV targets on the
+logs cluster — queryable via SQL, but invisible to the metrics product and the
+scrape stack where the capture and ingestion stages already report.
+
+This task closes that gap: per (topic, partition) it derives
+- how long since the Kafka engine last inserted anything (a stalled CH consumer), and
+- how old the newest consumed record is (end-to-end staleness),
+then dual-emits both as gauges — to the Prometheus pushgateway and, via OTLP/JSON,
+to the PostHog metrics ingest (same OTEL_METRICS_EXPORT_URL/TOKEN contract as the
+capture-logs and Node.js ingestion services; a no-op unless both are set).
+"""
+
+import time
+from typing import Any
+
+from django.conf import settings
+
+import requests
+import structlog
+from celery import shared_task
+from prometheus_client import Gauge
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
+from posthog.metrics import pushed_metrics_registry
+
+logger = structlog.get_logger(__name__)
+
+LAST_INSERT_AGE_METRIC = "clickhouse_kafka_last_insert_age_seconds"
+NEWEST_RECORD_AGE_METRIC = "clickhouse_kafka_newest_record_age_seconds"
+
+# trace_spans_kafka_metrics has no distributed wrapper (defined per-region in the
+# logs HCL); logs_kafka_metrics does, created by posthog/clickhouse migrations.
+LAG_TABLES = ("logs_kafka_metrics_distributed", "trace_spans_kafka_metrics")
+
+LAG_QUERY = """
+SELECT
+    _topic,
+    toUInt32(_partition) AS partition,
+    dateDiff('second', max(max_created_at), now()) AS last_insert_age_seconds,
+    dateDiff('second', max(max_observed_timestamp), now()) AS newest_record_age_seconds
+FROM {table}
+GROUP BY _topic, _partition
+"""
+
+LagRow = tuple[str, int, int, int]
+
+
+def build_otlp_payload(rows: list[LagRow], now_unix_nanos: int) -> dict[str, Any]:
+    """OTLP/JSON gauges in the wire shape the capture-logs /v1/metrics ingest parses
+    (camelCase, unix nanos as decimal strings) — the same shape the Node.js
+    OtlpJsonMetricExporter and the capture-logs self-push emit."""
+
+    def data_point(topic: str, partition: int, value: int) -> dict[str, Any]:
+        return {
+            "attributes": [
+                {"key": "topic", "value": {"stringValue": topic}},
+                {"key": "partition", "value": {"stringValue": str(partition)}},
+            ],
+            "startTimeUnixNano": str(now_unix_nanos),
+            "timeUnixNano": str(now_unix_nanos),
+            "asDouble": value,
+        }
+
+    metric_defs = [
+        (
+            LAST_INSERT_AGE_METRIC,
+            "Seconds since the ClickHouse Kafka engine last inserted a row, by topic and partition",
+            2,
+        ),
+        (
+            NEWEST_RECORD_AGE_METRIC,
+            "Age of the newest record consumed into ClickHouse, by topic and partition",
+            3,
+        ),
+    ]
+    return {
+        "resourceMetrics": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "clickhouse-logs"}},
+                    ]
+                },
+                "scopeMetrics": [
+                    {
+                        "scope": {"name": "logs-clickhouse-lag"},
+                        "metrics": [
+                            {
+                                "name": name,
+                                "description": description,
+                                "unit": "s",
+                                "gauge": {"dataPoints": [data_point(row[0], row[1], row[value_index]) for row in rows]},
+                            }
+                            for name, description, value_index in metric_defs
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+@shared_task(ignore_result=True, name="products.logs.backend.tasks.logs_clickhouse_lag_metrics_task")
+def logs_clickhouse_lag_metrics_task() -> None:
+    url = settings.OTEL_METRICS_EXPORT_URL
+    token = settings.OTEL_METRICS_EXPORT_TOKEN
+    if not url or not token:
+        return
+
+    rows: list[LagRow] = []
+    for table in LAG_TABLES:
+        try:
+            rows.extend(sync_execute(LAG_QUERY.format(table=table), workload=Workload.LOGS))
+        except Exception:
+            # A table can be absent in an environment (dev has no traces HCL role);
+            # the other topic's lag is still worth exporting.
+            logger.warning("logs_clickhouse_lag_query_failed", table=table, exc_info=True)
+    if not rows:
+        return
+
+    with pushed_metrics_registry("logs_clickhouse_lag") as registry:
+        insert_age_gauge = Gauge(
+            LAST_INSERT_AGE_METRIC,
+            "Seconds since the ClickHouse Kafka engine last inserted a row",
+            labelnames=["topic", "partition"],
+            registry=registry,
+        )
+        record_age_gauge = Gauge(
+            NEWEST_RECORD_AGE_METRIC,
+            "Age of the newest record consumed into ClickHouse",
+            labelnames=["topic", "partition"],
+            registry=registry,
+        )
+        for topic, partition, last_insert_age, newest_record_age in rows:
+            insert_age_gauge.labels(topic=topic, partition=str(partition)).set(last_insert_age)
+            record_age_gauge.labels(topic=topic, partition=str(partition)).set(newest_record_age)
+
+    payload = build_otlp_payload(rows, time.time_ns())
+    try:
+        response = requests.post(
+            url,
+            json=payload,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if response.status_code >= 300:
+            logger.warning("logs_clickhouse_lag_export_rejected", status=response.status_code)
+    except Exception:
+        logger.warning("logs_clickhouse_lag_export_failed", exc_info=True)

--- a/products/logs/backend/tasks/clickhouse_lag_metrics.py
+++ b/products/logs/backend/tasks/clickhouse_lag_metrics.py
@@ -15,6 +15,7 @@ capture-logs and Node.js ingestion services; a no-op unless both are set).
 """
 
 import time
+from collections.abc import Callable
 from typing import Any
 
 from django.conf import settings
@@ -66,16 +67,16 @@ def build_otlp_payload(rows: list[LagRow], now_unix_nanos: int) -> dict[str, Any
             "asDouble": value,
         }
 
-    metric_defs = [
+    metric_defs: list[tuple[str, str, Callable[[LagRow], int]]] = [
         (
             LAST_INSERT_AGE_METRIC,
             "Seconds since the ClickHouse Kafka engine last inserted a row, by topic and partition",
-            2,
+            lambda row: row[2],
         ),
         (
             NEWEST_RECORD_AGE_METRIC,
             "Age of the newest record consumed into ClickHouse, by topic and partition",
-            3,
+            lambda row: row[3],
         ),
     ]
     return {
@@ -94,9 +95,9 @@ def build_otlp_payload(rows: list[LagRow], now_unix_nanos: int) -> dict[str, Any
                                 "name": name,
                                 "description": description,
                                 "unit": "s",
-                                "gauge": {"dataPoints": [data_point(row[0], row[1], row[value_index]) for row in rows]},
+                                "gauge": {"dataPoints": [data_point(row[0], row[1], value_of(row)) for row in rows]},
                             }
-                            for name, description, value_index in metric_defs
+                            for name, description, value_of in metric_defs
                         ],
                     }
                 ],

--- a/products/logs/backend/test/test_clickhouse_lag_metrics.py
+++ b/products/logs/backend/test/test_clickhouse_lag_metrics.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, override_settings
+
+from parameterized import parameterized
+
+from products.logs.backend.tasks.clickhouse_lag_metrics import (
+    LAST_INSERT_AGE_METRIC,
+    NEWEST_RECORD_AGE_METRIC,
+    build_otlp_payload,
+    logs_clickhouse_lag_metrics_task,
+)
+
+NOW_NANOS = 1_700_000_060_000_000_000
+
+TASK_MODULE = "products.logs.backend.tasks.clickhouse_lag_metrics"
+
+
+class TestClickhouseLagMetrics(SimpleTestCase):
+    def test_payload_maps_rows_to_gauge_data_points(self) -> None:
+        rows = [("clickhouse_logs", 3, 12, 45), ("clickhouse_traces", 0, 700, 900)]
+
+        payload = build_otlp_payload(rows, NOW_NANOS)
+
+        metrics = {m["name"]: m for m in payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]}
+        assert set(metrics) == {LAST_INSERT_AGE_METRIC, NEWEST_RECORD_AGE_METRIC}
+
+        insert_points = metrics[LAST_INSERT_AGE_METRIC]["gauge"]["dataPoints"]
+        assert len(insert_points) == 2
+        assert insert_points[0]["asDouble"] == 12
+        assert insert_points[0]["timeUnixNano"] == str(NOW_NANOS)
+        attributes = {kv["key"]: kv["value"]["stringValue"] for kv in insert_points[0]["attributes"]}
+        assert attributes == {"topic": "clickhouse_logs", "partition": "3"}
+
+        record_points = metrics[NEWEST_RECORD_AGE_METRIC]["gauge"]["dataPoints"]
+        assert record_points[1]["asDouble"] == 900
+        attributes = {kv["key"]: kv["value"]["stringValue"] for kv in record_points[1]["attributes"]}
+        assert attributes == {"topic": "clickhouse_traces", "partition": "0"}
+
+    @parameterized.expand(
+        [
+            ("url_only", "http://capture:4318/i/v1/metrics", ""),
+            ("token_only", "", "phc_test"),
+            ("neither", "", ""),
+        ]
+    )
+    def test_task_is_noop_without_full_export_config(self, _name: str, url: str, token: str) -> None:
+        with (
+            override_settings(OTEL_METRICS_EXPORT_URL=url, OTEL_METRICS_EXPORT_TOKEN=token),
+            patch(f"{TASK_MODULE}.sync_execute") as mock_execute,
+            patch(f"{TASK_MODULE}.requests.post") as mock_post,
+        ):
+            logs_clickhouse_lag_metrics_task()
+
+        mock_execute.assert_not_called()
+        mock_post.assert_not_called()
+
+    @override_settings(OTEL_METRICS_EXPORT_URL="http://capture:4318/i/v1/metrics", OTEL_METRICS_EXPORT_TOKEN="phc_test")
+    def test_task_queries_both_lag_tables_and_posts_with_bearer_token(self) -> None:
+        with (
+            patch(f"{TASK_MODULE}.sync_execute") as mock_execute,
+            patch(f"{TASK_MODULE}.requests.post") as mock_post,
+        ):
+            mock_execute.side_effect = [
+                [("clickhouse_logs", 0, 5, 8)],
+                [("clickhouse_traces", 1, 2, 3)],
+            ]
+            mock_post.return_value = MagicMock(status_code=200)
+
+            logs_clickhouse_lag_metrics_task()
+
+        assert mock_execute.call_count == 2
+        queried_tables = [call.args[0] for call in mock_execute.call_args_list]
+        assert any("logs_kafka_metrics" in q for q in queried_tables)
+        assert any("trace_spans_kafka_metrics" in q for q in queried_tables)
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert mock_post.call_args.args[0] == "http://capture:4318/i/v1/metrics"
+        assert kwargs["headers"]["Authorization"] == "Bearer phc_test"
+        body = kwargs["json"]
+        names = {m["name"] for m in body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]}
+        assert names == {LAST_INSERT_AGE_METRIC, NEWEST_RECORD_AGE_METRIC}
+
+    @override_settings(OTEL_METRICS_EXPORT_URL="http://capture:4318/i/v1/metrics", OTEL_METRICS_EXPORT_TOKEN="phc_test")
+    def test_task_survives_one_table_failing_and_still_exports_the_other(self) -> None:
+        with (
+            patch(f"{TASK_MODULE}.sync_execute") as mock_execute,
+            patch(f"{TASK_MODULE}.requests.post") as mock_post,
+        ):
+            mock_execute.side_effect = [
+                Exception("table missing in this environment"),
+                [("clickhouse_traces", 1, 2, 3)],
+            ]
+            mock_post.return_value = MagicMock(status_code=200)
+
+            logs_clickhouse_lag_metrics_task()
+
+        mock_post.assert_called_once()
+        body = mock_post.call_args.kwargs["json"]
+        points = body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]["gauge"]["dataPoints"]
+        assert len(points) == 1


### PR DESCRIPTION
## Problem

The final stage of the logs/traces pipeline has no app-side process to instrument: ClickHouse Kafka engine tables consume `clickhouse_logs`/`clickhouse_traces` directly. When that stage lags (a stalled Kafka engine consumer, an MV backing up), the only signal lives in the `logs_kafka_metrics` / `trace_spans_kafka_metrics` MV target tables on the logs cluster — reachable by SQL, invisible to the metrics product and the scrape stack where the capture stage (#70518) and ingestion stage (#70516) now report.

## Changes

A per-minute Celery task (registered via `add_periodic_task_with_expiry` with a crontab, per the beat-restart warning in `scheduled.py`) that:

- queries both lag tables on the logs cluster (`Workload.LOGS`, same pattern as the existing `ingestion_lag` task), deriving per `(topic, partition)`:
  - `clickhouse_kafka_last_insert_age_seconds` — seconds since the Kafka engine last inserted anything (a stalled CH consumer)
  - `clickhouse_kafka_newest_record_age_seconds` — age of the newest consumed record (end-to-end staleness)
- dual-emits both gauges: to the Prometheus pushgateway (`pushed_metrics_registry`) and, as OTLP/JSON, to the PostHog metrics ingest under the same `OTEL_METRICS_EXPORT_URL`/`OTEL_METRICS_EXPORT_TOKEN` contract as the capture-logs and Node.js services.

The task is self-gated: without the two settings it returns immediately. A missing table (dev has no traces HCL role) is logged and skipped so the other topic still exports.

## How did you test this code?

Automated only (no manual testing):

- `products/logs/backend/test/test_clickhouse_lag_metrics.py` (SimpleTestCase, no DB) — catches: payload shape drift that would break the ingest parse (stringified nanos, gauge structure, topic/partition attributes), the task posting without config or crashing when unset (parameterized gating cases), dropping one of the two lag tables, and one table's failure taking down the other's export.
- `ruff check`/`format` clean.

Not run end to end; enabling `OTEL_METRICS_EXPORT_URL`/`OTEL_METRICS_EXPORT_TOKEN` on a deployment is the rollout/validation step, shared with the other two PRs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal observability only; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) directed by Daniel — the ClickHouse-stage piece of instrumenting the logs/traces pipeline end to end (capture: #70518, ingestion: #70516). Skills invoked: /writing-tests. Chose a Celery task in the logs product (facade re-export, mirroring `logs_alert_events_cleanup_task`) over a Temporal workflow or CH-side exporter because Django is the only component with logs-cluster query access plus an existing every-minute scheduling surface. Queries `logs_kafka_metrics_distributed` but `trace_spans_kafka_metrics` directly — the traces table has no distributed wrapper in the HCL roles.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*