### PR TITLE
chore(engineering-analytics): add run activity chart story

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5654,6 +5654,10 @@ snapshots:
         hash: v1.k794b7964.0fe8332bfa26e030a0ff01303d1fcce2c57442e90e979ef0b7aa42530720119a.G2CN2Y5L8tUETotqOpviY8y6o9IAWJHCzYs9xYRc1Mw
     scenes-app-engineering-analytics-repo-overview--repo-overview-failing--light:
         hash: v1.k794b7964.4e1ed6c540fca8e95dad14c8d479a3ffc5b8a0eec6083ddddeed1e2ceabfe5b6.UC2p5Di8xVfGABNMYuqx6WqTIf5fC3pr8WsFSlB0J5o
+    scenes-app-engineering-analytics-run-activity-chart--default--dark:
+        hash: v1.k794b7964.7f17c5ac7c6862493f7c4d59e6e3c3146c42e3d7b08908ee1716d387c129ba64.lPsE9KrOSZee9wJq8zjqYnvk09numvEFWOn4mdCOgJE
+    scenes-app-engineering-analytics-run-activity-chart--default--light:
+        hash: v1.k794b7964.f63752ff3ebf3bbee3be4ddc83d1ff657d9cdd11ee71e7283c30ce5a1aefde72.yTb8kpRqcG51TbM2CqgRmC5YvgE7-6pV1Trc7y5wuto
     scenes-app-engineering-analytics-test-health--flaky-test-leaderboard--dark:
         hash: v1.k794b7964.8e887d3516448ca8544b66f54ec2b15c348c795f5eeb38121d8822614ab6895a.FSJv5vBtsNGzICpMzsq58FRQDj-CMLwqFPl9IVKY4A4
     scenes-app-engineering-analytics-test-health--flaky-test-leaderboard--light:

--- a/products/engineering_analytics/frontend/components/RunActivityChart.stories.tsx
+++ b/products/engineering_analytics/frontend/components/RunActivityChart.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { RunActivityChart, type ActivityRun } from './RunActivityChart'
+
+const RUNS: ActivityRun[] = [
+    { runId: 1001, conclusion: 'success', startedAt: '2026-07-10T08:00:00Z', durationSeconds: 720 },
+    { runId: 1002, conclusion: 'success', startedAt: '2026-07-10T08:10:00Z', durationSeconds: 1080 },
+    { runId: 1003, conclusion: 'failure', startedAt: '2026-07-10T08:20:00Z', durationSeconds: 2700 },
+    { runId: 1004, conclusion: 'success', startedAt: '2026-07-10T08:30:00Z', durationSeconds: 840 },
+    { runId: 1005, conclusion: 'success', startedAt: '2026-07-10T08:40:00Z', durationSeconds: 1320 },
+    { runId: 1006, conclusion: 'timed_out', startedAt: '2026-07-10T09:00:00Z', durationSeconds: 4200 },
+    { runId: 1007, conclusion: 'success', startedAt: '2026-07-10T09:20:00Z', durationSeconds: 960 },
+    { runId: 1008, conclusion: 'failure', startedAt: '2026-07-10T09:30:00Z', durationSeconds: 1980 },
+    { runId: 1009, conclusion: 'success', startedAt: '2026-07-10T09:50:00Z', durationSeconds: 1140 },
+    { runId: 1010, conclusion: 'success', startedAt: '2026-07-10T10:00:00Z', durationSeconds: 780 },
+    { runId: 1011, conclusion: 'failure', startedAt: '2026-07-10T10:10:00Z', durationSeconds: 3300 },
+    { runId: 1012, conclusion: 'success', startedAt: '2026-07-10T10:30:00Z', durationSeconds: 900 },
+    { runId: 1013, conclusion: 'success', startedAt: '2026-07-10T11:00:00Z', durationSeconds: 1500 },
+    { runId: 1014, conclusion: 'failure', startedAt: '2026-07-10T11:10:00Z', durationSeconds: 2400 },
+    { runId: 1015, conclusion: 'success', startedAt: '2026-07-10T11:30:00Z', durationSeconds: 1020 },
+    { runId: 1016, conclusion: 'success', startedAt: '2026-07-10T12:00:00Z', durationSeconds: 1260 },
+]
+
+const meta: Meta<typeof RunActivityChart> = {
+    title: 'Scenes-App/Engineering Analytics/Run Activity Chart',
+    component: RunActivityChart,
+    parameters: {
+        layout: 'fullscreen',
+        mockDate: '2026-07-10T13:00:00Z',
+        testOptions: {
+            snapshotBrowsers: ['chromium'],
+            waitForSelector: '[data-attr="run-activity-chart-story"] svg',
+            viewport: { width: 1280, height: 520 },
+        },
+    },
+    decorators: [
+        (Story) => (
+            <div className="p-6" data-attr="run-activity-chart-story">
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        runs: RUNS,
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}


### PR DESCRIPTION
## Problem

The engineering analytics run activity visualization has no direct Storybook coverage. That makes visual changes harder to review independently and leaves regressions in its mixed run states without a focused fixture.

## Changes

- Add a deterministic Storybook story for the existing run activity chart.
- Cover passing, failing, timed-out, and overlapping workflow runs in one visual fixture.

## How did you test this code?

- `pnpm exec oxlint --quiet products/engineering_analytics/frontend/components/RunActivityChart.stories.tsx`
- `pnpm exec oxfmt products/engineering_analytics/frontend/components/RunActivityChart.stories.tsx`
- `pnpm --filter=@posthog/storybook build`
- Ran the frontend TypeScript compiler and confirmed it reports no errors for the story file. The full command remains blocked by pre-existing missing generated Kea type files elsewhere in the checkout.

The story guards against the run activity visualization disappearing or failing to render its duration and concurrency views with mixed outcomes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this adds development-only Storybook coverage.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI added the focused Storybook fixture on top of current `master`. The `/writing-tests` skill was used to keep the fixture deterministic and tied to a concrete visual regression risk. The story is intentionally independent of the separate chart redesign PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
