### PR TITLE
fix(error-tracking): show access denied instead of 403s in configuration

### DIFF
--- a/common/storybook/.storybook/app-context.ts
+++ b/common/storybook/.storybook/app-context.ts
@@ -90,5 +90,6 @@ export const getStorybookAppContext = (): AppContext => ({
         activity_log: 'viewer',
         customer_analytics: 'manager',
         llm_analytics: 'manager',
+        error_tracking: 'manager',
     },
 })

--- a/frontend/src/lib/utils/accessControlUtils.ts
+++ b/frontend/src/lib/utils/accessControlUtils.ts
@@ -116,6 +116,8 @@ export const resourceTypeToString = (resourceType: AccessControlResourceType): s
         return 'revenue analytics resource'
     } else if (resourceType === AccessControlResourceType.WebAnalytics) {
         return 'web analytics resource'
+    } else if (resourceType === AccessControlResourceType.ErrorTracking) {
+        return 'error tracking resource'
     } else if (resourceType === AccessControlResourceType.ExternalDataSource) {
         return 'data warehouse source'
     } else if (resourceType === AccessControlResourceType.Workflow) {

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 import { IconExternal, IconList } from '@posthog/icons'
 import { LemonButton, LemonDivider, Link } from '@posthog/lemon-ui'
 
+import { AccessDenied } from 'lib/components/AccessDenied'
 import { NotFound } from 'lib/components/NotFound'
 import { SupportedPlatforms } from 'lib/components/SupportedPlatforms/SupportedPlatforms'
 import { TimeSensitiveAuthenticationArea } from 'lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication'
@@ -65,6 +66,7 @@ export function Settings({
 }): JSX.Element {
     const {
         selectedSectionId,
+        selectedSection,
         selectedLevel,
         selectedSettingId,
         settings,
@@ -109,6 +111,15 @@ export function Settings({
     // Embeds (replay settings, error tracking config, side panel, modal) place the nav
     // in normal flow instead, so it sits beside the content rather than overlapping.
     const isFullScene = props.logicKey === 'settingsScene'
+
+    // Sections gated by access control render a generic denial instead of their settings,
+    // which would otherwise mount and immediately 403 against their endpoints.
+    const sectionAccessDeniedReason = selectedSection?.accessControl
+        ? getAccessControlDisabledReason(
+              selectedSection.accessControl.resourceType,
+              selectedSection.accessControl.minimumAccessLevel
+          )
+        : null
 
     // When embedded in a specific section (replay, logs, error tracking, etc. — anything that
     // passes a `sectionId`), the nav always lists that section's settings as in-context sub-tabs.
@@ -330,9 +341,13 @@ export function Settings({
         </Combobox>
     )
 
+    // Embeds show only the denied section's sub-tabs, so hide the nav along with the content.
+    // The full settings scene keeps its nav so other sections stay reachable.
+    const hideNav = hideSections || (settingsInSidebar && !!sectionAccessDeniedReason)
+
     return (
         <div className={clsx('Settings flex items-start', isCompact && 'Settings--compact')}>
-            {hideSections ? null : isCompact ? (
+            {hideNav ? null : isCompact ? (
                 <>
                     <Button variant="outline" left className="w-full" onClick={() => openCompactNavigation()}>
                         <IconList className="stroke-2 size-4 mr-1" />{' '}
@@ -386,7 +401,11 @@ export function Settings({
                 <AuthenticationAreaComponent>
                     <div className="space-y-2">
                         {headerSlot}
-                        <SettingsRenderer {...props} handleLocally={handleLocally} />
+                        {sectionAccessDeniedReason ? (
+                            <AccessDenied reason={sectionAccessDeniedReason} />
+                        ) : (
+                            <SettingsRenderer {...props} handleLocally={handleLocally} />
+                        )}
                     </div>
                 </AuthenticationAreaComponent>
             </div>

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -433,6 +433,10 @@ export const SETTINGS_MAP: SettingSection[] = [
         id: 'environment-error-tracking',
         title: 'Error tracking',
         group: 'Products',
+        accessControl: {
+            resourceType: AccessControlResourceType.ErrorTracking,
+            minimumAccessLevel: AccessControlLevel.Viewer,
+        },
         settings: [
             {
                 id: 'banner',
@@ -464,6 +468,10 @@ export const SETTINGS_MAP: SettingSection[] = [
         title: 'Error tracking',
         group: 'Products',
         hideFromNavigation: true,
+        accessControl: {
+            resourceType: AccessControlResourceType.ErrorTracking,
+            minimumAccessLevel: AccessControlLevel.Viewer,
+        },
         settings: [
             {
                 id: 'error-tracking-exception-autocapture',

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/AssignmentRules.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/AssignmentRules.tsx
@@ -11,6 +11,7 @@ import {
     AssigneeResolver,
 } from '../../../components/Assignee/AssigneeDisplay'
 import { assigneeSelectLogic } from '../../../components/Assignee/assigneeSelectLogic'
+import { errorTrackingEditAccessDisabledReason } from '../../../utils'
 import { RuleList } from '../rules/RuleList'
 import { ErrorTrackingAssignmentRule, ErrorTrackingRuleType } from '../rules/types'
 import { AssignmentRuleModal } from './AssignmentRuleModal'
@@ -40,7 +41,12 @@ export function AssignmentRules(): JSX.Element {
             pageKeyPrefix="assignment-rule"
             onMount={onMount}
             headerActions={
-                <LemonButton type="secondary" size="small" onClick={() => openCodeOwnersModal()}>
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    onClick={() => openCodeOwnersModal()}
+                    disabledReason={errorTrackingEditAccessDisabledReason() ?? undefined}
+                >
                     Code owners
                 </LemonButton>
             }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/IssueRateLimitSettings.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/IssueRateLimitSettings.tsx
@@ -11,6 +11,7 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 import { urls } from 'scenes/urls'
 
+import { errorTrackingEditAccessDisabledReason } from '../../../utils'
 import { issueRateLimitConfigLogic } from './issueRateLimitConfigLogic'
 import { BUCKET_OPTIONS } from './rateLimitConfigLogic'
 import { RateLimitHistoryChart } from './RateLimitHistoryChart'
@@ -97,7 +98,10 @@ function ConfigColumn(): JSX.Element {
                 <LemonButton
                     type="primary"
                     htmlType="submit"
-                    disabledReason={!configFormChanged ? 'No changes to save' : undefined}
+                    disabledReason={
+                        errorTrackingEditAccessDisabledReason() ??
+                        (!configFormChanged ? 'No changes to save' : undefined)
+                    }
                     loading={isConfigFormSubmitting}
                 >
                     Save

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSettings.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rate_limit/RateLimitSettings.tsx
@@ -10,6 +10,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 
+import { errorTrackingEditAccessDisabledReason } from '../../../utils'
 import { BypassRules } from '../bypass_rules/BypassRules'
 import { IssueRateLimitSettings } from './IssueRateLimitSettings'
 import { BUCKET_OPTIONS, rateLimitConfigLogic } from './rateLimitConfigLogic'
@@ -113,7 +114,10 @@ function ProjectRateLimitSection(): JSX.Element {
                             <LemonButton
                                 type="primary"
                                 htmlType="submit"
-                                disabledReason={!configFormChanged ? 'No changes to save' : undefined}
+                                disabledReason={
+                                    errorTrackingEditAccessDisabledReason() ??
+                                    (!configFormChanged ? 'No changes to save' : undefined)
+                                }
                                 loading={isConfigFormSubmitting}
                             >
                                 Save

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleList.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleList.tsx
@@ -14,6 +14,7 @@ import { cn } from 'lib/utils/css-classes'
 
 import { AnyPropertyFilter, FilterLogicalOperator } from '~/types'
 
+import { errorTrackingEditAccessDisabledReason } from '../../../utils'
 import { rulesLogic } from './rulesLogic'
 import { SortableRuleItem } from './SortableRuleItem'
 import { ErrorTrackingRule, ErrorTrackingRuleType } from './types'
@@ -142,15 +143,30 @@ export function RuleList({
                             {headerActions}
                             {rules.length > 1 && (
                                 <>
-                                    <LemonButton type="secondary" size="small" onClick={startSelectingRules}>
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={startSelectingRules}
+                                        disabledReason={errorTrackingEditAccessDisabledReason() ?? undefined}
+                                    >
                                         Select
                                     </LemonButton>
-                                    <LemonButton type="secondary" size="small" onClick={startReorderingRules}>
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={startReorderingRules}
+                                        disabledReason={errorTrackingEditAccessDisabledReason() ?? undefined}
+                                    >
                                         Reorder
                                     </LemonButton>
                                 </>
                             )}
-                            <LemonButton type="primary" size="small" onClick={() => openModal()}>
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                onClick={() => openModal()}
+                                disabledReason={errorTrackingEditAccessDisabledReason() ?? undefined}
+                            >
                                 Add rule
                             </LemonButton>
                         </>

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleModal.tsx
@@ -9,6 +9,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { AnyPropertyFilter, FilterLogicalOperator } from '~/types'
 
+import { errorTrackingEditAccessDisabledReason } from '../../../utils'
 import { DisabledRuleBanner } from './DisabledRuleBanner'
 import { MatchResultBanner } from './MatchResultBanner'
 
@@ -51,7 +52,7 @@ export function RuleModal({
 
     const isEditing = rule.id !== 'new'
     const defaultSaveDisabled = !filtersOptional && !hasFilters ? 'Add at least one filter' : undefined
-    const resolvedSaveDisabled = saveDisabledReason ?? defaultSaveDisabled
+    const resolvedSaveDisabled = errorTrackingEditAccessDisabledReason() ?? saveDisabledReason ?? defaultSaveDisabled
 
     const [confirmingDelete, setConfirmingDelete] = useState(false)
     const [confirmEnabled, setConfirmEnabled] = useState(false)
@@ -102,7 +103,8 @@ export function RuleModal({
                                 size="small"
                                 loading={deletingLoading}
                                 disabledReason={
-                                    confirmingDelete && !confirmEnabled ? 'Click again to confirm' : undefined
+                                    errorTrackingEditAccessDisabledReason() ??
+                                    (confirmingDelete && !confirmEnabled ? 'Click again to confirm' : undefined)
                                 }
                                 onClick={() => {
                                     if (confirmingDelete && confirmEnabled) {

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/Rules.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/Rules.tsx
@@ -21,6 +21,7 @@ import {
     AssigneeResolver,
 } from '../../../components/Assignee/AssigneeDisplay'
 import { AssigneeSelect } from '../../../components/Assignee/AssigneeSelect'
+import { errorTrackingEditAccessDisabledReason } from '../../../utils'
 import { rulesLogic } from './rulesLogic'
 import { ErrorTrackingAssignmentRule, ErrorTrackingRule, ErrorTrackingRuleType } from './types'
 
@@ -138,7 +139,10 @@ const ReorderRules = (): JSX.Element | null => {
                 size="small"
                 type="secondary"
                 onClick={startReorderingRules}
-                disabledReason={localRules.length > 0 ? 'Finish editing all rules before reordering' : undefined}
+                disabledReason={
+                    errorTrackingEditAccessDisabledReason() ??
+                    (localRules.length > 0 ? 'Finish editing all rules before reordering' : undefined)
+                }
             >
                 Reorder
             </LemonButton>
@@ -179,7 +183,12 @@ export const AddRule = ({ disabledReason }: { disabledReason: string | undefined
 
     return !hasNewRule && !isReorderingRules ? (
         <div>
-            <LemonButton type="primary" size="small" onClick={addRule} disabledReason={disabledReason}>
+            <LemonButton
+                type="primary"
+                size="small"
+                onClick={addRule}
+                disabledReason={errorTrackingEditAccessDisabledReason() ?? disabledReason}
+            >
                 Add rule
             </LemonButton>
         </div>
@@ -243,7 +252,12 @@ function Actions<T extends ErrorTrackingRule>({
                     </LemonButton>
                 </>
             ) : (
-                <LemonButton size="small" icon={<IconPencil />} onClick={() => setRuleEditable(rule.id)} />
+                <LemonButton
+                    size="small"
+                    icon={<IconPencil />}
+                    onClick={() => setRuleEditable(rule.id)}
+                    disabledReason={errorTrackingEditAccessDisabledReason() ?? undefined}
+                />
             )}
         </div>
     )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/spike_detection/SpikeDetectionSettings.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/spike_detection/SpikeDetectionSettings.tsx
@@ -9,7 +9,7 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { settingsLogic } from 'scenes/settings/settingsLogic'
 
-import { ERROR_TRACKING_LOGIC_KEY } from '../../../utils'
+import { ERROR_TRACKING_LOGIC_KEY, errorTrackingEditAccessDisabledReason } from '../../../utils'
 import { RecentSpikes } from './RecentSpikes'
 import { spikeDetectionConfigLogic } from './spikeDetectionConfigLogic'
 
@@ -111,7 +111,10 @@ export function SpikeDetectionSettings(): JSX.Element {
                     <LemonButton
                         type="primary"
                         htmlType="submit"
-                        disabledReason={!configFormChanged ? 'No changes to save' : undefined}
+                        disabledReason={
+                            errorTrackingEditAccessDisabledReason() ??
+                            (!configFormChanged ? 'No changes to save' : undefined)
+                        }
                         loading={isConfigFormSubmitting}
                     >
                         Save

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/symbol_sets/SymbolSets.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/symbol_sets/SymbolSets.tsx
@@ -21,6 +21,7 @@ import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
 import { pluralize } from 'lib/utils/strings'
 
 import { ReleasePreviewPill } from 'products/error_tracking/frontend/components/ReleasesPreview/ReleasePreviewPill'
+import { errorTrackingEditAccessDisabledReason } from 'products/error_tracking/frontend/utils'
 
 import { RESULTS_PER_PAGE, SymbolSetOrder, symbolSetLogic } from './symbolSetLogic'
 
@@ -79,6 +80,7 @@ export function SymbolSets(): JSX.Element {
                                     size="small"
                                     icon={<IconTrash />}
                                     loading={deleteSymbolSetResponseLoading}
+                                    disabledReason={errorTrackingEditAccessDisabledReason() ?? undefined}
                                     onClick={() =>
                                         LemonDialog.open({
                                             title: 'Delete symbol sets',
@@ -270,6 +272,7 @@ const SymbolSetTable = (): JSX.Element => {
                             size="xsmall"
                             tooltip="Delete symbol set"
                             icon={<IconTrash />}
+                            disabledReason={errorTrackingEditAccessDisabledReason() ?? undefined}
                             onClick={() =>
                                 LemonDialog.open({
                                     title: 'Delete symbol set',

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -4,9 +4,11 @@ import posthog from 'posthog-js'
 import { LemonBadge, LemonBanner, LemonButton, LemonTab, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { AccessDenied } from 'lib/components/AccessDenied'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { IconFeedback } from 'lib/lemon-ui/icons'
+import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
@@ -14,7 +16,7 @@ import { Settings } from 'scenes/settings/Settings'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { CyclotronJobFiltersType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, CyclotronJobFiltersType } from '~/types'
 
 import { IntegrationsMovedBanner } from '../../components/IntegrationsMovedBanner'
 import { ErrorTrackingIssueFilteringTool } from '../../components/IssueFilteringTool'
@@ -53,6 +55,11 @@ export function ErrorTrackingScene(): JSX.Element {
     const { setActiveTab } = useActions(errorTrackingSceneLogic)
     const hasRecommendations = useFeatureFlag('ERROR_TRACKING_RECOMMENDATIONS')
     const hasSourceMapsBanner = useFeatureFlag('ERROR_TRACKING_SOURCE_MAPS_BANNER')
+    // Same gate as the settings section: configuration endpoints require error tracking viewer access.
+    const configurationAccessDeniedReason = getAccessControlDisabledReason(
+        AccessControlResourceType.ErrorTracking,
+        AccessControlLevel.Viewer
+    )
 
     useOnMountEffect(() => {
         const utmSource = new URLSearchParams(window.location.search).get('utm_source')
@@ -103,7 +110,12 @@ export function ErrorTrackingScene(): JSX.Element {
         {
             key: 'configuration',
             label: 'Configuration',
-            content: (
+            disabledReason: configurationAccessDeniedReason ?? undefined,
+            content: configurationAccessDeniedReason ? (
+                // Deep links can activate the tab even though it's disabled, so the
+                // content must deny too — not just the tab button.
+                <AccessDenied reason={configurationAccessDeniedReason} />
+            ) : (
                 <>
                     <IntegrationsMovedBanner />
                     <Settings

--- a/products/error_tracking/frontend/utils.ts
+++ b/products/error_tracking/frontend/utils.ts
@@ -5,10 +5,17 @@ import { MouseEvent } from 'react'
 
 import { ErrorTrackingException } from 'lib/components/Errors/types'
 import { Dayjs, dayjs } from 'lib/dayjs'
+import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { componentsToDayJs, dateStringToComponents, dateStringToDayJs, isStringDateRegex } from 'lib/utils/dateFilters'
 import { Params } from 'scenes/sceneTypes'
 
 import { DateRange, ErrorTrackingIssue } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+/** Reason error tracking write actions are disabled, or null when the user has editor access. */
+export function errorTrackingEditAccessDisabledReason(): string | null {
+    return getAccessControlDisabledReason(AccessControlResourceType.ErrorTracking, AccessControlLevel.Editor)
+}
 
 export const ERROR_TRACKING_LOGIC_KEY = 'errorTracking'
 export const ERROR_TRACKING_LISTING_RESOLUTION = 20


### PR DESCRIPTION
This all applies only if an org has RBAC enabled. All of this is also enforced on backend - only exception from this rule is auto capture settings - this currently lives on the team model - I will migrate it in the follow up PR

### Viewer

If user has no `viewer` rights

| Navigation | Inside the page (can't get there via navigation. Had to use direct link or something) |
|--------|--------|
| <img width="718" height="334" alt="CleanShot 2026-07-13 at 19 33 03@2x" src="https://github.com/user-attachments/assets/bee82821-950e-4ed8-b126-c5344e8b5494" /> | <img width="2590" height="1410" alt="CleanShot 2026-07-13 at 19 37 51@2x" src="https://github.com/user-attachments/assets/a9df21f6-4527-457e-909b-3ef89ef6509c" /> | 


### Editor

If user has `viewer` rights but no `editor` rights, we display everything but each save or modify or new rule button is disabled with a reason:

<img width="2590" height="1410" alt="CleanShot 2026-07-13 at 19 58 12@2x" src="https://github.com/user-attachments/assets/a6147f3c-c342-4ab4-b462-1b0aed66fb08" />

