### PR TITLE
fix(hedgehog): seed actor state with user config on spawn

### DIFF
--- a/frontend/src/lib/components/HedgehogMode/HedgehogMode.tsx
+++ b/frontend/src/lib/components/HedgehogMode/HedgehogMode.tsx
@@ -38,7 +38,7 @@ export type HedgehogModeProps = {
 }
 
 export function HedgehogMode({ enabledOverride }: HedgehogModeProps): JSX.Element | null {
-    const { hedgehogModeEnabled } = useValues(hedgehogModeLogic)
+    const { hedgehogModeEnabled, hedgehogConfig } = useValues(hedgehogModeLogic)
     const { setHedgehogMode, setHedgehogModeEnabled, toggleHedgehogMode } = useActions(hedgehogModeLogic)
     const { isDarkModeOn } = useValues(themeLogic)
 
@@ -46,6 +46,9 @@ export function HedgehogMode({ enabledOverride }: HedgehogModeProps): JSX.Elemen
 
     const config: HedgehogModeConfig = {
         assetsUrl: getHedgehogModeAssetsUrl(),
+        // Seed the actor so it spawns with the user's options (e.g. ai_enabled / "free to roam")
+        // already applied, instead of defaulting to roaming until the first syncGame corrects it.
+        state: { options: hedgehogConfig.actor_options },
         platforms: {
             selector:
                 '.border, .border-t, .LemonButton--primary, .LemonButton--secondary:not(.LemonButton--status-alt:not(.LemonButton--active)), .LemonInput, .LemonSelect, .LemonTable, .LemonSwitch--bordered, .LemonBanner',


### PR DESCRIPTION
Seed the hedgehog actor's initial state with the user's saved options (e.g. `ai_enabled` / "free to roam") so it spawns with the correct configuration applied immediately, rather than defaulting to roaming behavior until the first `syncGame` call corrects it.