### PR TITLE
fix(marketing-analytics): materialize the touchpoints precompute once per read, not once per goal

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -1,5 +1,6 @@
 import math
 import uuid
+import threading
 from collections.abc import Sequence
 from dataclasses import (
     dataclass,
@@ -31,6 +32,7 @@ from posthog.models import PropertyDefinition, Team, User
 from products.access_control.backend.property_access_control import get_restricted_property_names
 from products.actions.backend.models.action import Action
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
+    LazyComputationResult,
     LazyComputationTable,
     ensure_precomputed,
 )
@@ -153,6 +155,39 @@ def build_touchpoints_precompute_query() -> ast.SelectQuery:
             ]
         ),
     )
+
+
+class SharedTouchpointsPrecompute:
+    """One touchpoints materialization shared by every conversion goal in a request.
+
+    `build_touchpoints_precompute_query()` takes no goal input and the range depends only on the
+    team's attribution window, so the call every goal makes is byte-identical. Each goal was driving
+    its own `ensure_precomputed` for the same window: redundant ClickHouse work, and concurrent
+    materializations of the same window risk landing under separate job_ids.
+
+    The first goal to ask does the work; the rest reuse its result. Goals run in a thread pool, hence
+    the lock.
+    """
+
+    def __init__(self, team: Team, config: MarketingAnalyticsConfig) -> None:
+        self._team = team
+        self._config = config
+        self._lock = threading.Lock()
+        self._result: Optional[LazyComputationResult] = None
+
+    def get(self, date_from: datetime, date_to: datetime) -> LazyComputationResult:
+        with self._lock:
+            if self._result is None:
+                window = timedelta(days=self._config.attribution_window_days)
+                self._result = ensure_precomputed(
+                    team=self._team,
+                    insert_query=build_touchpoints_precompute_query(),
+                    time_range_start=date_from - window,
+                    time_range_end=date_to,
+                    ttl_seconds=PRECOMPUTE_TTL_SECONDS,
+                    table=LazyComputationTable.MARKETING_TOUCHPOINTS_PREAGGREGATED,
+                )
+            return self._result
 
 
 @dataclass
@@ -291,10 +326,15 @@ class ConversionGoalProcessor:
         additional_conditions: Sequence[ast.Expr],
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
+        touchpoints: Optional[SharedTouchpointsPrecompute] = None,
     ) -> ast.SelectQuery:
-        """Generate main CTE query for conversion goal."""
+        """Generate main CTE query for conversion goal.
+
+        `touchpoints` lets callers running several goals share one touchpoints materialization. When
+        omitted the goal materializes its own, so standalone callers keep working unchanged.
+        """
         if self.goal.kind in ["EventsNode", "ActionsNode"]:
-            return self._generate_array_based_query(additional_conditions, date_from, date_to)
+            return self._generate_array_based_query(additional_conditions, date_from, date_to, touchpoints)
         return self._generate_direct_query(additional_conditions)
 
     def build_array_collection_query(self, additional_conditions: Sequence[ast.Expr]) -> ast.SelectQuery:
@@ -329,10 +369,11 @@ class ConversionGoalProcessor:
         additional_conditions: Sequence[ast.Expr],
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
+        touchpoints: Optional[SharedTouchpointsPrecompute] = None,
     ) -> ast.SelectQuery:
         """Generate array-based query with attribution logic for Events/Actions"""
         if self.config.attribution_window_days > 0:
-            return self._generate_funnel_query(additional_conditions, date_from, date_to)
+            return self._generate_funnel_query(additional_conditions, date_from, date_to, touchpoints)
         return self._generate_direct_query(additional_conditions)
 
     def _generate_funnel_query(
@@ -340,6 +381,7 @@ class ConversionGoalProcessor:
         additional_conditions: Sequence[ast.Expr],
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
+        touchpoints: Optional[SharedTouchpointsPrecompute] = None,
     ) -> ast.SelectQuery:
         """Generate multi-step funnel query with attribution window.
 
@@ -349,7 +391,7 @@ class ConversionGoalProcessor:
             # `_should_use_precompute` returns False unless both dates are set; narrow for mypy.
             assert date_from is not None and date_to is not None
             try:
-                precomputed = self._build_attribution_from_precomputes(date_from, date_to)
+                precomputed = self._build_attribution_from_precomputes(date_from, date_to, touchpoints)
                 if precomputed is not None:
                     return precomputed
             except Exception:
@@ -488,7 +530,12 @@ class ConversionGoalProcessor:
             where=ast.And(exprs=where_exprs),
         )
 
-    def _build_attribution_from_precomputes(self, date_from: datetime, date_to: datetime) -> Optional[ast.SelectQuery]:
+    def _build_attribution_from_precomputes(
+        self,
+        date_from: datetime,
+        date_to: datetime,
+        touchpoints: Optional[SharedTouchpointsPrecompute] = None,
+    ) -> Optional[ast.SelectQuery]:
         """Reusable-precompute read path: ensure both the config-agnostic touchpoints and the per-goal
         conversions are materialized, then attribute at read time by feeding a precompute-sourced array
         collection through the existing pipeline (all modes). Neither precompute depends on attribution
@@ -499,15 +546,13 @@ class ConversionGoalProcessor:
         # Touchpoints extend back by the attribution window; conversions only span the query range.
         # Both ensure_precomputed calls can materialize inline (PG + Redis + ClickHouse) when a slice
         # is stale, so they are timed separately from the AST work that follows.
+        #
+        # Touchpoints are config-agnostic, so a multi-goal read shares one materialization. Without a
+        # shared handle each goal materializes the same window itself, which is what a standalone
+        # caller gets.
+        shared_touchpoints = touchpoints or SharedTouchpointsPrecompute(self.team, self.config)
         with self.timings.measure("ma_ensure_touchpoints"):
-            touchpoints_result = ensure_precomputed(
-                team=self.team,
-                insert_query=build_touchpoints_precompute_query(),
-                time_range_start=date_from - window,
-                time_range_end=date_to,
-                ttl_seconds=PRECOMPUTE_TTL_SECONDS,
-                table=LazyComputationTable.MARKETING_TOUCHPOINTS_PREAGGREGATED,
-            )
+            touchpoints_result = shared_touchpoints.get(date_from, date_to)
         if not touchpoints_result.ready:
             return None
 

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -174,11 +174,13 @@ class SharedTouchpointsPrecompute:
         self._config = config
         self._lock = threading.Lock()
         self._result: Optional[LazyComputationResult] = None
+        self._range: Optional[tuple[datetime, datetime]] = None
 
     def get(self, date_from: datetime, date_to: datetime) -> LazyComputationResult:
         with self._lock:
             if self._result is None:
                 window = timedelta(days=self._config.attribution_window_days)
+                self._range = (date_from, date_to)
                 self._result = ensure_precomputed(
                     team=self._team,
                     insert_query=build_touchpoints_precompute_query(),
@@ -186,6 +188,15 @@ class SharedTouchpointsPrecompute:
                     time_range_end=date_to,
                     ttl_seconds=PRECOMPUTE_TTL_SECONDS,
                     table=LazyComputationTable.MARKETING_TOUCHPOINTS_PREAGGREGATED,
+                )
+            elif self._range != (date_from, date_to):
+                # One handle is scoped to one read, whose goals all share its date range. Handing back
+                # the first caller's window for a different range would attribute one window's
+                # touchpoints to another — silently, and in the shape of the double-counting bug this
+                # class exists to prevent.
+                raise ValueError(
+                    f"SharedTouchpointsPrecompute is scoped to one date range per read: "
+                    f"materialized {self._range}, asked for {(date_from, date_to)}"
                 )
             return self._result
 

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
@@ -10,7 +10,7 @@ from posthog.settings import TEST
 from products.marketing_analytics.backend.hogql_queries.constants import UNIFIED_CONVERSION_GOALS_CTE_ALIAS
 
 from .adapters.factory import MarketingSourceFactory
-from .conversion_goal_processor import ConversionGoalProcessor
+from .conversion_goal_processor import ConversionGoalProcessor, SharedTouchpointsPrecompute
 from .marketing_analytics_config import MarketingAnalyticsConfig
 
 # Cap on parallel per-goal ensure_precomputed workers.
@@ -35,6 +35,11 @@ class ConversionGoalsAggregator:
         if not self.processors:
             raise ValueError("Cannot create unified CTE without conversion goal processors")
 
+        # The touchpoints precompute is config-agnostic: every goal drives the exact same
+        # ensure_precomputed for the same window. Share one handle so it is materialized once for the
+        # whole read instead of once per goal.
+        touchpoints = SharedTouchpointsPrecompute(self.processors[0].team, self.config)
+
         # Step 1: Generate individual conversion goal queries, parallelised across goals
         # so ensure_precomputed's PG+Redis+ClickHouse round-trips collapse to max(overhead).
         def _build_base_query(processor: ConversionGoalProcessor) -> ast.SelectQuery:
@@ -49,6 +54,7 @@ class ConversionGoalsAggregator:
                 additional_conditions,
                 date_from=date_range.date_from(),
                 date_to=date_range.date_to(),
+                touchpoints=touchpoints,
             )
 
         # Skip the pool in TEST: Django's per-thread DB connections don't see

--- a/products/marketing_analytics/backend/hogql_queries/test_conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_conversion_goals_aggregator.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 import itertools
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from posthog.test.base import BaseTest, ClickhouseTestMixin
@@ -30,7 +30,7 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
 )
 from products.analytics_platform.backend.models.preaggregation_job import PreaggregationJob
 
-from .conversion_goal_processor import ConversionGoalProcessor
+from .conversion_goal_processor import ConversionGoalProcessor, SharedTouchpointsPrecompute
 from .conversion_goals_aggregator import ConversionGoalsAggregator
 from .marketing_analytics_config import MarketingAnalyticsConfig
 
@@ -647,3 +647,22 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
         # goal, so each keeps its own — sharing those would serve one goal's conversions for the other.
         assert tables.count(LazyComputationTable.MARKETING_TOUCHPOINTS_PREAGGREGATED) == 1
         assert tables.count(LazyComputationTable.MARKETING_CONVERSIONS_PREAGGREGATED) == len(processors)
+
+    def test_shared_touchpoints_rejects_a_second_date_range(self):
+        # The handle caches the first materialization, so reusing it for another range would attribute
+        # one window's touchpoints to another. Silently, if it just returned the cached result.
+        shared = SharedTouchpointsPrecompute(self.team, self.config)
+        date_from = datetime(2024, 1, 1, tzinfo=UTC)
+        date_to = datetime(2024, 1, 31, tzinfo=UTC)
+
+        with patch(
+            "products.marketing_analytics.backend.hogql_queries.conversion_goal_processor.ensure_precomputed",
+            side_effect=lambda **kwargs: LazyComputationResult(ready=True, job_ids=[uuid.uuid4()]),
+        ) as ensure:
+            first = shared.get(date_from, date_to)
+            assert shared.get(date_from, date_to) is first
+
+            with pytest.raises(ValueError, match="one date range per read"):
+                shared.get(date_from, date_to + timedelta(days=1))
+
+        assert ensure.call_count == 1

--- a/products/marketing_analytics/backend/hogql_queries/test_conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_conversion_goals_aggregator.py
@@ -24,6 +24,10 @@ from posthog.clickhouse.preaggregation.marketing_touchpoints_sql import TRUNCATE
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 from products.actions.backend.models.action import Action
+from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
+    LazyComputationResult,
+    LazyComputationTable,
+)
 from products.analytics_platform.backend.models.preaggregation_job import PreaggregationJob
 
 from .conversion_goal_processor import ConversionGoalProcessor
@@ -624,3 +628,22 @@ class TestConversionGoalsAggregator(ClickhouseTestMixin, BaseTest):
         assert "Holiday Promo" in sql_string, "SQL should contain mapped campaign name"
         assert "spring_sale_2024" in sql_string, "SQL should contain original campaign name in mapping"
         assert "holiday_campaign" in sql_string, "SQL should contain original campaign name in mapping"
+
+    def test_touchpoints_precompute_materialized_once_across_goals(self):
+        processors = [
+            self._create_test_processor(self._create_test_conversion_goal("goal1", "Sign Ups"), 0),
+            self._create_test_processor(self._create_test_conversion_goal("goal2", "Purchases"), 1),
+        ]
+        aggregator = ConversionGoalsAggregator(processors, self.config)
+
+        with patch(
+            "products.marketing_analytics.backend.hogql_queries.conversion_goal_processor.ensure_precomputed",
+            side_effect=lambda **kwargs: LazyComputationResult(ready=True, job_ids=[uuid.uuid4()]),
+        ) as ensure:
+            aggregator.generate_unified_cte(self.date_range, self._create_mock_additional_conditions_getter())
+
+        tables = [call.kwargs["table"] for call in ensure.call_args_list]
+        # Touchpoints are config-agnostic, so both goals share one materialization. Conversions embed the
+        # goal, so each keeps its own — sharing those would serve one goal's conversions for the other.
+        assert tables.count(LazyComputationTable.MARKETING_TOUCHPOINTS_PREAGGREGATED) == 1
+        assert tables.count(LazyComputationTable.MARKETING_CONVERSIONS_PREAGGREGATED) == len(processors)


### PR DESCRIPTION
## Problem

Instrumentation from #70256 and #70483 showed that building the conversion-goal CTE is where a marketing analytics dashboard load spends its time, and that it is not AST work. It is `ensure_precomputed` doing Postgres, Redis, and a synchronous ClickHouse INSERT on the request thread.

Reading the per-goal spans surfaced a separate problem. With two conversion goals, `ma_ensure_touchpoints` fired twice, at 3.504s and 3.506s:

```
series_0 (goal 1)                    series_1 (goal 2)
  ma_ensure_touchpoints  3.504s        ma_ensure_touchpoints  3.506s   <- same window, twice
  ma_ensure_conversions  6.390s        ma_ensure_conversions  6.480s
```

Touchpoints are config-agnostic. `build_touchpoints_precompute_query()` takes no goal input, and the range depends only on the team's attribution window, so every goal drives a byte-identical `ensure_precomputed` for the same window. The Dagster warmer already documents this ("one warmed window serves every goal"); the read path did not honor it.

Goals are built in a thread pool, so the two calls race. `test_config_agnostic_query_reuses_one_job` covers the sequential case, where the second call reuses the first's job. Concurrently there is no such guarantee: both goals can find the window stale and materialize it, landing under separate job_ids. The preagg tables are `ReplacingMergeTree` keyed on `job_id`, so duplicate jobs for one window are exactly the shape of double-counting bug this product has shipped before.

## Changes

`SharedTouchpointsPrecompute` holds one materialization for the whole read. The first goal to ask does the work, the rest reuse its result, and a lock makes that safe under the goal pool. `ConversionGoalsAggregator` builds one and hands it to every goal.

`generate_cte_query` takes an optional `touchpoints` handle. When it is omitted a goal materializes its own, exactly as before, so standalone callers and the existing direct-call tests are untouched.

Conversions stay per goal on purpose. That query embeds the goal's event, filters, and math, so sharing it would serve one goal's conversions for another. The new test pins both directions.

> [!NOTE]
> This does not make the dashboard faster. Wall time is still touchpoints followed by conversions within a goal, with goals running in parallel. What it removes is the redundant ClickHouse materialization and the concurrent same-window race. The blocking inline materialization is the real latency problem and is a separate change.

## How did you test this code?

Added `test_touchpoints_precompute_materialized_once_across_goals` to `test_conversion_goals_aggregator.py`. It runs two precompute-eligible goals through `generate_unified_cte` with `ensure_precomputed` mocked, and asserts touchpoints is ensured once while conversions is ensured once per goal.

It earns its place: every existing test passes both with and without the sharing, so nothing pinned this. I verified it fails on the unfixed code (`assert 2 == 1`) and passes with the fix. I extended the existing aggregator test rather than adding a file, and mocked `ensure_precomputed` because it is the I/O boundary whose duplicate invocation is the bug.

Full suite green: 533 tests across `products/marketing_analytics/backend/hogql_queries/` and `products/marketing_analytics/dags/`, including the 72 snapshots. ruff and ty pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Javier is chasing a slow marketing analytics dashboard. #70256 and #70483 were the instrumentation; this is the first fix to come out of reading it.

I (Claude Code) first proposed also overlapping the touchpoints and conversions ensures, since they are independent and running them concurrently would cut roughly 3.5s. We dropped it: the non-blocking read path we actually want removes the inline materialization altogether, which would make the overlap dead code. Hoisting survives that change, the overlap does not, so this PR is only the hoist. I invoked the repo's `/writing-tests` skill before adding the test.

Design note: I used a memoized handle rather than resolving touchpoints up front in the aggregator, so the work still only happens if a goal actually reaches the precompute path, and the aggregator does not need to reach into the processor's private eligibility gate.
