### PR TITLE
fix(mcp): rebuild image when the bundled sql guidance changes

### DIFF
--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -13,6 +13,7 @@ on:
         paths:
             - 'services/mcp/**'
             - '.github/workflows/cd-mcp-image.yml'
+            - 'products/posthog_ai/skills/querying-posthog-data/references/guidelines.md'
     # paths mirror the push trigger; the build-mcp-image label only forces a
     # build on PRs touching these paths, use workflow_dispatch otherwise.
     pull_request:
@@ -20,6 +21,7 @@ on:
         paths:
             - 'services/mcp/**'
             - '.github/workflows/cd-mcp-image.yml'
+            - 'products/posthog_ai/skills/querying-posthog-data/references/guidelines.md'
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Problem

The MCP server image inlines `products/posthog_ai/skills/querying-posthog-data/references/guidelines.md` into the `execute-sql` tool description at build time (`services/mcp/scripts/copy-instructions.ts`), but `cd-mcp-image.yml` only triggers on `services/mcp/**`. A guidance-only change merges cleanly and then never deploys: no image build runs, and prod serves the stale tool description until the next unrelated MCP commit happens to rebuild it. This just bit us in practice: a merged guidelines change produced zero CD runs for its merge commit.

## Changes

- Add the guidelines file to the workflow's `push` and `pull_request` trigger paths. It is the only build input outside `services/mcp/**`.

No job logic or gating changes: the `CD_DEPLOY_ENABLED` gate and the `build-mcp-image` label requirement for PR builds are untouched, so PRs touching only the guidelines file get a workflow run that skips unless labeled, same as MCP-code PRs today.

## How did you test this code?

Trigger-paths-only change; no runtime code. I verified the copy script's source list to confirm the guidelines file is the only out-of-tree input, and that the merge commit of the recent guidance change had no CD runs (the failure this fixes). Backwards compatible with unrebased branches: widening trigger paths cannot make existing PRs fail.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code while investigating why the merged guidance change from the execute-sql quality loop had not reached production. The `gating-production-deploys` skill was invoked before editing the workflow; this change adds trigger paths only and does not alter any gate.
