### PR TITLE
fix(hogli): don't crash ci:preflight on non-utf-8 check output

### DIFF
--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -202,7 +202,17 @@ def _run_diff_check(chk: DiffCheck, do_fix: bool) -> tuple[Status, str]:
     if shutil.which(cmd[0]) is None:
         return "skipped", f"{cmd[0]} not found"
     try:
-        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=_CHECK_TIMEOUT_SECONDS)
+        # errors="replace": a timed-out child's partial output can be cut mid-character, and a
+        # strict decode then raises UnicodeDecodeError from inside run() before the
+        # TimeoutExpired handler below ever sees it — crashing the whole preflight.
+        result = subprocess.run(
+            cmd,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            errors="replace",
+            timeout=_CHECK_TIMEOUT_SECONDS,
+        )
     except subprocess.TimeoutExpired:
         return "fail", f"`{cmd[0]}` timed out after {_CHECK_TIMEOUT_SECONDS}s"
     if result.returncode == 0:
@@ -225,7 +235,9 @@ _FETCH_TTL_SECONDS = 600  # skip re-fetching origin/master if refreshed this rec
 def _git_run(*args: str, timeout: float = 15.0) -> subprocess.CompletedProcess[str] | None:
     """Run a git command in the repo; None on OS error or timeout."""
     try:
-        return subprocess.run(["git", "-C", str(REPO_ROOT), *args], capture_output=True, text=True, timeout=timeout)
+        return subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args], capture_output=True, text=True, errors="replace", timeout=timeout
+        )
     except (OSError, subprocess.SubprocessError):
         return None
 

--- a/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import json
 
 import pytest
@@ -7,9 +8,26 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 from hogli.cli import cli
-from hogli_commands.ci_preflight import _staleness_risks
+from hogli_commands.ci_preflight import DiffCheck, _run_diff_check, _staleness_risks
 
 runner = CliRunner()
+
+
+class TestRunDiffCheck:
+    def test_survives_invalid_utf8_check_output(self) -> None:
+        # A timed-out (or otherwise misbehaving) child can emit output cut mid-character;
+        # a strict decode used to raise UnicodeDecodeError from inside subprocess.run —
+        # before the except clause could report the check — crashing preflight and, via
+        # the pre-push hook, blocking every push. The check must fail cleanly instead.
+        chk = DiffCheck(
+            key="bad-bytes",
+            label="emits invalid utf-8",
+            triggers=["*"],
+            verify=[sys.executable, "-c", r"import sys; sys.stdout.buffer.write(b'bad \xe2 byte'); sys.exit(1)"],
+        )
+        status, message = _run_diff_check(chk, do_fix=False)
+        assert status == "fail"
+        assert "bad" in message
 
 
 class TestKillSwitch:


### PR DESCRIPTION
## Problem

`hogli ci:preflight` crashes with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2` when a check subprocess emits output that isn't valid UTF-8 — most commonly a timed-out child whose partial output got cut mid-character. The decode happens inside `subprocess.run` (text mode is strict by default), so the exception escapes before the `TimeoutExpired` handler can report the check as failed.

Because the pre-push hook runs `ci:preflight --strict`, the crash blocks every push from the affected tree. Hit today on a plain two-file Python diff; also sent as `hogli devex:feedback`.

## Changes

- Decode check output and git output with `errors="replace"` in `_run_diff_check` and `_git_run`, so a mangled byte degrades to `�` in the failure message instead of crashing preflight.
- Regression test: a check whose command emits an invalid UTF-8 byte and exits nonzero now reports `fail` with its message, rather than raising.

## How did you test this code?

`hogli test tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py`: 12 passed (11 existing + the new one). The new test catches the realistic regression of someone removing `errors="replace"` from the subprocess call; before the fix it reproduces the crash exactly. Also verified `hogli ci:preflight --strict` goes green on the previously-crashing diff and that a real `git push` passes the pre-push hook with this fix in the tree.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None; behavior fix within the documented contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude (Claude Code) while pushing an unrelated notebooks test PR: the pre-push hook failed with this crash. Root-caused to the strict text-mode decode racing the timeout handler; fixed at both `subprocess.run` call sites rather than wrapping in a broad try/except, so genuine check failures still report their output.
