### PR TITLE
fix(data-warehouse): clarify coming-soon source tiles in the catalog

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
@@ -66,7 +66,11 @@ const SourceTile = memo(function SourceTile({
     )
 
     if (item.status === 'coming_soon') {
-        return <div className={TILE_CLASS}>{content}</div>
+        return (
+            <Tooltip title="This source isn't available yet. Choose 'Notify me' and we'll let you know when it launches.">
+                <div className={`${TILE_CLASS} cursor-default`}>{content}</div>
+            </Tooltip>
+        )
     }
 
     if (accessDisabledReason) {


### PR DESCRIPTION
## Problem

In the data-warehouse new-source catalog, a "coming soon" connector renders as a plain, non-interactive tile with a small "Notify me" button. Unlike the access-disabled tiles beside it (which get a tooltip and a `cursor-not-allowed` affordance), the coming-soon tile has no tooltip, no cursor change, and no explanation — so clicking the card body is a silent dead click. Session-replay review of the new-source onboarding flow showed users repeatedly clicking coming-soon tiles and getting no feedback before abandoning.

## Changes

Wrap the coming-soon tile in the same `Tooltip` pattern already used for access-disabled tiles. The tooltip explains the source isn't available yet and points to the "Notify me" action, and the tile now uses a default cursor so it doesn't read as clickable. No behavior change to the "Notify me" flow, the search, or any available/disabled tile.

## How did you test this code?

No automated tests were added — this is a presentational tooltip on an existing tile branch, reusing the already-imported `Tooltip` component and existing Tailwind classes, so there is no realistic regression a new test would catch that isn't already covered by the existing catalog logic tests. Local lint/typecheck could not be run in this environment (no `node_modules`); CI will run them.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code from a review of session summaries of the data-warehouse new-source onboarding flow. Across several sessions, users clicked coming-soon connector tiles and received no feedback (a dead click) before leaving the flow. The catalog already had a tooltip affordance for access-disabled tiles; this change extends the same pattern to coming-soon tiles rather than introducing anything new. The prefix-validation form and connection-error messaging were also reviewed and left unchanged — both already provide specific, actionable copy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
