### PR TITLE
feat(logs): expose severity_text on the log_attributes HogQL table

### DIFF
--- a/posthog/hogql/database/schema/logs.py
+++ b/posthog/hogql/database/schema/logs.py
@@ -124,6 +124,11 @@ class LogAttributesTable(Table):
         "service_name": StringDatabaseField(
             name="service_name", nullable=False, description="Service the attribute counts are scoped to."
         ),
+        "severity_text": StringDatabaseField(
+            name="severity_text",
+            nullable=False,
+            description="OpenTelemetry severity text the attribute counts are scoped to, e.g. 'INFO', 'ERROR'.",
+        ),
     }
 
     def to_printed_clickhouse(self, context):


### PR DESCRIPTION
## Problem

The logs facet-filtering work needs `severity_text` to be queryable on the `log_attributes` HogQL table. The physical column lives on `log_attributes3`, which `log_attributes_distributed` points at after the cutover migration. This PR adds the field to the HogQL schema so it can be selected and faceted.

## Changes

- Add `severity_text` to `LogAttributesTable.fields` in `posthog/hogql/database/schema/logs.py`.

> [!IMPORTANT]
> Stacked on [#70496](https://github.com/PostHog/posthog/pull/70496) (the migration that repoints `log_attributes_distributed` at `log_attributes3`). This PR must merge **after** that one - until the distributed table is backed by `log_attributes3`, `severity_text` does not exist on the underlying table and a query selecting it would error. GitHub will retarget this PR to `master` automatically once the base merges.

## How did you test this code?

Automated only (I'm an agent - no manual query against a live cluster):

- Verified in a Django shell (on the stacked base) that `severity_text` resolves on `LogAttributesTable` and `to_printed_clickhouse()` still prints `log_attributes_distributed`.
- `ruff check` / `ruff format --check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank asked me (Claude, via PostHog Code) to split the HogQL `severity_text` field out of the migration PR into its own PR, so the migration PR stays migration-only per the ClickHouse migration-only-PR convention. I rewrote the migration branch to drop the field and stacked this PR on top of it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
