### PR TITLE
chore(agents): add repo skill for analyzing insights across teams

### DIFF
--- a/.agents/skills/analyzing-insights-across-teams/SKILL.md
+++ b/.agents/skills/analyzing-insights-across-teams/SKILL.md
@@ -20,6 +20,9 @@ production Postgres tables are replicated into the project's data warehouse,
 so cross-team entity metadata **is** queryable with `posthog:execute-sql`.
 Do not stop at `system.insights` when the question spans teams.
 
+This skill is deliberately repo-local (`.agents/skills/`): it documents PostHog's internal dogfood setup,
+applies only to agents working in this repo, and must not move into the packaged `products/*/skills/` bundle that ships to every team.
+
 ## Synced tables
 
 | Entity           | US (prod-us)                     | EU (prod-eu)                        |
@@ -48,21 +51,29 @@ Do not stop at `system.insights` when the question spans teams.
    WHERE table_name = 'postgres.posthog_dashboarditem'
    ```
 
-2. Query with `posthog:execute-sql`, filtering or grouping by `team_id`. Join `postgres.posthog_team` for team names. Example — most active teams by insights created in the last 30 days:
+2. Query with `posthog:execute-sql`, filtering or grouping by `team_id`. Example — most active teams by insights created in the last 30 days:
 
    ```sql
-   SELECT i.team_id, any(t.name) AS team_name, count() AS insights_created
-   FROM postgres.posthog_dashboarditem AS i
-   LEFT JOIN postgres.posthog_team AS t ON t.id = i.team_id
-   WHERE NOT i.deleted AND i.saved AND i.created_at >= now() - INTERVAL 30 DAY
-   GROUP BY i.team_id
+   SELECT team_id, count() AS insights_created
+   FROM postgres.posthog_dashboarditem
+   WHERE NOT deleted AND saved AND created_at >= now() - INTERVAL 30 DAY
+   GROUP BY team_id
    ORDER BY insights_created DESC
    LIMIT 20
    ```
 
+   Join `postgres.posthog_team` on `id = team_id` for team names only when the output stays on an internal surface (see below).
+
 3. Remember the sync lag: these are periodic replicas, not live reads — fine for analysis, not for "right now" state.
 
-## Caveats
+## Output handling (required)
 
-- Query results may contain customer team names and metadata — keep them out of public surfaces (PR descriptions, commit messages, uploaded screenshots).
+Rows in these tables are customer data: team names, insight names, descriptions, and queries.
+
+- Never put customer team names, insight titles, or other row-level metadata on public surfaces — PR titles/descriptions, commit messages, issues, code comments, or uploaded screenshots. Aggregates and `team_id`-level figures without names are the ceiling for public copy.
+- Keep named results in the private conversation, internal docs, or auth-gated links.
+- Access is gated by membership in the internal dogfood project. If a query fails with a permissions error, report it and stop — do not look for another route to cross-team data.
+
+## Related
+
 - For cross-team **event/analytics** data (not entity metadata), see the `query-clickhouse-via-metabase` skill instead.

--- a/.agents/skills/analyzing-insights-across-teams/SKILL.md
+++ b/.agents/skills/analyzing-insights-across-teams/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: analyzing-insights-across-teams
+description: >
+  Analyze PostHog insights, dashboards, or teams beyond the current project by
+  querying the prod Postgres replicas synced into the dogfood data warehouse
+  (US project 2, "PostHog App + Website"). Use when asked to analyze insights
+  across all teams or projects, another team's insights, or fleet-wide
+  insight/dashboard usage — cases where `system.insights` only returns the
+  current project's rows and the agent would otherwise report the data as
+  inaccessible. Covers the synced table names for US and EU and the
+  column-verification workflow.
+---
+
+# Analyzing insights across teams
+
+`system.*` entity tables (e.g. `system.insights`) are scoped to the current project,
+and the generic `execute-sql` guidance says other teams' data is inaccessible.
+For the dogfood project (US project 2) that is not the whole story:
+production Postgres tables are replicated into the project's data warehouse,
+so cross-team entity metadata **is** queryable with `posthog:execute-sql`.
+Do not stop at `system.insights` when the question spans teams.
+
+## Synced tables
+
+| Entity           | US (prod-us)                     | EU (prod-eu)                        |
+| ---------------- | -------------------------------- | ----------------------------------- |
+| Insights         | `postgres.posthog_dashboarditem` | `eu_postgres_posthog_dashboarditem` |
+| Dashboards       | `postgres.posthog_dashboard`     | `eu_postgres_posthog_dashboard`     |
+| Teams / projects | `postgres.posthog_team`          | `eu_postgres_posthog_team`          |
+
+- Underscore aliases (e.g. `postgres_posthog_dashboarditem`) point at the same synced data.
+- These are replicas of the Django tables in this repo (`posthog_dashboarditem` backs the `Insight` model), so rows span every team; `team_id` is the scoping column.
+- More prod tables than these are synced. Before concluding cross-team data is inaccessible, check the catalog:
+
+  ```sql
+  SELECT table_name, description
+  FROM system.information_schema.tables
+  WHERE table_type = 'data_warehouse' AND table_name ILIKE '%postgres%'
+  ```
+
+## Workflow
+
+1. Confirm columns before projecting — synced schemas drift with the Django models:
+
+   ```sql
+   SELECT column_name, data_type
+   FROM system.information_schema.columns
+   WHERE table_name = 'postgres.posthog_dashboarditem'
+   ```
+
+2. Query with `posthog:execute-sql`, filtering or grouping by `team_id`. Join `postgres.posthog_team` for team names. Example — most active teams by insights created in the last 30 days:
+
+   ```sql
+   SELECT i.team_id, any(t.name) AS team_name, count() AS insights_created
+   FROM postgres.posthog_dashboarditem AS i
+   LEFT JOIN postgres.posthog_team AS t ON t.id = i.team_id
+   WHERE NOT i.deleted AND i.saved AND i.created_at >= now() - INTERVAL 30 DAY
+   GROUP BY i.team_id
+   ORDER BY insights_created DESC
+   LIMIT 20
+   ```
+
+3. Remember the sync lag: these are periodic replicas, not live reads — fine for analysis, not for "right now" state.
+
+## Caveats
+
+- Query results may contain customer team names and metadata — keep them out of public surfaces (PR descriptions, commit messages, uploaded screenshots).
+- For cross-team **event/analytics** data (not entity metadata), see the `query-clickhouse-via-metabase` skill instead.

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -37,9 +37,7 @@ SELECT id, name, short_id FROM system.insights WHERE NOT deleted LIMIT 10
 SELECT count() AS total FROM system.insight_variables
 ```
 
-All entities are scoped by a team by default. You cannot access another team's data through `system.*` tables unless you switch teams.
-One exception: another team's or instance's data may have been replicated into this project's data warehouse (e.g. a Postgres source syncing those tables).
-Before concluding cross-team data is inaccessible, list warehouse tables via `system.information_schema.tables` (`table_type = 'data_warehouse'`) and check whether a synced table covers it.
+All entities are scoped by a team by default. You cannot access data of another team unless you switch a team.
 
 ##### 2. Captured Data (Analytics Data)
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -37,7 +37,9 @@ SELECT id, name, short_id FROM system.insights WHERE NOT deleted LIMIT 10
 SELECT count() AS total FROM system.insight_variables
 ```
 
-All entities are scoped by a team by default. You cannot access data of another team unless you switch a team.
+All entities are scoped by a team by default. You cannot access another team's data through `system.*` tables unless you switch teams.
+One exception: another team's or instance's data may have been replicated into this project's data warehouse (e.g. a Postgres source syncing those tables).
+Before concluding cross-team data is inaccessible, list warehouse tables via `system.information_schema.tables` (`table_type = 'data_warehouse'`) and check whether a synced table covers it.
 
 ##### 2. Captured Data (Analytics Data)
 


### PR DESCRIPTION
## TL;DR

When asked to "analyze insights across all teams", agents working in this repo stop at the current project's insights because the SQL guidance tells them other teams' data is inaccessible. In the dogfood project it *is* accessible — prod Postgres replicas (insights, dashboards, teams, US + EU) are synced into the data warehouse. This PR adds a repo-local skill telling agents exactly that, without changing the guidance every customer's agents see.

## Problem

The `querying-posthog-data` guidelines (inlined into the `execute-sql` tool description) state that another team's data cannot be accessed. That's correct as a general rule, but for agents working in this repo against the dogfood project it causes refused or incomplete cross-team insight analysis, because the synced warehouse replicas cover that data. An earlier revision of this PR relaxed the general guideline; per feedback this should be repo-scoped only, so that change is reverted here.

## Changes

- New repo-local skill `.agents/skills/analyzing-insights-across-teams/SKILL.md`: names the synced tables (US `postgres.posthog_*`, EU `eu_postgres_posthog_*`), the column-verification workflow, a validated example query, sync-lag and public-surface caveats.
- Revert of the earlier guideline edit in `products/posthog_ai/skills/querying-posthog-data/references/guidelines.md` (back to master's wording).

## How did you test this code?

Docs/skill-only change. The example query and table names were validated live against the dogfood project's warehouse via `execute-sql` (catalog lookup through `system.information_schema.tables`, then the example aggregation). The skill's frontmatter was picked up by the agent harness skill list in-session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — the change is itself agent-facing documentation, scoped to this repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Produced with PostHog Code. Investigated why agents refuse cross-team insight analysis: traced the behavior to the team-scoping sentence in the `execute-sql` guidance, and confirmed via live `information_schema` queries that warehouse-synced replicas of the relevant prod tables exist and are queryable. First attempt edited the shared guidelines; reverted after feedback to keep the rule general and scope the exception to this repo as a `.agents/skills/` skill. Skills invoked: /writing-skills.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
