### PR TITLE
feat(web-analytics): make warm team concurrency launch-configurable

### DIFF
--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -436,6 +436,11 @@ class EagerWarmConfig(dagster.Config):
     # stable team set - a 24h window shifts between chunks and can drop the unwarmed
     # tail of the previous run.
     active_lookback_hours: int = pydantic.Field(default=24, ge=1, le=168)
+    # Per-team warm concurrency. The insert SELECTs execute on the shared offline
+    # tier, so raising this raises pressure there, not on aux - only go above the
+    # default when offline CPU is quiet (<~40% avg), and watch for 202
+    # TOO_MANY_SIMULTANEOUS_QUERIES, which is the tier's concurrency ceiling biting.
+    team_concurrency: int = pydantic.Field(default=WARM_TEAM_CONCURRENCY, ge=1, le=25)
 
 
 @dagster.op
@@ -581,7 +586,7 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext, config: EagerWar
             )
             return team_warmed, team_failed
 
-        with ThreadPoolExecutor(max_workers=WARM_TEAM_CONCURRENCY) as pool:
+        with ThreadPoolExecutor(max_workers=config.team_concurrency) as pool:
             for team_warmed, team_failed in pool.map(_warm, eligible):
                 warmed += team_warmed
                 failed += team_failed

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -440,7 +440,9 @@ class EagerWarmConfig(dagster.Config):
     # tier, so raising this raises pressure there, not on aux - only go above the
     # default when offline CPU is quiet (<~40% avg), and watch for 202
     # TOO_MANY_SIMULTANEOUS_QUERIES, which is the tier's concurrency ceiling biting.
-    team_concurrency: int = pydantic.Field(default=WARM_TEAM_CONCURRENCY, ge=1, le=25)
+    # None = use WARM_TEAM_CONCURRENCY (resolved at run time, so tests patching the
+    # constant still control the pool).
+    team_concurrency: int | None = pydantic.Field(default=None, ge=1, le=25)
 
 
 @dagster.op
@@ -586,7 +588,7 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext, config: EagerWar
             )
             return team_warmed, team_failed
 
-        with ThreadPoolExecutor(max_workers=config.team_concurrency) as pool:
+        with ThreadPoolExecutor(max_workers=config.team_concurrency or WARM_TEAM_CONCURRENCY) as pool:
             for team_warmed, team_failed in pool.map(_warm, eligible):
                 warmed += team_warmed
                 failed += team_failed


### PR DESCRIPTION
## Problem

The eager warm/backfill op runs teams through a fixed `ThreadPoolExecutor(max_workers=10)`. During the fleet backfill we may want to raise throughput when the offline tier (where the insert SELECTs execute) is quiet - but 10 is compiled in, so any experiment needs a deploy.

## Changes

- New `team_concurrency` run-config field (default 10 = current behavior, capped at 25). The scheduled hourly job passes no config and is unchanged; manual launches (including `web_analytics_eager_backfill`) can override it.
- The cap is deliberately conservative: the offline tier is shared (cohorts, exports, experiments) and its binding constraint is concurrency slots (202 TOO_MANY_SIMULTANEOUS_QUERIES), not CPU. The field's docstring carries the operating guidance: only raise when offline avg CPU is quiet (<~40%), watch for 202s.

Measured context: at 10 workers the backfill sustains ~12-27k inserts/hr with zero failures; tonight's offline tier sat at 40-77% CPU with one node over its core count, which is exactly the condition under which this knob should NOT be raised.

## How did you test this code?

- Mechanical change (constant -> validated config field with the constant as default); the op's existing tests exercise the pool path via direct invocation with default config. Field validation is pydantic (`ge=1, le=25`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during the live fleet backfill. Lucas asked whether increased concurrency was affordable; measurement said not right now (offline tier at 40-77% CPU, one node saturated by other tenants), so the knob ships with a conservative cap and explicit guidance instead of a raised default.