### PR TITLE
feat(logs): serve group-by aggregation from the log_attributes rollup

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -47,30 +47,35 @@ def create_clickhouse_tables():
     }
 
     def missing(queries):
-        return [q for q in queries if get_table_name(q) not in existing_tables]
+        # Returns the rendered SQL of the statements that still need to run. CREATE OR
+        # REPLACE statements are how the canonical schema repoints an existing table
+        # (e.g. a distributed table cut over to a new data table); they must run even
+        # when the table already exists so kept/reused databases converge.
+        built = map(build_query, queries)
+        return [sql for sql in built if get_table_name(sql) not in existing_tables or "CREATE OR REPLACE" in sql]
 
-    mergetree_queries = list(map(build_query, missing(CREATE_MERGETREE_TABLE_QUERIES)))
+    mergetree_queries = missing(CREATE_MERGETREE_TABLE_QUERIES)
     if mergetree_queries:
         run_clickhouse_statement_in_parallel(mergetree_queries)
 
-    distributed_queries = list(map(build_query, missing(CREATE_DISTRIBUTED_TABLE_QUERIES)))
+    distributed_queries = missing(CREATE_DISTRIBUTED_TABLE_QUERIES)
     if distributed_queries:
         run_clickhouse_statement_in_parallel(distributed_queries)
 
     if settings.IN_EVAL_TESTING:
-        kafka_table_queries = list(map(build_query, missing(CREATE_KAFKA_TABLE_QUERIES)))
+        kafka_table_queries = missing(CREATE_KAFKA_TABLE_QUERIES)
         if kafka_table_queries:
             run_clickhouse_statement_in_parallel(kafka_table_queries)
 
-    mv_queries = list(map(build_query, missing(CREATE_MV_TABLE_QUERIES)))
+    mv_queries = missing(CREATE_MV_TABLE_QUERIES)
     if mv_queries:
         run_clickhouse_statement_in_parallel(mv_queries)
 
-    view_queries = list(map(build_query, missing(CREATE_VIEW_QUERIES)))
+    view_queries = missing(CREATE_VIEW_QUERIES)
     if view_queries:
         run_clickhouse_statement_in_parallel(view_queries)
 
-    dictionary_queries = list(map(build_query, missing(CREATE_DICTIONARY_QUERIES)))
+    dictionary_queries = missing(CREATE_DICTIONARY_QUERIES)
     if dictionary_queries:
         run_clickhouse_statement_in_parallel(dictionary_queries)
 
@@ -90,6 +95,9 @@ def reset_clickhouse_tables():
     # Truncate clickhouse tables to default before running test
     # Mostly so that test runs locally work correctly
     from posthog.clickhouse.dead_letter_queue import TRUNCATE_DEAD_LETTER_QUEUE_TABLE_SQL
+    from posthog.clickhouse.logs.log_attributes2 import TABLE_NAME as LOG_ATTRIBUTES2_TABLE_NAME
+    from posthog.clickhouse.logs.log_attributes3 import TABLE_NAME as LOG_ATTRIBUTES3_TABLE_NAME
+    from posthog.clickhouse.logs.logs34 import TABLE_NAME as LOGS_TABLE_NAME
     from posthog.clickhouse.plugin_log_entries import TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL
     from posthog.heatmaps.sql import TRUNCATE_HEATMAPS_TABLE_SQL
     from posthog.models.ai.pg_embeddings import TRUNCATE_PG_EMBEDDINGS_TABLE_SQL
@@ -149,6 +157,11 @@ def reset_clickhouse_tables():
         TRUNCATE_HEATMAPS_TABLE_SQL(),
         TRUNCATE_PG_EMBEDDINGS_TABLE_SQL(),
         TRUNCATE_AI_EVENTS_TABLE_SQL(),
+        # Logs data tables (no TRUNCATE_* constants exist for these). Team-scoped rows must
+        # not outlive the Postgres test database, whose team-id sequence restarts every run.
+        f"TRUNCATE TABLE IF EXISTS {LOGS_TABLE_NAME}",
+        f"TRUNCATE TABLE IF EXISTS {LOG_ATTRIBUTES2_TABLE_NAME}",
+        f"TRUNCATE TABLE IF EXISTS {LOG_ATTRIBUTES3_TABLE_NAME}",
     ]
 
     # Drop created Kafka tables because some tests don't expect it.

--- a/products/logs/backend/group_by_query_runner.py
+++ b/products/logs/backend/group_by_query_runner.py
@@ -12,16 +12,20 @@ from posthog.clickhouse.client.connection import Workload
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models.filters.mixins.utils import cached_property
 
-from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunnerMixin
+from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunnerMixin, severity_level_to_expr
 
 if TYPE_CHECKING:
     from posthog.models import User
 
-# Hard byte budget with "throw": a grouped aggregation with partial input would report
-# silently wrong counts, so an over-budget scan must fail loudly (the UI asks the user
-# to narrow the window) rather than return truncated aggregates.
+# Hard byte budgets with "throw": a grouped aggregation with partial input would report
+# silently wrong counts, so an over-budget read must fail loudly (the UI asks the user
+# to narrow the window) rather than return truncated aggregates. The rollup is orders of
+# magnitude smaller than the logs table, so its budget is tighter — a rollup read that
+# approaches it means something pathological, and it should fail fast.
 MAX_READ_BYTES = 10_000_000_000
 MAX_EXECUTION_TIME = 60
+MAX_ROLLUP_READ_BYTES = 5_000_000_000
+MAX_ROLLUP_EXECUTION_TIME = 30
 
 DEFAULT_GROUP_LIMIT = 100
 MAX_GROUP_LIMIT = 500
@@ -42,12 +46,23 @@ ORDER_FIELDS = ("log_count", "error_count", "last_seen")
 class LogsGroupByQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):
     """Aggregates matching logs into groups by one attribute (or top-level field).
 
-    Single scan over the main `logs` table: the attribute maps live on the row
-    (`Map(LowCardinality(String), String)` with bloom-filter key indexes), so grouping
-    needs no join against the exploded `log_attributes` side table. One query returns
-    the top-N groups AND the total distinct-group/log counts, by nesting the GROUP BY
-    in a subquery and collecting `groupArray(N)` + `count()` + `sum()` in the outer
-    select — the same shape LogAttributesQueryRunner uses for its keys-only path.
+    Two query paths, picked per request:
+
+    - Rollup (`log_attributes`, the pre-aggregated attribute table): used whenever every
+      active filter is expressible on it — date range (10-minute buckets), service names,
+      severity (the rollup carries `severity_text` per row), resource fingerprint, and
+      resource-attribute filters (fingerprint subquery, same as facet counts). Orders of
+      magnitude cheaper than scanning `logs`, which keeps wide-window group-bys under the
+      read budget at scale. Trade-off: `last_seen` degrades to 10-minute bucket precision,
+      and attribute keys/values over 256 chars are absent (the rollup MV drops them).
+    - Fallback scan over the main `logs` table: for `column` grouping and for filters the
+      rollup has no dimension for (body search, log-attribute filters, non-severity log
+      filters). The attribute maps live on the row, so grouping needs no join.
+
+    Both paths return the top-N groups AND the total distinct-group/log counts in one
+    query, by nesting the GROUP BY in a subquery and collecting `groupArray(N)` +
+    `count()` + `sum()` in the outer select — the same shape LogAttributesQueryRunner
+    uses for its keys-only path.
 
     The group-by parameters are runner constructor args, not query-model fields, so the
     runner must be invoked via `calculate()` (which the logs API does) — never through
@@ -92,8 +107,8 @@ class LogsGroupByQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryR
     @cached_property
     def settings(self) -> HogQLGlobalSettings:
         return HogQLGlobalSettings(
-            max_execution_time=MAX_EXECUTION_TIME,
-            max_bytes_to_read=MAX_READ_BYTES,
+            max_execution_time=MAX_ROLLUP_EXECUTION_TIME if self._use_rollup else MAX_EXECUTION_TIME,
+            max_bytes_to_read=MAX_ROLLUP_READ_BYTES if self._use_rollup else MAX_READ_BYTES,
             read_overflow_mode="throw",
             timeout_overflow_mode="throw",
         )
@@ -118,20 +133,43 @@ class LogsGroupByQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryR
                 groupArray({limit})((group_value, log_count, error_count, last_seen)) AS groups,
                 count() AS total_groups,
                 sum(log_count) AS total_logs
-            FROM (
-                SELECT
-                    {group_expr} AS group_value,
-                    count() AS log_count,
-                    countIf(lower(severity_text) IN ('error', 'fatal')) AS error_count,
-                    max(timestamp) AS last_seen
-                FROM logs
-                WHERE {where}
-                GROUP BY group_value
-                ORDER BY {order_field} DESC, group_value ASC
-            )
+            FROM {inner}
             """,
             placeholders={
                 "limit": ast.Constant(value=self.group_limit),
+                "inner": self._rollup_subquery() if self._use_rollup else self._logs_subquery(),
+            },
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+    @cached_property
+    def _use_rollup(self) -> bool:
+        # The rollup can only serve the group-by when every active filter maps onto one of
+        # its dimensions; anything it can't express (body search, log-attribute filters,
+        # log filters other than severity_level, pagination cursors) forces the logs scan.
+        if self.group_by_source == "column":
+            return False
+        if self.query.searchTerm or self.query.liveLogsCheckpoint or self.query.after:
+            return False
+        if self._filter_builder.attribute_filters:
+            return False
+        return all(f.key == "severity_level" for f in self._filter_builder.log_filters)
+
+    def _logs_subquery(self) -> ast.SelectQuery:
+        query = parse_select(
+            """
+            SELECT
+                {group_expr} AS group_value,
+                count() AS log_count,
+                countIf(lower(severity_text) IN ('error', 'fatal')) AS error_count,
+                max(timestamp) AS last_seen
+            FROM logs
+            WHERE {where}
+            GROUP BY group_value
+            ORDER BY {order_field} DESC, group_value ASC
+            """,
+            placeholders={
                 # Fresh AST nodes per placeholder — resolution annotates nodes in place.
                 "group_expr": self._group_expr(),
                 "where": self._where(),
@@ -140,6 +178,61 @@ class LogsGroupByQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryR
         )
         assert isinstance(query, ast.SelectQuery)
         return query
+
+    def _rollup_subquery(self) -> ast.SelectQuery:
+        # attribute_count sums to the number of matching log rows, so the group counts and
+        # totals line up with what the logs scan would return (modulo bucket-edge precision).
+        query = parse_select(
+            """
+            SELECT
+                attribute_value AS group_value,
+                sum(attribute_count) AS log_count,
+                sumIf(attribute_count, lower(severity_text) IN ('error', 'fatal')) AS error_count,
+                max(time_bucket) AS last_seen
+            FROM log_attributes
+            WHERE {where}
+            GROUP BY group_value
+            ORDER BY {order_field} DESC, group_value ASC
+            """,
+            placeholders={
+                "where": self._rollup_where(),
+                "order_field": ast.Field(chain=[self.order_groups_by]),
+            },
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+    def _rollup_where(self) -> ast.Expr:
+        context_exprs = self._filter_builder.rollup_context_exprs()
+        exprs: list[ast.Expr] = [
+            # Closed bounds on 10-minute bucket starts: every bucket overlapping the window is
+            # included, so counts can include up to one bucket of out-of-window rows per edge.
+            parse_expr(
+                "time_bucket >= {date_from_start_of_interval} AND time_bucket <= {date_to_start_of_interval}",
+                placeholders=self.attributes_query_date_range.to_placeholders(),
+            ),
+            parse_expr(
+                # _use_rollup excludes the "column" source, so the remaining sources name
+                # their rollup attribute_type directly.
+                "attribute_type = {attribute_type} AND attribute_key = {attribute_key} AND attribute_value != ''",
+                placeholders={
+                    "attribute_type": ast.Constant(value=self.group_by_source),
+                    "attribute_key": ast.Constant(value=self.group_by),
+                },
+            ),
+            *context_exprs,
+        ]
+        if (severity_levels := self._filter_builder.severity_levels_expr()) is not None:
+            exprs.append(severity_levels)
+        # _use_rollup guarantees only severity_level filters remain in log_filters.
+        for log_filter in self._filter_builder.log_filters:
+            exprs.append(severity_level_to_expr(log_filter))
+        if self._filter_builder.resource_attribute_filters or self._filter_builder.resource_attribute_negative_filters:
+            # Only context filters may be pushed into the resource-fingerprint subquery: the
+            # outer attribute_type/attribute_key constraint would contradict the subquery's
+            # own attribute matching and empty it out.
+            exprs.append(self.resource_filter(existing_filters=context_exprs))
+        return ast.And(exprs=exprs)
 
     def _where(self) -> ast.Expr:
         # LogsFilterBuilder.where() filters at day-precision via time_bucket; add explicit

--- a/products/logs/backend/log_facet_values_query_runner.py
+++ b/products/logs/backend/log_facet_values_query_runner.py
@@ -1,9 +1,7 @@
-import datetime as dt
 from functools import cached_property
 from typing import cast
-from zoneinfo import ZoneInfo
 
-from posthog.schema import CachedLogsQueryResponse, IntervalType, LogsQuery
+from posthog.schema import CachedLogsQueryResponse, LogsQuery
 
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
@@ -12,7 +10,6 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
-from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 from products.logs.backend.logs_query_runner import (
     LogsFilterBuilder,
@@ -83,18 +80,6 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
             max_execution_time=30,
             max_bytes_to_read=10_000_000_000,
             read_overflow_mode="throw",
-        )
-
-    @cached_property
-    def _attributes_query_date_range(self) -> QueryDateRange:
-        # log_attributes is bucketed at 10-minute granularity; align bounds to it.
-        return QueryDateRange(
-            date_range=self.query.dateRange,
-            team=self.team,
-            interval=IntervalType.MINUTE,
-            interval_count=10,
-            now=dt.datetime.now(),
-            timezone_info=ZoneInfo("UTC"),
         )
 
     def _calculate(self) -> LogsQueryResponse:
@@ -171,28 +156,7 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
         # past the read cap at scale. The rollup carries severity_text and service_name, so severity
         # levels, service_name and other resource-attribute filters re-scope the counts; body-search
         # and log-attribute filters still aren't in the rollup.
-        date_range = self._attributes_query_date_range
-        where_exprs: list[ast.Expr] = []
-        if self.query.serviceNames:
-            where_exprs.append(
-                parse_expr(
-                    "service_name IN {serviceNames}",
-                    placeholders={
-                        "serviceNames": ast.Tuple(exprs=[ast.Constant(value=str(sn)) for sn in self.query.serviceNames])
-                    },
-                )
-            )
-        if self.query.severityLevels:
-            where_exprs.append(
-                parse_expr(
-                    "severity_text IN {severityLevels}",
-                    placeholders={
-                        "severityLevels": ast.Tuple(
-                            exprs=[ast.Constant(value=str(sl)) for sl in self.query.severityLevels]
-                        )
-                    },
-                )
-            )
+        date_range = self.attributes_query_date_range
         # Cross-filter by other resource attributes, excluding this facet's own key so selecting a
         # value doesn't collapse the facet to that single value.
         filter_builder = LogsFilterBuilder(
@@ -201,6 +165,11 @@ class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQue
             date_range,
             exclude_resource_attribute=self.facet_resource_attribute,
         )
+        where_exprs: list[ast.Expr] = []
+        if (service_names := filter_builder.service_names_expr()) is not None:
+            where_exprs.append(service_names)
+        if (severity_levels := filter_builder.severity_levels_expr()) is not None:
+            where_exprs.append(severity_levels)
         where_exprs.append(filter_builder.resource_filter(existing_filters=where_exprs))
 
         query = parse_select(

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -80,7 +80,7 @@ def _normalise_trace_id_filter(log_filter: LogPropertyFilter) -> None:
         log_filter.value = _trace_id_normalise_to_base64(str(log_filter.value))
 
 
-def _severity_level_to_expr(log_filter: LogPropertyFilter) -> ast.Expr:
+def severity_level_to_expr(log_filter: LogPropertyFilter) -> ast.Expr:
     """Translate a `severity_level` log property filter to a HogQL expression on `severity_text`.
 
     Only equality operators (Exact/IsNot) are exposed in the UI.
@@ -298,6 +298,39 @@ class LogsFilterBuilder:
                 f for f in self.resource_attribute_negative_filters if f.key != self.exclude_resource_attribute
             ]
 
+    def service_names_expr(self) -> ast.Expr | None:
+        if not self.query.serviceNames:
+            return None
+        return parse_expr(
+            "service_name IN {serviceNames}",
+            placeholders={
+                "serviceNames": ast.Tuple(exprs=[ast.Constant(value=str(sn)) for sn in self.query.serviceNames])
+            },
+        )
+
+    def resource_fingerprint_expr(self) -> ast.Expr | None:
+        if not self.query.resourceFingerprint:
+            return None
+        return parse_expr(
+            "resource_fingerprint = {resourceFingerprint}",
+            placeholders={"resourceFingerprint": ast.Constant(value=str(self.query.resourceFingerprint))},
+        )
+
+    def severity_levels_expr(self) -> ast.Expr | None:
+        if not self.query.severityLevels:
+            return None
+        return parse_expr(
+            "severity_text IN {severityLevels}",
+            placeholders={
+                "severityLevels": ast.Tuple(exprs=[ast.Constant(value=str(sl)) for sl in self.query.severityLevels])
+            },
+        )
+
+    def rollup_context_exprs(self) -> list[ast.Expr]:
+        """Filters that hold for any `log_attributes` rollup row, safe to push into the
+        resource-fingerprint subquery as well as the outer WHERE."""
+        return [expr for expr in (self.service_names_expr(), self.resource_fingerprint_expr()) if expr is not None]
+
     def where(self) -> ast.Expr:
         exprs: list[ast.Expr] = []
 
@@ -312,23 +345,11 @@ class LogsFilterBuilder:
             )
         )
 
-        if self.query.serviceNames and self.exclude_facet_field != "service_name":
-            exprs.append(
-                parse_expr(
-                    "service_name IN {serviceNames}",
-                    placeholders={
-                        "serviceNames": ast.Tuple(exprs=[ast.Constant(value=str(sn)) for sn in self.query.serviceNames])
-                    },
-                )
-            )
+        if self.exclude_facet_field != "service_name" and (service_names := self.service_names_expr()) is not None:
+            exprs.append(service_names)
 
-        if self.query.resourceFingerprint:
-            exprs.append(
-                parse_expr(
-                    "resource_fingerprint = {resourceFingerprint}",
-                    placeholders={"resourceFingerprint": ast.Constant(value=str(self.query.resourceFingerprint))},
-                )
-            )
+        if (resource_fingerprint := self.resource_fingerprint_expr()) is not None:
+            exprs.append(resource_fingerprint)
 
         if self.query.filterGroup:
             exprs.append(self.resource_filter(existing_filters=exprs))
@@ -340,7 +361,7 @@ class LogsFilterBuilder:
                 for log_filter in self.log_filters:
                     if log_filter.key == "severity_level":
                         if self.exclude_facet_field != "severity_text":
-                            exprs.append(_severity_level_to_expr(log_filter))
+                            exprs.append(severity_level_to_expr(log_filter))
                         continue
                     if log_filter.key in ("trace_id", "span_id"):
                         log_filter = log_filter.copy(deep=True)
@@ -361,17 +382,8 @@ class LogsFilterBuilder:
             exprs.append(get_lowercase_index_hint(search_filter, team=self.team))
             exprs.append(property_to_expr(search_filter, team=self.team))
 
-        if self.query.severityLevels and self.exclude_facet_field != "severity_text":
-            exprs.append(
-                parse_expr(
-                    "severity_text IN {severityLevels}",
-                    placeholders={
-                        "severityLevels": ast.Tuple(
-                            exprs=[ast.Constant(value=str(sl)) for sl in self.query.severityLevels]
-                        )
-                    },
-                )
-            )
+        if self.exclude_facet_field != "severity_text" and (severity_levels := self.severity_levels_expr()) is not None:
+            exprs.append(severity_levels)
 
         if self.query.liveLogsCheckpoint:
             try:
@@ -529,6 +541,18 @@ class LogsQueryRunnerMixin(QueryRunner):
             now=dt.datetime.now(),
             timezone_info=ZoneInfo("UTC"),
             exact_timerange=True,
+        )
+
+    @cached_property
+    def attributes_query_date_range(self) -> QueryDateRange:
+        # log_attributes is bucketed at 10-minute granularity; align bounds to it.
+        return QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=IntervalType.MINUTE,
+            interval_count=10,
+            now=dt.datetime.now(),
+            timezone_info=ZoneInfo("UTC"),
         )
 
     def where(self) -> ast.Expr:

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -989,7 +989,13 @@ class _LogsGroupByGroupSerializer(serializers.Serializer):
     error_count = serializers.IntegerField(
         help_text='Number of matching logs in this group at severity "error" or "fatal".',
     )
-    last_seen = serializers.CharField(help_text="ISO 8601 timestamp of the most recent matching log in this group.")
+    last_seen = serializers.CharField(
+        help_text=(
+            "ISO 8601 timestamp of the most recent matching log in this group. When the query is "
+            "served from the pre-aggregated attribute rollup (most queries), this has 10-minute "
+            "bucket precision rather than exact row precision."
+        )
+    )
 
 
 class _LogsGroupByResponseSerializer(serializers.Serializer):

--- a/products/logs/backend/test/test_group_by_query_runner.py
+++ b/products/logs/backend/test/test_group_by_query_runner.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
@@ -6,9 +7,22 @@ from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.schema import DateRange, FilterLogicalOperator, LogsQuery, PropertyGroupFilter
+from posthog.schema import (
+    DateRange,
+    FilterLogicalOperator,
+    LogPropertyFilter,
+    LogPropertyFilterType,
+    LogsQuery,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
+    PropertyOperator,
+)
+
+from posthog.hogql import ast
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.logs.log_attributes3 import TABLE_NAME as LOG_ATTRIBUTES3_TABLE_NAME
+from posthog.clickhouse.logs.logs34 import TABLE_NAME as LOGS_TABLE_NAME
 
 from products.logs.backend.group_by_query_runner import LogsGroupByQueryRunner
 
@@ -16,10 +30,31 @@ _FROZEN_NOW = "2026-06-23T13:00:00Z"
 _WINDOW = DateRange(date_from="2026-06-23T12:00:00Z", date_to="2026-06-23T13:00:00Z")
 
 
+def _filter_group(*filters: LogPropertyFilter) -> PropertyGroupFilter:
+    return PropertyGroupFilter(
+        type=FilterLogicalOperator.AND_,
+        values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=list(filters))],
+    )
+
+
+def _log_property_filter(key: str, filter_type: LogPropertyFilterType, value: str) -> LogPropertyFilter:
+    return LogPropertyFilter(key=key, operator=PropertyOperator.EXACT, type=filter_type, value=[value])
+
+
 class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        # Kept ClickHouse databases outlive the Postgres test database, whose team-id
+        # sequence restarts every run — so a previous run's rows can share this run's team
+        # ids. conftest's reset_clickhouse_tables clears these at session teardown; this
+        # covers what it misses (interrupted runs, SKIP_CLICKHOUSE_RESET).
+        sync_execute(f"TRUNCATE TABLE IF EXISTS {LOGS_TABLE_NAME}")
+        sync_execute(f"TRUNCATE TABLE IF EXISTS {LOG_ATTRIBUTES3_TABLE_NAME}")
+
     def _insert(self, rows: list[dict]) -> None:
         sql = "".join(json.dumps({"team_id": self.team.id, **r}) + "\n" for r in rows)
-        sync_execute(f"INSERT INTO logs FORMAT JSONEachRow\n{sql}")
+        sync_execute(f"INSERT INTO logs_distributed FORMAT JSONEachRow\n{sql}")
 
     def _log(
         self,
@@ -44,22 +79,25 @@ class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
             row["resource_attributes"] = resource_attributes
         return row
 
-    def _run(
+    def _runner(
         self,
         group_by: str,
         group_by_source: str = "log",
         order_groups_by: str = "log_count",
         group_limit: int = 100,
         service_names: list[str] | None = None,
-    ) -> dict:
+        severity_levels: list[str] | None = None,
+        search_term: str | None = None,
+        filter_group: PropertyGroupFilter | None = None,
+    ) -> LogsGroupByQueryRunner:
         query = LogsQuery(
             dateRange=_WINDOW,
-            filterGroup=PropertyGroupFilter(type=FilterLogicalOperator.AND_, values=[]),
-            severityLevels=[],
+            filterGroup=filter_group or PropertyGroupFilter(type=FilterLogicalOperator.AND_, values=[]),
+            severityLevels=severity_levels or [],
             serviceNames=service_names or [],
-            searchTerm=None,
+            searchTerm=search_term,
         )
-        runner = LogsGroupByQueryRunner(
+        return LogsGroupByQueryRunner(
             team=self.team,
             query=query,
             group_by=group_by,
@@ -67,7 +105,9 @@ class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
             order_groups_by=order_groups_by,
             group_limit=group_limit,
         )
-        results = runner.calculate().results
+
+    def _run(self, group_by: str, **kwargs: Any) -> dict[str, Any]:
+        results = self._runner(group_by, **kwargs).calculate().results
         assert isinstance(results, dict)
         return results
 
@@ -78,8 +118,8 @@ class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 self._log(attributes={"session_id": "s1"}, severity="info", minute=0),
                 self._log(attributes={"session_id": "s1"}, severity="error", minute=1),
                 self._log(attributes={"session_id": "s1"}, severity="fatal", minute=2),
-                self._log(attributes={"session_id": "s2"}, severity="info", minute=5),
-                self._log(attributes={"session_id": "s2"}, severity="info", minute=6),
+                self._log(attributes={"session_id": "s2"}, severity="info", minute=15),
+                self._log(attributes={"session_id": "s2"}, severity="info", minute=16),
                 # No session_id: must not surface as an empty-valued group.
                 self._log(severity="error", minute=7),
             ]
@@ -91,8 +131,9 @@ class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert results["total_logs"] == 5
         assert results["truncated"] is False
         s1, s2 = results["groups"]
-        assert s1 == {"value": "s1", "log_count": 3, "error_count": 2, "last_seen": "2026-06-23T12:02:00+00:00"}
-        assert s2 == {"value": "s2", "log_count": 2, "error_count": 0, "last_seen": "2026-06-23T12:06:00+00:00"}
+        # last_seen comes from the rollup path here, so it has 10-minute bucket precision.
+        assert s1 == {"value": "s1", "log_count": 3, "error_count": 2, "last_seen": "2026-06-23T12:00:00+00:00"}
+        assert s2 == {"value": "s2", "log_count": 2, "error_count": 0, "last_seen": "2026-06-23T12:10:00+00:00"}
 
     @parameterized.expand(
         [
@@ -143,10 +184,18 @@ class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert [g["value"] for g in by_count["groups"]] == ["noisy", "failing"]
         assert [g["value"] for g in by_errors["groups"]] == ["failing", "noisy"]
 
+    @parameterized.expand(
+        [
+            # Rollup path: bounds must land on the right 10-minute buckets.
+            ("rollup", None),
+            # Logs-scan path: the shared filter builder bounds only time_bucket (day precision);
+            # the runner must add per-row timestamp bounds or same-day rows outside the window
+            # leak into counts.
+            ("logs_scan", "log line"),
+        ]
+    )
     @freeze_time(_FROZEN_NOW)
-    def test_window_bounds_are_row_precise_not_day_precise(self) -> None:
-        # The shared filter builder bounds only time_bucket (day precision); the runner must
-        # add per-row timestamp bounds or same-day rows outside the window leak into counts.
+    def test_window_bounds_exclude_same_day_rows_outside_window(self, _name: str, search_term: str | None) -> None:
         self._insert(
             [
                 self._log(attributes={"session_id": "s1"}, hour=11, minute=30),
@@ -154,7 +203,7 @@ class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ]
         )
 
-        results = self._run("session_id")
+        results = self._run("session_id", search_term=search_term)
 
         assert results["total_logs"] == 1
         assert results["groups"][0]["log_count"] == 1
@@ -171,6 +220,104 @@ class TestGroupByQueryRunner(ClickhouseTestMixin, APIBaseTest):
         results = self._run("session_id", service_names=["api"])
 
         assert [g["value"] for g in results["groups"]] == ["s1"]
+
+    @parameterized.expand(
+        [
+            ("no_filters", {}, "log_attributes"),
+            ("resource_source", {"group_by_source": "resource"}, "log_attributes"),
+            ("severity_levels", {"severity_levels": ["error"]}, "log_attributes"),
+            (
+                "severity_level_log_filter",
+                {
+                    "filter_group": _filter_group(
+                        _log_property_filter("severity_level", LogPropertyFilterType.LOG, "error")
+                    )
+                },
+                "log_attributes",
+            ),
+            (
+                "resource_attribute_filter",
+                {
+                    "filter_group": _filter_group(
+                        _log_property_filter("env", LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE, "prod")
+                    )
+                },
+                "log_attributes",
+            ),
+            ("column_source", {"group_by": "severity_level", "group_by_source": "column"}, "logs"),
+            ("search_term", {"search_term": "boom"}, "logs"),
+            (
+                "log_attribute_filter",
+                {
+                    "filter_group": _filter_group(
+                        _log_property_filter("session_id", LogPropertyFilterType.LOG_ATTRIBUTE, "s1")
+                    )
+                },
+                "logs",
+            ),
+            (
+                "non_severity_log_filter",
+                {"filter_group": _filter_group(_log_property_filter("trace_id", LogPropertyFilterType.LOG, "abc"))},
+                "logs",
+            ),
+        ]
+    )
+    @freeze_time(_FROZEN_NOW)
+    def test_routes_to_rollup_only_when_filters_are_expressible(
+        self, _name: str, kwargs: dict[str, Any], expected_table: str
+    ) -> None:
+        # Routing to the wrong table means silently wrong counts (rollup can't express the
+        # filter) or read-cap failures at scale (logs scan where the rollup would do).
+        runner = self._runner(kwargs.pop("group_by", "session_id"), **kwargs)
+
+        outer = runner.to_query()
+        assert outer.select_from is not None
+        inner = outer.select_from.table
+        assert isinstance(inner, ast.SelectQuery)
+        assert inner.select_from is not None
+        table = inner.select_from.table
+        assert isinstance(table, ast.Field)
+        assert table.chain == [expected_table]
+
+    @freeze_time(_FROZEN_NOW)
+    def test_severity_filter_scopes_rollup_counts(self) -> None:
+        # The rollup path must apply severity predicates via its severity_text dimension;
+        # dropping them would count logs of every severity.
+        self._insert(
+            [
+                self._log(attributes={"session_id": "s1"}, severity="error", minute=0),
+                self._log(attributes={"session_id": "s1"}, severity="info", minute=1),
+                self._log(attributes={"session_id": "s2"}, severity="info", minute=2),
+            ]
+        )
+
+        results = self._run("session_id", severity_levels=["error"])
+
+        assert results["total_logs"] == 1
+        assert results["groups"] == [
+            {"value": "s1", "log_count": 1, "error_count": 1, "last_seen": "2026-06-23T12:00:00+00:00"}
+        ]
+
+    @freeze_time(_FROZEN_NOW)
+    def test_resource_attribute_filter_scopes_rollup_counts(self) -> None:
+        # Resource-attribute filters stay on the rollup path (fingerprint subquery); losing
+        # that wiring would silently ignore the filter and overcount.
+        self._insert(
+            [
+                self._log(attributes={"session_id": "s1"}, resource_attributes={"env": "prod"}),
+                self._log(attributes={"session_id": "s2"}, resource_attributes={"env": "dev"}, minute=1),
+            ]
+        )
+
+        results = self._run(
+            "session_id",
+            filter_group=_filter_group(
+                _log_property_filter("env", LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE, "prod")
+            ),
+        )
+
+        assert [g["value"] for g in results["groups"]] == ["s1"]
+        assert results["total_logs"] == 1
 
     @parameterized.expand(
         [
@@ -204,7 +351,7 @@ class TestGroupByAPI(ClickhouseTestMixin, APIBaseTest):
     @freeze_time(_FROZEN_NOW)
     def test_endpoint_returns_grouped_results(self) -> None:
         sync_execute(
-            "INSERT INTO logs FORMAT JSONEachRow\n"
+            "INSERT INTO logs_distributed FORMAT JSONEachRow\n"
             + json.dumps(
                 {
                     "team_id": self.team.id,

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1134,7 +1134,7 @@ export interface _LogsGroupByGroupApi {
     log_count: number
     /** Number of matching logs in this group at severity "error" or "fatal". */
     error_count: number
-    /** ISO 8601 timestamp of the most recent matching log in this group. */
+    /** ISO 8601 timestamp of the most recent matching log in this group. When the query is served from the pre-aggregated attribute rollup (most queries), this has 10-minute bucket precision rather than exact row precision. */
     last_seen: string
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -63450,7 +63450,7 @@ export namespace Schemas {
       log_count: number;
       /** Number of matching logs in this group at severity "error" or "fatal". */
       error_count: number;
-      /** ISO 8601 timestamp of the most recent matching log in this group. */
+      /** ISO 8601 timestamp of the most recent matching log in this group. When the query is served from the pre-aggregated attribute rollup (most queries), this has 10-minute bucket precision rather than exact row precision. */
       last_seen: string;
     }
 


### PR DESCRIPTION
## Problem

The logs group-by aggregation (`LOGS_GROUP_BY` flag) scans the raw `logs` table for every request under a hard 10 GB read budget with `read_overflow_mode='throw'`.
On wide windows for high-volume teams the scan blows the budget and the query fails outright, so grouping is unusable exactly where it is most useful.

The pre-aggregated `log_attributes` rollup now carries `severity_text` per row (gen 3, cut over in [#70496](https://github.com/PostHog/posthog/pull/70496), exposed to HogQL in [#70635](https://github.com/PostHog/posthog/pull/70635)), which was the missing dimension: group-by responses report per-group error counts and accept severity filters, so the rollup could not serve them before.

## Changes

**Group-by reads the rollup when it can, scans logs when it must** (`products/logs/backend/group_by_query_runner.py`):

```mermaid
flowchart LR
    Q[group-by request] --> E{filters expressible<br/>on the rollup?}
    E -->|date range, services,<br/>severity, resource filters| R[(log_attributes<br/>rollup)]
    E -->|body search, log-attribute or<br/>non-severity log filters,<br/>column grouping| L[(logs<br/>raw scan)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Q phYellow;
    class E phBlue;
    class R,L phGray;
```

- Rollup path: `sum(attribute_count)` for log counts, `sumIf(..., severity IN error/fatal)` for error counts, `max(time_bucket)` for last-seen, resource-attribute filters via the same fingerprint subquery the facet counts use.
- The rollup path runs under a tighter budget (5 GB / 30 s vs the scan's 10 GB / 60 s): the rollup is orders of magnitude smaller than `logs`, so a read approaching the scan budget there means something pathological and should fail fast.
- Fallback path is the existing raw-logs scan, unchanged.
- The shared rollup filter fragments (`service_names_expr`, `severity_levels_expr`, `resource_fingerprint_expr`, `attributes_query_date_range`) move onto `LogsFilterBuilder` / the runner mixin, and the facet-values runner now reuses them instead of hand-rolling the same expressions (second commit).

> [!NOTE]
> On the rollup path `last_seen` has 10-minute bucket precision and window bounds land on bucket edges, the same trade-off resource-attribute facet counts already make (the `last_seen` API field's help_text documents this). Attribute keys/values over 256 chars are absent from the rollup by design (the MV drops them).

**Test-infra hardening** (`posthog/conftest.py`): kept/reused ClickHouse test databases now converge and stay clean.

- `create_clickhouse_tables` re-runs `CREATE OR REPLACE` schema statements even when the table exists, so a kept database picks up distributed-table cutovers (all five such statements in the canonical schema are idempotent repoints).
- The logs data tables join the session-teardown truncate list. The Postgres test database's team-id sequence restarts every run while kept ClickHouse data survives, so a previous run's rollup rows can share the next run's team ids — which made the new group-by tests report phantom groups locally. The group-by test class also truncates at `setUpClass` to cover interrupted runs.

## How did you test this code?

Automated only (I'm an agent, no manual run against a live cluster):

- `products/logs/backend/test/`: group-by (25), facet values (21), and logs query runner suites all green on a fresh ClickHouse test database, twice (the second run is the real test for the cross-run contamination fix).
- New tests, each catching a regression nothing else covers:
  - routing matrix (9 cases): a query with an inexpressible filter served from the rollup returns silently wrong counts, and the reverse reintroduces read-cap failures.
  - severity filter on the rollup path: catches losing the severity predicate or the `severity_text` dimension end to end (MV → rollup → query).
  - resource-attribute filter on the rollup path: catches dropping the fingerprint-subquery wiring, which would silently ignore the filter.
  - window-bounds test parameterized over both paths: bucket-edge bounds on the rollup, per-row timestamp bounds on the scan.
- Adversarial review pass over the diff (routing completeness against every `LogsQuery` field the scan honors, AST-node reuse in the fingerprint subquery, facet-runner refactor equivalence) found no defects; the risky paths were verified by execution against ClickHouse.
- `hogli ci:preflight` clean (OpenAPI/MCP types regenerated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jon asked me (Claude, via PostHog Code) to finish the group-by-over-rollup work on top of the gen-3 rollup cutover ([#70496](https://github.com/PostHog/posthog/pull/70496)).
An earlier iteration of this branch carried the canonical-schema alignment and the HogQL `severity_text` column itself; both merged to master separately, and the branch was rebuilt on current master (hence the force-push).
Skills invoked: /writing-tests.
Decisions along the way: kept the group source `column` and any filter the rollup lacks a dimension for on the raw-scan fallback rather than approximating; only service/fingerprint context filters are pushed into the resource-fingerprint subquery, since the outer `attribute_key` constraint would contradict the subquery's own attribute matching and empty it out; the conftest hardening stays in this PR because the group-by tests are the first to read the rollup with per-test inserts, which is what surfaced the cross-run contamination.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
