### PR TITLE
feat(workflows): verify caller identity on push registration

### DIFF
--- a/products/messaging/backend/api/push_identity_tokens.md
+++ b/products/messaging/backend/api/push_identity_tokens.md
@@ -1,0 +1,60 @@
+# Push subscription identity verification
+
+Securing the binding of a mobile push device token to a `distinct_id`, so an attacker who only holds
+the (public, app-embedded) project token cannot point another user's notifications at their own device.
+
+## Why this is needed
+
+A push device token (FCM registration token / APNs device token) is a delivery **address**, not a
+credential — FCM/APNs issue one to any app instance, and an attacker owns their own token legitimately.
+Possession proves "deliver here", never "this device belongs to user X". Today `POST /api/push_subscriptions`
+authenticates with the **public project token**, which identifies the project but not the person, so any
+holder of it can register a device under an arbitrary `distinct_id` (notification takeover / "rebind").
+
+This mirrors what leading platforms do: the fix must require a server-attested proof that the caller may
+act for that `distinct_id`. Braze's "SDK Authentication" is the reference design — the customer's backend
+mints a short-lived signed JWT whose subject is the user id, and the platform verifies it. (Customer.io and
+Brevo/WonderPush "trust the client" and do **not** defend against this — the state we're leaving behind.)
+
+## The token
+
+A short-lived **JWT (HS256)** signed with the project's **secret API key** (`Team.secret_api_token`).
+Minted by the **customer's backend** (the only party that authenticated the end user), never in the app.
+
+| Claim    | Value                                                    |
+| -------- | -------------------------------------------------------- |
+| `sub`    | the `distinct_id` being registered                       |
+| `app_id` | the FCM `project_id` / APNs `bundle_id` the token is for |
+| `aud`    | `posthog:push_identity`                                  |
+| `exp`    | short expiry (SDK refreshes on failure)                  |
+
+Verification accepts the current **or** backup secret, so a key rotation doesn't reject in-flight tokens.
+`sub` and `app_id` are both bound, so a token minted for one identity/app can't authorize another.
+
+Reference signer + verifier: `push_identity_tokens.py` (`sign_push_identity_token` shows exactly what the
+customer backend produces; PostHog's ingestion only ever calls `verify_push_identity_token`).
+
+## Flow
+
+1. Customer backend authenticates the user, then mints the token for `(distinct_id, app_id)` with the
+   project secret key.
+2. The app receives the token and calls `POST /api/push_subscriptions` with the usual fields plus
+   `identity_token`.
+3. The endpoint verifies the signature, `exp`, and that `sub`/`app_id` match the registration.
+
+## Rollout — per integration, three stages
+
+Set `push_identity_verification` in the Firebase/APNs integration's `config` (mirrors Braze's staged
+rollout so it can be turned on without breaking existing traffic):
+
+- **`disabled`** (default) — `identity_token` ignored; current behavior.
+- **`optional`** — token is verified and the outcome recorded (`push_subscription_identity_verification`
+  metric, labelled by `mode`/`outcome`), but registration still succeeds. Use this to confirm the backend
+  is minting valid tokens before enforcing.
+- **`required`** — a registration without a valid token is rejected (`401`).
+
+## Not covered here (follow-ups)
+
+- SDK support for attaching `identity_token` and refreshing it on a verification-failure callback.
+- A Channels UI control for the per-integration mode (today it's a `config` value).
+- Clearing the binding on logout (an SDK/endpoint concern, analogous to Customer.io `clearIdentify`).

--- a/products/messaging/backend/api/push_identity_tokens.py
+++ b/products/messaging/backend/api/push_identity_tokens.py
@@ -1,0 +1,82 @@
+"""
+Signed identity tokens for push subscription registration.
+
+A push device token (FCM registration token / APNs device token) is a delivery *address*, not a
+credential: FCM/APNs hand a token to any app instance that registers, and an attacker owns their own
+token legitimately. So possession of a token proves "deliver to this device" — never "this device
+belongs to user X". Binding a token to a `distinct_id` therefore needs proof that the caller is
+allowed to act for that `distinct_id`. The public project token can't provide it: it is embedded in
+the mobile app and world-readable, so anyone can present it and claim any `distinct_id`.
+
+Following the pattern proven by Braze's "SDK Authentication", the customer's backend — the only party
+that actually authenticated the end user — mints a short-lived token asserting the user's
+`distinct_id`, signed with the project's secret API key. PostHog re-verifies the signature at
+registration time. An attacker holding only the public project token cannot forge it.
+
+We use symmetric HMAC (HS256) keyed by `Team.secret_api_token` rather than an asymmetric key pair:
+PostHog verifies its own ingestion, so there is no third-party verifier that would need a public key,
+and the secret already ships with built-in rotation via `secret_api_token_backup`. Verification
+accepts either the current or the backup secret so a key rotation doesn't reject in-flight tokens.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from posthog.models.team.team import Team
+
+PUSH_IDENTITY_TOKEN_AUDIENCE = "posthog:push_identity"
+_ALGORITHM = "HS256"
+
+# Short TTL: the token only needs to survive the round trip from the customer's backend, through the
+# app, to the registration call. Keeping it small bounds the replay window (a replay can only re-assert
+# the same (distinct_id, app_id) binding the legitimate user already holds, so the value is low anyway).
+DEFAULT_TTL = timedelta(minutes=5)
+
+
+def sign_push_identity_token(
+    secret_api_token: str,
+    distinct_id: str,
+    app_id: str,
+    ttl: timedelta = DEFAULT_TTL,
+) -> str:
+    """Mint a signed identity token.
+
+    This is the reference implementation of what the *customer's backend* runs after it has
+    authenticated the end user. It is not called by PostHog's own ingestion (which only verifies);
+    it lives here so the signing and verification rules stay in one place and the tests can exercise
+    the real round trip.
+    """
+    return jwt.encode(
+        {
+            "sub": distinct_id,
+            "app_id": app_id,
+            "aud": PUSH_IDENTITY_TOKEN_AUDIENCE,
+            "exp": datetime.now(UTC) + ttl,
+        },
+        secret_api_token,
+        algorithm=_ALGORITHM,
+    )
+
+
+def verify_push_identity_token(token: str, team: Team, distinct_id: str, app_id: str) -> bool:
+    """Return True iff `token` is a valid, unexpired identity assertion for exactly this
+    `(distinct_id, app_id)`, signed by the team's current or backup secret API key.
+
+    Binding the claim to `app_id` as well as `distinct_id` stops a token minted for one app being
+    replayed to register a device under a different app in the same project.
+    """
+    candidate_secrets = [secret for secret in (team.secret_api_token, team.secret_api_token_backup) if secret]
+    for secret in candidate_secrets:
+        try:
+            payload = jwt.decode(
+                token,
+                secret,
+                algorithms=[_ALGORITHM],
+                audience=PUSH_IDENTITY_TOKEN_AUDIENCE,
+            )
+        except jwt.InvalidTokenError:
+            continue
+        if payload.get("sub") == distinct_id and payload.get("app_id") == app_id:
+            return True
+    return False

--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
+from prometheus_client import Counter
 from rest_framework import status
 from rest_framework.request import Request
 
@@ -20,7 +21,22 @@ from posthog.models.team.team import Team
 from posthog.utils import load_data_from_request
 from posthog.utils_cors import cors_response
 
+from products.messaging.backend.api.push_identity_tokens import verify_push_identity_token
+
 VALID_PLATFORMS = ("android", "ios")
+
+# Per-integration enforcement for the signed identity token (see push_identity_tokens.py). Rolled out
+# in three stages, mirroring Braze's SDK-Authentication rollout so it can be enabled without breaking
+# existing traffic:
+#   "disabled" — default; the token is ignored (current behavior).
+#   "optional" — the token is verified and the outcome recorded, but registration still succeeds.
+#                Lets a customer confirm their backend is minting valid tokens before enforcing.
+#   "required" — an unsigned or invalid registration for a distinct_id is rejected.
+PUSH_IDENTITY_VERIFICATION_COUNTER = Counter(
+    "push_subscription_identity_verification",
+    "Outcome of push subscription identity-token verification, by enforcement mode.",
+    labelnames=["mode", "outcome"],
+)
 
 # A device registration payload is a handful of short string fields (distinct_id, device_token,
 # platform, app_id, api_key) — well under 1 KiB. Cap the raw request body far above that but far below
@@ -41,7 +57,7 @@ def _find_integration(team_id: int, app_id: str) -> Integration | None:
     return (
         Integration.objects.filter(team_id=team_id)
         .filter(Q(kind="firebase", config__project_id=app_id) | Q(kind="apns", config__bundle_id=app_id))
-        .only("id")
+        .only("id", "config")
         .first()
     )
 
@@ -184,6 +200,32 @@ def push_subscriptions(request: Request):
                 status_code=status.HTTP_400_BAD_REQUEST,
             ),
         )
+
+    # A device token is a delivery address, not a credential — the public project token authenticates
+    # the project, never the person. Require a signed assertion (minted by the customer's backend with
+    # the project secret key) that the caller may bind this distinct_id, so an attacker with only the
+    # public token can't point a victim's notifications at their own device. See push_identity_tokens.py.
+    verification_mode = integration.config.get("push_identity_verification", "disabled")
+    if verification_mode in ("optional", "required"):
+        identity_token = data.get("identity_token")
+        verified = isinstance(identity_token, str) and verify_push_identity_token(
+            identity_token, team, distinct_id, app_id
+        )
+        PUSH_IDENTITY_VERIFICATION_COUNTER.labels(
+            mode=verification_mode, outcome="verified" if verified else "unverified"
+        ).inc()
+        if not verified and verification_mode == "required":
+            return cors_response(
+                request,
+                generate_exception_response(
+                    "push_subscriptions",
+                    "A valid identity token is required to register this device. Your backend must mint "
+                    "one for the signed-in user with the project's secret API key.",
+                    type="authentication_error",
+                    code="identity_verification_failed",
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                ),
+            )
 
     encrypted_token = _encrypted_fields.encrypt(device_token)
     property_key = f"$device_push_subscription_{app_id}"

--- a/products/messaging/backend/api/test/test_push_identity_tokens.py
+++ b/products/messaging/backend/api/test/test_push_identity_tokens.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.models.team.team import Team
+
+from products.messaging.backend.api.push_identity_tokens import sign_push_identity_token, verify_push_identity_token
+
+# Realistic length (>= 32 bytes) — matches a real phs_ secret and avoids PyJWT's short-key warning.
+CURRENT_SECRET = "phs_current_secret_0123456789abcdef0123"
+BACKUP_SECRET = "phs_backup_secret_0123456789abcdef01234"
+DISTINCT_ID = "user-1"
+APP_ID = "my-firebase-project"
+
+
+class TestPushIdentityTokens(SimpleTestCase):
+    def _team(self, secret: str | None = CURRENT_SECRET, backup: str | None = None) -> Team:
+        return Team(secret_api_token=secret, secret_api_token_backup=backup)
+
+    def test_verifies_a_token_signed_with_the_current_secret(self):
+        token = sign_push_identity_token(CURRENT_SECRET, DISTINCT_ID, APP_ID)
+        assert verify_push_identity_token(token, self._team(), DISTINCT_ID, APP_ID) is True
+
+    def test_verifies_a_token_signed_with_the_backup_secret_after_rotation(self):
+        token = sign_push_identity_token(BACKUP_SECRET, DISTINCT_ID, APP_ID)
+        team = self._team(secret=CURRENT_SECRET, backup=BACKUP_SECRET)
+        assert verify_push_identity_token(token, team, DISTINCT_ID, APP_ID) is True
+
+    @parameterized.expand(
+        [
+            ("wrong_distinct_id", "someone-else", APP_ID),
+            ("wrong_app_id", DISTINCT_ID, "other-app"),
+        ]
+    )
+    def test_rejects_a_token_whose_claims_do_not_match_the_registration(self, _name, sub, app_id):
+        # The rebind guard: a token minted for one (distinct_id, app_id) cannot authorize a different one.
+        token = sign_push_identity_token(CURRENT_SECRET, sub, app_id)
+        assert verify_push_identity_token(token, self._team(), DISTINCT_ID, APP_ID) is False
+
+    def test_rejects_a_token_signed_with_a_different_secret(self):
+        token = sign_push_identity_token("phs_attacker_secret_0123456789abcdef012", DISTINCT_ID, APP_ID)
+        assert verify_push_identity_token(token, self._team(), DISTINCT_ID, APP_ID) is False
+
+    def test_rejects_an_expired_token(self):
+        token = sign_push_identity_token(CURRENT_SECRET, DISTINCT_ID, APP_ID, ttl=timedelta(seconds=-1))
+        assert verify_push_identity_token(token, self._team(), DISTINCT_ID, APP_ID) is False
+
+    def test_rejects_a_malformed_token(self):
+        assert verify_push_identity_token("not-a-jwt", self._team(), DISTINCT_ID, APP_ID) is False
+
+    def test_rejects_when_the_team_has_no_secret_configured(self):
+        token = sign_push_identity_token(CURRENT_SECRET, DISTINCT_ID, APP_ID)
+        assert verify_push_identity_token(token, self._team(secret=None), DISTINCT_ID, APP_ID) is False

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -10,6 +10,9 @@ from rest_framework import status
 
 from posthog.models.integration import Integration
 from posthog.models.team.team import Team
+from posthog.models.team.team_caching import set_team_in_cache
+
+from products.messaging.backend.api.push_identity_tokens import sign_push_identity_token
 
 
 class TestPushSubscriptionsAPI(BaseTest):
@@ -253,3 +256,87 @@ class TestPushSubscriptionsAPI(BaseTest):
 
         assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
         mock_capture.assert_not_called()
+
+    SECRET = "phs_project_secret_0123456789abcdef0123"
+
+    def _enable_identity_verification(self, mode: str):
+        self.firebase_integration.config["push_identity_verification"] = mode
+        self.firebase_integration.save()
+        self.team.secret_api_token = self.SECRET
+        self.team.save()
+        # The endpoint reads the team (and its secret) from cache; refresh it so the secret is present.
+        set_team_in_cache(self.team.api_token, self.team)
+
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_required_mode_accepts_a_valid_identity_token(self, mock_capture: MagicMock):
+        mock_capture.return_value = MagicMock(status_code=200)
+        self._enable_identity_verification("required")
+        token = sign_push_identity_token(self.SECRET, "user-1", "my-firebase-project")
+
+        response = self._post(
+            {
+                "distinct_id": "user-1",
+                "device_token": "fcm-device-token-abc",
+                "platform": "android",
+                "app_id": "my-firebase-project",
+                "identity_token": token,
+            }
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_capture.assert_called_once()
+
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_required_mode_rejects_registration_without_a_token(self, mock_capture: MagicMock):
+        self._enable_identity_verification("required")
+
+        response = self._post(
+            {
+                "distinct_id": "user-1",
+                "device_token": "fcm-device-token-abc",
+                "platform": "android",
+                "app_id": "my-firebase-project",
+            }
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        mock_capture.assert_not_called()
+
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_required_mode_rejects_a_token_minted_for_another_distinct_id(self, mock_capture: MagicMock):
+        # The rebind attack: an attacker can only mint a token for their own distinct_id, so it can't
+        # authorize binding a device under the victim's distinct_id.
+        self._enable_identity_verification("required")
+        attacker_token = sign_push_identity_token(self.SECRET, "attacker", "my-firebase-project")
+
+        response = self._post(
+            {
+                "distinct_id": "victim",
+                "device_token": "attacker-device-token",
+                "platform": "android",
+                "app_id": "my-firebase-project",
+                "identity_token": attacker_token,
+            }
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        mock_capture.assert_not_called()
+
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_optional_mode_stores_even_without_a_token(self, mock_capture: MagicMock):
+        # Monitor mode verifies and records the outcome but must not block delivery, so a customer can
+        # confirm their backend is minting valid tokens before switching to required.
+        mock_capture.return_value = MagicMock(status_code=200)
+        self._enable_identity_verification("optional")
+
+        response = self._post(
+            {
+                "distinct_id": "user-1",
+                "device_token": "fcm-device-token-abc",
+                "platform": "android",
+                "app_id": "my-firebase-project",
+            }
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_capture.assert_called_once()


### PR DESCRIPTION
## Problem

Follow-up to #65807, closing the one security finding we left open there: **"High: untrusted callers can rebind push subscriptions."**

A push device token (FCM registration token / APNs device token) is a delivery **address**, not a credential. FCM/APNs hand a token to any app instance, and an attacker owns their own token legitimately, so possession proves "deliver to this device" and never "this device belongs to user X". Today `POST /api/push_subscriptions` authenticates with the **public project token**, which is embedded in the app and world-readable. It identifies the project, not the person. So anyone with it can register their own device under a victim's `distinct_id` and receive that user's workflow push notifications (notification takeover).

This is a hard blocker before push goes GA. It doesn't affect the merged PR while push stays gated (no delivery yet), but it has to close before we turn delivery on.

> [!NOTE]
> This is a draft of what the fix should ideally look like. The backend half is here and testable. The mobile SDK half (attaching and refreshing the token) is a separate piece owned by the SDK team, and the SDK is still in development, so we can shape its contract now.

## Changes

I researched how the leading messaging platforms solve this. **Braze's "SDK Authentication"** is the reference design and the only one of the three I looked at that actually defends against the attack: the customer's backend (the only party that authenticated the end user) mints a short-lived signed token whose subject is the user id, and the platform verifies it. **Customer.io** and **Brevo/WonderPush** both "trust the client" - the client asserts the identity with no signature - which is exactly the hole we have now.

This PR adapts that pattern to PostHog's primitives:

- **Signed identity token** (`push_identity_tokens.py`). A short-lived JWT (HS256) signed with the project's **secret API key** (`Team.secret_api_token`), minted by the customer's backend, asserting `sub = distinct_id` and `app_id`. PostHog re-verifies it at registration. An attacker with only the public token can't forge it. Verification accepts the current **or** backup secret, so a key rotation doesn't reject in-flight tokens.
- **Graduated per-integration enforcement** on the endpoint (`push_identity_verification` in the Firebase/APNs integration `config`), mirroring Braze's staged rollout so it can be turned on without breaking existing traffic:

| Mode | Behavior |
| --- | --- |
| `disabled` (default) | token ignored - current behavior, nothing breaks |
| `optional` | token verified and outcome recorded (`push_subscription_identity_verification` metric), but registration still succeeds - lets a customer confirm their backend mints valid tokens before enforcing |
| `required` | a registration without a valid token is rejected (`401`) |

- A short integration doc (`push_identity_tokens.md`) describing the token, claims, flow, and rollout for the SDK/backend teams.

I chose symmetric HMAC over an asymmetric key pair (Braze uses RS256) because PostHog verifies its own ingestion - there's no third-party verifier that needs a public key - and the secret already ships with rotation. I also considered gating the endpoint behind a Project Secret API Key (PSAK), but PSAK auth is wired for team-scoped DRF viewsets, and this is a capture-style function view on `/api/push_subscriptions`. Signing keeps the SDK as the direct caller (good DX) while still requiring server-side proof.

**Before** - any holder of the public token can bind a victim's `distinct_id`:

```mermaid
flowchart LR
    App[App: public project token]:::phRed -->|"distinct_id + device_token"| EP["/api/push_subscriptions"]:::phYellow
    EP --> Store[(store token on person)]:::phGray
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
```

**After** (`required` mode) - only a backend-signed assertion can bind a `distinct_id`:

```mermaid
flowchart LR
    BE[Customer backend: authenticated user + secret key]:::phBlue -->|"mint signed identity_token"| App[App: public token]:::phRed
    App -->|"distinct_id + device_token + identity_token"| EP["/api/push_subscriptions"]:::phYellow
    EP -->|"verify sig, exp, sub==distinct_id"| Store[(store token on person)]:::phGray
    EP -->|"missing / invalid / wrong sub"| Reject[401]:::phRed
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
```

## How did you test this code?

I (Claude) could not run the suite in this environment - no Django install available - so these tests have **not** run locally yet and I'm relying on CI to execute them. They are:

- `test_push_identity_tokens.py` (pure `SimpleTestCase`, no DB): the signature/claim matrix on `verify_push_identity_token` - valid current-secret and backup-secret tokens pass; wrong `sub`, wrong `app_id`, wrong secret, expired, malformed, and no-secret-configured all fail. Catches any regression that would let a token authorize a `(distinct_id, app_id)` it wasn't minted for (the core rebind guard) or wrongly reject a valid one.
- `test_push_subscriptions.py` (endpoint wiring guards): `required` mode accepts a valid token (200) and rejects both a missing token and **a token minted for a different `distinct_id`** (401, capture never called - the actual attack); `optional` mode stores even without a token (monitor mode must not block). These prove the mode wiring end to end, which the pure tests can't.

Invoked `/writing-tests` before writing them and pushed the claim matrix down to the pure `SimpleTestCase` per its guidance, keeping the endpoint tests as thin wiring guards.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Included an in-repo integration doc (`push_identity_tokens.md`). No user-facing posthog.com docs yet - the customer-facing setup doc should land with the SDK support and the Channels UI toggle.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - directed by @dmarchuk, who should be the DRI/assignee (the create-PR tool couldn't set the assignee, so please assign yourself).

Authored by Claude ([session](https://claude.ai/code/session_01Bbav6vE7Tm24KkdRhZmvNM)). Skills invoked: `/adding-project-secret-api-key-auth` (to understand PostHog's secret-credential primitives), `/writing-tests`, and I followed the `/improving-drf-endpoints` rule for the endpoint. A research subagent gathered how Customer.io, Braze, and Brevo handle device-token-to-user binding (official docs), which is what pointed to the Braze signed-assertion pattern as the one that actually defends against this.

Decisions along the way: considered PSAK-gating the endpoint (rejected - it's a function-view capture route, not a team-scoped viewset) and an asymmetric RS256 JWT like Braze (rejected - no third-party verifier here, and HMAC off the existing secret reuses its rotation). Landed on HMAC-signed short-lived tokens with a per-integration `disabled -> optional -> required` rollout so it's safe to enable incrementally.

Known follow-ups, called out in the doc: SDK support for attaching/refreshing the token, a Channels UI control for the per-integration mode (today it's a `config` value), and clearing the binding on logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbav6vE7Tm24KkdRhZmvNM)_