### PR TITLE
feat(alerts): add email as a shared alert destination type (7/7)

### DIFF
--- a/.agents/skills/adopting-shared-alerting/SKILL.md
+++ b/.agents/skills/adopting-shared-alerting/SKILL.md
@@ -53,8 +53,8 @@ The adapter owns the product-shaped translation (model → `AlertSnapshot`, and 
 Pure builders for alert notification destinations, delivered as HogFunctions.
 
 - `EventKindSpec` — describes an alert-event kind (labels, message text) so Slack/Teams/webhook bodies render consistently. Products customize within its declarative vocabulary, never by supplying their own rendering: metric-shaped products use `details` (label/value rows), prose-shaped products use `body_lines` (e.g. one breach description per series for insight alerts), and `extra_buttons` adds actions beyond the primary button. All optional fields default to the standard logs-style layout.
-- `build_slack_destination_config` / `build_webhook_destination_config` / `build_teams_destination_config` — return an `AlertDestinationConfig` (the serializer payload plus the team it belongs to, carried alongside so it never enters serializer input).
-- `destination_filter(alert_id, event_id)`, `slack_blocks`, `teams_text`, `clip_hog_function_name` — helpers.
+- `build_slack_destination_config` / `build_webhook_destination_config` / `build_teams_destination_config` / `build_email_destination_config` — return an `AlertDestinationConfig` (the serializer payload plus the team it belongs to, carried alongside so it never enters serializer input). Email rides the same dispatch path as the rest (a `template-email` HogFunction consuming the internal event), NOT direct SMTP — insight alerts' legacy `EmailMessage` path is what this replaces on adoption.
+- `destination_filter(alert_id, event_id)`, `slack_blocks`, `teams_text`, `email_html`, `email_text`, `clip_hog_function_name` — helpers.
 
 ## Layer 1 — `common/alerting/scheduling.py`
 

--- a/common/alerting/destinations.py
+++ b/common/alerting/destinations.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-DestinationType = Literal["slack", "webhook", "teams"]
+DestinationType = Literal["slack", "webhook", "teams", "email"]
 
 ALERT_ID_PROPERTY = "alert_id"
 
@@ -27,6 +27,7 @@ TEMPLATE_ID_BY_DESTINATION_TYPE: dict[DestinationType, str] = {
     "slack": "template-slack",
     "webhook": "template-webhook",
     "teams": "template-microsoft-teams",
+    "email": "template-email",
 }
 DESTINATION_TYPE_BY_TEMPLATE_ID = {
     template_id: destination_type for destination_type, template_id in TEMPLATE_ID_BY_DESTINATION_TYPE.items()
@@ -255,5 +256,73 @@ def build_teams_destination_config(
         inputs={
             "webhookUrl": {"value": webhook_url},
             "text": {"value": teams_text(spec)},
+        },
+    )
+
+
+def email_subject(spec: EventKindSpec) -> str:
+    return spec.header
+
+
+def email_html(spec: EventKindSpec) -> str:
+    # Minimal semantic fragment — the email service owns deliverability, this owns
+    # structure. Same vocabulary order as Slack/Teams: header, prose, details, actions.
+    parts = [f"<h2>{spec.header}</h2>"]
+    parts.extend(f"<p>{line}</p>" for line in spec.body_lines)
+    if spec.details:
+        rows = "".join(f"<li><strong>{label}:</strong> {value}</li>" for label, value in spec.details)
+        parts.append(f"<ul>{rows}</ul>")
+    links = " · ".join(
+        f'<a href="{button.url}">{button.label}</a>'
+        for button in (Button(url=spec.button_url, label=spec.button_label), *spec.extra_buttons)
+    )
+    parts.append(f"<p>{links}</p>")
+    return "".join(parts)
+
+
+def email_text(spec: EventKindSpec) -> str:
+    parts = [spec.header, *spec.body_lines]
+    parts.extend(f"{label}: {value}" for label, value in spec.details)
+    parts.extend(
+        f"{button.label}: {button.url}"
+        for button in (Button(url=spec.button_url, label=spec.button_label), *spec.extra_buttons)
+    )
+    return "\n".join(parts)
+
+
+def build_email_destination_config(
+    *,
+    team: Any,
+    spec: EventKindSpec,
+    alert_id: str,
+    alert_name: str,
+    name: str,
+    to_email: str,
+    to_name: str = "",
+) -> AlertDestinationConfig:
+    # No `templating` key on the input: the CDP runtime defaults stored inputs to
+    # hog templating, so spec placeholder strings ({project.url}, ...) resolve the
+    # same way here as in the Slack/Teams/webhook inputs.
+    return _base_config(
+        team=team,
+        spec=spec,
+        alert_id=alert_id,
+        alert_name=alert_name,
+        name=name,
+        template_id=TEMPLATE_ID_BY_DESTINATION_TYPE["email"],
+        inputs={
+            "email": {
+                "value": {
+                    "to": {"email": to_email, "name": to_name},
+                    "from": {},
+                    "replyTo": "",
+                    "cc": "",
+                    "bcc": "",
+                    "subject": email_subject(spec),
+                    "preheader": "",
+                    "text": email_text(spec),
+                    "html": email_html(spec),
+                }
+            },
         },
     )

--- a/common/alerting/destinations.py
+++ b/common/alerting/destinations.py
@@ -86,6 +86,11 @@ class EventKindSpec:
     # Action buttons rendered after the primary button_url/button_label one.
     extra_buttons: tuple[Button, ...] = ()
 
+    @property
+    def all_buttons(self) -> tuple[Button, ...]:
+        """The primary button first, then any extras — the order rendered everywhere."""
+        return (Button(url=self.button_url, label=self.button_label), *self.extra_buttons)
+
     def destination_description(self, alert_name: str) -> str:
         return f'Sends {self.display_kind} notifications for {self.product_label} "{alert_name}".'
 
@@ -139,7 +144,7 @@ def slack_blocks(spec: EventKindSpec, context_elements: tuple[str, ...]) -> list
                     "text": {"text": button.label, "type": "plain_text"},
                     "type": "button",
                 }
-                for button in (Button(url=spec.button_url, label=spec.button_label), *spec.extra_buttons)
+                for button in spec.all_buttons
             ],
         },
     ]
@@ -153,12 +158,7 @@ def teams_text(spec: EventKindSpec) -> str:
     parts.extend(spec.body_lines)
     if spec.details:
         parts.append("\n\n".join(f"**{label}:** {value}" for label, value in spec.details))
-    parts.append(
-        " · ".join(
-            f"[{button.label}]({button.url})"
-            for button in (Button(url=spec.button_url, label=spec.button_label), *spec.extra_buttons)
-        )
-    )
+    parts.append(" · ".join(f"[{button.label}]({button.url})" for button in spec.all_buttons))
     return "\n\n".join(parts)
 
 

--- a/common/alerting/test/test_destinations.py
+++ b/common/alerting/test/test_destinations.py
@@ -1,4 +1,4 @@
-from common.alerting.destinations import Button, EventKindSpec, slack_blocks, teams_text
+from common.alerting.destinations import Button, EventKindSpec, build_email_destination_config, slack_blocks, teams_text
 
 DEFAULT_SPEC = EventKindSpec(
     event_id="$insight_alert_firing",
@@ -48,3 +48,31 @@ class TestSpecVocabularyRendering:
         assert teams_text(DEFAULT_SPEC) == (
             "**Insight alert firing**\n\n**Threshold:** 30\n\n[View insight](https://example.com/insight)"
         )
+
+    def test_email_destination_renders_vocabulary_into_native_email_input(self) -> None:
+        config = build_email_destination_config(
+            team=object(),
+            spec=PROSE_SPEC,
+            alert_id="alert-1",
+            alert_name="My alert",
+            name="Email · firing · My alert",
+            to_email="oncall@example.com",
+        )
+
+        assert config.payload["template_id"] == "template-email"
+        assert config.payload["filters"]["properties"][0] == {
+            "key": "alert_id",
+            "value": "alert-1",
+            "operator": "exact",
+            "type": "event",
+        }
+
+        email = config.payload["inputs"]["email"]["value"]
+        assert email["to"] == {"email": "oncall@example.com", "name": ""}
+        assert email["subject"] == "Insight alert firing"
+        assert "<p>Pageviews is 42, breaching 30</p>" in email["html"]
+        assert '<a href="https://example.com/alert">Manage alert</a>' in email["html"]
+        assert "Manage alert: https://example.com/alert" in email["text"]
+        # Stored without a templating key: the CDP runtime then defaults to hog
+        # templating, matching the placeholder syntax shared with slack/teams.
+        assert "templating" not in config.payload["inputs"]["email"]

--- a/posthog/alerting/destinations.py
+++ b/posthog/alerting/destinations.py
@@ -18,6 +18,8 @@ from uuid import UUID
 
 from django.db import transaction
 
+from rest_framework.request import Request
+
 from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
 from posthog.kafka_client.client import ProduceResult
 
@@ -31,7 +33,9 @@ class AlertDestinationOwnershipError(Exception):
     """Raised when deleting destinations that do not all belong to an alert."""
 
 
-def create_alert_destination_hog_functions(configs: list[AlertDestinationConfig], *, request: Any) -> list[HogFunction]:
+def create_alert_destination_hog_functions(
+    configs: list[AlertDestinationConfig], *, request: Request
+) -> list[HogFunction]:
     """Create one HogFunction per config, atomically."""
     created: list[HogFunction] = []
     with transaction.atomic():


### PR DESCRIPTION
## Problem

Alerting products want email notifications, and each does it differently today: insight alerts send direct SMTP via `EmailMessage` with their own Django templates and subscriber logic; logs alerts have no email at all. Same story as Slack/Teams/webhook before this stack: per-product delivery forks.

## Changes

Email becomes the fourth shared destination type in `common/alerting/destinations.py`:

- `build_email_destination_config` creates a `template-email` HogFunction wired to the same `alert_id` internal-event filter as the other three types, so dispatch, deletion, and ownership checks work identically with zero glue changes.
- Content renders from the same `EventKindSpec` vocabulary: `email_subject` / `email_html` / `email_text` lay out header, prose `body_lines`, detail rows, and action buttons. Products own what the email says, the platform owns the structure and flow.
- The stored input carries no `templating` key, which the CDP runtime resolves as hog templating, so the same `{project.url}`-style placeholder strings work across all four destination types (the template's `liquid` is only a UI default).

> [!NOTE]
> This replaces (on adoption) the direct `EmailMessage` path insight alerts use today rather than generalizing it. `template-email` requires the team's email integration to be configured, and the template is currently `status: hidden` / non-free, so product rollout gates on that.

## How did you test this code?

Automated only. Extended `common/alerting/test/test_destinations.py`: the email builder's payload contract (template id, filter linkage, native_email fields, no templating key) and vocabulary rendering (prose lines and extra buttons appear in html and text). No existing test covered any email path. Logs destination tests pass unchanged (no behavior change for existing destinations).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`adopting-shared-alerting` skill updated in the same PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude); skills invoked: `/writing-tests`.
- Key decision: route email through the existing `template-email` CDP destination instead of generalizing the direct-SMTP path, so all four destination types share one dispatch, filter, and lifecycle contract. Verified the per-input templating override in the nodejs runtime (`hog-inputs.service.ts`) before relying on hog placeholders.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*