### PR TITLE
feat(metrics): surface metrics product in app monitoring nav for alpha

### DIFF
--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -177,7 +177,13 @@
             "type": "mcp_analytics",
             "intents": ["llm_analytics"]
         },
-        { "path": "Metrics", "category": "Unreleased", "iconType": "metrics", "type": null, "intents": ["metrics"] },
+        {
+            "path": "Metrics",
+            "category": "App monitoring",
+            "iconType": "metrics",
+            "type": null,
+            "intents": ["metrics"]
+        },
         {
             "path": "Product analytics",
             "category": "Analytics",

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1942,7 +1942,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     {
         path: 'Metrics',
         intents: [ProductKey.METRICS],
-        category: ProductItemCategory.UNRELEASED,
+        category: ProductItemCategory.APP_MONITORING,
         iconType: 'metrics',
         iconColor: ['var(--color-product-metrics-light)', 'var(--color-product-metrics-dark)'] as FileSystemIconColor,
         href: urls.metrics(),

--- a/products/metrics/manifest.tsx
+++ b/products/metrics/manifest.tsx
@@ -30,7 +30,7 @@ export const manifest: ProductManifest = {
         {
             path: 'Metrics',
             intents: [ProductKey.METRICS],
-            category: ProductItemCategory.UNRELEASED,
+            category: ProductItemCategory.APP_MONITORING,
             iconType: 'metrics',
             iconColor: [
                 'var(--color-product-metrics-light)',


### PR DESCRIPTION
## Problem

Metrics is functionally ready for an alpha, and the docs already shipped (`/docs/metrics`), but the product never shows up in the app. Its manifest sits in the `UNRELEASED` category, which `user_product_list.py` filters out of the product tree entirely. So even people who have the `metrics` feature flag on can't see it in the nav. This is the one thing blocking a flagged alpha.

## Changes

Move the Metrics product from `ProductItemCategory.UNRELEASED` to `ProductItemCategory.APP_MONITORING`, so it renders in the product tree next to Logs and Tracing.

```diff
- category: ProductItemCategory.UNRELEASED,
+ category: ProductItemCategory.APP_MONITORING,
```

Everything else about its gating stays the same:

- Still behind `FEATURE_FLAGS.METRICS`, so only flagged users see it.
- Keeps `tags: ['alpha']`, so it renders with the alpha badge.

This is exactly the posture Tracing shipped its alpha with (`products/tracing/manifest.tsx` uses `APP_MONITORING` + its flag + an alpha tag). Flipping the category is the whole "make it visible to flagged users" step. Targeting the `metrics` flag to the right orgs is a separate in-app config action, not part of this PR.

`frontend/src/products.tsx` and `frontend/src/products.json` are regenerated from the manifest via `pnpm build:products` (not hand-edited).

## How did you test this code?

- Ran `pnpm build:products` and confirmed the regenerated `products.tsx` / `products.json` now show the Metrics entry under `App monitoring` (a re-run leaves no further diff).
- `hogli ci:preflight` is green (0 failures) on the diff.
- Reasoned through the backend product-category tests (`test_products.py`, `test_user_product_list.py`): 7 other products remain in `UNRELEASED` and `App monitoring` already exists, so the "expected categories" set and the `assert unreleased_products` checks still hold.

I (Claude, agent-assisted) could not run those Python tests locally — the sandbox has no Postgres connection, so they error at DB setup rather than on assertions. CI will run them with a database. I also did not spin up the full app to visually confirm the nav entry, for the same reason.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Docs already exist at `/docs/metrics` (shipped separately), so no docs change here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed this; assigned as DRI.

I (Claude) made the change. Daniel asked to get Metrics into alpha and "push it through." The direction came from a prior investigation (pasted in-session) that identified the category flip as the single code change needed to make the product visible to flagged users, using Tracing's manifest as the template. I verified that analysis against the current repo before acting: confirmed the `UNRELEASED` filter in `posthog/models/file_system/user_product_list.py`, the `APP_MONITORING` enum value, the Tracing precedent, and that the generated products files are the source of frontend product metadata.

No repo skills applied cleanly (this isn't a migration, DRF, or taxonomic-filter change). Out of scope and tracked separately: `metrics` flag targeting, the project-2 usage dashboard, and the `$group_0`/`$current_url` telemetry stamping that dashboard depends on.
