### PR TITLE
chore(agents): document detached-mode phrocs log paths

### DIFF
--- a/.agents/skills/hogli/SKILL.md
+++ b/.agents/skills/hogli/SKILL.md
@@ -14,7 +14,19 @@ Run `hogli --help` to get the full, current command list. Run `hogli <command> -
 
 ## Process logging (for agents/debugging)
 
-`hogli dev:setup --log` enables file logging for all phrocs processes. Logs go to `/tmp/posthog-<process>.log` where `<process>` matches the phrocs process key (see `bin/mprocs.yaml`).
+Where logs land depends on how the stack was launched:
+
+**Detached (`hogli up -d`)** — phrocs writes files under `.posthog/.generated/logs/` on every boot:
+
+- `phrocs.log` — the daemon's own stdio; the place to look when phrocs died at startup and the phrocs MCP tools are unreachable.
+- `<process>.log` — per-process output (truncated on each start), where `<process>` matches the phrocs process key (see `bin/mprocs.yaml`).
+- `hogli doctor:report` prints the `phrocs.log` path and tails its last lines.
+
+**TUI with `hogli dev:setup --log`, then `hogli start`** — adds a tee wrap per process:
+
+- `/tmp/posthog-<process>.log` — full stdout+stderr; persists in the generated config until `dev:setup` is re-run without `--log`.
+
+When the phrocs MCP is reachable, prefer `mcp__phrocs__get_process_logs` over grepping files.
 
 ## Key references
 


### PR DESCRIPTION
## Problem

- The hogli skill's process-logging section only documents the opt-in `hogli dev:setup --log` tee path (`/tmp/posthog-<process>.log`)
- `hogli up -d`, the launch command agents are told to use, writes logs to `.posthog/.generated/logs/` by default, which was undocumented, so an agent debugging a dead phrocs boot greps an empty `/tmp` path

## Changes

- Document the detached-mode defaults: `phrocs.log` (daemon stdio, the only artifact when phrocs dies at boot and the MCP is unreachable) and per-process `<process>.log` files, plus the `hogli doctor:report` tail
- Keep the `--log` tee path, now clearly scoped to TUI mode
- Point agents at `mcp__phrocs__get_process_logs` first when the MCP is reachable

## How did you test this code?

- Docs only. Every path claim verified against `tools/phrocs/detached.go`, `proc.go`, `devenv/generator.py`, and `doctor.py`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None beyond the skill itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, with /writing-skills invoked; a simplify review pass caught that plain `hogli doctor` does not tail phrocs.log (only `doctor:report` does) and corrected the claim before opening this PR
