### PR TITLE
fix: add hogql anti-pattern rules to mcp sql guidance

### DIFF
--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -13,8 +13,7 @@ Proactively use different search types depending on a task:
 - Dumping results to a file and using bash commands to process potentially large outputs.
 
 Substring search on events-table strings is a full scan: `LIKE '%term%'`, `ILIKE '%term%'`, and `position()` read the column for every row in the time range, and a leading `%` makes indexes useless.
-Before fuzzy-matching a property value, look up the real value with `read-data-schema` (`event_property_values`) and use equality or an anchored prefix (`LIKE 'term%'`).
-When substring search is genuinely needed, keep the timestamp window tight and filter `event` first.
+Before fuzzy-matching a property value, try `read-data-schema` (`event_property_values`) to find common exact values. If the requested value is not returned, or the user needs true contains semantics, keep the timestamp window tight, filter `event` first, and use the substring predicate.
 
 #### Data Groups
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -357,8 +357,8 @@ Find the reference for [Sparkline, SemVer, Session replays, Actions, Translation
 - Always handle nulls before array functions: `splitByChar(',', coalesce(field, ''))`
 - Performance: always filter `events` by timestamp
 - Performance: read properties with dot access (`properties.foo`, cast via `toFloat(properties.foo)`), never `JSONExtract*` on the `properties` blob
-- Count unique users with `uniq(person_id)` on events, never `uniq(distinct_id)` (one person can have many distinct_ids)
-- Avoid `GROUP BY` on unbounded high-cardinality expressions (raw URLs, ids, free text) over wide windows: the aggregation holds every distinct value in memory regardless of `LIMIT`; normalize the value (strip ids from paths) or narrow the window
+- Correctness: count unique users with `uniq(person_id)` on events, never `uniq(distinct_id)` (one person has many distinct_ids, so distinct_id overcounts users)
+- Memory: avoid `GROUP BY` on unbounded high-cardinality expressions (raw URLs, ids, free text) over wide windows: the aggregation holds every distinct value in memory regardless of `LIMIT`; normalize the value (strip ids from paths) or narrow the window
 
 ##### SQL Variables
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -12,6 +12,10 @@ Proactively use different search types depending on a task:
 - Full-text search with `hasToken`, `hasTokenCaseInsensitive`, etc. Make sure you pass string constants to `hasToken*` functions.
 - Dumping results to a file and using bash commands to process potentially large outputs.
 
+Substring search on events-table strings is a full scan: `LIKE '%term%'`, `ILIKE '%term%'`, and `position()` read the column for every row in the time range, and a leading `%` makes indexes useless.
+Before fuzzy-matching a property value, look up the real value with `read-data-schema` (`event_property_values`) and use equality or an anchored prefix (`LIKE 'term%'`).
+When substring search is genuinely needed, keep the timestamp window tight and filter `event` first.
+
 #### Data Groups
 
 PostHog has two distinct groups of data you can query:
@@ -213,6 +217,10 @@ You should use the skipping index signature to write optimized analytical querie
 
 All analytical queries and subqueries must always have time ranges set for supported tables (events). If the user doesn't state it, assume default time range based on the data volume, like a day, week, or month.
 
+The bound must be a `WHERE` predicate on `timestamp`. A time condition that appears only inside an aggregate argument, like `countIf(event = 'x' AND timestamp > now() - INTERVAL 1 DAY)`, filters nothing: every historical row is still read. Put the outer window in `WHERE` and keep only the split inside the aggregate.
+
+Point lookups need a time bound too. Filtering on a session id, trace id, distinct_id, or a property value without a timestamp bound scans the team's entire history, because those filters don't align with the table's date-first sort key. Derive the window from context (the session's day, the incident's date), or start with a recent window and widen only if the result is empty.
+
 **How you should use time ranges**
 
 <example>
@@ -252,6 +260,10 @@ You are allowed joining system data. Insights are the most used entity, so keep 
 **Analytical data**
 
 Prefer using analytical functions and subqueries for joins. Do not use raw joins on the events table.
+
+Scan `events` once per question where you can: conditional aggregates (`countIf`, `sumIf`, `uniqIf`, `argMax`) or a window function over one scan replace a self-join, repeated subqueries over the same rows, and UNIONs of the same range.
+CTEs are inlined, not materialized: a CTE referenced twice executes twice.
+Subqueries that correlate different events (like the example below) are fine.
 
 **How you should join data**
 
@@ -345,6 +357,8 @@ Find the reference for [Sparkline, SemVer, Session replays, Actions, Translation
 - Always handle nulls before array functions: `splitByChar(',', coalesce(field, ''))`
 - Performance: always filter `events` by timestamp
 - Performance: read properties with dot access (`properties.foo`, cast via `toFloat(properties.foo)`), never `JSONExtract*` on the `properties` blob
+- Count unique users with `uniq(person_id)` on events, never `uniq(distinct_id)` (one person can have many distinct_ids)
+- Avoid `GROUP BY` on unbounded high-cardinality expressions (raw URLs, ids, free text) over wide windows: the aggregation holds every distinct value in memory regardless of `LIMIT`; normalize the value (strip ids from paths) or narrow the window
 
 ##### SQL Variables
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -314,14 +314,7 @@ properties.foo.bar
 
 -- Keys with special characters
 properties.foo['bar-baz']
-
--- Typed reads: cast the dot access
-toFloat(properties.revenue)
 ```
-
-**Always use dot access for `properties` and `person.properties`. Never call `JSONExtractString`, `JSONExtractRaw`, `JSONHas`, or any other `JSONExtract*` function on those blobs.**
-Dot access compiles to a materialized column when one exists (up to ~100x faster) and falls back to JSON extraction only when none does, so hand-written `JSONExtract*` can only match or lose to `properties.foo`, and it stays slow even after the property is materialized later.
-`JSONExtract*` remains correct for JSON stored in other columns (activity log `detail`, action `steps_json`, data warehouse JSON columns) and for parsing a JSON string held inside a property's value.
 
 ##### Unsupported/changed functions
 
@@ -356,7 +349,6 @@ Find the reference for [Sparkline, SemVer, Session replays, Actions, Translation
 - `toStartOfWeek(timestamp, 1)` for Monday start (numeric, not string)
 - Always handle nulls before array functions: `splitByChar(',', coalesce(field, ''))`
 - Performance: always filter `events` by timestamp
-- Performance: read properties with dot access (`properties.foo`, cast via `toFloat(properties.foo)`), never `JSONExtract*` on the `properties` blob
 - Correctness: count unique users with `uniq(person_id)` on events, never `uniq(distinct_id)` (one person has many distinct_ids, so distinct_id overcounts users)
 - Memory: avoid `GROUP BY` on unbounded high-cardinality expressions (raw URLs, ids, free text) over wide windows: the aggregation holds every distinct value in memory regardless of `LIMIT`; normalize the value (strip ids from paths) or narrow the window
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -302,7 +302,14 @@ properties.foo.bar
 
 -- Keys with special characters
 properties.foo['bar-baz']
+
+-- Typed reads: cast the dot access
+toFloat(properties.revenue)
 ```
+
+**Always use dot access for `properties` and `person.properties`. Never call `JSONExtractString`, `JSONExtractRaw`, `JSONHas`, or any other `JSONExtract*` function on those blobs.**
+Dot access compiles to a materialized column when one exists (up to ~100x faster) and falls back to JSON extraction only when none does, so hand-written `JSONExtract*` can only match or lose to `properties.foo`, and it stays slow even after the property is materialized later.
+`JSONExtract*` remains correct for JSON stored in other columns (activity log `detail`, action `steps_json`, data warehouse JSON columns) and for parsing a JSON string held inside a property's value.
 
 ##### Unsupported/changed functions
 
@@ -337,6 +344,7 @@ Find the reference for [Sparkline, SemVer, Session replays, Actions, Translation
 - `toStartOfWeek(timestamp, 1)` for Monday start (numeric, not string)
 - Always handle nulls before array functions: `splitByChar(',', coalesce(field, ''))`
 - Performance: always filter `events` by timestamp
+- Performance: read properties with dot access (`properties.foo`, cast via `toFloat(properties.foo)`), never `JSONExtract*` on the `properties` blob
 
 ##### SQL Variables
 


### PR DESCRIPTION
## Problem

LLMs can write poor-performing HogQL. I created an [LLM judge evaluation](https://us.posthog.com/project/2/ai-evals/evaluations/019f3eb8-6e12-0000-2bcb-f801ac020d12) to find anti-patterns in LLM-written HogQL queries. 

## Changes

`products/posthog_ai/skills/querying-posthog-data/references/guidelines.md`. It's bundled into the MCP server, so the rules land in both the `execute-sql` tool description and the querying skill. 

- Don't hunt for event or property names with `LIKE '%term%'`. Look up the real names with `read-data-schema` and match them exactly. A wildcard search reads every row in the time range; an exact match lets ClickHouse skip most of the table.
- Every events query needs a time filter in its WHERE clause. A time condition inside `countIf(...)` doesn't count, and a selective-looking id filter (session, trace, user) doesn't either: without a time filter the whole history gets scanned.
- Read the events table once per question where possible, using conditional aggregates like `countIf` instead of self-joins or repeating the same subquery. A `WITH` subquery used twice runs twice.
- Count unique users with `uniq(person_id)`, not `uniq(distinct_id)`. This one is about correctness than speed
- Don't GROUP BY values with unlimited variety (raw URLs, ids, free text) over long time ranges. The database holds every distinct value in memory, and `LIMIT` doesn't help.

Left alone on purpose: the `uniq(distinct_id)` examples in `models-mcp.md`, which mirror backend code and belong to the MCP analytics team.

## How did you test this code?

Benchmarked the two biggest rewrites on our test ClickHouse cluster:

- Finding events with "insight" in the name: the wildcard version read 23x more rows (1.3B vs 56M) and 12x more data than matching the 48 exact names, for the identical result.
- Grouping by raw URL vs by URL with ids stripped out: same data read, but 6x more memory (2.9 GiB vs 495 MiB).

After this merges, the same evaluations that produced the fail rates above tell us whether the rules actually changed client behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: this PR is itself the guidance change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, directed by the assignee, as part of a quality loop: capture every MCP SQL query with its stated intent, score them with online evaluations, fix the guidance where the scores show problems, then watch the rates move. The rules come from the internal `optimizing-clickhouse-and-hogql-queries` skill plus the benchmarks above. Started as a single JSONExtract rule, expanded to the full measured set, then the JSONExtract rule was dropped on the assignee's direction after we confirmed the HogQL engine already rewrites the common form to the materialized column. No repo skills were invoked for the edits themselves (markdown-only change).

