### PR TITLE
fix(insights): restore back-to-source for funnel persons drill-downs

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
@@ -663,4 +663,61 @@ describe('dataNodeLogic', () => {
             'posthog_ai'
         )
     })
+
+    describe('backToSourceQuery', () => {
+        beforeEach(() => {
+            mockedQuery.mockResolvedValue({ results: [] })
+        })
+
+        const trendsSource = setLatestVersionsOnQuery({ kind: NodeKind.TrendsQuery, series: [] })
+        const funnelsSource = setLatestVersionsOnQuery({ kind: NodeKind.FunnelsQuery, series: [] })
+        const stickinessSource = setLatestVersionsOnQuery({ kind: NodeKind.StickinessQuery, series: [] })
+
+        // A persons drill-down opened as a data table ("Open as new insight" / "Back to source") must be
+        // able to reconstruct its source insight. Regression guard: this used to only handle the generic
+        // InsightActorsQuery (trends/lifecycle/paths), so funnel and stickiness drill-downs silently lost
+        // the "Back to source" affordance.
+        it.each([
+            ['InsightActorsQuery', { kind: NodeKind.InsightActorsQuery, source: trendsSource }, trendsSource],
+            [
+                'FunnelsActorsQuery',
+                { kind: NodeKind.FunnelsActorsQuery, source: funnelsSource, funnelStep: 1 },
+                funnelsSource,
+            ],
+            [
+                'StickinessActorsQuery',
+                { kind: NodeKind.StickinessActorsQuery, source: stickinessSource },
+                stickinessSource,
+            ],
+        ])('reconstructs the source InsightVizNode for a %s drill-down', (_name, actorsSource, expectedSource) => {
+            logic = dataNodeLogic({
+                key: testUniqueKey,
+                query: { kind: NodeKind.ActorsQuery, source: actorsSource as any, select: ['person'] },
+            })
+            logic.mount()
+
+            expect(logic.values.backToSourceQuery).toEqual({
+                kind: NodeKind.InsightVizNode,
+                source: expectedSource,
+                full: true,
+            })
+        })
+
+        it('returns null for a FunnelCorrelationActorsQuery drill-down (source is not an insight query)', () => {
+            logic = dataNodeLogic({
+                key: testUniqueKey,
+                query: {
+                    kind: NodeKind.ActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelCorrelationActorsQuery,
+                        source: { kind: NodeKind.FunnelCorrelationQuery, source: funnelsSource },
+                    } as any,
+                    select: ['person'],
+                },
+            })
+            logic.mount()
+
+            expect(logic.values.backToSourceQuery).toBeNull()
+        })
+    })
 })

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -76,7 +76,7 @@ import {
     isGroupsQuery,
     isDataVisualizationNode,
     isHogQLQuery,
-    isInsightActorsQuery,
+    isInsightActorsQueryLike,
     isInsightQueryNode,
     isMarketingAnalyticsTableQuery,
     isPersonsNode,
@@ -953,8 +953,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             (s) => [s.query],
             (query): InsightVizNode | null => {
                 const insightSource =
-                    (isActorsQuery(query) && isInsightActorsQuery(query.source) ? query.source.source : null) ??
-                    (isEventsQuery(query) && isInsightActorsQuery(query.source) ? query.source.source : null)
+                    (isActorsQuery(query) && isInsightActorsQueryLike(query.source) ? query.source.source : null) ??
+                    (isEventsQuery(query) && isInsightActorsQueryLike(query.source) ? query.source.source : null)
                 if (insightSource) {
                     const insightVizNode: InsightVizNode = {
                         kind: NodeKind.InsightVizNode,

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -27,6 +27,7 @@ import {
     ExperimentFunnelsQuery,
     ExperimentMetric,
     ExperimentTrendsQuery,
+    FunnelsActorsQuery,
     FunnelsDataWarehouseNode,
     FunnelsQuery,
     GoalLine,
@@ -69,6 +70,7 @@ import {
     SessionAttributionExplorerQuery,
     SessionQuery,
     SessionsQuery,
+    StickinessActorsQuery,
     StickinessQuery,
     TracesQuery,
     TrendsFormulaNode,
@@ -151,6 +153,23 @@ export function isActorsQuery(node?: Record<string, any> | null): node is Actors
 
 export function isInsightActorsQuery(node?: Record<string, any> | null): node is InsightActorsQuery {
     return node?.kind === NodeKind.InsightActorsQuery
+}
+
+/**
+ * Actor-query kinds whose `source` is a regular insight query, so a persons drill-down can be turned
+ * back into an `InsightVizNode` (e.g. for the "Back to source" affordance). Covers the generic
+ * `InsightActorsQuery` (Trends/Lifecycle/Paths/Retention) plus the funnel and stickiness variants.
+ * Excludes `FunnelCorrelationActorsQuery` and `ExperimentActorsQuery`, whose `source` is not an
+ * insight query and can't round-trip to an `InsightVizNode`.
+ */
+export function isInsightActorsQueryLike(
+    node?: Record<string, any> | null
+): node is InsightActorsQuery | FunnelsActorsQuery | StickinessActorsQuery {
+    return (
+        node?.kind === NodeKind.InsightActorsQuery ||
+        node?.kind === NodeKind.FunnelsActorsQuery ||
+        node?.kind === NodeKind.StickinessActorsQuery
+    )
 }
 
 export function isDataTableNode(node?: Record<string, any> | null): node is DataTableNode {


### PR DESCRIPTION
## Problem

Clicking "Open as new insight" on a funnel's persons modal was reported as "not working". Investigating that flow, the button does navigate and render a persons table, but for funnels it lands on a bare table with no "Back to source" link back to the funnel it came from — so it feels broken compared to the trends version.

The root cause: a persons drill-down opened as a data table reconstructs its source insight via `dataNodeLogic`'s `backToSourceQuery`, which only handled the generic `InsightActorsQuery` (trends / lifecycle / paths). Funnel drill-downs use `FunnelsActorsQuery` and stickiness uses `StickinessActorsQuery`, so the guard returned null and the "Back to source" button (plus the source-query options) silently disappeared. For funnels this is the only path — the sibling "View events" button returns null for non-trends drill-downs.

## Changes

- Added `isInsightActorsQueryLike` in `queries/utils.ts` covering the actor-query kinds whose `source` is a real insight query: `InsightActorsQuery`, `FunnelsActorsQuery`, `StickinessActorsQuery`. `FunnelCorrelationActorsQuery` and `ExperimentActorsQuery` stay excluded since their source isn't an insight query and can't round-trip to an `InsightVizNode`.
- `backToSourceQuery` now uses that guard, so funnel and stickiness drill-downs reconstruct their source `InsightVizNode` and show "Back to source" again.
- The `InsightActorsQueryOptions` control stays gated on `isInsightActorsQuery` (Trends-only), which is correct — funnel actors have no day/series options.

## How did you test this code?

Automated only (I'm an agent - no manual browser testing). I added 4 cases to `dataNodeLogic.test.ts` under a `backToSourceQuery` block:

- `FunnelsActorsQuery` and `StickinessActorsQuery` drill-downs now reconstruct the source `InsightVizNode` (the regression this PR fixes - no existing test covered `backToSourceQuery` at all).
- `InsightActorsQuery` still works (baseline).
- `FunnelCorrelationActorsQuery` still returns null (guards against over-broadening).

Ran locally, all green:

- `jest src/queries/nodes/DataNode/dataNodeLogic.test.ts` - 19 passed.
- `oxlint` on the changed files - clean.
- `tsgo --noEmit` - zero errors on the changed lines (`utils.ts`, the `backToSourceQuery` region, and the test file).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - no user-facing docs cover this affordance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sam asked me (Claude, via PostHog Code) to investigate a secondhand report that the funnel persons-modal "Open as new insight" button "didn't work", with no further detail. I traced the flow across `funnelPersonsModalLogic` → `personsModalLogic.exploreUrl` → `urls.insightNew` → `insightSceneLogic` → the rendered `DataTable`, and confirmed the query survives to the new insight and executes. The only funnel-specific defect I could pin down was the missing "Back to source" affordance, caused by `backToSourceQuery` recognizing only `InsightActorsQuery`.

Things I ruled out along the way: the async query-upgrade "drop to default trends" (that path doesn't fire for funnels, since funnel queries have no versioned nodes), and a hard render/execute failure (existing tests confirm the drill-down query is retained and tagged). Skill invoked: `/writing-tests` (the test is a kea-logic selector test - the cheapest level that still catches a revert of the selector, since a guard-only unit test would not).

One caveat worth a reviewer's eye: the reporter gave no reproduction, so I can't be 100% certain this missing "Back to source" is exactly what they hit versus some environment-specific symptom. This is nonetheless a real, verifiable funnel-specific bug in that exact flow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
