### PR TITLE
fix(workflows): exit runs gracefully when their step is edited away

### DIFF
--- a/nodejs/src/cdp/schema/hogflow.ts
+++ b/nodejs/src/cdp/schema/hogflow.ts
@@ -277,6 +277,9 @@ export const HogFlowSchema = z.object({
     edges: z.array(HogFlowEdgeSchema),
     variables: z.array(CyclotronJobInputSchemaTypeSchema).optional().nullable(),
     billable_action_types: z.array(z.string()).optional().nullable(),
+    // Selected by the worker (HOG_FLOW_FIELDS); pg returns timestamptz as a Date, fixtures use
+    // epoch millis. Used to distinguish live edits from malformed-from-birth graphs.
+    updated_at: z.union([z.number(), z.string(), z.date()]).optional(),
 })
 
 // NOTE: these are purposefully exported as interfaces to support kea typegen

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -586,6 +586,8 @@ describe('Hogflow Executor', () => {
                     startedAtTimestamp: DateTime.now().minus({ hours: 3 }).toMillis(),
                 }
                 mutateFlow(hogFlow)
+                // The flow was edited after the run arrived at the step - the live-edit case
+                hogFlow.updated_at = DateTime.now().toMillis()
 
                 const result = await executor.execute(invocation)
 
@@ -596,6 +598,25 @@ describe('Hogflow Executor', () => {
                 expect(result.metrics.map((m) => m.metric_name)).not.toContain('failed')
                 expect(result.logs.filter((l) => l.level === 'error')).toEqual([])
                 expect(result.logs.map((l) => l.message).join('\n')).toContain('Workflow exited')
+            })
+
+            it('still fails the run when the graph was malformed all along (no edit since the step started)', async () => {
+                const hogFlow = buildFlow()
+                const invocation = createExampleHogFlowInvocation(hogFlow)
+                invocation.state.currentAction = {
+                    id: 'delay',
+                    startedAtTimestamp: DateTime.now().minus({ hours: 3 }).toMillis(),
+                }
+                hogFlow.edges = hogFlow.edges.filter((edge) => edge.from !== 'delay')
+                // No edit since the run arrived: the missing edge is a bad definition, not a live edit
+                hogFlow.updated_at = DateTime.now().minus({ hours: 4 }).toMillis()
+
+                const result = await executor.execute(invocation)
+
+                expect(result.finished).toBe(true)
+                expect(result.error).toBe('No next action found for action delay')
+                expect(result.metrics.map((m) => m.metric_name)).toContain('failed')
+                expect(result.metrics.map((m) => m.metric_name)).not.toContain('exited_workflow_changed')
             })
         })
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -554,6 +554,51 @@ describe('Hogflow Executor', () => {
                 .build()
         }
 
+        describe('workflow definition changed mid-run', () => {
+            const buildFlow = (): HogFlow =>
+                createHogFlow({
+                    actions: {},
+                    edges: [
+                        { from: 'trigger', to: 'delay', type: 'continue' },
+                        { from: 'delay', to: 'exit', type: 'continue' },
+                    ],
+                })
+
+            it.each([
+                [
+                    'the current action was deleted',
+                    (hogFlow: HogFlow) => {
+                        hogFlow.actions = hogFlow.actions.filter((action) => action.id !== 'delay')
+                    },
+                ],
+                [
+                    'the current action no longer has a continue edge',
+                    (hogFlow: HogFlow) => {
+                        hogFlow.edges = hogFlow.edges.filter((edge) => edge.from !== 'delay')
+                    },
+                ],
+            ])('exits gracefully when %s', async (_desc, mutateFlow) => {
+                const hogFlow = buildFlow()
+                const invocation = createExampleHogFlowInvocation(hogFlow)
+                // Parked on the delay long enough that it has elapsed, so the handler advances
+                invocation.state.currentAction = {
+                    id: 'delay',
+                    startedAtTimestamp: DateTime.now().minus({ hours: 3 }).toMillis(),
+                }
+                mutateFlow(hogFlow)
+
+                const result = await executor.execute(invocation)
+
+                expect(result.finished).toBe(true)
+                expect(result.error).toBeUndefined()
+                const exitMetric = result.metrics.find((m) => m.metric_name === 'exited_workflow_changed')
+                expect(exitMetric).toMatchObject({ metric_kind: 'other', instance_id: 'delay' })
+                expect(result.metrics.map((m) => m.metric_name)).not.toContain('failed')
+                expect(result.logs.filter((l) => l.level === 'error')).toEqual([])
+                expect(result.logs.map((l) => l.message).join('\n')).toContain('Workflow exited')
+            })
+        })
+
         describe('early exit conditions', () => {
             let hogFlow: HogFlow
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -494,9 +494,11 @@ export class HogFlowExecutorService {
                     this.goToNextAction(result, currentAction, handlerResult.nextAction, 'succeeded')
                 }
             } catch (err) {
-                // A WorkflowChangedError is not this action failing — the graph moved underneath the
-                // run — so it skips the failure log/metric and is classified by the outer catch.
-                if (!(err instanceof WorkflowChangedError)) {
+                // A live-edit WorkflowChangedError is not this action failing - the graph moved
+                // underneath the run - so it skips the failure log/metric and is classified by the
+                // outer catch. The same error from an untouched flow is a malformed definition and
+                // keeps the failure treatment.
+                if (!this.isLiveEditWorkflowChange(err, invocation)) {
                     // Add logs and metric specifically for this action
                     this.logAction(result, currentAction, 'error', `Errored: ${String(err)}`) // TODO: Is this enough detail?
                     this.trackActionMetric(result, currentAction, 'failed')
@@ -507,9 +509,9 @@ export class HogFlowExecutorService {
         } catch (err) {
             // The workflow was edited underneath this run and its current step (or that step's next
             // edge) no longer exists. That's a user action, not a defect: finish the run as a
-            // deliberate exit — no result.error, so it doesn't count towards the workflow's failure
-            // rate — with its own metric so exits are attributable per workflow.
-            if (err instanceof WorkflowChangedError) {
+            // deliberate exit - no result.error, so it doesn't count towards the workflow's failure
+            // rate - with its own metric so exits are attributable per workflow.
+            if (this.isLiveEditWorkflowChange(err, invocation)) {
                 result.finished = true
                 this.log(
                     result,
@@ -531,6 +533,8 @@ export class HogFlowExecutorService {
             // The final catch - in this case we are always just logging the final outcome
             result.error = err.message
             result.finished = true // Explicitly set to true to prevent infinite loops
+            // (a WorkflowChangedError from an untouched flow lands here too: the graph was malformed
+            // all along, so it stays a failure the author can see rather than a quiet exit)
 
             this.maybeContinueToNextActionOnError(result)
 
@@ -542,6 +546,17 @@ export class HogFlowExecutorService {
         }
 
         return result
+    }
+
+    // A structural lookup miss only counts as a live edit when the flow was actually updated after
+    // the run arrived at its current step. Otherwise the graph was malformed from the start (a bad
+    // save, a lenient draft in a test run) and hiding it as a deliberate exit would bury the defect.
+    private isLiveEditWorkflowChange(err: unknown, invocation: CyclotronJobInvocationHogFlow): boolean {
+        if (!(err instanceof WorkflowChangedError)) {
+            return false
+        }
+        const stepStartedAt = invocation.state.currentAction?.startedAtTimestamp
+        return Boolean(stepStartedAt && invocation.hogFlow.updated_at > stepStartedAt)
     }
 
     private goToNextAction(

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -34,6 +34,7 @@ import { WaitUntilTimeWindowHandler } from './actions/wait_until_time_window'
 import { HogFlowDuplicateObserverService } from './hogflow-duplicate-observer.service'
 import { HogFlowFunctionsService } from './hogflow-functions.service'
 import {
+    WorkflowChangedError,
     actionIdForLogging,
     ensureCurrentAction,
     findContinueAction,
@@ -493,13 +494,40 @@ export class HogFlowExecutorService {
                     this.goToNextAction(result, currentAction, handlerResult.nextAction, 'succeeded')
                 }
             } catch (err) {
-                // Add logs and metric specifically for this action
-                this.logAction(result, currentAction, 'error', `Errored: ${String(err)}`) // TODO: Is this enough detail?
-                this.trackActionMetric(result, currentAction, 'failed')
+                // A WorkflowChangedError is not this action failing — the graph moved underneath the
+                // run — so it skips the failure log/metric and is classified by the outer catch.
+                if (!(err instanceof WorkflowChangedError)) {
+                    // Add logs and metric specifically for this action
+                    this.logAction(result, currentAction, 'error', `Errored: ${String(err)}`) // TODO: Is this enough detail?
+                    this.trackActionMetric(result, currentAction, 'failed')
+                }
 
                 throw err
             }
         } catch (err) {
+            // The workflow was edited underneath this run and its current step (or that step's next
+            // edge) no longer exists. That's a user action, not a defect: finish the run as a
+            // deliberate exit — no result.error, so it doesn't count towards the workflow's failure
+            // rate — with its own metric so exits are attributable per workflow.
+            if (err instanceof WorkflowChangedError) {
+                result.finished = true
+                this.log(
+                    result,
+                    'info',
+                    `Workflow exited: the workflow was edited and this run's current step no longer exists (${err.message})`
+                )
+                result.metrics.push({
+                    team_id: invocation.hogFlow.team_id,
+                    app_source_id: invocation.parentRunId ?? invocation.hogFlow.id,
+                    instance_id: invocation.state.currentAction?.id,
+                    metric_kind: 'other',
+                    metric_name: 'exited_workflow_changed',
+                    count: 1,
+                })
+
+                return result
+            }
+
             // The final catch - in this case we are always just logging the final outcome
             result.error = err.message
             result.finished = true // Explicitly set to true to prevent infinite loops

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -556,7 +556,9 @@ export class HogFlowExecutorService {
             return false
         }
         const stepStartedAt = invocation.state.currentAction?.startedAtTimestamp
-        return Boolean(stepStartedAt && invocation.hogFlow.updated_at > stepStartedAt)
+        // updated_at is a Date from pg in production and epoch millis in fixtures - normalize
+        const updatedAt = invocation.hogFlow.updated_at ? new Date(invocation.hogFlow.updated_at).getTime() : null
+        return Boolean(stepStartedAt && updatedAt && updatedAt > stepStartedAt)
     }
 
     private goToNextAction(

--- a/nodejs/src/cdp/services/hogflows/hogflow-utils.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-utils.ts
@@ -8,7 +8,7 @@ import { filterFunctionInstrumented } from '~/cdp/utils/hog-function-filtering'
 import { logger } from '~/common/utils/logger'
 import { captureException } from '~/common/utils/posthog'
 
-// The run's position (or the edge it needs next) no longer exists in the flow's graph — the
+// The run's position (or the edge it needs next) no longer exists in the flow's graph - the
 // workflow was edited underneath an in-flight run. This is a user action, not a defect: the
 // executor catches it and finishes the run as a graceful exit instead of a failure.
 export class WorkflowChangedError extends Error {}

--- a/nodejs/src/cdp/services/hogflows/hogflow-utils.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-utils.ts
@@ -8,10 +8,15 @@ import { filterFunctionInstrumented } from '~/cdp/utils/hog-function-filtering'
 import { logger } from '~/common/utils/logger'
 import { captureException } from '~/common/utils/posthog'
 
+// The run's position (or the edge it needs next) no longer exists in the flow's graph — the
+// workflow was edited underneath an in-flight run. This is a user action, not a defect: the
+// executor catches it and finishes the run as a graceful exit instead of a failure.
+export class WorkflowChangedError extends Error {}
+
 export const findActionById = (hogFlow: HogFlow, id: string): HogFlowAction => {
     const action = hogFlow.actions.find((action) => action.id === id)
     if (!action) {
-        throw new Error(`Action ${id} not found`)
+        throw new WorkflowChangedError(`Action ${id} not found`)
     }
 
     return action
@@ -41,7 +46,7 @@ export const findNextAction = (hogFlow: HogFlow, currentActionId: string, edgeIn
     }
 
     if (!nextActionId) {
-        throw new Error(`No next action found for action ${currentActionId}`)
+        throw new WorkflowChangedError(`No next action found for action ${currentActionId}`)
     }
 
     return findActionById(hogFlow, nextActionId)

--- a/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
@@ -94,7 +94,10 @@ describe('RecipientPreferencesService', () => {
             {} as Record<string, any>
         )
 
-        return createExampleInvocation(hogFlow, { inputs })
+        // HogFlow only overlaps HogFunctionType structurally; updated_at diverges (Date|number vs string)
+        return createExampleInvocation(hogFlow as unknown as Parameters<typeof createExampleInvocation>[0], {
+            inputs,
+        })
     }
 
     describe('shouldSkipAction', () => {

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -245,6 +245,7 @@ export type MinimalAppMetric = {
         | 'push_skipped'
         | 'quota_limited'
         | 'conversion'
+        | 'exited_workflow_changed'
     count: number
 }
 


### PR DESCRIPTION
## Problem

Editing a live workflow while people are mid-flow is the dominant way the workflows product gets used, but the executor has no concept of the graph changing underneath a run. If an edit deletes the step a run is parked on (or removes that step's outgoing edge), the next wake throws from `findActionById` / `findNextAction` and the run dies as a **failure**.

That's wrong twice over:

- A deliberate user edit is indistinguishable from a real defect - it inflates the workflow's error rate and buries genuine failures in noise.
- We have zero visibility into how often live edits strand in-flight runs. There is no metric, no log classification, nothing to size the problem with.

Related design context: #66380 (workflow revisions), which will build on this exit path - but this fix stands alone as an observability and correctness gap that exists today.

## Changes

- New `WorkflowChangedError`, thrown from exactly the two structural lookup sites: `findActionById` (the run's current action no longer exists) and `findNextAction` (its edge no longer exists). No other error is reclassified.
- The executor's action-level catch passes it through without the per-action failure log/metric, and the top-level catch finishes the run as a **deliberate exit** instead of a failure: no `result.error`, an info log with the reason, and a new `exited_workflow_changed` app metric with the orphaned step id as `instance_id`.
- Runs terminated by workflow edits are now attributable per workflow and per step, and measurable for the first time.

> [!NOTE]
> Behavior change for affected runs: they now end as a clean exit instead of an errored run. Runs whose current step still exists are untouched - live edits keep applying to in-flight runs exactly as before.

## How did you test this code?

Added two parameterized cases to the executor suite (`workflow definition changed mid-run`): current action deleted, and current action's continue edge removed. Both failed before the change (run finished with `result.error: "Action delay not found"` / `"No next action found"`) and pass after, asserting finished-without-error, the `exited_workflow_changed` metric, no `failed` metric, and no error-level logs. No existing test exercised either path.

Ran the executor, hogflow-utils, manager, and hog_function suites serialized locally: 57/58 green, the one failure being a pre-existing email round-trip test that needs a local SMTP server this machine doesn't run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the previous crash behavior; the metric is internal observability.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: /writing-tests. The error classification is deliberately narrow (two throw sites only) so real defects can't be silently reclassified as tidy exits; we considered folding in `ensureCurrentAction`'s no-trigger throw and rejected it since a trigger-less flow is malformed config, not a live edit. Tests were written first and confirmed red against the current behavior.
