### PR TITLE
feat: Add CSV export to Web Analytics

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -211,6 +211,7 @@
         "eventsource-parser": "^3.0.0",
         "fast-deep-equal": "catalog:",
         "fastpriorityqueue": "^0.7.5",
+        "fflate": "^0.8.2",
         "frimousse": "^0.3.0",
         "fuse.js": "catalog:",
         "hast-util-to-html": "^9.0.5",

--- a/frontend/src/scenes/web-analytics/WebAnalyticsExport.test.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsExport.test.tsx
@@ -13,11 +13,27 @@ import {
     TrendsAdapter,
     WebAnalyticsTableAdapter,
     WorldMapAdapter,
+    buildCsvFilenames,
 } from './webAnalyticsExportUtils'
 
 describe('WebAnalyticsExport adapters', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+    })
+
+    describe('buildCsvFilenames', () => {
+        it('slugifies titles and de-duplicates colliding stems so no zip entry is overwritten', () => {
+            expect(buildCsvFilenames(['Top paths', 'Sources', 'Sources', 'Referring domains: Sources'])).toEqual([
+                'top-paths.csv',
+                'sources.csv',
+                'sources-2.csv',
+                'referring-domains-sources.csv',
+            ])
+        })
+
+        it('falls back to a usable stem when a title has no alphanumerics', () => {
+            expect(buildCsvFilenames(['—', '///'])).toEqual(['tile.csv', 'tile-2.csv'])
+        })
     })
 
     describe('CalendarHeatmapAdapter', () => {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsExport.test.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsExport.test.tsx
@@ -14,11 +14,23 @@ import {
     WebAnalyticsTableAdapter,
     WorldMapAdapter,
     buildCsvFilenames,
+    csvFromTableData,
 } from './webAnalyticsExportUtils'
 
 describe('WebAnalyticsExport adapters', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+    })
+
+    describe('csvFromTableData', () => {
+        it.each(['=', '+', '-', '@'])(
+            'neutralizes a leading "%s" so spreadsheets do not evaluate the cell as a formula',
+            (prefix) => {
+                const csv = csvFromTableData([['header'], [`${prefix}cmd(1)`]])
+                expect(csv).toContain(`'${prefix}cmd(1)`)
+                expect(csv).not.toContain(`\n${prefix}cmd(1)`)
+            }
+        )
     })
 
     describe('buildCsvFilenames', () => {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsMenu.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconGear, IconSearch, IconStar, IconTarget, IconX } from '@posthog/icons'
+import { IconDownload, IconGear, IconSearch, IconStar, IconTarget, IconX } from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
@@ -17,6 +17,8 @@ import { isWebAnalyticsAchievementsEnabled } from './achievements/gating'
 import { webAnalyticsAchievementsLogic } from './achievements/webAnalyticsAchievementsLogic'
 import { webAnalyticsAchievementsPreferencesLogic } from './achievements/webAnalyticsAchievementsPreferencesLogic'
 import { ProductTab, TILE_LABELS, TileId } from './common'
+import { shareNudgeLogic } from './shareNudgeLogic'
+import { exportAllTilesAsCsvZip } from './webAnalyticsExportUtils'
 
 const ANALYTICS_TILES = [
     TileId.OVERVIEW,
@@ -34,14 +36,22 @@ const ANALYTICS_TILES = [
 ]
 
 export const WebAnalyticsMenu = (): JSX.Element => {
-    const { hasSavedFocusMode, hiddenTiles, isFocusModeActive, productTab, showFocusMode, useWebAnalyticsPrecompute } =
-        useValues(webAnalyticsLogic)
+    const {
+        hasSavedFocusMode,
+        hiddenTiles,
+        isFocusModeActive,
+        productTab,
+        showFocusMode,
+        tiles,
+        useWebAnalyticsPrecompute,
+    } = useValues(webAnalyticsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { achievementsOptOut } = useValues(webAnalyticsAchievementsPreferencesLogic)
 
     const { enterFocusMode, exitFocusMode, openFocusModeModal, setUseWebAnalyticsPrecompute, setTileVisibility } =
         useActions(webAnalyticsLogic)
     const { openModal: openAchievementsModal } = useActions(webAnalyticsAchievementsLogic)
+    const { exportTriggered } = useActions(shareNudgeLogic)
 
     const showTileToggles = featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TILE_TOGGLES]
     const showAchievements = isWebAnalyticsAchievementsEnabled(featureFlags, achievementsOptOut)
@@ -50,6 +60,18 @@ export const WebAnalyticsMenu = (): JSX.Element => {
     return (
         <ScenePanel>
             <ScenePanelActionsSection>
+                <ButtonPrimitive
+                    menuItem
+                    data-attr="web-analytics-export-all-csv"
+                    onClick={() => {
+                        if (exportAllTilesAsCsvZip(tiles)) {
+                            exportTriggered()
+                        }
+                    }}
+                >
+                    <IconDownload />
+                    Export all as CSV (.zip)
+                </ButtonPrimitive>
                 <Link to={urls.sessionAttributionExplorer()} buttonProps={{ menuItem: true }}>
                     <IconSearch /> Session Attribution Explorer
                 </Link>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsSceneMenuBar.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconBolt, IconGear, IconSearch, IconSparkles, IconStar, IconTarget, IconX } from '@posthog/icons'
+import { IconBolt, IconDownload, IconGear, IconSearch, IconSparkles, IconStar, IconTarget, IconX } from '@posthog/icons'
 import { Badge, Tooltip, TooltipContent, TooltipTrigger } from '@posthog/quill'
 
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
@@ -25,6 +25,8 @@ import { isWebAnalyticsAchievementsEnabled } from './achievements/gating'
 import { webAnalyticsAchievementsLogic } from './achievements/webAnalyticsAchievementsLogic'
 import { webAnalyticsAchievementsPreferencesLogic } from './achievements/webAnalyticsAchievementsPreferencesLogic'
 import { ProductTab, TILE_LABELS, TileId } from './common'
+import { shareNudgeLogic } from './shareNudgeLogic'
+import { exportAllTilesAsCsvZip } from './webAnalyticsExportUtils'
 
 const ANALYTICS_TILES = [
     TileId.OVERVIEW,
@@ -88,10 +90,18 @@ export function WebAnalyticsSceneMenuBar(): JSX.Element | null {
 }
 
 function WebAnalyticsSceneMenuBarInner(): JSX.Element {
-    const { hasSavedFocusMode, hiddenTiles, isFocusModeActive, productTab, shouldFilterTestAccounts, showFocusMode } =
-        useValues(webAnalyticsLogic)
+    const {
+        hasSavedFocusMode,
+        hiddenTiles,
+        isFocusModeActive,
+        productTab,
+        shouldFilterTestAccounts,
+        showFocusMode,
+        tiles,
+    } = useValues(webAnalyticsLogic)
     const { enterFocusMode, exitFocusMode, openFocusModeModal, setShouldFilterTestAccounts, setTileVisibility } =
         useActions(webAnalyticsLogic)
+    const { exportTriggered } = useActions(shareNudgeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { projectTreeRefEntry } = useValues(projectTreeDataLogic)
     const { currentTeam } = useValues(teamLogic)
@@ -155,6 +165,17 @@ function WebAnalyticsSceneMenuBarInner(): JSX.Element {
                         Weekly recap
                     </SceneMenuBarItem>
                 )}
+                <SceneMenuBarItem
+                    onClick={() => {
+                        if (exportAllTilesAsCsvZip(tiles)) {
+                            exportTriggered()
+                        }
+                    }}
+                    data-attr="web-analytics-menubar-export-all-csv"
+                >
+                    <IconDownload />
+                    Export all as CSV (.zip)
+                </SceneMenuBarItem>
                 <SceneMenuBarItem
                     onClick={() => window.location.assign(urls.sessionAttributionExplorer())}
                     data-attr="web-analytics-menubar-session-attribution"

--- a/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
@@ -38,15 +38,21 @@ export interface TileExportSection {
 }
 
 export function csvFromTableData(tableData: string[][]): string {
-    return Papa.unparse(tableData)
+    return Papa.unparse(tableData, { escapeFormulae: true })
 }
 
-export function downloadTableDataAsCsv(tableData: string[][], filename: string): void {
+export function downloadTableDataAsCsv(tableData: string[][], filename: string): boolean {
+    if (tableData.length === 0) {
+        lemonToast.warning('No data to export yet')
+        return false
+    }
     try {
         const file = new File([csvFromTableData(tableData)], filename, { type: 'text/csv' })
         downloadFile(file)
+        return true
     } catch {
         lemonToast.error('Export failed')
+        return false
     }
 }
 
@@ -99,6 +105,30 @@ function tileToTableData(query: QuerySchema, insightProps: InsightLogicProps): s
     return tableData.length > 0 ? tableData : null
 }
 
+function isTileStillLoading(insightProps: InsightLogicProps): boolean {
+    return insightDataLogic.findMounted(insightProps)?.values.insightDataLoading === true
+}
+
+export function anyTileStillLoading(tiles: WebAnalyticsTile[]): boolean {
+    for (const tile of tiles) {
+        if (tile.kind === 'query') {
+            if (isTileStillLoading(tile.insightProps)) {
+                return true
+            }
+        } else if (tile.kind === 'tabs') {
+            const activeTab = tile.tabs.find((tab) => tab.id === tile.activeTabId)
+            if (activeTab && isTileStillLoading(activeTab.insightProps)) {
+                return true
+            }
+        } else if (tile.kind === 'section') {
+            if (anyTileStillLoading(tile.tiles)) {
+                return true
+            }
+        }
+    }
+    return false
+}
+
 function tabSectionTitle(tile: { tileId: WebAnalyticsTile['tileId'] }, tab: TabsTileTab): string {
     const base = TILE_LABELS[tile.tileId]
     const tabTitle =
@@ -113,6 +143,9 @@ export function exportAllTilesAsCsvZip(tiles: WebAnalyticsTile[], filename = 'we
         return false
     }
     downloadTilesAsCsvZip(sections, filename)
+    if (anyTileStillLoading(tiles)) {
+        lemonToast.warning('Some tiles are still loading, so this export may be incomplete')
+    }
     return true
 }
 
@@ -143,7 +176,7 @@ export function exportTableData(tableData: string[][], format: ExporterFormat): 
     try {
         switch (format) {
             case ExporterFormat.CSV: {
-                const csv = Papa.unparse(tableData)
+                const csv = csvFromTableData(tableData)
                 void copyToClipboard(csv, 'table')
                 break
             }
@@ -162,7 +195,7 @@ export function exportTableData(tableData: string[][], format: ExporterFormat): 
                 break
             }
             case ExporterFormat.XLSX: {
-                const tsv = Papa.unparse(tableData, { delimiter: '\t' })
+                const tsv = Papa.unparse(tableData, { delimiter: '\t', escapeFormulae: true })
                 void copyToClipboard(tsv, 'table')
                 break
             }

--- a/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
@@ -1,8 +1,12 @@
+import { strToU8, zipSync } from 'fflate'
 import Papa from 'papaparse'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { downloadFile } from 'lib/utils/dom'
+import { slugify } from 'lib/utils/strings'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 import {
     DataTableNode,
@@ -20,12 +24,119 @@ import {
     WebStatsTableQueryResponse,
 } from '~/queries/schema/schema-general'
 import { isTrendsQuery, isWebExternalClicksQuery, isWebGoalsQuery, isWebStatsTableQuery } from '~/queries/utils'
-import { getDisplayColumnName } from '~/scenes/web-analytics/common'
-import { ChartDisplayType, ExporterFormat } from '~/types'
+import { TabsTileTab, TILE_LABELS, WebAnalyticsTile, getDisplayColumnName } from '~/scenes/web-analytics/common'
+import { ChartDisplayType, ExporterFormat, InsightLogicProps } from '~/types'
 
 export interface ExportAdapter {
     toTableData(): string[][]
     canHandle(): boolean
+}
+
+export interface TileExportSection {
+    title: string
+    tableData: string[][]
+}
+
+export function csvFromTableData(tableData: string[][]): string {
+    return Papa.unparse(tableData)
+}
+
+export function downloadTableDataAsCsv(tableData: string[][], filename: string): void {
+    try {
+        const file = new File([csvFromTableData(tableData)], filename, { type: 'text/csv' })
+        downloadFile(file)
+    } catch {
+        lemonToast.error('Export failed')
+    }
+}
+
+function slugifyTileTitle(title: string): string {
+    return slugify(title) || 'tile'
+}
+
+export function buildCsvFilenames(titles: string[]): string[] {
+    const seen = new Map<string, number>()
+    return titles.map((title) => {
+        const stem = slugifyTileTitle(title)
+        const count = seen.get(stem) ?? 0
+        seen.set(stem, count + 1)
+        return count === 0 ? `${stem}.csv` : `${stem}-${count + 1}.csv`
+    })
+}
+
+export function downloadTilesAsCsvZip(sections: TileExportSection[], filename: string): void {
+    try {
+        const populated = sections.filter((section) => section.tableData.length > 0)
+        const filenames = buildCsvFilenames(populated.map((section) => section.title))
+        const entries: Record<string, Uint8Array> = {}
+        populated.forEach((section, index) => {
+            entries[filenames[index]] = strToU8(csvFromTableData(section.tableData))
+        })
+        const zipped = zipSync(entries)
+        downloadFile(new File([zipped as BlobPart], filename, { type: 'application/zip' }))
+    } catch {
+        lemonToast.error('Export failed')
+    }
+}
+
+export function getExportAdapter(insightDataRaw: unknown, query: QuerySchema | undefined): ExportAdapter | null {
+    if (!insightDataRaw || !query) {
+        return null
+    }
+    const adapters: ExportAdapter[] = [
+        new CalendarHeatmapAdapter(insightDataRaw as TrendsQueryResponse, query),
+        new WorldMapAdapter(insightDataRaw as TrendsQueryResponse, query),
+        new WebAnalyticsTableAdapter(insightDataRaw as WebStatsTableQueryResponse, query),
+        new TrendsAdapter(insightDataRaw as TrendsQueryResponse, query),
+    ]
+    return adapters.find((a) => a.canHandle()) ?? null
+}
+
+function tileToTableData(query: QuerySchema, insightProps: InsightLogicProps): string[][] | null {
+    const insightDataRaw = insightDataLogic.findMounted(insightProps)?.values.insightDataRaw
+    const adapter = getExportAdapter(insightDataRaw, query)
+    const tableData = adapter?.toTableData() ?? []
+    return tableData.length > 0 ? tableData : null
+}
+
+function tabSectionTitle(tile: { tileId: WebAnalyticsTile['tileId'] }, tab: TabsTileTab): string {
+    const base = TILE_LABELS[tile.tileId]
+    const tabTitle =
+        typeof tab.title === 'string' ? tab.title : typeof tab.linkText === 'string' ? tab.linkText : tab.id
+    return base ? `${base}: ${tabTitle}` : tabTitle
+}
+
+export function exportAllTilesAsCsvZip(tiles: WebAnalyticsTile[], filename = 'web-analytics-export.zip'): boolean {
+    const sections = collectAllTilesTableData(tiles)
+    if (sections.length === 0) {
+        lemonToast.warning('No data to export yet')
+        return false
+    }
+    downloadTilesAsCsvZip(sections, filename)
+    return true
+}
+
+export function collectAllTilesTableData(tiles: WebAnalyticsTile[]): TileExportSection[] {
+    const sections: TileExportSection[] = []
+    for (const tile of tiles) {
+        if (tile.kind === 'query') {
+            const tableData = tileToTableData(tile.query, tile.insightProps)
+            if (tableData) {
+                sections.push({ title: tile.title ?? TILE_LABELS[tile.tileId] ?? tile.tileId, tableData })
+            }
+        } else if (tile.kind === 'tabs') {
+            const activeTab = tile.tabs.find((tab) => tab.id === tile.activeTabId)
+            if (activeTab) {
+                const tableData = tileToTableData(activeTab.query, activeTab.insightProps)
+                if (tableData) {
+                    sections.push({ title: tabSectionTitle(tile, activeTab), tableData })
+                }
+            }
+        } else if (tile.kind === 'section') {
+            sections.push(...collectAllTilesTableData(tile.tiles))
+        }
+    }
+    return sections
 }
 
 export function exportTableData(tableData: string[][], format: ExporterFormat): void {

--- a/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsExportUtils.ts
@@ -70,7 +70,7 @@ export function buildCsvFilenames(titles: string[]): string[] {
     })
 }
 
-export function downloadTilesAsCsvZip(sections: TileExportSection[], filename: string): void {
+export function downloadTilesAsCsvZip(sections: TileExportSection[], filename: string): boolean {
     try {
         const populated = sections.filter((section) => section.tableData.length > 0)
         const filenames = buildCsvFilenames(populated.map((section) => section.title))
@@ -80,8 +80,10 @@ export function downloadTilesAsCsvZip(sections: TileExportSection[], filename: s
         })
         const zipped = zipSync(entries)
         downloadFile(new File([zipped as BlobPart], filename, { type: 'application/zip' }))
+        return true
     } catch {
         lemonToast.error('Export failed')
+        return false
     }
 }
 
@@ -142,7 +144,9 @@ export function exportAllTilesAsCsvZip(tiles: WebAnalyticsTile[], filename = 'we
         lemonToast.warning('No data to export yet')
         return false
     }
-    downloadTilesAsCsvZip(sections, filename)
+    if (!downloadTilesAsCsvZip(sections, filename)) {
+        return false
+    }
     if (anyTileStillLoading(tiles)) {
         lemonToast.warning('Some tiles are still loading, so this export may be incomplete')
     }

--- a/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
+++ b/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
@@ -10,25 +10,12 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 
 import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataCollectionId, insightVizDataNodeKey } from '~/queries/nodes/InsightViz/insightVizKeys'
-import {
-    ProductIntentContext,
-    ProductKey,
-    QuerySchema,
-    TrendsQueryResponse,
-    WebStatsTableQueryResponse,
-} from '~/queries/schema/schema-general'
+import { ProductIntentContext, ProductKey, QuerySchema } from '~/queries/schema/schema-general'
 import { ExporterFormat, InsightLogicProps } from '~/types'
 
 import { TileId, WEB_ANALYTICS_DATA_COLLECTION_NODE_ID } from './common'
 import { shareNudgeLogic } from './shareNudgeLogic'
-import {
-    CalendarHeatmapAdapter,
-    ExportAdapter,
-    TrendsAdapter,
-    WebAnalyticsTableAdapter,
-    WorldMapAdapter,
-    exportTableData,
-} from './webAnalyticsExportUtils'
+import { ExportAdapter, downloadTableDataAsCsv, exportTableData, getExportAdapter } from './webAnalyticsExportUtils'
 import { webAnalyticsModalLogic } from './webAnalyticsModalLogic'
 
 const NO_ACTIVE_TAB_INSIGHT_PROPS: InsightLogicProps = {
@@ -64,18 +51,7 @@ export function useWebTileExportAdapter(
     const builtInsightDataLogic = insightDataLogic(insightProps)
     const { insightDataRaw } = useValues(builtInsightDataLogic)
 
-    return useMemo(() => {
-        if (!insightDataRaw || !query) {
-            return null
-        }
-        const adapters: ExportAdapter[] = [
-            new CalendarHeatmapAdapter(insightDataRaw as TrendsQueryResponse, query),
-            new WorldMapAdapter(insightDataRaw as TrendsQueryResponse, query),
-            new WebAnalyticsTableAdapter(insightDataRaw as WebStatsTableQueryResponse, query),
-            new TrendsAdapter(insightDataRaw as TrendsQueryResponse, query),
-        ]
-        return adapters.find((a) => a.canHandle()) ?? null
-    }, [insightDataRaw, query])
+    return useMemo(() => getExportAdapter(insightDataRaw, query), [insightDataRaw, query])
 }
 
 interface UseWebTileOverflowMenuItemsArgs {
@@ -137,6 +113,18 @@ export function useWebTileOverflowMenuItems({
                 label: 'Copy',
                 items: copyItems,
                 'data-attr': 'web-analytics-copy-dropdown',
+            },
+            {
+                label: 'Download CSV',
+                disabledReason: adapter ? undefined : 'No exportable data yet',
+                'data-attr': `web-analytics-tile-download-csv-${tileId}`,
+                onClick: () => {
+                    if (!adapter) {
+                        return
+                    }
+                    downloadTableDataAsCsv(adapter.toTableData(), `web-analytics-${tileId}.csv`)
+                    exportTriggered()
+                },
             },
         ]
 

--- a/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
+++ b/frontend/src/scenes/web-analytics/webTileHeaderHooks.tsx
@@ -122,8 +122,9 @@ export function useWebTileOverflowMenuItems({
                     if (!adapter) {
                         return
                     }
-                    downloadTableDataAsCsv(adapter.toTableData(), `web-analytics-${tileId}.csv`)
-                    exportTriggered()
+                    if (downloadTableDataAsCsv(adapter.toTableData(), `web-analytics-${tileId}.csv`)) {
+                        exportTriggered()
+                    }
                 },
             },
         ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1031,6 +1031,9 @@ importers:
       fastpriorityqueue:
         specifier: ^0.7.5
         version: 0.7.5
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       frimousse:
         specifier: ^0.3.0
         version: 0.3.0(react@18.3.1)(typescript@6.0.3)


### PR DESCRIPTION
## Problem
Users want to be able to export Web Analytics results via CSV
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Add an CSV export button
<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
