### PR TITLE
fix(docker): add common/alerting to llm-analytics worker image

### DIFF
--- a/Dockerfile.llm-analytics
+++ b/Dockerfile.llm-analytics
@@ -50,6 +50,7 @@ COPY manage.py manage.py
 COPY common/esbuilder common/esbuilder
 COPY common/hogvm common/hogvm/
 COPY common/migration_utils common/migration_utils/
+COPY common/alerting common/alerting/
 COPY posthog posthog/
 COPY products/ products/
 COPY ee ee/


### PR DESCRIPTION
## Problem

`temporal-worker-llm-analytics` on dev has been failing every ArgoCD sync since this morning (deploy-failed alert at 08:37 UTC, 2026-07-14). The migration-check PreSync hook crashes on Django startup:

```
ModuleNotFoundError: No module named 'common.alerting'
```

Import chain: `posthog/urls.py` → rest_router → `products/logs/backend/routes.py` → `alerts_api.py` → `alert_state_machine.py` → `from common.alerting.state_machine import …`.

What happened:

- #68936 (Jul 13, 21:21 UTC) created `common/alerting` and made products/logs import it, but didn't add it to any Docker build.
- #70586 (Jul 14, 02:04 UTC, mendral-app[bot]) fixed the **root** `Dockerfile` + `.dockerignore` — but `Dockerfile.llm-analytics` maintains its own `COPY common/…` list and was missed.
- The breakage lay dormant until #64651 touched `start_temporal_worker.py` (on `cd-llm-analytics-image.yml`'s path filter), triggering the first llm-analytics image rebuild with the new import. That image lacks `common/alerting`, so the hook Job dies, the sync fails 3×, and the deploy gate times out.

Re-building from any current commit fails identically until this lands.

## Changes

One line: copy `common/alerting` into the llm-analytics worker image, mirroring the root `Dockerfile` (`.dockerignore` already allowlists it via #70586).

Merging this self-triggers a rebuild (`Dockerfile.llm-analytics` is on the workflow's path filter), which should let the dev app sync.

Non-blocking follow-up worth considering: the runtime `common.*` imports reachable from Django are exactly `{alerting, hogvm, migration_utils}` (verified by grep), so this image is complete after this change — but the next new `common/` package will hit the same trap. An image-boot smoke test on this Dockerfile (like the root image's post-build verification) would catch it at build time instead of at deploy time.

## How did you test this code?

Verified the failure mode from git history and the Argo sync events: the image at `a41c01928b` contains `products/logs` importing `common.alerting` while its Dockerfile never copies it; the root `Dockerfile` fix in #70586 is the exact same change for the main image. Grepped all `common.*` runtime imports to confirm no other package is missing from the COPY list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)