### PR TITLE
feat(insights): extend day-of-week filtering to stickiness, lifecycle, and funnel trends

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -263,7 +263,7 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
         select_from = ast.JoinExpr(table=ast.Field(chain=[table_entity.table_name]), alias=self.EVENT_TABLE_ALIAS)
 
         date_range = self._date_range()
-        where_exprs: list[ast.Expr] = [
+        where_exprs: list[ast.Expr | None] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.GtEq,
                 left=ast.Field(chain=["timestamp"]),
@@ -274,10 +274,8 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
                 left=ast.Field(chain=["timestamp"]),
                 right=ast.Constant(value=date_range.date_to()),
             ),
+            self._day_of_week_filter_expr(ast.Field(chain=["timestamp"])),
         ]
-        day_of_week_filter = self._day_of_week_filter_expr(ast.Field(chain=["timestamp"]))
-        if day_of_week_filter is not None:
-            where_exprs.append(day_of_week_filter)
         where = ast.And(exprs=[expr for expr in where_exprs if expr is not None])
 
         if not skip_step_filter:

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -13,6 +13,7 @@ from posthog.schema import (
     FunnelExclusionEventsNode,
     FunnelMathType,
     FunnelsDataWarehouseNode,
+    FunnelVizType,
     GroupNode,
     StepOrderValue,
 )
@@ -205,6 +206,7 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
 
         where_exprs = [
             self._date_range_expr(),
+            self._day_of_week_filter_expr(ast.Field(chain=[self.EVENT_TABLE_ALIAS, "timestamp"])),
             self._entity_expr(skip_entity_filter),
             *self._properties_expr(),
             self._aggregation_target_filter(),
@@ -273,6 +275,9 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
                 right=ast.Constant(value=date_range.date_to()),
             ),
         ]
+        day_of_week_filter = self._day_of_week_filter_expr(ast.Field(chain=["timestamp"]))
+        if day_of_week_filter is not None:
+            where_exprs.append(day_of_week_filter)
         where = ast.And(exprs=[expr for expr in where_exprs if expr is not None])
 
         if not skip_step_filter:
@@ -635,6 +640,14 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
                 ),
             ]
         )
+
+    def _day_of_week_filter_expr(self, timestamp_field: ast.Expr) -> ast.Expr | None:
+        # daysOfWeek only applies to the funnel trends visualization. Regular funnels and
+        # time-to-convert are untouched: dropping mid-sequence events has ambiguous semantics
+        # there, which needs a product decision first.
+        if self.context.funnelsFilter.funnelVizType != FunnelVizType.TRENDS:
+            return None
+        return self._date_range().day_of_week_filter_expr(timestamp_field)
 
     def _entity_expr(self, skip_entity_filter: bool) -> ast.Expr | None:
         query, funnelsFilter = self.context.query, self.context.funnelsFilter

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -596,6 +596,8 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
                     date_from=prev_date_from.isoformat() if prev_date_from else None,
                     date_to=prev_date_to.isoformat() if prev_date_to else None,
                     explicitDate=True,
+                    # a day-of-week filter applies to the shifted range too
+                    daysOfWeek=self.query.dateRange.daysOfWeek if self.query.dateRange else None,
                 ),
                 "compareFilter": None,
             }

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_data_warehouse.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_data_warehouse.py
@@ -12,6 +12,8 @@ from posthog.test.base import (
     snapshot_clickhouse_queries,
 )
 
+from parameterized import parameterized
+
 from posthog.schema import (
     ActorsQuery,
     DataWarehousePersonPropertyFilter,
@@ -209,6 +211,44 @@ class TestFunnelDataWarehouse(ClickhouseTestMixin, BaseTest):
         results = response.results
         assert results[0]["count"] == 5
         assert results[1]["count"] == 1
+
+    def _days_of_week_trends_query(self, table_name: str, days_of_week: list[int] | None) -> FunnelsQuery:
+        node = FunnelsDataWarehouseNode(
+            id=table_name,
+            table_name=table_name,
+            id_field="uuid",
+            aggregation_target_field="user_id",
+            timestamp_field="created",
+        )
+        return FunnelsQuery(
+            kind="FunnelsQuery",
+            dateRange=DateRange(date_from="2025-11-01", date_to="2025-11-07", daysOfWeek=days_of_week),
+            interval="day",
+            series=[node, node],
+            funnelsFilter=FunnelsFilter(funnelVizType="trends"),
+        )
+
+    @parameterized.expand(
+        [
+            # funnels_data.csv has one row per day Nov 1 (Sat) through Nov 6 (Thu); Nov 3 is the only Monday
+            ("mondays_only", [1], 1),
+            ("empty_means_unfiltered", [], 6),
+        ]
+    )
+    def test_data_warehouse_trends_days_of_week_filters_entrances(self, _name, days_of_week, expected_entrances):
+        # The data-warehouse trends query builds its own WHERE clause, separate from the events path,
+        # so it needs its own day-of-week coverage
+        table_name = self.setup_data_warehouse()
+
+        with freeze_time("2025-11-08"):
+            response = FunnelsQueryRunner(
+                query=self._days_of_week_trends_query(table_name, days_of_week),
+                team=self.team,
+                just_summarize=True,
+            ).calculate()
+
+        total_entrances = sum(row["reached_from_step_count"] for row in response.results)
+        assert total_entrances == expected_entrances
 
     @snapshot_clickhouse_queries
     def test_funnels_data_warehouse_and_regular_nodes(self):

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -3451,6 +3451,155 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
 
 
 @override_settings(IN_UNIT_TESTING=True)
+class TestFunnelTrendsDaysOfWeekUDF(ClickhouseTestMixin, APIBaseTest):
+    maxDiff = None
+
+    def _build_query(self, days_of_week: Optional[list[int]]) -> FunnelsQuery:
+        return FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-06-07 00:00:00",  # Monday
+                date_to="2021-06-13 23:59:59",  # Sunday
+                daysOfWeek=days_of_week,
+            ),
+            interval="day",
+            series=[EventsNode(event="step one"), EventsNode(event="step two")],
+            funnelsFilter=FunnelsFilter(
+                funnelVizType="trends",
+                funnelWindowInterval=7,
+                funnelWindowIntervalUnit="day",
+            ),
+        )
+
+    def _create_days_of_week_journeys(self):
+        journeys_for(
+            {
+                # enters and converts on Monday
+                "user_monday": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 7, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 7, 11)},
+                ],
+                # enters on Monday, converts on Tuesday
+                "user_cross": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 7, 12)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 8, 12)},
+                ],
+                # enters and converts on Saturday
+                "user_saturday": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 12, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 12, 11)},
+                ],
+            },
+            self.team,
+        )
+
+    @parameterized.expand(
+        [
+            # the filter applies to every funnel event, so user_cross's Tuesday step two is
+            # dropped (entered but not converted) and user_saturday's entrance doesn't count
+            ("mondays_only", [1], (2, 1), (0, 0)),
+            ("empty_means_unfiltered", [], (2, 2), (1, 1)),
+        ]
+    )
+    def test_days_of_week_filters_entrances_and_conversions(
+        self, _name, days_of_week, expected_monday, expected_saturday
+    ):
+        self._create_days_of_week_journeys()
+
+        results = (
+            FunnelsQueryRunner(query=self._build_query(days_of_week), team=self.team, just_summarize=True)
+            .calculate()
+            .results
+        )
+
+        self.assertEqual(len(results), 7)
+        monday, saturday = results[0], results[5]
+        self.assertEqual(
+            (monday["reached_from_step_count"], monday["reached_to_step_count"]),
+            expected_monday,
+        )
+        self.assertEqual(
+            (saturday["reached_from_step_count"], saturday["reached_to_step_count"]),
+            expected_saturday,
+        )
+
+    @parameterized.expand(
+        [
+            ("monday_filter_includes_it", [1], 1),
+            ("sunday_filter_excludes_it", [7], 0),
+        ]
+    )
+    def test_days_of_week_uses_project_timezone(self, _name, days_of_week, expected_entrants):
+        self.team.timezone = "Asia/Tokyo"
+        self.team.save()
+        # 20:00 UTC Sunday = 05:00 Monday June 7th in Asia/Tokyo
+        journeys_for(
+            {
+                "user_boundary": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 6, 20)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 6, 21)},
+                ],
+            },
+            self.team,
+        )
+
+        results = (
+            FunnelsQueryRunner(query=self._build_query(days_of_week), team=self.team, just_summarize=True)
+            .calculate()
+            .results
+        )
+
+        self.assertEqual(sum(row["reached_from_step_count"] for row in results), expected_entrants)
+
+    def test_days_of_week_actors_match_chart(self):
+        self._create_days_of_week_journeys()
+        query = self._build_query([1])
+
+        converted = get_actors(
+            query,
+            self.team,
+            funnel_trends_entrance_period_start="2021-06-07 00:00:00",
+            funnel_trends_drop_off=False,
+        )
+        dropped_off = get_actors(
+            query,
+            self.team,
+            funnel_trends_entrance_period_start="2021-06-07 00:00:00",
+            funnel_trends_drop_off=True,
+        )
+
+        # user_monday converted within the selected days; user_cross's Tuesday conversion is
+        # filtered, so they show as dropped off; user_saturday never entered
+        self.assertEqual(len(converted), 1)
+        self.assertEqual(len(dropped_off), 1)
+
+    def test_days_of_week_does_not_affect_steps_viz(self):
+        # A regular (steps) funnel must ignore daysOfWeek until dropping mid-sequence
+        # events gets defined semantics there
+        journeys_for(
+            {
+                "user_saturday": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 12, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 12, 11)},
+                ],
+            },
+            self.team,
+        )
+
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-06-07 00:00:00",
+                date_to="2021-06-13 23:59:59",
+                daysOfWeek=[1],
+            ),
+            series=[EventsNode(event="step one"), EventsNode(event="step two")],
+        )
+        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+        self.assertEqual(results[0]["count"], 1)
+        self.assertEqual(results[1]["count"], 1)
+
+
+@override_settings(IN_UNIT_TESTING=True)
 class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
     """Compare-to-previous on funnel TRENDS viz. Tagged-row contract that later viz modes will reuse."""
 
@@ -3462,9 +3611,10 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         date_to: str = "2021-06-13 23:59:59",
         compare: bool = True,
         compare_to: Optional[str] = None,
+        days_of_week: Optional[list[int]] = None,
     ) -> FunnelsQuery:
         return FunnelsQuery(
-            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            dateRange=DateRange(date_from=date_from, date_to=date_to, daysOfWeek=days_of_week),
             interval="day",
             series=[EventsNode(event="step one"), EventsNode(event="step two")],
             funnelsFilter=FunnelsFilter(
@@ -3512,6 +3662,36 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         # Day labels for current period start at 2021-06-07; previous at 2021-05-31.
         self.assertEqual(current_series["days"][0], "2021-06-07")
         self.assertEqual(previous_series["days"][0], "2021-05-31")
+
+    def test_days_of_week_filters_previous_period_too(self):
+        # The previous-period clone must keep the daysOfWeek filter, or the comparison
+        # series silently reverts to unfiltered data
+        journeys_for(
+            {
+                "current_monday_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 7, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 7, 11)},
+                ],
+                "previous_monday_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 5, 31, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 5, 31, 11)},
+                ],
+                "previous_saturday_user": [
+                    {"event": "step one", "timestamp": datetime(2021, 6, 5, 10)},
+                    {"event": "step two", "timestamp": datetime(2021, 6, 5, 11)},
+                ],
+            },
+            self.team,
+        )
+
+        results = FunnelsQueryRunner(query=self._build_query(days_of_week=[1]), team=self.team).calculate().results
+
+        previous_series = next(r for r in results if r["compare_label"] == "previous")
+        # Monday 2021-05-31 converts; Saturday 2021-06-05 must be filtered out of the
+        # previous period as well (index 5, conversion rate would be 100.0 unfiltered)
+        self.assertEqual(previous_series["days"][0], "2021-05-31")
+        self.assertEqual(previous_series["data"][0], 100.0)
+        self.assertEqual(previous_series["data"][5], 0.0)
 
     def test_compare_with_custom_offset_shifts_previous_window(self):
         # Custom offset `-30d` puts the previous window 30 days before the current window's start

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -347,7 +347,6 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
                     timings=self.timings,
                 )
             )
-            # Days of week: lifecycle statuses are derived from activity on the selected days only
             day_of_week_filter = self.query_date_range.day_of_week_filter_expr(self.timestamp_field)
             if day_of_week_filter is not None:
                 event_filters.append(day_of_week_filter)

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -347,6 +347,10 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
                     timings=self.timings,
                 )
             )
+            # Days of week: lifecycle statuses are derived from activity on the selected days only
+            day_of_week_filter = self.query_date_range.day_of_week_filter_expr(self.timestamp_field)
+            if day_of_week_filter is not None:
+                event_filters.append(day_of_week_filter)
         with self.timings.measure("properties"):
             if self.query.properties is not None and self.query.properties != []:
                 event_filters.append(property_to_expr(self.query.properties, self.team))

--- a/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
@@ -782,10 +782,10 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-    def _create_query_runner(self, date_from, date_to, interval) -> LifecycleQueryRunner:
+    def _create_query_runner(self, date_from, date_to, interval, days_of_week=None) -> LifecycleQueryRunner:
         series = [EventsNode(event="$pageview")]
         query = LifecycleQuery(
-            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            dateRange=DateRange(date_from=date_from, date_to=date_to, daysOfWeek=days_of_week),
             interval=interval,
             series=series,
         )
@@ -805,8 +805,100 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
             query_type="LifecycleEventsQuery",
         )
 
-    def _run_lifecycle_query(self, date_from, date_to, interval):
-        return self._create_query_runner(date_from, date_to, interval).calculate()
+    def _run_lifecycle_query(self, date_from, date_to, interval, days_of_week=None):
+        return self._create_query_runner(date_from, date_to, interval, days_of_week).calculate()
+
+    @parameterized.expand(
+        [
+            (
+                "mondays_only",
+                [1],
+                [
+                    # dormant lands the day after last selected-day activity, which can be an
+                    # excluded day (Tue Jan 14) — buckets are deliberately kept so it stays visible
+                    {"status": "dormant", "data": [0, -1, 0, 0, 0, 0, 0]},
+                    {"status": "new", "data": [1, 0, 0, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 0, 0, 0, 0, 0]},
+                    {"status": "returning", "data": [0, 0, 0, 0, 0, 0, 0]},
+                ],
+            ),
+            (
+                "empty_means_unfiltered",
+                [],
+                [
+                    {"status": "dormant", "data": [0, -1, 0, -1, 0, 0, 0]},
+                    {"status": "new", "data": [1, 0, 0, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 1, 0, 0, 0, 0]},
+                    {"status": "returning", "data": [0, 0, 0, 0, 0, 0, 0]},
+                ],
+            ),
+        ]
+    )
+    def test_days_of_week_filters_lifecycle_statuses(self, _name, days_of_week, expected):
+        # 2020-01-13 is a Monday; p1 is active Mon and Wed
+        self._create_events(data=[("p1", ["2020-01-13T12:00:00Z", "2020-01-15T12:00:00Z"])])
+        flush_persons_and_events()
+
+        response = self._run_lifecycle_query("2020-01-13", "2020-01-19", IntervalType.DAY, days_of_week)
+
+        # every day bucket stays in the response, including excluded days
+        assert response.results[0]["days"] == [
+            "2020-01-13",
+            "2020-01-14",
+            "2020-01-15",
+            "2020-01-16",
+            "2020-01-17",
+            "2020-01-18",
+            "2020-01-19",
+        ]
+        assertLifecycleResults(response.results, expected)
+
+    @parameterized.expand(
+        [
+            ("monday_filter_includes_it", [1], 1),
+            ("sunday_filter_excludes_it", [7], 0),
+        ]
+    )
+    def test_days_of_week_uses_project_timezone(self, _name, days_of_week, expected_new_count):
+        self.team.timezone = "Asia/Tokyo"
+        self.team.save()
+        # 20:00 UTC Sunday = 05:00 Monday in Asia/Tokyo
+        self._create_events(data=[("p1", ["2020-01-12T20:00:00Z"])])
+        flush_persons_and_events()
+
+        response = self._run_lifecycle_query("2020-01-13", "2020-01-19", IntervalType.DAY, days_of_week)
+
+        new_series = next(r for r in response.results if r["status"] == "new")
+        assert sum(new_series["data"]) == expected_new_count
+
+    def test_days_of_week_actors_match_chart(self):
+        # The actors query must honor daysOfWeek like the chart does, or the persons modal
+        # would list people whose only events fall on deselected days
+        self._create_events(
+            data=[
+                ("p_mon", ["2020-01-13T12:00:00Z"]),  # Monday
+                ("p_sat", ["2020-01-18T12:00:00Z"]),  # Saturday
+            ]
+        )
+        flush_persons_and_events()
+
+        runner = self._create_query_runner("2020-01-13", "2020-01-19", IntervalType.DAY, days_of_week=[1])
+
+        monday_new_actors = execute_hogql_query(
+            team=self.team,
+            query="SELECT actor_id FROM {actors_query}",
+            placeholders={"actors_query": runner.to_actors_query(day="2020-01-13", status="new")},
+            query_type="LifecycleActorsQuery",
+        )
+        saturday_new_actors = execute_hogql_query(
+            team=self.team,
+            query="SELECT actor_id FROM {actors_query}",
+            placeholders={"actors_query": runner.to_actors_query(day="2020-01-18", status="new")},
+            query_type="LifecycleActorsQuery",
+        )
+
+        assert len(monday_new_actors.results) == 1
+        assert len(saturday_new_actors.results) == 0
 
     def test_lifecycle_query_rejects_empty_series(self):
         query = LifecycleQuery(

--- a/products/product_analytics/backend/hogql_queries/stickiness/stickiness_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/stickiness/stickiness_query_runner.py
@@ -414,6 +414,11 @@ class StickinessQueryRunner(AnalyticsQueryRunner[StickinessQueryResponse]):
             ]
         )
 
+        # Days of week: "days active" counts activity on the selected days only
+        day_of_week_filter = date_range.day_of_week_filter_expr(ast.Field(chain=["timestamp"]))
+        if day_of_week_filter is not None:
+            filters.append(day_of_week_filter)
+
         # Series
         if isinstance(series, EventsNode) and series.event is not None:
             filters.append(

--- a/products/product_analytics/backend/hogql_queries/stickiness/stickiness_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/stickiness/stickiness_query_runner.py
@@ -414,7 +414,6 @@ class StickinessQueryRunner(AnalyticsQueryRunner[StickinessQueryResponse]):
             ]
         )
 
-        # Days of week: "days active" counts activity on the selected days only
         day_of_week_filter = date_range.day_of_week_filter_expr(ast.Field(chain=["timestamp"]))
         if day_of_week_filter is not None:
             filters.append(day_of_week_filter)

--- a/products/product_analytics/backend/hogql_queries/stickiness/test/test_stickiness_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/stickiness/test/test_stickiness_query_runner.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from posthog.schema import (
     ActionsNode,
     CohortPropertyFilter,
@@ -276,6 +278,7 @@ class TestStickinessQueryRunner(ClickhouseTestMixin, APIBaseTest):
         filters: Optional[StickinessFilter] = None,
         filter_test_accounts: Optional[bool] = False,
         compare_filters: Optional[CompareFilter] = None,
+        days_of_week: Optional[list[int]] = None,
     ):
         query_series: list[EventsNode | ActionsNode | DataWarehouseNode] = (
             [EventsNode(event="$pageview")] if series is None else series
@@ -286,7 +289,7 @@ class TestStickinessQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         query = StickinessQuery(
             series=query_series,
-            dateRange=DateRange(date_from=query_date_from, date_to=query_date_to),
+            dateRange=DateRange(date_from=query_date_from, date_to=query_date_to, daysOfWeek=days_of_week),
             interval=query_interval,
             intervalCount=intervalCount,
             properties=properties,
@@ -789,6 +792,122 @@ class TestStickinessQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.results[1]["count"] == 2
         assert response.results[1]["compare_label"] == "previous"
         assert response.results[1]["data"] == [0, 0, 0, 0, 1, 0, 0, 0, 1]
+
+    @parameterized.expand(
+        [
+            ("mon_tue_only", [1, 2], [0, 1, 0, 0, 0, 0, 0]),
+            ("empty_means_unfiltered", [], [0, 0, 1, 0, 0, 0, 0]),
+            ("all_days_means_unfiltered", [1, 2, 3, 4, 5, 6, 7], [0, 0, 1, 0, 0, 0, 0]),
+        ]
+    )
+    def test_days_of_week_restricts_days_active(self, _name, days_of_week, expected_data):
+        # 2020-01-13 is a Monday; p1 is active Mon, Tue, and Sat
+        self._create_events(
+            [
+                SeriesTestData(
+                    distinct_id="p1",
+                    events=[
+                        Series(
+                            event="$pageview",
+                            timestamps=[
+                                "2020-01-13T12:00:00Z",  # Monday
+                                "2020-01-14T12:00:00Z",  # Tuesday
+                                "2020-01-18T12:00:00Z",  # Saturday
+                            ],
+                        )
+                    ],
+                    properties={},
+                )
+            ]
+        )
+
+        response = self._run_query(date_from="2020-01-13", date_to="2020-01-19", days_of_week=days_of_week)
+
+        assert response.results[0]["data"] == expected_data
+
+    @parameterized.expand(
+        [
+            ("monday_filter_includes_it", [1], 1),
+            ("sunday_filter_excludes_it", [7], 0),
+        ]
+    )
+    def test_days_of_week_uses_project_timezone(self, _name, days_of_week, expected_count):
+        self.team.timezone = "Asia/Tokyo"
+        self.team.save()
+        # 20:00 UTC Sunday = 05:00 Monday in Asia/Tokyo
+        self._create_events(
+            [
+                SeriesTestData(
+                    distinct_id="p1",
+                    events=[Series(event="$pageview", timestamps=["2020-01-12T20:00:00Z"])],
+                    properties={},
+                )
+            ]
+        )
+
+        response = self._run_query(date_from="2020-01-13", date_to="2020-01-19", days_of_week=days_of_week)
+
+        assert sum(response.results[0]["data"]) == expected_count
+
+    def test_days_of_week_actors_match_chart(self):
+        # The actors query must honor daysOfWeek like the chart does, or the persons modal
+        # would list people whose only events fall on deselected days
+        self._create_events(
+            [
+                SeriesTestData(
+                    distinct_id="p_weekday",
+                    events=[Series(event="$pageview", timestamps=["2020-01-15T12:00:00Z"])],  # Wednesday
+                    properties={},
+                ),
+                SeriesTestData(
+                    distinct_id="p_weekend",
+                    events=[Series(event="$pageview", timestamps=["2020-01-18T12:00:00Z"])],  # Saturday
+                    properties={},
+                ),
+            ]
+        )
+
+        query = self._get_query(date_from="2020-01-13", date_to="2020-01-19", days_of_week=[6, 7])
+        runner = get_query_runner(query=StickinessActorsQuery(source=query, day=1, operator="exact"), team=self.team)
+        actors = runner.calculate()
+
+        assert len(actors.results) == 1
+
+    def test_days_of_week_filters_compare_previous_period(self):
+        # Current period 2020-01-13..19, previous period 2020-01-06..12; 2020-01-06 is a Monday
+        self._create_events(
+            [
+                SeriesTestData(
+                    distinct_id="p1",
+                    events=[
+                        Series(
+                            event="$pageview",
+                            timestamps=[
+                                "2020-01-06T12:00:00Z",  # Monday, previous period
+                                "2020-01-07T12:00:00Z",  # Tuesday, previous period
+                                "2020-01-14T12:00:00Z",  # Tuesday, current period
+                            ],
+                        )
+                    ],
+                    properties={},
+                )
+            ]
+        )
+
+        response = self._run_query(
+            date_from="2020-01-13",
+            date_to="2020-01-19",
+            compare_filters=CompareFilter(compare=True),
+            days_of_week=[1],
+        )
+
+        current, previous = response.results[0], response.results[1]
+        assert current["compare_label"] == "current"
+        assert current["count"] == 0
+        assert previous["compare_label"] == "previous"
+        # Only the previous period's Monday event counts toward days active
+        assert previous["count"] == 1
+        assert previous["data"][0] == 1
 
     def test_criteria(self):
         self._create_events(


### PR DESCRIPTION
## Problem

The `daysOfWeek` field on the shared `DateRange` schema filters insights down to events that occurred on selected weekdays (ISO 1=Monday…7=Sunday), evaluated in the project timezone. It replaced the old `hideWeekends` display toggle with a true query-level filter, but so far only trends applies it. Stickiness, lifecycle, and funnel trends ignore the field.

## Changes

Wires the existing `QueryDateRange.day_of_week_filter_expr` helper into three more runners, one commit each. Absent or empty `daysOfWeek` still means unfiltered (the helper returns `None`), so existing queries and HogQL snapshots are unchanged.

- **Stickiness** – filter ANDed into the event `where_clause`. "Days active" now counts activity on the selected days only. The actors query reuses the same events query, and each compare series resolves its own `QueryDateRange` subclass, so the persons list and compare-to-previous are filtered too.
- **Lifecycle** – filter ANDed into the shared `event_filter`, so new/returning/resurrecting/dormant statuses derive from selected-day activity only; the actors query inherits it.
- **Funnel trends** – filter ANDed into `FunnelEventQuery`'s WHERE assembly (events and data-warehouse branches), gated on `funnelVizType == trends`. Regular funnels and time-to-convert are deliberately untouched (dropping mid-sequence events there needs a product decision first). The compare path clones the query with a rebuilt `DateRange`, which silently dropped `daysOfWeek` – it now carries the filter into the previous-period series.

> [!NOTE]
> **Lifecycle keeps excluded-day buckets** (trends drops them for day interval). In lifecycle, "dormant" lands on the day *after* last activity, which can itself be an excluded day (active Monday → dormant Tuesday under a Mondays-only filter). Dropping those buckets would hide real dormant counts, so all buckets stay; new/returning/resurrecting are simply zero on excluded days. A test locks this decision in.

> [!NOTE]
> **Funnel trends filters every funnel event**, not just the entrance: a step-two event on a deselected day counts as a drop-off. This matches the "count only events on selected days" semantics and is asserted in a test.

Paths, retention, regular funnels, and the calendar heatmap remain out of scope, as does the frontend gate that exposes the day chips.

## How did you test this code?

Ran the three touched test files locally against ClickHouse (`test_stickiness_query_runner.py`, `test_lifecycle_query_runner.py`, `test_funnel_trends.py`), plus `test_funnel.py` and `test_funnel_trends_actors.py` to guard the viz-type gate – all green, all HogQL snapshots unchanged. Data-warehouse-fixture tests couldn't run in the sandbox (no local object storage); they rely on CI here.

New parameterized tests per runner, each catching a regression nothing covered before:

- weekday filter changes counts (would pass unfiltered if the WHERE wiring is dropped)
- an event late Sunday UTC that is Monday in the project timezone is included by a Monday filter (catches a runner passing a non-timezone-converted timestamp to the helper)
- empty `daysOfWeek` = unfiltered
- persons list matches the chart (actors query wiring)
- stickiness + funnel trends: compare-to-previous series is filtered (funnels previously rebuilt `DateRange` without `daysOfWeek`)
- lifecycle: excluded-day buckets retained with dormant counts visible
- funnels: steps viz ignores `daysOfWeek` (guards the gate)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Backend-only; the user-facing docs for day-of-week filtering apply once the frontend exposes it beyond trends.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) from a written brief. Skills invoked: `/writing-tests`. Key decisions: gate the funnel filter on `funnelVizType == trends` inside `FunnelEventQuery` rather than in `funnel_trends.py`, since the WHERE exprs are assembled in the shared event query; keep lifecycle's excluded-day buckets (dormant lands on excluded days); preserve `daysOfWeek` in the funnels previous-period query clone, which was found to drop it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*