### PR TITLE
feat(experiments): add property-based exposure freeze for local evaluation

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentModals.tsx
@@ -14,6 +14,8 @@ import {
     Link,
 } from '@posthog/lemon-ui'
 
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
@@ -127,6 +129,94 @@ export function EditConclusionModal(): JSX.Element {
             }
         >
             <ConclusionForm />
+        </LemonModal>
+    )
+}
+
+export function FreezeExposureModal(): JSX.Element {
+    const { experiment, freezeExposureLoading, freezeExposureCheck, freezeExposurePropertyConditions } =
+        useValues(experimentLogic)
+    const { freezeExposure, setFreezeExposurePropertyConditions } = useActions(experimentLogic)
+    const { closeFreezeExposureModal } = useActions(modalsLogic)
+    const { isFreezeExposureModalOpen } = useValues(modalsLogic)
+    const { aggregationLabel } = useValues(groupsModel)
+
+    const groupTypeIndex = experiment.feature_flag?.filters?.aggregation_group_type_index
+    const isGroupAggregated = groupTypeIndex != null
+    const aggregationTargetName = isGroupAggregated ? aggregationLabel(groupTypeIndex).plural : 'users'
+    const taxonomicGroupTypes = isGroupAggregated
+        ? [`${TaxonomicFilterGroupType.GroupsPrefix}_${groupTypeIndex}` as TaxonomicFilterGroupType]
+        : [TaxonomicFilterGroupType.PersonProperties]
+
+    const reasons = freezeExposureCheck?.reasons ?? []
+
+    return (
+        <LemonModal
+            isOpen={isFreezeExposureModalOpen}
+            onClose={closeFreezeExposureModal}
+            title="Freeze exposure with a property condition"
+            width={600}
+            footer={
+                <div className="flex items-center gap-2">
+                    <LemonButton type="secondary" onClick={closeFreezeExposureModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        data-attr="experiment-property-freeze-confirm"
+                        loading={freezeExposureLoading}
+                        disabledReason={
+                            freezeExposurePropertyConditions.length === 0 &&
+                            'Add at least one property condition to freeze on'
+                        }
+                        onClick={() =>
+                            freezeExposure({
+                                freezeMode: 'property',
+                                propertyConditions: freezeExposurePropertyConditions,
+                            })
+                        }
+                    >
+                        Freeze exposure
+                    </LemonButton>
+                </div>
+            }
+        >
+            <div className="space-y-4 text-sm">
+                {reasons.includes('local_evaluation') && (
+                    <LemonBanner type="warning">
+                        This flag is mostly evaluated with <b>server-side local evaluation</b>, which can't resolve the
+                        static cohort a regular exposure freeze uses — the freeze wouldn't take effect for those
+                        evaluations.
+                    </LemonBanner>
+                )}
+                {reasons.includes('group_aggregated') && (
+                    <LemonBanner type="warning">
+                        This experiment's flag targets {aggregationTargetName}, which can't be held in the person cohort
+                        a regular exposure freeze uses.
+                    </LemonBanner>
+                )}
+                <p>
+                    Instead, freeze by narrowing the release conditions with a property condition. New{' '}
+                    {aggregationTargetName} stop matching, everyone already enrolled keeps their variant, and metrics
+                    keep updating. The condition evaluates everywhere, including local evaluation.
+                </p>
+                <p>
+                    This works best when enrollment is gated on the property — for example a signup-date cutoff for an
+                    experiment that only new {aggregationTargetName} enter. Pick a property your SDK code already passes
+                    when evaluating the flag, since local evaluation only sees the properties you send it.
+                </p>
+                <div>
+                    <LemonLabel>Only keep serving {aggregationTargetName} matching</LemonLabel>
+                    <div className="mt-2">
+                        <PropertyFilters
+                            propertyFilters={freezeExposurePropertyConditions}
+                            onChange={setFreezeExposurePropertyConditions}
+                            pageKey={`experiment-freeze-exposure-${experiment.id}`}
+                            taxonomicGroupTypes={taxonomicGroupTypes}
+                        />
+                    </div>
+                </div>
+            </div>
         </LemonModal>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentSceneMenuBar.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentSceneMenuBar.tsx
@@ -47,7 +47,6 @@ import {
     canFreezeExposure,
     confirmArchiveExperiment,
     confirmDeleteExperiment,
-    confirmFreezeExposure,
     confirmUnfreezeExposure,
     hasFrozenExposureStamps,
 } from '../experimentActions'
@@ -74,6 +73,7 @@ function ExperimentSceneMenuBarInner(): JSX.Element | null {
         isExperimentStopped,
         isCreatingExperimentDashboard,
         freezeExposureLoading,
+        freezeExposureCheckLoading,
         unfreezeExposureLoading,
         showDebugPanel,
     } = useValues(experimentLogic)
@@ -84,9 +84,10 @@ function ExperimentSceneMenuBarInner(): JSX.Element | null {
         createExperimentDashboard,
         resetRunningExperiment,
         toggleDebugPanel,
+        freezeExposureClicked,
     } = useActions(experimentLogic)
     // Promise-returning dispatch so the confirm dialogs can await completion (shouldAwaitSubmit).
-    const { freezeExposure, unfreezeExposure } = useAsyncActions(experimentLogic)
+    const { unfreezeExposure } = useAsyncActions(experimentLogic)
     const { currentProjectId } = useValues(projectLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const { openPauseExperimentModal, openResumeExperimentModal } = useActions(modalsLogic)
@@ -305,9 +306,15 @@ function ExperimentSceneMenuBarInner(): JSX.Element | null {
                                 {showFreezeExposure && (
                                     <SceneMenuBarItem
                                         opensFloatingUi
-                                        onClick={() => confirmFreezeExposure(() => freezeExposure())}
-                                        disabled={freezeExposureLoading}
-                                        tooltip={freezeExposureLoading ? 'Freezing exposure…' : undefined}
+                                        onClick={() => freezeExposureClicked()}
+                                        disabled={freezeExposureLoading || freezeExposureCheckLoading}
+                                        tooltip={
+                                            freezeExposureLoading
+                                                ? 'Freezing exposure…'
+                                                : freezeExposureCheckLoading
+                                                  ? 'Checking freeze options…'
+                                                  : undefined
+                                        }
                                         data-attr={`${RESOURCE_TYPE}-menubar-freeze-exposure`}
                                     >
                                         <IconLock />

--- a/frontend/src/scenes/experiments/ExperimentView/PageHeader.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/PageHeader.tsx
@@ -42,7 +42,6 @@ import {
     canFreezeExposure,
     confirmArchiveExperiment,
     confirmDeleteExperiment,
-    confirmFreezeExposure,
     confirmUnfreezeExposure,
     hasFrozenExposureStamps,
 } from '../experimentActions'
@@ -50,7 +49,12 @@ import { experimentLogic } from '../experimentLogic'
 import { isExperimentExposureFrozen, isExperimentPaused } from '../experimentsLogic'
 import { modalsLogic } from '../modalsLogic'
 import { isLegacyExperiment } from '../utils'
-import { FinishExperimentModal, PauseExperimentModal, ResumeExperimentModal } from './ExperimentModals'
+import {
+    FinishExperimentModal,
+    FreezeExposureModal,
+    PauseExperimentModal,
+    ResumeExperimentModal,
+} from './ExperimentModals'
 import { ExperimentSceneMenuBar } from './ExperimentSceneMenuBar'
 
 export function PageHeaderCustom(): JSX.Element {
@@ -64,6 +68,7 @@ export function PageHeaderCustom(): JSX.Element {
         experimentLoading,
         launchExperimentLoading,
         freezeExposureLoading,
+        freezeExposureCheckLoading,
         unfreezeExposureLoading,
     } = useValues(experimentLogic)
     const {
@@ -74,9 +79,10 @@ export function PageHeaderCustom(): JSX.Element {
         createExperimentDashboard,
         updateExperiment,
         setHogfettiTrigger,
+        freezeExposureClicked,
     } = useActions(experimentLogic)
     // Promise-returning dispatch so the confirm dialogs can await completion (shouldAwaitSubmit).
-    const { freezeExposure, unfreezeExposure } = useAsyncActions(experimentLogic)
+    const { unfreezeExposure } = useAsyncActions(experimentLogic)
     const { currentProjectId } = useValues(projectLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const hasMultipleProjects = (currentOrganization?.projects?.length ?? 0) > 1
@@ -267,9 +273,10 @@ export function PageHeaderCustom(): JSX.Element {
                                                 <ButtonPrimitive
                                                     menuItem
                                                     data-attr="freeze-exposure"
-                                                    onClick={() => confirmFreezeExposure(() => freezeExposure())}
+                                                    onClick={() => freezeExposureClicked()}
                                                     disabledReasons={{
                                                         'Freezing exposure...': freezeExposureLoading,
+                                                        'Checking freeze options...': freezeExposureCheckLoading,
                                                     }}
                                                 >
                                                     <IconLock /> Freeze exposure
@@ -332,6 +339,7 @@ export function PageHeaderCustom(): JSX.Element {
 
                         <PauseExperimentModal />
                         <ResumeExperimentModal />
+                        <FreezeExposureModal />
                     </ScenePanelActionsSection>
                     <ExperimentDebugToggle />
                 </ScenePanel>

--- a/frontend/src/scenes/experiments/experimentActions.tsx
+++ b/frontend/src/scenes/experiments/experimentActions.tsx
@@ -20,13 +20,13 @@ export function hasFrozenExposureStamps(experiment: Pick<Experiment, 'feature_fl
     return !!experiment.feature_flag?.filters?.groups?.some((group) => group.exposure_frozen === true)
 }
 
-/** Whether an experiment can have its exposure frozen (ignoring permissions). */
+/** Whether an experiment can have its exposure frozen (ignoring permissions).
+ * Group-aggregated experiments qualify too — they can't use the snapshot-cohort freeze
+ * (a person cohort can't hold groups), but the property-based freeze covers them. */
 export function canFreezeExposure(
     experiment: Pick<Experiment, 'start_date' | 'end_date' | 'status' | 'feature_flag' | 'holdout_id' | 'holdout'>
 ): boolean {
     const flagFilters = experiment.feature_flag?.filters
-    // Freezing exposure narrows the flag to a person cohort, which group-aggregated flags can't use.
-    const isGroupAggregated = flagFilters?.aggregation_group_type_index != null
     // Holdout assignment and early access enrollment (super_groups) are evaluated before release
     // conditions, so the freeze couldn't stop enrollment through them — the backend rejects these.
     const hasHoldout =
@@ -40,7 +40,6 @@ export function canFreezeExposure(
         !hasEnded(experiment) &&
         !isExperimentPaused(experiment) &&
         !isExperimentExposureFrozen(experiment) &&
-        !isGroupAggregated &&
         !hasHoldout &&
         !hasSuperGroups
     )
@@ -89,7 +88,7 @@ export function confirmUnfreezeExposure(onConfirm: () => Promise<void>): void {
             <div className="text-sm text-secondary max-w-md">
                 <p>
                     New users can <b>enroll again</b> under the flag's original release conditions. Everyone already
-                    enrolled keeps their variant, and the snapshot cohort is removed.
+                    enrolled keeps their variant, and the conditions the freeze added are removed.
                 </p>
                 <p>
                     Heads up: users enrolled before the freeze and after the unfreeze joined at different times, which

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -2,6 +2,7 @@ import { api } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { userLogic } from 'scenes/userLogic'
 
@@ -1323,6 +1324,83 @@ describe('experimentLogic', () => {
             expect(errorMock).toHaveBeenCalledWith('Experiment exposure is already frozen.')
             expect(logic.values.freezeExposureLoading).toBe(false)
             createSpy.mockRestore()
+        })
+    })
+
+    describe('freezeExposureClicked', () => {
+        it('surfaces the property freeze modal instead of the confirm dialog when the check recommends it', async () => {
+            const getSpy = jest.spyOn(api, 'get').mockResolvedValue({
+                recommended_freeze_mode: 'property',
+                reasons: ['local_evaluation'],
+                local_evaluation_share: 0.9,
+                flag_called_event_count: 100,
+            })
+            const dialogSpy = jest.spyOn(LemonDialog, 'open').mockImplementation(() => {})
+
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(experiment)
+            await expectLogic(keyed, () => {
+                keyed.actions.freezeExposureClicked()
+            })
+                .toDispatchActions(['setFreezeExposureCheck', 'openFreezeExposureModal'])
+                .toFinishAllListeners()
+
+            expect(getSpy).toHaveBeenCalledWith(
+                expect.stringContaining(`/experiments/${experiment.id}/freeze_exposure_check`)
+            )
+            // The property mode is a proxy the user must confirm — never freeze via the plain dialog.
+            expect(dialogSpy).not.toHaveBeenCalled()
+            // Person-aggregated experiments get an editable signup-date cutoff prefilled.
+            expect(keyed.values.freezeExposurePropertyConditions).toHaveLength(1)
+            expect(keyed.values.freezeExposurePropertyConditions[0].key).toBe('created_at')
+
+            getSpy.mockRestore()
+            dialogSpy.mockRestore()
+            keyed.unmount()
+        })
+
+        it('opens the regular confirm dialog when the check recommends the cohort mode', async () => {
+            const getSpy = jest.spyOn(api, 'get').mockResolvedValue({
+                recommended_freeze_mode: 'cohort',
+                reasons: [],
+                local_evaluation_share: 0,
+                flag_called_event_count: 100,
+            })
+            const dialogSpy = jest.spyOn(LemonDialog, 'open').mockImplementation(() => {})
+
+            logic.actions.setExperiment(experiment)
+            await expectLogic(logic, () => {
+                logic.actions.freezeExposureClicked()
+            }).toFinishAllListeners()
+
+            expect(dialogSpy).toHaveBeenCalled()
+
+            getSpy.mockRestore()
+            dialogSpy.mockRestore()
+        })
+
+        it('sends the property conditions in the freeze request body in property mode', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValue({ ...experiment, status: 'exposure_frozen' })
+            const condition = { key: 'created_at', type: 'person', operator: 'is_date_before', value: '2026-07-01' }
+
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(experiment)
+            await expectLogic(keyed, () => {
+                keyed.actions.freezeExposure({ freezeMode: 'property', propertyConditions: [condition as any] })
+            }).toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledWith(
+                expect.stringContaining(`/experiments/${experiment.id}/freeze_exposure`),
+                {
+                    freeze_mode: 'property',
+                    property_conditions: [condition],
+                }
+            )
+
+            createSpy.mockRestore()
+            keyed.unmount()
         })
     })
 

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -57,6 +57,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
 import {
+    AnyPropertyFilter,
     BreakdownAttributionType,
     BreakdownType,
     CohortType,
@@ -68,7 +69,9 @@ import {
     FeatureFlagType,
     InsightType,
     MultivariateFlagVariant,
+    PropertyFilterType,
     PropertyMathType,
+    PropertyOperator,
 } from '~/types'
 
 import {
@@ -78,6 +81,7 @@ import {
     NEW_EXPERIMENT_FORCE_REFRESH_AFTER_MINUTES,
     MetricInsightId,
 } from './constants'
+import { confirmFreezeExposure } from './experimentActions'
 import type { experimentLogicType } from './experimentLogicType'
 import { experimentMetricsLogic } from './experimentMetricsLogic'
 import { experimentSceneLogic } from './experimentSceneLogic'
@@ -137,6 +141,14 @@ export type ExperimentWarningKey =
     | 'running_but_no_rollout'
     | 'ended_but_multiple_variants_rolled_out'
     | 'not_started_but_multiple_variants_rolled_out'
+
+/** Response of the freeze_exposure_check endpoint — which freeze mode fits this experiment. */
+export interface ExperimentFreezeExposureCheck {
+    recommended_freeze_mode: 'cohort' | 'property'
+    reasons: ('local_evaluation' | 'group_aggregated')[]
+    local_evaluation_share: number | null
+    flag_called_event_count: number
+}
 
 export interface ExperimentWarning {
     key: ExperimentWarningKey
@@ -529,6 +541,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 'closePauseExperimentModal',
                 'closeResumeExperimentModal',
                 'closeFinishExperimentModal',
+                'openFreezeExposureModal',
+                'closeFreezeExposureModal',
                 'openReleaseConditionsModal',
                 'closePrimaryMetricsReorderModal',
                 'closeSecondaryMetricsReorderModal',
@@ -581,8 +595,14 @@ export const experimentLogic = kea<experimentLogicType>([
         }) => ({ selectedVariantKey, releaseToEveryone, openCleanupPr: openCleanupPr ?? false }),
         pauseExperiment: true,
         resumeExperiment: true,
-        freezeExposure: true,
+        freezeExposureClicked: true,
+        freezeExposure: (payload?: { freezeMode: 'property'; propertyConditions: AnyPropertyFilter[] }) => ({
+            payload,
+        }),
         setFreezeExposureLoading: (loading: boolean) => ({ loading }),
+        setFreezeExposureCheckLoading: (loading: boolean) => ({ loading }),
+        setFreezeExposureCheck: (check: ExperimentFreezeExposureCheck | null) => ({ check }),
+        setFreezeExposurePropertyConditions: (conditions: AnyPropertyFilter[]) => ({ conditions }),
         unfreezeExposure: true,
         setUnfreezeExposureLoading: (loading: boolean) => ({ loading }),
         archiveExperiment: (disableFeatureFlag: boolean = false) => ({ disableFeatureFlag }),
@@ -1151,6 +1171,24 @@ export const experimentLogic = kea<experimentLogicType>([
                 setFreezeExposureLoading: (_, { loading }) => loading,
             },
         ],
+        freezeExposureCheckLoading: [
+            false,
+            {
+                setFreezeExposureCheckLoading: (_, { loading }) => loading,
+            },
+        ],
+        freezeExposureCheck: [
+            null as ExperimentFreezeExposureCheck | null,
+            {
+                setFreezeExposureCheck: (_, { check }) => check,
+            },
+        ],
+        freezeExposurePropertyConditions: [
+            [] as AnyPropertyFilter[],
+            {
+                setFreezeExposurePropertyConditions: (_, { conditions }) => conditions,
+            },
+        ],
         unfreezeExposureLoading: [
             false,
             {
@@ -1453,16 +1491,68 @@ export const experimentLogic = kea<experimentLogicType>([
                 lemonToast.error(error.detail || 'Failed to resume experiment')
             }
         },
-        freezeExposure: async () => {
+        freezeExposureClicked: async () => {
+            if (values.freezeExposureLoading || values.freezeExposureCheckLoading) {
+                return
+            }
+            // Detect-and-default: the common case freezes with a cohort after a plain confirm, but
+            // when the cohort mode can't work (local-evaluation SDKs, group-aggregated flags) the
+            // property-based freeze is surfaced instead — never applied silently, since it's a
+            // proxy the user must confirm.
+            actions.setFreezeExposureCheckLoading(true)
+            let check: ExperimentFreezeExposureCheck | null = null
+            try {
+                check = await api.get(
+                    `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/freeze_exposure_check`
+                )
+            } catch {
+                check = null
+            } finally {
+                actions.setFreezeExposureCheckLoading(false)
+            }
+            const isGroupAggregated = values.experiment.feature_flag?.filters?.aggregation_group_type_index != null
+            if (check?.recommended_freeze_mode === 'property' || (!check && isGroupAggregated)) {
+                actions.setFreezeExposureCheck(
+                    check ?? {
+                        recommended_freeze_mode: 'property',
+                        reasons: ['group_aggregated'],
+                        local_evaluation_share: null,
+                        flag_called_event_count: 0,
+                    }
+                )
+                actions.setFreezeExposurePropertyConditions(
+                    isGroupAggregated
+                        ? []
+                        : [
+                              {
+                                  key: 'created_at',
+                                  type: PropertyFilterType.Person,
+                                  operator: PropertyOperator.IsDateBefore,
+                                  value: dayjs().utc().format('YYYY-MM-DD HH:mm:ss'),
+                              },
+                          ]
+                )
+                actions.openFreezeExposureModal()
+            } else {
+                confirmFreezeExposure(() => asyncActions.freezeExposure())
+            }
+        },
+        freezeExposure: async ({ payload }) => {
             if (values.freezeExposureLoading) {
                 return
             }
             actions.setFreezeExposureLoading(true)
             try {
-                const response: Experiment = await api.create(
-                    `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/freeze_exposure`
-                )
+                const url = `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/freeze_exposure`
+                const response: Experiment =
+                    payload?.freezeMode === 'property'
+                        ? await api.create(url, {
+                              freeze_mode: 'property',
+                              property_conditions: payload.propertyConditions,
+                          })
+                        : await api.create(url)
                 actions.setExperiment(response)
+                actions.closeFreezeExposureModal()
                 refreshTreeItem('experiment', String(values.experimentId))
                 lemonToast.success('Exposure frozen — enrolled users keep their variant and metrics keep updating')
             } catch (error: any) {

--- a/frontend/src/scenes/experiments/modalsLogic.ts
+++ b/frontend/src/scenes/experiments/modalsLogic.ts
@@ -22,6 +22,8 @@ export const modalsLogic = kea<modalsLogicType>([
         closeFinishExperimentModal: true,
         openPauseExperimentModal: true,
         closePauseExperimentModal: true,
+        openFreezeExposureModal: true,
+        closeFreezeExposureModal: true,
         openResumeExperimentModal: true,
         closeResumeExperimentModal: true,
         openEditConclusionModal: true,
@@ -84,6 +86,13 @@ export const modalsLogic = kea<modalsLogicType>([
             {
                 openPauseExperimentModal: () => true,
                 closePauseExperimentModal: () => false,
+            },
+        ],
+        isFreezeExposureModalOpen: [
+            false,
+            {
+                openFreezeExposureModal: () => true,
+                closeFreezeExposureModal: () => false,
             },
         ],
         isResumeExperimentModalOpen: [

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -597,6 +597,9 @@ SPECTACULAR_SETTINGS = {
         # BulkUpdateTagsRequest and its UUID subclass, so the shared enum can't be component-prefixed
         # unambiguously and auto-resolves to a hash name. Pin it to a stable name.
         "BulkUpdateTagsActionEnum": ["add", "remove", "set"],
+        # The experiments freeze mode appears on both the freeze_exposure request (`freeze_mode`)
+        # and the freeze_exposure_check response (`recommended_freeze_mode`) — pin one shared name.
+        "ExperimentFreezeModeEnum": ["cohort", "property"],
         # Full signal taxonomy on the report `signals` endpoint; the source-config serializer's
         # subset enums keep their own auto-resolved names.
         "SignalSourceProduct": "products.signals.backend.enums.SIGNAL_SOURCE_PRODUCT_VALUES",

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -65,6 +65,7 @@ from products.experiments.backend.models.experiment import (
     EXPOSURE_FROZEN_COHORT_KEY,
     EXPOSURE_FROZEN_GROUP_KEY,
     EXPOSURE_FROZEN_GROUP_MARKER,
+    EXPOSURE_FROZEN_PROPERTIES_KEY,
     LEGACY_METRIC_KINDS,
     Experiment,
     ExperimentHoldout,
@@ -142,6 +143,29 @@ FREEZE_EXPOSURE_RESOLVE_CONCURRENCY = 4
 # Shared by snapshot creation and cleanup: cleanup only touches cohorts carrying this prefix, so a
 # cohort id stamped into the (user-editable) flag filters can't point it at an arbitrary cohort.
 FREEZE_EXPOSURE_SNAPSHOT_NAME_PREFIX = "Exposure snapshot for experiment "
+
+# How the freeze narrows the flag's release groups. "cohort" snapshots the exposed users into a
+# static cohort — exact, but unresolvable by SDKs doing server-side local evaluation (static cohorts
+# are excluded from the local-eval flag definitions), capped at FREEZE_EXPOSURE_MAX_EXPOSED_USERS,
+# and person-only. "property" ANDs caller-chosen property conditions into each group instead — a
+# proxy that is only correct when enrollment is gated on those properties (e.g. signup date), but it
+# evaluates locally, is instant, and works for group-aggregated flags too.
+ExperimentFreezeMode = Literal["cohort", "property"]
+
+# Local-evaluation detection for freeze_exposure_check: the share of the flag's recent
+# $feature_flag_called events carrying locally_evaluated=true. Above the threshold the flag is
+# treated as evaluated by local-evaluation SDKs, for which a static-cohort freeze silently degrades
+# (the SDK can't resolve the cohort and falls back to /decide, or to the default under
+# only_evaluate_locally). The minimum keeps a handful of stray events from classifying the flag.
+FREEZE_EXPOSURE_LOCAL_EVAL_LOOKBACK_DAYS = 3
+FREEZE_EXPOSURE_LOCAL_EVAL_MIN_EVENTS = 20
+FREEZE_EXPOSURE_LOCAL_EVAL_SHARE_THRESHOLD = 0.5
+# Property-condition types that flag release conditions support and local evaluation can resolve.
+# Cohort conditions defeat the purpose of the property mode, and flag-dependency ("flag") or
+# behavioral conditions aren't locally evaluable either.
+FREEZE_EXPOSURE_ALLOWED_PROPERTY_TYPES = {"person", "group"}
+# Operators that match on key presence alone, so the condition needs no value.
+_VALUELESS_PROPERTY_OPERATORS = {"is_set", "is_not_set"}
 
 # Auto-saved sample-size estimate, not a user edit: skip the "experiment updated" event.
 RUNNING_TIME_ONLY_CHANGED_FIELDS = ["running_time_calculation"]
@@ -1783,7 +1807,14 @@ class ExperimentService:
     # Not wrapped in @transaction.atomic at the method level: building the snapshot cohort writes to
     # ClickHouse and Postgres (non-transactional side effects), so rather than rely on rollback we
     # clean up the cohort by hand if the locked phase below fails.
-    def freeze_exposure(self, experiment: Experiment, *, request: Any) -> Experiment:
+    def freeze_exposure(
+        self,
+        experiment: Experiment,
+        *,
+        request: Any,
+        freeze_mode: ExperimentFreezeMode = "cohort",
+        property_conditions: list[dict] | None = None,
+    ) -> Experiment:
         """Freeze exposure on a running experiment while metrics keep flowing.
 
         Moves the experiment into an "exposure frozen" state: it snapshots the
@@ -1793,6 +1824,10 @@ class ExperimentService:
         (``multivariate.variants`` is left untouched). Unlike ``end_experiment``,
         ``end_date`` stays null so long-term metrics (revenue/LTV/renewals/retention)
         keep accumulating — the whole point of freezing exposure.
+
+        ``freeze_mode="property"`` narrows with the caller's ``property_conditions``
+        instead of a snapshot cohort — see _freeze_exposure_with_properties. The rest
+        of this docstring describes the default cohort mode.
 
         The snapshot is built synchronously, *before* the flag is narrowed, so the
         flag never points at an unpopulated cohort (which would briefly match no
@@ -1819,6 +1854,11 @@ class ExperimentService:
         ``request`` is required because FeatureFlagSerializer needs a real request
         with authentication and session context to persist the flag change.
         """
+        if freeze_mode == "property":
+            return self._freeze_exposure_with_properties(experiment, property_conditions, request=request)
+        if property_conditions:
+            raise ValidationError("property_conditions is only accepted with the property freeze mode.")
+
         # Phase timings are logged at the end: the freeze spans several backends (ClickHouse scan,
         # personhog RPCs, cohort build with its cache side effects, flag save) whose relative cost
         # can't be reconstructed from any single backend's logs — see experiment_freeze_exposure_timing.
@@ -1882,7 +1922,9 @@ class ExperimentService:
                 # return the flag's default for everyone. This is the standard behavior of any static-cohort flag,
                 # not specific to freezing — it just means a frozen experiment is evaluated server-side via /decide
                 # rather than locally.
-                new_filters = self._transform_filters_for_frozen_exposure(locked_flag.filters, exposure_snapshot.id)
+                new_filters = self._transform_filters_for_frozen_exposure(
+                    locked_flag.filters, cohort_id=exposure_snapshot.id
+                )
 
                 # 5. Persist the narrowed filters via the gated flag write.
                 #
@@ -1913,7 +1955,9 @@ class ExperimentService:
 
         # end_date intentionally left null — metrics keep flowing.
 
-        self._report_lifecycle_event(experiment, "experiment exposure frozen", request=request)
+        self._report_lifecycle_event(
+            experiment, "experiment exposure frozen", request=request, extra_metadata={"freeze_mode": "cohort"}
+        )
 
         # flag_save_ms includes the transaction commit, so it carries the on-commit flag cache
         # rebuilds; cohort_build_ms carries the cohort dependency cache warm-up triggered by the
@@ -1932,7 +1976,9 @@ class ExperimentService:
 
         return experiment
 
-    def _validate_freeze_exposure_state(self, experiment: Experiment) -> None:
+    def _validate_freeze_exposure_state(
+        self, experiment: Experiment, *, freeze_mode: ExperimentFreezeMode = "cohort"
+    ) -> None:
         """Guards for freeze_exposure, run twice: unlocked before the expensive snapshot build to
         fail fast, and again under the flag lock to fail closed against whatever landed mid-build."""
         if experiment.is_draft:
@@ -1954,8 +2000,13 @@ class ExperimentService:
         flag = experiment.feature_flag
         if flag.deleted:
             raise ValidationError("Experiment's feature flag has been deleted.")
-        if flag.aggregation_group_type_index is not None:
-            raise ValidationError("Group-aggregated experiments cannot have their exposure frozen.")
+        if freeze_mode == "cohort" and flag.aggregation_group_type_index is not None:
+            # Cohort-mode only: a person cohort can't hold groups. The property mode can freeze
+            # group-aggregated flags with a group-property condition.
+            raise ValidationError(
+                "Group-aggregated experiments cannot have their exposure frozen with a cohort. "
+                "Use the property-based freeze instead."
+            )
         # Holdout assignment and early-access enrollment (super_groups) are evaluated by the flag
         # matcher before release conditions, so narrowing the release groups to a cohort cannot stop
         # new users from entering through those paths. Fail closed rather than freeze partially.
@@ -1974,6 +2025,204 @@ class ExperimentService:
         # the frozen state (derived from the per-group key) could never be detected.
         if not flag_filters.get("groups"):
             raise ValidationError("Experiment's feature flag has no release conditions to freeze.")
+
+    def _freeze_exposure_with_properties(
+        self, experiment: Experiment, property_conditions: list[dict] | None, *, request: Any
+    ) -> Experiment:
+        """Freeze exposure by AND-ing the given property conditions into every release group.
+
+        The local-evaluation-compatible counterpart to the cohort freeze: property conditions are
+        shipped in the local-eval flag definitions and resolve without a server round-trip, whereas
+        a static cohort cannot be evaluated locally (SDKs fall back to /decide, or to the default
+        under only_evaluate_locally). No ClickHouse scan, no person resolution, no cohort — so no
+        exposed-user cap, and group-aggregated flags are supported with group-property conditions.
+
+        The conditions are a *proxy* for "already enrolled": only correct when enrollment is gated
+        on them (e.g. a signup-date cutoff for a new-user experiment). An old user whose first
+        exposure lands after the freeze still matches and enrolls. Callers must surface this
+        choice to the user rather than apply it silently — see freeze_exposure_check.
+
+        Local evaluation only sees properties the caller passes to the SDK; it never fetches person
+        properties. The chosen property must be one the customer's code already sends, which is why
+        the conditions are caller-supplied rather than derived here.
+        """
+        freeze_started_at = time.monotonic()
+
+        # Phase 1 — unlocked: fail obviously-invalid requests before taking the flag lock.
+        self._validate_freeze_exposure_state(experiment, freeze_mode="property")
+        validated_conditions = self._validate_freeze_property_conditions(experiment, property_conditions)
+
+        with transaction.atomic():
+            # Same locking discipline as the cohort path: re-check every guard against the fresh
+            # flag row so a concurrent freeze/pause/end/edit can't slip underneath the save.
+            locked_flag = (
+                FeatureFlag.objects.select_for_update()
+                .filter(pk=experiment.feature_flag_id, team_id=experiment.team_id)
+                .first()
+            )
+            if locked_flag is None:
+                raise ValidationError("Experiment's feature flag has been deleted.")
+            experiment.refresh_from_db()
+            experiment.feature_flag = locked_flag
+            self._validate_freeze_exposure_state(experiment, freeze_mode="property")
+            self._validate_freeze_property_conditions(experiment, property_conditions)
+
+            new_filters = self._transform_filters_for_frozen_exposure(
+                locked_flag.filters, property_conditions=validated_conditions
+            )
+            update_flag(
+                locked_flag,
+                {"filters": new_filters},
+                team=self.team,
+                user=self.user,
+                request=request,
+            )
+
+        # Refresh so the experiment's nested flag reflects the narrowed filters when serialized.
+        locked_flag.refresh_from_db()
+        experiment.feature_flag = locked_flag
+
+        # end_date intentionally left null — metrics keep flowing.
+
+        self._report_lifecycle_event(
+            experiment, "experiment exposure frozen", request=request, extra_metadata={"freeze_mode": "property"}
+        )
+
+        logger.info(
+            "experiment_freeze_exposure_timing",
+            team_id=self.team.pk,
+            experiment_id=experiment.pk,
+            freeze_mode="property",
+            total_ms=round((time.monotonic() - freeze_started_at) * 1000),
+        )
+
+        return experiment
+
+    def _validate_freeze_property_conditions(
+        self, experiment: Experiment, property_conditions: list[dict] | None
+    ) -> list[dict]:
+        """Validate the caller-supplied narrowing conditions for the property freeze mode.
+
+        Enforces what makes the mode work at all — conditions a local-evaluation SDK can resolve
+        (person/group properties, matching the flag's aggregation) — and a minimal shape so the
+        stamped EXPOSURE_FROZEN_PROPERTIES_KEY round-trips cleanly on unfreeze. Full flag-filter
+        validation still runs in the FeatureFlagSerializer when the narrowed filters are saved.
+        """
+        if not property_conditions:
+            raise ValidationError("The property freeze mode requires at least one property condition.")
+
+        group_type_index = experiment.feature_flag.aggregation_group_type_index
+        expected_type = "person" if group_type_index is None else "group"
+        for condition in property_conditions:
+            if not isinstance(condition, dict) or not isinstance(condition.get("key"), str) or not condition["key"]:
+                raise ValidationError("Each freeze property condition must be an object with a property key.")
+            condition_type = condition.get("type", "person")
+            if condition_type not in FREEZE_EXPOSURE_ALLOWED_PROPERTY_TYPES:
+                raise ValidationError(
+                    f"Freeze property conditions must be locally evaluable {expected_type} properties; "
+                    f"'{condition_type}' conditions are not supported."
+                )
+            if condition_type != expected_type:
+                raise ValidationError(
+                    f"This experiment's feature flag aggregates by {expected_type}, "
+                    f"so freeze conditions must be {expected_type} properties."
+                )
+            if expected_type == "group" and condition.get("group_type_index") != group_type_index:
+                raise ValidationError(
+                    "Freeze property conditions must target the same group type as the experiment's feature flag."
+                )
+            operator = condition.get("operator")
+            if not isinstance(operator, str) or not operator:
+                raise ValidationError("Each freeze property condition must have an operator.")
+            if operator not in _VALUELESS_PROPERTY_OPERATORS and condition.get("value") in (None, "", []):
+                raise ValidationError(f"Freeze property condition on '{condition['key']}' is missing a value.")
+        return [deepcopy(condition) for condition in property_conditions]
+
+    def check_freeze_exposure(self, experiment: Experiment) -> dict[str, Any]:
+        """Recommend a freeze mode for the experiment, without freezing anything.
+
+        The cohort mode is exact but silently degrades for flags evaluated by server-side
+        local-evaluation SDKs (static cohorts are excluded from the local-eval definitions), and it
+        can't hold groups. This check detects those cases so the UI can steer the user to the
+        property mode *before* they freeze — never swapping modes silently, since the property mode
+        is a proxy the user must confirm. The over-cap case (too many exposed users) is not
+        pre-detected here — it would need the same expensive scan the freeze itself runs — so
+        callers steer to the property mode when the cohort freeze is rejected for size instead.
+
+        Local evaluation is detected per flag from the recent share of $feature_flag_called events
+        with locally_evaluated=true. Flags with send_feature_flag_events disabled emit none and
+        can't be classified (share stays null, cohort recommended) — the property mode remains
+        available explicitly.
+        """
+        flag_filters = experiment.feature_flag.filters or {} if experiment.feature_flag_id else {}
+        reasons: list[str] = []
+        if flag_filters.get("aggregation_group_type_index") is not None:
+            reasons.append("group_aggregated")
+
+        local_share: float | None = None
+        event_count = 0
+        query = ast.SelectQuery(
+            select=[
+                ast.Call(
+                    name="countIf",
+                    args=[
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Call(name="toString", args=[ast.Field(chain=["properties", "locally_evaluated"])]),
+                            right=ast.Constant(value="true"),
+                        )
+                    ],
+                ),
+                ast.Call(name="count", args=[]),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(
+                exprs=[
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["event"]),
+                        right=ast.Constant(value="$feature_flag_called"),
+                    ),
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["properties", "$feature_flag"]),
+                        right=ast.Constant(value=experiment.get_feature_flag_key()),
+                    ),
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.GtEq,
+                        left=ast.Field(chain=["timestamp"]),
+                        right=ast.Constant(
+                            value=timezone.now() - timedelta(days=FREEZE_EXPOSURE_LOCAL_EVAL_LOOKBACK_DAYS)
+                        ),
+                    ),
+                ]
+            ),
+        )
+        try:
+            with tags_context(
+                product=Product.EXPERIMENTS,
+                team_id=self.team.pk,
+                org_id=self.team.organization_id,
+            ):
+                response = execute_hogql_query(query, team=self.team)
+            local_count, event_count = response.results[0]
+            if event_count >= FREEZE_EXPOSURE_LOCAL_EVAL_MIN_EVENTS:
+                local_share = local_count / event_count
+                if local_share > FREEZE_EXPOSURE_LOCAL_EVAL_SHARE_THRESHOLD:
+                    reasons.append("local_evaluation")
+        except Exception:
+            # Detection is best-effort: an unclassifiable flag falls back to the cohort
+            # recommendation (today's behavior) rather than blocking the freeze flow.
+            logger.exception(
+                "experiment_freeze_exposure_check_failed", team_id=self.team.pk, experiment_id=experiment.pk
+            )
+
+        return {
+            "recommended_freeze_mode": "property" if reasons else "cohort",
+            "reasons": reasons,
+            "local_evaluation_share": local_share,
+            "flag_called_event_count": event_count,
+        }
 
     def _fetch_exposed_person_uuids(self, experiment: Experiment) -> list[str]:
         """Return the UUIDs of persons already exposed to the experiment, bounded by time and count.
@@ -2132,26 +2381,41 @@ class ExperimentService:
         return cohort
 
     @staticmethod
-    def _transform_filters_for_frozen_exposure(current_filters: dict, cohort_id: int) -> dict:
-        """AND a static-cohort condition into every release group and stamp the freeze key.
+    def _transform_filters_for_frozen_exposure(
+        current_filters: dict, *, cohort_id: int | None = None, property_conditions: list[dict] | None = None
+    ) -> dict:
+        """AND the narrowing condition(s) into every release group and stamp the freeze key.
+
+        The narrowing is either the snapshot-cohort condition (``cohort_id``, cohort mode) or the
+        caller's ``property_conditions`` (property mode) — exactly one must be given.
 
         AND (not a new group): groups are OR'd, so a separate group would *widen* access.
         AND (not replace): the original per-group ``properties``/``rollout_percentage`` are
         preserved so a future unfreeze or manual revert strips back to exactly the original.
-        The frozen state lives in the structured EXPOSURE_FROZEN_GROUP_KEY on each group;
-        the marker is merely prepended to the (preserved) ``description`` as a human-readable
-        note. Everything else (``multivariate``, ``payloads``, aggregation index) is left
-        byte-for-byte.
+        The frozen state lives in the structured EXPOSURE_FROZEN_GROUP_KEY on each group; the
+        mode-specific companion key (EXPOSURE_FROZEN_COHORT_KEY / EXPOSURE_FROZEN_PROPERTIES_KEY)
+        records what was added so unfreeze strips exactly that. The marker is merely prepended to
+        the (preserved) ``description`` as a human-readable note. Everything else
+        (``multivariate``, ``payloads``, aggregation index) is left byte-for-byte.
         """
-        cohort_condition = {"key": "id", "type": "cohort", "value": cohort_id, "operator": "in"}
+        assert (cohort_id is None) != (property_conditions is None)
+        if cohort_id is not None:
+            added_conditions = [{"key": "id", "type": "cohort", "value": cohort_id, "operator": "in"}]
+        else:
+            assert property_conditions is not None
+            added_conditions = property_conditions
 
         new_groups = []
         for group in current_filters.get("groups", []):
-            # One deepcopy per group so the new filters never alias the original flag's dicts.
+            # One deepcopy per group so the new filters never alias the original flag's dicts
+            # (or the caller's conditions).
             new_group = deepcopy(group)
-            new_group["properties"] = [*new_group.get("properties", []), cohort_condition]
+            new_group["properties"] = [*new_group.get("properties", []), *deepcopy(added_conditions)]
             new_group[EXPOSURE_FROZEN_GROUP_KEY] = True
-            new_group[EXPOSURE_FROZEN_COHORT_KEY] = cohort_id
+            if cohort_id is not None:
+                new_group[EXPOSURE_FROZEN_COHORT_KEY] = cohort_id
+            else:
+                new_group[EXPOSURE_FROZEN_PROPERTIES_KEY] = deepcopy(added_conditions)
             existing_description = new_group.get("description")
             new_group["description"] = (
                 f"{EXPOSURE_FROZEN_GROUP_MARKER} {existing_description}"
@@ -2164,13 +2428,15 @@ class ExperimentService:
     @staticmethod
     def _strip_frozen_exposure_from_filters(current_filters: dict) -> tuple[dict, list[int]]:
         """Inverse of _transform_filters_for_frozen_exposure: remove the freeze stamps from every
-        release group — the AND'd snapshot-cohort condition (identified via the per-group
-        EXPOSURE_FROZEN_COHORT_KEY, so user-added cohort conditions survive), the two structured
-        keys, and the description marker note. Groups without the freeze key pass through untouched.
+        release group — the AND'd narrowing conditions (identified via the per-group
+        EXPOSURE_FROZEN_COHORT_KEY / EXPOSURE_FROZEN_PROPERTIES_KEY, so user-added conditions
+        survive), the structured keys, and the description marker note. Groups without the freeze
+        key pass through untouched.
 
-        Returns the stripped filters plus the snapshot cohort ids that were referenced, so callers
-        can clean up the then-orphaned cohorts once the stripped filters are persisted — and only
-        then: deleting earlier would yank the cohort from under a still-frozen flag if the save fails.
+        Returns the stripped filters plus the snapshot cohort ids that were referenced (cohort-mode
+        freezes only), so callers can clean up the then-orphaned cohorts once the stripped filters
+        are persisted — and only then: deleting earlier would yank the cohort from under a
+        still-frozen flag if the save fails.
         """
         new_groups = []
         cohort_ids: list[int] = []
@@ -2192,6 +2458,18 @@ class ExperimentService:
                         and condition.get("value") == cohort_id
                     )
                 ]
+            frozen_properties = new_group.pop(EXPOSURE_FROZEN_PROPERTIES_KEY, None)
+            if frozen_properties:
+                # Remove one occurrence per stamped condition, scanning from the end — the freeze
+                # appended them last, so an identical user-authored condition that predates the
+                # freeze survives.
+                remaining = list(new_group.get("properties", []))
+                for frozen_condition in frozen_properties:
+                    for index in range(len(remaining) - 1, -1, -1):
+                        if remaining[index] == frozen_condition:
+                            del remaining[index]
+                            break
+                new_group["properties"] = remaining
             description = new_group.get("description")
             if isinstance(description, str) and EXPOSURE_FROZEN_GROUP_MARKER in description:
                 stripped_description = description.replace(EXPOSURE_FROZEN_GROUP_MARKER, "").strip()

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -27,6 +27,12 @@ EXPOSURE_FROZEN_GROUP_KEY = "exposure_frozen"
 # can remove exactly that condition even if users added their own cohort conditions meanwhile.
 EXPOSURE_FROZEN_COHORT_KEY = "exposure_frozen_cohort"
 
+# Companion key for the property-based freeze mode: records the exact property conditions the freeze
+# AND-ed into the group (instead of a snapshot cohort), so unfreezing can remove exactly those
+# conditions even if users added their own property conditions meanwhile. Property-based freezing
+# exists because static cohorts cannot be resolved by SDKs doing server-side local evaluation.
+EXPOSURE_FROZEN_PROPERTIES_KEY = "exposure_frozen_properties"
+
 # Human-readable note prepended to each release group's `description` when freezing. Purely
 # informational — the description stays user-editable prose and carries no state.
 EXPOSURE_FROZEN_GROUP_MARKER = "Added automatically when the experiment exposure was frozen to stop new enrollment."

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -22,7 +22,7 @@ from posthog.schema import (
     ExperimentRunningTimeCalculation,
 )
 
-from posthog.api.documentation import FeatureFlagFiltersSchemaSerializer
+from posthog.api.documentation import FeatureFlagFiltersSchemaSerializer, ValueField
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
 from posthog.api.shared import UserBasicSerializer
 from posthog.models.team.team import Team
@@ -1017,6 +1017,82 @@ class ArchiveExperimentSerializer(serializers.Serializer):
             "When the linked feature flag is still enabled, also disable and archive it along with "
             "the experiment. Has no effect if the flag is already disabled (it is archived either way)."
         ),
+    )
+
+
+class FreezePropertyConditionSerializer(serializers.Serializer):
+    key = serializers.CharField(
+        help_text="Key of the property the freeze condition matches on, e.g. `created_at`. Under server-side "
+        "local evaluation only properties the SDK caller passes in are visible, so pick one your code already sends."
+    )
+    # CharField rather than ChoiceField: `type` is a collision-prone enum name across the API schema,
+    # and the allowed values are enforced by the freeze service anyway.
+    type = serializers.CharField(
+        default="person",
+        help_text="Condition type: `person` for person-aggregated flags, `group` for group-aggregated flags. "
+        "Cohort, flag-dependency, and behavioral conditions are not locally evaluable and are rejected.",
+    )
+    operator = serializers.CharField(
+        default="exact",
+        help_text="Property filter operator, e.g. `is_date_before`, `exact`, `lt`.",
+    )
+    value = ValueField(
+        required=False,
+        help_text="Value the condition compares against, e.g. an ISO date for `is_date_before`. "
+        "Optional only for `is_set` / `is_not_set` operators.",
+    )
+    group_type_index = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="For `group` conditions: must match the feature flag's aggregation group type index.",
+    )
+
+
+class FreezeExposureSerializer(serializers.Serializer):
+    freeze_mode = serializers.ChoiceField(
+        choices=["cohort", "property"],
+        default="cohort",
+        help_text="How to narrow the flag's release conditions. `cohort` (default) snapshots the already-exposed "
+        "users into a static cohort — exact, but not resolvable by SDKs doing server-side local evaluation and "
+        "capped in size. `property` ANDs the given property conditions into each release condition instead — "
+        "locally evaluable and instant, but only correct when enrollment is gated on those properties "
+        "(e.g. a signup-date cutoff).",
+    )
+    property_conditions = serializers.ListField(
+        child=FreezePropertyConditionSerializer(),
+        required=False,
+        allow_null=True,
+        help_text="Property conditions to AND into every release condition. Required when `freeze_mode` is "
+        "`property`, rejected otherwise.",
+    )
+
+    def validate(self, attrs: dict) -> dict:
+        if attrs.get("freeze_mode") == "property" and not attrs.get("property_conditions"):
+            raise ValidationError("property_conditions is required when freeze_mode is 'property'.")
+        if attrs.get("freeze_mode") != "property" and attrs.get("property_conditions"):
+            raise ValidationError("property_conditions is only accepted when freeze_mode is 'property'.")
+        return attrs
+
+
+class FreezeExposureCheckSerializer(serializers.Serializer):
+    recommended_freeze_mode = serializers.ChoiceField(
+        choices=["cohort", "property"],
+        help_text="Freeze mode the caller should offer. `property` when the cohort mode would not work for this "
+        "experiment; `cohort` otherwise.",
+    )
+    reasons = serializers.ListField(
+        child=serializers.ChoiceField(choices=["local_evaluation", "group_aggregated"]),
+        help_text="Why the cohort mode is unsafe: `local_evaluation` (the flag is predominantly evaluated by "
+        "server-side local-evaluation SDKs, which cannot resolve static cohorts) and/or `group_aggregated` "
+        "(the flag targets groups, which a person cohort cannot hold). Empty when the cohort mode is fine.",
+    )
+    local_evaluation_share = serializers.FloatField(
+        allow_null=True,
+        help_text="Share (0–1) of the flag's recent $feature_flag_called events with locally_evaluated=true. "
+        "Null when the flag emitted too few events to classify (e.g. send_feature_flag_events disabled).",
+    )
+    flag_called_event_count = serializers.IntegerField(
+        help_text="Number of $feature_flag_called events for the flag in the detection window."
     )
 
 

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -61,6 +61,8 @@ from products.experiments.backend.presentation.serializers import (
     ExperimentSerializer,
     ExperimentSessionContextResponseSerializer,
     ExperimentWriteSerializer,
+    FreezeExposureCheckSerializer,
+    FreezeExposureSerializer,
     RecalculateMetricsRequestSerializer,
     RunningTimeCalculationInputSerializer,
     RunningTimeCalculationResultSerializer,
@@ -607,7 +609,7 @@ class EnterpriseExperimentsViewSet(
         return Response(ExperimentSerializer(resumed_experiment, context=self.get_serializer_context()).data)
 
     @extend_schema(
-        request=None,
+        request=FreezeExposureSerializer,
         responses=ExperimentSerializer,
     )
     @action(methods=["POST"], detail=True, required_scopes=["experiment:write"])
@@ -615,20 +617,54 @@ class EnterpriseExperimentsViewSet(
         """
         Freeze exposure on a running experiment while metrics keep flowing.
 
-        Snapshots the already-exposed users into a static cohort and narrows the
-        linked feature flag so only those users keep matching — new users can no
-        longer enter the experiment. ``end_date`` is left null so long-term metrics
-        (revenue/LTV/renewals/retention) keep accumulating. Enrolled users keep
-        their assigned variant. The serialized status becomes 'exposure_frozen'.
+        In the default cohort mode, snapshots the already-exposed users into a
+        static cohort and narrows the linked feature flag so only those users keep
+        matching — new users can no longer enter the experiment. In the property
+        mode (``freeze_mode="property"``), ANDs the given ``property_conditions``
+        into every release condition instead — locally evaluable and instant, but
+        only correct when enrollment is gated on those properties (use
+        ``freeze_exposure_check`` to see which mode fits). Either way, ``end_date``
+        is left null so long-term metrics (revenue/LTV/renewals/retention) keep
+        accumulating. Enrolled users keep their assigned variant. The serialized
+        status becomes 'exposure_frozen'.
 
         Returns 400 if the experiment is not running, exposure is already frozen,
-        the experiment is group-aggregated (group flags cannot be frozen with a
-        person cohort), or the exposed set is too large to snapshot synchronously.
+        the experiment is group-aggregated in cohort mode (group flags cannot be
+        frozen with a person cohort), or the exposed set is too large to snapshot
+        synchronously in cohort mode.
+        """
+        experiment: Experiment = self.get_object()
+        request_serializer = FreezeExposureSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        service = ExperimentService(team=self.team, user=request.user)
+        frozen_experiment = service.freeze_exposure(
+            experiment,
+            request=request,
+            freeze_mode=request_serializer.validated_data["freeze_mode"],
+            property_conditions=request_serializer.validated_data.get("property_conditions"),
+        )
+        return Response(ExperimentSerializer(frozen_experiment, context=self.get_serializer_context()).data)
+
+    @extend_schema(
+        responses=FreezeExposureCheckSerializer,
+    )
+    @action(methods=["GET"], detail=True, required_scopes=["experiment:read"])
+    def freeze_exposure_check(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """
+        Recommend a freeze mode for the experiment, without freezing anything.
+
+        The cohort mode silently degrades for feature flags evaluated by
+        server-side local-evaluation SDKs — static cohorts are excluded from the
+        local-evaluation flag definitions, so those SDKs fall back to /decide (or
+        to the default under only_evaluate_locally) — and it cannot freeze
+        group-aggregated flags. This endpoint detects both cases (local evaluation
+        via the recent share of $feature_flag_called events with
+        locally_evaluated=true) so the freeze UI can steer the user to the
+        property-based freeze before they freeze.
         """
         experiment: Experiment = self.get_object()
         service = ExperimentService(team=self.team, user=request.user)
-        frozen_experiment = service.freeze_exposure(experiment, request=request)
-        return Response(ExperimentSerializer(frozen_experiment, context=self.get_serializer_context()).data)
+        return Response(FreezeExposureCheckSerializer(service.check_freeze_exposure(experiment)).data)
 
     @extend_schema(
         request=None,

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -44,6 +44,7 @@ from products.experiments.backend.models.experiment import (
     EXPOSURE_FROZEN_COHORT_KEY,
     EXPOSURE_FROZEN_GROUP_KEY,
     EXPOSURE_FROZEN_GROUP_MARKER,
+    EXPOSURE_FROZEN_PROPERTIES_KEY,
     Experiment,
     ExperimentHoldout,
     ExperimentMetricResult,
@@ -3813,6 +3814,249 @@ class TestExperimentService(APIBaseTest):
     # ------------------------------------------------------------------
     # Unfreeze exposure
     # ------------------------------------------------------------------
+
+    _FREEZE_PROPERTY_CONDITION = {
+        "key": "created_at",
+        "type": "person",
+        "operator": "is_date_before",
+        "value": "2026-07-01",
+    }
+
+    def test_freeze_exposure_property_mode_success(self) -> None:
+        experiment = self._create_running_experiment(name="Freeze Property", feature_flag_key="freeze-property-flag")
+        original_variants = deepcopy(experiment.feature_flag.filters["multivariate"])
+
+        # The whole point of the property mode: no exposure scan, no snapshot cohort.
+        with patch.object(
+            ExperimentService, "_fetch_exposed_person_uuids", side_effect=AssertionError("scan must not run")
+        ):
+            frozen = self._service().freeze_exposure(
+                experiment,
+                request=self._make_request(),
+                freeze_mode="property",
+                property_conditions=[self._FREEZE_PROPERTY_CONDITION],
+            )
+        frozen.feature_flag.refresh_from_db()
+
+        assert not Cohort.objects.filter(team=self.team, name__startswith="Exposure snapshot").exists()
+
+        groups = frozen.feature_flag.filters["groups"]
+        assert len(groups) >= 1
+        for group in groups:
+            assert group["properties"][-1] == self._FREEZE_PROPERTY_CONDITION
+            assert group[EXPOSURE_FROZEN_GROUP_KEY] is True
+            assert group[EXPOSURE_FROZEN_PROPERTIES_KEY] == [self._FREEZE_PROPERTY_CONDITION]
+            assert EXPOSURE_FROZEN_COHORT_KEY not in group
+            assert EXPOSURE_FROZEN_GROUP_MARKER in group["description"]
+
+        assert frozen.feature_flag.filters["multivariate"] == original_variants
+        assert frozen.end_date is None
+        assert frozen.is_running is True
+        assert frozen.is_exposure_frozen is True
+
+    def test_freeze_exposure_property_mode_unfreeze_round_trip(self) -> None:
+        experiment = self._create_running_experiment(
+            name="Property Round Trip", feature_flag_key="property-roundtrip-flag"
+        )
+        flag = experiment.feature_flag
+        # One bare group, plus one whose user-authored condition is identical to the freeze
+        # condition — unfreeze must remove only the occurrence the freeze appended.
+        catch_all = {"properties": [], "rollout_percentage": 100}
+        overlapping = {
+            "properties": [deepcopy(self._FREEZE_PROPERTY_CONDITION)],
+            "rollout_percentage": 100,
+            "description": "Signup gated",
+        }
+        self._update_flag_filters(flag, {**flag.filters, "groups": [catch_all, overlapping]})
+        original_filters = deepcopy(flag.filters)
+
+        frozen = self._service().freeze_exposure(
+            experiment,
+            request=self._make_request(),
+            freeze_mode="property",
+            property_conditions=[self._FREEZE_PROPERTY_CONDITION],
+        )
+        frozen.feature_flag.refresh_from_db()
+        assert frozen.feature_flag.filters["groups"][1]["properties"] == [
+            self._FREEZE_PROPERTY_CONDITION,
+            self._FREEZE_PROPERTY_CONDITION,
+        ]
+
+        unfrozen = self._service().unfreeze_exposure(frozen, request=self._make_request())
+        unfrozen.feature_flag.refresh_from_db()
+
+        assert unfrozen.feature_flag.filters == original_filters
+        assert unfrozen.is_exposure_frozen is False
+        assert unfrozen.is_running is True
+
+    @parameterized.expand(
+        [
+            ("no_conditions", None, "at least one property condition"),
+            ("empty_conditions", [], "at least one property condition"),
+            (
+                "cohort_condition",
+                [{"key": "id", "type": "cohort", "value": 1, "operator": "in"}],
+                "not supported",
+            ),
+            (
+                "flag_dependency_condition",
+                [{"key": "other-flag", "type": "flag", "operator": "flag_evaluates_to", "value": True}],
+                "not supported",
+            ),
+            (
+                "group_condition_on_person_flag",
+                [{"key": "plan", "type": "group", "group_type_index": 0, "operator": "exact", "value": "free"}],
+                "must be person properties",
+            ),
+            ("missing_key", [{"type": "person", "operator": "exact", "value": "x"}], "property key"),
+            ("missing_operator", [{"key": "created_at", "type": "person", "value": "2026-01-01"}], "operator"),
+            (
+                "missing_value",
+                [{"key": "created_at", "type": "person", "operator": "is_date_before"}],
+                "missing a value",
+            ),
+        ]
+    )
+    def test_freeze_exposure_property_mode_rejects_invalid_conditions(
+        self, _name: str, conditions: list[dict] | None, expected_error: str
+    ) -> None:
+        experiment = self._create_running_experiment(
+            name="Property Invalid", feature_flag_key=f"property-invalid-{_name}"
+        )
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().freeze_exposure(
+                experiment, request=self._make_request(), freeze_mode="property", property_conditions=conditions
+            )
+        assert expected_error.lower() in str(ctx.exception).lower()
+        experiment.refresh_from_db()
+        assert experiment.is_exposure_frozen is False
+
+    def test_freeze_exposure_cohort_mode_rejects_property_conditions(self) -> None:
+        experiment = self._create_running_experiment(name="Cohort No Props", feature_flag_key="cohort-no-props-flag")
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().freeze_exposure(
+                experiment,
+                request=self._make_request(),
+                property_conditions=[self._FREEZE_PROPERTY_CONDITION],
+            )
+        assert "only accepted with the property freeze mode" in str(ctx.exception)
+
+    def test_freeze_exposure_property_mode_group_aggregated(self) -> None:
+        experiment = self._create_running_experiment(name="Property Groups", feature_flag_key="property-groups-flag")
+        flag = experiment.feature_flag
+        flag.filters = {**flag.filters, "aggregation_group_type_index": 0}
+        flag.save()
+        experiment.refresh_from_db()
+
+        group_condition = {
+            "key": "plan",
+            "type": "group",
+            "group_type_index": 0,
+            "operator": "exact",
+            "value": "enterprise",
+        }
+        frozen = self._service().freeze_exposure(
+            experiment, request=self._make_request(), freeze_mode="property", property_conditions=[group_condition]
+        )
+        frozen.feature_flag.refresh_from_db()
+
+        assert frozen.is_exposure_frozen is True
+        for group in frozen.feature_flag.filters["groups"]:
+            assert group["properties"][-1] == group_condition
+
+    @parameterized.expand(
+        [
+            (
+                "person_condition",
+                {"key": "created_at", "type": "person", "operator": "is_date_before", "value": "2026-01-01"},
+                "must be group properties",
+            ),
+            (
+                "wrong_group_type_index",
+                {"key": "plan", "type": "group", "group_type_index": 1, "operator": "exact", "value": "x"},
+                "same group type",
+            ),
+        ]
+    )
+    def test_freeze_exposure_property_mode_group_aggregated_condition_mismatch(
+        self, _name: str, condition: dict, expected_error: str
+    ) -> None:
+        experiment = self._create_running_experiment(
+            name="Property Groups Bad", feature_flag_key=f"property-groups-bad-{_name}"
+        )
+        flag = experiment.feature_flag
+        flag.filters = {**flag.filters, "aggregation_group_type_index": 0}
+        flag.save()
+        experiment.refresh_from_db()
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().freeze_exposure(
+                experiment, request=self._make_request(), freeze_mode="property", property_conditions=[condition]
+            )
+        assert expected_error.lower() in str(ctx.exception).lower()
+
+    @parameterized.expand(
+        [
+            ("mostly_local", 90, 100, "property", ["local_evaluation"], 0.9),
+            ("mostly_remote", 5, 100, "cohort", [], 0.05),
+            # Below FREEZE_EXPOSURE_LOCAL_EVAL_MIN_EVENTS the flag can't be classified.
+            ("too_few_events", 5, 5, "cohort", [], None),
+            ("no_events", 0, 0, "cohort", [], None),
+        ]
+    )
+    def test_check_freeze_exposure_local_evaluation_detection(
+        self,
+        _name: str,
+        local: int,
+        total: int,
+        expected_mode: str,
+        expected_reasons: list[str],
+        expected_share: float | None,
+    ) -> None:
+        experiment = self._create_running_experiment(name="Freeze Check", feature_flag_key=f"freeze-check-{_name}")
+        with patch(
+            "products.experiments.backend.experiment_service.execute_hogql_query",
+            return_value=MagicMock(results=[[local, total]]),
+        ):
+            result = self._service().check_freeze_exposure(experiment)
+
+        assert result["recommended_freeze_mode"] == expected_mode
+        assert result["reasons"] == expected_reasons
+        assert result["local_evaluation_share"] == expected_share
+        assert result["flag_called_event_count"] == total
+
+    def test_check_freeze_exposure_group_aggregated_recommends_property(self) -> None:
+        experiment = self._create_running_experiment(
+            name="Freeze Check Groups", feature_flag_key="freeze-check-groups-flag"
+        )
+        flag = experiment.feature_flag
+        flag.filters = {**flag.filters, "aggregation_group_type_index": 0}
+        flag.save()
+        experiment.refresh_from_db()
+
+        with patch(
+            "products.experiments.backend.experiment_service.execute_hogql_query",
+            return_value=MagicMock(results=[[0, 0]]),
+        ):
+            result = self._service().check_freeze_exposure(experiment)
+
+        assert result["recommended_freeze_mode"] == "property"
+        assert result["reasons"] == ["group_aggregated"]
+
+    def test_check_freeze_exposure_survives_query_failure(self) -> None:
+        # Detection is best-effort — an unclassifiable flag must fall back to the cohort
+        # recommendation instead of blocking the freeze flow with a 500.
+        experiment = self._create_running_experiment(
+            name="Freeze Check Fail", feature_flag_key="freeze-check-fail-flag"
+        )
+        with patch(
+            "products.experiments.backend.experiment_service.execute_hogql_query",
+            side_effect=Exception("boom"),
+        ):
+            result = self._service().check_freeze_exposure(experiment)
+
+        assert result["recommended_freeze_mode"] == "cohort"
+        assert result["local_evaluation_share"] is None
 
     def test_unfreeze_exposure_restores_original_filters(self) -> None:
         experiment = self._create_running_experiment(name="Unfreeze Test", feature_flag_key="unfreeze-flag")

--- a/products/experiments/backend/test/test_freeze_exposure_clickhouse.py
+++ b/products/experiments/backend/test/test_freeze_exposure_clickhouse.py
@@ -76,6 +76,39 @@ class TestFreezeExposureClickhouse(ClickhouseTestMixin, APIBaseTest):
     def _service(self) -> ExperimentService:
         return ExperimentService(team=self.team, user=self.user)
 
+    def test_check_freeze_exposure_counts_locally_evaluated_share(self) -> None:
+        # CH-backed proof for the detection query in check_freeze_exposure — the unit tests stub
+        # execute_hogql_query, so this is what catches a broken query (wrong event, wrong property,
+        # wrong window) that would misclassify every flag.
+        experiment = self._create_running_experiment("freeze-local-eval-flag")
+        recent = timezone.now() - timedelta(hours=1)
+
+        for index in range(3):
+            self._expose_person(
+                f"local-{index}",
+                "freeze-local-eval-flag",
+                recent,
+                extra_properties={"locally_evaluated": True},
+            )
+        self._expose_person("remote-1", "freeze-local-eval-flag", recent)
+        # Other flags and events outside the lookback window must not count.
+        self._expose_person("other-flag", "some-other-flag", recent, extra_properties={"locally_evaluated": True})
+        self._expose_person(
+            "stale",
+            "freeze-local-eval-flag",
+            timezone.now() - timedelta(days=5),
+            extra_properties={"locally_evaluated": True},
+        )
+        flush_persons_and_events()
+
+        with patch("products.experiments.backend.experiment_service.FREEZE_EXPOSURE_LOCAL_EVAL_MIN_EVENTS", 4):
+            result = self._service().check_freeze_exposure(experiment)
+
+        assert result["flag_called_event_count"] == 4
+        assert result["local_evaluation_share"] == 0.75
+        assert result["recommended_freeze_mode"] == "property"
+        assert result["reasons"] == ["local_evaluation"]
+
     def test_fetch_exposed_person_uuids_returns_only_the_exposed_set(self) -> None:
         experiment = self._create_running_experiment("freeze-fetch-flag")
         assert experiment.start_date is not None

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -5608,6 +5608,59 @@ class TestExperimentCRUD(_HoistFlagConfigClientMixin, APILicensedTest):
         )
         self.assertEqual(second_unfreeze.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_freeze_exposure_property_mode_endpoint(self) -> None:
+        data = self._create_running_experiment(
+            name="Property Freeze Endpoint", flag_key="property-freeze-endpoint-flag"
+        )
+        experiment_id = data["id"]
+
+        freeze_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/freeze_exposure/",
+            {
+                "freeze_mode": "property",
+                "property_conditions": [
+                    {"key": "created_at", "type": "person", "operator": "is_date_before", "value": "2026-07-01"}
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(freeze_response.status_code, status.HTTP_200_OK)
+        body = freeze_response.json()
+        self.assertEqual(body["status"], "exposure_frozen")
+        self.assertIsNone(body["end_date"])
+        # The narrowing is the property condition itself — no snapshot cohort involved.
+        for group in body["feature_flag"]["filters"]["groups"]:
+            self.assertEqual(group["properties"][-1]["key"], "created_at")
+
+    def test_freeze_exposure_property_mode_requires_conditions(self) -> None:
+        data = self._create_running_experiment(name="Property Freeze Invalid", flag_key="property-freeze-invalid-flag")
+        experiment_id = data["id"]
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/freeze_exposure/",
+            {"freeze_mode": "property"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_freeze_exposure_check_endpoint(self) -> None:
+        data = self._create_running_experiment(name="Freeze Check Endpoint", flag_key="freeze-check-endpoint-flag")
+        experiment_id = data["id"]
+
+        with patch(
+            "products.experiments.backend.experiment_service.execute_hogql_query",
+            return_value=MagicMock(results=[[95, 100]]),
+        ):
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/experiments/{experiment_id}/freeze_exposure_check/"
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["recommended_freeze_mode"], "property")
+        self.assertEqual(body["reasons"], ["local_evaluation"])
+        self.assertEqual(body["local_evaluation_share"], 0.95)
+        self.assertEqual(body["flag_called_event_count"], 100)
+
     def test_freeze_exposure_draft_returns_400(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1698,6 +1698,74 @@ export interface EndExperimentApi {
 }
 
 /**
+ * * `cohort` - cohort
+ * * `property` - property
+ */
+export type ExperimentFreezeModeEnumApi = (typeof ExperimentFreezeModeEnumApi)[keyof typeof ExperimentFreezeModeEnumApi]
+
+export const ExperimentFreezeModeEnumApi = {
+    Cohort: 'cohort',
+    Property: 'property',
+} as const
+
+export interface FreezePropertyConditionApi {
+    /** Key of the property the freeze condition matches on, e.g. `created_at`. Under server-side local evaluation only properties the SDK caller passes in are visible, so pick one your code already sends. */
+    key: string
+    /** Condition type: `person` for person-aggregated flags, `group` for group-aggregated flags. Cohort, flag-dependency, and behavioral conditions are not locally evaluable and are rejected. */
+    type?: string
+    /** Property filter operator, e.g. `is_date_before`, `exact`, `lt`. */
+    operator?: string
+    /** Value the condition compares against, e.g. an ISO date for `is_date_before`. Optional only for `is_set` / `is_not_set` operators. */
+    value?: string | number | boolean | (string | number)[]
+    /**
+     * For `group` conditions: must match the feature flag's aggregation group type index.
+     * @nullable
+     */
+    group_type_index?: number | null
+}
+
+export interface FreezeExposureApi {
+    /** How to narrow the flag's release conditions. `cohort` (default) snapshots the already-exposed users into a static cohort — exact, but not resolvable by SDKs doing server-side local evaluation and capped in size. `property` ANDs the given property conditions into each release condition instead — locally evaluable and instant, but only correct when enrollment is gated on those properties (e.g. a signup-date cutoff).
+     *
+     * * `cohort` - cohort
+     * * `property` - property */
+    freeze_mode?: ExperimentFreezeModeEnumApi
+    /**
+     * Property conditions to AND into every release condition. Required when `freeze_mode` is `property`, rejected otherwise.
+     * @nullable
+     */
+    property_conditions?: FreezePropertyConditionApi[] | null
+}
+
+/**
+ * * `local_evaluation` - local_evaluation
+ * * `group_aggregated` - group_aggregated
+ */
+export type ReasonsEnumApi = (typeof ReasonsEnumApi)[keyof typeof ReasonsEnumApi]
+
+export const ReasonsEnumApi = {
+    LocalEvaluation: 'local_evaluation',
+    GroupAggregated: 'group_aggregated',
+} as const
+
+export interface FreezeExposureCheckApi {
+    /** Freeze mode the caller should offer. `property` when the cohort mode would not work for this experiment; `cohort` otherwise.
+     *
+     * * `cohort` - cohort
+     * * `property` - property */
+    recommended_freeze_mode: ExperimentFreezeModeEnumApi
+    /** Why the cohort mode is unsafe: `local_evaluation` (the flag is predominantly evaluated by server-side local-evaluation SDKs, which cannot resolve static cohorts) and/or `group_aggregated` (the flag targets groups, which a person cohort cannot hold). Empty when the cohort mode is fine. */
+    reasons: ReasonsEnumApi[]
+    /**
+     * Share (0–1) of the flag's recent $feature_flag_called events with locally_evaluated=true. Null when the flag emitted too few events to classify (e.g. send_feature_flag_events disabled).
+     * @nullable
+     */
+    local_evaluation_share: number | null
+    /** Number of $feature_flag_called events for the flag in the detection window. */
+    flag_called_event_count: number
+}
+
+/**
  * * `manual` - Manual
  * * `cold_run` - Cold Run
  * * `stale_refresh` - Stale Refresh

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -25,6 +25,8 @@ import type {
     ExperimentsPromptTemplatesRetrieve200Item,
     ExperimentsSessionContextRetrieveParams,
     ExperimentsTimeseriesResultsRetrieveParams,
+    FreezeExposureApi,
+    FreezeExposureCheckApi,
     PaginatedExperimentBasicListApi,
     PaginatedExperimentHoldoutListApi,
     PaginatedExperimentSavedMetricListApi,
@@ -549,24 +551,60 @@ export const getExperimentsFreezeExposureCreateUrl = (projectId: string, id: num
 /**
  * Freeze exposure on a running experiment while metrics keep flowing.
  *
- * Snapshots the already-exposed users into a static cohort and narrows the
- * linked feature flag so only those users keep matching — new users can no
- * longer enter the experiment. ``end_date`` is left null so long-term metrics
- * (revenue/LTV/renewals/retention) keep accumulating. Enrolled users keep
- * their assigned variant. The serialized status becomes 'exposure_frozen'.
+ * In the default cohort mode, snapshots the already-exposed users into a
+ * static cohort and narrows the linked feature flag so only those users keep
+ * matching — new users can no longer enter the experiment. In the property
+ * mode (``freeze_mode="property"``), ANDs the given ``property_conditions``
+ * into every release condition instead — locally evaluable and instant, but
+ * only correct when enrollment is gated on those properties (use
+ * ``freeze_exposure_check`` to see which mode fits). Either way, ``end_date``
+ * is left null so long-term metrics (revenue/LTV/renewals/retention) keep
+ * accumulating. Enrolled users keep their assigned variant. The serialized
+ * status becomes 'exposure_frozen'.
  *
  * Returns 400 if the experiment is not running, exposure is already frozen,
- * the experiment is group-aggregated (group flags cannot be frozen with a
- * person cohort), or the exposed set is too large to snapshot synchronously.
+ * the experiment is group-aggregated in cohort mode (group flags cannot be
+ * frozen with a person cohort), or the exposed set is too large to snapshot
+ * synchronously in cohort mode.
  */
 export const experimentsFreezeExposureCreate = async (
     projectId: string,
     id: number,
+    freezeExposureApi?: FreezeExposureApi,
     options?: RequestInit
 ): Promise<ExperimentApi> => {
     return apiMutator<ExperimentApi>(getExperimentsFreezeExposureCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(freezeExposureApi),
+    })
+}
+
+export const getExperimentsFreezeExposureCheckRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiments/${id}/freeze_exposure_check/`
+}
+
+/**
+ * Recommend a freeze mode for the experiment, without freezing anything.
+ *
+ * The cohort mode silently degrades for feature flags evaluated by
+ * server-side local-evaluation SDKs — static cohorts are excluded from the
+ * local-evaluation flag definitions, so those SDKs fall back to /decide (or
+ * to the default under only_evaluate_locally) — and it cannot freeze
+ * group-aggregated flags. This endpoint detects both cases (local evaluation
+ * via the recent share of $feature_flag_called events with
+ * locally_evaluated=true) so the freeze UI can steer the user to the
+ * property-based freeze before they freeze.
+ */
+export const experimentsFreezeExposureCheckRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<FreezeExposureCheckApi> => {
+    return apiMutator<FreezeExposureCheckApi>(getExperimentsFreezeExposureCheckRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -990,6 +990,78 @@ export const ExperimentsEndCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Freeze exposure on a running experiment while metrics keep flowing.
+ *
+ * In the default cohort mode, snapshots the already-exposed users into a
+ * static cohort and narrows the linked feature flag so only those users keep
+ * matching — new users can no longer enter the experiment. In the property
+ * mode (``freeze_mode="property"``), ANDs the given ``property_conditions``
+ * into every release condition instead — locally evaluable and instant, but
+ * only correct when enrollment is gated on those properties (use
+ * ``freeze_exposure_check`` to see which mode fits). Either way, ``end_date``
+ * is left null so long-term metrics (revenue/LTV/renewals/retention) keep
+ * accumulating. Enrolled users keep their assigned variant. The serialized
+ * status becomes 'exposure_frozen'.
+ *
+ * Returns 400 if the experiment is not running, exposure is already frozen,
+ * the experiment is group-aggregated in cohort mode (group flags cannot be
+ * frozen with a person cohort), or the exposed set is too large to snapshot
+ * synchronously in cohort mode.
+ */
+export const experimentsFreezeExposureCreateBodyFreezeModeDefault = `cohort`
+export const experimentsFreezeExposureCreateBodyPropertyConditionsItemTypeDefault = `person`
+export const experimentsFreezeExposureCreateBodyPropertyConditionsItemOperatorDefault = `exact`
+
+export const ExperimentsFreezeExposureCreateBody = /* @__PURE__ */ zod.object({
+    freeze_mode: zod
+        .enum(['cohort', 'property'])
+        .describe('\* `cohort` - cohort\n\* `property` - property')
+        .default(experimentsFreezeExposureCreateBodyFreezeModeDefault)
+        .describe(
+            "How to narrow the flag's release conditions. `cohort` (default) snapshots the already-exposed users into a static cohort — exact, but not resolvable by SDKs doing server-side local evaluation and capped in size. `property` ANDs the given property conditions into each release condition instead — locally evaluable and instant, but only correct when enrollment is gated on those properties (e.g. a signup-date cutoff).\n\n\* `cohort` - cohort\n\* `property` - property"
+        ),
+    property_conditions: zod
+        .array(
+            zod.object({
+                key: zod
+                    .string()
+                    .describe(
+                        'Key of the property the freeze condition matches on, e.g. `created_at`. Under server-side local evaluation only properties the SDK caller passes in are visible, so pick one your code already sends.'
+                    ),
+                type: zod
+                    .string()
+                    .default(experimentsFreezeExposureCreateBodyPropertyConditionsItemTypeDefault)
+                    .describe(
+                        'Condition type: `person` for person-aggregated flags, `group` for group-aggregated flags. Cohort, flag-dependency, and behavioral conditions are not locally evaluable and are rejected.'
+                    ),
+                operator: zod
+                    .string()
+                    .default(experimentsFreezeExposureCreateBodyPropertyConditionsItemOperatorDefault)
+                    .describe('Property filter operator, e.g. `is_date_before`, `exact`, `lt`.'),
+                value: zod
+                    .union([
+                        zod.string(),
+                        zod.number(),
+                        zod.boolean(),
+                        zod.array(zod.union([zod.string(), zod.number()])),
+                    ])
+                    .optional()
+                    .describe(
+                        'Value the condition compares against, e.g. an ISO date for `is_date_before`. Optional only for `is_set` \/ `is_not_set` operators.'
+                    ),
+                group_type_index: zod
+                    .number()
+                    .nullish()
+                    .describe("For `group` conditions: must match the feature flag's aggregation group type index."),
+            })
+        )
+        .nullish()
+        .describe(
+            'Property conditions to AND into every release condition. Required when `freeze_mode` is `property`, rejected otherwise.'
+        ),
+})
+
+/**
  * Trigger a batch recalculation of all metrics for this experiment.
  *
  * Returns 201 with the new pending recalculation, or 200 with the active one if a recalculation is

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -1032,6 +1032,9 @@ tools:
     experiments-eligible-feature-flags:
         operation: experiments_eligible_feature_flags_retrieve
         enabled: false
+    experiments-freeze-exposure-check-retrieve:
+        operation: experiments_freeze_exposure_check_retrieve
+        enabled: false
     experiments-freeze-exposure-create:
         operation: experiments_freeze_exposure_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -23727,6 +23727,18 @@ export namespace Schemas {
     }
 
     /**
+     * * `cohort` - cohort
+     * * `property` - property
+     */
+    export type ExperimentFreezeModeEnum = typeof ExperimentFreezeModeEnum[keyof typeof ExperimentFreezeModeEnum];
+
+
+    export const ExperimentFreezeModeEnum = {
+      Cohort: 'cohort',
+      Property: 'property',
+    } as const;
+
+    /**
      * * `categorical` - categorical
      * * `numeric` - numeric
      * * `boolean` - boolean
@@ -27040,6 +27052,64 @@ export namespace Schemas {
     export interface ForgetResponse {
       /** Whether a row was actually removed (false if the key didn't exist). */
       deleted: boolean;
+    }
+
+    export interface FreezePropertyCondition {
+      /** Key of the property the freeze condition matches on, e.g. `created_at`. Under server-side local evaluation only properties the SDK caller passes in are visible, so pick one your code already sends. */
+      key: string;
+      /** Condition type: `person` for person-aggregated flags, `group` for group-aggregated flags. Cohort, flag-dependency, and behavioral conditions are not locally evaluable and are rejected. */
+      type?: string;
+      /** Property filter operator, e.g. `is_date_before`, `exact`, `lt`. */
+      operator?: string;
+      /** Value the condition compares against, e.g. an ISO date for `is_date_before`. Optional only for `is_set` / `is_not_set` operators. */
+      value?: string | number | boolean | (string | number)[];
+      /**
+         * For `group` conditions: must match the feature flag's aggregation group type index.
+         * @nullable
+         */
+      group_type_index?: number | null;
+    }
+
+    export interface FreezeExposure {
+      /** How to narrow the flag's release conditions. `cohort` (default) snapshots the already-exposed users into a static cohort — exact, but not resolvable by SDKs doing server-side local evaluation and capped in size. `property` ANDs the given property conditions into each release condition instead — locally evaluable and instant, but only correct when enrollment is gated on those properties (e.g. a signup-date cutoff).
+       *
+       * * `cohort` - cohort
+       * * `property` - property */
+      freeze_mode?: ExperimentFreezeModeEnum;
+      /**
+         * Property conditions to AND into every release condition. Required when `freeze_mode` is `property`, rejected otherwise.
+         * @nullable
+         */
+      property_conditions?: FreezePropertyCondition[] | null;
+    }
+
+    /**
+     * * `local_evaluation` - local_evaluation
+     * * `group_aggregated` - group_aggregated
+     */
+    export type ReasonsEnum = typeof ReasonsEnum[keyof typeof ReasonsEnum];
+
+
+    export const ReasonsEnum = {
+      LocalEvaluation: 'local_evaluation',
+      GroupAggregated: 'group_aggregated',
+    } as const;
+
+    export interface FreezeExposureCheck {
+      /** Freeze mode the caller should offer. `property` when the cohort mode would not work for this experiment; `cohort` otherwise.
+       *
+       * * `cohort` - cohort
+       * * `property` - property */
+      recommended_freeze_mode: ExperimentFreezeModeEnum;
+      /** Why the cohort mode is unsafe: `local_evaluation` (the flag is predominantly evaluated by server-side local-evaluation SDKs, which cannot resolve static cohorts) and/or `group_aggregated` (the flag targets groups, which a person cohort cannot hold). Empty when the cohort mode is fine. */
+      reasons: ReasonsEnum[];
+      /**
+         * Share (0–1) of the flag's recent $feature_flag_called events with locally_evaluated=true. Null when the flag emitted too few events to classify (e.g. send_feature_flag_events disabled).
+         * @nullable
+         */
+      local_evaluation_share: number | null;
+      /** Number of $feature_flag_called events for the flag in the detection window. */
+      flag_called_event_count: number;
     }
 
     export interface GapAction {


### PR DESCRIPTION
## Problem

"Freeze exposure" narrows an experiment's flag to a static cohort of already-exposed persons. Static cohorts are excluded from the local-evaluation flag definitions.

## Changes

- New \`freeze_mode="property"\` on \`POST .../freeze_exposure\`: ANDs caller-supplied property conditions into every release condition instead of a snapshot cohort. Locally evaluable, instant (no ClickHouse scan, no cohort build, no exposed-user cap), and works for group-aggregated flags (group-property conditions matching the flag's aggregation). Unfreeze/reset/ship-variant strip it cleanly via a new \`exposure_frozen_properties\` group stamp.
- New \`GET .../freeze_exposure_check\`: recommends a freeze mode by measuring the share of the flag's recent \`$feature_flag_called\` events with \`locally_evaluated=true\`, plus the group-aggregation check.
- Frontend detect-and-default flow: clicking "Freeze exposure" runs the check first. Common case keeps today's one-click cohort confirm. When the cohort mode is unsafe, a modal explains why and asks the user to confirm editable property conditions (default: person \`created_at\` before now) – the property mode is a proxy that's only correct for enrollment gated on the property, so it is never applied silently. Group-aggregated experiments now get the freeze option too.
- The cohort mode is unchanged and stays the default.

> [!NOTE]
> Sticky bucketing remains the durable long-term answer; this is deliberately a narrow, local-evaluation-compatible stopgap on the existing freeze machinery.

## How did you test this code?

Automated tests only (the sandbox has no Postgres/ClickHouse, so backend tests will run in CI):

- \`test_experiment_service.py\`: property-mode freeze stamps/strips round-trip byte-for-byte (including a user condition identical to the frozen one – strip removes only the appended occurrence), condition validation matrix (cohort/flag types, aggregation mismatch, missing key/operator/value), group-aggregated support, and \`check_freeze_exposure\` threshold logic including query-failure fallback. These catch regressions the cohort-mode tests can't: a freeze that silently builds a cohort anyway, or an unfreeze that can't reverse a property-mode freeze.
- \`test_presentation_api.py\`: wiring guards – property-mode request body reaches the service, missing conditions 400, check endpoint serializes.
- \`test_freeze_exposure_clickhouse.py\`: CH-backed proof the detection query counts \`locally_evaluated\` per flag within the window (the unit tests stub \`execute_hogql_query\`).
- Jest (\`experimentLogic.test.ts\`, ran locally, all green): check-recommends-property opens the modal and never the plain confirm dialog; cohort recommendation keeps the dialog; property freeze sends the request body.

Not done here: \`hogli build:openapi\` (needs a running DB; generated types for the new request/response schemas need a regen – preflight flags this as the only advisory).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) from a handoff plan Marcel provided. Skills invoked: /improving-drf-endpoints, /writing-tests, /adopting-generated-api-types. Notable decisions: the freeze request field is \`freeze_mode\` (not \`mode\`, which is an enum-collision-prone name); conditions are a list (\`property_conditions\`) rather than a single condition since the UI's PropertyFilters naturally edits a list and ANDed person properties stay locally evaluable; the over-cap case is not pre-detected by the check endpoint (it would need the same expensive scan the freeze runs) – the cohort freeze's size rejection remains the signal there. The plan's open question about SDK behavior on unresolvable static cohorts was already answered by an existing design note in \`freeze_exposure\`, so no flags-team confirmation was needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*