### PR TITLE
fix(data-warehouse): derive partition count in compact threshold check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -803,6 +803,11 @@ class DeltaTableHelper:
         time tracks total files — a high partition_count must not let a table accumulate
         tens of thousands of files while staying under the per-partition bar.
 
+        When `partition_count` is None it is derived from the table's actual layout (the
+        distinct file directories in the delta log, no extra I/O) — only md5 partitioning
+        persists a count on the schema, so datetime/numerical-partitioned tables always
+        arrive here with None.
+
         Returns True if compaction ran, False if it was skipped. Cheap when the table is
         healthy: one S3 LIST via `get_file_uris`. Intended for pre-write defensive cleanup
         so a sync that arrived at a fragmented state (e.g. an earlier attempt that failed
@@ -814,6 +819,11 @@ class DeltaTableHelper:
 
         file_uris = await self.get_file_uris()
         total_files = len(file_uris)
+        if partition_count is None:
+            # One directory per partition value; unpartitioned tables collapse to the single
+            # table root. Without this, a partitioned table with no persisted count reads as
+            # one giant partition and trips the per-partition threshold on every run.
+            partition_count = len({uri.rsplit("/", 1)[0] for uri in file_uris})
         # Treat unpartitioned tables as one "partition" for the threshold math.
         effective_partitions = max(partition_count or 1, 1)
         files_per_partition = total_files / effective_partitions

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -228,7 +228,7 @@ class TestCompactIfFragmented:
         ("below_default_threshold", 100, 10, None, False),
         # 5,000 / 10 = 500 fpp, well above default 200 -> fire
         ("above_default_threshold", 5_000, 10, None, True),
-        # partition_count=None treated as 1; 250 fpp >> default 200 -> fire
+        # partition_count=None on an unpartitioned layout derives 1 partition; 250 fpp >> 200 -> fire
         ("unpartitioned_above_default", 250, None, None, True),
         # Custom threshold: 100 / 10 = 10 fpp, threshold=5 -> fire
         ("custom_threshold_fires", 100, 10, 5, True),
@@ -253,15 +253,53 @@ class TestCompactIfFragmented:
     ):
         helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
         mock_delta = MagicMock()
+        file_uris = [f"s3://bucket/table/f{i}.parquet" for i in range(file_count)]
         with (
             patch.object(helper, "get_delta_table", AsyncMock(return_value=mock_delta)),
-            patch.object(helper, "get_file_uris", AsyncMock(return_value=[f"f{i}" for i in range(file_count)])),
+            patch.object(helper, "get_file_uris", AsyncMock(return_value=file_uris)),
             patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
         ):
             kwargs: dict = {"partition_count": partition_count}
             if threshold_kw is not None:
                 kwargs["threshold"] = threshold_kw
             ran = await helper.compact_if_fragmented(**kwargs)
+
+        assert ran is expected_ran
+        if expected_ran:
+            mock_compact.assert_called_once()
+        else:
+            mock_compact.assert_not_called()
+
+    # (case_name, files_per_dir, dir_count, expected_ran)
+    _DERIVATION_CASES: list[tuple[str, int, int, bool]] = [
+        # 300 files / 3 derived partitions = 100 fpp < 200 and total < 5,000 -> skip.
+        # Before derivation, None meant 1 partition (300 fpp) and this healthy table
+        # compacted on every run.
+        ("healthy_partitioned_table_skips", 100, 3, False),
+        # Genuinely fragmented per partition: 750/3 = 250 fpp > 200 -> still fires.
+        ("fragmented_partitioned_table_fires", 250, 3, True),
+    ]
+
+    @parameterized.expand(_DERIVATION_CASES)
+    @pytest.mark.asyncio
+    async def test_partition_count_derived_from_layout(
+        self, _name: str, files_per_dir: int, dir_count: int, expected_ran: bool
+    ):
+        # Only md5 partitioning persists a partition_count; datetime/numerical schemas pass
+        # None. The count must come from the layout or every >200-file partitioned table
+        # would defensively compact at the start of every sync run.
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        file_uris = [
+            f"s3://bucket/table/_ph_partition_key={d}/f{i}.parquet"
+            for d in range(dir_count)
+            for i in range(files_per_dir)
+        ]
+        with (
+            patch.object(helper, "get_delta_table", AsyncMock(return_value=MagicMock())),
+            patch.object(helper, "get_file_uris", AsyncMock(return_value=file_uris)),
+            patch.object(helper, "compact_table", AsyncMock()) as mock_compact,
+        ):
+            ran = await helper.compact_if_fragmented(partition_count=None)
 
         assert ran is expected_ran
         if expected_ran:


### PR DESCRIPTION
## Problem

`compact_if_fragmented` decides "fragmented" from files-per-partition, using the `partition_count` its caller passes. Only md5 partitioning persists a `partition_count` on the schema — datetime- and numerical-partitioned schemas never get one (`append_partition_key_to_table` only produces a count for md5 bucketing), so `run_pre_write_defensive_compact` passes None for them. With None the threshold math treats the table as a single partition, so any datetime-partitioned table with more than 200 total files reads as fragmented and gets a defensive compact plus vacuum at the start of every sync run, even when it is perfectly healthy.

This is the same blind spot [#70499](https://github.com/PostHog/posthog/pull/70499) fixed for the CDC post-load path by deriving the count at its call site. This PR moves the derivation into `compact_if_fragmented` itself, so every `run_maintenance` caller (the v2 and v3 pre-write defensive path today) gets the correct math without each call site reimplementing it.

## Changes

When `partition_count` is None, `compact_if_fragmented` derives it from the table's actual layout: the number of distinct file directories in the delta log's file paths (one directory per partition value; unpartitioned tables collapse to the single table root). No extra I/O — it reuses the `get_file_uris` result the threshold math already fetched.

> [!NOTE]
> Behavior change: partitioned tables whose schemas persist no `partition_count` stop compacting at the start of every sync run and only compact when genuinely past the thresholds (200 files per partition, 5,000 total). The total-files backstop is unaffected.

Checked that no open PR touches this function: [#70495](https://github.com/PostHog/posthog/pull/70495) edits the merge-loop region and [#70504](https://github.com/PostHog/posthog/pull/70504) the commit-metadata region of the same file, both away from `compact_if_fragmented`. Once this and #70499 both land, the call-site derivation in `pipelines/common/load.py` becomes redundant (passing a non-None count simply skips the helper's derivation) and can be dropped in a small cleanup.

## How did you test this code?

Extended `TestCompactIfFragmented` in `test_delta_table_helper.py`:

- `healthy_partitioned_table_skips`: 300 files across 3 partition directories with `partition_count=None` must not compact — this case fails on the old code (None meant 1 partition, 300 files-per-partition, compact every run), so it pins exactly the regression this PR fixes.
- `fragmented_partitioned_table_fires`: 750 files across 3 directories (250 per partition) still compacts — guards the derivation from over-suppressing real fragmentation.
- The existing threshold cases now use directory-shaped fake URIs so the unpartitioned case keeps meaning "single root directory" under the new derivation.

The derivation lives in the helper, so the coverage lives there too — an extract-level test with a mocked helper cannot observe it, and the existing `TestRunPreWriteDefensiveCompact` pass-through cases (schema over resource, both-None passes None) remain correct as-is.

Ran locally: `pytest .../pipelines/pipeline/test/test_delta_table_helper.py .../pipelines/common/test/test_extract.py` (74 passed). `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, internal pipeline behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up flagged while working on #70499, implemented by Claude Code (Claude Fable 5). Skills invoked: /writing-tests. The task allowed either a call-site fix in `run_pre_write_defensive_compact` or moving the derivation into `compact_if_fragmented`; I (Claude) chose the helper after verifying the two open PRs touching `delta_table_helper.py` (#70495, #70504) edit disjoint function regions — one implementation fixes all callers and avoids a second copy of the derivation block. Branched from fresh master, independent of #70499.
