### PR TITLE
chore(ci): narrow and speed up product test sweeps

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -441,34 +441,39 @@ jobs:
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
-            - name: Compute schema cache key from merge-base
+            - name: Compute schema cache key
               id: schema-key
-              if: github.event_name == 'pull_request'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: |
-                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
-                  # The fetch-depth:1000 checkout + base-ref fetch above ensure the
-                  # full ancestry needed to find the divergence point is available.
-                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
-                  if [ -z "$MERGE_BASE" ]; then
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                      # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                      SCHEMA_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                      MIGRATION_REF="$SCHEMA_BASE"
+                  else
+                      # Product jobs run in parallel with the migration job on master,
+                      # so restore the previous push's schema and let pytest apply any delta.
+                      SCHEMA_BASE=$(git rev-parse HEAD^ 2>/dev/null || echo "")
+                      MIGRATION_REF=HEAD
+                  fi
+                  if [ -z "$SCHEMA_BASE" ]; then
                       echo "key=" >> $GITHUB_OUTPUT
                       echo "migrations_key=" >> $GITHUB_OUTPUT
-                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                      echo "::notice::schema base not found — schema cache will be skipped"
                       exit 0
                   fi
-                  # Exact branch-point key, kept as the fallback restore key below.
-                  echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
-                  # Shared key: hash merge-base schema inputs, not PR head, so PR migrations still
-                  # apply as the pytest delta. uv.lock covers third-party migration changes; the
-                  # postgres image is folded in so a server-version bump invalidates the key.
+                  # Exact base key, kept as the fallback restore key below.
+                  echo "key=posthog-schema-master-${SCHEMA_BASE}" >> $GITHUB_OUTPUT
+                  # Shared key: hash the schema inputs. On PRs this is the merge base;
+                  # on master it is HEAD, with the previous SHA key as a safe fallback
+                  # when the current push introduces a migration.
                   # Non-Django migration frameworks are excluded from this Postgres schema dump.
                   # SCHEMA_CACHE_EPOCH (workflow env) prefixes the key as a manual cache-bust knob.
-                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$MERGE_BASE" \
+                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$MIGRATION_REF" \
                       | grep -E '/migrations/[^/]+\.py$|^[0-9a-f]+ uv\.lock$' \
                       | grep -vE '/(clickhouse|async_migrations)/migrations/' \
                       | LC_ALL=C sort) || true
-                  PG_IMAGE=$(git show "${MERGE_BASE}:docker-compose.base.yml" 2>/dev/null \
+                  PG_IMAGE=$(git show "${MIGRATION_REF}:docker-compose.base.yml" 2>/dev/null \
                       | grep -m1 -E '^[[:space:]]*image:[[:space:]]*postgres:' | tr -d '[:space:]')
                   if [ -z "$MIG_FILES" ]; then
                       echo "migrations_key=" >> $GITHUB_OUTPUT
@@ -496,7 +501,7 @@ jobs:
                   # On PRs, use the path filter to detect legacy changes.
                   LEGACY_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.legacy }}
                   SCHEMA_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.schema }}
-                  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
+                  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || format('{0}^', github.sha) }}
                   TURBO_SCM_HEAD: ${{ github.sha }}
                   # Kill switch — drop comma-separated products from the matrix; empty = run all.
                   SKIP_PRODUCT_TESTS: ${{ vars.SKIP_PRODUCT_TESTS || '' }}
@@ -762,7 +767,7 @@ jobs:
                   bin/ci-wait-for-docker wait temporal
                   python manage.py register_temporal_search_attributes
             - name: Restore schema cache from master
-              if: ${{ github.event_name == 'pull_request' && needs.turbo-discover.outputs.schema_cache_key != '' }}
+              if: ${{ needs.turbo-discover.outputs.schema_cache_key != '' }}
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: schema.sql.gz
@@ -772,7 +777,7 @@ jobs:
                       ${{ needs.turbo-discover.outputs.schema_cache_key }}
             - name: Prime test_posthog from cached schema
               # No-op on cache miss; pytest --reuse-db falls back to a full migrate.
-              if: ${{ github.event_name == 'pull_request' }}
+              if: ${{ needs.turbo-discover.outputs.schema_cache_key != '' }}
               run: |
                   if [ ! -f schema.sql.gz ]; then
                       echo "::notice::Schema cache miss — pytest --reuse-db will run full migrations"

--- a/.github/scripts/turbo-discover-staleness.test.js
+++ b/.github/scripts/turbo-discover-staleness.test.js
@@ -12,10 +12,18 @@ const path = require('path')
 const {
     collectTestFiles,
     checkProductStaleness,
+    includeDependencyScopedProducts,
     productPrefix,
     productEffectiveCost,
     STALENESS_FALLBACK_SECONDS_PER_FILE,
 } = require('./turbo-discover')
+
+test('dependency-scoped products only join full sweeps when affected', () => {
+    const allProducts = ['experiments', 'signals', 'surveys']
+
+    assert.deepEqual(includeDependencyScopedProducts(allProducts, ['signals']), ['signals', 'surveys'])
+    assert.deepEqual(includeDependencyScopedProducts(allProducts, ['experiments']), allProducts)
+})
 
 test('productPrefix converts dashes to underscores', () => {
     assert.equal(productPrefix('warehouse-sources'), 'products/warehouse_sources/')

--- a/.github/scripts/turbo-discover-staleness.test.js
+++ b/.github/scripts/turbo-discover-staleness.test.js
@@ -10,6 +10,7 @@ const os = require('os')
 const path = require('path')
 
 const {
+    changedPathToProduct,
     collectTestFiles,
     checkProductStaleness,
     includeDependencyScopedProducts,
@@ -18,11 +19,24 @@ const {
     STALENESS_FALLBACK_SECONDS_PER_FILE,
 } = require('./turbo-discover')
 
+test('changedPathToProduct only maps known product paths', () => {
+    const products = new Set(['warehouse-sources', 'signals'])
+
+    assert.equal(changedPathToProduct('products/warehouse_sources/backend/models.py', products), 'warehouse-sources')
+    assert.equal(changedPathToProduct('products/signals/package.json', products), 'signals')
+    assert.equal(changedPathToProduct('products/unknown/backend/test.py', products), null)
+    assert.equal(changedPathToProduct('posthog/models/team.py', products), null)
+})
+
 test('dependency-scoped products only join full sweeps when affected', () => {
-    const allProducts = ['experiments', 'signals', 'surveys']
+    const allProducts = ['experiments', 'signals', 'surveys', 'warehouse-sources', 'web-analytics']
 
     assert.deepEqual(includeDependencyScopedProducts(allProducts, ['signals']), ['signals', 'surveys'])
-    assert.deepEqual(includeDependencyScopedProducts(allProducts, ['experiments']), allProducts)
+    assert.deepEqual(includeDependencyScopedProducts(allProducts, ['experiments', 'warehouse-sources']), [
+        'experiments',
+        'surveys',
+        'warehouse-sources',
+    ])
 })
 
 test('productPrefix converts dashes to underscores', () => {

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -53,6 +53,12 @@ const EXCLUDED_PATH_SEGMENTS = ['/temporal/']
 // the temporal durations must count toward product sizing so the product is sharded for that load —
 // otherwise a huge suite lands in one unsharded bucket and times out.
 const PRODUCTS_RUNNING_TEMPORAL_IN_JOB = new Set(['warehouse-sources'])
+
+// These products declare their non-product Python dependencies as Turbo task
+// inputs, so they do not need to join a full product sweep unless Turbo marks
+// them affected. Keep this list deliberately small: missing an input would skip
+// a product test that should have run.
+const DEPENDENCY_SCOPED_PRODUCTS = new Set(['experiments'])
 // Products that always get their own matrix entry instead of being packed with
 // others — isolates a flaky/hang-prone product so it can't cancel bucket-mates
 // at the job timeout. Trade-off: a dedicated runner.
@@ -132,6 +138,13 @@ function getIsolatedProducts(contractTasks) {
 
 function getAffectedTaskProducts(tasks) {
     return [...new Set(tasks.map((t) => packageToProduct(t.package.name)))].sort()
+}
+
+function includeDependencyScopedProducts(allProducts, affectedProducts) {
+    const affectedProductSet = new Set(affectedProducts)
+    return allProducts.filter(
+        (product) => !DEPENDENCY_SCOPED_PRODUCTS.has(product) || affectedProductSet.has(product)
+    )
 }
 
 function getAllProducts(testTasks) {
@@ -500,7 +513,15 @@ function buildMatrix(products, durations) {
 }
 
 // Exported for unit tests only — not part of the public API.
-module.exports = { collectTestFiles, checkProductStaleness, productPrefix, productEffectiveCost, STALENESS_COVERAGE_THRESHOLD, STALENESS_FALLBACK_SECONDS_PER_FILE }
+module.exports = {
+    collectTestFiles,
+    checkProductStaleness,
+    includeDependencyScopedProducts,
+    productPrefix,
+    productEffectiveCost,
+    STALENESS_COVERAGE_THRESHOLD,
+    STALENESS_FALLBACK_SECONDS_PER_FILE,
+}
 
 // --- Main ---
 if (require.main === module) {
@@ -511,10 +532,10 @@ const schemaChanged = process.env.SCHEMA_CHANGED === 'true'
 let allTestTasks, affectedTestTasks, affectedContractTasks, contractTasks
 try {
     allTestTasks = parseTurboTasks(runTurbo(['run', 'backend:test', '--dry-run=json']))
+    console.error(`Turbo affected base: ${process.env.TURBO_SCM_BASE || '(default)'}`)
+    console.error(`Turbo affected head: ${process.env.TURBO_SCM_HEAD || '(default)'}`)
+    affectedTestTasks = parseAffectedTasks(runTurbo(affectedArgs('backend:test')))
     if (!legacyChanged) {
-        console.error(`Turbo affected base: ${process.env.TURBO_SCM_BASE || '(default)'}`)
-        console.error(`Turbo affected head: ${process.env.TURBO_SCM_HEAD || '(default)'}`)
-        affectedTestTasks = parseAffectedTasks(runTurbo(affectedArgs('backend:test')))
         affectedContractTasks = parseAffectedTasks(runTurbo(affectedArgs('backend:contract-check')))
         contractTasks = parseTurboTasks(runTurbo(['run', 'backend:contract-check', '--dry-run=json']))
     }
@@ -526,17 +547,19 @@ try {
     process.exit(1)
 }
 const allProducts = getAllProducts(allTestTasks)
+const affectedProducts = getAffectedTaskProducts(affectedTestTasks)
 
 let products
 let runLegacy
 
 if (legacyChanged) {
-    console.error('Legacy code changed — testing all products')
-    products = allProducts
+    console.error(`Legacy code changed — testing all products except unaffected dependency-scoped products`)
+    console.error(`Affected products: ${JSON.stringify(affectedProducts)}`)
+    logAffectedReasons('backend:test', affectedTestTasks)
+    products = includeDependencyScopedProducts(allProducts, affectedProducts)
     runLegacy = true
 } else {
     const isolatedProducts = getIsolatedProducts(contractTasks)
-    const affectedProducts = getAffectedTaskProducts(affectedTestTasks)
     const nonIsolatedAffectedProducts = affectedProducts.filter((p) => !isolatedProducts.has(p))
 
     console.error(`Isolated products (have contract-check): ${JSON.stringify([...isolatedProducts].sort())}`)
@@ -544,11 +567,12 @@ if (legacyChanged) {
     logAffectedReasons('backend:test', affectedTestTasks)
 
     if (nonIsolatedAffectedProducts.length > 0) {
-        // Non-isolated product changed — must test everything
+        // Non-isolated product changed — test every product except dependency-scoped
+        // products whose declared inputs were unaffected.
         console.error(
-            `Non-isolated products changed: ${JSON.stringify(nonIsolatedAffectedProducts)} — testing all products + Django`
+            `Non-isolated products changed: ${JSON.stringify(nonIsolatedAffectedProducts)} — testing affected dependency-scoped products, all other products, and Django`
         )
-        products = allProducts
+        products = includeDependencyScopedProducts(allProducts, affectedProducts)
         runLegacy = true
     } else if (affectedProducts.length > 0) {
         // Only isolated products changed — check whether their contract surface was affected

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -58,7 +58,17 @@ const PRODUCTS_RUNNING_TEMPORAL_IN_JOB = new Set(['warehouse-sources'])
 // inputs, so they do not need to join a full product sweep unless Turbo marks
 // them affected. Keep this list deliberately small: missing an input would skip
 // a product test that should have run.
-const DEPENDENCY_SCOPED_PRODUCTS = new Set(['experiments'])
+const DEPENDENCY_SCOPED_PRODUCTS = new Set([
+    'endpoints',
+    'experiments',
+    'logs',
+    'product-analytics',
+    'revenue-analytics',
+    'signals',
+    'tasks',
+    'warehouse-sources',
+    'web-analytics',
+])
 // Products that always get their own matrix entry instead of being packed with
 // others — isolates a flaky/hang-prone product so it can't cancel bucket-mates
 // at the job timeout. Trade-off: a dedicated runner.
@@ -138,6 +148,25 @@ function getIsolatedProducts(contractTasks) {
 
 function getAffectedTaskProducts(tasks) {
     return [...new Set(tasks.map((t) => packageToProduct(t.package.name)))].sort()
+}
+
+function changedPathToProduct(file, allProductSet) {
+    const match = file.match(/^products\/([^/]+)\//)
+    if (!match) {return null}
+    const product = match[1].replace(/_/g, '-')
+    return allProductSet.has(product) ? product : null
+}
+
+function getDirectlyChangedProducts(allProducts) {
+    if (!process.env.TURBO_SCM_BASE) {return []}
+    const args = ['diff', '--name-only', process.env.TURBO_SCM_BASE]
+    if (process.env.TURBO_SCM_HEAD) {
+        args.push(process.env.TURBO_SCM_HEAD)
+    }
+    args.push('--', 'products/')
+    const files = execFileSync('git', args, { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+    const allProductSet = new Set(allProducts)
+    return [...new Set(files.map((file) => changedPathToProduct(file, allProductSet)).filter(Boolean))].sort()
 }
 
 function includeDependencyScopedProducts(allProducts, affectedProducts) {
@@ -515,6 +544,7 @@ function buildMatrix(products, durations) {
 // Exported for unit tests only — not part of the public API.
 module.exports = {
     collectTestFiles,
+    changedPathToProduct,
     checkProductStaleness,
     includeDependencyScopedProducts,
     productPrefix,
@@ -553,24 +583,24 @@ let products
 let runLegacy
 
 if (legacyChanged) {
-    console.error(`Legacy code changed — testing all products except unaffected dependency-scoped products`)
-    console.error(`Affected products: ${JSON.stringify(affectedProducts)}`)
-    logAffectedReasons('backend:test', affectedTestTasks)
-    products = includeDependencyScopedProducts(allProducts, affectedProducts)
+    console.error('Legacy code changed — testing all products')
+    products = allProducts
     runLegacy = true
 } else {
     const isolatedProducts = getIsolatedProducts(contractTasks)
-    const nonIsolatedAffectedProducts = affectedProducts.filter((p) => !isolatedProducts.has(p))
+    const directlyChangedProducts = getDirectlyChangedProducts(allProducts)
+    const nonIsolatedChangedProducts = directlyChangedProducts.filter((p) => !isolatedProducts.has(p))
 
     console.error(`Isolated products (have contract-check): ${JSON.stringify([...isolatedProducts].sort())}`)
+    console.error(`Directly changed products: ${JSON.stringify(directlyChangedProducts)}`)
     console.error(`Affected products: ${JSON.stringify(affectedProducts)}`)
     logAffectedReasons('backend:test', affectedTestTasks)
 
-    if (nonIsolatedAffectedProducts.length > 0) {
+    if (nonIsolatedChangedProducts.length > 0) {
         // Non-isolated product changed — test every product except dependency-scoped
         // products whose declared inputs were unaffected.
         console.error(
-            `Non-isolated products changed: ${JSON.stringify(nonIsolatedAffectedProducts)} — testing affected dependency-scoped products, all other products, and Django`
+            `Non-isolated products changed: ${JSON.stringify(nonIsolatedChangedProducts)} — testing affected dependency-scoped products, all other products, and Django`
         )
         products = includeDependencyScopedProducts(allProducts, affectedProducts)
         runLegacy = true

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -361,34 +361,39 @@ jobs:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
-            - name: Compute schema cache key from merge-base
+            - name: Compute schema cache key
               id: schema-key
-              if: github.event_name == 'pull_request'
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: |
-                  # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
-                  # The fetch-depth:1000 checkout + base-ref fetch above ensure the
-                  # full ancestry needed to find the divergence point is available.
-                  MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
-                  if [ -z "$MERGE_BASE" ]; then
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                      # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                      SCHEMA_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                      MIGRATION_REF="$SCHEMA_BASE"
+                  else
+                      # Product jobs run in parallel with the migration job on master,
+                      # so restore the previous push's schema and let pytest apply any delta.
+                      SCHEMA_BASE=$(git rev-parse HEAD^ 2>/dev/null || echo "")
+                      MIGRATION_REF=HEAD
+                  fi
+                  if [ -z "$SCHEMA_BASE" ]; then
                       echo "key=" >> $GITHUB_OUTPUT
                       echo "migrations_key=" >> $GITHUB_OUTPUT
-                      echo "::notice::merge-base not found (branch too stale?) — schema cache will be skipped"
+                      echo "::notice::schema base not found — schema cache will be skipped"
                       exit 0
                   fi
-                  # Exact branch-point key, kept as the fallback restore key below.
-                  echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
-                  # Shared key: hash merge-base schema inputs, not PR head, so PR migrations still
-                  # apply as the pytest delta. uv.lock covers third-party migration changes; the
-                  # postgres image is folded in so a server-version bump invalidates the key.
+                  # Exact base key, kept as the fallback restore key below.
+                  echo "key=posthog-schema-master-${SCHEMA_BASE}" >> $GITHUB_OUTPUT
+                  # Shared key: hash the schema inputs. On PRs this is the merge base;
+                  # on master it is HEAD, with the previous SHA key as a safe fallback
+                  # when the current push introduces a migration.
                   # Non-Django migration frameworks are excluded from this Postgres schema dump.
                   # SCHEMA_CACHE_EPOCH (workflow env) prefixes the key as a manual cache-bust knob.
-                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$MERGE_BASE" \
+                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$MIGRATION_REF" \
                       | grep -E '/migrations/[^/]+\.py$|^[0-9a-f]+ uv\.lock$' \
                       | grep -vE '/(clickhouse|async_migrations)/migrations/' \
                       | LC_ALL=C sort) || true
-                  PG_IMAGE=$(git show "${MERGE_BASE}:docker-compose.base.yml" 2>/dev/null \
+                  PG_IMAGE=$(git show "${MIGRATION_REF}:docker-compose.base.yml" 2>/dev/null \
                       | grep -m1 -E '^[[:space:]]*image:[[:space:]]*postgres:' | tr -d '[:space:]')
                   if [ -z "$MIG_FILES" ]; then
                       echo "migrations_key=" >> $GITHUB_OUTPUT
@@ -433,7 +438,7 @@ jobs:
                   # On PRs, use the path filter to detect legacy changes.
                   LEGACY_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.legacy }}
                   SCHEMA_CHANGED: ${{ github.event_name != 'pull_request' || needs.changes.outputs.schema }}
-                  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
+                  TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || format('{0}^', github.sha) }}
                   TURBO_SCM_HEAD: ${{ github.sha }}
                   # Kill switch — drop comma-separated products from the matrix; empty = run all.
                   SKIP_PRODUCT_TESTS: ${{ vars.SKIP_PRODUCT_TESTS || '' }}
@@ -725,7 +730,7 @@ jobs:
               run: bin/ci-wait-for-docker wait
 
             - name: Restore schema cache from master
-              if: ${{ github.event_name == 'pull_request' && needs.turbo-discover.outputs.schema_cache_key != '' }}
+              if: ${{ needs.turbo-discover.outputs.schema_cache_key != '' }}
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: schema.sql.gz
@@ -736,7 +741,7 @@ jobs:
 
             - name: Prime test_posthog from cached schema
               # Treat cache problems as misses; db:restore-test-db recreates the DB after failure.
-              if: ${{ github.event_name == 'pull_request' }}
+              if: ${{ needs.turbo-discover.outputs.schema_cache_key != '' }}
               run: |
                   if [ ! -f schema.sql.gz ]; then
                       echo "::notice::Schema cache miss — pytest --reuse-db will run full migrations"

--- a/products/experiments/turbo.json
+++ b/products/experiments/turbo.json
@@ -1,0 +1,30 @@
+{
+    "extends": ["//"],
+    "tasks": {
+        "backend:test": {
+            "inputs": [
+                "backend/**/*.py",
+                "!backend/**/__pycache__/**",
+                "stats/**/*.py",
+                "../../pyproject.toml",
+                "../../uv.lock",
+                "../../common/**/*.py",
+                "../../posthog/**/*.py",
+                "../../ee/**/*.py",
+                "../../products/actions/backend/**/*.py",
+                "../../products/ai_observability/backend/**/*.py",
+                "../../products/analytics_platform/backend/**/*.py",
+                "../../products/approvals/backend/**/*.py",
+                "../../products/cohorts/backend/**/*.py",
+                "../../products/data_tools/backend/**/*.py",
+                "../../products/event_definitions/backend/**/*.py",
+                "../../products/feature_flags/backend/**/*.py",
+                "../../products/notifications/backend/**/*.py",
+                "../../products/product_tours/backend/**/*.py",
+                "../../products/surveys/backend/**/*.py",
+                "../../products/tasks/backend/**/*.py",
+                "../../products/warehouse_sources/backend/**/*.py"
+            ]
+        }
+    }
+}

--- a/products/logs/turbo.json
+++ b/products/logs/turbo.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["//"],
+    "tasks": {
+        "backend:test": {
+            "inputs": [
+                "backend/**/*.py",
+                "!backend/**/__pycache__/**",
+                "skills/**/*.py",
+                "../../pyproject.toml",
+                "../../uv.lock",
+                "../../common/**/*.py",
+                "../../products/cdp/**/*.py",
+                "../../products/exports/**/*.py",
+                "../../products/signals/**/*.py"
+            ]
+        }
+    }
+}

--- a/products/product_analytics/turbo.json
+++ b/products/product_analytics/turbo.json
@@ -8,16 +8,14 @@
                 "../../pyproject.toml",
                 "../../uv.lock",
                 "../../common/**/*.py",
-                "../../products/data_modeling/**/*.py",
-                "../../products/data_warehouse/**/*.py",
-                "../../products/product_analytics/**/*.py",
+                "../../products/actions/**/*.py",
+                "../../products/alerts/**/*.py",
+                "../../products/annotations/**/*.py",
+                "../../products/cohorts/**/*.py",
+                "../../products/dashboards/**/*.py",
+                "../../products/event_definitions/**/*.py",
                 "../../products/warehouse_sources/**/*.py"
             ]
-        },
-        "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
-            "outputs": [],
-            "cache": true
         }
     }
 }

--- a/products/revenue_analytics/turbo.json
+++ b/products/revenue_analytics/turbo.json
@@ -9,15 +9,9 @@
                 "../../uv.lock",
                 "../../common/**/*.py",
                 "../../products/data_modeling/**/*.py",
-                "../../products/data_warehouse/**/*.py",
-                "../../products/product_analytics/**/*.py",
+                "../../products/data_tools/**/*.py",
                 "../../products/warehouse_sources/**/*.py"
             ]
-        },
-        "backend:contract-check": {
-            "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
-            "outputs": [],
-            "cache": true
         }
     }
 }

--- a/products/signals/turbo.json
+++ b/products/signals/turbo.json
@@ -1,0 +1,32 @@
+{
+    "extends": ["//"],
+    "tasks": {
+        "backend:test": {
+            "inputs": [
+                "backend/**/*.py",
+                "!backend/**/__pycache__/**",
+                "../../pyproject.toml",
+                "../../uv.lock",
+                "../../common/**/*.py",
+                "../../products/actions/**/*.py",
+                "../../products/alerts/**/*.py",
+                "../../products/business_knowledge/**/*.py",
+                "../../products/cdp/**/*.py",
+                "../../products/cohorts/**/*.py",
+                "../../products/conversations/**/*.py",
+                "../../products/dashboards/**/*.py",
+                "../../products/data_warehouse/**/*.py",
+                "../../products/error_tracking/**/*.py",
+                "../../products/experiments/**/*.py",
+                "../../products/feature_flags/**/*.py",
+                "../../products/notebooks/**/*.py",
+                "../../products/product_analytics/**/*.py",
+                "../../products/skills/**/*.py",
+                "../../products/surveys/**/*.py",
+                "../../products/tasks/**/*.py",
+                "../../products/warehouse_sources/**/*.py",
+                "../../products/workflows/**/*.py"
+            ]
+        }
+    }
+}

--- a/products/tasks/turbo.json
+++ b/products/tasks/turbo.json
@@ -1,6 +1,22 @@
 {
     "extends": ["//"],
     "tasks": {
+        "backend:test": {
+            "inputs": [
+                "backend/**/*.py",
+                "!backend/**/__pycache__/**",
+                "../../pyproject.toml",
+                "../../uv.lock",
+                "../../common/**/*.py",
+                "../../products/ai_observability/**/*.py",
+                "../../products/error_tracking/**/*.py",
+                "../../products/event_definitions/**/*.py",
+                "../../products/feature_flags/**/*.py",
+                "../../products/mcp_store/**/*.py",
+                "../../products/signals/**/*.py",
+                "../../products/slack_app/**/*.py"
+            ]
+        },
         "backend:contract-check": {
             "inputs": ["backend/facade/**", "backend/presentation/**", "backend/routes.py"],
             "outputs": [],

--- a/products/warehouse_sources/turbo.json
+++ b/products/warehouse_sources/turbo.json
@@ -1,6 +1,21 @@
 {
     "extends": ["//"],
     "tasks": {
+        "backend:test": {
+            "inputs": [
+                "backend/**/*.py",
+                "!backend/**/__pycache__/**",
+                "../../pyproject.toml",
+                "../../uv.lock",
+                "../../common/**/*.py",
+                "../../products/cdp/**/*.py",
+                "../../products/data_modeling/**/*.py",
+                "../../products/data_tools/**/*.py",
+                "../../products/data_warehouse/**/*.py",
+                "../../products/warehouse_sources_queue/**/*.py",
+                "../../products/workflows/**/*.py"
+            ]
+        },
         "backend:contract-check": {
             "inputs": [
                 "backend/facade/**",

--- a/products/web_analytics/turbo.json
+++ b/products/web_analytics/turbo.json
@@ -5,23 +5,14 @@
             "inputs": [
                 "backend/**/*.py",
                 "!backend/**/__pycache__/**",
-                "stats/**/*.py",
                 "../../pyproject.toml",
                 "../../uv.lock",
                 "../../common/**/*.py",
                 "../../products/actions/**/*.py",
-                "../../products/ai_observability/**/*.py",
                 "../../products/analytics_platform/**/*.py",
-                "../../products/approvals/**/*.py",
                 "../../products/cohorts/**/*.py",
-                "../../products/data_tools/**/*.py",
-                "../../products/event_definitions/**/*.py",
-                "../../products/feature_flags/**/*.py",
                 "../../products/notifications/**/*.py",
-                "../../products/product_tours/**/*.py",
-                "../../products/surveys/**/*.py",
-                "../../products/tasks/**/*.py",
-                "../../products/warehouse_sources/**/*.py"
+                "../../products/replay_vision/**/*.py"
             ]
         }
     }


### PR DESCRIPTION
## Problem

Several expensive product test buckets join broad backend sweeps when unrelated product code changes. Master product shards also rebuild the Django test schema from scratch, which adds substantial setup time across each matrix entry.

**Why:** Reduce unnecessary CI runs and shorten product test feedback without skipping changes to declared Python dependencies.

## Changes

- Scope the highest-cost product suites to their direct cross-product Python dependencies during product-only sweeps.
- Distinguish directly changed products from dependent tests affected by those changes, preserving product isolation behavior.
- Keep full product coverage for legacy backend, shared infrastructure, and CI workflow changes.
- Restore the previous master schema cache for product shards and apply migration deltas through pytest.

## How did you test this code?

- `node --test .github/scripts/turbo-discover-staleness.test.js` verifies direct product-path detection and dependency-scoped sweep selection.
- `npx --yes turbo@2.9.14 run backend:test --dry-run=json` verifies Turbo resolves every scoped product's backend, shared, and cross-product inputs.
- `npx --yes oxfmt@latest --check products/*/turbo.json` for the changed product configs.
- `actionlint .github/workflows/ci-backend.yml`
- `git diff --check`

`bin/hogli lint:workflows` could not run because the task image has no Python executable; standalone actionlint passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code using the `/authoring-ci-workflows` and `/writing-tests` skills. CI job data showed expensive product buckets were frequently pulled into sweeps by unrelated non-isolated product changes, while master shards repeatedly paid schema setup costs. The dependency maps are checked against current cross-product Python imports, and true legacy changes still run the complete product matrix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
