### PR TITLE
fix(conversations): pin zendesk import redirects against ssr

### DIFF
--- a/products/conversations/backend/temporal/zendesk_import/client.py
+++ b/products/conversations/backend/temporal/zendesk_import/client.py
@@ -6,13 +6,15 @@ import re
 import time
 import base64
 from dataclasses import dataclass
-from typing import Any
-from urllib.parse import urljoin, urlsplit
+from typing import Any, cast
+from urllib.parse import urljoin, urlparse, urlsplit, urlunparse
 
+import requests
 import structlog
 from requests import Response
+from requests.adapters import HTTPAdapter
 
-from posthog.security.url_validation import is_url_allowed
+from posthog.security.url_validation import has_authority_bypass_chars, validate_url_and_pin_ips
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 
@@ -38,6 +40,9 @@ ATTACHMENT_CHUNK_BYTES = 64 * 1024
 # Attachment content_url lives on the Zendesk host and 302-redirects to an external CDN, so we
 # must follow at least one hop. Bound it so a redirect loop can't spin forever.
 MAX_ATTACHMENT_REDIRECTS = 5
+# The credential probe follows Zendesk's own same-host canonicalization redirects (trailing
+# slash, account host-mapping) by hand. Bounded so a redirect loop can't hang the settings request.
+MAX_PROBE_REDIRECTS = 3
 _REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 # A Zendesk subdomain is a single DNS label: alphanumerics + hyphens, no leading/trailing
@@ -78,6 +83,65 @@ class ZendeskAttachmentTooLargeError(Exception):
     Distinct from a transport failure so the caller can skip the attachment (count it
     as oversized) without treating it as a retryable download error.
     """
+
+
+class _PinnedIPAdapter(HTTPAdapter):
+    """Requests adapter that connects to a pre-validated IP instead of re-resolving DNS.
+
+    Eliminates the DNS-rebinding TOCTOU window: an off-host attachment redirect is validated
+    with ``validate_url_and_pin_ips`` and the resulting IP is pinned here, so the socket goes to
+    the exact address the SSRF allowlist checked. TLS SNI + cert verification still use the
+    original hostname (via ``assert_hostname`` / ``server_hostname``), not the IP.
+
+    Single-use, not thread-safe — created per off-host download hop.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._pin_map: dict[str, str] = {}
+        self._current_original_host: str | None = None
+
+    def pin(self, hostname: str, ip: str) -> None:
+        self._pin_map[hostname.lower()] = ip
+
+    def send(  # type: ignore[override]
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,
+        timeout: None | float | tuple[float, float] = None,
+        verify: bool | str = True,
+        cert: None | str | tuple[str, str] = None,
+        proxies: dict[str, str] | None = None,
+    ) -> Response:
+        parsed = urlparse(request.url or "")
+        host = (parsed.hostname or "").lower()
+        ip_str = self._pin_map.get(host)
+        if ip_str is not None:
+            self._current_original_host = host
+            ip_netloc = f"[{ip_str}]" if ":" in ip_str else ip_str
+            if parsed.port:
+                ip_netloc = f"{ip_netloc}:{parsed.port}"
+            request.url = urlunparse((parsed.scheme, ip_netloc, parsed.path, parsed.params, parsed.query, ""))
+            original_netloc = f"{host}:{parsed.port}" if parsed.port else host
+            if request.headers is not None:
+                request.headers["Host"] = original_netloc
+        else:
+            self._current_original_host = None
+        return super().send(request, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
+
+    def cert_verify(self, conn: object, url: str, verify: bool | str, cert: None | str | tuple[str, str]) -> None:
+        super().cert_verify(conn, url, verify, cert)  # type: ignore[arg-type]
+        original = getattr(self, "_current_original_host", None)
+        if original:
+            # Mutating urllib3 pool internals so TLS SNI/cert checks use the original hostname
+            # rather than the pinned IP. These attrs exist at runtime but aren't statically typed,
+            # so go through an Any-typed handle to avoid a read-only-property assignment error.
+            pool = cast(Any, conn)
+            if hasattr(conn, "assert_hostname"):
+                pool.assert_hostname = original
+            conn_kw = getattr(conn, "conn_kw", None)
+            if isinstance(conn_kw, dict):
+                conn_kw["server_hostname"] = original
 
 
 @dataclass(frozen=True)
@@ -141,30 +205,59 @@ class ZendeskImportClient:
         response hand back an http:// URL on the right host, which passes but sends the reusable
         Basic auth token in cleartext over the wire. Zendesk only ever returns https URLs, so
         anything else is rejected.
+
+        A backslash (or %5c) before the ``@`` makes urlsplit read the host after it while
+        requests/urllib3 treat the backslash as the authority terminator and connect to the host
+        *before* it — so "https://evil.example\\@acme.zendesk.com/" would pass a naive host check
+        yet send the token to evil.example. Reject that ambiguity outright.
         """
+        if has_authority_bypass_chars(url):
+            raise ValueError(f"Refusing to fetch URL with ambiguous authority: {url!r}")
         parts = urlsplit(url)
         host = parts.hostname
         if parts.scheme.lower() != "https" or host is None or host.lower() != self._host:
             raise ValueError(f"Refusing to fetch non-https or off-host URL (expected https://{self._host}): {url!r}")
 
-    def _validate_download_redirect(self, url: str) -> tuple[str, bool]:
-        """Validate an attachment redirect target and decide whether to keep the auth token.
+    def _offhost_redirect_session(self, url: str) -> requests.Session:
+        """Build a single-use session that connects to the SSRF-validated, IP-pinned redirect host.
 
-        Returns (url, send_auth). A hop that stays on the pinned Zendesk host keeps the Basic
-        auth token; an off-host hop (the CDN the content_url 302s to) must be https and pass the
-        SSRF allowlist (no internal/metadata hosts) AND has the token stripped, so the reusable
-        Zendesk credential is never sent to a host the API response chose.
+        ``validate_url_and_pin_ips`` re-resolves and checks the host, and the returned IP is pinned
+        onto the adapter so the follow-up GET connects to the exact address we validated. This
+        closes the DNS-rebinding TOCTOU: without pinning, ``requests`` would resolve the hostname
+        again and an attacker could return a public IP during validation, then rebind to an
+        internal/metadata address before the connect.
         """
+        allowed, reason, pinned_ips = validate_url_and_pin_ips(url)
+        if not allowed:
+            raise ValueError(f"Refusing to follow attachment redirect to disallowed host ({reason}): {url!r}")
+        adapter = _PinnedIPAdapter()
+        hostname = (urlparse(url).hostname or "").lower()
+        if pinned_ips:
+            adapter.pin(hostname, str(next(iter(pinned_ips))))
+        session = requests.Session()
+        session.mount("https://", adapter)
+        return session
+
+    def _validate_download_redirect(self, url: str) -> tuple[str, requests.Session | None]:
+        """Validate an attachment redirect target and pick the session for the next hop.
+
+        Returns (url, session). A hop that stays on the pinned Zendesk host reuses the tracked
+        client session and keeps the Basic auth token. An off-host hop (the CDN the content_url
+        302s to) must be https and pass the SSRF allowlist (no internal/metadata hosts); it gets a
+        fresh IP-pinned session with no auth header, so the reusable Zendesk credential is never
+        sent to a host the API response chose and DNS can't be rebound after validation.
+        """
+        # A backslash/%5c authority-bypass makes urlsplit see the pinned host (keeping the token +
+        # tracked session) while requests connects elsewhere — reject before any host comparison.
+        if has_authority_bypass_chars(url):
+            raise ValueError(f"Refusing to follow attachment redirect with ambiguous authority: {url!r}")
         parts = urlsplit(url)
         host = (parts.hostname or "").lower()
         if parts.scheme.lower() != "https":
             raise ValueError(f"Refusing to follow non-https attachment redirect: {url!r}")
         if host == self._host:
-            return url, True
-        allowed, reason = is_url_allowed(url)
-        if not allowed:
-            raise ValueError(f"Refusing to follow attachment redirect to disallowed host ({reason}): {url!r}")
-        return url, False
+            return url, None
+        return url, self._offhost_redirect_session(url)
 
     def _request(self, method: str, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
         if path.startswith("http"):
@@ -253,51 +346,64 @@ class ZendeskImportClient:
         # The content_url the API hands us must start on the pinned Zendesk host.
         self._assert_expected_host(content_url)
         url = content_url
-        send_auth = True
+        # None => use the tracked client session (on-host, carries the Zendesk token). A non-None
+        # value is a fresh IP-pinned, no-auth session for an off-host CDN hop.
+        offhost_session: requests.Session | None = None
         attempt = 0
         redirects = 0
-        while True:
-            headers = self._headers if send_auth else {}
-            with self._session.get(url, headers=headers, timeout=120, stream=True) as response:
-                if response.status_code == 429:
-                    self._handle_rate_limit(response, url, attempt)
-                    attempt += 1
-                    continue
-                # Zendesk 302s the on-host content_url to an external CDN. Follow it by hand
-                # (the session never auto-follows) so each hop is host/scheme-validated and the
-                # Zendesk token is dropped before we touch any off-host URL.
-                if response.status_code in _REDIRECT_STATUSES:
-                    redirects += 1
-                    if redirects > MAX_ATTACHMENT_REDIRECTS:
-                        raise ValueError(f"Too many redirects while downloading attachment: {content_url!r}")
-                    location = response.headers.get("Location")
-                    if not location:
-                        raise ValueError(f"Attachment redirect missing Location: {content_url!r}")
-                    url, send_auth = self._validate_download_redirect(urljoin(url, location))
-                    attempt = 0
-                    continue
-                response.raise_for_status()
-                # Precheck the declared size so a server-advertised oversized body is rejected
-                # before we read any of it.
-                declared = response.headers.get("Content-Length")
-                if declared is not None:
-                    try:
-                        if int(declared) > max_bytes:
-                            raise ZendeskAttachmentTooLargeError(
-                                f"Attachment exceeds {max_bytes} bytes (Content-Length={declared})"
-                            )
-                    except ValueError:
-                        pass
-                # A lying/absent Content-Length can't sneak past: abort once streamed bytes
-                # cross the cap instead of buffering the whole response.
-                buffer = bytearray()
-                for chunk in response.iter_content(chunk_size=ATTACHMENT_CHUNK_BYTES):
-                    if not chunk:
+        try:
+            while True:
+                session = offhost_session or self._session
+                headers = {} if offhost_session is not None else self._headers
+                with session.get(url, headers=headers, timeout=120, stream=True, allow_redirects=False) as response:
+                    if response.status_code == 429:
+                        self._handle_rate_limit(response, url, attempt)
+                        attempt += 1
                         continue
-                    buffer.extend(chunk)
-                    if len(buffer) > max_bytes:
-                        raise ZendeskAttachmentTooLargeError(f"Attachment exceeds {max_bytes} bytes while streaming")
-                return bytes(buffer)
+                    # Zendesk 302s the on-host content_url to an external CDN. Follow it by hand
+                    # (never auto-follow) so each hop is host/scheme-validated, the Zendesk token is
+                    # dropped before any off-host URL, and the validated IP is pinned for the connect.
+                    if response.status_code in _REDIRECT_STATUSES:
+                        redirects += 1
+                        if redirects > MAX_ATTACHMENT_REDIRECTS:
+                            raise ValueError(f"Too many redirects while downloading attachment: {content_url!r}")
+                        location = response.headers.get("Location")
+                        if not location:
+                            raise ValueError(f"Attachment redirect missing Location: {content_url!r}")
+                        next_url, next_session = self._validate_download_redirect(urljoin(url, location))
+                        # Close a prior off-host session before replacing it (multi-hop chains).
+                        if offhost_session is not None and next_session is not offhost_session:
+                            offhost_session.close()
+                        url, offhost_session = next_url, next_session
+                        attempt = 0
+                        continue
+                    response.raise_for_status()
+                    # Precheck the declared size so a server-advertised oversized body is rejected
+                    # before we read any of it.
+                    declared = response.headers.get("Content-Length")
+                    if declared is not None:
+                        try:
+                            if int(declared) > max_bytes:
+                                raise ZendeskAttachmentTooLargeError(
+                                    f"Attachment exceeds {max_bytes} bytes (Content-Length={declared})"
+                                )
+                        except ValueError:
+                            pass
+                    # A lying/absent Content-Length can't sneak past: abort once streamed bytes
+                    # cross the cap instead of buffering the whole response.
+                    buffer = bytearray()
+                    for chunk in response.iter_content(chunk_size=ATTACHMENT_CHUNK_BYTES):
+                        if not chunk:
+                            continue
+                        buffer.extend(chunk)
+                        if len(buffer) > max_bytes:
+                            raise ZendeskAttachmentTooLargeError(
+                                f"Attachment exceeds {max_bytes} bytes while streaming"
+                            )
+                    return bytes(buffer)
+        finally:
+            if offhost_session is not None:
+                offhost_session.close()
 
 
 def validate_zendesk_credentials(credentials: ZendeskCredentials) -> bool:
@@ -310,6 +416,7 @@ def validate_zendesk_credentials(credentials: ZendeskCredentials) -> bool:
     subdomain = normalize_subdomain(credentials.subdomain)
     if not _SUBDOMAIN_LABEL_RE.match(subdomain):
         return False
+    host = f"{subdomain}.zendesk.com".lower()
     token = base64.b64encode(f"{credentials.email_address}/token:{credentials.api_token}".encode("ascii")).decode(
         "ascii"
     )
@@ -325,12 +432,28 @@ def validate_zendesk_credentials(credentials: ZendeskCredentials) -> bool:
     # slow/unresponsive host would pin the Django worker indefinitely; without the try/except a
     # transport-level error (DNS/connection/SSL) would escape as a 500 instead of the intended
     # "credentials rejected" 400. Any failure to reach + authenticate == invalid credentials.
+    url = f"https://{host}/api/v2/tickets/count"
     try:
-        res = session.get(
-            f"https://{subdomain}.zendesk.com/api/v2/tickets/count",
-            headers={"Authorization": f"Basic {token}"},
-            timeout=10,
-        )
-        return res.status_code == 200
+        # Follow Zendesk's own canonicalization redirects (trailing slash, host-mapping) by hand
+        # so valid credentials on a redirecting account aren't misreported as invalid. Only same-
+        # host https hops are followed — the token never leaves the pinned Zendesk host, and an
+        # off-host or cleartext redirect is treated as a failed probe rather than chased.
+        for _ in range(MAX_PROBE_REDIRECTS + 1):
+            res = session.get(url, headers={"Authorization": f"Basic {token}"}, timeout=10)
+            if res.status_code not in _REDIRECT_STATUSES:
+                return res.status_code == 200
+            location = res.headers.get("Location")
+            if not location:
+                return False
+            nxt = urljoin(url, location)
+            # Same authority-bypass guard as the attachment path: a backslash/%5c can make urlsplit
+            # read the pinned host while requests connects elsewhere with the token attached.
+            if has_authority_bypass_chars(nxt):
+                return False
+            parts = urlsplit(nxt)
+            if parts.scheme.lower() != "https" or (parts.hostname or "").lower() != host:
+                return False
+            url = nxt
+        return False
     except Exception:
         return False

--- a/products/conversations/backend/temporal/zendesk_import/client.py
+++ b/products/conversations/backend/temporal/zendesk_import/client.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 from urllib.parse import urljoin, urlparse, urlsplit, urlunparse
 
+import idna
 import requests
 import structlog
 from requests import Response
@@ -101,8 +102,25 @@ class _PinnedIPAdapter(HTTPAdapter):
         self._pin_map: dict[str, str] = {}
         self._current_original_host: str | None = None
 
+    @staticmethod
+    def _canonical_host(hostname: str) -> str:
+        """Match the ASCII/punycode host `requests` derives when preparing the request.
+
+        `requests` IDNA-encodes Unicode hosts (uts46) before send(), so a pin keyed by the raw
+        Unicode host ("éxample.test") would never match the "xn--…" host seen at send time — the
+        lookup would miss and fall back to live DNS, reopening the rebinding window. Encode the
+        same way (idempotent on already-ASCII/punycode input) so both sides agree.
+        """
+        host = hostname.lower()
+        if not host:
+            return host
+        try:
+            return idna.encode(host, uts46=True).decode("ascii")
+        except idna.IDNAError:
+            return host
+
     def pin(self, hostname: str, ip: str) -> None:
-        self._pin_map[hostname.lower()] = ip
+        self._pin_map[self._canonical_host(hostname)] = ip
 
     def send(  # type: ignore[override]
         self,
@@ -114,7 +132,7 @@ class _PinnedIPAdapter(HTTPAdapter):
         proxies: dict[str, str] | None = None,
     ) -> Response:
         parsed = urlparse(request.url or "")
-        host = (parsed.hostname or "").lower()
+        host = self._canonical_host(parsed.hostname or "")
         ip_str = self._pin_map.get(host)
         if ip_str is not None:
             self._current_original_host = host
@@ -130,7 +148,7 @@ class _PinnedIPAdapter(HTTPAdapter):
         return super().send(request, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
 
     def cert_verify(self, conn: object, url: str, verify: bool | str, cert: None | str | tuple[str, str]) -> None:
-        super().cert_verify(conn, url, verify, cert)  # type: ignore[arg-type]
+        super().cert_verify(conn, url, verify, cert)
         original = getattr(self, "_current_original_host", None)
         if original:
             # Mutating urllib3 pool internals so TLS SNI/cert checks use the original hostname

--- a/products/conversations/backend/temporal/zendesk_import/client.py
+++ b/products/conversations/backend/temporal/zendesk_import/client.py
@@ -7,10 +7,12 @@ import time
 import base64
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import urljoin, urlsplit
 
 import structlog
 from requests import Response
+
+from posthog.security.url_validation import is_url_allowed
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 
@@ -32,6 +34,11 @@ MAX_RATE_LIMIT_SLEEP_SECONDS = 30
 # Stream attachment bodies in bounded chunks so an oversized file is aborted mid-download
 # instead of being fully buffered in the worker's memory before the size check.
 ATTACHMENT_CHUNK_BYTES = 64 * 1024
+
+# Attachment content_url lives on the Zendesk host and 302-redirects to an external CDN, so we
+# must follow at least one hop. Bound it so a redirect loop can't spin forever.
+MAX_ATTACHMENT_REDIRECTS = 5
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 # A Zendesk subdomain is a single DNS label: alphanumerics + hyphens, no leading/trailing
 # hyphen, <= 63 chars. Pinning to this stops a crafted subdomain (e.g. "attacker.example#")
@@ -85,9 +92,12 @@ class ZendeskImportClient:
         subdomain = normalize_subdomain(credentials.subdomain)
         if not _SUBDOMAIN_LABEL_RE.match(subdomain):
             raise ValueError(f"Invalid Zendesk subdomain: {credentials.subdomain!r}")
-        # Pin every request (including absolute next_page / attachment URLs echoed back by
-        # the API) to this host so a malicious/compromised API response can't redirect us at
-        # internal services.
+        # Pin the base host and validate every URL we're handed (absolute next_page / attachment
+        # content_url echoed back by the API) against it. Redirects are the escape hatch: the
+        # session never auto-follows (allow_redirects=False), so an HTTP 302 can't silently
+        # retarget a token-bearing request at an internal service. The one legitimate redirect
+        # (attachment content_url -> CDN) is followed manually with per-hop SSRF validation in
+        # download_attachment.
         self._host = f"{subdomain}.zendesk.com".lower()
         self._base_url = f"https://{self._host}"
         token = base64.b64encode(f"{credentials.email_address}/token:{credentials.api_token}".encode("ascii")).decode(
@@ -100,6 +110,7 @@ class ZendeskImportClient:
         self._session = make_tracked_session(
             redact_values=(token, credentials.api_token, credentials.email_address),
             capture=False,
+            allow_redirects=False,
         )
         self._headers = {"Authorization": f"Basic {token}"}
 
@@ -136,6 +147,25 @@ class ZendeskImportClient:
         if parts.scheme.lower() != "https" or host is None or host.lower() != self._host:
             raise ValueError(f"Refusing to fetch non-https or off-host URL (expected https://{self._host}): {url!r}")
 
+    def _validate_download_redirect(self, url: str) -> tuple[str, bool]:
+        """Validate an attachment redirect target and decide whether to keep the auth token.
+
+        Returns (url, send_auth). A hop that stays on the pinned Zendesk host keeps the Basic
+        auth token; an off-host hop (the CDN the content_url 302s to) must be https and pass the
+        SSRF allowlist (no internal/metadata hosts) AND has the token stripped, so the reusable
+        Zendesk credential is never sent to a host the API response chose.
+        """
+        parts = urlsplit(url)
+        host = (parts.hostname or "").lower()
+        if parts.scheme.lower() != "https":
+            raise ValueError(f"Refusing to follow non-https attachment redirect: {url!r}")
+        if host == self._host:
+            return url, True
+        allowed, reason = is_url_allowed(url)
+        if not allowed:
+            raise ValueError(f"Refusing to follow attachment redirect to disallowed host ({reason}): {url!r}")
+        return url, False
+
     def _request(self, method: str, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
         if path.startswith("http"):
             self._assert_expected_host(path)
@@ -149,6 +179,11 @@ class ZendeskImportClient:
                 self._handle_rate_limit(response, path, attempt)
                 attempt += 1
                 continue
+            # The API returns JSON directly; a redirect here is anomalous. The session doesn't
+            # auto-follow, so refuse it rather than letting a token-bearing request chase an
+            # unvalidated Location.
+            if response.status_code in _REDIRECT_STATUSES:
+                raise ValueError(f"Refusing to follow unexpected redirect from Zendesk API: {path!r}")
             response.raise_for_status()
             return response.json()
 
@@ -215,13 +250,31 @@ class ZendeskImportClient:
         return comments
 
     def download_attachment(self, content_url: str, *, max_bytes: int) -> bytes:
+        # The content_url the API hands us must start on the pinned Zendesk host.
         self._assert_expected_host(content_url)
+        url = content_url
+        send_auth = True
         attempt = 0
+        redirects = 0
         while True:
-            with self._session.get(content_url, headers=self._headers, timeout=120, stream=True) as response:
+            headers = self._headers if send_auth else {}
+            with self._session.get(url, headers=headers, timeout=120, stream=True) as response:
                 if response.status_code == 429:
-                    self._handle_rate_limit(response, content_url, attempt)
+                    self._handle_rate_limit(response, url, attempt)
                     attempt += 1
+                    continue
+                # Zendesk 302s the on-host content_url to an external CDN. Follow it by hand
+                # (the session never auto-follows) so each hop is host/scheme-validated and the
+                # Zendesk token is dropped before we touch any off-host URL.
+                if response.status_code in _REDIRECT_STATUSES:
+                    redirects += 1
+                    if redirects > MAX_ATTACHMENT_REDIRECTS:
+                        raise ValueError(f"Too many redirects while downloading attachment: {content_url!r}")
+                    location = response.headers.get("Location")
+                    if not location:
+                        raise ValueError(f"Attachment redirect missing Location: {content_url!r}")
+                    url, send_auth = self._validate_download_redirect(urljoin(url, location))
+                    attempt = 0
                     continue
                 response.raise_for_status()
                 # Precheck the declared size so a server-advertised oversized body is rejected
@@ -266,6 +319,7 @@ def validate_zendesk_credentials(credentials: ZendeskCredentials) -> bool:
     session = make_tracked_session(
         redact_values=(token, credentials.api_token, credentials.email_address),
         capture=False,
+        allow_redirects=False,
     )
     # Runs synchronously inside the settings-page create() request handler. Without a timeout a
     # slow/unresponsive host would pin the Django worker indefinitely; without the try/except a

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_client.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_client.py
@@ -1,3 +1,4 @@
+import ipaddress
 from collections.abc import Iterable
 
 import pytest
@@ -57,6 +58,51 @@ class TestValidateZendeskCredentials:
             assert validate_zendesk_credentials(credentials) is False
             mock_session.assert_not_called()
 
+    def _probe_response(self, status_code: int, *, location: str | None = None) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = {"Location": location} if location else {}
+        return resp
+
+    def test_follows_same_host_redirect_to_success(self) -> None:
+        # Zendesk canonicalizes the probe endpoint (e.g. trailing slash) with a same-host 301.
+        # Valid credentials behind such a redirect must still validate.
+        credentials = ZendeskCredentials(subdomain="acme", email_address="user@acme.com", api_token="tok")
+        session = MagicMock()
+        session.get.side_effect = [
+            self._probe_response(301, location="https://acme.zendesk.com/api/v2/tickets/count/"),
+            self._probe_response(200),
+        ]
+        with patch(f"{M}.make_tracked_session", return_value=session):
+            assert validate_zendesk_credentials(credentials) is True
+        assert session.get.call_count == 2
+
+    def test_refuses_offhost_probe_redirect(self) -> None:
+        # A redirect that leaves the pinned Zendesk host must not be chased with the token; the
+        # probe reports invalid rather than following it.
+        credentials = ZendeskCredentials(subdomain="acme", email_address="user@acme.com", api_token="tok")
+        session = MagicMock()
+        session.get.side_effect = [
+            self._probe_response(302, location="https://evil.example.com/steal"),
+            self._probe_response(200),
+        ]
+        with patch(f"{M}.make_tracked_session", return_value=session):
+            assert validate_zendesk_credentials(credentials) is False
+        assert session.get.call_count == 1
+
+    def test_refuses_probe_redirect_with_authority_bypass(self) -> None:
+        # Backslash authority-bypass in the probe Location parses to the pinned host but requests
+        # would connect elsewhere — must not be followed with the token.
+        credentials = ZendeskCredentials(subdomain="acme", email_address="user@acme.com", api_token="tok")
+        session = MagicMock()
+        session.get.side_effect = [
+            self._probe_response(302, location="https://evil.example\\@acme.zendesk.com/steal"),
+            self._probe_response(200),
+        ]
+        with patch(f"{M}.make_tracked_session", return_value=session):
+            assert validate_zendesk_credentials(credentials) is False
+        assert session.get.call_count == 1
+
 
 class TestDownloadAttachmentSizeCap:
     def _client(self) -> ZendeskImportClient:
@@ -101,37 +147,69 @@ class TestDownloadAttachmentRedirects:
             ZendeskCredentials(subdomain="acme", email_address="agent@acme.com", api_token="tok")
         )
 
-    def test_follows_offhost_cdn_redirect_dropping_auth(self) -> None:
+    def test_follows_offhost_cdn_redirect_dropping_auth_and_pinning_ip(self) -> None:
         # content_url is on the Zendesk host and 302s to an external CDN. We must follow the hop,
-        # but the reusable Zendesk token must NOT be sent to the CDN.
+        # but on a fresh IP-pinned session (no DNS-rebinding window) and without ever sending the
+        # reusable Zendesk token to the CDN.
         client = self._client()
         redirect = _FakeStreamResponse(status_code=302, headers={"Location": "https://cdn.zdusercontent.com/blob"})
         final = _FakeStreamResponse(headers={"Content-Length": "3"}, chunks=[b"abc"])
         client._session = MagicMock()
-        client._session.get.side_effect = [redirect, final]
+        client._session.get.return_value = redirect
 
-        with patch(f"{M}.is_url_allowed", return_value=(True, None)):
+        offhost_session = MagicMock()
+        offhost_session.get.return_value = final
+        pinned = (True, None, {ipaddress.ip_address("203.0.113.10")})
+
+        with (
+            patch(f"{M}.validate_url_and_pin_ips", return_value=pinned) as mock_validate,
+            patch(f"{M}.requests.Session", return_value=offhost_session),
+        ):
             assert client.download_attachment("https://acme.zendesk.com/attachments/x", max_bytes=10) == b"abc"
 
-        first_headers = client._session.get.call_args_list[0].kwargs["headers"]
-        second_headers = client._session.get.call_args_list[1].kwargs["headers"]
-        assert "Authorization" in first_headers
-        assert "Authorization" not in second_headers
+        # On-host hop carried the token; the SSRF-validated off-host hop did not.
+        assert "Authorization" in client._session.get.call_args_list[0].kwargs["headers"]
+        assert offhost_session.get.call_count == 1
+        assert offhost_session.get.call_args.kwargs["headers"] == {}
+        # The redirect target was re-validated + IP-pinned before the off-host connect.
+        mock_validate.assert_called_once_with("https://cdn.zdusercontent.com/blob")
 
     def test_refuses_redirect_to_internal_host(self) -> None:
-        # A 302 pointing at an internal/metadata host must be refused before the followed request
-        # goes out — the session no longer auto-follows, and the SSRF allowlist blocks the hop.
+        # A 302 pointing at an internal/metadata host must be refused: the session never
+        # auto-follows and validate_url_and_pin_ips blocks the hop before any off-host connect.
         client = self._client()
         redirect = _FakeStreamResponse(
             status_code=302, headers={"Location": "https://169.254.169.254/latest/meta-data/"}
         )
         client._session = MagicMock()
-        client._session.get.side_effect = [redirect]
+        client._session.get.return_value = redirect
+        offhost_session = MagicMock()
 
-        with patch(f"{M}.is_url_allowed", return_value=(False, "Disallowed target IP")):
+        with (
+            patch(f"{M}.validate_url_and_pin_ips", return_value=(False, "Disallowed target IP", set())),
+            patch(f"{M}.requests.Session", return_value=offhost_session),
+        ):
             with pytest.raises(ValueError):
                 client.download_attachment("https://acme.zendesk.com/attachments/x", max_bytes=10)
         assert client._session.get.call_count == 1
+        offhost_session.get.assert_not_called()
+
+    def test_refuses_redirect_with_authority_bypass(self) -> None:
+        # A 302 whose Location uses a backslash authority-bypass parses to the pinned host but
+        # requests would connect to the attacker host — refuse before following, token intact.
+        client = self._client()
+        redirect = _FakeStreamResponse(
+            status_code=302, headers={"Location": "https://evil.example\\@acme.zendesk.com/steal"}
+        )
+        client._session = MagicMock()
+        client._session.get.return_value = redirect
+        offhost_session = MagicMock()
+
+        with patch(f"{M}.requests.Session", return_value=offhost_session):
+            with pytest.raises(ValueError):
+                client.download_attachment("https://acme.zendesk.com/attachments/x", max_bytes=10)
+        assert client._session.get.call_count == 1
+        offhost_session.get.assert_not_called()
 
 
 class TestExpectedHostGuard:
@@ -149,6 +227,10 @@ class TestExpectedHostGuard:
             pytest.param("http://acme.zendesk.com/api/v2/tickets/1/comments.json", id="http_downgrade"),
             pytest.param("https://evil.example.com/steal", id="off_host"),
             pytest.param("https://acme.zendesk.com.evil.com/steal", id="suffix_host"),
+            # Backslash authority-bypass: urlsplit reads the host after the "\@" as acme.zendesk.com
+            # while requests connects to evil.example before it — the token must never go out.
+            pytest.param("https://evil.example\\@acme.zendesk.com/steal", id="backslash_authority_bypass"),
+            pytest.param("https://evil.example%5c@acme.zendesk.com/steal", id="encoded_backslash_bypass"),
         ],
     )
     def test_download_attachment_refuses_and_sends_nothing(self, url: str) -> None:

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_client.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_client.py
@@ -8,10 +8,23 @@ from products.conversations.backend.temporal.zendesk_import.client import (
     ZendeskAttachmentTooLargeError,
     ZendeskCredentials,
     ZendeskImportClient,
+    _PinnedIPAdapter,
     validate_zendesk_credentials,
 )
 
 M = "products.conversations.backend.temporal.zendesk_import.client"
+
+
+class TestPinnedIPAdapter:
+    def test_idn_host_pin_matches_punycode_lookup(self) -> None:
+        # requests IDNA-encodes the host before send(), so a pin under the raw Unicode host must
+        # still resolve when send() looks it up by the "xn--" form — otherwise the lookup misses
+        # and falls back to live DNS (rebinding window).
+        adapter = _PinnedIPAdapter()
+        adapter.pin("éxample.test", "203.0.113.10")
+        assert adapter._pin_map == {"xn--xample-9ua.test": "203.0.113.10"}
+        assert adapter._canonical_host("xn--xample-9ua.test") == "xn--xample-9ua.test"
+        assert adapter._canonical_host("ÉXAMPLE.test") == "xn--xample-9ua.test"
 
 
 class _FakeStreamResponse:

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_client.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_client.py
@@ -14,8 +14,10 @@ M = "products.conversations.backend.temporal.zendesk_import.client"
 
 
 class _FakeStreamResponse:
-    def __init__(self, *, headers: dict[str, str] | None = None, chunks: Iterable[bytes] = ()) -> None:
-        self.status_code = 200
+    def __init__(
+        self, *, status_code: int = 200, headers: dict[str, str] | None = None, chunks: Iterable[bytes] = ()
+    ) -> None:
+        self.status_code = status_code
         self.headers = headers or {}
         self._chunks = list(chunks)
         self.consumed_chunks = 0
@@ -91,6 +93,45 @@ class TestDownloadAttachmentSizeCap:
         client._session.get.return_value = resp
 
         assert client.download_attachment("https://acme.zendesk.com/a", max_bytes=10) == b"abcdef"
+
+
+class TestDownloadAttachmentRedirects:
+    def _client(self) -> ZendeskImportClient:
+        return ZendeskImportClient(
+            ZendeskCredentials(subdomain="acme", email_address="agent@acme.com", api_token="tok")
+        )
+
+    def test_follows_offhost_cdn_redirect_dropping_auth(self) -> None:
+        # content_url is on the Zendesk host and 302s to an external CDN. We must follow the hop,
+        # but the reusable Zendesk token must NOT be sent to the CDN.
+        client = self._client()
+        redirect = _FakeStreamResponse(status_code=302, headers={"Location": "https://cdn.zdusercontent.com/blob"})
+        final = _FakeStreamResponse(headers={"Content-Length": "3"}, chunks=[b"abc"])
+        client._session = MagicMock()
+        client._session.get.side_effect = [redirect, final]
+
+        with patch(f"{M}.is_url_allowed", return_value=(True, None)):
+            assert client.download_attachment("https://acme.zendesk.com/attachments/x", max_bytes=10) == b"abc"
+
+        first_headers = client._session.get.call_args_list[0].kwargs["headers"]
+        second_headers = client._session.get.call_args_list[1].kwargs["headers"]
+        assert "Authorization" in first_headers
+        assert "Authorization" not in second_headers
+
+    def test_refuses_redirect_to_internal_host(self) -> None:
+        # A 302 pointing at an internal/metadata host must be refused before the followed request
+        # goes out — the session no longer auto-follows, and the SSRF allowlist blocks the hop.
+        client = self._client()
+        redirect = _FakeStreamResponse(
+            status_code=302, headers={"Location": "https://169.254.169.254/latest/meta-data/"}
+        )
+        client._session = MagicMock()
+        client._session.get.side_effect = [redirect]
+
+        with patch(f"{M}.is_url_allowed", return_value=(False, "Disallowed target IP")):
+            with pytest.raises(ValueError):
+                client.download_attachment("https://acme.zendesk.com/attachments/x", max_bytes=10)
+        assert client._session.get.call_count == 1
 
 
 class TestExpectedHostGuard:


### PR DESCRIPTION
## Problem

Zendesk import's HTTP client claimed to pin every request to the team's `*.zendesk.com` host, but the session still auto-followed redirects. Attachment `content_url`s legitimately 302 to an external CDN, so redirects are required, yet the hop was not validated. That meant a malicious or compromised API response could retarget a token-bearing request off-host.

This worker runs on the video-export task queue, not behind warehouse Smokescreen egress, so the host pin was the main SSRF control and it was incomplete.

## Changes

- Create the Zendesk session with `allow_redirects=False` (client + credential probe).
- Refuse unexpected `3xx` responses from JSON API calls instead of chasing `Location` with the auth token.
- Follow attachment redirects manually with a bounded hop limit:
  - stay on the pinned Zendesk host → keep Basic auth
  - off-host → require `https`, pass `is_url_allowed`, and strip `Authorization` so the Zendesk token never leaves the Zendesk host
- Add tests for CDN follow (auth dropped) and blocked internal/metadata redirect.
