### PR TITLE
fix(metabase): surface a clean error when the instance is unreachable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
@@ -163,23 +163,27 @@ def _connection_error_message(error: Exception) -> str:
     port=3000): ... SSLError(... WRONG_VERSION_NUMBER ...)"). Returning that verbatim leaks the
     customer's host/IP and tells them nothing they can act on.
     """
+    # Match on the exception type first: substring checks against str(error) alone would misfire on
+    # a hostname that happens to contain "ssl"/"timeout" (e.g. https://sslserver.com).
     text = str(error).lower()
-    if "wrong_version_number" in text:
-        return (
-            "Couldn't establish a secure (HTTPS) connection to your Metabase instance. "
-            "PostHog connects over HTTPS, so the instance must be served over HTTPS. Check the Instance URL."
-        )
-    if "ssl" in text or "certificate" in text:
+    if isinstance(error, requests.exceptions.SSLError):
+        if "wrong_version_number" in text:
+            return (
+                "Couldn't establish a secure (HTTPS) connection to your Metabase instance. "
+                "PostHog connects over HTTPS, so the instance must be served over HTTPS. Check the Instance URL."
+            )
         return (
             "Couldn't establish a secure (TLS) connection to your Metabase instance. "
             "Check that the Instance URL is correct and its TLS certificate is valid."
         )
-    if "timed out" in text or "timeout" in text:
+    if isinstance(error, requests.exceptions.Timeout):
         return (
             "Connecting to your Metabase instance timed out. "
             "Check that the Instance URL is correct and reachable from the public internet."
         )
-    if "name or service not known" in text or "nodename nor servname" in text or "failed to resolve" in text:
+    if isinstance(error, requests.exceptions.ConnectionError) and (
+        "name or service not known" in text or "nodename nor servname" in text or "failed to resolve" in text
+    ):
         return (
             "Couldn't resolve the Metabase host. "
             "Check that the Instance URL is spelled correctly and reachable from the public internet."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
@@ -156,6 +156,40 @@ def _resolve_auth_headers(base_url: str, auth: MetabaseAuth, logger: FilteringBo
     return {"X-Metabase-Session": token, "Accept": "application/json"}
 
 
+def _connection_error_message(error: Exception) -> str:
+    """Translate a low-level requests connection failure into a short, actionable message.
+
+    requests surfaces these as host-revealing blobs (e.g. "HTTPSConnectionPool(host='<ip>',
+    port=3000): ... SSLError(... WRONG_VERSION_NUMBER ...)"). Returning that verbatim leaks the
+    customer's host/IP and tells them nothing they can act on.
+    """
+    text = str(error).lower()
+    if "wrong_version_number" in text:
+        return (
+            "Couldn't establish a secure (HTTPS) connection to your Metabase instance. "
+            "PostHog connects over HTTPS, so the instance must be served over HTTPS. Check the Instance URL."
+        )
+    if "ssl" in text or "certificate" in text:
+        return (
+            "Couldn't establish a secure (TLS) connection to your Metabase instance. "
+            "Check that the Instance URL is correct and its TLS certificate is valid."
+        )
+    if "timed out" in text or "timeout" in text:
+        return (
+            "Connecting to your Metabase instance timed out. "
+            "Check that the Instance URL is correct and reachable from the public internet."
+        )
+    if "name or service not known" in text or "nodename nor servname" in text or "failed to resolve" in text:
+        return (
+            "Couldn't resolve the Metabase host. "
+            "Check that the Instance URL is spelled correctly and reachable from the public internet."
+        )
+    return (
+        "Couldn't connect to your Metabase instance. "
+        "Check that the Instance URL is correct and reachable from the public internet."
+    )
+
+
 def _extract_items(data: Any) -> list[dict[str, Any]]:
     """Normalize Metabase's two list shapes into a flat list of records.
 
@@ -201,7 +235,7 @@ def validate_credentials(
     try:
         response = session.get(f"{base_url}/api/user/current", headers=headers, timeout=10, allow_redirects=False)
     except requests.exceptions.RequestException as e:
-        return False, str(e)
+        return False, _connection_error_message(e)
 
     if response.is_redirect or response.is_permanent_redirect:
         return False, HOST_NOT_ALLOWED_ERROR

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
@@ -189,13 +189,29 @@ class TestValidateCredentials:
         assert valid is False
         assert msg == "Invalid Metabase host"
 
-    def test_request_exception_returns_failure(self):
-        import requests
-
-        with self._patch_session(raises=requests.exceptions.ConnectionError("boom")):
+    def test_connection_error_does_not_leak_raw_exception(self):
+        # requests connection errors embed the customer's host/IP and give the user nothing to act
+        # on. The (fictional-range) IP and the raw blob must never reach the user; a friendly,
+        # actionable message must.
+        raw = "HTTPSConnectionPool(host='203.0.113.10', port=3000): Max retries exceeded"
+        with self._patch_session(raises=requests.exceptions.ConnectionError(raw)):
             valid, msg = validate_credentials("https://x.metabaseapp.com", _api_key_auth())
             assert valid is False
-            assert "boom" in (msg or "")
+            assert msg is not None
+            assert "203.0.113.10" not in msg
+            assert "HTTPSConnectionPool" not in msg
+            assert "Instance URL" in msg
+
+    def test_wrong_version_number_points_at_https(self):
+        # HTTPS forced onto a plaintext port surfaces as SSL WRONG_VERSION_NUMBER; the guidance
+        # should tell the user the instance must be served over HTTPS, without leaking the host.
+        raw = "HTTPSConnectionPool(host='203.0.113.10', port=3000): SSLError([SSL: WRONG_VERSION_NUMBER])"
+        with self._patch_session(raises=requests.exceptions.SSLError(raw)):
+            valid, msg = validate_credentials("https://x.metabaseapp.com", _api_key_auth())
+            assert valid is False
+            assert msg is not None
+            assert "203.0.113.10" not in msg
+            assert "HTTPS" in msg
 
     def test_rejects_redirect_response(self):
         with self._patch_session(_response(status_code=302)) as patched:


### PR DESCRIPTION
## Problem

When a user creates a Metabase source and the instance is unreachable, credential validation returned the raw `requests` connection exception straight to the user. That string leaks the customer's host/IP and gives them nothing to act on. The most common shape is an HTTPS/TLS mismatch (`SSLError(... WRONG_VERSION_NUMBER ...)`) that happens when PostHog forces HTTPS onto an instance served over plaintext.

## Changes

`validate_credentials` now translates a `requests` connection failure into a short, actionable message (`_connection_error_message`) instead of returning `str(e)`:

- SSL `WRONG_VERSION_NUMBER` → explains the instance must be served over HTTPS.
- Other TLS/certificate errors, timeouts, and DNS-resolution failures each get their own guidance.
- Everything else falls back to a generic "couldn't connect, check the Instance URL" message.

The raw exception (host/IP included) is no longer surfaced.

## How did you test this code?

Updated the existing `validate_credentials` unit tests: renamed `test_request_exception_returns_failure` (which had asserted the raw message leaked) to assert the raw blob and IP are *not* surfaced, and added a WRONG_VERSION_NUMBER case asserting the HTTPS guidance appears without leaking the host. These lock in the regression that a future change returning `str(e)` would leak connection internals. Verified the translation helper's branch logic in isolation. Full pytest run wasn't possible in this environment (dependencies not installed).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged data-warehouse source-creation validation failures; this Metabase case was the clear "internal error leaking to the user" one (a raw `requests` connection exception surfaced verbatim). No skills beyond `/writing-tests` were needed. Chose to translate at the `validate_credentials` boundary rather than in the shared view layer so sync-time retry behavior is untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
