### PR TITLE
fix(mysql): retry SSLZeroReturnError peer-close on connect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -321,6 +321,13 @@ _CANT_CONNECT_TO_SERVER_CODE = 2003
 # Postgres source, which retries its own "SSL connection has been closed unexpectedly" on connect.
 _SSL_UNEXPECTED_EOF_TOKEN = "[SSL: UNEXPECTED_EOF_WHILE_READING]"
 
+# Newer OpenSSL/Python raise `ssl.SSLZeroReturnError` — "TLS/SSL connection has been closed (EOF)" —
+# for the same peer-closed-the-TLS-connection condition the token above covers, just a different
+# rendering (a clean SSL_ERROR_ZERO_RETURN close rather than an abrupt read EOF). pymysql wraps it as
+# the same 2003 connect failure, so it's equally transient and must be retried too. Match the stable
+# phrase, not the volatile `_ssl.c:<line>` suffix that shifts across Python builds.
+_SSL_CONNECTION_CLOSED_EOF_TOKEN = "TLS/SSL connection has been closed (EOF)"
+
 # paramiko raises a bare, message-less EOFError from `start_client` when the SSH gateway accepts
 # the TCP connection but closes it during the SSH handshake — a non-SSH service on the port, a
 # bastion refusing PostHog's IPs, or a proxy that resets the stream. sshtunnel doesn't wrap it
@@ -344,10 +351,12 @@ def _is_transient_connect_drop(e: BaseException) -> bool:
       A fresh attempt recovers. The one 2013 that is *not* transient is the SSL-version
       mismatch (a deterministic config error, already non-retryable): it arrives with an
       `[SSL: ...` suffix, so exclude that and let it surface.
-    - `2003` (can't connect) carrying an `[SSL: UNEXPECTED_EOF_WHILE_READING]` cause:
-      the peer aborted the TLS handshake with an unexpected EOF — the SSL-flavoured
-      sibling of the 2013 drop, equally transient. The generic 2003 (wrong host/port,
-      firewall) stays non-retryable, so match only the unexpected-EOF token.
+    - `2003` (can't connect) carrying an SSL peer-close cause — either
+      `[SSL: UNEXPECTED_EOF_WHILE_READING]` (an abrupt read EOF) or "TLS/SSL connection
+      has been closed (EOF)" (`SSLZeroReturnError`, a clean close): the peer dropped the
+      TLS connection mid-handshake — the SSL-flavoured sibling of the 2013 drop, equally
+      transient. The generic 2003 (wrong host/port, firewall) stays non-retryable, so
+      match only the SSL peer-close tokens.
     """
     if not isinstance(e, pymysql.err.OperationalError):
         return False
@@ -356,7 +365,7 @@ def _is_transient_connect_drop(e: BaseException) -> bool:
     if code == _LOST_CONNECTION_DURING_QUERY_CODE:
         return "[SSL:" not in args_text
     if code == _CANT_CONNECT_TO_SERVER_CODE:
-        return _SSL_UNEXPECTED_EOF_TOKEN in args_text
+        return _SSL_UNEXPECTED_EOF_TOKEN in args_text or _SSL_CONNECTION_CLOSED_EOF_TOKEN in args_text
     return False
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -887,17 +887,21 @@ class TestIsTransientConnectDrop:
             )
         )
 
-    def test_matches_ssl_unexpected_eof_on_connect(self):
-        # The peer aborted the TLS handshake with an unexpected EOF, wrapped by pymysql as the
-        # 2003 connect failure. A transient drop (overloaded server, proxy idle cull, failover) —
-        # the in-process retry must catch it instead of letting the first blip surface as noise.
-        assert _is_transient_connect_drop(
-            pymysql.err.OperationalError(
-                2003,
-                "Can't connect to MySQL server on 'db.example.com' "
-                "([SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1032))",
-            )
-        )
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # The peer aborted the TLS handshake with an unexpected read EOF.
+            "Can't connect to MySQL server on 'db.example.com' "
+            "([SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1032))",
+            # The `SSLZeroReturnError` rendering of the same peer-closed-the-TLS-connection drop.
+            "Can't connect to MySQL server on 'db.example.com' (TLS/SSL connection has been closed (EOF) (_ssl.c:1032))",
+        ],
+    )
+    def test_matches_ssl_peer_close_on_connect(self, message):
+        # pymysql wraps an SSL peer-close mid-handshake as the 2003 connect failure. A transient
+        # drop (overloaded server, proxy idle cull, failover) — the in-process retry must catch it
+        # instead of letting the first blip surface as the non-retryable "Can't connect" config error.
+        assert _is_transient_connect_drop(pymysql.err.OperationalError(2003, message))
 
     @pytest.mark.parametrize(
         "code,message",


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError(2003, "Can't connect to MySQL server on '<host>' (TLS/SSL connection has been closed (EOF) (_ssl.c:1032))")` from the MySQL warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019f5ca9-c12b-7433-8485-2a28078b9cf2)). It was raised from `_connect_with_transient_retry` while reconnecting mid-sync.

The underlying cause is `ssl.SSLZeroReturnError` — the TLS peer closed the connection. This is exactly the transient class the source already retries in-process for the `[SSL: UNEXPECTED_EOF_WHILE_READING]` rendering (an overloaded server, a proxy/load-balancer idle cull, a failover, a momentary network blip). But `_is_transient_connect_drop` only matched that one token, so the `SSLZeroReturnError` rendering fell through: the retry re-raised on the first attempt, and the error then hit the non-retryable `"Can't connect to MySQL server on"` classifier. The sync gave up on a blip a fresh attempt would have recovered.

## Changes

Recognize the second rendering of the SSL peer-close ("TLS/SSL connection has been closed (EOF)") as a transient connect drop, so both are retried in-process by `_connect_with_transient_retry`. Match the stable phrase only, not the volatile `_ssl.c:<line>` suffix, and keep it scoped to the 2003 branch so the generic "can't connect" config errors (wrong host/port, firewall) stay non-retryable.

This does not add anything to `NonRetryableErrors` and does not touch the global retry policy — the fix keeps a transient error retryable, which it should have been all along.

## How did you test this code?

Extended `TestIsTransientConnectDrop` — parameterized the existing SSL peer-close case to cover both the `UNEXPECTED_EOF_WHILE_READING` and the new `TLS/SSL connection has been closed (EOF)` renderings. Guards against re-narrowing the matcher so the new rendering silently becomes non-retryable again; no existing case exercised it.

Ran locally:

```
python -m pytest test_mysql.py::TestIsTransientConnectDrop test_mysql.py::TestConnectTransientRetry
19 passed
```

Also ran `ruff check` and `ruff format --check` on both changed files — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Pulled the issue and a representative event via the PostHog MCP error-tracking tools, read the full stack trace to confirm the failure originates in `mysql.py` (`_connect_with_transient_retry`), and read the source's existing transient/non-retryable classification.

Decision: fixable bug, not a user/upstream error. The message is a transient infrastructure drop, and the source already treats the sibling SSL-EOF token as retryable — this rendering just wasn't matched. So the fix is to widen the transient matcher, not to add a `NonRetryableErrors` entry. Invoked `/writing-tests` before touching the test file; chose to parameterize the existing test rather than add a near-duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
