### PR TITLE
chore(engineering-analytics): expect all three views in viewset tests

### DIFF
--- a/products/data_warehouse/backend/models/test/test_managed_viewset.py
+++ b/products/data_warehouse/backend/models/test/test_managed_viewset.py
@@ -286,13 +286,19 @@ class TestDataWarehouseManagedViewSetModel(BaseTest):
 
 
 class TestEngineeringAnalyticsManagedViewSet(BaseTest):
-    """sync_views for the non-materialized engineering-analytics kind: it must create a
-    query-time saved query (no materialization schedule, no managed DAG), stay idempotent, and
+    """sync_views for the non-materialized engineering-analytics kind: it must create the
+    query-time saved queries (no materialization schedule, no managed DAG), stay idempotent, and
     create nothing for a team without a qualifying GitHub source.
     """
 
     PREFIX = "myprefix"
-    VIEW_NAME = "engineering_analytics_job_costs"
+    # All engineering-analytics views share one qualifying-source gate, so they appear
+    # together or not at all (see products/engineering_analytics/SPEC.md §5).
+    VIEW_NAMES = {
+        "engineering_analytics_job_costs",
+        "engineering_analytics_ci_job_history",
+        "engineering_analytics_ci_failures",
+    }
 
     def _github_source(self) -> ExternalDataSource:
         return ExternalDataSource.objects.create(
@@ -337,11 +343,10 @@ class TestEngineeringAnalyticsManagedViewSet(BaseTest):
         viewset.sync_views()
 
         views = self._views(viewset)
-        self.assertEqual(len(views), 1)
-        view = views[0]
-        self.assertEqual(view.name, self.VIEW_NAME)
-        self.assertFalse(view.is_materialized)
-        self.assertIsNone(view.sync_frequency_interval)
+        self.assertEqual({view.name for view in views}, self.VIEW_NAMES)
+        for view in views:
+            self.assertFalse(view.is_materialized)
+            self.assertIsNone(view.sync_frequency_interval)
         # A non-materialized view is computed at query time — it must never be scheduled for
         # materialization, nor get a managed (revenue-analytics) DAG.
         mock_schedule.assert_not_called()
@@ -359,8 +364,8 @@ class TestEngineeringAnalyticsManagedViewSet(BaseTest):
         viewset.sync_views()
         second = self._views(viewset)
 
-        self.assertEqual(len(first), 1)
-        self.assertEqual([v.id for v in first], [v.id for v in second])
+        self.assertEqual({v.name for v in first}, self.VIEW_NAMES)
+        self.assertEqual(sorted(v.id for v in first), sorted(v.id for v in second))
 
     @patch(SCHEDULE_MATERIALIZATION)
     def test_sync_views_creates_nothing_without_qualifying_source(self, _):


### PR DESCRIPTION
## Problem

Backend CI on master has been red since 08:05 UTC today (`Product tests (data-warehouse (1/2))`), failing every PR that includes both of these merges:

- #70431 added `TestEngineeringAnalyticsManagedViewSet`, asserting `sync_views()` creates exactly **one** view (`engineering_analytics_job_costs`).
- #70556 (merged in parallel) made the engineering-analytics viewset expose **three** views (`job_costs`, `ci_job_history`, `ci_failures`) behind the same qualifying-source gate.

Each PR was green on its own branch; combined on master, `test_sync_views_creates_non_materialized_view` and `test_sync_views_is_idempotent` fail with `AssertionError: 3 != 1`.

## Changes

Assert on the set of expected view names instead of a count of one, per the SPEC's "they appear together or not at all" contract. The same guards still hold for every view: non-materialized, no sync schedule, materialization never scheduled, no managed DAG, idempotent re-sync, and nothing created without a qualifying source.

## How did you test this code?

`hogli test products/data_warehouse/backend/models/test/test_managed_viewset.py` – 17 passed (was 2 failing on master). No new tests; this realigns the two stale assertions with the intended three-view behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) with Sinan directing, while chasing a red check on an unrelated PR (#70418). Root-caused the master breakage to the #70431/#70556 merge race, confirmed master itself fails at the same commit, and reproduced locally before fixing. Skills invoked: /debugging-ci-failures, /writing-tests.
