### PR TITLE
feat(dashboards): add layout compaction modes

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -422,6 +422,7 @@ export const FEATURE_FLAGS = {
     POSTHOG_AI_QUEUE_MESSAGES_SYSTEM: 'posthog-ai-queue-messages-system', // owner: #team-posthog-ai
     POSTHOG_CODE_BILLING: 'posthog-code-billing', // owner: #team-posthog-code
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
+    PRODUCT_ANALYTICS_DASHBOARD_LAYOUT_COMPACTION: 'product-analytics-dashboard-layout-compaction', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -22,6 +22,7 @@ import { DashboardPlacement, DashboardType, DataColorThemeModel, QueryBasedInsig
 import { teamLogic } from '../teamLogic'
 import { AddInsightToDashboardModal } from './addInsightToDashboardModal/AddInsightToDashboardModal'
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
+import { DashboardCompactionControl } from './DashboardCompactionControl'
 import { DashboardHeader } from './DashboardHeader'
 import { DashboardOverridesBanner } from './DashboardOverridesBanner'
 import { DashboardPublicAccessBanner } from './DashboardPublicAccessBanner'
@@ -140,7 +141,10 @@ function DashboardScene({
                                 DashboardPlacement.ProjectHomepage,
                                 DashboardPlacement.Builtin,
                             ].includes(placement) && (
-                                <DashboardZoomControl layoutZoom={layoutZoom} setLayoutZoom={setLayoutZoom} />
+                                <>
+                                    <DashboardCompactionControl />
+                                    <DashboardZoomControl layoutZoom={layoutZoom} setLayoutZoom={setLayoutZoom} />
+                                </>
                             )}
                     </SceneStickyBar>
 

--- a/frontend/src/scenes/dashboard/DashboardCompactionControl.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCompactionControl.tsx
@@ -2,6 +2,8 @@ import { useActions, useValues } from 'kea'
 
 import { LemonSelect } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
 import { DashboardLayoutCompactType } from '~/types'
 
 import { dashboardLogic } from './dashboardLogic'
@@ -9,8 +11,9 @@ import { dashboardLogic } from './dashboardLogic'
 export function DashboardCompactionControl(): JSX.Element | null {
     const { currentLayoutSize, layoutCompactType } = useValues(dashboardLogic)
     const { setLayoutCompactType } = useActions(dashboardLogic)
+    const layoutCompactionEnabled = useFeatureFlag('PRODUCT_ANALYTICS_DASHBOARD_LAYOUT_COMPACTION')
 
-    if (currentLayoutSize === 'xs') {
+    if (!layoutCompactionEnabled || currentLayoutSize === 'xs') {
         return null
     }
 

--- a/frontend/src/scenes/dashboard/DashboardCompactionControl.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCompactionControl.tsx
@@ -1,0 +1,34 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonSelect } from '@posthog/lemon-ui'
+
+import { DashboardLayoutCompactType } from '~/types'
+
+import { dashboardLogic } from './dashboardLogic'
+
+export function DashboardCompactionControl(): JSX.Element | null {
+    const { currentLayoutSize, layoutCompactType } = useValues(dashboardLogic)
+    const { setLayoutCompactType } = useActions(dashboardLogic)
+
+    if (currentLayoutSize === 'xs') {
+        return null
+    }
+
+    return (
+        <div className="hidden items-center gap-2 text-sm text-muted md:flex">
+            <span>Compaction</span>
+            <LemonSelect<DashboardLayoutCompactType>
+                size="small"
+                value={layoutCompactType}
+                onChange={setLayoutCompactType}
+                options={[
+                    { value: 'vertical', label: 'Vertical' },
+                    { value: 'horizontal', label: 'Horizontal' },
+                    { value: 'wrap', label: 'Wrap' },
+                    { value: 'none', label: 'None' },
+                ]}
+                tooltip="Choose how tiles close gaps in the dashboard layout"
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react'
 import { useActions, useAsyncActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 
@@ -50,7 +51,7 @@ jest.mock('lib/hooks/useResizeObserver', () => ({
 }))
 
 jest.mock('lib/hooks/useFeatureFlag', () => ({
-    useFeatureFlag: () => true,
+    useFeatureFlag: jest.fn(),
 }))
 
 jest.mock('scenes/surveys/hooks/useSurveyLinkedInsights', () => ({
@@ -149,10 +150,12 @@ jest.mock('@posthog/products-dashboards/frontend/components/DashboardWidgetItem/
 const mockedUseValues = useValues as jest.Mock
 const mockedUseActions = useActions as jest.Mock
 const mockedUseAsyncActions = useAsyncActions as jest.Mock
+const mockedUseFeatureFlag = useFeatureFlag as jest.Mock
 
 describe('DashboardItems', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        mockedUseFeatureFlag.mockReturnValue(true)
 
         mockedUseValues.mockImplementation((logic) => {
             if (logic === dashboardLogic) {
@@ -251,6 +254,17 @@ describe('DashboardItems', () => {
         expect(container.querySelector('[data-attr="react-grid-layout"]')).toHaveAttribute(
             'data-compactor',
             'horizontal-compactor'
+        )
+    })
+
+    it('uses vertical compaction when layout compaction modes are disabled', () => {
+        mockedUseFeatureFlag.mockReturnValue(false)
+
+        const { container } = render(<DashboardItems />)
+
+        expect(container.querySelector('[data-attr="react-grid-layout"]')).toHaveAttribute(
+            'data-compactor',
+            'vertical-compactor'
         )
     })
 

--- a/frontend/src/scenes/dashboard/DashboardItems.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.test.tsx
@@ -95,6 +95,9 @@ jest.mock('./items/DashboardTextItem', () => ({
 
 jest.mock('react-grid-layout', () => {
     return {
+        horizontalCompactor: 'horizontal-compactor',
+        noCompactor: 'no-compactor',
+        verticalCompactor: 'vertical-compactor',
         useContainerWidth: () => ({
             width: 1200,
             containerRef: { current: null },
@@ -106,6 +109,7 @@ jest.mock('react-grid-layout', () => {
             margin,
             resizeConfig,
             dragConfig,
+            compactor,
             children,
         }: {
             className: string
@@ -113,6 +117,7 @@ jest.mock('react-grid-layout', () => {
             margin: [number, number]
             resizeConfig: { enabled: boolean }
             dragConfig: { enabled: boolean }
+            compactor: string
             children: any
         }) => (
             <div
@@ -122,6 +127,7 @@ jest.mock('react-grid-layout', () => {
                 data-margin={margin.join(',')}
                 data-resize-enabled={String(resizeConfig.enabled)}
                 data-drag-enabled={String(dragConfig.enabled)}
+                data-compactor={compactor}
             >
                 {children}
             </div>
@@ -130,6 +136,7 @@ jest.mock('react-grid-layout', () => {
 })
 
 jest.mock('react-grid-layout/extras', () => ({
+    wrapCompactor: 'wrap-compactor',
     GridBackground: ({ rowHeight, margin }: { rowHeight: number; margin: [number, number] }) => (
         <div data-attr="grid-background" data-row-height={String(rowHeight)} data-margin={margin.join(',')} />
     ),
@@ -175,6 +182,7 @@ describe('DashboardItems', () => {
                     dataColorThemeId: null,
                     canEditDashboard: true,
                     layoutZoom: 0.75,
+                    layoutCompactType: 'horizontal',
                 }
             }
 
@@ -240,6 +248,10 @@ describe('DashboardItems', () => {
     it('matches snapshot in edit mode with layout zoom enabled', () => {
         const { container } = render(<DashboardItems />)
         expect(container.firstChild).toMatchSnapshot()
+        expect(container.querySelector('[data-attr="react-grid-layout"]')).toHaveAttribute(
+            'data-compactor',
+            'horizontal-compactor'
+        )
     })
 
     it('shows widget tiles on public dashboards', () => {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -19,6 +19,7 @@ import { getDashboardWidgetFetchDisplayError } from '@posthog/products-dashboard
 
 import { InsightCard } from 'lib/components/Cards/InsightCard'
 import { EditModeEdge } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -105,6 +106,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         scrollToBottomSignal,
     } = useValues(dashboardLogic)
     const { layoutZoom = 1, layoutCompactType } = useValues(dashboardLogic)
+    const layoutCompactionEnabled = useFeatureFlag('PRODUCT_ANALYTICS_DASHBOARD_LAYOUT_COMPACTION')
     const {
         updateLayouts,
         updateContainerWidth,
@@ -509,7 +511,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                         onWidthChange={handleWidthChange}
                         breakpoints={BREAKPOINTS}
                         cols={BREAKPOINT_COLUMN_COUNTS}
-                        compactor={LAYOUT_COMPACTORS[layoutCompactType]}
+                        compactor={layoutCompactionEnabled ? LAYOUT_COMPACTORS[layoutCompactType] : verticalCompactor}
                         onResizeStart={handleResizeStart}
                         onResize={handleResize}
                         onResizeStop={handleResizeStop}

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -4,8 +4,15 @@ import clsx from 'clsx'
 import { useActions, useAsyncActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { RefObject, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Layout, Responsive as ReactGridLayout, useContainerWidth } from 'react-grid-layout'
-import { GridBackground } from 'react-grid-layout/extras'
+import {
+    horizontalCompactor,
+    Layout,
+    noCompactor,
+    Responsive as ReactGridLayout,
+    useContainerWidth,
+    verticalCompactor,
+} from 'react-grid-layout'
+import { GridBackground, wrapCompactor } from 'react-grid-layout/extras'
 
 import { DashboardWidgetItem } from '@posthog/products-dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem'
 import { getDashboardWidgetFetchDisplayError } from '@posthog/products-dashboards/frontend/widgets/constants'
@@ -39,6 +46,12 @@ const DRAG_AUTO_SCROLL_SPEED = 50
 const BASE_ROW_HEIGHT = 80
 const BASE_MARGIN: [number, number] = [16, 16]
 const CONTAINER_PADDING: [number, number] = [0, 0]
+const LAYOUT_COMPACTORS = {
+    vertical: verticalCompactor,
+    horizontal: horizontalCompactor,
+    wrap: wrapCompactor,
+    none: noCompactor,
+}
 
 interface DashboardItemsProps {
     showCreateAnomalyAlertButton?: boolean
@@ -91,7 +104,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         widgetRefreshStatus,
         scrollToBottomSignal,
     } = useValues(dashboardLogic)
-    const { layoutZoom = 1 } = useValues(dashboardLogic)
+    const { layoutZoom = 1, layoutCompactType } = useValues(dashboardLogic)
     const {
         updateLayouts,
         updateContainerWidth,
@@ -496,6 +509,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                         onWidthChange={handleWidthChange}
                         breakpoints={BREAKPOINTS}
                         cols={BREAKPOINT_COLUMN_COUNTS}
+                        compactor={LAYOUT_COMPACTORS[layoutCompactType]}
                         onResizeStart={handleResizeStart}
                         onResize={handleResize}
                         onResizeStop={handleResizeStop}

--- a/frontend/src/scenes/dashboard/DashboardZoomControl.tsx
+++ b/frontend/src/scenes/dashboard/DashboardZoomControl.tsx
@@ -1,12 +1,10 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 
-import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Scene } from 'scenes/sceneTypes'
-
-import { DashboardLayoutCompactType } from '~/types'
 
 import { dashboardLogic } from './dashboardLogic'
 
@@ -16,28 +14,14 @@ interface DashboardZoomControlProps {
 }
 
 export function DashboardZoomControl({ layoutZoom, setLayoutZoom }: DashboardZoomControlProps): JSX.Element | null {
-    const { dashboard, currentLayoutSize, layoutCompactType } = useValues(dashboardLogic)
-    const { setLayoutCompactType } = useActions(dashboardLogic)
+    const { dashboard, currentLayoutSize } = useValues(dashboardLogic)
 
     if (currentLayoutSize === 'xs') {
         return null
     }
 
     return (
-        <div className="flex items-center gap-2 text-sm text-muted hidden md:flex">
-            <span>Compaction</span>
-            <LemonSelect<DashboardLayoutCompactType>
-                size="small"
-                value={layoutCompactType}
-                onChange={setLayoutCompactType}
-                options={[
-                    { value: 'vertical', label: 'Vertical' },
-                    { value: 'horizontal', label: 'Horizontal' },
-                    { value: 'wrap', label: 'Wrap' },
-                    { value: 'none', label: 'None' },
-                ]}
-                tooltip="Choose how tiles close gaps in the dashboard layout"
-            />
+        <div className="hidden md:flex">
             <Shortcut
                 name="DashboardLayoutZoomToggle"
                 keybind={[['z']]}

--- a/frontend/src/scenes/dashboard/DashboardZoomControl.tsx
+++ b/frontend/src/scenes/dashboard/DashboardZoomControl.tsx
@@ -1,10 +1,12 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
 
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Scene } from 'scenes/sceneTypes'
+
+import { DashboardLayoutCompactType } from '~/types'
 
 import { dashboardLogic } from './dashboardLogic'
 
@@ -14,7 +16,8 @@ interface DashboardZoomControlProps {
 }
 
 export function DashboardZoomControl({ layoutZoom, setLayoutZoom }: DashboardZoomControlProps): JSX.Element | null {
-    const { dashboard, currentLayoutSize } = useValues(dashboardLogic)
+    const { dashboard, currentLayoutSize, layoutCompactType } = useValues(dashboardLogic)
+    const { setLayoutCompactType } = useActions(dashboardLogic)
 
     if (currentLayoutSize === 'xs') {
         return null
@@ -22,6 +25,19 @@ export function DashboardZoomControl({ layoutZoom, setLayoutZoom }: DashboardZoo
 
     return (
         <div className="flex items-center gap-2 text-sm text-muted hidden md:flex">
+            <span>Compaction</span>
+            <LemonSelect<DashboardLayoutCompactType>
+                size="small"
+                value={layoutCompactType}
+                onChange={setLayoutCompactType}
+                options={[
+                    { value: 'vertical', label: 'Vertical' },
+                    { value: 'horizontal', label: 'Horizontal' },
+                    { value: 'wrap', label: 'Wrap' },
+                    { value: 'none', label: 'None' },
+                ]}
+                tooltip="Choose how tiles close gaps in the dashboard layout"
+            />
             <Shortcut
                 name="DashboardLayoutZoomToggle"
                 keybind={[['z']]}

--- a/frontend/src/scenes/dashboard/__snapshots__/DashboardItems.test.tsx.snap
+++ b/frontend/src/scenes/dashboard/__snapshots__/DashboardItems.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`DashboardItems matches snapshot in edit mode with layout zoom enabled 1
     <div
       data-attr="react-grid-layout"
       data-class-name="dashboard-edit-mode box-content pb-[40vh]"
+      data-compactor="horizontal-compactor"
       data-drag-enabled="true"
       data-margin="14.4,14.4"
       data-resize-enabled="false"

--- a/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
+++ b/frontend/src/scenes/dashboard/dashboardActivityDescriber.tsx
@@ -157,6 +157,7 @@ const dashboardActionsMapping: Record<
     tiles: () => null,
     last_viewed_at: () => null,
     quick_filter_ids: () => null,
+    layout_compact_type: () => null,
 }
 
 export function dashboardActivityDescriber(logItem: ActivityLogItem, asNotification?: boolean): HumanizedChange {

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -451,6 +451,27 @@ describe('dashboardLogic', () => {
             )
         })
 
+        it('saving after compaction change calls api', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setLayoutCompactType('horizontal')
+            }).toFinishAllListeners()
+
+            jest.spyOn(api, 'update')
+
+            await expectLogic(logic, () => {
+                logic.actions.saveEditModeChanges()
+            }).toFinishAllListeners()
+
+            expect(api.update).toHaveBeenCalledWith(
+                `api/environments/${MOCK_TEAM_ID}/dashboards/5`,
+                expect.objectContaining({
+                    layout_compact_type: 'horizontal',
+                })
+            )
+        })
+
         it('confirms a real save with a success toast', async () => {
             await expectLogic(logic).toFinishAllListeners()
 
@@ -520,6 +541,20 @@ describe('dashboardLogic', () => {
 
             const restoredTileLayouts = logic.values.dashboard?.tiles.find((t) => t.id === firstTile.id)?.layouts
             expect(restoredTileLayouts).toEqual(originalLayouts)
+        })
+
+        it('discarding edit mode restores the compaction setting', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setLayoutCompactType('none')
+            }).toMatchValues({ layoutCompactType: 'none' })
+
+            await expectLogic(logic, () => {
+                logic.actions.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ layoutCompactType: 'vertical' })
         })
 
         describe('layoutEditMode', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -92,6 +92,7 @@ import {
     Breadcrumb,
     DashboardLayoutSize,
     DashboardMode,
+    DashboardLayoutCompactType,
     DashboardPlacement,
     DashboardTemplateEditorType,
     DashboardTile,
@@ -381,6 +382,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         cancelEditMode: true,
         /** Make it easier to handle organizing the layout when theres lots of tiles by zooming out */
         setLayoutZoom: (layoutZoom: number) => ({ layoutZoom }),
+        setLayoutCompactType: (layoutCompactType: DashboardLayoutCompactType) => ({ layoutCompactType }),
         /** Optimistic pin/unpin toggle. */
         togglePinned: true,
         /** Open/close the Terraform export modal. */
@@ -530,6 +532,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         const persistedVariables = currentDashboard.persisted_variables || {}
                         const persistedBreakdownColors = currentDashboard.breakdown_colors || []
                         const persistedThemeId = currentDashboard.data_color_theme_id ?? null
+                        const persistedLayoutCompactType = currentDashboard.layout_compact_type ?? 'vertical'
 
                         const filtersChanged = !equal(persistedFilters, values.effectiveEditBarFilters || {})
                         const variablesChanged = !equal(
@@ -541,6 +544,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             values.temporaryBreakdownColors || []
                         )
                         const themeChanged = (values.dataColorThemeId ?? null) !== persistedThemeId
+                        const layoutCompactTypeChanged = values.layoutCompactType !== persistedLayoutCompactType
 
                         const layoutsChanged = (currentDashboard.tiles || []).some((tile) => {
                             const originalLayouts = values.dashboardLayouts?.[tile.id]?.sm
@@ -553,6 +557,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             !variablesChanged &&
                             !breakdownColorsChanged &&
                             !themeChanged &&
+                            !layoutCompactTypeChanged &&
                             !layoutsChanged
                         ) {
                             actions.resetUrlFilters()
@@ -573,6 +578,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                                 variables: values.effectiveDashboardVariableOverrides,
                                 breakdown_colors: values.temporaryBreakdownColors,
                                 data_color_theme_id: values.dataColorThemeId,
+                                layout_compact_type: values.layoutCompactType,
                                 tiles: layoutsToUpdate,
                             }
                         )
@@ -1134,6 +1140,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 },
             },
         ],
+        layoutCompactType: [
+            'vertical' as DashboardLayoutCompactType,
+            {
+                loadDashboardSuccess: (_, { dashboard }) => dashboard?.layout_compact_type ?? 'vertical',
+                loadDashboardMetadataSuccess: (_, { dashboard }) => dashboard?.layout_compact_type ?? 'vertical',
+                saveEditModeChangesSuccess: (_, { dashboard }) => dashboard?.layout_compact_type ?? 'vertical',
+                setLayoutCompactType: (_, { layoutCompactType }) => layoutCompactType,
+            },
+        ],
         pendingInsertion: [
             null as PendingInsertion | null,
             {
@@ -1534,13 +1549,17 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (dashboard, urlVariables) => ({ ...dashboard?.persisted_variables, ...urlVariables }),
         ],
         hasUnsavedLayoutChanges: [
-            (s) => [s.dashboard, s.dashboardLayouts],
+            (s) => [s.dashboard, s.dashboardLayouts, s.layoutCompactType],
             (
                 dashboard: DashboardType<QueryBasedInsightModel> | null,
-                dashboardLayouts: Record<DashboardTile['id'], DashboardTile['layouts']>
+                dashboardLayouts: Record<DashboardTile['id'], DashboardTile['layouts']>,
+                layoutCompactType: DashboardLayoutCompactType
             ): boolean => {
                 if (!dashboard) {
                     return false
+                }
+                if (layoutCompactType !== (dashboard.layout_compact_type ?? 'vertical')) {
+                    return true
                 }
                 return (dashboard.tiles || []).some((tile: DashboardTile<QueryBasedInsightModel>) => {
                     const originalSm = dashboardLayouts?.[tile.id]?.sm
@@ -2866,9 +2885,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
             eventUsageLogic.actions.reportDashboardEditModeDiscardPrompt(values.dashboard, 'shown')
             LemonDialog.open({
-                title: 'Discard layout changes?',
+                title: 'Discard dashboard changes?',
                 description:
-                    'You have moved tiles around but not saved. If you discard now, the layout will revert to its last saved state.',
+                    'You have unsaved dashboard layout changes. If you discard now, the layout will revert to its last saved state.',
                 primaryButton: {
                     children: 'Discard changes',
                     status: 'danger',
@@ -2907,6 +2926,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 clearDOMTextSelection()
                 lemonToast.info('Now editing the dashboard – press E or click Save to persist changes')
             } else if (source === DashboardEventSource.DashboardHeaderDiscardChanges) {
+                actions.setLayoutCompactType(values.dashboard?.layout_compact_type ?? 'vertical')
                 // reset filters to that before previewing
                 actions.resetIntermittentFilters()
                 actions.restoreUrlStateAtEditModeEntry(values.urlSearchParamsAtEditModeEntry)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2621,6 +2621,7 @@ export type DashboardTemplateScope = 'team' | 'global' | 'feature_flag' | 'organ
 
 export interface DashboardType<T = InsightModel> extends DashboardBasicType {
     tiles: DashboardTile<T>[]
+    layout_compact_type?: DashboardLayoutCompactType
     filters: DashboardFilter
     variables?: Record<string, HogQLVariable>
     persisted_filters?: DashboardFilter | null
@@ -2735,6 +2736,7 @@ export interface DashboardTemplateVariableType {
 }
 
 export type DashboardLayoutSize = 'sm' | 'xs'
+export type DashboardLayoutCompactType = 'vertical' | 'horizontal' | 'wrap' | 'none'
 
 export interface OrganizationInviteType {
     id: string

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -550,6 +550,34 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         dashboard.refresh_from_db()
         self.assertEqual(dashboard.name, "dashboard new name")
 
+    @parameterized.expand(
+        [
+            ("vertical",),
+            ("horizontal",),
+            ("wrap",),
+            ("none",),
+        ]
+    )
+    def test_update_dashboard_layout_compact_type(self, layout_compact_type: str) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="dashboard", created_by=self.user)
+
+        _, response_data = self.dashboard_api.update_dashboard(
+            dashboard.pk, {"layout_compact_type": layout_compact_type}
+        )
+
+        assert response_data["layout_compact_type"] == layout_compact_type
+        dashboard.refresh_from_db()
+        assert dashboard.layout_compact_type == layout_compact_type
+
+    def test_cannot_update_dashboard_with_invalid_layout_compact_type(self) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="dashboard", created_by=self.user)
+
+        self.dashboard_api.update_dashboard(
+            dashboard.pk,
+            {"layout_compact_type": "diagonal"},
+            expected_status=status.HTTP_400_BAD_REQUEST,
+        )
+
     def test_cannot_update_dashboard_with_invalid_filters(self):
         dashboard = Dashboard.objects.create(
             team=self.team,
@@ -1705,6 +1733,20 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
 
         original_text_tile = next(t for t in dashboard_with_tiles["tiles"] if t.get("text"))
         assert text_tile["text"]["id"] == original_text_tile["text"]["id"]
+
+    def test_dashboard_duplication_copies_layout_compact_type(self) -> None:
+        existing_dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="existing dashboard",
+            created_by=self.user,
+            layout_compact_type=Dashboard.LayoutCompactType.HORIZONTAL,
+        )
+
+        _, duplicate_response = self.dashboard_api.create_dashboard(
+            {"name": "duplicate", "use_dashboard": existing_dashboard.id}
+        )
+
+        assert duplicate_response["layout_compact_type"] == Dashboard.LayoutCompactType.HORIZONTAL
 
     def test_dashboard_duplication_without_tile_duplicate_excludes_soft_deleted_tiles(self):
         existing_dashboard = Dashboard.objects.create(team=self.team, name="existing dashboard", created_by=self.user)

--- a/posthog/api/test/dashboards/test_dashboard_delete_tile.py
+++ b/posthog/api/test/dashboards/test_dashboard_delete_tile.py
@@ -8,6 +8,7 @@ from rest_framework import status
 
 from posthog.api.test.dashboards import DashboardAPI
 
+from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
 
@@ -181,6 +182,40 @@ class TestDashboardDeleteTile(APIBaseTest):
         assert left_top.layouts["sm"] == {"x": 0, "y": 0, "w": 6, "h": 5}
         assert right_top.layouts["sm"] == {"x": 6, "y": 0, "w": 6, "h": 5}
         assert right_gapped.layouts["sm"] == {"x": 6, "y": 5, "w": 6, "h": 5}
+
+    def test_delete_tile_compacts_horizontally(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard(
+            {"name": "dashboard", "layout_compact_type": Dashboard.LayoutCompactType.HORIZONTAL}
+        )
+        _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="left")
+        _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="middle")
+        _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="right")
+
+        tile_ids = [tile["id"] for tile in dashboard_json["tiles"]]
+        for index, tile_id in enumerate(tile_ids):
+            DashboardTile.objects.filter(id=tile_id).update(layouts={"sm": {"x": index * 3, "y": 0, "w": 3, "h": 5}})
+
+        self._delete_tile(dashboard_id, tile_ids[1])
+
+        right = DashboardTile.objects.get(id=tile_ids[2])
+        assert right.layouts["sm"] == {"x": 3, "y": 0, "w": 3, "h": 5}
+
+    def test_delete_tile_does_not_compact_when_disabled(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard(
+            {"name": "dashboard", "layout_compact_type": Dashboard.LayoutCompactType.NONE}
+        )
+        _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="top")
+        _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="middle")
+        _, dashboard_json = self.dashboard_api.create_text_tile(dashboard_id, text="bottom")
+
+        tile_ids = [tile["id"] for tile in dashboard_json["tiles"]]
+        for index, tile_id in enumerate(tile_ids):
+            DashboardTile.objects.filter(id=tile_id).update(layouts={"sm": {"x": 0, "y": index * 5, "w": 6, "h": 5}})
+
+        self._delete_tile(dashboard_id, tile_ids[1])
+
+        bottom = DashboardTile.objects.get(id=tile_ids[2])
+        assert bottom.layouts["sm"] == {"x": 0, "y": 10, "w": 6, "h": 5}
 
     def test_delete_tile_leaves_tiles_without_layouts_alone(self) -> None:
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -167,6 +167,7 @@ DASHBOARD_SHARED_FIELDS = [
     "persisted_variables",
     "team_id",
     "quick_filter_ids",
+    "layout_compact_type",
 ]
 
 
@@ -251,12 +252,10 @@ def _tile_rects_overlap(rect_a: dict[str, int], rect_b: dict[str, int]) -> bool:
     )
 
 
-def _compact_tile_layouts(tiles: list[DashboardTile]) -> set[int]:
-    """Vertically compact tile layouts in place, mirroring the dashboard grid's default
-    react-grid-layout vertical compaction (gravity up). Each breakpoint is compacted
-    independently: tiles keep their x/w/h and are pulled up to the lowest free row.
-    Returns the ids of tiles whose layouts changed.
-    """
+def _compact_tile_layouts(tiles: list[DashboardTile], compact_type: Dashboard.LayoutCompactType) -> set[int]:
+    if compact_type in {Dashboard.LayoutCompactType.NONE, Dashboard.LayoutCompactType.WRAP}:
+        return set()
+
     for tile in tiles:
         if isinstance(tile.layouts, str):
             tile.layouts = json.loads(tile.layouts)
@@ -272,20 +271,30 @@ def _compact_tile_layouts(tiles: list[DashboardTile]) -> set[int]:
             tile for tile in tiles if isinstance(tile.layouts, dict) and isinstance(tile.layouts.get(breakpoint), dict)
         ]
         placed: list[dict[str, int]] = []
-        for tile in DashboardTile.sort_tiles_by_layout(entries, breakpoint):
+        sorted_entries = DashboardTile.sort_tiles_by_layout(entries, breakpoint)
+        if compact_type == Dashboard.LayoutCompactType.HORIZONTAL:
+            sorted_entries = sorted(
+                entries,
+                key=lambda tile: (
+                    tile.layouts[breakpoint].get("x", 0),
+                    tile.layouts[breakpoint].get("y", 0),
+                ),
+            )
+
+        for tile in sorted_entries:
             layout = tile.layouts[breakpoint]
             rect = {"x": layout.get("x", 0), "y": layout.get("y", 0), "w": layout.get("w", 1), "h": layout.get("h", 1)}
-            # Drop the tile to the lowest free row. Jump past colliding tiles rather than
-            # scanning row-by-row, so an editor-supplied giant height can't blow up the loop.
-            new_y = 0
+            compact_axis = "x" if compact_type == Dashboard.LayoutCompactType.HORIZONTAL else "y"
+            size_axis = "w" if compact_axis == "x" else "h"
+            new_position = 0
             while True:
-                collisions = [pr for pr in placed if _tile_rects_overlap({**rect, "y": new_y}, pr)]
+                collisions = [pr for pr in placed if _tile_rects_overlap({**rect, compact_axis: new_position}, pr)]
                 if not collisions:
                     break
-                new_y = max(pr["y"] + pr["h"] for pr in collisions)
-            placed.append({**rect, "y": new_y})
-            if new_y != layout.get("y", 0):
-                layout["y"] = new_y
+                new_position = max(pr[compact_axis] + pr[size_axis] for pr in collisions)
+            placed.append({**rect, compact_axis: new_position})
+            if new_position != layout.get(compact_axis, 0):
+                layout[compact_axis] = new_position
                 changed.add(tile.id)
 
     return changed
@@ -1313,6 +1322,9 @@ class DashboardSerializer(DashboardMetadataSerializer):
             validated_data["quick_filter_ids"] = self._filter_out_non_existing_quick_filter_ids(
                 existing_dashboard.quick_filter_ids, team_id
             )
+
+        if existing_dashboard and "layout_compact_type" not in validated_data:
+            validated_data["layout_compact_type"] = existing_dashboard.layout_compact_type
 
         dashboard = Dashboard.objects.create(team_id=team_id, filters=filters, **validated_data)
 
@@ -2698,7 +2710,7 @@ class DashboardsViewSet(
             tile.save(update_fields=["deleted"])
 
             remaining = list(DashboardTile.objects.filter(dashboard=dashboard))
-            changed_ids = _compact_tile_layouts(remaining)
+            changed_ids = _compact_tile_layouts(remaining, Dashboard.LayoutCompactType(dashboard.layout_compact_type))
             if changed_ids:
                 DashboardTile.objects.bulk_update(
                     [remaining_tile for remaining_tile in remaining if remaining_tile.id in changed_ids],

--- a/products/dashboards/backend/migrations/0015_dashboard_layout_compact_type.py
+++ b/products/dashboards/backend/migrations/0015_dashboard_layout_compact_type.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboards", "0014_backfill_dashboardtemplate_button_tile_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="dashboard",
+            name="layout_compact_type",
+            field=models.CharField(
+                choices=[
+                    ("vertical", "Vertical"),
+                    ("horizontal", "Horizontal"),
+                    ("wrap", "Wrap"),
+                    ("none", "None"),
+                ],
+                default="vertical",
+                help_text="How dashboard tiles close gaps in the grid layout.",
+                max_length=10,
+            ),
+        ),
+    ]

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0014_backfill_dashboardtemplate_button_tile_type
+0015_dashboard_layout_compact_type

--- a/products/dashboards/backend/models/dashboard.py
+++ b/products/dashboards/backend/models/dashboard.py
@@ -21,6 +21,12 @@ class DashboardManager(RootTeamManager):
 
 
 class Dashboard(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.Model):
+    class LayoutCompactType(models.TextChoices):
+        VERTICAL = "vertical", "Vertical"
+        HORIZONTAL = "horizontal", "Horizontal"
+        WRAP = "wrap", "Wrap"
+        NONE = "none", "None"
+
     class CreationMode(models.TextChoices):
         DEFAULT = "default", "Default"
         TEMPLATE = (
@@ -78,6 +84,12 @@ class Dashboard(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.M
         "product_analytics.Insight", related_name="dashboards", through="DashboardTile", blank=True
     )  # type: models.ManyToManyField
     quick_filter_ids = models.JSONField(default=list, blank=True, null=True)
+    layout_compact_type = models.CharField(
+        max_length=10,
+        choices=LayoutCompactType,
+        default=LayoutCompactType.VERTICAL,
+        help_text="How dashboard tiles close gaps in the grid layout.",
+    )
 
     # Deprecated in favour of app-wide tagging model. See EnterpriseTaggedItem
     deprecated_tags: ArrayField = ArrayField(models.CharField(max_length=32), null=True, blank=True, default=list)

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -308,6 +308,21 @@ export type DashboardApiPersistedVariables = { [key: string]: unknown } | null
 export type DashboardApiTilesItem = { [key: string]: unknown }
 
 /**
+ * * `vertical` - Vertical
+ * * `horizontal` - Horizontal
+ * * `wrap` - Wrap
+ * * `none` - None
+ */
+export type LayoutCompactTypeEnumApi = (typeof LayoutCompactTypeEnumApi)[keyof typeof LayoutCompactTypeEnumApi]
+
+export const LayoutCompactTypeEnumApi = {
+    Vertical: 'vertical',
+    Horizontal: 'horizontal',
+    Wrap: 'wrap',
+    None: 'none',
+} as const
+
+/**
  * Serializer mixin that handles tags for objects.
  */
 export interface DashboardApi {
@@ -365,6 +380,13 @@ export interface DashboardApi {
      * @nullable
      */
     quick_filter_ids?: string[] | null
+    /** How dashboard tiles close gaps in the grid layout.
+     *
+     * * `vertical` - Vertical
+     * * `horizontal` - Horizontal
+     * * `wrap` - Wrap
+     * * `none` - None */
+    layout_compact_type?: LayoutCompactTypeEnumApi
     /** @nullable */
     readonly tiles: readonly DashboardApiTilesItem[] | null
     /** Template key to create the dashboard from a predefined template. */

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -154,6 +154,13 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
             .array(zod.string())
             .nullish()
             .describe('List of quick filter IDs associated with this dashboard'),
+        layout_compact_type: zod
+            .enum(['vertical', 'horizontal', 'wrap', 'none'])
+            .describe('\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None')
+            .optional()
+            .describe(
+                'How dashboard tiles close gaps in the grid layout.\n\n\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None'
+            ),
         use_template: zod
             .string()
             .optional()
@@ -201,6 +208,13 @@ export const DashboardsUpdateBody = /* @__PURE__ */ zod
             .array(zod.string())
             .nullish()
             .describe('List of quick filter IDs associated with this dashboard'),
+        layout_compact_type: zod
+            .enum(['vertical', 'horizontal', 'wrap', 'none'])
+            .describe('\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None')
+            .optional()
+            .describe(
+                'How dashboard tiles close gaps in the grid layout.\n\n\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None'
+            ),
         use_template: zod
             .string()
             .optional()
@@ -2621,6 +2635,13 @@ export const DashboardsCreateFromTemplateJsonCreateBody = /* @__PURE__ */ zod
             .array(zod.string())
             .nullish()
             .describe('List of quick filter IDs associated with this dashboard'),
+        layout_compact_type: zod
+            .enum(['vertical', 'horizontal', 'wrap', 'none'])
+            .describe('\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None')
+            .optional()
+            .describe(
+                'How dashboard tiles close gaps in the grid layout.\n\n\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None'
+            ),
         use_template: zod
             .string()
             .optional()
@@ -2664,6 +2685,13 @@ export const DashboardsCreateUnlistedDashboardCreateBody = /* @__PURE__ */ zod
             .array(zod.string())
             .nullish()
             .describe('List of quick filter IDs associated with this dashboard'),
+        layout_compact_type: zod
+            .enum(['vertical', 'horizontal', 'wrap', 'none'])
+            .describe('\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None')
+            .optional()
+            .describe(
+                'How dashboard tiles close gaps in the grid layout.\n\n\* `vertical` - Vertical\n\* `horizontal` - Horizontal\n\* `wrap` - Wrap\n\* `none` - None'
+            ),
         use_template: zod
             .string()
             .optional()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15312,6 +15312,22 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `vertical` - Vertical
+     * * `horizontal` - Horizontal
+     * * `wrap` - Wrap
+     * * `none` - None
+     */
+    export type LayoutCompactTypeEnum = typeof LayoutCompactTypeEnum[keyof typeof LayoutCompactTypeEnum];
+
+
+    export const LayoutCompactTypeEnum = {
+      Vertical: 'vertical',
+      Horizontal: 'horizontal',
+      Wrap: 'wrap',
+      None: 'none',
+    } as const;
+
+    /**
      * Serializer mixin that handles tags for objects.
      */
     export interface Dashboard {
@@ -15369,6 +15385,13 @@ export namespace Schemas {
          * @nullable
          */
       quick_filter_ids?: string[] | null;
+      /** How dashboard tiles close gaps in the grid layout.
+       *
+       * * `vertical` - Vertical
+       * * `horizontal` - Horizontal
+       * * `wrap` - Wrap
+       * * `none` - None */
+      layout_compact_type?: LayoutCompactTypeEnum;
       /** @nullable */
       readonly tiles: readonly DashboardTilesItem[] | null;
       /** Template key to create the dashboard from a predefined template. */

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -68,6 +68,13 @@ export const DashboardsCreateBody = /* @__PURE__ */ zod
             .array(zod.string())
             .nullish()
             .describe('List of quick filter IDs associated with this dashboard'),
+        layout_compact_type: zod
+            .enum(['vertical', 'horizontal', 'wrap', 'none'])
+            .describe('* `vertical` - Vertical\n* `horizontal` - Horizontal\n* `wrap` - Wrap\n* `none` - None')
+            .optional()
+            .describe(
+                'How dashboard tiles close gaps in the grid layout.\n\n* `vertical` - Vertical\n* `horizontal` - Horizontal\n* `wrap` - Wrap\n* `none` - None'
+            ),
         use_template: zod
             .string()
             .optional()

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -67,6 +67,9 @@ const dashboardCreate = (): ToolBase<typeof DashboardCreateSchema, WithPostHogUr
         if (params.quick_filter_ids !== undefined) {
             body['quick_filter_ids'] = params.quick_filter_ids
         }
+        if (params.layout_compact_type !== undefined) {
+            body['layout_compact_type'] = params.layout_compact_type
+        }
         if (params.use_template !== undefined) {
             body['use_template'] = params.use_template
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create.json
@@ -24,6 +24,11 @@
         "description": {
             "type": "string"
         },
+        "layout_compact_type": {
+            "description": "How dashboard tiles close gaps in the grid layout.\n\n* `vertical` - Vertical\n* `horizontal` - Horizontal\n* `wrap` - Wrap\n* `none` - None",
+            "enum": ["vertical", "horizontal", "wrap", "none"],
+            "type": "string"
+        },
         "name": {
             "anyOf": [
                 {


### PR DESCRIPTION
## Problem

**Why:** Dashboard layouts currently always use vertical compaction. Users need control over how tiles close gaps when arranging a dashboard, with a safe rollout path.

## Changes

- Add vertical, horizontal, wrap, and no-compaction dashboard modes
- Gate the selector and non-default behavior behind `product-analytics-dashboard-layout-compaction`
- Persist the setting through dashboard APIs, duplication, generated types, and MCP schemas

No screenshot included because the local dev stack was unavailable.

## How did you test this code?

- Added frontend coverage for enabled and disabled compaction behavior
- Existing logic and API tests cover save, discard, validation, and duplication
- `git diff --check` passes
- Formatter, TypeScript, and focused Jest reruns are blocked because this checkout has no flox environment or `node_modules`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No matching dashboard layout documentation exists. The setting is labeled in the dashboard edit controls.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Added an inactive client-side rollout flag and gated both the control and effective compactor. Used `/instrument-feature-flags` and `/writing-tests` for this update.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
