### PR TITLE
fix(custom): reject unsupported endpoint.incremental keys

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -337,14 +337,39 @@ def _validate_resource_graph(manifest: dict[str, Any]) -> dict[str, Optional[Res
     return resolved
 
 
+# Keys the Custom source accepts inside ``endpoint.incremental``. The REST engine's
+# ``Incremental(**config)`` constructor takes a fixed set of kwargs, so any other key
+# (e.g. a dlt option copied from upstream docs) reaches it as an unexpected kwarg and
+# crashes sync setup with a ``TypeError`` the pipeline doesn't convert to non-retryable —
+# Temporal then retries a deterministic failure. ``cursor_type``/``datetime_format`` are
+# custom-source-only hints stripped before the engine (see
+# ``_strip_engine_unsupported_incremental_keys``); the rest map to the engine directly.
+_SUPPORTED_INCREMENTAL_KEYS = frozenset(
+    {
+        "start_param",
+        "end_param",
+        "cursor_path",
+        "initial_value",
+        "end_value",
+        "last_value_func",
+        "row_order",
+        "convert",
+        "transform",
+        "cursor_type",
+        "datetime_format",
+    }
+)
+
+
 def _validate_incremental_configs(manifest: dict[str, Any]) -> None:
     """Reject incremental config values that would deterministically crash at sync time.
 
     The structural schema doesn't model ``endpoint.incremental``, so hand-authored
     mistakes here would otherwise only surface mid-sync: a non-string ``datetime_format``
     as a strftime error (and only from the second sync onward, once a watermark is
-    stored), and a missing ``start_param`` as a bare ``KeyError`` the REST engine raises
-    from ``setup_incremental_object``.
+    stored), a missing ``start_param`` as a bare ``KeyError`` the REST engine raises
+    from ``setup_incremental_object``, and an unsupported key as a ``TypeError`` from the
+    engine's ``Incremental(**config)`` constructor.
     """
     for resource in manifest.get("resources") or []:
         if not isinstance(resource, dict):
@@ -353,6 +378,13 @@ def _validate_incremental_configs(manifest: dict[str, Any]) -> None:
         incremental = endpoint.get("incremental") if isinstance(endpoint, dict) else None
         if not isinstance(incremental, dict):
             continue
+        unsupported = sorted(set(incremental) - _SUPPORTED_INCREMENTAL_KEYS)
+        if unsupported:
+            raise ManifestValidationError(
+                f"Resource {resource.get('name')!r}: endpoint.incremental has unsupported "
+                f"{'keys' if len(unsupported) > 1 else 'key'} {', '.join(unsupported)}. "
+                f"Allowed keys: {', '.join(sorted(_SUPPORTED_INCREMENTAL_KEYS))}"
+            )
         datetime_format = incremental.get("datetime_format")
         if datetime_format is not None and not isinstance(datetime_format, str):
             raise ManifestValidationError(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -2462,6 +2462,41 @@ class TestCustomSourceIncrementalStartParam(SimpleTestCase):
         assert err is not None and "start_param" in err and "'users'" in err
 
 
+class TestCustomSourceIncrementalUnsupportedKeys(SimpleTestCase):
+    def _manifest(self) -> dict:
+        manifest = _minimal_manifest()
+        manifest["resources"][0]["endpoint"]["incremental"] = {
+            "cursor_path": "updated_at",
+            "start_param": "since",
+            "upstream_row_order": "asc",
+        }
+        return manifest
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.custom.source.rest_api_resources")
+    def test_unsupported_key_raises_non_retryable_before_engine(self, mock_resources):
+        mock_resources.return_value = [_fake_resource("users")]
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(self._manifest()))
+        inputs = MagicMock(
+            team_id=1,
+            schema_name="users",
+            job_id="job-1",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=None,
+        )
+        with self.assertRaises(NonRetryableException) as ctx:
+            source.source_for_pipeline(config, inputs)
+        assert "upstream_row_order" in str(ctx.exception)
+        mock_resources.assert_not_called()
+
+    def test_unsupported_key_rejected_at_validation(self):
+        source = CustomSource()
+        config = CustomSourceConfig(manifest_json=json.dumps(self._manifest()), auth_token="abc")
+        ok, err = source.validate_credentials(config, team_id=999)
+        assert ok is False
+        assert err is not None and "upstream_row_order" in err and "'users'" in err
+
+
 def _apikey_manifest() -> dict:
     """A minimal manifest whose auth is an api_key in a query param, so the
     injected secret is registered for value-based redaction."""


### PR DESCRIPTION
## Problem

Error tracking surfaced a `TypeError: Incremental.__init__() got an unexpected keyword argument 'upstream_row_order'` originating from the custom data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019f5e91-d284-7502-8774-83e6f67c4d37)).

A custom source's `endpoint.incremental` block is a free-form dict that the structural schema doesn't model. When a manifest carries a key the REST engine's `Incremental(**config)` constructor doesn't accept (here an option that looks copied from upstream dlt docs), the key flows straight through to the constructor as an unexpected keyword argument and crashes sync setup.

Worse, `source_for_pipeline` only converts `ValueError` into a non-retryable failure. A `TypeError` slips past that handler, so Temporal retried a deterministic crash instead of failing fast, and there was no create-time feedback for the mistake.

## Changes

`_validate_incremental_configs` now rejects any `endpoint.incremental` key outside the set the source actually supports, raising `ManifestValidationError` with the offending key and the allowed keys. That validator already runs on all three paths (create/update validation, preview, and sync), so:

- Authoring a bad manifest fails at validation with a clear message.
- A manifest stored before this check now fails the sync fast and non-retryably (the `ManifestValidationError` is a `ValueError`, which `source_for_pipeline` already maps to `NonRetryableException`) instead of crash-looping.

This mirrors the existing handling for a missing `start_param` and a non-string `datetime_format` in the same validator.

## How did you test this code?

Added `TestCustomSourceIncrementalUnsupportedKeys` with two cases, mirroring the existing `start_param` tests:

- sync path: an unsupported key raises `NonRetryableException` before the engine is invoked (`rest_api_resources` not called).
- validation path: `validate_credentials` returns `(False, err)` naming the key and resource.

These guard the exact regression from the linked issue: an unsupported incremental key must be a fast non-retryable failure, not a retried `TypeError`. No existing test covered an unknown incremental key.

Ran the incremental-related `SimpleTestCase` classes locally (29 passed). The OAuth2 `BaseTest` classes in the same file need Postgres, which isn't available in this environment, so I didn't run those; my change doesn't touch that code.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook by Claude (Claude Code). Confirmed the crash frame in `common/rest_source/config_setup.py:setup_incremental_object` and traced the call path from the custom source's sync into `Incremental(**config)`.

Decision: fixable bug, not a user/upstream error. The crash is a deterministic config problem our code should catch and reject cleanly rather than a transient or credential failure. Considered silently stripping the unknown key (like `_strip_engine_unsupported_incremental_keys` does for `cursor_type`/`datetime_format`) but rejected that: dropping an incremental option the user set could silently change sync semantics, so an explicit validation error is safer and clearer.

Skill invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
