### PR TITLE
fix(logs): retry errored alert notification after kafka enqueue failure

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -260,8 +260,12 @@ class _DispatchedAlert:
     """Phase 2 output: notification dispatched, ready for the cohort bulk save.
 
     `notification_failed` is the source of truth for state rollback: if True,
-    the state machine's `new_state` is replaced with the alert's existing state
-    so the next cycle re-tries the notification.
+    the state machine's `new_state` and `consecutive_failures` are both reset to
+    the alert's pre-check values so the next cycle re-evaluates as if this check
+    never happened and re-tries the notification. The counter matters as much as
+    the state: the error notification fires on the 0 -> 1 failure-counter edge,
+    so persisting an advanced counter after a failed enqueue would silence the
+    retry forever.
 
     `produce_result` is the pending Kafka delivery for this alert's
     notification (None when no notification was attempted or the enqueue itself
@@ -281,6 +285,7 @@ class _DispatchedAlert:
             return dataclasses.replace(
                 self.evaluation.outcome,
                 new_state=AlertState(self.evaluation.alert.state),
+                consecutive_failures=self.evaluation.alert.consecutive_failures,
             )
         return self.evaluation.outcome
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -260,12 +260,15 @@ class _DispatchedAlert:
     """Phase 2 output: notification dispatched, ready for the cohort bulk save.
 
     `notification_failed` is the source of truth for state rollback: if True,
-    the state machine's `new_state` and `consecutive_failures` are both reset to
-    the alert's pre-check values so the next cycle re-evaluates as if this check
-    never happened and re-tries the notification. The counter matters as much as
-    the state: the error notification fires on the 0 -> 1 failure-counter edge,
-    so persisting an advanced counter after a failed enqueue would silence the
-    retry forever.
+    the state machine's `new_state` is reset to the alert's pre-check value so
+    the next cycle re-evaluates and re-tries the notification, and
+    `consecutive_failures` may heal downward but never advance. The counter
+    matters as much as the state: the error notification fires on the 0 -> 1
+    failure-counter edge, so persisting an advanced counter after a failed
+    enqueue would silence the retry forever. A successful evaluation's counter
+    reset is kept, though — only delivery failed, and voiding the evidence that
+    evaluation recovered would let a later error skip its notify edge and drag
+    a stale streak toward BROKEN.
 
     `produce_result` is the pending Kafka delivery for this alert's
     notification (None when no notification was attempted or the enqueue itself
@@ -285,7 +288,10 @@ class _DispatchedAlert:
             return dataclasses.replace(
                 self.evaluation.outcome,
                 new_state=AlertState(self.evaluation.alert.state),
-                consecutive_failures=self.evaluation.alert.consecutive_failures,
+                consecutive_failures=min(
+                    self.evaluation.alert.consecutive_failures,
+                    self.evaluation.outcome.consecutive_failures,
+                ),
             )
         return self.evaluation.outcome
 

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -1267,6 +1267,39 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
+    def test_errored_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
+        mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception("CH down")
+        alert = self._make_alert()
+        now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
+
+        # Non-transient classification so the failure notifies at all; the enqueue
+        # failure must then roll back the failure counter, or the second check
+        # never sees the 0 -> 1 notify edge and the notification is lost.
+        with (
+            patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce,
+            patch(
+                "products.logs.backend.alert_error_classifier.classify_query_error",
+                return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
+            ),
+        ):
+            mock_produce.side_effect = Exception("Kafka down")
+            _evaluate_and_save_one(alert, now1, _make_stats())
+
+            mock_produce.side_effect = None
+            mock_produce.reset_mock()
+            _evaluate_and_save_one(alert, now2, _make_stats())
+
+        errored_calls = [
+            c
+            for c in mock_produce.call_args_list
+            if c.kwargs.get("event") and c.kwargs["event"].event == "$logs_alert_errored"
+        ]
+        assert len(errored_calls) == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_broken_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
         mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -1300,6 +1300,44 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
+    def test_enqueue_failure_keeps_successful_checks_counter_reset(self, _mock_capture, mock_query_cls):
+        # The rollback may heal the counter downward but never restore a stale
+        # streak: a successful evaluation whose FIRE enqueue failed still proves
+        # the alert works, so its counter reset must survive the rollback and a
+        # later error must see a fresh 0 -> 1 notify edge.
+        _mock_buckets(mock_query_cls, [50])
+        alert = self._make_alert(state=LogsAlertConfiguration.State.ERRORED, consecutive_failures=3)
+        now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
+
+        with (
+            patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce,
+            patch(
+                "products.logs.backend.alert_error_classifier.classify_query_error",
+                return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
+            ),
+        ):
+            mock_produce.side_effect = Exception("Kafka down")
+            _evaluate_and_save_one(alert, now1, _make_stats())
+
+            alert.refresh_from_db()
+            assert alert.consecutive_failures == 0
+
+            mock_produce.side_effect = None
+            mock_produce.reset_mock()
+            mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception("CH down")
+            _evaluate_and_save_one(alert, now2, _make_stats())
+
+        errored_calls = [
+            c
+            for c in mock_produce.call_args_list
+            if c.kwargs.get("event") and c.kwargs["event"].event == "$logs_alert_errored"
+        ]
+        assert len(errored_calls) == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_broken_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
         mock_query_cls.return_value.execute_rolling_checks.side_effect = Exception(
             "Code: 160. DB::Exception: Estimated query execution time is too long"


### PR DESCRIPTION
## Problem

#69299 moved the errored-alert notification onto the failure-counter edge: notify when `consecutive_failures` goes 0 to 1, stay quiet on repeats. The Kafka enqueue-failure rollback in the temporal dispatch path wasn't updated to match. It restores the alert's state but persists the advanced counter, so if Kafka is down when an alert first errors, no subsequent check ever sees the notify edge again. The "your alert is erroring" heads-up is silently lost until the alert goes BROKEN at 5 failures.

## Changes

`_DispatchedAlert.committed_outcome` now rolls back `consecutive_failures` along with `new_state` when a notification fails to enqueue, via `min(pre_check_counter, outcome_counter)` rather than a plain restore:

- A failed **error** enqueue keeps the pre-check counter (never advances), so the next check re-sees the 0 → 1 notify edge and re-sends.
- A failed **FIRE** enqueue on an alert recovering from an error streak keeps the outcome's reset-to-0 (heals downward), so a stale streak can't survive a delivery failure and drag the alert toward BROKEN on its next error.

> [!NOTE]
> The rollback is deliberately asymmetric: it may heal downward but never advances. Failed-enqueue cycles don't count toward the BROKEN threshold either way, since a voided cycle shouldn't move the counter in any direction.

## How did you test this code?

Automated only. Two new tests, each proven to fail without its corresponding fix:

- `test_errored_notification_retried_after_kafka_failure` (mirrors the existing broken-retry test): Kafka down on the first errored check, up on the second, asserts exactly one `$logs_alert_errored` goes out. No existing test covered the error notification + enqueue failure + retry combination.
- `test_enqueue_failure_keeps_successful_checks_counter_reset`: an ERRORED alert with a prior streak has a successful breached check whose FIRE enqueue fails; asserts the persisted counter is 0 (not the stale streak) and a subsequent error still notifies. Added after Greptile flagged that a plain restore would resurrect the stale streak and skip the next error's notify edge.

Full `test_logs_alerting_activities.py` suite passes (88 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, internal reliability fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude); skills invoked: `/writing-tests`.
- Surfaced while rebasing the shared-alerting extraction stack (#68936 and up) onto master: a stack test asserting the notification retry started failing against #69299's counter-keyed notification, which exposed this latent regression. Extracted here as a standalone fix so the refactor stack stays behavior-neutral.
- Verified the test catches the regression by running it with the fix stashed (fails) and applied (passes).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

