### PR TITLE
fix(data-warehouse): pin oauth account listing to the source's integration kind

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -45,6 +45,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.event_usage import report_user_action
 from posthog.exceptions_capture import capture_exception
+from posthog.models.integration import Integration
 from posthog.models.user import User
 from posthog.permissions import (
     AccessControlPermission,
@@ -234,6 +235,25 @@ def get_sensitive_field_names(fields: list[FieldType]) -> set[str]:
                 if option.fields:
                     sensitive.update(get_sensitive_field_names(option.fields))
     return sensitive
+
+
+def get_oauth_account_select_kinds(fields: list[FieldType]) -> set[str]:
+    """The integration kinds a source's account pickers are allowed to read from, declared by the
+    `integrationKind` of each `oauth-account-select` field. Every OAuth account listing is served by
+    one endpoint that takes an integration id from the caller, so this is what the endpoint checks
+    that id against — a Google integration id must not be able to route its token into the LinkedIn
+    Ads client just because both rows belong to the caller's team."""
+    kinds: set[str] = set()
+    for field in fields:
+        if isinstance(field, SourceFieldOauthAccountSelectConfig):
+            kinds.add(field.integrationKind)
+        elif isinstance(field, SourceFieldSwitchGroupConfig):
+            kinds.update(get_oauth_account_select_kinds(field.fields))
+        elif isinstance(field, SourceFieldSelectConfig):
+            for option in field.options:
+                if option.fields:
+                    kinds.update(get_oauth_account_select_kinds(option.fields))
+    return kinds
 
 
 def _add_name_variants(target: set[str], name: str) -> None:
@@ -1772,6 +1792,23 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
 
         if not isinstance(source, OAuthMixin):
             raise ValidationError(f"Source type {source_type} does not support listing OAuth accounts")
+
+        # The integration id is caller-supplied and each source looks it up by (id, team_id) only, so
+        # without this a same-team integration of a different provider would be accepted here and its
+        # OAuth token handed to this source's provider. Pin it to the kind(s) the source's picker
+        # declares before any of that runs.
+        expected_kinds = get_oauth_account_select_kinds(source.get_source_config.fields)
+        if not expected_kinds:
+            raise ValidationError(f"Source type {source_type} does not support listing OAuth accounts")
+        if not Integration.objects.filter(
+            id=integration_id_int, team_id=self.team_id, kind__in=expected_kinds
+        ).exists():
+            # One message for "gone" and "wrong kind" alike: from the UI both mean the picker is holding
+            # a connection this source can't use, and neither tells the caller anything about ids it
+            # isn't already allowed to see.
+            raise ValidationError(
+                f"No {source_type} connection was found for this integration. Please reconnect the integration."
+            )
 
         cache_key = f"oauth_accounts/{self.team_id}/{source_type}/{integration_id_int}"
         cached = cache.get(cache_key)

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -10896,6 +10896,31 @@ class TestOAuthAccountsEndpoint(APIBaseTest):
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, response.content
 
+    def test_integration_of_another_kind_is_rejected(self):
+        # Same team, so the (id, team_id) lookup each source does would accept it: only the kind check
+        # stops this Bing token from being sent to LinkedIn's API.
+        integration = self._bing_integration()
+        with patch(f"{self._LINKEDIN_MODULE}.linkedin_ads_client_for_integration") as client_for_integration:
+            response = self.client.get(self._url("LinkedinAds", integration.id))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        client_for_integration.assert_not_called()
+
+    def test_integration_from_another_team_is_rejected(self):
+        other_team = Team.objects.create(organization=self.organization)
+        integration = Integration.objects.create(
+            team=other_team,
+            kind="linkedin-ads",
+            config={},
+            sensitive_config={"access_token": "token"},
+            integration_id="linkedin_other_team",
+        )
+        with patch(f"{self._LINKEDIN_MODULE}.linkedin_ads_client_for_integration") as client_for_integration:
+            response = self.client.get(self._url("LinkedinAds", integration.id))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        client_for_integration.assert_not_called()
+
     @override_settings(BING_ADS_DEVELOPER_TOKEN="dev_token")
     def test_bing_success_returns_accounts(self):
         integration = self._bing_integration()


### PR DESCRIPTION
## Problem

The `oauth_accounts` endpoint takes an `integration_id` from the caller and hands it straight to the source's `get_oauth_accounts()`. Every source resolves it by `(id, team_id)` only — `OAuthMixin.get_oauth_integration()` for Bing Ads, `_credentials()` for Google Search Console, `_get_integration()` for LinkedIn Ads. None of them check `kind`.

So `?source_type=LinkedinAds&integration_id=<a Google integration in the same team>` builds a LinkedIn client from the Google row and sends that OAuth token to `api.linkedin.com`. LinkedIn rejects it and the user sees a "re-authorize LinkedIn" message that has nothing to do with what went wrong.

Not cross-tenant: the lookups are team-scoped and the endpoint is behind `TeamMemberAdminManagementPermission` plus a write scope, so the caller already has access to every integration they can name. What is left is a token for provider A being disclosed to provider B, and a misleading error. Greptile flagged it as P1/security on #69817; the hole is older than that PR (Bing Ads and Google Search Console adopted the picker in #65692 with the same gap), so it is fixed here rather than in the LinkedIn PR.

## Changes

The picker already declares the kind it reads from: `SourceFieldOauthAccountSelectConfig.integrationKind`, whose schema description is "Integration kind to validate and route the account fetch through". The `validate` half was never written. This adds it once, in the endpoint, instead of in each of the sources.

- **`get_oauth_account_select_kinds(fields)`** walks a source config for its `oauth-account-select` fields and returns the `integrationKind`s they declare. Recursive through switch groups and select options, mirroring the existing `get_sensitive_field_names()` next to it.
- **`oauth_accounts`** resolves those kinds from the source it just routed to and requires the integration to match one, before the cache lookup and before any client is built. A source with no picker field (an `OAuthMixin` that never adopted it, e.g. Salesforce) yields an empty set and gets the existing "does not support listing OAuth accounts" 400 — the `NotImplementedError` catch stays as a backstop.

A missing integration id and a wrong-kind integration id now produce the same actionable 400. That is deliberate: from the UI both mean the picker is holding a connection this source cannot use, and one message tells the caller nothing about ids they are not already allowed to see. It also keeps `test_bing_missing_integration_returns_400` honest — that path now short-circuits in the endpoint rather than inside `BingAdsSource.get_oauth_accounts()`.

Covers Bing Ads, Google Search Console and LinkedIn Ads today, and the six remaining ad sources as they adopt the picker.

## How did you test this code?

Two tests in `TestOAuthAccountsEndpoint`, both asserting the client is never constructed (`client_for_integration.assert_not_called()`) — a 400 alone would not prove the token stayed home:

- `test_integration_of_another_kind_is_rejected` — a Bing integration id passed with `source_type=LinkedinAds`. Same team, so the `(id, team_id)` lookup each source does would happily return it; only the kind check stops the Bing token from reaching LinkedIn.
- `test_integration_from_another_team_is_rejected` — pins the team scoping that already existed, so a future refactor of this check cannot quietly drop it.

All 22 tests in `TestOAuthAccountsEndpoint` pass (20 existing, 2 new). `ruff` and `mypy` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Stacked on #69817 (LinkedIn Ads picker) so the review of the shared endpoint is separate from the review of the source that surfaced it — that PR is already approved and this touches the Bing and GSC paths too. Merge base flips to `master` once #69817 lands.

Chose the endpoint over the sources: the alternative is seven copies of the same `kind` check, one per ad source, added by seven separate PRs and easy to forget in the eighth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
