### PR TITLE
feat(feature-flags): bulk enable/disable flags

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -395,8 +395,8 @@ export function OverviewTab({
 
     const { currentProjectId } = useValues(projectLogic)
     const { paramsFromFilters } = useValues(featureFlagsLogic({}))
-    const { bulkDeleteResponseLoading } = useValues(flagSelectionLogic)
-    const { bulkDeleteFlags } = useActions(flagSelectionLogic)
+    const { bulkDeleteResponseLoading, bulkUpdateStatusResponseLoading } = useValues(flagSelectionLogic)
+    const { bulkDeleteFlags, bulkUpdateFlagStatus } = useActions(flagSelectionLogic)
 
     const [matchingFlagIds, setMatchingFlagIds] = useState<readonly number[] | null>(null)
     const [matchingFlagIdsLoading, setMatchingFlagIdsLoading] = useState(false)
@@ -642,6 +642,31 @@ export function OverviewTab({
                             !isAllMatchingSelected &&
                             ctx.selectedCount >= FLAGS_PER_PAGE &&
                             totalMatchingCount > ctx.selectedCount
+                        const openBulkStatusDialog = (active: boolean): void => {
+                            LemonDialog.open({
+                                title: `${active ? 'Enable' : 'Disable'} ${ctx.selectedCount} feature flag${
+                                    ctx.selectedCount !== 1 ? 's' : ''
+                                }?`,
+                                description: active
+                                    ? 'The selected flags will be immediately rolled out to the users matching their release conditions.'
+                                    : 'The selected flags will be immediately rolled back from the users matching their release conditions.',
+                                primaryButton: {
+                                    children: active ? 'Enable' : 'Disable',
+                                    type: 'primary',
+                                    onClick: () => {
+                                        bulkUpdateFlagStatus({
+                                            ids: [...ctx.selectedKeys],
+                                            active,
+                                            allMatching: isAllMatchingSelected,
+                                        })
+                                        ctx.clearSelection()
+                                        setMatchingFlagIds(null)
+                                    },
+                                    size: 'small',
+                                },
+                                secondaryButton: { children: 'Cancel', type: 'tertiary', size: 'small' },
+                            })
+                        }
                         return (
                             <>
                                 {isAllMatchingSelected && (
@@ -679,6 +704,24 @@ export function OverviewTab({
                                         setMatchingFlagIds(null)
                                     }}
                                 />
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    loading={bulkUpdateStatusResponseLoading}
+                                    disabledReason={bulkUpdateStatusResponseLoading ? 'Updating…' : undefined}
+                                    onClick={() => openBulkStatusDialog(true)}
+                                >
+                                    Enable
+                                </LemonButton>
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    loading={bulkUpdateStatusResponseLoading}
+                                    disabledReason={bulkUpdateStatusResponseLoading ? 'Updating…' : undefined}
+                                    onClick={() => openBulkStatusDialog(false)}
+                                >
+                                    Disable
+                                </LemonButton>
                                 <LemonButton
                                     type="primary"
                                     status="danger"

--- a/frontend/src/scenes/feature-flags/flagSelectionLogic.ts
+++ b/frontend/src/scenes/feature-flags/flagSelectionLogic.ts
@@ -2,7 +2,10 @@ import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea
 import { loaders } from 'kea-loaders'
 import { beforeUnload } from 'kea-router'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import api from 'lib/api'
+import { pluralize } from 'lib/utils/strings'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { featureFlagsLogic } from './featureFlagsLogic'
@@ -19,6 +22,13 @@ export interface DeletedFlagInfo {
 
 export interface BulkDeleteResult {
     deleted: DeletedFlagInfo[]
+    errors: Array<{ id: number; key?: string; reason: string }>
+}
+
+export interface BulkUpdateStatusResult {
+    // Echoes the requested target state so the success toast can describe the direction (enable vs disable).
+    active: boolean
+    updated: Array<{ id: number; key: string; active: boolean }>
     errors: Array<{ id: number; key?: string; reason: string }>
 }
 
@@ -66,6 +76,34 @@ export const flagSelectionLogic = kea<flagSelectionLogicType>([
                 },
             },
         ],
+        bulkUpdateStatusResponse: [
+            null as BulkUpdateStatusResult | null,
+            {
+                bulkUpdateFlagStatus: async ({
+                    ids,
+                    active,
+                    allMatching,
+                }: {
+                    ids: number[]
+                    active: boolean
+                    allMatching: boolean
+                }) => {
+                    const url = `api/projects/${values.currentProjectId}/feature_flags/bulk_update_status/`
+                    // "Select all matching" resolves to filters (like bulk delete) so we don't ship an
+                    // unbounded id list; an explicit selection sends the ids directly.
+                    if (allMatching) {
+                        const { limit, offset, ...filters } = values.paramsFromFilters
+                        const response = (await api.create(url, { active, filters })) as Omit<
+                            BulkUpdateStatusResult,
+                            'active'
+                        >
+                        return { active, ...response }
+                    }
+                    const response = (await api.create(url, { active, ids })) as Omit<BulkUpdateStatusResult, 'active'>
+                    return { active, ...response }
+                },
+            },
+        ],
     })),
 
     selectors({
@@ -79,10 +117,31 @@ export const flagSelectionLogic = kea<flagSelectionLogicType>([
                 actions.loadFeatureFlags()
             }
         },
+        bulkUpdateFlagStatusSuccess: ({ bulkUpdateStatusResponse }) => {
+            if (!bulkUpdateStatusResponse) {
+                return
+            }
+            const { active, updated, errors } = bulkUpdateStatusResponse
+            if (updated.length > 0) {
+                lemonToast.success(`${active ? 'Enabled' : 'Disabled'} ${pluralize(updated.length, 'feature flag')}`)
+            }
+            if (errors.length > 0) {
+                lemonToast.warning(
+                    `${pluralize(errors.length, 'feature flag')} could not be ${active ? 'enabled' : 'disabled'}`
+                )
+            }
+            if (updated.length === 0 && errors.length === 0) {
+                lemonToast.info('No feature flags needed updating')
+            }
+            actions.loadFeatureFlags()
+        },
+        bulkUpdateFlagStatusFailure: () => {
+            lemonToast.error('Failed to update feature flag status')
+        },
     })),
 
     beforeUnload(({ values }) => ({
-        enabled: () => values.bulkDeleteResponseLoading,
-        message: 'Bulk delete is in progress. Leaving may result in incomplete deletion.',
+        enabled: () => values.bulkDeleteResponseLoading || values.bulkUpdateStatusResponseLoading,
+        message: 'A bulk action is in progress. Leaving may leave it incomplete.',
     })),
 ])

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2681,7 +2681,7 @@ class BulkDeleteResponseSerializer(serializers.Serializer):
     )
 
 
-class BulkUpdateStatusRequestSerializer(serializers.Serializer):
+class FeatureFlagBulkUpdateStatusRequestSerializer(serializers.Serializer):
     active = serializers.BooleanField(
         help_text=(
             "Target enabled state to apply to every matched flag. `true` enables the flag "
@@ -2702,20 +2702,20 @@ class BulkUpdateStatusRequestSerializer(serializers.Serializer):
     )
 
 
-class BulkUpdateStatusUpdatedItemSerializer(serializers.Serializer):
+class FeatureFlagBulkUpdateStatusUpdatedItemSerializer(serializers.Serializer):
     id = serializers.IntegerField(help_text="ID of the flag whose enabled state changed.")
     key = serializers.CharField(help_text="The flag key.")
     active = serializers.BooleanField(help_text="The flag's enabled state after the update.")
 
 
-class BulkUpdateStatusResponseSerializer(serializers.Serializer):
+class FeatureFlagBulkUpdateStatusResponseSerializer(serializers.Serializer):
     """
     Schema-only — see ``BulkDeleteResponseSerializer`` for why the declared ``errors`` field must
     never be validated against. The handler builds the response dict directly; this exists only so
     drf-spectacular can render the response in the OpenAPI spec.
     """
 
-    updated = BulkUpdateStatusUpdatedItemSerializer(
+    updated = FeatureFlagBulkUpdateStatusUpdatedItemSerializer(
         many=True, help_text="Flags whose enabled state was changed. Flags already in the target state are omitted."
     )
     # Explicit ListSerializer avoids the many=True descriptor magic that confuses type checkers.
@@ -3574,9 +3574,9 @@ class FeatureFlagViewSet(
         )
 
     @extend_schema(
-        request=BulkUpdateStatusRequestSerializer,
+        request=FeatureFlagBulkUpdateStatusRequestSerializer,
         responses={
-            200: OpenApiResponse(response=BulkUpdateStatusResponseSerializer),
+            200: OpenApiResponse(response=FeatureFlagBulkUpdateStatusResponseSerializer),
             400: OpenApiResponse(
                 response=ErrorResponseSerializer,
                 description="Invalid input — e.g., `active` missing/not a boolean, both filters and ids supplied, neither supplied, or unknown filter keys.",

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2681,6 +2681,50 @@ class BulkDeleteResponseSerializer(serializers.Serializer):
     )
 
 
+class BulkUpdateStatusRequestSerializer(serializers.Serializer):
+    active = serializers.BooleanField(
+        help_text=(
+            "Target enabled state to apply to every matched flag. `true` enables the flag "
+            "(rolls it out to users matching its release conditions); `false` disables it (rolls it back)."
+        ),
+    )
+    filters = BulkDeleteFiltersSerializer(
+        required=False,
+        help_text=(
+            "Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. "
+            "Use this to update every flag matching a search/active/tags/etc. filter instead of supplying explicit IDs."
+        ),
+    )
+    ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        required=False,
+        help_text="Explicit feature flag IDs to update. Mutually exclusive with `filters`.",
+    )
+
+
+class BulkUpdateStatusUpdatedItemSerializer(serializers.Serializer):
+    id = serializers.IntegerField(help_text="ID of the flag whose enabled state changed.")
+    key = serializers.CharField(help_text="The flag key.")
+    active = serializers.BooleanField(help_text="The flag's enabled state after the update.")
+
+
+class BulkUpdateStatusResponseSerializer(serializers.Serializer):
+    """
+    Schema-only — see ``BulkDeleteResponseSerializer`` for why the declared ``errors`` field must
+    never be validated against. The handler builds the response dict directly; this exists only so
+    drf-spectacular can render the response in the OpenAPI spec.
+    """
+
+    updated = BulkUpdateStatusUpdatedItemSerializer(
+        many=True, help_text="Flags whose enabled state was changed. Flags already in the target state are omitted."
+    )
+    # Explicit ListSerializer avoids the many=True descriptor magic that confuses type checkers.
+    errors: serializers.ListSerializer = serializers.ListSerializer(  # type: ignore[assignment]
+        child=BulkDeleteErrorItemSerializer(),
+        help_text="Flags that could not be updated (e.g. archived flags cannot be enabled), with reasons.",
+    )
+
+
 # ClickHouse cost attribution: this viewset currently has no direct ClickHouse calls —
 # all ClickHouse work is delegated to helpers (user_blast_radius.py, flag_analytics.py)
 # that already tag their queries. If you add a new ClickHouse query reachable from an
@@ -3525,6 +3569,219 @@ class FeatureFlagViewSet(
         return Response(
             {
                 "deleted": deleted,
+                "errors": errors,
+            }
+        )
+
+    @extend_schema(
+        request=BulkUpdateStatusRequestSerializer,
+        responses={
+            200: OpenApiResponse(response=BulkUpdateStatusResponseSerializer),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description="Invalid input — e.g., `active` missing/not a boolean, both filters and ids supplied, neither supplied, or unknown filter keys.",
+            ),
+        },
+    )
+    @action(methods=["POST"], detail=False, required_scopes=["feature_flag:write"])
+    def bulk_update_status(self, request: request.Request, **kwargs):
+        """
+        Bulk enable or disable feature flags by filter criteria or explicit IDs.
+
+        Accepts either:
+        - {"active": bool, "ids": [...]} - explicit flag IDs, or
+        - {"active": bool, "filters": {...}} - same filter params as the list endpoint.
+
+        `ids` and `filters` are mutually exclusive. Enabling a flag rolls it out to the users matching
+        its release conditions immediately; disabling rolls it back. Archived flags cannot be enabled.
+        Flags already in the target state are skipped (not re-written, not logged).
+
+        Mirrors `bulk_delete`: database writes and cache invalidation are batched, and because
+        `queryset.update()` bypasses `ModelActivityMixin`, an "updated" activity log entry recording the
+        `active` change is written per flag via `bulk_log_activity` so the audit trail matches the
+        single-flag update path.
+        """
+        from django.utils import timezone
+
+        from posthog.models.activity_logging.activity_log import Change, Detail, LogActivityEntry, bulk_log_activity
+        from posthog.rbac.user_access_control import access_level_satisfied_for_resource
+        from posthog.tasks.remote_config import update_team_remote_config
+
+        from products.feature_flags.backend.models.feature_flag import set_feature_flags_for_team_in_cache
+        from products.feature_flags.backend.tasks import update_team_flags_cache, update_team_service_flags_cache
+
+        active = request.data.get("active")
+        if not isinstance(active, bool):
+            return Response(
+                {"error": "`active` is required and must be a boolean"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        filters = request.data.get("filters", {})
+        explicit_ids = request.data.get("ids", [])
+
+        if filters and explicit_ids:
+            return Response(
+                {"error": "Provide either filters or ids, not both"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not filters and not explicit_ids:
+            return Response(
+                {"error": "Must provide either filters or ids"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Validate filter keys against the same allowlist as bulk_delete to prevent accidental mass updates.
+        if filters:
+            valid_filter_keys = set(BulkDeleteFiltersSerializer().fields.keys())
+            unknown_keys = set(filters.keys()) - valid_filter_keys
+            if unknown_keys:
+                return Response(
+                    {"error": f"Unknown filter keys: {', '.join(sorted(unknown_keys))}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        # Build base queryset (same scoping/exclusions as list, matching_ids, and bulk_delete).
+        queryset = self.queryset.filter(team__project_id=self.project_id, deleted=False)
+
+        # Exclude internal flags (same as list/matching_ids/bulk_delete endpoints)
+        survey_flag_ids = Survey.get_internal_flag_ids(project_id=self.project_id)
+        product_tour_internal_targeting_flags = ProductTour.all_objects.filter(
+            team__project_id=self.project_id, internal_targeting_flag__isnull=False
+        ).values_list("internal_targeting_flag_id", flat=True)
+        queryset = queryset.exclude(Q(id__in=survey_flag_ids)).exclude(Q(id__in=product_tour_internal_targeting_flags))
+
+        if filters:
+            queryset = exclude_archived_unless_requested(queryset, requested="archived" in filters)
+            queryset = self._apply_filters(filters, queryset)
+        else:
+            # Validate and convert IDs (same coercion as bulk_delete)
+            validated_ids = []
+            invalid_ids = []
+            for flag_id in explicit_ids:
+                if isinstance(flag_id, int):
+                    validated_ids.append(flag_id)
+                elif isinstance(flag_id, str) and flag_id.isdigit():
+                    validated_ids.append(int(flag_id))
+                else:
+                    invalid_ids.append(flag_id)
+
+            if not validated_ids and not invalid_ids:
+                return Response(
+                    {"error": "No flag IDs provided"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            queryset = queryset.filter(id__in=validated_ids)
+
+        # Apply access control - filter to only editable flags (same logic as bulk_delete)
+        if self.user_access_control:
+            flags_for_access_check = list(queryset.only("id"))
+            self.user_access_control.preload_object_access_controls(cast(list, flags_for_access_check))
+
+            editable_ids = []
+            for flag in flags_for_access_check:
+                user_access_level = self.user_access_control.get_user_access_level(flag)
+                if user_access_level and access_level_satisfied_for_resource(
+                    "feature_flag", user_access_level, "editor"
+                ):
+                    editable_ids.append(flag.id)
+
+            queryset = queryset.filter(id__in=editable_ids)
+
+        # select_related("team") so per-flag team.organization_id/team.project_id access below is not N+1.
+        flags_list = list(queryset.select_related("team"))
+
+        updated = []
+        errors = []
+
+        # Report invalid or missing IDs (only for ID-based updates), matching bulk_delete's semantics.
+        if explicit_ids:
+            found_ids = {flag.id for flag in flags_list}
+            for flag_id in explicit_ids:
+                if not isinstance(flag_id, int) and not (isinstance(flag_id, str) and flag_id.isdigit()):
+                    errors.append({"id": flag_id, "reason": "Invalid flag ID format"})
+                else:
+                    numeric_id = int(flag_id) if isinstance(flag_id, str) else flag_id
+                    if numeric_id not in found_ids:
+                        errors.append({"id": numeric_id, "reason": "Flag not found"})
+
+        current_user = request.user if request.user.is_authenticated else None
+        was_impersonated = is_impersonated(request)
+
+        flags_to_update: list[FeatureFlag] = []
+        activity_log_entries: list[LogActivityEntry] = []
+
+        for flag in flags_list:
+            # Enabling an archived flag is not allowed — mirrors the single-flag UI, which requires
+            # unarchiving first. (Disabling an archived flag is a harmless no-op, handled just below.)
+            if active and flag.archived:
+                errors.append({"id": flag.id, "key": flag.key, "reason": "Cannot enable an archived feature flag"})
+                continue
+
+            # Skip no-ops so we neither write rows nor log activity for flags already in the target state.
+            if flag.active == active:
+                continue
+
+            flags_to_update.append(flag)
+            activity_log_entries.append(
+                LogActivityEntry(
+                    organization_id=flag.team.organization_id,
+                    team_id=flag.team_id,
+                    user=current_user,
+                    was_impersonated=was_impersonated,
+                    item_id=flag.id,
+                    scope="FeatureFlag",
+                    activity="updated",
+                    detail=Detail(
+                        name=flag.key,
+                        changes=[
+                            Change(
+                                type="FeatureFlag",
+                                field="active",
+                                action="changed",
+                                before=flag.active,
+                                after=active,
+                            )
+                        ],
+                    ),
+                )
+            )
+            updated.append({"id": flag.id, "key": flag.key, "active": active})
+
+        # Perform bulk database update + manual cache invalidation.
+        # queryset.update() bypasses Django signals (and ModelActivityMixin), so cache invalidation and
+        # activity logging are done manually below — once for the whole batch instead of once per flag.
+        if flags_to_update:
+            sample_flag = flags_to_update[0]
+            team_id = sample_flag.team_id
+            project_id = sample_flag.team.project_id
+            now_timestamp = timezone.now()
+            update_ids = [flag.id for flag in flags_to_update]
+
+            with transaction.atomic():
+                FeatureFlag.objects.filter(id__in=update_ids, team_id=team_id).update(
+                    active=active,
+                    last_modified_by=current_user,
+                    updated_at=now_timestamp,
+                )
+
+                if activity_log_entries:
+                    bulk_log_activity(activity_log_entries)
+
+                # Cache invalidation - same work the signals would do, but once instead of N times
+                def invalidate_caches():
+                    set_feature_flags_for_team_in_cache(project_id)
+                    update_team_service_flags_cache.delay(team_id)
+                    update_team_flags_cache.delay(team_id)
+                    update_team_remote_config.delay(team_id)
+
+                transaction.on_commit(invalidate_caches)
+
+        return Response(
+            {
+                "updated": updated,
                 "errors": errors,
             }
         )

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -12435,6 +12435,149 @@ class TestFeatureFlagBulkDelete(APIBaseTest):
         assert flag_with_deleted_exp.key == f"flag_with_deleted_exp:deleted:{flag_with_deleted_exp.id}"
 
 
+class TestFeatureFlagBulkUpdateStatus(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        FeatureFlag.objects.filter(team=self.team).delete()
+
+    def _create_flag(self, key: str, active: bool = True, archived: bool = False) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            active=active,
+            archived=archived,
+            filters={"groups": [{"rollout_percentage": 50, "properties": []}]},
+        )
+
+    @parameterized.expand([("enable", True), ("disable", False)])
+    def test_bulk_update_status_flips_active_and_skips_noops(self, _name, target):
+        already = self._create_flag("already_at_target", active=target)
+        to_change = self._create_flag("needs_change", active=not target)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_update_status/",
+            {"active": target, "ids": [already.id, to_change.id]},
+        )
+
+        assert response.status_code == 200, response.json()
+        data = response.json()
+        # Only the flag that actually changed is reported; the flag already in the target state is skipped.
+        assert {u["id"] for u in data["updated"]} == {to_change.id}
+        assert all(u["active"] is target for u in data["updated"])
+        assert data["errors"] == []
+
+        already.refresh_from_db()
+        to_change.refresh_from_db()
+        assert already.active is target
+        assert to_change.active is target
+
+    def test_bulk_update_status_logs_active_change_per_updated_flag(self):
+        from posthog.models.activity_logging.activity_log import ActivityLog
+
+        flags = [self._create_flag(f"flag_{i}", active=False) for i in range(3)]
+        flag_ids = {f.id for f in flags}
+        ActivityLog.objects.filter(team_id=self.team.id, scope="FeatureFlag").delete()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_update_status/",
+            {"active": True, "ids": [f.id for f in flags]},
+        )
+
+        assert response.status_code == 200
+        assert len(response.json()["updated"]) == 3
+
+        logs = ActivityLog.objects.filter(team_id=self.team.id, scope="FeatureFlag", activity="updated")
+        assert logs.count() == 3
+        assert {int(log.item_id) for log in logs if log.item_id is not None} == flag_ids
+        for log in logs:
+            assert log.user == self.user
+            changes = log.detail.get("changes") or []
+            assert len(changes) == 1
+            assert changes[0]["field"] == "active"
+            assert changes[0]["before"] is False
+            assert changes[0]["after"] is True
+
+    def test_bulk_update_status_cross_project_isolation(self):
+        my_flag = self._create_flag("my_flag", active=False)
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        other_flag = FeatureFlag.objects.create(
+            team=other_team,
+            created_by=self.user,
+            key="other_team_flag",
+            active=False,
+            filters={"groups": [{"rollout_percentage": 50, "properties": []}]},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_update_status/",
+            {"active": True, "ids": [my_flag.id, other_flag.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert {u["id"] for u in data["updated"]} == {my_flag.id}
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["id"] == other_flag.id
+        assert data["errors"][0]["reason"] == "Flag not found"
+
+        my_flag.refresh_from_db()
+        other_flag.refresh_from_db()
+        assert my_flag.active is True
+        assert other_flag.active is False
+
+    def test_bulk_update_status_cannot_enable_archived_flag(self):
+        archived = self._create_flag("archived_flag", active=False, archived=True)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_update_status/",
+            {"active": True, "ids": [archived.id]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated"] == []
+        assert len(data["errors"]) == 1
+        assert data["errors"][0]["id"] == archived.id
+        assert data["errors"][0]["reason"] == "Cannot enable an archived feature flag"
+
+        archived.refresh_from_db()
+        assert archived.active is False
+
+    def test_bulk_update_status_by_filter_only_updates_matching_flags(self):
+        matching = self._create_flag("checkout_flow", active=False)
+        other = self._create_flag("unrelated", active=False)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_update_status/",
+            {"active": True, "filters": {"search": "checkout"}},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert {u["id"] for u in data["updated"]} == {matching.id}
+
+        matching.refresh_from_db()
+        other.refresh_from_db()
+        assert matching.active is True
+        assert other.active is False
+
+    @parameterized.expand(
+        [
+            ("missing_active", {"ids": [1]}),
+            ("non_boolean_active", {"active": "yes", "ids": [1]}),
+            ("neither_ids_nor_filters", {"active": True}),
+            ("both_ids_and_filters", {"active": True, "ids": [1], "filters": {"search": "x"}}),
+        ]
+    )
+    def test_bulk_update_status_invalid_request_returns_400(self, _name, payload):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/bulk_update_status/",
+            payload,
+        )
+        assert response.status_code == 400, response.json()
+
+
 class TestFeatureFlagLimits(APIBaseTest):
     """Tests for feature flag creation and update limits."""
 

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -12492,6 +12492,7 @@ class TestFeatureFlagBulkUpdateStatus(APIBaseTest):
         assert {int(log.item_id) for log in logs if log.item_id is not None} == flag_ids
         for log in logs:
             assert log.user == self.user
+            assert log.detail is not None
             changes = log.detail.get("changes") or []
             assert len(changes) == 1
             assert changes[0]["field"] == "active"

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -1332,6 +1332,39 @@ export interface BulkKeysResponseApi {
     warning?: string
 }
 
+export interface FeatureFlagBulkUpdateStatusRequestApi {
+    /** Target enabled state to apply to every matched flag. `true` enables the flag (rolls it out to users matching its release conditions); `false` disables it (rolls it back). */
+    active: boolean
+    /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to update every flag matching a search/active/tags/etc. filter instead of supplying explicit IDs. */
+    filters?: BulkDeleteFiltersApi
+    /**
+     * Explicit feature flag IDs to update. Mutually exclusive with `filters`.
+     * @items.minimum 1
+     */
+    ids?: number[]
+}
+
+export interface FeatureFlagBulkUpdateStatusUpdatedItemApi {
+    /** ID of the flag whose enabled state changed. */
+    id: number
+    /** The flag key. */
+    key: string
+    /** The flag's enabled state after the update. */
+    active: boolean
+}
+
+/**
+ * Schema-only — see ``BulkDeleteResponseSerializer`` for why the declared ``errors`` field must
+ * never be validated against. The handler builds the response dict directly; this exists only so
+ * drf-spectacular can render the response in the OpenAPI spec.
+ */
+export interface FeatureFlagBulkUpdateStatusResponseApi {
+    /** Flags whose enabled state was changed. Flags already in the target state are omitted. */
+    updated: FeatureFlagBulkUpdateStatusUpdatedItemApi[]
+    /** Flags that could not be updated (e.g. archived flags cannot be enabled), with reasons. */
+    errors: BulkDeleteErrorItemApi[]
+}
+
 /**
  * * `add` - add
  * * `remove` - remove

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -23,6 +23,8 @@ import type {
     EvaluationContextSuggestionRequestApi,
     EvaluationContextSuggestionResponseApi,
     FeatureFlagApi,
+    FeatureFlagBulkUpdateStatusRequestApi,
+    FeatureFlagBulkUpdateStatusResponseApi,
     FeatureFlagCreateRequestSchemaApi,
     FeatureFlagStatusResponseApi,
     FeatureFlagTestEvaluationRequestApi,
@@ -935,6 +937,39 @@ export const featureFlagsBulkKeysRetrieve = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(bulkKeysRequestApi),
+    })
+}
+
+export const getFeatureFlagsBulkUpdateStatusCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/feature_flags/bulk_update_status/`
+}
+
+/**
+ * Bulk enable or disable feature flags by filter criteria or explicit IDs.
+ *
+ * Accepts either:
+ * - {"active": bool, "ids": [...]} - explicit flag IDs, or
+ * - {"active": bool, "filters": {...}} - same filter params as the list endpoint.
+ *
+ * `ids` and `filters` are mutually exclusive. Enabling a flag rolls it out to the users matching
+ * its release conditions immediately; disabling rolls it back. Archived flags cannot be enabled.
+ * Flags already in the target state are skipped (not re-written, not logged).
+ *
+ * Mirrors `bulk_delete`: database writes and cache invalidation are batched, and because
+ * `queryset.update()` bypasses `ModelActivityMixin`, an "updated" activity log entry recording the
+ * `active` change is written per flag via `bulk_log_activity` so the audit trail matches the
+ * single-flag update path.
+ */
+export const featureFlagsBulkUpdateStatusCreate = async (
+    projectId: string,
+    featureFlagBulkUpdateStatusRequestApi: FeatureFlagBulkUpdateStatusRequestApi,
+    options?: RequestInit
+): Promise<FeatureFlagBulkUpdateStatusResponseApi> => {
+    return apiMutator<FeatureFlagBulkUpdateStatusResponseApi>(getFeatureFlagsBulkUpdateStatusCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(featureFlagBulkUpdateStatusRequestApi),
     })
 }
 

--- a/products/feature_flags/frontend/generated/api.zod.ts
+++ b/products/feature_flags/frontend/generated/api.zod.ts
@@ -1291,6 +1291,86 @@ export const FeatureFlagsBulkKeysRetrieveBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Bulk enable or disable feature flags by filter criteria or explicit IDs.
+ *
+ * Accepts either:
+ * - {"active": bool, "ids": [...]} - explicit flag IDs, or
+ * - {"active": bool, "filters": {...}} - same filter params as the list endpoint.
+ *
+ * `ids` and `filters` are mutually exclusive. Enabling a flag rolls it out to the users matching
+ * its release conditions immediately; disabling rolls it back. Archived flags cannot be enabled.
+ * Flags already in the target state are skipped (not re-written, not logged).
+ *
+ * Mirrors `bulk_delete`: database writes and cache invalidation are batched, and because
+ * `queryset.update()` bypasses `ModelActivityMixin`, an "updated" activity log entry recording the
+ * `active` change is written per flag via `bulk_log_activity` so the audit trail matches the
+ * single-flag update path.
+ */
+
+export const FeatureFlagsBulkUpdateStatusCreateBody = /* @__PURE__ */ zod.object({
+    active: zod
+        .boolean()
+        .describe(
+            'Target enabled state to apply to every matched flag. `true` enables the flag (rolls it out to users matching its release conditions); `false` disables it (rolls it back).'
+        ),
+    filters: zod
+        .object({
+            active: zod
+                .enum(['true', 'false', 'STALE'])
+                .describe('\* `true` - true\n\* `false` - false\n\* `STALE` - STALE')
+                .optional()
+                .describe('Filter by active state.\n\n\* `true` - true\n\* `false` - false\n\* `STALE` - STALE'),
+            created_by_id: zod.number().optional().describe('Filter to flags created by a specific user ID.'),
+            search: zod.string().optional().describe('Search by feature flag key or name (case-insensitive).'),
+            type: zod
+                .enum(['boolean', 'multivariant', 'experiment', 'remote_config'])
+                .describe(
+                    '\* `boolean` - boolean\n\* `multivariant` - multivariant\n\* `experiment` - experiment\n\* `remote_config` - remote_config'
+                )
+                .optional()
+                .describe(
+                    'Filter by flag type.\n\n\* `boolean` - boolean\n\* `multivariant` - multivariant\n\* `experiment` - experiment\n\* `remote_config` - remote_config'
+                ),
+            evaluation_runtime: zod
+                .enum(['server', 'client', 'all'])
+                .describe('\* `server` - Server\n\* `client` - Client\n\* `all` - All')
+                .optional()
+                .describe(
+                    'Filter by evaluation runtime.\n\n\* `server` - Server\n\* `client` - Client\n\* `all` - All'
+                ),
+            excluded_properties: zod
+                .string()
+                .optional()
+                .describe('JSON-encoded property filter to exclude. Same shape as the list endpoint.'),
+            tags: zod
+                .array(zod.string())
+                .optional()
+                .describe('Tag names to filter by. Flags carrying at least one of these tags match.'),
+            excluded_tags: zod
+                .array(zod.string())
+                .optional()
+                .describe('Tag names to exclude. Flags carrying any of these tags are filtered out.'),
+            has_evaluation_contexts: zod
+                .boolean()
+                .optional()
+                .describe('When true, only matches flags with at least one evaluation context.'),
+            archived: zod
+                .boolean()
+                .optional()
+                .describe('Filter by archived state. When omitted, archived flags are excluded.'),
+        })
+        .describe("Allowed filter keys for bulk_delete — same shape as the list endpoint's query params.")
+        .optional()
+        .describe(
+            "Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to update every flag matching a search\/active\/tags\/etc. filter instead of supplying explicit IDs."
+        ),
+    ids: zod
+        .array(zod.number().min(1))
+        .optional()
+        .describe('Explicit feature flag IDs to update. Mutually exclusive with `filters`.'),
+})
+
+/**
  * Bulk update tags on multiple objects.
  *
  * PAT access: this action has no ``required_scopes=`` on the decorator —

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -184,6 +184,9 @@ tools:
             Resolve feature flag IDs to their string keys in one call. Pass `ids` as a list of integer flag IDs. Returns
             `keys` as a mapping of stringified ID to key for the IDs that exist in this project. Useful when you have
             IDs from another tool (e.g., dependent flags, scheduled changes) and need the keys for downstream calls.
+    feature-flags-bulk-update-status-create:
+        operation: feature_flags_bulk_update_status_create
+        enabled: false
     feature-flags-bulk-update-tags-create:
         operation: feature_flags_bulk_update_tags_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26156,6 +26156,39 @@ export namespace Schemas {
       readonly is_used_in_replay_settings: boolean;
     }
 
+    export interface FeatureFlagBulkUpdateStatusRequest {
+      /** Target enabled state to apply to every matched flag. `true` enables the flag (rolls it out to users matching its release conditions); `false` disables it (rolls it back). */
+      active: boolean;
+      /** Filter criteria — same shape as the list endpoint's query params. Mutually exclusive with `ids`. Use this to update every flag matching a search/active/tags/etc. filter instead of supplying explicit IDs. */
+      filters?: BulkDeleteFilters;
+      /**
+         * Explicit feature flag IDs to update. Mutually exclusive with `filters`.
+         * @items.minimum 1
+         */
+      ids?: number[];
+    }
+
+    export interface FeatureFlagBulkUpdateStatusUpdatedItem {
+      /** ID of the flag whose enabled state changed. */
+      id: number;
+      /** The flag key. */
+      key: string;
+      /** The flag's enabled state after the update. */
+      active: boolean;
+    }
+
+    /**
+     * Schema-only — see ``BulkDeleteResponseSerializer`` for why the declared ``errors`` field must
+     * never be validated against. The handler builds the response dict directly; this exists only so
+     * drf-spectacular can render the response in the OpenAPI spec.
+     */
+    export interface FeatureFlagBulkUpdateStatusResponse {
+      /** Flags whose enabled state was changed. Flags already in the target state are omitted. */
+      updated: FeatureFlagBulkUpdateStatusUpdatedItem[];
+      /** Flags that could not be updated (e.g. archived flags cannot be enabled), with reasons. */
+      errors: BulkDeleteErrorItem[];
+    }
+
     export interface FeatureFlagConditionPropertyAnalysis {
       /** Property key */
       key: string;


### PR DESCRIPTION
## Problem

Feature flags could be enabled or disabled one at a time only. The flags table already supports bulk selection (bulk delete, bulk tag editing), but flipping the status of a batch meant opening each flag individually. This brings status changes to parity with the other bulk actions, in the same vein as the recent event-definitions bulk tag editing work.

## Changes

- **Backend:** `FeatureFlagViewSet` gains a `bulk_update_status` action. It accepts either explicit `ids` or list-endpoint `filters` (mutually exclusive, mirroring `bulk_delete`), scopes by project, skips flags already in the target state, and refuses to enable archived flags.
- **Logging:** `queryset.update()` bypasses `ModelActivityMixin`, so the action writes one "updated" activity entry per changed flag via `bulk_log_activity`, recording the `active` before/after. The History tab now shows a bulk status change the same way it shows a single-flag toggle.
- **Frontend:** the flags table selection bar gets **Enable** and **Disable** buttons next to the existing tag/delete actions. Each opens a confirmation dialog (enabling rolls out immediately, disabling rolls back), then reports the result with a toast. "Select all matching" resolves to filters so we don't ship an unbounded id list.

Generated frontend/MCP types for the new endpoint are left for CI's `check-openapi-types` job to regenerate and auto-commit. The button calls `api.create()` directly and doesn't depend on the generated client.

> [!NOTE]
> No screenshot: this session had no dev stack to run the app. The buttons render in the same selection bar as the existing "Delete selected" button, only when rows are selected.

## How did you test this code?

I'm an agent and this session had no local Postgres, no `node_modules`, and no `hogli`, so I could not run pytest, Jest, or the type/lint pipeline locally. CI will. What I did run: **ruff** (check + format) passes on both changed Python files, and the module imports cleanly under the project venv (blocked only at the DB connection, i.e. past all import/reference resolution). I also confirmed the activity-log encoder round-trips the boolean `before`/`after` so the logging assertions hold.

Automated tests added — `TestFeatureFlagBulkUpdateStatus` in `products/feature_flags/backend/api/test/test_feature_flag.py`. Each targets a status-specific regression not covered by the existing `bulk_delete` suite:
- `flips_active_and_skips_noops` (parameterized enable/disable) — guards the core flip plus the no-op skip (a flag already in the target state must not be re-written or reported).
- `logs_active_change_per_updated_flag` — the "logging that goes with it": if the manual `bulk_log_activity` call is dropped, the bulk path silently stops writing history. Asserts one `active` change entry per changed flag.
- `cross_project_isolation` — IDOR guard: a flag in another project is reported "Flag not found" and left untouched.
- `cannot_enable_archived_flag` — safety rule: a bulk enable must not silently roll out an archived flag.
- `by_filter_only_updates_matching_flags` — wiring guard that the filters branch (used by "select all matching") works for status, not just ids.
- `invalid_request_returns_400` (parameterized) — wiring guard for the manual validation (missing/non-boolean `active`, neither/both of ids+filters).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover per-flag status toggling that would need updating for the bulk equivalent.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Skills invoked while shaping this change: `/improving-drf-endpoints` (viewset/serializer + schema annotations), `/adopting-generated-api-types` (frontend API usage), and `/writing-tests` (the value gate — kept coverage to the six status-specific regressions above).

Key decisions:
- Modeled the action on the sibling `bulk_delete` rather than inventing a new shape — same ids/filters duality, same project scoping, same access-control filter, same batched-update + manual-cache-invalidation structure. The point of "same vein" is that a reviewer reads the two actions side by side.
- Matched the sibling `bulkDeleteFlags` in `flagSelectionLogic` (raw `api.create` + a small handwritten result type) instead of the generated client, since the generated function won't exist until CI regenerates types and nothing else imports it.
- No `report_user_action` call — `bulk_delete` doesn't emit one either, so "logging" here means the activity/audit log, which is what the flag History tab reads.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
