### PR TITLE
feat(flags): filter feature flags by payload presence

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagFilters.test.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagFilters.test.tsx
@@ -117,6 +117,22 @@ describe('FeatureFlagFiltersSection', () => {
         expect(container.querySelector('[data-attr="feature-flag-select-runtime"]')).not.toBeInTheDocument()
     })
 
+    it('shows only payloads filter when payloads is enabled', () => {
+        const { container } = render(
+            <FeatureFlagFiltersSection
+                filters={mockFilters}
+                setFeatureFlagsFilters={mockSetFilters}
+                searchPlaceholder="Search"
+                filtersConfig={{ payloads: true }}
+            />
+        )
+
+        expect(container.querySelector('[data-attr="feature-flag-select-payloads"]')).toBeInTheDocument()
+        expect(container.querySelector('[data-attr="feature-flag-search"]')).not.toBeInTheDocument()
+        expect(container.querySelector('[data-attr="feature-flag-select-type"]')).not.toBeInTheDocument()
+        expect(container.querySelector('[data-attr="feature-flag-select-runtime"]')).not.toBeInTheDocument()
+    })
+
     it('shows multiple filters when multiple are configured', () => {
         const { container } = render(
             <FeatureFlagFiltersSection
@@ -146,6 +162,7 @@ describe('FeatureFlagFiltersSection', () => {
                     status: true,
                     createdBy: true,
                     runtime: true,
+                    payloads: true,
                 }}
             />
         )
@@ -155,6 +172,7 @@ describe('FeatureFlagFiltersSection', () => {
         expect(container.querySelector('[data-attr="feature-flag-select-status"]')).toBeInTheDocument()
         expect(container.querySelector('[data-attr="feature-flag-select-created-by"]')).toBeInTheDocument()
         expect(container.querySelector('[data-attr="feature-flag-select-runtime"]')).toBeInTheDocument()
+        expect(container.querySelector('[data-attr="feature-flag-select-payloads"]')).toBeInTheDocument()
     })
 
     it('ignores false values in config', () => {

--- a/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagFilters.tsx
@@ -13,6 +13,7 @@ export interface FeatureFlagFiltersConfig {
     status?: boolean
     createdBy?: boolean
     runtime?: boolean
+    payloads?: boolean
     tags?: boolean
 }
 
@@ -37,10 +38,12 @@ export function FeatureFlagFiltersSection({
         status: false,
         createdBy: false,
         runtime: false,
+        payloads: false,
         tags: false,
         ...filtersConfig,
     }
-    const hasNonSearchFilters = config.type || config.status || config.createdBy || config.runtime || config.tags
+    const hasNonSearchFilters =
+        config.type || config.status || config.createdBy || config.runtime || config.payloads || config.tags
 
     return (
         <div className="flex justify-between gap-2 flex-wrap">
@@ -213,6 +216,35 @@ export function FeatureFlagFiltersSection({
                                 ]}
                                 value={filters.evaluation_runtime ?? 'any'}
                                 data-attr="feature-flag-select-runtime"
+                            />
+                        </>
+                    )}
+                    {config.payloads && (
+                        <>
+                            <span className="ml-1">
+                                <b>Payload</b>
+                            </span>
+                            <LemonSelect
+                                dropdownMatchSelectWidth={false}
+                                size="small"
+                                onChange={(hasPayloads) => {
+                                    const { has_payloads, ...restFilters } = filters || {}
+                                    setFeatureFlagsFilters(
+                                        {
+                                            ...restFilters,
+                                            ...(hasPayloads !== 'any' ? { has_payloads: hasPayloads } : {}),
+                                            page: 1,
+                                        },
+                                        true
+                                    )
+                                }}
+                                options={[
+                                    { label: 'Any', value: 'any', 'data-attr': 'feature-flag-select-payloads-any' },
+                                    { label: 'Has payload', value: 'true' },
+                                    { label: 'No payload', value: 'false' },
+                                ]}
+                                value={filters.has_payloads ?? 'any'}
+                                data-attr="feature-flag-select-payloads"
                             />
                         </>
                     )}

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -574,6 +574,7 @@ export function OverviewTab({
                 createdBy: true,
                 tags: true,
                 runtime: true,
+                payloads: true,
             }}
             countText={countTextNode}
         />

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
@@ -1,5 +1,5 @@
 import { router } from 'kea-router'
-import { expectLogic } from 'kea-test-utils'
+import { expectLogic, partial } from 'kea-test-utils'
 
 import api from 'lib/api'
 import { showApprovalRequiredToast } from 'scenes/approvals/ApprovalRequiredBanner'
@@ -273,6 +273,22 @@ describe('the feature flags logic', () => {
             router.actions.push(urls.featureFlags(), { tab: 'history' })
         }).toMatchValues({
             activeTab: FeatureFlagsTab.HISTORY,
+        })
+    })
+
+    it('reads has_payloads from the URL as a string when the router coerces it to a boolean', async () => {
+        await expectLogic(logic, () => {
+            router.actions.push(urls.featureFlags(), { has_payloads: true })
+        }).toMatchValues({
+            filters: partial({ has_payloads: 'true' }),
+        })
+    })
+
+    it('drops an unrecognized has_payloads url value instead of applying it as a filter', async () => {
+        await expectLogic(logic, () => {
+            router.actions.push(urls.featureFlags(), { has_payloads: 'any' })
+        }).toMatchValues({
+            filters: partial({ has_payloads: undefined }),
         })
     })
 

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -90,11 +90,20 @@ export function flagMatchesType(flag: FeatureFlagType, type?: string): boolean {
     return true
 }
 
+export function flagMatchesPayloads(flag: FeatureFlagType, hasPayloads?: string): boolean {
+    if (!hasPayloads) {
+        return true
+    }
+    const hasAnyPayload = Object.keys(flag.filters.payloads ?? {}).length > 0
+    return hasPayloads === 'true' ? hasAnyPayload : !hasAnyPayload
+}
+
 export function flagMatchesFilters(flag: FeatureFlagType, filters: FeatureFlagsFilters): boolean {
     return (
         flagMatchesSearch(flag, filters.search) &&
         flagMatchesStatus(flag, filters.active) &&
         flagMatchesType(flag, filters.type) &&
+        flagMatchesPayloads(flag, filters.has_payloads) &&
         // Archived flags are hidden unless explicitly filtered for, mirroring the API default
         (filters.archived === 'true' ? !!flag.archived : !flag.archived) &&
         (!filters.created_by_id?.length ||
@@ -137,6 +146,7 @@ export interface FeatureFlagsFilters {
     order?: string
     page?: number
     evaluation_runtime?: string
+    has_payloads?: string
     tags?: string[]
     excluded_tags?: string[]
 }
@@ -150,6 +160,7 @@ const DEFAULT_FILTERS: FeatureFlagsFilters = {
     order: undefined,
     page: 1,
     evaluation_runtime: undefined,
+    has_payloads: undefined,
     tags: undefined,
     excluded_tags: undefined,
 }
@@ -424,8 +435,18 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                 actions.setActiveTab(tabInURL)
             }
 
-            const { page, created_by_id, active, archived, type, search, order, evaluation_runtime, tags } =
-                searchParams
+            const {
+                page,
+                created_by_id,
+                active,
+                archived,
+                type,
+                search,
+                order,
+                evaluation_runtime,
+                has_payloads,
+                tags,
+            } = searchParams
             const pageFiltersFromUrl: Partial<FeatureFlagsFilters> = {
                 created_by_id: parseNumericArrayFilter(created_by_id),
                 type,
@@ -437,6 +458,14 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
 
             pageFiltersFromUrl.active = active !== undefined ? String(active) : undefined
             pageFiltersFromUrl.archived = archived !== undefined ? String(archived) : undefined
+            // Only 'true'/'false' are meaningful; drop anything else so a hand-edited URL value
+            // doesn't apply a filter while the dropdown still reads "Any"
+            pageFiltersFromUrl.has_payloads =
+                has_payloads === true || has_payloads === 'true'
+                    ? 'true'
+                    : has_payloads === false || has_payloads === 'false'
+                      ? 'false'
+                      : undefined
             pageFiltersFromUrl.page = page !== undefined ? parseInt(page) : undefined
             pageFiltersFromUrl.search = search !== undefined ? String(search) : undefined
 

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2901,6 +2901,14 @@ class FeatureFlagViewSet(
                 enum=["true", "false"],
                 description="Filter feature flags by presence of evaluation contexts. 'true' returns only flags with at least one evaluation context, 'false' returns only flags without.",
             ),
+            OpenApiParameter(
+                "has_payloads",
+                OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                enum=["true", "false"],
+                description="Filter feature flags by whether they carry a JSON payload. 'true' returns only flags with at least one payload value, 'false' returns only flags without. Distinct from the 'remote_config' type: an ordinary boolean or multivariant flag can also carry payloads.",
+            ),
         ]
     )
     def list(self, request, *args, **kwargs):
@@ -3635,6 +3643,17 @@ class FeatureFlagViewSet(
                     queryset = queryset.filter(eval_tag_count__gt=0)
                 else:
                     queryset = queryset.filter(eval_tag_count=0)
+            elif key == "has_payloads":
+                if isinstance(value, bool):
+                    filter_value = value
+                else:
+                    filter_value = str(value).lower() in ("true", "1", "yes")
+
+                empty_payloads = Q(filters__payloads__isnull=True) | Q(filters__payloads={})
+                if filter_value:
+                    queryset = queryset.exclude(empty_payloads)
+                else:
+                    queryset = queryset.filter(empty_payloads)
 
         return queryset
 

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -6268,6 +6268,38 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert len(response["results"]) == 1
         assert response["results"][0]["key"] == feature_flag.key
 
+    def test_get_flags_with_has_payloads_filter(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="with_payload",
+            filters={"groups": [], "payloads": {"true": '"blue"'}},
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="with_variant_payload",
+            filters={"multivariate": {"variants": [{"key": "control"}]}, "payloads": {"control": '"on"'}},
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="empty_payload",
+            filters={"groups": [], "payloads": {}},
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="no_payload_key",
+            filters={"groups": []},
+        )
+
+        with_payloads = self.client.get("/api/projects/@current/feature_flags?has_payloads=true").json()
+        assert sorted(flag["key"] for flag in with_payloads["results"]) == ["with_payload", "with_variant_payload"]
+
+        without_payloads = self.client.get("/api/projects/@current/feature_flags?has_payloads=false").json()
+        assert sorted(flag["key"] for flag in without_payloads["results"]) == ["empty_payload", "no_payload_key"]
+
     def test_get_flags_with_search(self):
         FeatureFlag.objects.create(team=self.team, created_by=self.user, key="blue_search_term_button")
         FeatureFlag.objects.create(

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -1751,6 +1751,10 @@ export type FeatureFlagsListParams = {
      */
     has_evaluation_contexts?: FeatureFlagsListHasEvaluationContexts
     /**
+     * Filter feature flags by whether they carry a JSON payload. 'true' returns only flags with at least one payload value, 'false' returns only flags without. Distinct from the 'remote_config' type: an ordinary boolean or multivariant flag can also carry payloads.
+     */
+    has_payloads?: FeatureFlagsListHasPayloads
+    /**
      * Number of results to return per page.
      */
     limit?: number
@@ -1797,6 +1801,13 @@ export type FeatureFlagsListHasEvaluationContexts =
     (typeof FeatureFlagsListHasEvaluationContexts)[keyof typeof FeatureFlagsListHasEvaluationContexts]
 
 export const FeatureFlagsListHasEvaluationContexts = {
+    False: 'false',
+    True: 'true',
+} as const
+
+export type FeatureFlagsListHasPayloads = (typeof FeatureFlagsListHasPayloads)[keyof typeof FeatureFlagsListHasPayloads]
+
+export const FeatureFlagsListHasPayloads = {
     False: 'false',
     True: 'true',
 } as const

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -70141,6 +70141,10 @@ export namespace Schemas {
      */
     has_evaluation_contexts?: FeatureFlagsListHasEvaluationContexts;
     /**
+     * Filter feature flags by whether they carry a JSON payload. 'true' returns only flags with at least one payload value, 'false' returns only flags without. Distinct from the 'remote_config' type: an ordinary boolean or multivariant flag can also carry payloads.
+     */
+    has_payloads?: FeatureFlagsListHasPayloads;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -70189,6 +70193,14 @@ export namespace Schemas {
 
 
     export const FeatureFlagsListHasEvaluationContexts = {
+      False: 'false',
+      True: 'true',
+    } as const;
+
+    export type FeatureFlagsListHasPayloads = typeof FeatureFlagsListHasPayloads[keyof typeof FeatureFlagsListHasPayloads];
+
+
+    export const FeatureFlagsListHasPayloads = {
       False: 'false',
       True: 'true',
     } as const;

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -83,6 +83,12 @@ export const FeatureFlagsListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "Filter feature flags by presence of evaluation contexts. 'true' returns only flags with at least one evaluation context, 'false' returns only flags without."
         ),
+    has_payloads: zod
+        .enum(['false', 'true'])
+        .optional()
+        .describe(
+            "Filter feature flags by whether they carry a JSON payload. 'true' returns only flags with at least one payload value, 'false' returns only flags without. Distinct from the 'remote_config' type: an ordinary boolean or multivariant flag can also carry payloads."
+        ),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     search: zod.string().optional().describe('Search by feature flag key or name. Case insensitive.'),

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -140,6 +140,7 @@ const featureFlagGetAll = (): ToolBase<
                 excluded_properties: params.excluded_properties,
                 excluded_tags: params.excluded_tags,
                 has_evaluation_contexts: params.has_evaluation_contexts,
+                has_payloads: params.has_payloads,
                 limit: params.limit,
                 offset: params.offset,
                 search: params.search,


### PR DESCRIPTION
**_Quick Preamble:_** 

First time contribution, hopefully deemed useful, maybe mergeable -> mainly done to play around in the PostHog repo.

---

## Problem

The feature flags list already filters by status, type, tags, creator, and runtime, but there's no way to narrow to flags that carry a JSON payload. If you're auditing which flags ship a payload (remote config, or an ordinary boolean/multivariant flag with a payload attached), you have to open each flag to check. This adds a payload filter to close that gap, on both the API and the flags list UI.

## Changes

- **API** (`FeatureFlagViewSet._apply_filters`): new `has_payloads` query param on `GET /api/projects/{id}/feature_flags/`. `true` returns flags whose `filters.payloads` is a non-empty object, `false` returns flags with no payload (missing key or `{}`). Declared with an `OpenApiParameter` on `list`, so it flows into the generated frontend types and the `feature-flag-get-all` MCP tool.
- **UI** (`FeatureFlagFiltersSection`): a **Payload** dropdown (Any / Has payload / No payload), matching the existing Runtime filter's shape. Wired into `FeatureFlags.tsx` and gated behind the existing `filtersConfig`.
- **List logic** (`featureFlagsLogic`): the flags list applies the filter server-side and re-applies it client-side over the current page, so I added `flagMatchesPayloads` to mirror the backend definition (non-empty `filters.payloads`). The URL param is normalized on read to `'true' | 'false' | undefined`, so an unexpected value (e.g. a hand-edited `?has_payloads=any`) doesn't silently apply a filter while the dropdown still reads "Any".
- Regenerated OpenAPI / MCP artifacts (`api.schemas.ts`, MCP `generated.ts` / `api.ts` / tool wiring).

> [!NOTE]
> "Has payload" is defined as a non-empty `filters.payloads` object, so remote config flags (which store their config there) count as having a payload. This is intentional and called out in the param description — payload presence is distinct from the `remote_config` type, since a plain boolean or multivariant flag can also carry a payload.

**Default (any):**

<img width="2526" height="1472" alt="any_selected" src="https://github.com/user-attachments/assets/b1dd0b71-a145-4862-8301-6902490fb9c9" />

**Has Payload:**

<img width="2526" height="1472" alt="has_payload_selected" src="https://github.com/user-attachments/assets/2dcb71cf-2ce3-4160-ad0b-4b7a0fe503e8" />


## How did you test this code?

I clicked through the flags list UI manually — the Payload dropdown filters correctly across Any / Has payload / No payload, and the URL param round-trips. Alongside that, the automated coverage (the parts Claude ran):

- **Backend** `test_get_flags_with_has_payloads_filter` (passed): covers `has_payloads=true`/`false` across a boolean flag with a payload, a multivariant flag with a variant payload, a flag with an empty `payloads: {}`, and a flag with no `payloads` key. Catches the queryset predicate treating "empty dict" or "missing key" as "has payload".
- **Frontend** `featureFlagsLogic.test.ts` + `FeatureFlagFilters.test.tsx` (75 passed): new cases for the URL round-trip when the router coerces `has_payloads` to a boolean, for an unrecognized URL value being dropped rather than filtered, and for the Payload filter rendering both on its own and alongside the other filters.
- `hogli ci:preflight` reports 0 failures; generated types regenerated with no drift after rebasing on master.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. The API reference at posthog.com/docs/api is generated from the OpenAPI spec (the param description ships with it), and the sibling list filters (`has_evaluation_contexts`, `evaluation_runtime`) aren't hand-documented, so this follows the existing convention.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @JamesPatrickGill; the payload filter itself was built beforehand and Claude picked it up from the working tree. In this session Claude ran `/code-review` over the diff, which surfaced an edge case: the URL param wasn't normalized, so a value the dropdown never emits (`any`, or anything non-`true`/`false`) would apply a real filter while the control still showed "Any". That's fixed at the parse boundary (strictly better than the `evaluation_runtime` sibling, which has the same latent quirk) with a regression test added. Claude also confirmed the backend/client payload definitions agree, checked docs in both this repo and posthog.com, and rebased onto master with the generated files regenerated cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
