### PR TITLE
feat(heatmaps): surface a notice when an iframe heatmap is height-capped

### DIFF
--- a/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
+++ b/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
@@ -35,6 +35,10 @@ import type { heatmapDataLogicType } from './heatmapDataLogicType'
 // The endpoint defaults to a bounded page for API callers; the overlay renders every point.
 const UNBOUNDED_HEATMAP_LIMIT = 0
 
+// Limit canvas height to prevent browser freezing with heatmap.js
+// Large canvases (e.g., 24000px) cause heatmap.js to block the main thread
+export const MAX_HEATMAP_HEIGHT = 8000
+
 export const HEATMAP_COLOR_PALETTE_OPTIONS: LemonSelectOption<string>[] = [
     { value: 'default', label: 'Default (multicolor)' },
     { value: 'red', label: 'Red (monocolor)' },
@@ -416,14 +420,23 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
         heightOverride: [
             (s) => [s.maxYFromEvents, s.windowHeight],
             (maxYFromEvents: number, windowHeight: number): number => {
-                // Limit canvas height to prevent browser freezing with heatmap.js
-                // Large canvases (e.g., 24000px) cause heatmap.js to block the main thread
-                const MAX_HEATMAP_HEIGHT = 8000
                 if (maxYFromEvents > 0) {
                     const calculatedHeight = Math.ceil((maxYFromEvents + 100) / 100) * 100
                     return Math.min(Math.max(calculatedHeight, windowHeight), MAX_HEATMAP_HEIGHT)
                 }
                 return Math.max(DEFAULT_HEATMAP_HEIGHT, windowHeight)
+            },
+        ],
+
+        // True when captured points extend past the rendered canvas cap, so the overlay is clipped
+        isHeightCapped: [
+            (s) => [s.maxYFromEvents],
+            (maxYFromEvents: number): boolean => {
+                if (maxYFromEvents <= 0) {
+                    return false
+                }
+                const calculatedHeight = Math.ceil((maxYFromEvents + 100) / 100) * 100
+                return calculatedHeight > MAX_HEATMAP_HEIGHT
             },
         ],
 

--- a/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
@@ -373,7 +373,7 @@ export function HeatmapsBrowser(): JSX.Element {
                     <LemonDivider className="my-4" />
                     <div className="relative border">
                         {isHeightCapped && (
-                            <LemonBanner type="info" dismissKey="heatmap-height-capped">
+                            <LemonBanner type="info">
                                 This heatmap is capped at {MAX_HEATMAP_HEIGHT.toLocaleString()}px tall to keep rendering
                                 fast, so data below that point isn't shown.
                             </LemonBanner>

--- a/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
@@ -9,7 +9,7 @@ import { pngHoggie } from 'lib/brand/hoggies'
 import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
 import { AuthorizedUrlListType, appEditorUrl } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
-import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
+import { heatmapDataLogic, MAX_HEATMAP_HEIGHT } from 'lib/components/heatmaps/heatmapDataLogic'
 import { dayjs } from 'lib/dayjs'
 import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
@@ -352,7 +352,8 @@ export function HeatmapsBrowser(): JSX.Element {
     const logic = heatmapsBrowserLogic({ iframeRef })
     const clickmapLogic = recordingClickmapLogic({ iframeRef })
 
-    const { displayUrl, isBrowserUrlAuthorized, hasValidReplayIframeData, isBrowserUrlValid } = useValues(logic)
+    const { displayUrl, isBrowserUrlAuthorized, hasValidReplayIframeData, isBrowserUrlValid, isHeightCapped } =
+        useValues(logic)
     const { clickmapAvailable } = useValues(clickmapLogic)
 
     return (
@@ -371,6 +372,12 @@ export function HeatmapsBrowser(): JSX.Element {
                     />
                     <LemonDivider className="my-4" />
                     <div className="relative border">
+                        {isHeightCapped && (
+                            <LemonBanner type="info" dismissKey="heatmap-height-capped">
+                                This heatmap is capped at {MAX_HEATMAP_HEIGHT.toLocaleString()}px tall to keep rendering
+                                fast, so data below that point isn't shown.
+                            </LemonBanner>
+                        )}
                         {hasValidReplayIframeData ? (
                             <FixedReplayHeatmapBrowser iframeRef={iframeRef} />
                         ) : displayUrl ? (

--- a/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
@@ -2,6 +2,8 @@ import { useActions, useValues } from 'kea'
 import React from 'react'
 
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
+import { MAX_HEATMAP_HEIGHT } from 'lib/components/heatmaps/heatmapDataLogic'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { heatmapsBrowserLogic } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
 
 export function IframeHeatmapBrowser({
@@ -11,34 +13,42 @@ export function IframeHeatmapBrowser({
 }): JSX.Element {
     const logic = heatmapsBrowserLogic()
 
-    const { widthOverride, heightOverride, dataUrl, displayUrl } = useValues(logic)
+    const { widthOverride, heightOverride, dataUrl, displayUrl, isHeightCapped } = useValues(logic)
     const { onIframeLoad } = useActions(logic)
 
     return (
-        <div className="flex flex-row gap-x-2 w-full">
-            <div className="relative flex justify-center flex-1 w-full overflow-visible">
-                <div
-                    className="relative"
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{ width: widthOverride, height: heightOverride }}
-                >
-                    <HeatmapCanvas positioning="absolute" widthOverride={widthOverride} context="in-app" />
-                    <iframe
-                        id="heatmap-iframe"
-                        ref={iframeRef}
-                        title="Heatmap browser"
-                        className="bg-white"
+        <div className="flex flex-col gap-y-2 w-full">
+            {isHeightCapped && (
+                <LemonBanner type="info" dismissKey="heatmap-height-capped">
+                    This heatmap is capped at {MAX_HEATMAP_HEIGHT.toLocaleString()}px tall to keep rendering fast, so
+                    clicks and scrolls below that point aren't shown.
+                </LemonBanner>
+            )}
+            <div className="flex flex-row gap-x-2 w-full">
+                <div className="relative flex justify-center flex-1 w-full overflow-visible">
+                    <div
+                        className="relative"
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{ width: widthOverride, height: heightOverride }}
-                        src={displayUrl || dataUrl || ''}
-                        onLoad={onIframeLoad}
-                        // these two sandbox values are necessary so that the site and toolbar can run
-                        // this is a very loose sandbox,
-                        // but we specify it so that at least other capabilities are denied
-                        sandbox="allow-scripts allow-same-origin"
-                        // we don't allow things such as camera access though
-                        allow=""
-                    />
+                    >
+                        <HeatmapCanvas positioning="absolute" widthOverride={widthOverride} context="in-app" />
+                        <iframe
+                            id="heatmap-iframe"
+                            ref={iframeRef}
+                            title="Heatmap browser"
+                            className="bg-white"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ width: widthOverride, height: heightOverride }}
+                            src={displayUrl || dataUrl || ''}
+                            onLoad={onIframeLoad}
+                            // these two sandbox values are necessary so that the site and toolbar can run
+                            // this is a very loose sandbox,
+                            // but we specify it so that at least other capabilities are denied
+                            sandbox="allow-scripts allow-same-origin"
+                            // we don't allow things such as camera access though
+                            allow=""
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/IframeHeatmapBrowser.tsx
@@ -2,8 +2,6 @@ import { useActions, useValues } from 'kea'
 import React from 'react'
 
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
-import { MAX_HEATMAP_HEIGHT } from 'lib/components/heatmaps/heatmapDataLogic'
-import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { heatmapsBrowserLogic } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
 
 export function IframeHeatmapBrowser({
@@ -13,42 +11,34 @@ export function IframeHeatmapBrowser({
 }): JSX.Element {
     const logic = heatmapsBrowserLogic()
 
-    const { widthOverride, heightOverride, dataUrl, displayUrl, isHeightCapped } = useValues(logic)
+    const { widthOverride, heightOverride, dataUrl, displayUrl } = useValues(logic)
     const { onIframeLoad } = useActions(logic)
 
     return (
-        <div className="flex flex-col gap-y-2 w-full">
-            {isHeightCapped && (
-                <LemonBanner type="info" dismissKey="heatmap-height-capped">
-                    This heatmap is capped at {MAX_HEATMAP_HEIGHT.toLocaleString()}px tall to keep rendering fast, so
-                    clicks and scrolls below that point aren't shown.
-                </LemonBanner>
-            )}
-            <div className="flex flex-row gap-x-2 w-full">
-                <div className="relative flex justify-center flex-1 w-full overflow-visible">
-                    <div
-                        className="relative"
+        <div className="flex flex-row gap-x-2 w-full">
+            <div className="relative flex justify-center flex-1 w-full overflow-visible">
+                <div
+                    className="relative"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ width: widthOverride, height: heightOverride }}
+                >
+                    <HeatmapCanvas positioning="absolute" widthOverride={widthOverride} context="in-app" />
+                    <iframe
+                        id="heatmap-iframe"
+                        ref={iframeRef}
+                        title="Heatmap browser"
+                        className="bg-white"
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{ width: widthOverride, height: heightOverride }}
-                    >
-                        <HeatmapCanvas positioning="absolute" widthOverride={widthOverride} context="in-app" />
-                        <iframe
-                            id="heatmap-iframe"
-                            ref={iframeRef}
-                            title="Heatmap browser"
-                            className="bg-white"
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{ width: widthOverride, height: heightOverride }}
-                            src={displayUrl || dataUrl || ''}
-                            onLoad={onIframeLoad}
-                            // these two sandbox values are necessary so that the site and toolbar can run
-                            // this is a very loose sandbox,
-                            // but we specify it so that at least other capabilities are denied
-                            sandbox="allow-scripts allow-same-origin"
-                            // we don't allow things such as camera access though
-                            allow=""
-                        />
-                    </div>
+                        src={displayUrl || dataUrl || ''}
+                        onLoad={onIframeLoad}
+                        // these two sandbox values are necessary so that the site and toolbar can run
+                        // this is a very loose sandbox,
+                        // but we specify it so that at least other capabilities are denied
+                        sandbox="allow-scripts allow-same-origin"
+                        // we don't allow things such as camera access though
+                        allow=""
+                    />
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -67,6 +67,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 'hrefMatchType',
                 'widthOverride',
                 'heightOverride',
+                'isHeightCapped',
                 'commonFilters',
                 'heatmapFilters',
                 'heatmapFixedPositionMode',

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -144,7 +144,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                 <FilterPanel captureMethod={type} onCaptureMethodChange={changeCaptureMethod} />
                 <SceneDivider />
                 {isHeightCapped && (
-                    <LemonBanner type="info" dismissKey="heatmap-height-capped" className="mb-2">
+                    <LemonBanner type="info" className="mb-2">
                         This heatmap is capped at {MAX_HEATMAP_HEIGHT.toLocaleString()}px tall to keep rendering fast,
                         so data below that point isn't shown.
                     </LemonBanner>

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.tsx
@@ -8,6 +8,7 @@ import { LemonTag, Spinner } from '@posthog/lemon-ui'
 import { pngHoggie } from 'lib/brand/hoggies'
 import { appEditorUrl } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { HeatmapCanvas } from 'lib/components/heatmaps/HeatmapCanvas'
+import { MAX_HEATMAP_HEIGHT } from 'lib/components/heatmaps/heatmapDataLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
@@ -41,6 +42,7 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
         desiredNumericWidth,
         effectiveWidth,
         scalePercent,
+        isHeightCapped,
     } = useValues(logic)
     const {
         setName,
@@ -141,6 +143,12 @@ export function HeatmapScene({ id }: { id: string }): JSX.Element {
                 <HeatmapHeader />
                 <FilterPanel captureMethod={type} onCaptureMethodChange={changeCaptureMethod} />
                 <SceneDivider />
+                {isHeightCapped && (
+                    <LemonBanner type="info" dismissKey="heatmap-height-capped" className="mb-2">
+                        This heatmap is capped at {MAX_HEATMAP_HEIGHT.toLocaleString()}px tall to keep rendering fast,
+                        so data below that point isn't shown.
+                    </LemonBanner>
+                )}
                 <div ref={measureRef} className="w-full">
                     <div
                         className="border mx-auto bg-surface-primary rounded-lg"

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -62,6 +62,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                 'commonFilters',
                 'widthOverride',
                 'heightOverride',
+                'isHeightCapped',
             ],
         ],
         actions: [


### PR DESCRIPTION
## Problem

The in-app iframe heatmap renders both the embedded page and the overlay at a computed height that is hard-capped at 8000px, to stop heatmap.js from blocking the main thread on very large canvases. Any page whose captured scroll depth runs past that gets silently clipped, so the heatmap "cuts off" with no explanation. And because the pre-cap height derives from the max y of the events loaded for the currently selected viewport-width band, the cut-off point looks different at different screen widths, which reads as a bug rather than a limit.

## Changes

- Hoisted `MAX_HEATMAP_HEIGHT = 8000` in `heatmapDataLogic.ts` to an exported module-level constant so the height and the notice share one source of truth.
- Added an `isHeightCapped` selector that mirrors the exact `heightOverride` arithmetic, so the flag can't disagree with the actual clamp.
- Connected `isHeightCapped` through `heatmapsBrowserLogic`.
- `IframeHeatmapBrowser` shows a dismissable `LemonBanner` above the iframe when capped: "This heatmap is capped at 8,000px tall to keep rendering fast, so clicks and scrolls below that point aren't shown."

No change to the cap itself. This only tells the user when it's in effect.

## How did you test this code?

### Manually in local dev

Banner shows in edit/saved mode when there is data beyond the max 8000px boundary.

<img width="1592" height="542" alt="image" src="https://github.com/user-attachments/assets/0aca9eee-fd01-4322-bf75-c57807d89b94" />

Typecheck passes for the touched files (`pnpm --filter=@posthog/frontend typescript:check`) after regenerating the two affected kea `*LogicType.ts` files. I (Claude) did not run the app to verify the banner visually. To verify manually: open a heatmap for a tall page at a narrow width where scroll depth exceeds 8000px and confirm the banner appears, then widen until the page fits under the cap and confirm it disappears.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code), directed by @xljones. The work started as a question about the max capturable height of an iframe heatmap, which traced to the `MAX_HEATMAP_HEIGHT` clamp in `heatmapDataLogic.ts`, then turned into surfacing that limit to the user. Chose to derive `isHeightCapped` from the same arithmetic as `heightOverride` rather than a separate threshold so the two can't drift, and to expose the px value from the shared constant so the banner copy stays in sync. No skills were invoked. Scope is the live in-app overlay only; the saved/screenshot path has its own separate constraints and is untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
