### PR TITLE
chore(mcp): note fully-qualified table_name pitfall in execute-sql prompt

### DIFF
--- a/services/mcp/src/templates/execute-sql-prompt.md
+++ b/services/mcp/src/templates/execute-sql-prompt.md
@@ -18,7 +18,7 @@ If a `query-*` tool fits, use it. Default to `query-*`; SQL is the escape hatch,
 
 ### Common pitfalls
 
-- **`information_schema` filters need the fully-qualified `table_name`.** A `system.*` entity is stored as `table_name = 'system.insights'`, not `'insights'` — filtering on the bare name, or splitting it into `table_schema = 'system' AND table_name = 'insights'`, silently returns zero rows rather than erroring.
+- **`information_schema` needs the fully-qualified `table_name`:** a `system.*` entity is `'system.insights'`, not `'insights'`; the bare name (or a `table_schema = 'system'` split) silently returns zero rows.
 
 ### Format SQL for readability
 

--- a/services/mcp/src/templates/execute-sql-prompt.md
+++ b/services/mcp/src/templates/execute-sql-prompt.md
@@ -19,6 +19,7 @@ If a `query-*` tool fits, use it. Default to `query-*`; SQL is the escape hatch,
 ### Common pitfalls
 
 - **For `system.*` entities, filter `information_schema` by the fully-qualified `table_name`:** use `'system.insights'`, not `'insights'`; the bare name (or a `table_schema = 'system'` split) silently returns zero rows.
+- **The `posthog.`-namespaced tables (`ai_events`, `trace_spans`, `metrics`) aren't in `information_schema` at all** — no `table_name` surfaces them, with or without the prefix; use the column lists documented below.
 
 ### Format SQL for readability
 

--- a/services/mcp/src/templates/execute-sql-prompt.md
+++ b/services/mcp/src/templates/execute-sql-prompt.md
@@ -18,7 +18,7 @@ If a `query-*` tool fits, use it. Default to `query-*`; SQL is the escape hatch,
 
 ### Common pitfalls
 
-- **`information_schema` needs the fully-qualified `table_name`:** a `system.*` entity is `'system.insights'`, not `'insights'`; the bare name (or a `table_schema = 'system'` split) silently returns zero rows.
+- **For `system.*` entities, filter `information_schema` by the fully-qualified `table_name`:** use `'system.insights'`, not `'insights'`; the bare name (or a `table_schema = 'system'` split) silently returns zero rows.
 
 ### Format SQL for readability
 

--- a/services/mcp/src/templates/execute-sql-prompt.md
+++ b/services/mcp/src/templates/execute-sql-prompt.md
@@ -16,6 +16,10 @@ If a `query-*` tool fits, use it. Default to `query-*`; SQL is the escape hatch,
 
 {schema_discovery}
 
+### Common pitfalls
+
+- **`information_schema` filters need the fully-qualified `table_name`.** A `system.*` entity is stored as `table_name = 'system.insights'`, not `'insights'` — filtering on the bare name, or splitting it into `table_schema = 'system' AND table_name = 'insights'`, silently returns zero rows rather than erroring.
+
 ### Format SQL for readability
 
 Write SQL a human can scan: multi-line with indentation, one column/CTE per line, and inline `--` comments for non-obvious logic. This matters most for queries you save via `view-create` / `view-update` — the SQL editor stores and renders the string verbatim, so a minified one-liner stays unreadable for whoever opens the view later.

--- a/services/mcp/src/templates/execute-sql-prompt.md
+++ b/services/mcp/src/templates/execute-sql-prompt.md
@@ -19,7 +19,6 @@ If a `query-*` tool fits, use it. Default to `query-*`; SQL is the escape hatch,
 ### Common pitfalls
 
 - **For `system.*` entities, filter `information_schema` by the fully-qualified `table_name`:** use `'system.insights'`, not `'insights'`; the bare name (or a `table_schema = 'system'` split) silently returns zero rows.
-- **The `posthog.`-namespaced tables (`ai_events`, `trace_spans`, `metrics`) aren't in `information_schema` at all** — no `table_name` surfaces them, with or without the prefix; use the column lists documented below.
 
 ### Format SQL for readability
 


### PR DESCRIPTION
## Problem

An observability-gaps Signals scout hit friction against `system.information_schema`: filtering the column catalog with `table_schema = 'system' AND table_name = 'insights'` returned **zero rows** (header only), even though `SELECT * FROM system.insights` worked fine. It burned two dead queries before falling back.

Root cause is a naming gotcha, not a bug: each `information_schema` row stores `table_name` as the table's fully-qualified name (`system.insights`), while `table_schema` is the bucket (`system`). So the bare `insights`, or a `table_schema='system' AND table_name='insights'` split, matches nothing and silently returns empty rather than erroring. The correct form (`table_name = 'system.insights'`) is already documented in the schema-discovery prompts, but nothing warned against the intuitive-but-wrong split.

## Changes

Add a short "Common pitfalls" section to the execute-sql tool prompt (`services/mcp/src/templates/execute-sql-prompt.md`), right after the schema-discovery block, calling out the fully-qualified `table_name` requirement.

**Why:** surfaced via MCP agent feedback from a Signals scout; the one-line guard should stop agents re-deriving the wrong filter shape.

## How did you test this code?

Reproduced both queries live against a real project via `execute-sql`: `table_schema='system' AND table_name='insights'` → 0 rows; `table_name='system.insights'` → all 17 columns. Change is prompt-only markdown, no code path affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Confirmed the mechanism by reading `posthog/hogql/database/schema/information_schema.py` (rows set `table_name` to the fully-qualified name) and grepped the prompt surfaces (`schema-discovery.md`, `entity-schema-discovery.md`, `querying-posthog-data/references/guidelines.md`) — all already use the correct `'system.insights'` form, so this adds a preventive pitfall note rather than fixing an incorrect example. No skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BE8C0JFNF/p1784034108341949?thread_ts=1784034108.341949&cid=C0BE8C0JFNF)*
