### PR TITLE
feat(replay): dogfood posthog.metrics from replay and replay vision frontends

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -186,6 +186,7 @@ jest.mock('posthog-js', () => {
         updateEarlyAccessFeatureEnrollment: jest.fn(),
         people: { set: jest.fn() },
         featureFlags: { override: jest.fn() },
+        metrics: { count: jest.fn(), gauge: jest.fn(), histogram: jest.fn() },
     }
     mock.init = jest.fn(() => mock)
 

--- a/frontend/src/lib/operationalMetrics.test.ts
+++ b/frontend/src/lib/operationalMetrics.test.ts
@@ -1,0 +1,41 @@
+import posthog from 'posthog-js'
+
+import { metricCount, metricHistogram } from 'lib/operationalMetrics'
+
+describe('operationalMetrics', () => {
+    // posthog-js is mocked app-wide in jest.setup.ts, including posthog.metrics.
+    const metrics = posthog.metrics as unknown as { count: jest.Mock; histogram: jest.Mock }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(posthog as { metrics?: unknown }).metrics = metrics
+    })
+
+    it('forwards counts with attributes in the options envelope', () => {
+        metricCount('replay_test_total', 2, { kind: 'meta' })
+
+        expect(metrics.count).toHaveBeenCalledWith('replay_test_total', 2, { attributes: { kind: 'meta' } })
+    })
+
+    it('omits the options envelope when there are no attributes', () => {
+        metricCount('replay_test_total')
+
+        expect(metrics.count).toHaveBeenCalledWith('replay_test_total', 1, undefined)
+    })
+
+    it('forwards histograms with unit and attributes', () => {
+        metricHistogram('replay_test_ms', 187, 'ms', { source: 'list' })
+
+        expect(metrics.histogram).toHaveBeenCalledWith('replay_test_ms', 187, {
+            unit: 'ms',
+            attributes: { source: 'list' },
+        })
+    })
+
+    it('is a no-op when the SDK build has no metrics extension', () => {
+        ;(posthog as { metrics?: unknown }).metrics = undefined
+
+        expect(() => metricCount('replay_test_total')).not.toThrow()
+        expect(() => metricHistogram('replay_test_ms', 1, 'ms')).not.toThrow()
+    })
+})

--- a/frontend/src/lib/operationalMetrics.ts
+++ b/frontend/src/lib/operationalMetrics.ts
@@ -1,0 +1,29 @@
+import type { MetricAttributes } from 'posthog-js'
+import posthog from 'posthog-js'
+
+/**
+ * Operational metrics into the PostHog Metrics product via the SDK's aggregated
+ * `posthog.metrics` API (samples are batched to one data point per series every 10s).
+ *
+ * Attributes must stay low-cardinality: no user ids, session ids, or URLs. Every distinct
+ * attribute combination is its own series, and no user or session context is attached.
+ *
+ * Both helpers are hard no-ops when the loaded posthog-js build doesn't ship the metrics
+ * extension, and they swallow errors so telemetry can never break product code.
+ */
+
+export function metricCount(name: string, value: number = 1, attributes?: MetricAttributes): void {
+    try {
+        posthog.metrics?.count(name, value, attributes ? { attributes } : undefined)
+    } catch {
+        // never let telemetry break the product
+    }
+}
+
+export function metricHistogram(name: string, value: number, unit: string, attributes?: MetricAttributes): void {
+    try {
+        posthog.metrics?.histogram(name, value, { unit, ...(attributes ? { attributes } : {}) })
+    } catch {
+        // never let telemetry break the product
+    }
+}

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -187,8 +187,11 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
             actions.reportUsageIfFullyLoaded()
         },
 
-        loadRecordingMetaFailure: () => {
-            metricCount('replay_player_load_failures', 1, { kind: 'meta' })
+        loadRecordingMetaFailure: ({ errorObject }) => {
+            // A 404 is an expected outcome (expired or deleted recording), not a player
+            // failure; separate series so real failures stay alertable.
+            const is404 = (errorObject as { status?: number } | undefined)?.status === 404
+            metricCount('replay_player_load_failures', 1, { kind: is404 ? 'meta_not_found' : 'meta' })
         },
 
         loadNextSnapshotSource: () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic.ts
@@ -14,6 +14,7 @@ import {
 } from '@posthog/replay-shared'
 
 import { Dayjs, dayjs, now } from 'lib/dayjs'
+import { metricCount } from 'lib/operationalMetrics'
 
 import {
     RecordingSegment,
@@ -186,6 +187,10 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
             actions.reportUsageIfFullyLoaded()
         },
 
+        loadRecordingMetaFailure: () => {
+            metricCount('replay_player_load_failures', 1, { kind: 'meta' })
+        },
+
         loadNextSnapshotSource: () => {
             actions.reportUsageIfFullyLoaded()
         },
@@ -265,6 +270,7 @@ export const sessionRecordingDataCoordinatorLogic = kea<sessionRecordingDataCoor
                 } else {
                     // Give up loudly: nothing re-triggers processing from here, so surface a terminal
                     // error instead of leaving the player buffering forever.
+                    metricCount('replay_player_load_failures', 1, { kind: 'snapshot_processing' })
                     actions.snapshotProcessingFailed()
                 }
                 return

--- a/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.test.ts
@@ -1,0 +1,42 @@
+import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
+
+import { initKeaTests } from '~/test/init'
+import { SessionPlayerData, SessionRecordingType } from '~/types'
+
+import { sessionRecordingEventUsageLogic } from './sessionRecordingEventUsageLogic'
+
+describe('sessionRecordingEventUsageLogic', () => {
+    let logic: ReturnType<typeof sessionRecordingEventUsageLogic.build>
+
+    const playerData = {
+        durationMs: 1000,
+        sessionRecordingId: 'abc',
+    } as SessionPlayerData
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.clearAllMocks()
+        logic = sessionRecordingEventUsageLogic()
+        logic.mount()
+    })
+
+    // snapshot_source is caller-controlled at runtime, so anything outside the
+    // allowlist must be normalized to keep the metric series bounded
+    it.each([
+        ['web', 'web'],
+        ['mobile', 'mobile'],
+        ['some-arbitrary-caller-value', 'unknown'],
+        [undefined, 'unknown'],
+    ])('reports recording loaded metric with snapshot_source %p as %p', async (rawSource, expectedLabel) => {
+        const metadata = { snapshot_source: rawSource } as unknown as SessionRecordingType
+
+        await expectLogic(logic, () => {
+            logic.actions.reportRecordingLoaded(playerData, metadata)
+        }).toFinishAllListeners()
+
+        expect(posthog.metrics?.count).toHaveBeenCalledWith('replay_player_recordings_loaded', 1, {
+            attributes: { snapshot_source: expectedLabel },
+        })
+    })
+})

--- a/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
@@ -96,7 +96,9 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
                 snapshot_source: snapshotSource,
             }
             posthog.capture(`recording loaded`, payload)
-            metricCount('replay_player_recordings_loaded', 1, { snapshot_source: snapshotSource })
+            // the runtime value is caller-controlled, so allowlist it to keep the metric series bounded
+            const snapshotSourceLabel = ['web', 'mobile'].includes(snapshotSource) ? snapshotSource : 'unknown'
+            metricCount('replay_player_recordings_loaded', 1, { snapshot_source: snapshotSourceLabel })
         },
         reportRecordingsListFilterAdded: ({ filterType }) => {
             posthog.capture('recording list filter added', { filter_type: filterType })

--- a/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
@@ -85,19 +85,18 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
     }),
     listeners(() => ({
         reportRecordingLoaded: ({ playerData, metadata }) => {
+            // older recordings did not store this, and so "null" is equivalent to web,
+            // but for reporting we want to distinguish between not loaded and no value to load
+            const snapshotSource = metadata?.snapshot_source || 'unknown'
             const payload: Partial<RecordingViewedProps> = {
                 duration: playerData.durationMs,
                 recording_id: playerData.sessionRecordingId,
                 start_time: playerData.start?.valueOf() ?? 0,
                 end_time: playerData.end?.valueOf() ?? 0,
-                // older recordings did not store this, and so "null" is equivalent to web,
-                // but for reporting we want to distinguish between not loaded and no value to load
-                snapshot_source: metadata?.snapshot_source || 'unknown',
+                snapshot_source: snapshotSource,
             }
             posthog.capture(`recording loaded`, payload)
-            metricCount('replay_player_recordings_loaded', 1, {
-                snapshot_source: metadata?.snapshot_source || 'unknown',
-            })
+            metricCount('replay_player_recordings_loaded', 1, { snapshot_source: snapshotSource })
         },
         reportRecordingsListFilterAdded: ({ filterType }) => {
             posthog.capture('recording list filter added', { filter_type: filterType })

--- a/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
@@ -3,6 +3,7 @@ import posthog from 'posthog-js'
 
 import { isLogEntryPropertyFilter, isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { isActionFilter, isEventFilter } from 'lib/components/UniversalFilters/utils'
+import { metricCount, metricHistogram } from 'lib/operationalMetrics'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { MiniFilterKey } from 'scenes/session-recordings/player/inspector/miniFiltersLogic'
 import { InspectorListItemType } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
@@ -94,11 +95,15 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
                 snapshot_source: metadata?.snapshot_source || 'unknown',
             }
             posthog.capture(`recording loaded`, payload)
+            metricCount('replay_player_recordings_loaded', 1, {
+                snapshot_source: metadata?.snapshot_source || 'unknown',
+            })
         },
         reportRecordingsListFilterAdded: ({ filterType }) => {
             posthog.capture('recording list filter added', { filter_type: filterType })
         },
         reportRecordingsListFetched: ({ loadTime, filters, defaultDurationFilter }) => {
+            metricHistogram('replay_list_load_ms', loadTime, 'ms')
             try {
                 const filterValues = filtersFromUniversalFilterGroups(filters)
 

--- a/products/replay_vision/frontend/logics/observationsDockLogic.ts
+++ b/products/replay_vision/frontend/logics/observationsDockLogic.ts
@@ -1,6 +1,7 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { metricCount } from 'lib/operationalMetrics'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { visionObservationsList, visionScannersObserveCreate } from '../generated/api'
@@ -140,6 +141,7 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                     const response = await visionObservationsList(String(teamId), { session_id: props.sessionId })
                     actions.loadObservationsSuccess(response.results ?? [])
                 } catch {
+                    metricCount('replay_vision_frontend_observations_load_failures')
                     actions.loadObservationsFailure()
                 }
             },
@@ -147,6 +149,10 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
             // Poll while in flight and through the observe grace window; rescheduled on failure so one hiccup can't kill it.
             loadObservationsSuccess: reschedulePoll,
             loadObservationsFailure: reschedulePoll,
+
+            observeFailure: () => {
+                metricCount('replay_vision_frontend_observe_failures')
+            },
 
             observe: async ({ scannerId }) => {
                 actions.setScannerPickerOpen(false)

--- a/products/replay_vision/frontend/logics/observationsDockLogic.ts
+++ b/products/replay_vision/frontend/logics/observationsDockLogic.ts
@@ -150,10 +150,6 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
             loadObservationsSuccess: reschedulePoll,
             loadObservationsFailure: reschedulePoll,
 
-            observeFailure: () => {
-                metricCount('replay_vision_frontend_observe_failures')
-            },
-
             observe: async ({ scannerId }) => {
                 actions.setScannerPickerOpen(false)
                 const teamId = teamLogic.values.currentTeamId
@@ -176,6 +172,9 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                     actions.loadObservations()
                     refreshVisionQuota()
                 } catch (error: any) {
+                    // Counted here rather than on observeFailure, which also fires for benign
+                    // paths (scanner already run, no team) that would pollute the failure rate.
+                    metricCount('replay_vision_frontend_observe_failures')
                     lemonToast.error(`Failed to start observation${error.detail ? `: ${error.detail}` : ''}`)
                     actions.observeFailure()
                 }

--- a/products/replay_vision/frontend/logics/visionScannersListLogic.ts
+++ b/products/replay_vision/frontend/logics/visionScannersListLogic.ts
@@ -1,6 +1,7 @@
 import { actions, afterMount, connect, isBreakpoint, kea, listeners, path } from 'kea'
 import { loaders } from 'kea-loaders'
 
+import { metricCount } from 'lib/operationalMetrics'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { visionScannersList } from '../generated/api'
@@ -53,6 +54,8 @@ export const visionScannersListLogic = kea<visionScannersListLogicType>([
                         if (error instanceof Error && isBreakpoint(error)) {
                             throw error
                         }
+                        // Degrades silently to the stale list, so count it or it is invisible.
+                        metricCount('replay_vision_frontend_scanners_load_failures')
                         return values.scanners
                     }
                 },


### PR DESCRIPTION
## Problem

Follow-up to #70535, which mirrors the backend Prometheus instrumentation for session replay and replay vision into the PostHog Metrics product via OTel. The frontends send nothing to Metrics, and they also can't use the OTel path: the browser-side story is the SDK's new `posthog.metrics` API, which we don't dogfood anywhere yet. A few frontend failure modes (replay vision scanner list fetches, observation polling) currently degrade completely silently.

## Changes

Adds `frontend/src/lib/operationalMetrics.ts`, a thin wrapper over `posthog.metrics.count/histogram` that no-ops when the loaded posthog-js build doesn't ship the metrics extension and swallows errors so telemetry can never break product code. Attributes are documented as low-cardinality only.

New metric series (aggregated by the SDK to one data point per series every 10s):

| Metric | Where | Why |
|---|---|---|
| `replay_player_recordings_loaded` (count, `snapshot_source`) | player usage logic, next to the existing `recording loaded` event | An alertable heartbeat of successful player loads |
| `replay_player_load_failures` (count, `kind`: meta / snapshot_processing) | player data coordinator failure paths | What dead-ends viewers, from the browser's perspective |
| `replay_list_load_ms` (histogram, unit ms) | recordings list fetch reporting | User-perceived list latency, currently only an event property |
| `replay_vision_frontend_scanners_load_failures` (count) | scanner list loader | Fails soft to a stale list today, invisible without a metric |
| `replay_vision_frontend_observations_load_failures` (count) | observations dock polling | Polling failure was only a cleared loading flag |
| `replay_vision_frontend_observe_failures` (count) | on-demand observe trigger | Failed manual scans, complements the backend observation metrics |

Also adds `metrics` to the app-wide posthog-js jest mock (`frontend/jest.setup.ts`), matching the real SDK surface.

Requires posthog-js >= the metrics API (the pinned 1.399.2 already ships it). No behavior change for products: every call is wrapped and fail-silent.

## How did you test this code?

- `frontend/src/lib/operationalMetrics.test.ts` (new): locks the options envelope shape (`{ attributes }` / `{ unit, attributes }`, easy to silently get wrong, and the SDK would just record nothing useful) and the no-op guard for SDK builds without the metrics extension. No existing test covers this new module.
- Existing suites for every touched logic pass: `sessionRecordingDataCoordinatorLogic.test.ts` plus the replay vision frontend logic tests (21 tests).
- Full frontend typecheck: the only errors are pre-existing stale local kea typegen noise; after regenerating the touched logic's type file, zero errors attributable to this diff.
- Not done: no manual end-to-end verification that series appear in the Metrics UI (needs a browser session against a project with the metrics extension enabled).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal dogfooding instrumentation only, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Claude Fable 5) in the same session as #70535, directed by the assignee. Skills invoked: `/writing-tests`.

Decisions along the way:

- Backend/infra metrics stay on OTel (see #70535); this PR deliberately uses `posthog.metrics` because it is the browser-side surface and worth dogfooding. Verified the pinned posthog-js 1.399.2 ships the API before building.
- Instrumentation lives in kea logics at existing failure/reporting sites, not in components, and only failure paths plus two load signals were instrumented, resisting the temptation to mirror every analytics event as a metric.
- The helper is named `operationalMetrics` because `lib/internalMetrics.ts` already exists (the legacy time-to-see-data module).
- The app-wide jest mock for posthog-js needed a `metrics` entry; per-file `jest.mock` calls can't override it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
