### PR TITLE
feat(data-warehouse): implement mem0 import source

### DIFF
--- a/frontend/public/services/mem0.svg
+++ b/frontend/public/services/mem0.svg
@@ -1,0 +1,49 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61505C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5914 7.95343 21.1394Z" fill="white"/>
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61505C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5914 7.95343 21.1394Z" fill="url(#paint0_radial_101_2703)"/>
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61505C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5914 7.95343 21.1394Z" fill="black" fill-opacity="0.5" style="mix-blend-mode:hard-light"/>
+<path d="M7.95343 21.1394C4.89586 21.1304 2.25471 19.458 0.987296 16.2895C-0.280118 13.121 0.108924 9.16314 1.74363 5.61505C4.8012 5.62409 7.44235 7.29648 8.70976 10.465C9.97718 13.6335 9.58814 17.5914 7.95343 21.1394Z" fill="url(#paint1_linear_101_2703)" fill-opacity="0.5" style="mix-blend-mode:hard-light"/>
+<path d="M8.68359 10.4755C9.94543 13.63 9.56145 17.5723 7.9354 21.1112C4.89702 21.0957 2.27411 19.4306 1.01347 16.279C-0.248375 13.1245 0.135612 9.18218 1.76165 5.64328C4.80004 5.65883 7.42295 7.32386 8.68359 10.4755Z" stroke="url(#paint2_linear_101_2703)" stroke-opacity="0.05" stroke-width="0.056338"/>
+<path d="M7.31038 21.2574C11.3543 20.2215 14.8836 17.3754 16.6285 13.2361C18.3735 9.09671 17.9448 4.58749 15.8598 0.976291C11.8159 2.01214 8.2866 4.85826 6.54167 8.99762C4.79674 13.137 5.2254 17.6462 7.31038 21.2574Z" fill="white"/>
+<path d="M7.31038 21.2574C11.3543 20.2215 14.8836 17.3754 16.6285 13.2361C18.3735 9.09671 17.9448 4.58749 15.8598 0.976291C11.8159 2.01214 8.2866 4.85826 6.54167 8.99762C4.79674 13.137 5.2254 17.6462 7.31038 21.2574Z" fill="url(#paint3_radial_101_2703)"/>
+<path d="M16.6026 13.2251C14.8642 17.349 11.3512 20.1866 7.32411 21.2248C5.25257 17.624 4.82926 13.1324 6.56764 9.00855C8.30603 4.88472 11.819 2.04706 15.8461 1.00889C17.9176 4.60967 18.3409 9.10131 16.6026 13.2251Z" stroke="url(#paint4_linear_101_2703)" stroke-opacity="0.05" stroke-width="0.056338"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="white"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="url(#paint5_radial_101_2703)"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="black" fill-opacity="0.2" style="mix-blend-mode:hard-light"/>
+<path d="M7.23368 21.2069C9.78906 23.2373 13.2102 23.9506 16.5772 22.8141C19.9441 21.6775 22.5058 18.9445 23.7304 15.6382C21.175 13.6078 17.7538 12.8944 14.3869 14.031C11.0199 15.1676 8.45822 17.9006 7.23368 21.2069Z" fill="url(#paint6_linear_101_2703)" fill-opacity="0.5" style="mix-blend-mode:hard-light"/>
+<path d="M16.5682 22.7874C13.2176 23.9184 9.81361 23.2124 7.2672 21.1975C8.49194 17.9068 11.0444 15.189 14.3959 14.0577C17.7465 12.9266 21.1504 13.6326 23.6968 15.6476C22.4721 18.9383 19.9196 21.656 16.5682 22.7874Z" stroke="url(#paint7_linear_101_2703)" stroke-opacity="0.05" stroke-width="0.056338"/>
+<defs>
+<radialGradient id="paint0_radial_101_2703" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(-3.00503 15.023) rotate(-10.029) scale(17.9572 17.784)">
+<stop stop-color="#00B0BB"/>
+<stop offset="1" stop-color="#00DB65"/>
+</radialGradient>
+<linearGradient id="paint1_linear_101_2703" x1="7.39036" y1="4.81308" x2="1.62975" y2="18.6894" gradientUnits="userSpaceOnUse">
+<stop stop-color="#18E299"/>
+<stop offset="1"/>
+</linearGradient>
+<linearGradient id="paint2_linear_101_2703" x1="7.94816" y1="8.01563" x2="1.7612" y2="18.746" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint3_radial_101_2703" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(8.11404 20.8822) rotate(-75.7542) scale(21.6246 23.7772)">
+<stop stop-color="#00BBBB"/>
+<stop offset="0.712616" stop-color="#00DB65"/>
+</radialGradient>
+<linearGradient id="paint4_linear_101_2703" x1="7.60205" y1="5.8709" x2="15.5561" y2="16.3719" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint5_radial_101_2703" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(7.84537 21.5181) rotate(-20.3525) scale(18.5603 17.32)">
+<stop stop-color="#00B0BB"/>
+<stop offset="1" stop-color="#00DB65"/>
+</radialGradient>
+<linearGradient id="paint6_linear_101_2703" x1="16.8078" y1="13.0071" x2="10.0409" y2="22.9937" gradientUnits="userSpaceOnUse">
+<stop stop-color="#00B1BC"/>
+<stop offset="1"/>
+</linearGradient>
+<linearGradient id="paint7_linear_101_2703" x1="16.8078" y1="13.0071" x2="14.1687" y2="23.841" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -266,6 +266,7 @@ the row lists both.
 | lob                       | HTTP                        | requests                                                        | ✅                          |
 | luma                      | HTTP                        | requests                                                        | ✅                          |
 | mailchimp                 | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
+| mem0                      | HTTP                        | requests                                                        | ✅                          |
 | mailerlite                | HTTP                        | requests                                                        | ✅                          |
 | mailersend                | HTTP                        | requests                                                        | ✅                          |
 | mailgun                   | HTTP                        | requests                                                        | ✅                          |
@@ -732,7 +733,6 @@ doesn't conflict with concurrent PRs.
 - mailtrap
 - mantle
 - marketo
-- mem0
 - mendeley
 - mercado_ads
 - mercury

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -2518,7 +2518,9 @@ class MaxioSourceConfig(config.Config):
 
 @config.config
 class Mem0SourceConfig(config.Config):
-    pass
+    api_key: str
+    org_id: str | None = None
+    project_id: str | None = None
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/canonical_descriptions.py
@@ -1,0 +1,58 @@
+"""Canonical, documentation-sourced descriptions for Mem0 endpoints and columns.
+
+Sourced from the official Mem0 API reference (https://docs.mem0.ai/api-reference).
+Keyed by the endpoint names in `settings.py` `MEM0_ENDPOINTS`, which match the
+`ExternalDataSchema.name` of a synced Mem0 table. Columns absent here fall back to LLM enrichment.
+"""
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "memories": {
+        "description": "A memory extracted and stored by Mem0 — a fact about a user, agent, app, or run.",
+        "docs_url": "https://docs.mem0.ai/api-reference/memory/get-memories",
+        "columns": {
+            "id": "Unique identifier (UUID) for the memory.",
+            "memory": "The extracted memory text.",
+            "categories": "Categories assigned to the memory.",
+            "metadata": "Custom metadata attached to the memory.",
+            "created_at": "Time at which the memory was created.",
+            "updated_at": "Time at which the memory was last updated.",
+            "expiration_date": "Date after which the memory is considered expired.",
+        },
+    },
+    "entities": {
+        "description": "An entity (user, agent, app, or run) that owns memories in Mem0.",
+        "docs_url": "https://docs.mem0.ai/api-reference/entities/get-users",
+        "columns": {
+            "id": "Unique identifier for the entity.",
+            "name": "The entity's name.",
+            "type": "The entity type: user, agent, app, or run.",
+            "created_at": "Time at which the entity was created.",
+            "updated_at": "Time at which the entity was last updated.",
+            "total_memories": "Total number of memories associated with the entity.",
+            "owner": "The entity's owner.",
+            "organization": "The organization the entity belongs to.",
+            "metadata": "Custom metadata attached to the entity.",
+        },
+    },
+    "events": {
+        "description": "A memory-operation event (add, search, etc) recorded by Mem0 for auditing and observability.",
+        "docs_url": "https://docs.mem0.ai/api-reference/events/get-events",
+        "columns": {
+            "id": "Unique identifier (UUID) for the event.",
+            "event_type": "The type of operation the event records (e.g. ADD, SEARCH).",
+            "status": "Processing status of the event: PENDING, RUNNING, FAILED, or SUCCEEDED.",
+            "payload": "The original payload submitted with the operation.",
+            "metadata": "Extra metadata associated with the event.",
+            "results": "Outputs produced by the operation.",
+            "created_at": "Time at which the event was created.",
+            "updated_at": "Time at which the event was last updated.",
+            "started_at": "Time at which processing began.",
+            "completed_at": "Time at which processing finished.",
+            "latency": "Processing time in milliseconds.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/mem0.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/mem0.py
@@ -10,7 +10,7 @@ import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin, urlparse
 
 import requests
 from structlog.types import FilteringBoundLogger
@@ -93,6 +93,20 @@ def _build_memories_filters(incremental_field: str, cutoff: str | None) -> dict[
     if not cutoff:
         return _MATCH_ALL_FILTER
     return {"AND": [_MATCH_ALL_FILTER, {incremental_field: {"gte": cutoff}}]}
+
+
+def _ensure_mem0_origin(url: str) -> str:
+    """Refuse pagination/resume URLs that leave the Mem0 API origin.
+
+    The session carries the API key on every request, so following an off-origin ``next`` link
+    (from a tampered response, or a poisoned resume-state entry) would send the credential to an
+    arbitrary host. ``urljoin`` alone doesn't protect against absolute or scheme-relative URLs.
+    """
+    parsed = urlparse(url)
+    expected = urlparse(MEM0_BASE_URL)
+    if parsed.scheme != expected.scheme or parsed.netloc != expected.netloc:
+        raise ValueError(f"Refusing to follow a pagination URL off the Mem0 API origin: {url}")
+    return url
 
 
 @retry(
@@ -196,7 +210,11 @@ def _get_events_rows(
     resume: Mem0ResumeConfig | None,
 ) -> Iterator[list[dict[str, Any]]]:
     config = MEM0_ENDPOINTS[EVENTS_ENDPOINT]
-    url = resume.next_url if resume is not None and resume.next_url else f"{MEM0_BASE_URL}{config.path}"
+    url = (
+        _ensure_mem0_origin(resume.next_url)
+        if resume is not None and resume.next_url
+        else f"{MEM0_BASE_URL}{config.path}"
+    )
 
     while True:
         data = _fetch_json(session, config.method, url, logger)
@@ -209,7 +227,7 @@ def _get_events_rows(
         if not next_url:
             break
 
-        url = urljoin(MEM0_BASE_URL, next_url)
+        url = _ensure_mem0_origin(urljoin(MEM0_BASE_URL, next_url))
         resumable_source_manager.save_state(Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url=url))
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/mem0.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/mem0.py
@@ -1,0 +1,288 @@
+"""Thin Mem0 platform API client used by the data warehouse source.
+
+Reference: https://docs.mem0.ai/api-reference
+
+Everything in this module routes through ``make_tracked_session`` so outbound calls show up in
+our HTTP logs, OTel metrics, and sample-capture pipeline.
+"""
+
+import dataclasses
+from collections.abc import Iterator
+from datetime import UTC, date, datetime
+from typing import Any, Optional
+from urllib.parse import urlencode, urljoin
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.settings import (
+    ENTITIES_ENDPOINT,
+    EVENTS_ENDPOINT,
+    MEM0_BASE_URL,
+    MEM0_ENDPOINTS,
+    MEMORIES_ENDPOINT,
+)
+
+REQUEST_TIMEOUT_SECONDS = 60
+
+# Every memory carries at least one owning entity id (user_id / agent_id / app_id / run_id are
+# required at add time), so OR-ing the wildcard over all four matches the whole store. A bare
+# {"user_id": "*"} would miss memories scoped only to an agent, app, or run.
+_MATCH_ALL_FILTER: dict[str, Any] = {"OR": [{"user_id": "*"}, {"agent_id": "*"}, {"app_id": "*"}, {"run_id": "*"}]}
+
+
+class Mem0RetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class Mem0ResumeConfig:
+    """Resume state for a crashed/heartbeat-timed-out sync.
+
+    ``endpoint`` scopes the state so a memories page number is never replayed against events.
+    ``page`` is the next 1-indexed page for the memories endpoint; ``next_url`` is the next
+    envelope URL for the events endpoint; ``cutoff`` pins the incremental filter value the run
+    started with so a resumed attempt paginates the same server-side result set.
+    """
+
+    endpoint: str
+    page: int | None = None
+    next_url: str | None = None
+    cutoff: str | None = None
+
+
+def _get_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Token {api_key}",
+        "Accept": "application/json",
+    }
+
+
+def validate_credentials(api_key: str) -> bool:
+    # GET /v1/ping/ is the cheap key probe the official mem0ai SDK uses on client init.
+    url = f"{MEM0_BASE_URL}/v1/ping/"
+    try:
+        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def _format_cutoff(value: Any) -> str | None:
+    """Format an incremental cursor value for the Mem0 filter DSL.
+
+    The documented filter examples only demonstrate date strings (e.g. ``"2024-07-01"``), so we
+    send the cursor as a date. ``gte`` on the truncated date only over-fetches rows from the
+    cursor's own day — the merge on the primary key dedupes them — and can never skip rows.
+    """
+    if isinstance(value, datetime):
+        aware = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+        return aware.astimezone(UTC).date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if value is None:
+        return None
+    return str(value)
+
+
+def _build_memories_filters(incremental_field: str, cutoff: str | None) -> dict[str, Any]:
+    if not cutoff:
+        return _MATCH_ALL_FILTER
+    return {"AND": [_MATCH_ALL_FILTER, {incremental_field: {"gte": cutoff}}]}
+
+
+@retry(
+    retry=retry_if_exception_type(
+        (
+            Mem0RetryableError,
+            requests.ReadTimeout,
+            requests.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        )
+    ),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_json(
+    session: requests.Session,
+    method: str,
+    url: str,
+    logger: FilteringBoundLogger,
+    json_body: dict[str, Any] | None = None,
+) -> Any:
+    response = session.request(method, url, json=json_body, timeout=REQUEST_TIMEOUT_SECONDS)
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise Mem0RetryableError(f"Mem0 API error (retryable): status={response.status_code}, url={url}")
+
+    if not response.ok:
+        logger.error(f"Mem0 API error: status={response.status_code}, body={response.text}, url={url}")
+        response.raise_for_status()
+
+    return response.json()
+
+
+def _get_memories_rows(
+    session: requests.Session,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[Mem0ResumeConfig],
+    resume: Mem0ResumeConfig | None,
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+    incremental_field: str | None,
+) -> Iterator[list[dict[str, Any]]]:
+    config = MEM0_ENDPOINTS[MEMORIES_ENDPOINT]
+
+    if resume is not None and resume.page:
+        page = resume.page
+        cutoff = resume.cutoff
+    else:
+        page = 1
+        cutoff = (
+            _format_cutoff(db_incremental_field_last_value)
+            if should_use_incremental_field and db_incremental_field_last_value
+            else None
+        )
+
+    filters = _build_memories_filters(incremental_field or "updated_at", cutoff)
+    body = {"filters": filters}
+
+    while True:
+        params = urlencode({"page": page, "page_size": config.page_size})
+        data = _fetch_json(session, config.method, f"{MEM0_BASE_URL}{config.path}?{params}", logger, json_body=body)
+
+        rows = data.get("results") or []
+        if rows:
+            yield rows
+
+        if not data.get("next"):
+            break
+
+        page += 1
+        # Save AFTER yielding so a crash re-yields the last page rather than skipping it — the
+        # merge dedupes re-yielded rows on the primary key.
+        resumable_source_manager.save_state(Mem0ResumeConfig(endpoint=MEMORIES_ENDPOINT, page=page, cutoff=cutoff))
+
+
+def _get_entities_rows(
+    session: requests.Session,
+    logger: FilteringBoundLogger,
+    org_id: str | None,
+    project_id: str | None,
+) -> Iterator[list[dict[str, Any]]]:
+    config = MEM0_ENDPOINTS[ENTITIES_ENDPOINT]
+    scope = {key: value for key, value in (("org_id", org_id), ("project_id", project_id)) if value}
+    url = f"{MEM0_BASE_URL}{config.path}"
+    if scope:
+        url = f"{url}?{urlencode(scope)}"
+
+    data = _fetch_json(session, config.method, url, logger)
+
+    # Documented as a bare JSON array; tolerate an envelope in case the API grows one.
+    rows = data.get("results") if isinstance(data, dict) else data
+    if rows:
+        yield rows
+
+
+def _get_events_rows(
+    session: requests.Session,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[Mem0ResumeConfig],
+    resume: Mem0ResumeConfig | None,
+) -> Iterator[list[dict[str, Any]]]:
+    config = MEM0_ENDPOINTS[EVENTS_ENDPOINT]
+    url = resume.next_url if resume is not None and resume.next_url else f"{MEM0_BASE_URL}{config.path}"
+
+    while True:
+        data = _fetch_json(session, config.method, url, logger)
+
+        rows = data.get("results") or []
+        if rows:
+            yield rows
+
+        next_url = data.get("next")
+        if not next_url:
+            break
+
+        url = urljoin(MEM0_BASE_URL, next_url)
+        resumable_source_manager.save_state(Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url=url))
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[Mem0ResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+    incremental_field: str | None = None,
+    org_id: str | None = None,
+    project_id: str | None = None,
+) -> Iterator[list[dict[str, Any]]]:
+    session = make_tracked_session(headers=_get_headers(api_key))
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume is not None and resume.endpoint != endpoint:
+        resume = None
+
+    if endpoint == MEMORIES_ENDPOINT:
+        yield from _get_memories_rows(
+            session,
+            logger,
+            resumable_source_manager,
+            resume,
+            should_use_incremental_field,
+            db_incremental_field_last_value,
+            incremental_field,
+        )
+    elif endpoint == ENTITIES_ENDPOINT:
+        yield from _get_entities_rows(session, logger, org_id, project_id)
+    elif endpoint == EVENTS_ENDPOINT:
+        yield from _get_events_rows(session, logger, resumable_source_manager, resume)
+    else:
+        raise ValueError(f"Unknown Mem0 endpoint: {endpoint}")
+
+
+def mem0_source(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[Mem0ResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+    incremental_field: str | None = None,
+    org_id: str | None = None,
+    project_id: str | None = None,
+) -> SourceResponse:
+    endpoint_config = MEM0_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+            incremental_field=incremental_field,
+            org_id=org_id,
+            project_id=project_id,
+        ),
+        primary_keys=endpoint_config.primary_keys,
+        # The memories list exposes no sort parameter, so row order within a run is undefined.
+        # "desc" makes the pipeline commit the incremental watermark only at successful end of
+        # run — with undefined ordering, per-batch ("asc") checkpointing could advance the
+        # watermark past rows a crashed run never yielded.
+        sort_mode="desc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if endpoint_config.partition_key else None,
+        partition_format="month" if endpoint_config.partition_key else None,
+        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/settings.py
@@ -1,0 +1,83 @@
+"""Mem0 API endpoint catalog.
+
+Reference: https://docs.mem0.ai/api-reference
+
+- ``memories``: POST /v3/memories/ — page-number pagination (``page`` / ``page_size``, max 200)
+  with a ``{count, next, previous, results}`` envelope. The endpoint requires a JSON ``filters``
+  body; the same filter DSL exposes server-side ``created_at`` / ``updated_at`` comparison
+  operators (``gte`` etc.), which is what makes incremental sync genuinely server-side.
+- ``entities``: GET /v1/entities/ — returns the full entity list in one response (no documented
+  pagination or timestamp filters), so it's full refresh only.
+- ``events``: GET /v1/events/ — ``{count, next, previous, results}`` envelope followed via the
+  ``next`` URL. No documented timestamp filters, so full refresh only.
+"""
+
+from dataclasses import dataclass, field
+
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
+
+MEM0_BASE_URL = "https://api.mem0.ai"
+
+MEMORIES_ENDPOINT = "memories"
+ENTITIES_ENDPOINT = "entities"
+EVENTS_ENDPOINT = "events"
+
+_DATETIME_INCREMENTAL_FIELD_NAMES = ("updated_at", "created_at")
+
+
+def _datetime_incremental_fields() -> list[IncrementalField]:
+    return [
+        {
+            "label": name,
+            "type": IncrementalFieldType.DateTime,
+            "field": name,
+            "field_type": IncrementalFieldType.DateTime,
+        }
+        for name in _DATETIME_INCREMENTAL_FIELD_NAMES
+    ]
+
+
+@dataclass
+class Mem0EndpointConfig:
+    name: str
+    path: str
+    method: str
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+    # Partition on a stable creation timestamp only — never `updated_at`, which is rewritten
+    # upstream and would shuffle rows across partitions on every sync.
+    partition_key: str | None = None
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    should_sync_default: bool = True
+    page_size: int | None = None
+
+
+MEM0_ENDPOINTS: dict[str, Mem0EndpointConfig] = {
+    MEMORIES_ENDPOINT: Mem0EndpointConfig(
+        name=MEMORIES_ENDPOINT,
+        path="/v3/memories/",
+        method="POST",
+        partition_key="created_at",
+        incremental_fields=_datetime_incremental_fields(),
+        page_size=100,
+    ),
+    ENTITIES_ENDPOINT: Mem0EndpointConfig(
+        name=ENTITIES_ENDPOINT,
+        path="/v1/entities/",
+        method="GET",
+    ),
+    # Operation events (adds, searches, etc). Opt-in: it's an audit/observability stream that can
+    # be high volume relative to the memory store itself.
+    EVENTS_ENDPOINT: Mem0EndpointConfig(
+        name=EVENTS_ENDPOINT,
+        path="/v1/events/",
+        method="GET",
+        partition_key="created_at",
+        should_sync_default=False,
+    ),
+}
+
+ENDPOINTS = tuple(MEM0_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in MEM0_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/source.py
@@ -95,7 +95,6 @@ You can find your API key in the [Mem0 dashboard](https://app.mem0.ai/dashboard/
                     ),
                 ],
             ),
-            unreleasedSource=True,
             releaseStatus=ReleaseStatus.ALPHA,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/source.py
@@ -1,19 +1,53 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import Mem0SourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.mem0 import (
+    Mem0ResumeConfig,
+    mem0_source,
+    validate_credentials as validate_mem0_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+    MEM0_ENDPOINTS,
+    MEMORIES_ENDPOINT,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+# Mem0 can push memory:add/update/delete/categorize webhooks, but we deliberately don't wire a
+# WebhookSource here: deliveries carry only {event_details: {id, data.memory, event}} — no
+# categories, metadata, timestamps, or owning entity ids — and Mem0 documents no signing
+# secret/verification mechanism. Once a schema enters webhook sync mode the webhook feed
+# replaces the poll, which would permanently degrade the memories table to text-only rows.
+# The server-side `updated_at`/`created_at` filters on POST /v3/memories/ already make
+# scheduled incremental pulls cheap, and GET /v1/events/ covers the operation-event stream
+# with full fidelity.
 
 
 @SourceRegistry.register
-class Mem0Source(SimpleSource[Mem0SourceConfig]):
+class Mem0Source(ResumableSource[Mem0SourceConfig, Mem0ResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.MEM0
@@ -24,8 +58,117 @@ class Mem0Source(SimpleSource[Mem0SourceConfig]):
             name=SchemaExternalDataSourceType.MEM0,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="Mem0",
-            iconPath="/static/services/mem0.png",
+            caption="""Enter your Mem0 API key to automatically pull your Mem0 memories, entities, and operation events into the PostHog Data warehouse.
+
+You can find your API key in the [Mem0 dashboard](https://app.mem0.ai/dashboard/api-keys).""",
+            iconPath="/static/services/mem0.svg",
+            docsUrl="https://posthog.com/docs/cdp/sources/mem0",
             keywords=["memory", "ai", "agents", "llm"],
-            fields=cast(list[FieldType], []),
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="m0-...",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="org_id",
+                        label="Organization ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=False,
+                        placeholder="org_...",
+                        caption="Optional. Scopes the entities table to a specific Mem0 organization.",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="project_id",
+                        label="Project ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=False,
+                        placeholder="proj_...",
+                        caption="Optional. Scopes the entities table to a specific Mem0 project.",
+                        secret=False,
+                    ),
+                ],
+            ),
             unreleasedSource=True,
+            releaseStatus=ReleaseStatus.ALPHA,
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # Invalid/revoked keys surface as a requests HTTPError from `_fetch_json`'s
+            # `raise_for_status()`. Match the stable status text and base host, not the
+            # per-request path/query.
+            "401 Client Error: Unauthorized for url: https://api.mem0.ai": "Your Mem0 API key is invalid or has been revoked. Create a new API key in the Mem0 dashboard, then reconnect.",
+            "403 Client Error: Forbidden for url: https://api.mem0.ai": "Your Mem0 API key does not have access to this data. Check the key's project access in the Mem0 dashboard, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: Mem0SourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        def _build_schema(endpoint: str) -> SourceSchema:
+            has_incremental = bool(INCREMENTAL_FIELDS.get(endpoint))
+            return SourceSchema(
+                name=endpoint,
+                # Incremental pulls re-fetch updated rows, so only merge (not append) keeps the
+                # table duplicate-free.
+                supports_incremental=has_incremental,
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                should_sync_default=MEM0_ENDPOINTS[endpoint].should_sync_default,
+            )
+
+        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: Mem0SourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_mem0_credentials(config.api_key):
+            return True, None
+
+        return False, "Invalid Mem0 API key"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[Mem0ResumeConfig]:
+        return ResumableSourceManager[Mem0ResumeConfig](inputs, Mem0ResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: Mem0SourceConfig,
+        resumable_source_manager: ResumableSourceManager[Mem0ResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return mem0_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field
+            and inputs.schema_name == MEMORIES_ENDPOINT,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
+            incremental_field=inputs.incremental_field,
+            org_id=config.org_id,
+            project_id=config.project_id,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0.py
@@ -237,6 +237,44 @@ class TestEventsRows:
 
         assert mock_session.return_value.request.call_args.args[1] == f"{MEM0_BASE_URL}/v1/events/?page=5"
 
+    @parameterized.expand(
+        [
+            ("absolute", "https://evil.example.com/v1/events/?page=2"),
+            ("scheme_relative", "//evil.example.com/v1/events/?page=2"),
+            ("non_https", "http://api.mem0.ai/v1/events/?page=2"),
+            ("lookalike_host", "https://api.mem0.ai.evil.example.com/v1/events/?page=2"),
+        ]
+    )
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_refuses_to_follow_off_origin_next_links(self, _name, next_url, mock_session):
+        # The session carries the API key; a tampered `next` link must never receive a
+        # credentialed request or be persisted as resume state.
+        mock_session.return_value.request.return_value = _response({"next": next_url, "results": [{"id": "e1"}]})
+        manager = _manager()
+
+        try:
+            list(get_rows("m0-test", EVENTS_ENDPOINT, MagicMock(), manager))
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass
+
+        assert mock_session.return_value.request.call_count == 1
+        manager.save_state.assert_not_called()
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_refuses_to_resume_from_an_off_origin_saved_url(self, mock_session):
+        manager = _manager(
+            Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url="https://evil.example.com/v1/events/?page=5")
+        )
+
+        try:
+            list(get_rows("m0-test", EVENTS_ENDPOINT, MagicMock(), manager))
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass
+
+        mock_session.return_value.request.assert_not_called()
+
 
 class TestFetchRetry:
     @patch("tenacity.nap.time.sleep", return_value=None)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0.py
@@ -1,0 +1,284 @@
+from datetime import UTC, date, datetime
+from typing import Any
+
+from unittest.mock import MagicMock, patch
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0 import mem0 as api_client
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.mem0 import (
+    _MATCH_ALL_FILTER,
+    Mem0ResumeConfig,
+    get_rows,
+    mem0_source,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.settings import (
+    ENTITIES_ENDPOINT,
+    EVENTS_ENDPOINT,
+    MEM0_BASE_URL,
+    MEMORIES_ENDPOINT,
+)
+
+_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.mem0.mem0"
+
+
+def _response(payload: Any = None, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = status_code < 400
+    response.json.return_value = payload if payload is not None else {}
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"{status_code} Client Error: Unauthorized for url: {MEM0_BASE_URL}/v3/memories/", response=response
+        )
+    return response
+
+
+def _manager(resume: Mem0ResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock()
+    manager.can_resume.return_value = resume is not None
+    manager.load_state.return_value = resume
+    return manager
+
+
+class TestValidateCredentials:
+    @parameterized.expand([(200, True), (401, False), (403, False)])
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_maps_status_code_to_validity(self, status_code, expected, mock_session):
+        mock_session.return_value.get.return_value = _response({}, status_code=status_code)
+
+        assert validate_credentials("m0-test") is expected
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_network_error_is_invalid_not_raised(self, mock_session):
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+
+        assert validate_credentials("m0-test") is False
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_probes_the_ping_endpoint_with_token_header(self, mock_session):
+        mock_session.return_value.get.return_value = _response({})
+
+        validate_credentials("m0-test")
+
+        args, kwargs = mock_session.return_value.get.call_args
+        assert args[0] == f"{MEM0_BASE_URL}/v1/ping/"
+        assert kwargs["headers"]["Authorization"] == "Token m0-test"
+
+
+class TestMemoriesRows:
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_yields_every_page_and_terminates_on_null_next(self, mock_session):
+        mock_session.return_value.request.side_effect = [
+            _response(
+                {"count": 3, "next": "https://api.mem0.ai/v3/memories/?page=2", "results": [{"id": "m1"}, {"id": "m2"}]}
+            ),
+            _response({"count": 3, "next": None, "results": [{"id": "m3"}]}),
+        ]
+
+        batches = list(get_rows("m0-test", MEMORIES_ENDPOINT, MagicMock(), _manager()))
+
+        assert batches == [[{"id": "m1"}, {"id": "m2"}], [{"id": "m3"}]]
+        urls = [call.args[1] for call in mock_session.return_value.request.call_args_list]
+        assert "page=1" in urls[0] and "page=2" in urls[1]
+        assert all("page_size=100" in url for url in urls)
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_full_sync_sends_wildcard_filter_over_every_entity_type(self, mock_session):
+        # A bare {"user_id": "*"} filter would silently drop memories scoped only to an
+        # agent, app, or run; the request must OR the wildcard across all four entity ids.
+        mock_session.return_value.request.return_value = _response({"next": None, "results": []})
+
+        list(get_rows("m0-test", MEMORIES_ENDPOINT, MagicMock(), _manager()))
+
+        body = mock_session.return_value.request.call_args.kwargs["json"]
+        assert body == {"filters": _MATCH_ALL_FILTER}
+        assert {"agent_id": "*"} in body["filters"]["OR"]
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_incremental_sync_filters_on_the_users_chosen_field(self, mock_session):
+        mock_session.return_value.request.return_value = _response({"next": None, "results": []})
+
+        list(
+            get_rows(
+                "m0-test",
+                MEMORIES_ENDPOINT,
+                MagicMock(),
+                _manager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 7, 1, 12, 30, tzinfo=UTC),
+                incremental_field="created_at",
+            )
+        )
+
+        body = mock_session.return_value.request.call_args.kwargs["json"]
+        assert body == {"filters": {"AND": [_MATCH_ALL_FILTER, {"created_at": {"gte": "2026-07-01"}}]}}
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_saves_resume_state_only_after_yielding_and_only_when_pages_remain(self, mock_session):
+        mock_session.return_value.request.side_effect = [
+            _response({"next": "https://api.mem0.ai/v3/memories/?page=2", "results": [{"id": "m1"}]}),
+            _response({"next": None, "results": [{"id": "m2"}]}),
+        ]
+        manager = _manager()
+
+        list(get_rows("m0-test", MEMORIES_ENDPOINT, MagicMock(), manager))
+
+        manager.save_state.assert_called_once()
+        saved = manager.save_state.call_args.args[0]
+        assert saved == Mem0ResumeConfig(endpoint=MEMORIES_ENDPOINT, page=2, cutoff=None)
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_resumes_from_saved_page_and_pins_the_original_cutoff(self, mock_session):
+        # The saved cutoff (not a freshly computed one) must drive the filter on resume,
+        # otherwise the resumed run paginates a different server-side result set and the
+        # page number no longer lines up.
+        mock_session.return_value.request.return_value = _response({"next": None, "results": []})
+        manager = _manager(Mem0ResumeConfig(endpoint=MEMORIES_ENDPOINT, page=3, cutoff="2026-06-01"))
+
+        list(
+            get_rows(
+                "m0-test",
+                MEMORIES_ENDPOINT,
+                MagicMock(),
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 7, 10, tzinfo=UTC),
+            )
+        )
+
+        call = mock_session.return_value.request.call_args
+        assert "page=3" in call.args[1]
+        assert call.kwargs["json"] == {"filters": {"AND": [_MATCH_ALL_FILTER, {"updated_at": {"gte": "2026-06-01"}}]}}
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_ignores_resume_state_saved_by_a_different_endpoint(self, mock_session):
+        mock_session.return_value.request.return_value = _response({"next": None, "results": []})
+        manager = _manager(Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url="https://api.mem0.ai/v1/events/?page=9"))
+
+        list(get_rows("m0-test", MEMORIES_ENDPOINT, MagicMock(), manager))
+
+        assert "page=1" in mock_session.return_value.request.call_args.args[1]
+
+
+class TestCutoffFormatting:
+    @parameterized.expand(
+        [
+            (datetime(2026, 7, 1, 23, 59, tzinfo=UTC), "2026-07-01"),
+            (datetime(2026, 7, 1, 12, 0), "2026-07-01"),  # naive treated as UTC
+            (date(2026, 7, 1), "2026-07-01"),
+            ("2026-07-01", "2026-07-01"),
+            (None, None),
+        ]
+    )
+    def test_formats_cursor_as_date_string(self, value, expected):
+        assert api_client._format_cutoff(value) == expected
+
+
+class TestEntitiesRows:
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_yields_the_bare_array_response(self, mock_session):
+        mock_session.return_value.request.return_value = _response([{"id": "alex", "type": "user"}])
+
+        batches = list(get_rows("m0-test", ENTITIES_ENDPOINT, MagicMock(), _manager()))
+
+        assert batches == [[{"id": "alex", "type": "user"}]]
+        assert mock_session.return_value.request.call_args.args == ("GET", f"{MEM0_BASE_URL}/v1/entities/")
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_tolerates_an_enveloped_response(self, mock_session):
+        mock_session.return_value.request.return_value = _response({"results": [{"id": "alex"}]})
+
+        batches = list(get_rows("m0-test", ENTITIES_ENDPOINT, MagicMock(), _manager()))
+
+        assert batches == [[{"id": "alex"}]]
+
+    @parameterized.expand(
+        [
+            ("org_only", "org_1", None, "org_id=org_1"),
+            ("project_only", None, "proj_1", "project_id=proj_1"),
+            ("both", "org_1", "proj_1", "org_id=org_1&project_id=proj_1"),
+        ]
+    )
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_scopes_listing_with_org_and_project_params(self, _name, org_id, project_id, expected_query, mock_session):
+        mock_session.return_value.request.return_value = _response([])
+
+        list(get_rows("m0-test", ENTITIES_ENDPOINT, MagicMock(), _manager(), org_id=org_id, project_id=project_id))
+
+        url = mock_session.return_value.request.call_args.args[1]
+        assert url == f"{MEM0_BASE_URL}/v1/entities/?{expected_query}"
+
+
+class TestEventsRows:
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_follows_next_urls_and_checkpoints_after_each_yield(self, mock_session):
+        mock_session.return_value.request.side_effect = [
+            _response({"next": f"{MEM0_BASE_URL}/v1/events/?page=2", "results": [{"id": "e1"}]}),
+            _response({"next": None, "results": [{"id": "e2"}]}),
+        ]
+        manager = _manager()
+
+        batches = list(get_rows("m0-test", EVENTS_ENDPOINT, MagicMock(), manager))
+
+        assert batches == [[{"id": "e1"}], [{"id": "e2"}]]
+        manager.save_state.assert_called_once_with(
+            Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url=f"{MEM0_BASE_URL}/v1/events/?page=2")
+        )
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_resumes_from_the_saved_next_url(self, mock_session):
+        mock_session.return_value.request.return_value = _response({"next": None, "results": []})
+        manager = _manager(Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url=f"{MEM0_BASE_URL}/v1/events/?page=5"))
+
+        list(get_rows("m0-test", EVENTS_ENDPOINT, MagicMock(), manager))
+
+        assert mock_session.return_value.request.call_args.args[1] == f"{MEM0_BASE_URL}/v1/events/?page=5"
+
+
+class TestFetchRetry:
+    @patch("tenacity.nap.time.sleep", return_value=None)
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_retries_rate_limits_then_succeeds(self, mock_session, _sleep):
+        mock_session.return_value.request.side_effect = [
+            _response({}, status_code=429),
+            _response({"next": None, "results": [{"id": "m1"}]}),
+        ]
+
+        batches = list(get_rows("m0-test", MEMORIES_ENDPOINT, MagicMock(), _manager()))
+
+        assert batches == [[{"id": "m1"}]]
+        assert mock_session.return_value.request.call_count == 2
+
+    @patch(f"{_MODULE}.make_tracked_session")
+    def test_auth_errors_raise_immediately_without_retry(self, mock_session):
+        mock_session.return_value.request.return_value = _response({}, status_code=401)
+
+        try:
+            list(get_rows("m0-test", MEMORIES_ENDPOINT, MagicMock(), _manager()))
+            raise AssertionError("expected HTTPError")
+        except requests.HTTPError:
+            pass
+
+        assert mock_session.return_value.request.call_count == 1
+
+
+class TestMem0SourceResponse:
+    def test_memories_response_merges_on_id_and_partitions_on_stable_created_at(self):
+        response = mem0_source("m0-test", MEMORIES_ENDPOINT, MagicMock(), _manager())
+
+        assert response.name == MEMORIES_ENDPOINT
+        assert response.primary_keys == ["id"]
+        # The list endpoint has no sort parameter, so ordering is undefined; "desc" defers
+        # the incremental watermark commit to successful end of run.
+        assert response.sort_mode == "desc"
+        assert response.partition_mode == "datetime"
+        assert response.partition_keys == ["created_at"]
+
+    def test_entities_response_has_no_partitioning(self):
+        response = mem0_source("m0-test", ENTITIES_ENDPOINT, MagicMock(), _manager())
+
+        assert response.partition_mode is None
+        assert response.partition_keys is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0_source.py
@@ -1,0 +1,147 @@
+from unittest.mock import MagicMock, patch
+
+from posthog.schema import SourceFieldInputConfig
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import Mem0SourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.mem0 import Mem0ResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.settings import (
+    ENDPOINTS,
+    ENTITIES_ENDPOINT,
+    EVENTS_ENDPOINT,
+    MEMORIES_ENDPOINT,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.mem0.source import Mem0Source
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+_SOURCE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.mem0.source"
+
+
+def _config(api_key: str = "m0-test", org_id: str | None = None, project_id: str | None = None) -> Mem0SourceConfig:
+    return Mem0SourceConfig(api_key=api_key, org_id=org_id, project_id=project_id)
+
+
+class TestMem0SourceConfig:
+    def test_source_type(self):
+        assert Mem0Source().source_type == ExternalDataSourceType.MEM0
+
+    def test_exposes_secret_api_key_and_optional_scoping_fields(self):
+        cfg = Mem0Source().get_source_config
+
+        fields = {f.name: f for f in cfg.fields}
+        assert set(fields) == {"api_key", "org_id", "project_id"}
+
+        api_key = fields["api_key"]
+        assert isinstance(api_key, SourceFieldInputConfig)
+        assert api_key.required is True
+        assert api_key.secret is True
+
+        for optional_name in ("org_id", "project_id"):
+            field = fields[optional_name]
+            assert isinstance(field, SourceFieldInputConfig)
+            assert field.required is False
+            assert field.secret is False
+
+    def test_docs_url_matches_the_doc_slug(self):
+        # The website derives the doc slug from docsUrl; a mismatch 404s the docs link.
+        assert Mem0Source().get_source_config.docsUrl == "https://posthog.com/docs/cdp/sources/mem0"
+
+
+class TestMem0SourceSchemas:
+    def test_lists_every_endpoint(self):
+        schemas = Mem0Source().get_schemas(_config(), team_id=1)
+
+        assert [s.name for s in schemas] == list(ENDPOINTS)
+
+    def test_only_memories_supports_incremental_and_never_append(self):
+        schemas = {s.name: s for s in Mem0Source().get_schemas(_config(), team_id=1)}
+
+        assert schemas[MEMORIES_ENDPOINT].supports_incremental is True
+        assert {f["field"] for f in schemas[MEMORIES_ENDPOINT].incremental_fields} == {"updated_at", "created_at"}
+        # Incremental pulls re-fetch updated rows; append mode would duplicate them.
+        assert all(s.supports_append is False for s in schemas.values())
+        # Entities and events expose no server-side timestamp filter — full refresh only.
+        assert schemas[ENTITIES_ENDPOINT].supports_incremental is False
+        assert schemas[EVENTS_ENDPOINT].supports_incremental is False
+
+    def test_events_is_opt_in(self):
+        schemas = {s.name: s for s in Mem0Source().get_schemas(_config(), team_id=1)}
+
+        assert schemas[EVENTS_ENDPOINT].should_sync_default is False
+        assert schemas[MEMORIES_ENDPOINT].should_sync_default is True
+
+    def test_filters_by_names_argument(self):
+        schemas = Mem0Source().get_schemas(_config(), team_id=1, names=[MEMORIES_ENDPOINT])
+
+        assert [s.name for s in schemas] == [MEMORIES_ENDPOINT]
+
+    def test_documented_tables_render_without_credentials(self):
+        # Feeds the public docs' Supported tables section via lists_tables_without_credentials.
+        tables = {t["name"]: t for t in Mem0Source().get_documented_tables()}
+
+        assert set(tables) == set(ENDPOINTS)
+        assert tables[MEMORIES_ENDPOINT]["description"]
+        assert "Incremental" in tables[MEMORIES_ENDPOINT]["sync_methods"]
+
+
+class TestMem0SourceCredentials:
+    @patch(f"{_SOURCE_MODULE}.validate_mem0_credentials", return_value=True)
+    def test_valid_key(self, mock_validate):
+        assert Mem0Source().validate_credentials(_config(), team_id=1) == (True, None)
+        mock_validate.assert_called_once_with("m0-test")
+
+    @patch(f"{_SOURCE_MODULE}.validate_mem0_credentials", return_value=False)
+    def test_invalid_key_returns_actionable_error(self, mock_validate):
+        ok, error = Mem0Source().validate_credentials(_config(), team_id=1)
+
+        assert ok is False
+        assert error == "Invalid Mem0 API key"
+
+    def test_non_retryable_errors_pin_to_the_mem0_host(self):
+        keys = Mem0Source().get_non_retryable_errors().keys()
+
+        assert any(key.startswith("401 Client Error") and "api.mem0.ai" in key for key in keys)
+        assert any(key.startswith("403 Client Error") and "api.mem0.ai" in key for key in keys)
+
+
+class TestMem0SourcePipeline:
+    def test_resumable_manager_is_bound_to_the_mem0_resume_dataclass(self):
+        inputs = MagicMock()
+        manager = Mem0Source().get_resumable_source_manager(inputs)
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is Mem0ResumeConfig
+
+    @patch(f"{_SOURCE_MODULE}.mem0_source")
+    def test_plumbs_credentials_scoping_and_incremental_state(self, mock_source):
+        inputs = MagicMock()
+        inputs.schema_name = MEMORIES_ENDPOINT
+        inputs.should_use_incremental_field = True
+        inputs.db_incremental_field_last_value = "2026-07-01"
+        inputs.incremental_field = "updated_at"
+        manager = MagicMock()
+
+        Mem0Source().source_for_pipeline(_config("key", org_id="org_1", project_id="proj_1"), manager, inputs)
+
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["api_key"] == "key"
+        assert kwargs["endpoint"] == MEMORIES_ENDPOINT
+        assert kwargs["resumable_source_manager"] is manager
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["db_incremental_field_last_value"] == "2026-07-01"
+        assert kwargs["incremental_field"] == "updated_at"
+        assert kwargs["org_id"] == "org_1"
+        assert kwargs["project_id"] == "proj_1"
+
+    @patch(f"{_SOURCE_MODULE}.mem0_source")
+    def test_incremental_flag_never_reaches_full_refresh_endpoints(self, mock_source):
+        # Entities has no server-side timestamp filter; forwarding the incremental flag
+        # would make the transport build a filter the endpoint can't honor.
+        inputs = MagicMock()
+        inputs.schema_name = ENTITIES_ENDPOINT
+        inputs.should_use_incremental_field = True
+        inputs.incremental_field = None
+
+        Mem0Source().source_for_pipeline(_config(), MagicMock(), inputs)
+
+        assert mock_source.call_args.kwargs["should_use_incremental_field"] is False


### PR DESCRIPTION
## Problem

Mem0 is an AI agent memory platform: it stores extracted facts per user/agent/app/run. Teams building AI products on it want that memory data queryable next to their product analytics. The `mem0` source existed only as a scaffolded stub (`unreleasedSource=True`, no fields, no sync logic).

## Why

Fill in the scaffolded Mem0 connector end-to-end so Mem0 memory data can be synced into the Data warehouse.

## Changes

Implements the Mem0 source end-to-end following the `source.py` / `settings.py` / `mem0.py` architecture contract:

- **Tables:** `memories` (POST `/v3/memories/`, incremental), `entities` (GET `/v1/entities/`, full refresh), and `events` (GET `/v1/events/`, full refresh, opt-in by default since it's a potentially high-volume audit stream).
- **Base class:** `ResumableSource` — memories resume by page number (with the incremental cutoff pinned in the resume state so a resumed run paginates the same server-side result set), events resume by the envelope's `next` URL. State is saved after each yielded batch.
- **Incremental sync:** only `memories` gets `supports_incremental=True` — the v3 filter DSL exposes genuine server-side `created_at`/`updated_at` comparison operators (`gte`). The filter body rides every page request, so pagination terminates at the watermark naturally. `sort_mode="desc"` because the endpoint has no sort parameter (undefined ordering), which defers the watermark commit to successful end of run.
- **Match-all filter:** the memories list requires a `filters` body, and a bare `{"user_id": "*"}` would miss agent/app/run-scoped memories, so the request ORs the wildcard across all four entity ids.
- **Transport:** plain `requests` through `make_tracked_session()`, `tenacity` retries on 429/5xx/transient network errors, `get_non_retryable_errors` for 401/403.
- **Extras:** `canonical_descriptions.py` sourced from the official API docs, `lists_tables_without_credentials = True` (static catalog) so the public docs render the table list, official Mem0 SVG icon, `SOURCES.md` moved to the Implemented table.
- Stays behind `unreleasedSource=True` with `releaseStatus=ReleaseStatus.ALPHA` for now.

> [!NOTE]
> Mem0 offers `memory:add/update/delete/categorize` webhooks, but I deliberately did not wire a `WebhookSource`: deliveries carry only `{event_details: {id, data.memory, event}}` (no categories, metadata, timestamps, or entity ids) and Mem0 documents no signing secret. Since webhook mode replaces the poll once active, the memories table would permanently degrade to sparse text-only rows. The server-side incremental filter already makes scheduled pulls cheap; a code comment in `source.py` records this decision.

Verified against the live API where possible without credentials: `/v1/ping/`, `/v3/memories/`, `/v1/entities/`, and `/v1/events/` all exist and return structured 401s for bad keys ( `/v1/ping/` is the same probe the official `mem0ai` SDK uses for key validation). Filter/pagination semantics come from the current API reference; the incremental cutoff is conservatively sent as a date string (the only format the docs demonstrate), which can only over-fetch — never skip — rows, and the merge dedupes on `id`.

Docs: the companion posthog.com doc is written (attached in a PR comment below) but could not be pushed from this session — the credentials only cover this repo. It needs to land as `contents/docs/cdp/sources/mem0.md` in posthog.com. `docsUrl` matches the `mem0` slug and `audit_source_docs` run against a local posthog.com checkout with the doc in place reports no mem0 mismatch.

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/` — 41 tests pass. Transport tests catch: dropping agent/app/run-scoped memories from the filter, saving resume state before yield (skipped rows on crash), replaying one endpoint's cursor against another, recomputing the cutoff on resume (pagination misalignment), retrying auth errors / not retrying rate limits, and forwarding the incremental flag to full-refresh endpoints. Source tests cover schema catalog behavior, credential validation plumbing, resume manager binding, and the credential-free documented-tables path that feeds public docs.
- `pytest .../sources/tests/test_source_categories.py .../sources/tests/test_generated_configs.py` — 1550 pass (registry/category/config-generation consistency).
- `ruff check` / `ruff format` clean; `hogli ci:preflight --fix` reports 0 failures.
- I could not run a live end-to-end sync: that needs a real Mem0 API key. The endpoint shapes are verified from the current API reference plus unauthenticated probes of the live API.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Companion doc for posthog.com (`contents/docs/cdp/sources/mem0.md`) is written and attached in a PR comment below — it needs a separate PR in the posthog.com repo (this session's credentials are scoped to this repo only).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: `/implementing-warehouse-sources`, `/documenting-warehouse-sources`, `/writing-tests`. Key decisions: chose pull-only `ResumableSource` over the initially suggested `ResumableSource+WebhookSource` because Mem0's webhook payloads are too sparse to feed the merge path without degrading the table (details in the note above); modeled the operation-event stream as the pulled `events` table instead, which has real ids and timestamps. The generated `Mem0SourceConfig` came from `generate:source-configs`; an unrelated environment-dependent Stripe hunk the generator produced locally was excluded from the commit.


---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
