### PR TITLE
fix(aio): remove redundant back button from evaluation detail page

### DIFF
--- a/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
+++ b/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
@@ -3,7 +3,7 @@ import { Field, Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconArrowLeft, IconInfo, IconPlay, IconTrends, IconWarning } from '@posthog/icons'
+import { IconInfo, IconPlay, IconTrends, IconWarning } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -211,9 +211,7 @@ export function AIObservabilityEvaluation(): JSX.Element {
     }
 
     const handleCancel = (): void => {
-        if (hasUnsavedChanges) {
-            resetEvaluation()
-        }
+        resetEvaluation()
         push(combineUrl(urls.aiObservabilityEvaluations(), searchParams).url)
     }
 
@@ -283,9 +281,11 @@ export function AIObservabilityEvaluation(): JSX.Element {
                             Open in Playground
                         </LemonButton>
                     ) : null}
-                    <LemonButton type="secondary" icon={<IconArrowLeft />} onClick={handleCancel}>
-                        {hasUnsavedChanges ? 'Cancel' : 'Back'}
-                    </LemonButton>
+                    {hasUnsavedChanges && (
+                        <LemonButton type="secondary" onClick={handleCancel}>
+                            Cancel
+                        </LemonButton>
+                    )}
                     {activeTab !== 'runs' && (
                         <AccessControlAction
                             resourceType={AccessControlResourceType.LlmAnalytics}


### PR DESCRIPTION
## Problem

The AI evals evaluation detail page (`/ai-evals/evaluations/<id>`) rendered its own "Back" button in the header actions, next to "Trend insight" and "Open in Playground". The page already has the standard scene breadcrumb back arrow (`SceneBreadcrumbBackButton`) at the top, so the custom button was a second, redundant way to navigate back.

## Changes

- Removed the custom back button from the evaluation detail header.
- The button doubled as "Cancel" when the form had unsaved changes, so that affordance is kept: a plain "Cancel" button (no back arrow) now renders next to "Save changes" only while there are unsaved changes. It still discards the changes and returns to the evaluations list.
- Simplified `handleCancel` since it's now only reachable with unsaved changes, and dropped the unused `IconArrowLeft` import.

### Before

Note both the breadcrumb back arrow (top left, above the title) and the custom "Back" button in the header actions:

![eval-before](https://raw.githubusercontent.com/PostHog/pr-assets/a6adb4fc8d7e2d5e816cab551f37dd22bd3f203c/2026/07/121fb2bc-f019-445a-bf77-1f4281b0c983.png)

### After

The breadcrumb back arrow remains as the single way back:

![eval-after](https://raw.githubusercontent.com/PostHog/pr-assets/43eca98cc501ca1b3ef5c81a946efb8c6cae4274/2026/07/370eee1c-a93c-486b-ba67-05724a9dc583.png)

## How did you test this code?

I (or, actually Claude) verified the change in the local dev app: logged in, opened an evaluation detail page, and captured the before/after screenshots above by checking out the pre-change and post-change versions of the scene against the same running stack. The header renders without the Back button after the change, and the breadcrumb back arrow still works.

Also ran the frontend TypeScript check. The three pre-existing implicit-any errors reported in this file are on untouched lines and come from missing kea typegen artifacts in the local worktree, not from this change. No new tests: this removes a redundant control, and the remaining behavior (cancel resets the form and navigates back) is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code). Andy pointed out the page has a back button even though the standard breadcrumb back arrow already covers navigation. I confirmed `SceneBreadcrumbBackButton` is the standard scene chrome (it's what `SceneTitleSection` renders) and that the custom `LemonButton` was the redundant one. Considered removing the button entirely, but kept its "Cancel" mode so users editing the form still have a discard action next to "Save changes". Screenshots were captured with the `/run` + `run-posthog` skills driving the local dev stack via Playwright.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*