### PR TITLE
fix(engineering-analytics): declare the @posthog/quill-charts dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3238,6 +3238,9 @@ importers:
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@posthog/quill-charts':
+        specifier: workspace:*
+        version: link:../../packages/quill/packages/charts
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)

--- a/products/engineering_analytics/package.json
+++ b/products/engineering_analytics/package.json
@@ -6,6 +6,7 @@
     },
     "dependencies": {
         "@posthog/icons": "catalog:",
+        "@posthog/quill-charts": "workspace:*",
         "kea": "catalog:",
         "kea-loaders": "catalog:",
         "kea-router": "catalog:"


### PR DESCRIPTION
## Problem

`products/engineering_analytics` imports `@posthog/quill-charts` in three frontend files (`RepoOverviewScene`, `MetricTile`, `StatCard` — added in #69919 / #69516) but never declared it in its `package.json`. With pnpm's isolated node_modules the import isn't resolvable from that package. It has worked by accident on existing checkouts, where leftover root `node_modules/@posthog/quill-*` symlinks from older installs satisfied the resolver.

On a clean `pnpm install` those stale links are pruned and local dev breaks hard: vite's dependency scan fails with

```
(!) Failed to run dependency scan. Skipping dependency pre-bundling.
  @posthog/quill-charts (imported by .../products/engineering_analytics/...)
```

With pre-bundling skipped, vite discovers dependencies at runtime instead — every page load triggers "optimized dependencies changed. reloading", the forced reload interrupts React mid-mount, and the app dies with `NotFoundError: Failed to execute 'removeChild' on 'Node'` on effectively every navigation.

## Changes

One line: add `"@posthog/quill-charts": "workspace:*"` to `products/engineering_analytics/package.json` dependencies (plus the lockfile entry), matching how `products/metrics` and `products/revenue_analytics` declare the same dependency.

## How did you test this code?

- Reproduced the failure on a clean install: `require.resolve('@posthog/quill-charts', ...)` from the product directory fails, and the vite dev server logs the failed dependency scan followed by a reload loop.
- After the fix + `pnpm install`: resolution succeeds, the dependency scan completes ("scanning dependencies…" → "bundling dependencies…" with no error), and a headless browser loads the app with no console errors.
- No behavior change to any built artifact — production builds resolved this through the bundler workspace config all along, which is why CI never caught it; only dev serve on a clean install breaks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — dependency declaration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude in a PostHog Code session while debugging Sam's repeatedly-crashing local dev stack; the crash was chased through two red herrings (stale lockfile, stale quill dist builds) before a clean `pnpm install` made the failure deterministic and the failed vite dependency scan named this import.
- Also cross-checked every other `products/*` package for quill imports vs declarations — `engineering_analytics` is the only offender.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
