### PR TITLE
fix(replay): tidy up saved-filters filter editor UI

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4937,23 +4937,23 @@ snapshots:
     replay-tabs-home-filters-banner--product-analytics-over-limit--dark:
         hash: v1.k794b7964.e43831aab10f34ebb833d39856c8285ca3ec054b018c07a8eea2dc6551d12119.w0JYkgk5ujwBybY8356Xe93bi6ky_z7Skt5wuoRPX1g
     replay-tabs-home-filters-banner--product-analytics-over-limit--light:
-        hash: v1.k794b7964.3455a8a462eb913f7d478672c16b5fa56fd4591efcc09b5ad1119707842f80b3.FMUgEs84D1HWKB2fVtRZP_Dsk6HYgaz604k3bLZqwFI
+        hash: v1.k794b7964.e338b80ff0cdbd414dc92b76641efb7560f4be240c814a3ff995914f7a34ac5c.gjqnN9mJx2Z2iF34W3oG_UO6slLlN5qNY3XOfMsm0fY
     replay-tabs-home-filters-banner--product-analytics-under-limit--dark:
         hash: v1.k794b7964.c4cc11f519896f1493409b60c0a04da6023d71a83374094c29c2666c65c205cf.aabEMRgGPdgSlwx4q2x34yULwzqiBwz2CI6LUyV5eak
     replay-tabs-home-filters-banner--product-analytics-under-limit--light:
-        hash: v1.k794b7964.8aef11640f2612fd00277924ac07729da66aad48389f4c62c09766a0bffd7e79.Oki9d0hynyBIzPd1dnBscUIL1eiTrxspvKYclw4ZO90
+        hash: v1.k794b7964.1b0064609d6933870d97507fde03a00df873b2fd5c2c5396db1d6b37c4d3cef1._Cm5cCDaX-P4_4PnAI4QSlR13YJcEs85p94DHdhDEGM
     replay-tabs-home-success--filters-expanded--dark:
         hash: v1.k794b7964.7f58d696106b07e8b83f39ceadd4afedd2ea3b9f5f54ee830ac47ef892a491df.oro7TiUySJjhJ8DgIKv2MQa-3bli9EEwFGB4wjvw_Rw
     replay-tabs-home-success--filters-expanded--light:
-        hash: v1.k794b7964.ed929373330766184871ab4391f60a9f990f33619f5e543a2d9f200750af5d61.XKzHPhDcfbRTUjkuvuLvDttjIkS8EsKol7G434_fZY4
+        hash: v1.k794b7964.2c7829688de58fdac4ec7b5a29aad114abe746106b7740199e5bcf6710e93709.XK_CXqwYtAdN3etTCmAxtroSOM0743Qi_s3U8o3H5Bo
     replay-tabs-home-success--filters-expanded-lots-of-results--dark:
         hash: v1.k794b7964.03f4cfafeac55d46708f6535d81f83561cdd5303f21990a0bd7552d734fafcd9.xg6GQwjqNts-8iDh1YHzv_T9wpgC3WWcDfOi4RXrJmY
     replay-tabs-home-success--filters-expanded-lots-of-results--light:
-        hash: v1.k794b7964.f235bb42f1bac1209abb9791a0919e1acf48186a47e085db5156dc960b1a221e.0dziDcsbtzHrDsFSne7Yh8YdpbOrqURtg8r2oFXsH_o
+        hash: v1.k794b7964.0c69c90d085a99b0499ef915f1bc4e51e2acb4506a760e01567a9390fbfd8da8.wY2EdNdJ1fIcSR6f8wzWh1iG8n2KiE175tyiS-oY34g
     replay-tabs-home-success--filters-expanded-lots-of-results-narrow--dark:
-        hash: v1.k794b7964.8b3d5326acff02eba0bc8abd245a7316b2384eacd95519ca9a47625d6a1f2d06.Pr8cB1knQtSQfMoTBaKaDlOjMO4H3FKGKNRmCzwBMY0
+        hash: v1.k794b7964.6d0369b1097f2c04c5812d3fd97ccc6812e21ff46e96e32d429f387443afda9a.OI2h2E6NjaIBU9qz6FfY1mkhF8G7FLOghGS84giuohQ
     replay-tabs-home-success--filters-expanded-lots-of-results-narrow--light:
-        hash: v1.k794b7964.0d511b1df87dfdead8a9fed5556558a60deff91aff038b989849eeaad00c1210.R_GlOaoNPaM3re81ccG2zGUFyzhq3ZcG9UunuOqRpH8
+        hash: v1.k794b7964.60afab820198007e72068b2957f7d9829644f7a0d71296878aa0bcb98c296f1e.t5sK2_OrCMUGVB6a_5y0HK94rAF-JbEkfflfAUouKPU
     replay-tabs-home-success--recent-recordings--dark:
         hash: v1.k794b7964.1674be6fbb15e43b13462761569849fcadf46d5196c19bffd49258d3150a8856.1J-EStkYw8t1u-ouQ0txgIrfcll4bFrP60Raz75wRvU
     replay-tabs-home-success--recent-recordings--light:

--- a/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.scss
+++ b/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.scss
@@ -2,7 +2,10 @@
     gap: 0.375rem;
     height: 1.625rem;
     padding: 0.125rem 0.625rem;
-    overflow: hidden;
+
+    // `visible` (not `hidden`) so the event pill's absolutely-positioned count badge isn't clipped at
+    // the top-right corner. Long labels are truncated in JS via `midEllipsis`, not by this overflow.
+    overflow: visible;
     color: var(--text-3000);
     white-space: nowrap;
     cursor: default;

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -699,8 +699,8 @@ export const ReplayFiltersTab = ({
         <div className={clsx('relative bg-surface-primary w-full h-full', className)}>
             <ProductAnalyticsOverLimitBanner />
             {appliedSavedFilter && (
-                <div className="border-b px-2 py-3 flex flex-wrap items-center gap-2">
-                    <div className="flex items-center gap-2 min-w-0 flex-1 basis-3/5">
+                <div className="border-b px-2 py-2 flex flex-wrap items-center gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
                         <span className="font-medium whitespace-nowrap shrink-0">Loaded saved filter:</span>
                         <SavedFilterNameEditor
                             appliedSavedFilter={appliedSavedFilter}
@@ -747,7 +747,7 @@ export const ReplayFiltersTab = ({
                     )}
                 </div>
             )}
-            <div className="flex items-center py-2 justify-between">
+            <div className="flex items-center py-2 justify-between px-2">
                 <AndOrFilterSelect
                     // Reflect the effective operand, not just the outer group: legacy saved filters can
                     // carry the match-any on the inner group while the outer stays AND. Toggling syncs
@@ -781,7 +781,7 @@ export const ReplayFiltersTab = ({
                     suffix={['filter', 'filters']}
                     size="small"
                 />
-                <div className="mr-2">
+                <div>
                     {compactActions ? (
                         resetButton
                     ) : (
@@ -880,7 +880,7 @@ export const ReplayFiltersTab = ({
                 <>
                     <LemonDivider className="mt-4" />
 
-                    <div className="flex items-center py-2 justify-between px-1 gap-2">
+                    <div className="flex items-center py-2 justify-between px-2 gap-2">
                         {showFeedbackButton && (
                             <LemonButton
                                 id="replay-filters-feedback-button"


### PR DESCRIPTION
## Problem

A coworker reviewing the session-replay **Saved filters** filter editor flagged three small visual nits:

1. The "Loaded saved filter:" box looks unnecessarily big.
2. The count badge (the little "1") on an event filter pill like `Pageview` gets cut off.
3. The right-edge spacing is inconsistent. The "Filter out internal and test users" toggle sits at a different right margin than the "Save as new filter" button.

## Changes

All cosmetic, no behavior change.

- **Box too big** (`RecordingsUniversalFiltersEmbed.tsx`): dropped the "Loaded saved filter:" row from `py-3` to `py-2` so it matches the neighboring rows, and removed `flex-1 basis-3/5` from the label wrapper so the box only takes the width it needs.
- **Clipped badge** (`UniversalFilterButton.scss`): changed the pill from `overflow: hidden` to `overflow: visible` so the absolutely-positioned count badge isn't clipped at the top-right corner. Label truncation is unaffected, it happens in JS via `midEllipsis`, not via this overflow.
- **Inconsistent spacing** (`RecordingsUniversalFiltersEmbed.tsx`): standardized every row on `px-2`. Added `px-2` to the "Match … filters" row and removed the `mr-2` toggle wrapper, and changed the footer row from `px-1` to `px-2`. The toggle and the Save button now line up on the same right edge as the applied-filters pills.

> [!NOTE]
> `UniversalFilterButton.scss` is shared across insights, logs, error tracking, and experiments filter bars. The overflow change is low risk (the badge is meant to overflow, and truncation is JS-side), but the one spot worth eyeballing there is the close-button hover background at a pill's rounded corner.

## How did you test this code?

I (Claude, agent-assisted) made className/SCSS-only edits and ran the frontend formatter over them. I did **not** run the app or capture screenshots, and there are no automated tests for these purely visual changes. Manual visual verification is still needed:

- Session replay: load a saved filter, confirm the box is no taller than the "Match … filters" row, add an event filter with a property and confirm its count badge is fully visible, and confirm the toggle and Save button share the same right margin.
- Regression check for the shared SCSS: open Product analytics insight filters, Logs, and Error tracking filter bars and confirm pills, close buttons, and long labels still render fine.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim relayed a coworker's screenshot feedback on the replay saved-filters editor. I traced each of the three nits to specific className/SCSS in `RecordingsUniversalFiltersEmbed.tsx` and the shared `UniversalFilterButton.scss`, then applied the minimal fixes. No skills were invoked (pure styling change). The one judgment call was the badge fix: rather than repositioning the shared `IconWithCount` badge or scoping a new class, I flipped the pill's `overflow` to `visible`, since truncation is already handled in JS by `midEllipsis` so the container overflow was only clipping the badge. Called out the shared-component blast radius in the note above so reviewers know where to look.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
