### PR TITLE
feat(autoresearch): speed up backend test suite startup and enable in-shard parallelism

### DIFF
--- a/bin/clone-test-db-for-xdist
+++ b/bin/clone-test-db-for-xdist
@@ -22,16 +22,30 @@ psql_admin() {
 
 clone() {
     local src="$1" dest="$2"
-    # TEMPLATE requires no active connections on the source DB.
-    psql_admin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${src}' AND pid <> pg_backend_pid();" > /dev/null
     psql_admin "DROP DATABASE IF EXISTS ${dest};" > /dev/null
     psql_admin "CREATE DATABASE ${dest} TEMPLATE ${src};" > /dev/null
     echo "cloned ${src} -> ${dest}"
 }
 
-for i in $(seq 0 $((WORKERS - 1))); do
-    clone "${SOURCE_DB}" "${SOURCE_DB}_gw${i}"
-    if psql_admin "SELECT 1 FROM pg_database WHERE datname = '${SOURCE_DB}_persons'" | grep -q 1; then
-        clone "${SOURCE_DB}_persons" "${SOURCE_DB}_gw${i}_persons"
-    fi
-done
+# Concurrent clones of the SAME template fail ("source database is being
+# accessed"), so clones are sequential per source — but the main and persons
+# streams use different templates, so they run concurrently.
+clone_stream() {
+    local src="$1" suffix="$2"
+    # TEMPLATE requires no active connections on the source DB.
+    psql_admin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${src}' AND pid <> pg_backend_pid();" > /dev/null
+    for i in $(seq 0 $((WORKERS - 1))); do
+        clone "${src}" "${SOURCE_DB}_gw${i}${suffix}"
+    done
+}
+
+clone_stream "${SOURCE_DB}" "" &
+MAIN_PID=$!
+PERSONS_PID=""
+if psql_admin "SELECT 1 FROM pg_database WHERE datname = '${SOURCE_DB}_persons'" | grep -q 1; then
+    clone_stream "${SOURCE_DB}_persons" "_persons" &
+    PERSONS_PID=$!
+fi
+wait "$MAIN_PID"
+[ -n "$PERSONS_PID" ] && wait "$PERSONS_PID"
+echo "done: ${WORKERS} worker database(s) per stream"

--- a/bin/clone-test-db-for-xdist
+++ b/bin/clone-test-db-for-xdist
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Clone the migrated test databases into per-worker copies for pytest-xdist.
+# pytest-django suffixes each worker's DB as <name>_gwN, and posthog/conftest.py
+# derives the persons DB as <name>_gwN_persons; cloning both via
+# CREATE DATABASE ... TEMPLATE skips re-running Django + sqlx migrations per
+# worker, so `pytest -n N --reuse-db` starts instantly on every worker.
+#
+# Usage: bin/clone-test-db-for-xdist <num_workers> [source_db]
+set -euo pipefail
+
+WORKERS="${1:?usage: clone-test-db-for-xdist <num_workers> [source_db]}"
+SOURCE_DB="${2:-test_posthog}"
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-posthog}"
+export PGPASSWORD="${PGPASSWORD:-posthog}"
+
+psql_admin() {
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d postgres -v ON_ERROR_STOP=1 -qAt -c "$1"
+}
+
+clone() {
+    local src="$1" dest="$2"
+    # TEMPLATE requires no active connections on the source DB.
+    psql_admin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${src}' AND pid <> pg_backend_pid();" > /dev/null
+    psql_admin "DROP DATABASE IF EXISTS ${dest};" > /dev/null
+    psql_admin "CREATE DATABASE ${dest} TEMPLATE ${src};" > /dev/null
+    echo "cloned ${src} -> ${dest}"
+}
+
+for i in $(seq 0 $((WORKERS - 1))); do
+    clone "${SOURCE_DB}" "${SOURCE_DB}_gw${i}"
+    if psql_admin "SELECT 1 FROM pg_database WHERE datname = '${SOURCE_DB}_persons'" | grep -q 1; then
+        clone "${SOURCE_DB}_persons" "${SOURCE_DB}_gw${i}_persons"
+    fi
+done

--- a/conftest.py
+++ b/conftest.py
@@ -206,12 +206,72 @@ def _cheapen_freezegun_module_hash() -> None:
     api._get_module_attributes_hash = _fast_module_attributes_hash  # ty: ignore[invalid-assignment]
 
 
+def _skip_noop_migrate() -> None:
+    # pytest-django runs `migrate` per session even on a reused, fully-migrated DB
+    # (--reuse-db / schema cache in CI), paying ~1.3s of graph building and project
+    # state rendering just to conclude there is nothing to apply. Short-circuit the
+    # bare invocation when every migration on disk is already recorded as applied —
+    # one recorder query plus load_disk, no graph, no state render, no signals.
+    # Any targeted/fancy invocation (app label, --fake, --run-syncdb, --check, ...)
+    # and any error falls through to the original handler, so a cold DB, a PR's
+    # unapplied migrations, and migration-framework tests behave exactly as before.
+    from django.core.management.commands import migrate as migrate_cmd  # noqa: PLC0415 — deferred import
+
+    orig_handle = migrate_cmd.Command.handle
+
+    def handle(self, *args, **options):
+        if not args and not options.get("app_label"):
+            passthrough_flags = ("migration_name", "fake", "fake_initial", "run_syncdb", "check_unapplied", "prune")
+            if not any(options.get(flag) for flag in passthrough_flags):
+                try:
+                    import pkgutil  # noqa: PLC0415
+                    import importlib  # noqa: PLC0415
+
+                    from django.apps import apps  # noqa: PLC0415
+                    from django.db import connections  # noqa: PLC0415
+                    from django.db.migrations.loader import MigrationLoader  # noqa: PLC0415
+                    from django.db.migrations.recorder import MigrationRecorder  # noqa: PLC0415
+
+                    # Discover on-disk migration names with pkgutil (same rule as
+                    # MigrationLoader.load_disk: skip subpackages and _/~ prefixes)
+                    # without importing every migration module (~1s for our tree).
+                    disk_migrations = set()
+                    for app_config in apps.get_app_configs():
+                        module_name, _explicit = MigrationLoader.migrations_module(app_config.label)
+                        if module_name is None:
+                            continue
+                        try:
+                            module = importlib.import_module(module_name)
+                        except ModuleNotFoundError:
+                            continue
+                        # Namespace/odd packages: defer to the real migrate rather than guessing.
+                        if not hasattr(module, "__path__"):
+                            raise LookupError(f"unexpected migrations module shape for {app_config.label}")
+                        for _finder, name, is_pkg in pkgutil.iter_modules(module.__path__):
+                            if not is_pkg and name[0] not in "_~":
+                                disk_migrations.add((app_config.label, name))
+
+                    connection = connections[options["database"]]
+                    recorder = MigrationRecorder(connection)
+                    if recorder.has_table() and disk_migrations <= recorder.applied_migrations().keys():
+                        if options.get("verbosity", 1) >= 1:
+                            self.stdout.write("All disk migrations already applied — skipping migrate.")
+                        return
+                except Exception:
+                    pass
+        return orig_handle(self, *args, **options)
+
+    handle.__wrapped__ = orig_handle  # exposes the original for the canary tests
+    migrate_cmd.Command.handle = handle  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+
 def pytest_configure(config) -> None:
     _cache_reverse_rel_identity()
     _cache_select_masks()
     _cache_drf_field_info()
     _cache_url_resolution()
     _cheapen_freezegun_module_hash()
+    _skip_noop_migrate()
 
 
 def pytest_collection_finish() -> None:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -372,7 +372,9 @@ services:
         # (maybe only in Pycharm) keeps many idle transactions open
         # and eventually kills postgres, these settings aim to stop that happening.
         # They are only for DEV and should not be used in production.
-        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000 -c max_prepared_transactions=10
+        # fsync/synchronous_commit/full_page_writes off: dev and CI data is disposable,
+        # so commits skip WAL durability waits — a real win on CI runners with real disks.
+        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000 -c max_prepared_transactions=10 -c fsync=off -c synchronous_commit=off -c full_page_writes=off
 
     redis7:
         extends:

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1144,3 +1144,7 @@ environment:
         bin_script: ensure-local-setup
         description: Idempotent local-dev bootstrap (e.g. the wizard OAuth app); runs automatically on hogli start
         hidden: true
+    clone:test:db:for:xdist:
+        bin_script: clone-test-db-for-xdist
+        description: TEMPLATE-clone the migrated test DBs into per-worker copies for pytest-xdist
+        hidden: true

--- a/posthog/api/rest_router.py
+++ b/posthog/api/rest_router.py
@@ -6,8 +6,6 @@ from django.apps import apps
 from rest_framework import decorators, exceptions, viewsets
 from rest_framework_extensions.routers import NestedRegistryItem
 
-# Preload to work around circular imports in `ee.hogai.{core.agent_modes,chat_agent,tools}`.
-import posthog.temporal.ai  # noqa: F401
 from posthog.api import data_color_theme, metalytics, my_notifications, project, user_integration, user_push_token
 from posthog.api.csp_reporting import CSPReportingViewSet
 from posthog.api.js_snippet import JsSnippetViewSet

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -10,14 +10,6 @@ from django.utils.crypto import get_random_string
 
 import posthoganalytics
 from drf_spectacular.utils import extend_schema
-from google.genai.types import GenerateContentConfig, Schema
-from openai.types.chat import (
-    ChatCompletionMessageParam,
-    ChatCompletionSystemMessageParam,
-    ChatCompletionUserMessageParam,
-)
-from posthoganalytics.ai.gemini import genai
-from posthoganalytics.ai.openai import OpenAI
 from prometheus_client import Counter
 from rest_framework import exceptions, response, serializers, viewsets
 from rest_framework.decorators import action
@@ -255,6 +247,12 @@ class SetupWizardViewSet(viewsets.ViewSet):
         )
 
         if model in GEMINI_SUPPORTED_MODELS:
+            # noqa comments: keep the google.genai import (~1s of pydantic model
+            # construction) off the router import path — it loads with the wizard
+            # module in every Django process and pytest session otherwise.
+            from google.genai.types import GenerateContentConfig, Schema  # noqa: PLC0415
+            from posthoganalytics.ai.gemini import genai  # noqa: PLC0415
+
             api_key = settings.GEMINI_API_KEY
             if not api_key:
                 error = exceptions.ValidationError(ERROR_GEMINI_API_KEY_NOT_CONFIGURED)
@@ -309,6 +307,15 @@ class SetupWizardViewSet(viewsets.ViewSet):
             response_data = response.parsed
 
         elif model in OPENAI_SUPPORTED_MODELS:
+            # noqa comments: keep the openai SDK import off the router import path
+            # (loads with the wizard module in every Django process otherwise).
+            from openai.types.chat import (  # noqa: PLC0415
+                ChatCompletionMessageParam,
+                ChatCompletionSystemMessageParam,
+                ChatCompletionUserMessageParam,
+            )
+            from posthoganalytics.ai.openai import OpenAI  # noqa: PLC0415
+
             system_message = ChatCompletionSystemMessageParam(
                 role="system",
                 content=system_prompt,

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -42,7 +42,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.data["host"] == "http://localhost:8010"
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_requires_hash_header(self, mock_openai):
         response = self.client.post(
             self.query_url,
@@ -55,7 +55,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     @patch("django.conf.settings.DEBUG", False)
     def test_query_endpoint_rate_limit(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
@@ -86,7 +86,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_invalid_hash(self, mock_openai):
         response = self.client.post(
             self.query_url,
@@ -99,7 +99,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
         mock_openai_instance.chat.completions.create.return_value = MagicMock(
@@ -118,7 +118,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.json() == {"data": {"foo": "bar"}}
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_uses_default_model(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
         mock_openai_instance.chat.completions.create.return_value = MagicMock(
@@ -143,7 +143,7 @@ class SetupWizardTests(APIBaseTest):
         mock_openai_instance.chat.completions.create.assert_called_once()
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_accepts_valid_openai_model(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
         mock_openai_instance.chat.completions.create.return_value = MagicMock(
@@ -168,7 +168,7 @@ class SetupWizardTests(APIBaseTest):
         mock_openai_instance.chat.completions.create.assert_called_once()
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.genai.Client")
+    @patch("posthoganalytics.ai.gemini.genai.Client")
     @patch("django.conf.settings.GEMINI_API_KEY", "test-key")
     def test_query_endpoint_accepts_valid_gemini_model(self, mock_genai_client):
         mock_client_instance = mock_genai_client.return_value
@@ -213,7 +213,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", True)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_mock_wizard_data_in_debug_with_fixture_header(self, mock_openai):
         """Test that mock wizard data is used when DEBUG=True and X-PostHog-Wizard-Fixture-Generation header is present"""
         mock_openai_instance = mock_openai.return_value
@@ -248,7 +248,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", True)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_mock_wizard_data_overrides_existing_cache(self, mock_openai):
         """Test that mock wizard data overrides existing cache data when conditions are met"""
         mock_openai_instance = mock_openai.return_value
@@ -284,7 +284,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", False)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_no_mock_when_debug_false(self, mock_openai):
         """Test that mock wizard data is NOT used when DEBUG=False even with fixture header"""
         # Clear any existing cache data
@@ -307,7 +307,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", True)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_no_mock_without_fixture_header(self, mock_openai):
         """Test that mock wizard data is NOT used when DEBUG=True but fixture header is missing"""
         # Clear any existing cache data

--- a/posthog/api/wizard/utils.py
+++ b/posthog/api/wizard/utils.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from google.genai.types import Type
+if TYPE_CHECKING:
+    from google.genai.types import Type
 
 
 def get_type_enum(json_type: str) -> Type:
     """Convert JSON Schema type to Gemini Type enum"""
+    from google.genai.types import (
+        Type,  # noqa: PLC0415 — keeps the heavy google.genai import off the router import path
+    )
+
     type_mapping = {
         "string": Type.STRING,
         "number": Type.NUMBER,

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -185,6 +185,30 @@ def reset_clickhouse_tables():
     run_clickhouse_statement_in_parallel(list(CREATE_DATA_QUERIES()))
 
 
+def _persons_migrations_current(database_url: str, migrations_path: str) -> bool:
+    """True when every migration file on disk is already recorded in _sqlx_migrations.
+
+    One short psycopg query instead of two sqlx subprocess spawns (~0.5s per pytest
+    session, and per xdist worker). Fail-open: any error means "not current" and the
+    real sqlx path runs.
+    """
+    import psycopg  # noqa: PLC0415 — deferred so conftest import stays cheap
+
+    try:
+        disk_versions = {
+            int(name.split("_", 1)[0])
+            for name in os.listdir(migrations_path)
+            if name.endswith(".sql") and name.split("_", 1)[0].isdigit()
+        }
+        if not disk_versions:
+            return False
+        with psycopg.connect(database_url, connect_timeout=3) as conn:
+            applied = {row[0] for row in conn.execute("SELECT version FROM _sqlx_migrations").fetchall()}
+        return disk_versions <= applied
+    except Exception:
+        return False
+
+
 def run_persons_sqlx_migrations(keepdb: bool = False):
     """Run sqlx migrations for persons tables in separate test_posthog_persons database.
 
@@ -212,6 +236,9 @@ def run_persons_sqlx_migrations(keepdb: bool = False):
     # conftest.py is at posthog/conftest.py, go up one level to repo root
     migrations_path = os.path.join(os.path.dirname(__file__), "..", "rust", "persons_migrations")
     migrations_path = os.path.abspath(migrations_path)
+
+    if keepdb and _persons_migrations_current(database_url, migrations_path):
+        return
 
     env = {**os.environ, "DATABASE_URL": database_url}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,11 @@ junit_family = xunit1
 # nothing in this repo uses the `faker` fixture or the library (faker is a transitive dep)
 # -p pytest_boot_gc opens the boot GC window (gc.disable) before pytest-django runs
 # django.setup(), which happens before conftest files load; the root conftest closes it
-addopts = -p no:warnings -p no:tach -p no:langsmith_plugin -p no:faker -p pytest_boot_gc --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
+# -p no:unraisableexception -p no:threadexception: both plugins run gc_collect_harder()
+# (several full gc.collect passes over the whole heap, seconds per session at our heap sizes)
+# during cleanup to surface __del__/thread exceptions as warnings — but with -p no:warnings
+# those warnings can never escalate to failures here, so the collections are pure teardown cost
+addopts = -p no:warnings -p no:tach -p no:langsmith_plugin -p no:faker -p no:unraisableexception -p no:threadexception -p pytest_boot_gc --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
 
 markers =
     ee


### PR DESCRIPTION
## Problem

Backend CI spends a meaningful share of every Django shard's wall-clock on fixed startup costs that repeat identically across all ~50 shards: a no-op `migrate` against the schema-cache-primed DB, sqlx subprocess spawns for an already-migrated persons DB, heavyweight SDK imports pulled in by the DRF router, and pytest teardown GC passes that feed warnings we already suppress. Within each shard, pytest also runs single-process even though `pytest-xdist` is installed and the settings already isolate Postgres, Redis, and ClickHouse per worker.

Created with Autoresearch.

## Changes

Fixed-cost reductions, paid once per pytest session and per CI shard:

- **pytest.ini** disables the `unraisableexception` and `threadexception` plugins. Their session-cleanup `gc_collect_harder()` full-heap passes (~3s measured) only exist to raise warnings that `-p no:warnings` already suppresses, so they were pure teardown cost.
- **conftest.py** adds `_skip_noop_migrate()`, a fail-open fast path that skips Django's migrate machinery (~1.3s of graph build and project-state render, measured down to 0.05s) when every on-disk migration, discovered via `pkgutil` without importing the modules, is already recorded as applied. Any targeted invocation (`app_label`, `--fake`, `--run-syncdb`, `--check`, `--prune`) or any error falls through to the real migrate, so cold DBs and PR-delta migrations behave exactly as before.
- **posthog/conftest.py** adds `_persons_migrations_current()`: one psycopg query against `_sqlx_migrations` replaces two sqlx subprocess spawns (~0.5s → ~0.02s) when the persons DB is already fully migrated. Fail-open on any mismatch or error.
- **posthog/api/rest_router.py** drops the stale `import posthog.temporal.ai` circular-import workaround, which pulled the langgraph/chat-agent stack (~4.6s of imports) into every Django process. I verified all previously-circular import orders (`ee.hogai.core.agent_modes`, `chat_agent`, `tools`, both router-first and graph-first) now resolve without it.
- **posthog/api/wizard/** defers the `google.genai` import (~1s of pydantic model construction for its generated types module) and the `openai` SDK import from module level into the request handlers that actually call those APIs. The wizard module previously loaded both SDKs via the DRF router in every Django process. Test mocks now patch the SDK source modules instead of the wizard module attributes.
- **docker-compose.dev.yml** runs the disposable dev/CI Postgres with `fsync`, `synchronous_commit`, and `full_page_writes` off, so commits skip WAL durability waits.

In-shard parallelism enabler:

- **bin/clone-test-db-for-xdist** TEMPLATE-clones the migrated main and persons test databases into per-worker copies (`test_posthog_gwN`, `test_posthog_gwN_persons`), so `pytest -n N --reuse-db` starts on every worker without re-running Django or sqlx migrations. Per-worker isolation for Postgres, Redis DB index, and ClickHouse database already exists in settings via `PYTEST_XDIST_WORKER`; this fills the missing provisioning step. Not wired into CI yet — see note below.

> [!NOTE]
> The clone script is a building block for running CI Django shards with `pytest -n N --dist worksteal`. Wiring that into `ci-backend.yml` needs care around syrupy snapshot-update mode and pytest-split duration collection under xdist, so it's intentionally left for a follow-up.

> [!WARNING]
> The Postgres durability flags apply to local dev too (data is disposable there, and the service already carries dev-only flags), but flag it if you know a reason dev needs durable commits.

## How did you test this code?

Automated tests run locally against a warm dockerized stack (I could not run the full CI matrix locally):

- Benchmark set (`posthog/api/test/test_organization.py`, `test_team.py`, `notebooks` — 320 DB-heavy API tests): green single-process and with `-n 4 --dist worksteal` after `bin/clone-test-db-for-xdist 4`.
- `posthog/api/wizard/` (35 tests) green with the deferred SDK imports and repointed mocks.
- Membership/RBAC surfaces (`test_organization_members.py`, `rbac/test/test_user_access_control.py`, `test_organization.py`, 245 tests) green.
- Migrate fast path: verified warm skip (0.05s), and that un-recording one applied migration makes the next `migrate` fall through to the real executor and attempt application.
- Persons fast path: verified warm skip (~0.02s) and fall-through when the persons DB doesn't exist.
- Schema-heavy query-runner tests (`posthog/hogql_queries/test/test_query_runner.py`) green.

Measured effects (local, M-series Mac, warm DB): per-session fixed cost drops by ~3-5s (migrate ~1.3s, sqlx ~0.5s, teardown GC ~3s under profiling, SDK imports ~1s on the router path); these costs repeat on every CI shard.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — no user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code autoresearch session) iterating on a fixed 320-test benchmark with profiling (cProfile, query/redis census, import tracing) between measurements. Notable rejected experiments, kept out of this PR: pydantic `defer_build` on `posthog/schema.py` (saved ~0.9s of import but cost ~3.3s of lazy per-model builds during tests), and a conftest memo for `OrganizationMembership` lookups (broke `snapshot_postgres_queries_context` tests that assert exact query sequences). No repo skills were invoked; changes follow existing conftest patch patterns and `PLC0415` deferred-import conventions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
