### PR TITLE
chore(analytics-platform): move the serve-stale eligibility gate next to the lazy executor

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/stale_policy.py
+++ b/products/analytics_platform/backend/lazy_computation/stale_policy.py
@@ -1,0 +1,40 @@
+"""Who may be served stale, and for how long.
+
+The executor's `stale_while_revalidate_seconds` is the *serve* half of RFC 5861: a request that would
+otherwise materialize inline gets its complete-but-stale rows back instantly instead of blocking. The
+rule for *who* may take that grace is the same in every product, and getting it wrong is a data-freezing
+bug rather than a slow query — a background refresher served its own stale rows persists them as a fresh
+result and never recomputes, so nothing refreshes again. Hence one implementation, here, next to the
+executor, instead of one per product.
+
+Products supply the triggers of their own warmers; the CACHE_WARMUP feature tag is the primary,
+product-agnostic gate. Callers that take the grace must have a revalidation path (a background refresher,
+or an enqueue on `stale=True`), otherwise they serve stale until the grace runs out.
+"""
+
+from posthog.clickhouse.query_tagging import Feature, get_query_tag_value
+
+# Refreshers every product inherits. The generic insight cache warmer's CACHE_WARMUP feature tag does not
+# always survive to the ensure call (lazy modules re-stamp feature=QUERY before ensuring), but its trigger
+# does — without it, warmer runs get served stale and persist that into the insight cache as fresh.
+SHARED_BACKGROUND_WARMING_TRIGGERS = frozenset({"warmingV2"})
+
+
+def is_background_warming_request(extra_triggers: frozenset[str] = frozenset()) -> bool:
+    """True when this request *is* a refresh mechanism rather than a consumer of one.
+
+    `extra_triggers` are the calling product's own warmer triggers, unioned with the shared set. The
+    feature tag is the primary gate: it classifies refreshers by category, including warmers the caller
+    does not know by name.
+    """
+    if get_query_tag_value("feature") == Feature.CACHE_WARMUP:
+        return True
+    return get_query_tag_value("trigger") in (SHARED_BACKGROUND_WARMING_TRIGGERS | extra_triggers)
+
+
+def resolve_stale_while_revalidate_seconds(
+    grace_seconds: float,
+    extra_triggers: frozenset[str] = frozenset(),
+) -> float | None:
+    """The serve-stale grace this request may take: None for refreshers, `grace_seconds` for user reads."""
+    return None if is_background_warming_request(extra_triggers) else grace_seconds

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -28,7 +28,7 @@ from posthog.hogql.property import property_to_expr
 from posthog.hogql.transforms.preaggregated_table_transformation import is_integer_timezone
 
 from posthog import redis
-from posthog.clickhouse.query_tagging import Feature, get_query_tag_value, tag_queries
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import Team
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
@@ -36,6 +36,10 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     TtlSchedule,
     ensure_precomputed,
     parse_ttl_schedule,
+)
+from products.analytics_platform.backend.lazy_computation.stale_policy import (
+    is_background_warming_request as shared_is_background_warming_request,
+    resolve_stale_while_revalidate_seconds,
 )
 
 logger = structlog.get_logger(__name__)
@@ -110,23 +114,17 @@ def list_oom_pinned_team_ids() -> list[int]:
 # so the two cannot drift apart.
 REVALIDATION_TRIGGER = "webAnalyticsStaleRevalidation"
 
-# Requests tagged with any of these triggers ARE the refresh mechanism: they must never
-# be served stale (they'd freeze the cache serving stale to themselves) and they keep
-# the framework's full wait budget. This named set is the belt; the primary gate in
-# `is_background_warming_request` is the CACHE_WARMUP feature tag, which classifies
-# refreshers by category — including warmers this module doesn't know by name (e.g.
-# the generic insight cache warmer, trigger "warmingV2"), which would otherwise be
-# served stale and persist it into the insight cache under a fresh timestamp.
+# Web's own refreshers. These ARE the refresh mechanism: they must never be served stale
+# (they'd freeze the cache serving stale to themselves) and they keep the framework's full
+# wait budget. Warmers shared across products (e.g. the generic insight cache warmer,
+# trigger "warmingV2") live in SHARED_BACKGROUND_WARMING_TRIGGERS and are unioned in by
+# `is_background_warming_request`. This named set is the belt; the primary gate there is the
+# CACHE_WARMUP feature tag, which classifies refreshers by category — including warmers this
+# module doesn't know by name.
 BACKGROUND_WARMING_TRIGGERS = frozenset(
     {
         "webAnalyticsEagerBaselineWarming",
         "webAnalyticsQueryWarming",
-        # The generic insight cache warmer. Its Feature.CACHE_WARMUP tag does NOT
-        # survive to the ensure call (the lazy modules re-stamp feature=QUERY before
-        # ensuring), but the trigger does — without it here, warmer runs would be
-        # served stale and persist stale rows into the insight cache as a fresh
-        # blocking result.
-        "warmingV2",
         REVALIDATION_TRIGGER,
     }
 )
@@ -160,9 +158,7 @@ WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUE_FAILED = Counter(
 
 
 def is_background_warming_request() -> bool:
-    if get_query_tag_value("feature") == Feature.CACHE_WARMUP:
-        return True
-    return get_query_tag_value("trigger") in BACKGROUND_WARMING_TRIGGERS
+    return shared_is_background_warming_request(BACKGROUND_WARMING_TRIGGERS)
 
 
 # One revalidation per (team, family, query shape) per window: a dashboard burst — or a
@@ -231,8 +227,8 @@ def web_ensure_precomputed(*, team: Team, **kwargs: Any) -> LazyComputationResul
     result to `handle_stale_served` so the background revalidation actually happens.
     """
     if "stale_while_revalidate_seconds" not in kwargs:
-        kwargs["stale_while_revalidate_seconds"] = (
-            None if is_background_warming_request() else STALE_WHILE_REVALIDATE_SECONDS
+        kwargs["stale_while_revalidate_seconds"] = resolve_stale_while_revalidate_seconds(
+            STALE_WHILE_REVALIDATE_SECONDS, BACKGROUND_WARMING_TRIGGERS
         )
     pinned = is_team_oom_pinned(team.id)
     if "ttl_seconds" in kwargs:


### PR DESCRIPTION
## Problem

The lazy executor takes a `stale_while_revalidate_seconds` grace: a request that would otherwise materialize inline gets its complete-but-stale rows back instantly. Web analytics is the only product using it, so the rule for *who* may take that grace lives in `web_lazy_precompute_common.py`.

That rule is not web-specific, and getting it wrong is not a slow query, it is a data-freezing bug. A background refresher served its own stale rows persists them as fresh and never recomputes, so the data never refreshes again. The subtle part is that the feature tag alone is not enough: some lazy modules re-stamp `feature=QUERY` before ensuring, which clobbers a warmer's `CACHE_WARMUP` tag, so the trigger has to catch it too. Any product adopting serve-stale has to rediscover that.

Marketing analytics is about to adopt it (its dashboard blocks ~10s on inline materialization), so this moves the gate somewhere both products can share rather than copying the subtlety.

## Changes

New `products/analytics_platform/backend/lazy_computation/stale_policy.py`, next to the executor it guards:

- `is_background_warming_request(extra_triggers)` - the `CACHE_WARMUP` feature tag as the primary gate, unioned with the shared warmer triggers and whatever the calling product adds.
- `resolve_stale_while_revalidate_seconds(grace, extra_triggers)` - `None` for refreshers, the grace for user reads.
- `SHARED_BACKGROUND_WARMING_TRIGGERS` now holds `warmingV2`, the generic insight cache warmer, which was living in web's set despite not being web's.

Web delegates to it. Its public surface is unchanged: `is_background_warming_request()` keeps its name and signature, `BACKGROUND_WARMING_TRIGGERS` is still exported, and its call sites in `web_stats_paths_lazy_precompute.py` are untouched. Web's set keeps only web's own triggers.

No behavior change.

## How did you test this code?

No new tests, deliberately. Web's `test_stale_while_revalidate_grace_by_trigger` is parameterized over exactly these cases and now runs through the shared code, so the shared logic is already pinned. Rather than assume that, I checked it: removing `warmingV2` from `SHARED_BACKGROUND_WARMING_TRIGGERS` fails the `insight_warmer_feature_clobbered` case with "background context {'trigger': 'warmingV2', 'feature': QUERY} must not be served stale". A new test in this PR would be redundant coverage of a path that is already guarded.

Since this touches another team's code, I ran the full web analytics query suite: 712 passed, 17 skipped, 248 snapshots, plus ruff and ty.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This is the first of two PRs. Javier is chasing a marketing analytics dashboard that spends ~10s materializing precompute windows inline on the request thread; instrumentation in #70256 and #70483 pinned it to the two `ensure_precomputed` calls in the conversion-goal path. Serve-stale is the fix, and web analytics had already built the whole pattern, so the follow-up PR adopts it for marketing rather than inventing anything.

I (Claude Code) offered Javier the cheaper option of copying web's gate into marketing. He chose to promote it to the shared layer instead, which is why web is touched here. The split keeps this PR a pure no-behavior-change refactor that the web owners can review on its own, with the marketing behavior change landing separately.
