### PR TITLE
feat(conversations): create email-channel tickets for anonymous widget requesters

### DIFF
--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -3,13 +3,14 @@ import uuid
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from posthog.models.comment import Comment
 
-from products.conversations.backend.models import Ticket
-from products.conversations.backend.models.constants import ChannelDetail, Status
+from products.conversations.backend.models import EmailChannel, Ticket
+from products.conversations.backend.models.constants import Channel, ChannelDetail, Status
 from products.conversations.backend.services.identity import compute_identity_hash
 
 
@@ -232,6 +233,96 @@ class TestWidgetAPI(BaseTest):
         ticket = Ticket.objects.get(id=response.json()["ticket_id"])
         self.assertEqual(ticket.anonymous_traits["name"], "John")
         self.assertEqual(ticket.anonymous_traits["email"], "john@example.com")
+
+    def _create_email_channel(self, verified=True, from_email="support@help.example.com", is_default=False):
+        return EmailChannel.objects.create(
+            team=self.team,
+            inbound_token=from_email,
+            from_email=from_email,
+            from_name="Support",
+            domain=from_email.split("@")[1],
+            domain_verified=verified,
+            is_default=is_default,
+        )
+
+    def test_anonymous_email_ticket_uses_the_default_channel(self):
+        self.team.conversations_settings = {**self.team.conversations_settings, "email_enabled": True}
+        self.team.save()
+        # Oldest channel is not the default; the newer one is
+        self._create_email_channel(from_email="old@help.example.com")
+        default = self._create_email_channel(from_email="chosen@help.example.com", is_default=True)
+
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {
+                "message": "Help",
+                "widget_session_id": self.widget_session_id,
+                "distinct_id": self.distinct_id,
+                "traits": {"email": "jane@example.com"},
+            },
+            **self._get_headers(),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ticket = Ticket.objects.get(id=response.json()["ticket_id"])
+        self.assertEqual(ticket.email_config_id, default.id)
+
+    def test_anonymous_email_trait_creates_email_channel_ticket(self):
+        self.team.conversations_settings = {**self.team.conversations_settings, "email_enabled": True}
+        self.team.save()
+        email_config = self._create_email_channel()
+
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {
+                "message": "My data is missing\nIt disappeared yesterday",
+                "widget_session_id": self.widget_session_id,
+                "distinct_id": self.distinct_id,
+                "traits": {"name": "Jane", "email": "jane@example.com"},
+            },
+            **self._get_headers(),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ticket = Ticket.objects.get(id=response.json()["ticket_id"])
+        self.assertEqual(ticket.channel_source, Channel.EMAIL)
+        self.assertEqual(ticket.email_from, "jane@example.com")
+        self.assertEqual(ticket.email_config_id, email_config.id)
+        self.assertEqual(ticket.email_subject, "My data is missing")
+        # Still tied to the widget session, so the requester can also see replies in the widget
+        self.assertEqual(ticket.widget_session_id, self.widget_session_id)
+        self.assertEqual(ticket.anonymous_traits["email"], "jane@example.com")
+
+    @parameterized.expand(
+        [
+            ("no_email_trait", {"name": "Jane"}, True, True),
+            ("email_channel_disabled", {"email": "jane@example.com"}, False, True),
+            ("no_verified_email_channel", {"email": "jane@example.com"}, True, False),
+            ("invalid_email_trait", {"email": "not-an-email"}, True, True),
+        ]
+    )
+    def test_ticket_stays_on_widget_channel(self, _name, traits, email_enabled, channel_verified):
+        if email_enabled:
+            self.team.conversations_settings = {**self.team.conversations_settings, "email_enabled": True}
+            self.team.save()
+        self._create_email_channel(verified=channel_verified)
+
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {
+                "message": "Hello",
+                "widget_session_id": self.widget_session_id,
+                "distinct_id": self.distinct_id,
+                "traits": traits,
+            },
+            **self._get_headers(),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ticket = Ticket.objects.get(id=response.json()["ticket_id"])
+        self.assertEqual(ticket.channel_source, "widget")
+        self.assertFalse(ticket.email_from)
+        self.assertIsNone(ticket.email_config_id)
 
     def test_get_messages(self):
         ticket = Ticket.objects.create_with_number(
@@ -695,6 +786,34 @@ class TestWidgetIdentityVerification(BaseTest):
         ticket = Ticket.objects.get(id=response.json()["ticket_id"])
         self.assertEqual(ticket.distinct_id, self.distinct_id)
         self.assertTrue(ticket.identity_verified)
+
+    def test_verified_identity_ticket_stays_on_widget_channel_despite_email_trait(self):
+        self.team.conversations_settings = {**self.team.conversations_settings, "email_enabled": True}
+        self.team.save()
+        EmailChannel.objects.create(
+            team=self.team,
+            inbound_token="widget_iv_inbound_token",
+            from_email="support@iv.example.com",
+            from_name="Support",
+            domain="iv.example.com",
+            domain_verified=True,
+        )
+
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {
+                "identity_distinct_id": self.distinct_id,
+                "identity_hash": self.identity_hash,
+                "message": "Hello from identity mode",
+                "traits": {"email": "jane@example.com"},
+            },
+            **self._get_headers(),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ticket = Ticket.objects.get(id=response.json()["ticket_id"])
+        self.assertEqual(ticket.channel_source, "widget")
+        self.assertFalse(ticket.email_from)
 
     def test_anonymous_message_creates_unverified_ticket(self):
         # A widget_session_id-only (no HMAC) request is not server-attested.

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -13,7 +13,10 @@ Anonymous users are controlled by widget_session_id. Verified users are controll
 
 import uuid
 import logging
+from typing import Any
 
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from django.db.models import F, Q
 
 from rest_framework import serializers, status
@@ -47,11 +50,47 @@ from products.conversations.backend.cache import (
     set_cached_messages,
     set_cached_tickets,
 )
-from products.conversations.backend.models import Ticket
-from products.conversations.backend.models.constants import ChannelDetail
+from products.conversations.backend.models import EmailChannel, Ticket
+from products.conversations.backend.models.constants import Channel, ChannelDetail
 from products.conversations.backend.services.identity import verify_identity_hash
 
 logger = logging.getLogger(__name__)
+
+
+def _email_ticket_overrides(team: Team, traits: dict, identity_verified: bool, message: str) -> dict[str, Any]:
+    """Anonymous requesters who leave an email address get an email-channel ticket, so team
+    replies always reach them by email (they may never reopen the widget). Identified users
+    see replies in the widget, so their tickets stay on the widget channel. Requires the team
+    to have email enabled and a verified channel to send from; otherwise no overrides.
+    """
+    if identity_verified:
+        return {}
+    email = (traits or {}).get("email")
+    # 254 = the max length of Ticket.email_from (EmailField); a longer-but-syntactically-valid
+    # address would pass validate_email and then 500 on insert
+    if not email or not isinstance(email, str) or len(email) > 254:
+        return {}
+    try:
+        validate_email(email)
+    except DjangoValidationError:
+        return {}
+    if not (team.conversations_settings or {}).get("email_enabled"):
+        return {}
+    # Prefer the team's default channel; fall back to the oldest verified one
+    email_config = (
+        EmailChannel.objects.filter(team=team, domain_verified=True).order_by("-is_default", "created_at").first()
+    )
+    if not email_config:
+        return {}
+    # Strip control chars — the subject becomes an email header; splitlines() already drops newlines
+    first_line = next((line for line in message.splitlines() if line.strip()), "")
+    subject = "".join(ch for ch in first_line if ch.isprintable())[:200]
+    return {
+        "channel_source": Channel.EMAIL,
+        "email_config": email_config,
+        "email_from": email,
+        "email_subject": subject or "Support request",
+    }
 
 
 class IdentityVerificationFailed(Exception):
@@ -202,19 +241,23 @@ class WidgetMessageView(APIView):
                 if conversations_settings.get("widget_enabled")
                 else ChannelDetail.WIDGET_API
             )
-            ticket = Ticket.objects.create_with_number(
-                team=team,
-                widget_session_id=widget_session_id,
-                distinct_id=distinct_id,
-                channel_source="widget",
-                channel_detail=widget_channel_detail,
-                status="new",
-                anonymous_traits=traits,
-                unread_team_count=1,
-                session_id=session_id,
-                session_context=session_context,
-                identity_verified=verified_distinct_id is not None,
+            create_kwargs: dict[str, Any] = {
+                "team": team,
+                "widget_session_id": widget_session_id,
+                "distinct_id": distinct_id,
+                "channel_source": "widget",
+                "channel_detail": widget_channel_detail,
+                "status": "new",
+                "anonymous_traits": traits,
+                "unread_team_count": 1,
+                "session_id": session_id,
+                "session_context": session_context,
+                "identity_verified": verified_distinct_id is not None,
+            }
+            create_kwargs.update(
+                _email_ticket_overrides(team, traits, verified_distinct_id is not None, message_content)
             )
+            ticket = Ticket.objects.create_with_number(**create_kwargs)
 
             try:
                 report_team_action(team, "support ticket created", {"channel_source": ticket.channel_source})


### PR DESCRIPTION
## Problem

Anonymous widget requesters who leave an email address get a widget-channel ticket. Team replies then only appear back in the widget, which someone who submitted from a page they won't return to (for example a logged-out auth page) may never reopen. Their support answer effectively goes nowhere.

## Changes

When an anonymous requester supplies a valid email trait and the team has email enabled with a verified channel, the ticket is created on the email channel, sending from the team's primary channel. Team replies are then emailed. The ticket keeps its widget session binding, so it also stays visible in the widget. Identity-verified users are unchanged: they keep widget-channel tickets and see replies in the side panel.

Backend only. Stacked on #70725 (primary email channel), which this uses to pick the send-from identity.

> [!WARNING]
> **Open decision — please weigh in before this leaves draft.** This applies to every conversations team's widget, not just PostHog's own support. An anonymous request can set `email_from` to any address it types; once a team (or a public AI) replies, that address receives mail from the team's verified domain. That's a potential backscatter / impersonation vector, bounded only by the widget throttles. The ticket is flagged as unverified in the agent view (an `IdentityBadge`), which warns the agent about the claimed identity but does not stop the outbound email. Options discussed: restrict email-channel promotion to identity-verified requesters, require address verification (double opt-in) before emailing, or gate behind an explicit per-team setting. Kept draft until we pick one.

Cheap hardening already included: the email is length-capped to the model's limit (avoids a 500 on insert), and the subject (taken from the first message line) is stripped of control characters before it becomes an email header.

## How did you test this code?

Automated only:

- `test_widget.py`: an anonymous email trait creates an email-channel ticket with the right recipient, config, and subject while keeping the widget session binding; a parameterized set locks the guardrails (no email trait, email channel disabled, no verified channel, invalid email all stay widget-channel); identity-verified users keep widget-channel tickets even with an email trait; and the ticket uses the team's primary channel rather than the oldest. Full `test_widget.py` suite passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Abigail directed this; I (Claude, via PostHog Code) wrote it. Carved out of a larger switchover branch. Skills invoked: `/improving-drf-endpoints` (widget endpoint) and `/writing-tests`.

This started as an unconditional product-wide behavior. A multi-agent review flagged the outbound-email abuse surface, which is why it's a separate draft PR with the decision called out rather than folded into the routing change. The channel selection prefers the team's primary channel (from the base PR) and falls back to the oldest verified one.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
