### PR TITLE
fix(hogli): pin docker compose project name to posthog

### DIFF
--- a/tools/hogli-commands/hogli_commands/devenv/generator.py
+++ b/tools/hogli-commands/hogli_commands/devenv/generator.py
@@ -47,12 +47,10 @@ class DevenvConfig(BaseModel):
 
 
 def _get_docker_compose_base() -> str:
-    # Pin the project name explicitly so the shared dev stack (db, clickhouse,
-    # kafka, etc.) is reused across worktrees even when the invoking shell
-    # hasn't sourced .envrc (COMPOSE_PROJECT_NAME would otherwise default to
-    # the current directory name, creating a conflicting duplicate stack).
-    project_name = os.environ.get("COMPOSE_PROJECT_NAME", "posthog")
-    return f"docker compose -p {project_name} -f docker-compose.dev.yml -f docker-compose.profiles.yml"
+    # Pin the project name so worktrees share one dev stack instead of each
+    # defaulting to its own directory name.
+    project_name = os.environ.get("COMPOSE_PROJECT_NAME") or "posthog"
+    return f"docker compose -p {shlex.quote(project_name)} -f docker-compose.dev.yml -f docker-compose.profiles.yml"
 
 
 def build_docker_compose_command(profiles: list[str], action: str = "up -d") -> str:

--- a/tools/hogli-commands/hogli_commands/devenv/generator.py
+++ b/tools/hogli-commands/hogli_commands/devenv/generator.py
@@ -47,7 +47,12 @@ class DevenvConfig(BaseModel):
 
 
 def _get_docker_compose_base() -> str:
-    return "docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml"
+    # Pin the project name explicitly so the shared dev stack (db, clickhouse,
+    # kafka, etc.) is reused across worktrees even when the invoking shell
+    # hasn't sourced .envrc (COMPOSE_PROJECT_NAME would otherwise default to
+    # the current directory name, creating a conflicting duplicate stack).
+    project_name = os.environ.get("COMPOSE_PROJECT_NAME", "posthog")
+    return f"docker compose -p {project_name} -f docker-compose.dev.yml -f docker-compose.profiles.yml"
 
 
 def build_docker_compose_command(profiles: list[str], action: str = "up -d") -> str:

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -14,7 +14,13 @@ import pytest
 from unittest import mock
 
 import yaml
-from hogli_commands.devenv.generator import DevenvConfig, MprocsConfig, MprocsGenerator, load_devenv_config
+from hogli_commands.devenv.generator import (
+    DevenvConfig,
+    MprocsConfig,
+    MprocsGenerator,
+    build_docker_compose_command,
+    load_devenv_config,
+)
 from hogli_commands.devenv.registry import ProcessRegistry, create_mprocs_registry
 from hogli_commands.devenv.resolver import Capability, Intent, IntentMap, IntentResolver, load_intent_map
 from hogli_commands.devenv.wizard import _parse_exclude_input
@@ -438,6 +444,40 @@ class TestDockerProfiles:
         # feature_flags needs etcd (coordination)
         result = resolver.resolve(["feature_flags"])
         assert "etcd" in result.docker_profiles
+
+
+class TestDockerComposeProjectName:
+    """Test project-name selection in the generated docker compose command."""
+
+    def test_defaults_to_posthog_when_unset(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("COMPOSE_PROJECT_NAME", raising=False)
+
+        cmd = build_docker_compose_command([])
+
+        assert "-p posthog " in cmd
+
+    def test_defaults_to_posthog_when_empty(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("COMPOSE_PROJECT_NAME", "")
+
+        cmd = build_docker_compose_command([])
+
+        assert "-p posthog " in cmd
+
+    @parameterized.expand(
+        [
+            ("plain name", "posthog-worktree", "posthog-worktree"),
+            ("value with a space", "posthog dev", "posthog dev"),
+            ("value with shell metacharacters", "posthog; rm -rf /", "posthog; rm -rf /"),
+        ]
+    )
+    def test_project_name_from_env_is_shell_quoted(self, _name: str, env_value: str, expected_value: str) -> None:
+        with mock.patch.dict(os.environ, {"COMPOSE_PROJECT_NAME": env_value}):
+            cmd = build_docker_compose_command([])
+
+        # The quoted project name must round-trip through shlex.split as a single token,
+        # proving it can't be split into extra shell arguments or inject shell syntax.
+        tokens = shlex.split(cmd)
+        assert tokens[tokens.index("-p") + 1] == expected_value
 
 
 class TestIntentMapLoading:


### PR DESCRIPTION
## Problem

`hogli up` and `bin/start` shell out to `docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml` without an explicit project name. Compose falls back to `COMPOSE_PROJECT_NAME` from the environment, which `.envrc` sets to `posthog` so the shared dev stack (db, clickhouse, kafka, etc.) gets reused across worktrees instead of duplicated per checkout.

That only works if the shell invoking `hogli` has actually sourced `.envrc`. When it hasn't (a non-interactive shell where direnv's hook never fired), Compose names the project after the current directory instead. I run `hogli` across several worktrees of this repo, one at a time, and hit exactly this: switching worktrees spun up a second, differently-named copy of the stack, which then failed outright once it collided with the first copy's `proxy` container on host port 8010.

## Changes

`_get_docker_compose_base()` in `tools/hogli-commands/hogli_commands/devenv/generator.py` now passes `-p <project>` explicitly, reading `COMPOSE_PROJECT_NAME` from the environment with a `posthog` fallback. This makes the shared-stack behavior deterministic regardless of whether the invoking shell sourced `.envrc`.

## How did you test this code?

- Ran the existing `test_devenv.py` suite: 74 tests pass.
- Called `_get_docker_compose_base()` directly with `COMPOSE_PROJECT_NAME` unset and set to `posthog`; both return `docker compose -p posthog -f ...`.
- Regenerated `mprocs.yaml` via `hogli dev:generate` and confirmed the generated docker-compose command includes `-p posthog`.
- Reproduced the original failure end to end: ran `hogli up -d` from a shell with `COMPOSE_PROJECT_NAME` unset, the exact failure condition. Before the fix this errored with `port is already allocated` while trying to create a directory-named duplicate stack. After the fix, `docker-compose` exits 0 and reuses the existing `posthog-*` containers with no conflicts.
- `hogli ci:preflight --strict` passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Phil was debugging an ingestion crash loop in a local dev worktree with Claude Code. That turned out to be a personal environment issue, fixed outside this PR. While restarting the stack to verify that fix, we hit this separate docker-compose project-naming issue, traced it to `generator.py`, and Phil asked Claude to test the fix and open this PR.