### PR TITLE
fix(access-control): use tracing navigation icon

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/ScopeIcon.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/ScopeIcon.tsx
@@ -10,6 +10,7 @@ import {
     IconFlask,
     IconHome,
     IconLive,
+    IconListTree,
     IconLlmAnalytics,
     IconMessage,
     IconNotebook,
@@ -84,7 +85,7 @@ export function ScopeIcon(props: { scope: APIScopeObject }): JSX.Element | null 
         case 'web_analytics':
             return <IconPieChart />
         case 'tracing':
-            return <IconLive />
+            return <IconListTree />
         default:
             return null
     }


### PR DESCRIPTION
## Problem

The tracing resource in access control settings shows a different icon from the tracing item in the navigation.

## Changes

Use the same `IconListTree` mapping as the tracing navigation item.

## How did you test this code?

- Ran `git diff --check` successfully.
- The repository checkout does not include the `oxlint` or `oxfmt` binaries, so frontend lint and formatting checks were unavailable.
- No manual UI verification was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed for this icon-only UI fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI made the focused frontend change and created this draft PR. No repo-provided skills were needed. The existing navigation icon mapping was used as the source of truth; no API, backend, or generated files were changed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
