### PR TITLE
fix(aio): recognize AI observability aliases

### DIFF
--- a/products/posthog_ai/backend/services/system_prompt/prompt.py
+++ b/products/posthog_ai/backend/services/system_prompt/prompt.py
@@ -38,7 +38,7 @@ PostHog products:
 - **Feature flags** – targeting rules, gradual rollouts, kill switches
 - **Experiments** – A/B testing and no-code A/B testing with statistical rigor
 - **Surveys** – in-app questionnaires, NPS, user feedback collection
-- **AI observability** – monitor AI/LLM application costs, latency, and quality
+- **AI observability** (also called AIO, LLM analytics, or LLMA) – monitor AI/LLM application costs, latency, and quality
 - **Data warehouse** – connect external data sources (Stripe, Hubspot, Postgres, etc.) for combined analysis
 - **Data pipelines (CDP)** – import data from 20+ sources, transform events in real-time, and export to external destinations
 - **Revenue analytics** – track and analyze revenue metrics alongside product data

--- a/products/posthog_ai/backend/tests/test_system_prompt.py
+++ b/products/posthog_ai/backend/tests/test_system_prompt.py
@@ -25,6 +25,7 @@ class TestPostHogAISystemPrompt(APIBaseTest):
         assert "# Tone and style" in prompt
         # The MCP is reachable through its single entry point.
         assert "mcp__posthog__exec" in prompt
+        assert "AI observability** (also called AIO, LLM analytics, or LLMA)" in prompt
 
     def test_does_not_inject_groups_billing_core_memory_or_project_context(self):
         prompt = self._build()["append"]


### PR DESCRIPTION
## Problem

PostHog AI can treat the common shorthand "AIO" as an unknown tool instead of recognizing the AI observability product.

**Why:** People use AIO, LLM analytics, and LLMA interchangeably. The agent should resolve those names before asking for clarification.

## Changes

- Add AIO, LLM analytics, and LLMA as aliases in the PostHog product glossary injected into the agent system prompt.
- Extend the existing prompt test to protect the alias mapping.

## How did you test this code?

- `uv run hogli ci:preflight --fix` passed for both changed files.
- `ruff check products/posthog_ai/backend/services/system_prompt/prompt.py products/posthog_ai/backend/tests/test_system_prompt.py` passed.
- Directly imported the system prompt and verified the alias text is present.
- `uv run pytest products/posthog_ai/backend/tests/test_system_prompt.py -q` could not complete because the local Postgres host `db` is unavailable in this workspace. The added assertion guards against removing the alias mapping.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This changes internal agent terminology resolution rather than a documented product workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI made this focused change after tracing discovery from the skill index to the PostHog AI system prompt. It used the `/writing-skills`, `/working-with-skills`, and `/writing-tests` guidance. The product glossary was chosen over adding a broad umbrella skill because the failure is terminology resolution, not a missing workflow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
