### PR TITLE
feat(inbox): share filters via URL params

### DIFF
--- a/frontend/src/scenes/inbox/filterOptions.tsx
+++ b/frontend/src/scenes/inbox/filterOptions.tsx
@@ -17,7 +17,7 @@ import {
 } from '@posthog/icons'
 import { LemonTagType } from '@posthog/lemon-ui'
 
-import { InboxSortDirection, InboxSortField } from './logics/inboxFiltersLogic'
+import type { InboxSortDirection, InboxSortField } from './logics/inboxFiltersLogic'
 import { SignalReportPriority } from './types'
 
 /**

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -20,8 +20,8 @@ import {
     InboxReportCloseMethod,
     InboxReportOpenMethod,
 } from './inboxAnalytics'
-import { inboxFiltersLogic } from './logics/inboxFiltersLogic'
 import type { inboxSceneLogicType } from './inboxSceneLogicType'
+import { inboxFiltersLogic } from './logics/inboxFiltersLogic'
 import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from './logics/reportListLogic'
 import { scratchpadLogic } from './logics/scratchpadLogic'
 import { signalSourcesLogic } from './signalSourcesLogic'

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -20,6 +20,7 @@ import {
     InboxReportCloseMethod,
     InboxReportOpenMethod,
 } from './inboxAnalytics'
+import { inboxFiltersLogic } from './logics/inboxFiltersLogic'
 import type { inboxSceneLogicType } from './inboxSceneLogicType'
 import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from './logics/reportListLogic'
 import { scratchpadLogic } from './logics/scratchpadLogic'
@@ -187,6 +188,9 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
     path(['scenes', 'inbox', 'inboxSceneLogic']),
 
     connect(() => ({
+        // Mount inboxFiltersLogic with the scene so its URL sync (shareable filter params) applies on
+        // deep-link load, before the filter bar / list have rendered.
+        logic: [inboxFiltersLogic],
         values: [signalSourcesLogic, ['isSessionAnalysisRunning'], userLogic, ['user']],
         actions: [signalSourcesLogic, ['loadSourceConfigs']],
     })),

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
@@ -11,6 +11,7 @@ const DEFAULT_STATE: InboxFilterState = {
     priorityFilter: [],
     sortField: 'priority',
     sortDirection: 'asc',
+    searchQuery: '',
 }
 
 describe('inboxFiltersLogic', () => {
@@ -41,19 +42,21 @@ describe('inboxFiltersLogic', () => {
 
         it.each<[string, InboxFilterState, Record<string, string>]>([
             [
-                'scope + multiple sources + priorities + custom sort',
+                'scope + sources + priorities + custom sort + search',
                 {
                     scope: 'entire-project',
                     sourceProductFilter: ['error_tracking', 'github'],
                     priorityFilter: ['P0', 'P2'],
                     sortField: 'created_at',
                     sortDirection: 'desc',
+                    searchQuery: 'checkout crash',
                 },
                 {
                     scope: 'entire-project',
                     source: 'error_tracking,github',
                     priority: 'P0,P2',
                     sort: 'created_at:desc',
+                    search: 'checkout crash',
                 },
             ],
             [
@@ -66,15 +69,17 @@ describe('inboxFiltersLogic', () => {
             expect(parseFilterSearchParams(expectedParams)).toEqual(state)
         })
 
-        // A shared link is authoritative but untrusted: unknown values (and a malformed teammate id, which
-        // would otherwise reach the report-list API as a bad reviewer UUID) must not leak into filter state.
-        it('drops unknown sources, priorities, malformed teammate scope and sort, falling back to defaults', () => {
+        // A shared link is authoritative but untrusted: unknown values (a malformed teammate id, which would
+        // otherwise reach the report-list API as a bad reviewer UUID, and a syntactically valid but
+        // unsupported sort combination the Sort control can't display) must not leak into filter state.
+        it('drops unknown sources, priorities, malformed teammate scope and unsupported sort', () => {
             expect(
                 parseFilterSearchParams({
                     scope: 'teammate:not-a-uuid',
                     source: 'error_tracking,bogus_source',
                     priority: 'P9,P1',
-                    sort: 'foo:sideways',
+                    // priority:desc has a valid field and direction but is not one of the offered sort options.
+                    sort: 'priority:desc',
                 })
             ).toEqual({
                 ...DEFAULT_STATE,

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
@@ -1,20 +1,80 @@
-import { buildSignalReportListOrdering } from './inboxFiltersLogic'
+import {
+    buildSignalReportListOrdering,
+    filterSearchParams,
+    InboxFilterState,
+    parseFilterSearchParams,
+} from './inboxFiltersLogic'
 
-describe('buildSignalReportListOrdering', () => {
-    it('leads with the selected time field so "Newest first" surfaces the newest reports', () => {
-        // The list is flat, so created_at must be the primary key — not a sub-sort within status buckets.
-        expect(buildSignalReportListOrdering('created_at', 'desc')).toBe('-created_at,status,-updated_at')
+const DEFAULT_STATE: InboxFilterState = {
+    scope: 'for-you',
+    sourceProductFilter: [],
+    priorityFilter: [],
+    sortField: 'priority',
+    sortDirection: 'asc',
+}
+
+describe('inboxFiltersLogic', () => {
+    describe('buildSignalReportListOrdering', () => {
+        it('leads with the selected time field so "Newest first" surfaces the newest reports', () => {
+            // The list is flat, so created_at must be the primary key — not a sub-sort within status buckets.
+            expect(buildSignalReportListOrdering('created_at', 'desc')).toBe('-created_at,status,-updated_at')
+        })
+
+        it('leads with created_at ascending for "Oldest first"', () => {
+            expect(buildSignalReportListOrdering('created_at', 'asc')).toBe('created_at,status,-updated_at')
+        })
+
+        it('leads with updated_at and drops the redundant tiebreak for "Last updated first"', () => {
+            expect(buildSignalReportListOrdering('updated_at', 'desc')).toBe('-updated_at,status')
+        })
+
+        it('leads with priority for "Priority first"', () => {
+            expect(buildSignalReportListOrdering('priority', 'asc')).toBe('priority,status,-updated_at')
+        })
     })
 
-    it('leads with created_at ascending for "Oldest first"', () => {
-        expect(buildSignalReportListOrdering('created_at', 'asc')).toBe('created_at,status,-updated_at')
-    })
+    describe('filter URL params', () => {
+        // Keeps shared links clean: a default view must not carry any filter params.
+        it('omits all default filters from the URL', () => {
+            expect(filterSearchParams(DEFAULT_STATE)).toEqual({})
+        })
 
-    it('leads with updated_at and drops the redundant tiebreak for "Last updated first"', () => {
-        expect(buildSignalReportListOrdering('updated_at', 'desc')).toBe('-updated_at,status')
-    })
+        it.each<[string, InboxFilterState, Record<string, string>]>([
+            [
+                'scope + multiple sources + priorities + custom sort',
+                {
+                    scope: 'entire-project',
+                    sourceProductFilter: ['error_tracking', 'github'],
+                    priorityFilter: ['P0', 'P2'],
+                    sortField: 'created_at',
+                    sortDirection: 'desc',
+                },
+                { scope: 'entire-project', source: 'error_tracking,github', priority: 'P0,P2', sort: 'created_at:desc' },
+            ],
+            [
+                'teammate scope only',
+                { ...DEFAULT_STATE, scope: 'teammate:abc-123' },
+                { scope: 'teammate:abc-123' },
+            ],
+        ])('round-trips %s through encode/decode', (_name, state, expectedParams) => {
+            expect(filterSearchParams(state)).toEqual(expectedParams)
+            expect(parseFilterSearchParams(expectedParams)).toEqual(state)
+        })
 
-    it('leads with priority for "Priority first"', () => {
-        expect(buildSignalReportListOrdering('priority', 'asc')).toBe('priority,status,-updated_at')
+        // A shared link is authoritative but untrusted: unknown values must not leak into the filter state.
+        it('drops unknown sources, priorities, scope and sort, falling back to defaults', () => {
+            expect(
+                parseFilterSearchParams({
+                    scope: 'nonsense',
+                    source: 'error_tracking,bogus_source',
+                    priority: 'P9,P1',
+                    sort: 'foo:sideways',
+                })
+            ).toEqual({
+                ...DEFAULT_STATE,
+                sourceProductFilter: ['error_tracking'],
+                priorityFilter: ['P1'],
+            })
+        })
     })
 })

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
@@ -49,7 +49,12 @@ describe('inboxFiltersLogic', () => {
                     sortField: 'created_at',
                     sortDirection: 'desc',
                 },
-                { scope: 'entire-project', source: 'error_tracking,github', priority: 'P0,P2', sort: 'created_at:desc' },
+                {
+                    scope: 'entire-project',
+                    source: 'error_tracking,github',
+                    priority: 'P0,P2',
+                    sort: 'created_at:desc',
+                },
             ],
             [
                 'teammate scope only',

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.test.ts
@@ -53,19 +53,20 @@ describe('inboxFiltersLogic', () => {
             ],
             [
                 'teammate scope only',
-                { ...DEFAULT_STATE, scope: 'teammate:abc-123' },
-                { scope: 'teammate:abc-123' },
+                { ...DEFAULT_STATE, scope: 'teammate:0199ed4a-5c03-0000-3220-df21df612e95' },
+                { scope: 'teammate:0199ed4a-5c03-0000-3220-df21df612e95' },
             ],
         ])('round-trips %s through encode/decode', (_name, state, expectedParams) => {
             expect(filterSearchParams(state)).toEqual(expectedParams)
             expect(parseFilterSearchParams(expectedParams)).toEqual(state)
         })
 
-        // A shared link is authoritative but untrusted: unknown values must not leak into the filter state.
-        it('drops unknown sources, priorities, scope and sort, falling back to defaults', () => {
+        // A shared link is authoritative but untrusted: unknown values (and a malformed teammate id, which
+        // would otherwise reach the report-list API as a bad reviewer UUID) must not leak into filter state.
+        it('drops unknown sources, priorities, malformed teammate scope and sort, falling back to defaults', () => {
             expect(
                 parseFilterSearchParams({
-                    scope: 'nonsense',
+                    scope: 'teammate:not-a-uuid',
                     source: 'error_tracking,bogus_source',
                     priority: 'P9,P1',
                     sort: 'foo:sideways',

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -1,8 +1,11 @@
 import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
+import { urls } from 'scenes/urls'
 
+import { INBOX_PRIORITY_OPTIONS, INBOX_SOURCE_OPTIONS } from '../filterOptions'
 import { INBOX_SCOPE_FOR_YOU, InboxScope, SignalReportPriority } from '../types'
 import type { inboxFiltersLogicType } from './inboxFiltersLogicType'
 
@@ -15,6 +18,94 @@ export interface InboxReviewerOption {
 
 export type InboxSortField = 'priority' | 'created_at' | 'updated_at'
 export type InboxSortDirection = 'asc' | 'desc'
+
+const DEFAULT_SORT_FIELD: InboxSortField = 'priority'
+const DEFAULT_SORT_DIRECTION: InboxSortDirection = 'asc'
+
+// Query-param keys that mirror the filter state so a view can be shared via URL.
+const FILTER_URL_KEYS = ['scope', 'source', 'priority', 'sort'] as const
+
+const VALID_SOURCE_VALUES = new Set(INBOX_SOURCE_OPTIONS.map((o) => o.value))
+const VALID_PRIORITIES = new Set<string>(INBOX_PRIORITY_OPTIONS)
+const VALID_SORT_FIELDS = new Set<string>(['priority', 'created_at', 'updated_at'])
+
+export interface InboxFilterState {
+    scope: InboxScope
+    sourceProductFilter: string[]
+    priorityFilter: SignalReportPriority[]
+    sortField: InboxSortField
+    sortDirection: InboxSortDirection
+}
+
+function parseScopeParam(raw: unknown): InboxScope {
+    if (typeof raw === 'string' && (raw === 'entire-project' || raw.startsWith('teammate:'))) {
+        return raw as InboxScope
+    }
+    return INBOX_SCOPE_FOR_YOU
+}
+
+function parseListParam(raw: unknown, valid: Set<string>): string[] {
+    if (typeof raw !== 'string' || raw.length === 0) {
+        return []
+    }
+    return raw.split(',').filter((v) => valid.has(v))
+}
+
+/** Decode the filter query params into filter state, ignoring unknown/invalid values and falling back to defaults. */
+export function parseFilterSearchParams(searchParams: Record<string, any>): InboxFilterState {
+    let sortField = DEFAULT_SORT_FIELD
+    let sortDirection = DEFAULT_SORT_DIRECTION
+    if (typeof searchParams.sort === 'string') {
+        const [field, direction] = searchParams.sort.split(':')
+        if (VALID_SORT_FIELDS.has(field) && (direction === 'asc' || direction === 'desc')) {
+            sortField = field as InboxSortField
+            sortDirection = direction
+        }
+    }
+    return {
+        scope: parseScopeParam(searchParams.scope),
+        sourceProductFilter: parseListParam(searchParams.source, VALID_SOURCE_VALUES),
+        priorityFilter: parseListParam(searchParams.priority, VALID_PRIORITIES) as SignalReportPriority[],
+        sortField,
+        sortDirection,
+    }
+}
+
+function sameSet(a: string[], b: string[]): boolean {
+    return a.length === b.length && [...a].sort().join(',') === [...b].sort().join(',')
+}
+
+/** Build the query params that mirror the current (non-default) filter state. Defaults are omitted so a shared URL stays clean. */
+export function filterSearchParams(values: InboxFilterState): Record<string, string> {
+    const params: Record<string, string> = {}
+    if (values.scope !== INBOX_SCOPE_FOR_YOU) {
+        params.scope = values.scope
+    }
+    if (values.sourceProductFilter.length > 0) {
+        params.source = values.sourceProductFilter.join(',')
+    }
+    if (values.priorityFilter.length > 0) {
+        params.priority = values.priorityFilter.join(',')
+    }
+    if (values.sortField !== DEFAULT_SORT_FIELD || values.sortDirection !== DEFAULT_SORT_DIRECTION) {
+        params.sort = `${values.sortField}:${values.sortDirection}`
+    }
+    return params
+}
+
+/**
+ * Build the state-mirroring inbox URL for the current pathname: keep any non-filter query params,
+ * drop stale filter keys, then write the current non-default filter state back on. `replace: true`
+ * keeps filter toggles out of the browser history.
+ */
+function currentUrlWithFilters(values: InboxFilterState): [string, Record<string, any>, any, { replace: boolean }] {
+    const searchParams = { ...router.values.searchParams }
+    for (const key of FILTER_URL_KEYS) {
+        delete searchParams[key]
+    }
+    Object.assign(searchParams, filterSearchParams(values))
+    return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
+}
 
 /**
  * Build the `ordering` query param. The list is a flat list (no status section
@@ -45,6 +136,11 @@ export function buildSignalReportListOrdering(field: InboxSortField, direction: 
  *   `sourceProductFilter`, `priorityFilter` (all persisted). `searchQuery` is NOT
  *   persisted on desktop, so it isn't here either.
  *
+ * Filter state (scope, source, priority, sort) is also mirrored to the URL query
+ * string so a specific view can be shared via a link. The URL is authoritative on
+ * load whenever any filter param is present; a bare `/inbox` falls back to the
+ * persisted state (and is then reflected back into the URL so it stays shareable).
+ *
  * The central `inboxSceneLogic` connects these values, maps them to list-API
  * params (`source_product`, `priority`, `ordering`), and reloads on change.
  */
@@ -60,6 +156,9 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
         setSort: (field: InboxSortField, direction: InboxSortDirection) => ({ field, direction }),
         toggleSourceProduct: (source: string) => ({ source }),
         togglePriority: (priority: SignalReportPriority) => ({ priority }),
+        // Bulk-set variants used when hydrating from the URL (a shared link is authoritative).
+        setSourceProducts: (sources: string[]) => ({ sources }),
+        setPriorities: (priorities: SignalReportPriority[]) => ({ priorities }),
         clearFilters: true,
         // Debounced server-side org-member search for the scope (teammate) picker.
         searchAvailableReviewers: (query: string) => ({ query }),
@@ -113,14 +212,14 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             },
         ],
         sortField: [
-            'priority' as InboxSortField,
+            DEFAULT_SORT_FIELD as InboxSortField,
             { persist: true },
             {
                 setSort: (_, { field }) => field,
             },
         ],
         sortDirection: [
-            'asc' as InboxSortDirection,
+            DEFAULT_SORT_DIRECTION as InboxSortDirection,
             { persist: true },
             {
                 setSort: (_, { direction }) => direction,
@@ -132,6 +231,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             {
                 toggleSourceProduct: (state, { source }) =>
                     state.includes(source) ? state.filter((s) => s !== source) : [...state, source],
+                setSourceProducts: (_, { sources }) => sources,
                 clearFilters: () => [],
             },
         ],
@@ -141,6 +241,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             {
                 togglePriority: (state, { priority }) =>
                     state.includes(priority) ? state.filter((p) => p !== priority) : [...state, priority],
+                setPriorities: (_, { priorities }) => priorities,
                 clearFilters: () => [],
             },
         ],
@@ -154,6 +255,65 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             (searchQuery, sourceProductFilter, priorityFilter): boolean =>
                 searchQuery.trim().length > 0 || sourceProductFilter.length > 0 || priorityFilter.length > 0,
         ],
+    }),
+
+    actionToUrl(({ values }) => {
+        // Every filter mutation rewrites the current URL from the full (non-default) filter state.
+        const toUrl = (): [string, Record<string, any>, any, { replace: boolean }] => currentUrlWithFilters(values)
+        return {
+            setScope: toUrl,
+            applyDefaultScope: toUrl,
+            setSort: toUrl,
+            toggleSourceProduct: toUrl,
+            togglePriority: toUrl,
+            setSourceProducts: toUrl,
+            setPriorities: toUrl,
+            clearFilters: toUrl,
+        }
+    }),
+
+    urlToAction(({ actions, values }) => {
+        const applyFromUrl = (_: unknown, searchParams: Record<string, any>): void => {
+            const hasFilterParams = FILTER_URL_KEYS.some((key) => key in searchParams)
+            if (!hasFilterParams) {
+                // Bare inbox URL: keep the persisted state, but reflect any non-default filters back
+                // into the URL so the current view is immediately shareable.
+                const desired = filterSearchParams(values)
+                if (Object.keys(desired).length > 0) {
+                    router.actions.replace(
+                        router.values.location.pathname,
+                        { ...router.values.searchParams, ...desired },
+                        router.values.hashParams
+                    )
+                }
+                return
+            }
+
+            // A shared link is authoritative: apply the params it carries and reset the rest to defaults.
+            const parsed = parseFilterSearchParams(searchParams)
+            if (values.scope !== parsed.scope) {
+                actions.setScope(parsed.scope)
+            }
+            if (!sameSet(values.sourceProductFilter, parsed.sourceProductFilter)) {
+                actions.setSourceProducts(parsed.sourceProductFilter)
+            }
+            if (!sameSet(values.priorityFilter, parsed.priorityFilter)) {
+                actions.setPriorities(parsed.priorityFilter)
+            }
+            if (values.sortField !== parsed.sortField || values.sortDirection !== parsed.sortDirection) {
+                actions.setSort(parsed.sortField, parsed.sortDirection)
+            }
+        }
+
+        return {
+            [urls.inbox()]: applyFromUrl,
+            [urls.inbox(':tab')]: applyFromUrl,
+            [urls.inboxScratchpad()]: applyFromUrl,
+            [urls.inboxFindings()]: applyFromUrl,
+            [urls.inboxScout(':skillName')]: applyFromUrl,
+            [urls.inboxScout(':skillName', ':findingId')]: applyFromUrl,
+            [urls.inboxReport(':tab', ':reportId')]: applyFromUrl,
+        }
     }),
 
     afterMount(({ actions }) => {

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -6,7 +6,7 @@ import api from 'lib/api'
 import { isUUIDLike } from 'lib/utils/guards'
 import { urls } from 'scenes/urls'
 
-import { INBOX_PRIORITY_OPTIONS, INBOX_SOURCE_OPTIONS } from '../filterOptions'
+import { INBOX_PRIORITY_OPTIONS, INBOX_SORT_OPTIONS, INBOX_SOURCE_OPTIONS } from '../filterOptions'
 import { INBOX_SCOPE_FOR_YOU, InboxScope, SignalReportPriority } from '../types'
 import type { inboxFiltersLogicType } from './inboxFiltersLogicType'
 
@@ -24,11 +24,13 @@ const DEFAULT_SORT_FIELD: InboxSortField = 'priority'
 const DEFAULT_SORT_DIRECTION: InboxSortDirection = 'asc'
 
 // Query-param keys that mirror the filter state so a view can be shared via URL.
-const FILTER_URL_KEYS = ['scope', 'source', 'priority', 'sort'] as const
+const FILTER_URL_KEYS = ['scope', 'source', 'priority', 'sort', 'search'] as const
 
 const VALID_SOURCE_VALUES = new Set(INBOX_SOURCE_OPTIONS.map((o) => o.value))
 const VALID_PRIORITIES = new Set<string>(INBOX_PRIORITY_OPTIONS)
-const VALID_SORT_FIELDS = new Set<string>(['priority', 'created_at', 'updated_at'])
+// Only the field/direction combinations the Sort control actually offers — validating the field and
+// direction independently would accept keys like `priority:desc` that have no matching UI option.
+const VALID_SORT_KEYS = new Set(INBOX_SORT_OPTIONS.map((o) => `${o.field}:${o.direction}`))
 
 export interface InboxFilterState {
     scope: InboxScope
@@ -36,6 +38,7 @@ export interface InboxFilterState {
     priorityFilter: SignalReportPriority[]
     sortField: InboxSortField
     sortDirection: InboxSortDirection
+    searchQuery: string
 }
 
 function parseScopeParam(raw: unknown): InboxScope {
@@ -63,12 +66,10 @@ function parseListParam(raw: unknown, valid: Set<string>): string[] {
 export function parseFilterSearchParams(searchParams: Record<string, any>): InboxFilterState {
     let sortField = DEFAULT_SORT_FIELD
     let sortDirection = DEFAULT_SORT_DIRECTION
-    if (typeof searchParams.sort === 'string') {
+    if (typeof searchParams.sort === 'string' && VALID_SORT_KEYS.has(searchParams.sort)) {
         const [field, direction] = searchParams.sort.split(':')
-        if (VALID_SORT_FIELDS.has(field) && (direction === 'asc' || direction === 'desc')) {
-            sortField = field as InboxSortField
-            sortDirection = direction
-        }
+        sortField = field as InboxSortField
+        sortDirection = direction as InboxSortDirection
     }
     return {
         scope: parseScopeParam(searchParams.scope),
@@ -76,6 +77,7 @@ export function parseFilterSearchParams(searchParams: Record<string, any>): Inbo
         priorityFilter: parseListParam(searchParams.priority, VALID_PRIORITIES) as SignalReportPriority[],
         sortField,
         sortDirection,
+        searchQuery: typeof searchParams.search === 'string' ? searchParams.search : '',
     }
 }
 
@@ -97,6 +99,9 @@ export function filterSearchParams(values: InboxFilterState): Record<string, str
     }
     if (values.sortField !== DEFAULT_SORT_FIELD || values.sortDirection !== DEFAULT_SORT_DIRECTION) {
         params.sort = `${values.sortField}:${values.sortDirection}`
+    }
+    if (values.searchQuery.trim().length > 0) {
+        params.search = values.searchQuery
     }
     return params
 }
@@ -214,11 +219,13 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
                 setFilters: () => true,
             },
         ],
-        // Not persisted – matches desktop (searchQuery is excluded from `partialize`).
+        // Not persisted – matches desktop (searchQuery is excluded from `partialize`). It is mirrored to
+        // the URL though, so a shared link reproduces the search too and hydration can reset it.
         searchQuery: [
             '',
             {
                 setSearchQuery: (_, { searchQuery }) => searchQuery,
+                setFilters: (_, { filters }) => filters.searchQuery,
                 clearFilters: () => '',
             },
         ],
@@ -281,6 +288,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             setSort: toUrl,
             toggleSourceProduct: toUrl,
             togglePriority: toUrl,
+            setSearchQuery: toUrl,
             clearFilters: toUrl,
         }
     }),
@@ -311,7 +319,8 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
                 !sameSet(values.sourceProductFilter, parsed.sourceProductFilter) ||
                 !sameSet(values.priorityFilter, parsed.priorityFilter) ||
                 values.sortField !== parsed.sortField ||
-                values.sortDirection !== parsed.sortDirection
+                values.sortDirection !== parsed.sortDirection ||
+                values.searchQuery !== parsed.searchQuery
             if (changed) {
                 actions.setFilters(parsed)
             }

--- a/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxFiltersLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
+import { isUUIDLike } from 'lib/utils/guards'
 import { urls } from 'scenes/urls'
 
 import { INBOX_PRIORITY_OPTIONS, INBOX_SOURCE_OPTIONS } from '../filterOptions'
@@ -38,8 +39,15 @@ export interface InboxFilterState {
 }
 
 function parseScopeParam(raw: unknown): InboxScope {
-    if (typeof raw === 'string' && (raw === 'entire-project' || raw.startsWith('teammate:'))) {
-        return raw as InboxScope
+    if (typeof raw === 'string') {
+        if (raw === 'entire-project') {
+            return raw
+        }
+        // Validate the teammate id so a malformed shared link falls back to the default scope
+        // instead of forwarding junk to the report-list API as a reviewer UUID.
+        if (raw.startsWith('teammate:') && isUUIDLike(raw.slice('teammate:'.length))) {
+            return raw as InboxScope
+        }
     }
     return INBOX_SCOPE_FOR_YOU
 }
@@ -156,9 +164,9 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
         setSort: (field: InboxSortField, direction: InboxSortDirection) => ({ field, direction }),
         toggleSourceProduct: (source: string) => ({ source }),
         togglePriority: (priority: SignalReportPriority) => ({ priority }),
-        // Bulk-set variants used when hydrating from the URL (a shared link is authoritative).
-        setSourceProducts: (sources: string[]) => ({ sources }),
-        setPriorities: (priorities: SignalReportPriority[]) => ({ priorities }),
+        // Atomically apply a full filter set. Used when hydrating from a shared URL so the whole view
+        // is restored in one action — one list refresh, no fan-out race between partial states.
+        setFilters: (filters: InboxFilterState) => ({ filters }),
         clearFilters: true,
         // Debounced server-side org-member search for the scope (teammate) picker.
         searchAvailableReviewers: (query: string) => ({ query }),
@@ -192,15 +200,18 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             {
                 setScope: (_, { scope }) => scope,
                 applyDefaultScope: (_, { scope }) => scope,
+                setFilters: (_, { filters }) => filters.scope,
             },
         ],
         // Whether the user has explicitly picked a scope. Once true, the empty-inbox auto-default
         // no longer fires, so a deliberate choice of "For you" is respected even with zero reports.
+        // A shared link is an explicit choice too, so hydrating from the URL sets it.
         hasUserChosenScope: [
             false,
             { persist: true },
             {
                 setScope: () => true,
+                setFilters: () => true,
             },
         ],
         // Not persisted – matches desktop (searchQuery is excluded from `partialize`).
@@ -216,6 +227,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             { persist: true },
             {
                 setSort: (_, { field }) => field,
+                setFilters: (_, { filters }) => filters.sortField,
             },
         ],
         sortDirection: [
@@ -223,6 +235,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             { persist: true },
             {
                 setSort: (_, { direction }) => direction,
+                setFilters: (_, { filters }) => filters.sortDirection,
             },
         ],
         sourceProductFilter: [
@@ -231,7 +244,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             {
                 toggleSourceProduct: (state, { source }) =>
                     state.includes(source) ? state.filter((s) => s !== source) : [...state, source],
-                setSourceProducts: (_, { sources }) => sources,
+                setFilters: (_, { filters }) => filters.sourceProductFilter,
                 clearFilters: () => [],
             },
         ],
@@ -241,7 +254,7 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             {
                 togglePriority: (state, { priority }) =>
                     state.includes(priority) ? state.filter((p) => p !== priority) : [...state, priority],
-                setPriorities: (_, { priorities }) => priorities,
+                setFilters: (_, { filters }) => filters.priorityFilter,
                 clearFilters: () => [],
             },
         ],
@@ -260,14 +273,14 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
     actionToUrl(({ values }) => {
         // Every filter mutation rewrites the current URL from the full (non-default) filter state.
         const toUrl = (): [string, Record<string, any>, any, { replace: boolean }] => currentUrlWithFilters(values)
+        // `setFilters` is intentionally absent: it only fires while hydrating from the URL, which is
+        // already the source of truth in that path, so re-deriving the URL from it would be redundant.
         return {
             setScope: toUrl,
             applyDefaultScope: toUrl,
             setSort: toUrl,
             toggleSourceProduct: toUrl,
             togglePriority: toUrl,
-            setSourceProducts: toUrl,
-            setPriorities: toUrl,
             clearFilters: toUrl,
         }
     }),
@@ -290,18 +303,17 @@ export const inboxFiltersLogic = kea<inboxFiltersLogicType>([
             }
 
             // A shared link is authoritative: apply the params it carries and reset the rest to defaults.
+            // Only dispatch when something actually changed — urlToAction also fires on plain navigation
+            // (opening a report, switching tabs), and we don't want a redundant list refresh each time.
             const parsed = parseFilterSearchParams(searchParams)
-            if (values.scope !== parsed.scope) {
-                actions.setScope(parsed.scope)
-            }
-            if (!sameSet(values.sourceProductFilter, parsed.sourceProductFilter)) {
-                actions.setSourceProducts(parsed.sourceProductFilter)
-            }
-            if (!sameSet(values.priorityFilter, parsed.priorityFilter)) {
-                actions.setPriorities(parsed.priorityFilter)
-            }
-            if (values.sortField !== parsed.sortField || values.sortDirection !== parsed.sortDirection) {
-                actions.setSort(parsed.sortField, parsed.sortDirection)
+            const changed =
+                values.scope !== parsed.scope ||
+                !sameSet(values.sourceProductFilter, parsed.sourceProductFilter) ||
+                !sameSet(values.priorityFilter, parsed.priorityFilter) ||
+                values.sortField !== parsed.sortField ||
+                values.sortDirection !== parsed.sortDirection
+            if (changed) {
+                actions.setFilters(parsed)
             }
         }
 

--- a/frontend/src/scenes/inbox/logics/reportListLogic.ts
+++ b/frontend/src/scenes/inbox/logics/reportListLogic.ts
@@ -113,6 +113,7 @@ export const reportListLogic = kea<reportListLogicType>([
                 'togglePriority',
                 'setScope',
                 'applyDefaultScope',
+                'setFilters',
                 'clearFilters',
             ],
         ],
@@ -257,6 +258,7 @@ export const reportListLogic = kea<reportListLogicType>([
         togglePriority: () => actions.refresh(),
         setScope: () => actions.refresh(),
         applyDefaultScope: () => actions.refresh(),
+        setFilters: () => actions.refresh(),
         clearFilters: () => actions.refresh(),
         // For-you scope needs the current user's uuid; reload once it resolves.
         [userLogic.actionTypes.loadUserSuccess]: () => {


### PR DESCRIPTION
## Problem

Inbox users had no way to share the exact view they were looking at. The author (reviewer scope), source, priority and sort filters lived only in local storage, so a link to `/inbox` always dropped the recipient into their own persisted filters. If you spotted something worth handing off ("look at the error-tracking reports assigned to me, priority first") you had to describe the filters in words.

## Changes

Filter state now round-trips through the URL query string:

- `scope` — the author/reviewer scope (`for-you`, `entire-project`, `teammate:<uuid>`)
- `source` — comma-separated source products
- `priority` — comma-separated priorities
- `sort` — `field:direction`

The logic (`inboxFiltersLogic`) gained `actionToUrl`/`urlToAction`. Any filter change rewrites the current URL (with `replace: true`, so toggles don't pile up in history). Defaults are omitted, keeping shared links clean. On load a link is authoritative for the filters it carries and resets the rest to defaults, so it reproduces the sender's view faithfully; a bare `/inbox` keeps the persisted state and reflects it back into the URL so the current view is immediately shareable. Unknown or malformed param values are dropped rather than trusted.

Local storage persistence is unchanged. The logic is now connected into `inboxSceneLogic` so its URL sync applies on a cold deep-link before the filter bar renders.

## How did you test this code?

Added unit tests on the pure encode/decode functions in `inboxFiltersLogic.test.ts`: a round-trip through `filterSearchParams` → `parseFilterSearchParams`, that default filters produce an empty param set (clean links), and that unknown source/priority/scope/sort values fall back to defaults. These guard the two ways shared links break silently — a default leaking into the URL, or an invalid param leaking into the filter state. No existing test covered URL syncing (it didn't exist before).

I (Claude, the PostHog Slack app) could not run the frontend typecheck or jest locally — dependencies aren't installed in this environment — so CI is the first place these run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy Maguire asked for the inbox author and source filters to become shareable URL params. I chose to sync the full filter/sort set (scope, source, priority, sort) rather than just the two named ones, so a link reproduces the whole view. Key design decision: make the link authoritative on load but fall back to persisted state on a bare URL, which keeps existing local-storage persistence intact while enabling sharing. Invoked the `/writing-tests` skill before adding tests and kept them at the cheapest rung (pure functions) rather than a full kea-router harness test.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1784029883955299)*
