### PR TITLE
fix(postgres): treat missing incremental field as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -372,6 +372,17 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "key for the table in its sync settings, or switch it to full table replication, then "
                 "re-enable the sync."
             ),
+            # The schema's sync type wants an incremental cursor (incremental/append) but no
+            # incremental field is stored in its config, so `_build_query`/`_build_count_query`
+            # raise this before emitting any SQL. The stored config is fixed until the customer
+            # changes it, so every retry re-hits the same wall — non-retryable, like the missing
+            # primary key above. Reset doesn't clear `incremental_field`, so this isn't a transient
+            # reset artifact.
+            "incremental_field and incremental_field_type can't be None": (
+                "This table is set to sync incrementally but has no incremental field configured, so "
+                "PostHog can't build its sync query. Choose an incremental field for the table in its "
+                "sync settings, or switch it to full table replication, then re-enable the sync."
+            ),
             "failed: timeout expired": None,
             # NOTE: "SSL connection has been closed unexpectedly" is intentionally NOT listed here.
             # It denotes an established SSL connection being dropped on connect or mid-stream (idle

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -727,6 +727,29 @@ class TestPostgresSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Non-integer incremental cursor error should be non-retryable: {error_msg}"
 
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            # schema, table_name, should_use_incremental_field, table_type, incremental_field,
+            # incremental_field_type, db_incremental_field_last_value
+            lambda: _build_query("public", "my_table", True, None, None, None, None),
+            # _build_count_query has no `table_type` parameter
+            lambda: _build_count_query("public", "my_table", True, None, None, None),
+        ],
+    )
+    def test_missing_incremental_field_is_non_retryable(self, source, builder):
+        # Drive the real raise sites so a message change that breaks the classifier key is caught.
+        with pytest.raises(ValueError) as exc_info:
+            builder()
+        error_msg = str(exc_info.value)
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Missing incremental field error should be non-retryable: {error_msg}"
+
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Missing incremental field error should surface an actionable message"
+        assert "incremental field" in friendly[0]
+
     def test_exhausted_recovery_conflict_retries_are_non_retryable(self, source):
         error_msg = str(_recovery_conflict_abort_error(10))
         non_retryable = source.get_non_retryable_errors()


### PR DESCRIPTION
## Problem

Error tracking surfaced a live `ValueError: incremental_field and incremental_field_type can't be None` from the Postgres data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019f609b-773f-7e83-80d1-de63983ef582)). It fires in `_build_query` / `_build_count_query` in `postgres.py` before any SQL is emitted.

The trigger is a schema whose sync type wants an incremental cursor (incremental or append) but has no `incremental_field` stored in its config. `import_data_sync` passes `should_use_incremental_field=True` with `incremental_field=None`, and the query builders raise.

That stored config is fixed until the customer changes it, so the failure is deterministic. Today it surfaces as a bare `ValueError` that stays retryable, so every attempt re-hits the same wall, burns the retry budget, and files repeated error-tracking noise, while the customer gets no guidance.

## Changes

Classify the error as non-retryable in `PostgresSource.get_non_retryable_errors` and map it to an actionable message: the table is set to sync incrementally but has no incremental field configured, so choose one or switch to full table replication, then re-enable the sync.

This mirrors the existing `No primary key defined for table` entry — same class of user-config inconsistency. I checked the reset-pipeline path: it clears the watermark but not `incremental_field`, so this is a persistent config state rather than a transient reset artifact, which is why non-retryable is the right call rather than leaving it to retry.

No change to the query builders or the raise sites themselves — the message they raise is already stable, and the friendly text is surfaced through the classifier the same way every other entry is.

## How did you test this code?

Added `test_missing_incremental_field_is_non_retryable`, parameterized over both `_build_query` and `_build_count_query`. It drives the real raise sites (rather than hardcoding the string) so a future message change that breaks the classifier key is caught, then asserts the error is classified non-retryable and surfaces an actionable message.

I (Claude) could not run the suite in this environment — Python deps aren't installed here (no `pytest`/`django`). I ran `ruff check` and `ruff format --check` (both pass) and `py_compile` on both edited files. The new test should run under CI.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged the error-tracking issue via the PostHog MCP tools, traced the call path from `import_data_sync` → `PostgresSource.source_for_pipeline` → `postgres_source` → `_build_query`, and confirmed the failure originates in this source's code. Invoked `/writing-tests` before adding the test.

Decision: treated this as a user/upstream config error (non-retryable) rather than a code bug, because there is nothing sensible the code can do without an incremental field and retrying can never succeed. Considered fixing at the raise site but the classifier is the established pattern for surfacing actionable messages here, so I kept the change scoped to `get_non_retryable_errors`. Confirmed no open PR already covers this — the closest (#68293) handles incremental field *type drift* and explicitly skips the `None` case.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
