### PR TITLE
fix(llm-gateway): count fable tokens via opus alias on bedrock mantle

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -25,6 +25,7 @@ from llm_gateway.bedrock import (
     count_tokens_with_bedrock_mantle,
     ensure_bedrock_configured,
     map_to_bedrock_model,
+    supports_runtime_count_tokens,
 )
 from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
 from llm_gateway.cloudflare import (
@@ -635,30 +636,43 @@ async def _bedrock_count_tokens_impl(
     status_code = "200"
 
     try:
-        input_tokens = await count_tokens_with_bedrock(
-            data,
-            bedrock_model,
-            bedrock_region_name,
-            settings.request_timeout,
-            product=product,
-        )
-        return {"input_tokens": input_tokens}
-    except Exception as e:
-        # bedrock-runtime CountTokens doesn't support every Claude model (cross-Region-inference-only
-        # models like claude-opus-4-8 return a ValidationException). AWS's recommended path for those
-        # is Anthropic's count_tokens API on the bedrock-mantle endpoint — try it before giving up.
-        logger.exception(
-            "Bedrock CountTokens failed",
-            model=bedrock_model,
-            product=product,
-            **_bedrock_runtime_exception_log_fields(e),
-        )
-        BEDROCK_COUNT_TOKENS_ERRORS.labels(
-            transport="runtime",
-            error_type=type(e).__name__,
-            product=product,
-        ).inc()
-        logger.info("Attempting bedrock-mantle count_tokens fallback", model=bedrock_model, product=product)
+        runtime_error_log_fields: dict[str, Any] = {}
+        if supports_runtime_count_tokens(bedrock_model):
+            try:
+                input_tokens = await count_tokens_with_bedrock(
+                    data,
+                    bedrock_model,
+                    bedrock_region_name,
+                    settings.request_timeout,
+                    product=product,
+                )
+                return {"input_tokens": input_tokens}
+            except Exception as e:
+                # bedrock-runtime CountTokens can still fail for supported models. AWS's recommended
+                # path in that case is Anthropic's count_tokens API on the bedrock-mantle endpoint —
+                # try it before giving up.
+                logger.exception(
+                    "Bedrock CountTokens failed",
+                    model=bedrock_model,
+                    product=product,
+                    **_bedrock_runtime_exception_log_fields(e),
+                )
+                BEDROCK_COUNT_TOKENS_ERRORS.labels(
+                    transport="runtime",
+                    error_type=type(e).__name__,
+                    product=product,
+                ).inc()
+                logger.info("Attempting bedrock-mantle count_tokens fallback", model=bedrock_model, product=product)
+                runtime_error_log_fields = _bedrock_runtime_exception_log_fields(e)
+        else:
+            # Cross-Region-inference-only models always fail runtime CountTokens with a
+            # ValidationException — skip the guaranteed-failing round-trip and count on mantle.
+            logger.info(
+                "Skipping bedrock-runtime CountTokens for CRIS-only model",
+                model=bedrock_model,
+                product=product,
+            )
+
         try:
             input_tokens = await count_tokens_with_bedrock_mantle(
                 data,
@@ -676,7 +690,7 @@ async def _bedrock_count_tokens_impl(
                 model=bedrock_model,
                 product=product,
                 **_exception_log_fields(mantle_exc, prefix="mantle"),
-                **_bedrock_runtime_exception_log_fields(e),
+                **runtime_error_log_fields,
             )
             BEDROCK_COUNT_TOKENS_ERRORS.labels(
                 transport="mantle",

--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -36,6 +36,14 @@ COUNT_TOKENS_ROUTING_PROPERTIES: Final[frozenset[str]] = frozenset({"model"})
 RUNTIME_COUNT_TOKENS_BODY_PROPERTIES: Final[frozenset[str]] = frozenset({"messages", "max_tokens"})
 MANTLE_COUNT_TOKENS_BODY_PROPERTIES: Final[frozenset[str]] = frozenset({"messages", "system", "tool_choice", "tools"})
 
+# claude-fable-5 is gated behind the provider_data_share retention mode on mantle, even for
+# count_tokens, so counting it under the account-default mode is rejected with a 400.
+# claude-opus-4-8 uses the same tokenizer and is allowed under the default mode — counting via
+# the alias returns identical numbers while count-only payloads stay out of provider-share scope.
+MANTLE_COUNT_TOKENS_MODEL_ALIASES: Final[dict[str, str]] = {
+    "anthropic.claude-fable-5": "anthropic.claude-opus-4-8",
+}
+
 BEDROCK_ANTHROPIC_MODEL_PREFIXES: Final[tuple[str, ...]] = (
     "anthropic.",
     "global.anthropic.",
@@ -295,6 +303,16 @@ def _record_count_tokens_sanitization_report(
     )
 
 
+def supports_runtime_count_tokens(bedrock_model: str) -> bool:
+    """Whether bedrock-runtime CountTokens accepts this model id.
+
+    Runtime CountTokens only supports dated foundation-model ids ("...-20250929-v1:0").
+    Cross-Region-inference-only ids (e.g. us.anthropic.claude-opus-4-8) carry no ":<version>"
+    suffix and always fail with a ValidationException — callers should go straight to mantle.
+    """
+    return ":" in bedrock_model
+
+
 async def count_tokens_with_bedrock(
     request_data: dict[str, Any],
     model: str,
@@ -378,6 +396,7 @@ async def count_tokens_with_bedrock_mantle(
     body, mantle takes the native Anthropic shape (model + messages + optional system/tools).
     """
     mantle_model = _strip_regional_inference_prefix(model)
+    mantle_model = MANTLE_COUNT_TOKENS_MODEL_ALIASES.get(mantle_model, mantle_model)
     body: dict[str, Any] = {"model": mantle_model, "messages": request_data.get("messages")}
     body["messages"], report = _sanitize_bedrock_count_tokens_messages(body["messages"])
     _record_count_tokens_top_level_drops(report, request_data, body_properties=MANTLE_COUNT_TOKENS_BODY_PROPERTIES)

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -333,8 +333,9 @@ class TestBedrockFallback:
 class TestBedrockCountTokensViaProvider:
     @pytest.fixture
     def valid_request_body(self) -> dict[str, Any]:
+        # A dated foundation-model id — the runtime CountTokens path; CRIS-only ids skip runtime.
         return {
-            "model": "us.anthropic.claude-sonnet-4-6",
+            "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             "messages": [{"role": "user", "content": "Hello"}],
         }
 
@@ -374,8 +375,16 @@ class TestBedrockCountTokensViaProvider:
     @pytest.mark.parametrize(
         "model,expected_model_id",
         [
-            pytest.param("us.anthropic.claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-6", id="already_bedrock"),
-            pytest.param("claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-6", id="anthropic_name_mapped"),
+            pytest.param(
+                "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                id="already_bedrock",
+            ),
+            pytest.param(
+                "claude-sonnet-4-5",
+                "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                id="anthropic_name_mapped",
+            ),
         ],
     )
     @patch("llm_gateway.api.anthropic.get_settings")
@@ -505,7 +514,8 @@ class TestBedrockCountTokensViaProvider:
         mock_settings.request_timeout = 300.0
         mock_get_settings.return_value = mock_settings
 
-        # Mirrors bedrock-runtime rejecting CountTokens for a CRIS-only model like claude-opus-4-8.
+        # Mirrors bedrock-runtime rejecting CountTokens for a model the gateway expected it to
+        # support (CRIS-only models never reach runtime — they skip straight to mantle).
         mock_count_tokens.side_effect = ClientError(
             {
                 "Error": {
@@ -553,7 +563,7 @@ class TestBedrockCountTokensViaProvider:
         assert mantle_count_tokens_call.kwargs["product"] == "llm_gateway"
         mock_logger.exception.assert_called_once_with(
             "Bedrock CountTokens failed",
-            model="us.anthropic.claude-sonnet-4-6",
+            model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             product="llm_gateway",
             runtime_status=400,
             runtime_error_type="ClientError",
@@ -562,9 +572,46 @@ class TestBedrockCountTokensViaProvider:
         )
         mock_logger.info.assert_any_call(
             "Attempting bedrock-mantle count_tokens fallback",
-            model="us.anthropic.claude-sonnet-4-6",
+            model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
             product="llm_gateway",
         )
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            pytest.param("claude-fable-5", id="fable_5"),
+            pytest.param("us.anthropic.claude-sonnet-4-6", id="sonnet_4_6_cris_id"),
+        ],
+    )
+    @patch("llm_gateway.api.anthropic.get_settings")
+    @patch("llm_gateway.api.anthropic.count_tokens_with_bedrock_mantle", new_callable=AsyncMock)
+    @patch("llm_gateway.api.anthropic.count_tokens_with_bedrock")
+    def test_skips_runtime_count_tokens_for_cris_only_models(
+        self,
+        mock_count_tokens: MagicMock,
+        mock_mantle_count_tokens: AsyncMock,
+        mock_get_settings: MagicMock,
+        authenticated_client: TestClient,
+        model: str,
+    ) -> None:
+        mock_settings = MagicMock()
+        mock_settings.bedrock_region_name = "us-east-1"
+        mock_settings.request_timeout = 300.0
+        mock_get_settings.return_value = mock_settings
+
+        mock_mantle_count_tokens.return_value = 55
+
+        response = authenticated_client.post(
+            "/v1/messages/count_tokens",
+            json={"model": model, "messages": [{"role": "user", "content": "Hello"}]},
+            headers={"Authorization": "Bearer phx_test_key", "X-PostHog-Provider": "bedrock"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["input_tokens"] == 55
+        # CRIS-only models must not pay the guaranteed-failing runtime round-trip.
+        mock_count_tokens.assert_not_called()
+        assert mock_mantle_count_tokens.await_count == 1
 
     @patch("llm_gateway.api.anthropic.get_settings")
     @patch("llm_gateway.api.anthropic.count_tokens_with_bedrock")
@@ -607,7 +654,7 @@ class TestBedrockCountTokensViaProvider:
 
         mock_count_tokens.return_value = 42
         body = {
-            "model": "claude-sonnet-4-6",
+            "model": "claude-sonnet-4-5",
             "messages": [{"role": "user", "content": "Hello"}],
             "max_tokens": 2048,
             "system": "Be brief.",
@@ -629,7 +676,7 @@ class TestBedrockCountTokensViaProvider:
 
         assert response.status_code == 200
         request_data = mock_count_tokens.call_args.args[0]
-        assert request_data["model"] == "claude-sonnet-4-6"
+        assert request_data["model"] == "claude-sonnet-4-5"
         assert request_data["messages"] == body["messages"]
         assert request_data["system"] == body["system"]
         assert request_data["tools"] == body["tools"]
@@ -947,6 +994,37 @@ class TestBedrockMantleCountTokens:
             dropped_items_total=2,
             dropped_paths_truncated=False,
         )
+
+    @pytest.mark.asyncio
+    @patch("llm_gateway.bedrock._sign_bedrock_mantle_request")
+    @patch("llm_gateway.bedrock.httpx.AsyncClient")
+    async def test_aliases_fable_count_tokens_to_opus_tokenizer(
+        self,
+        mock_async_client_cls: MagicMock,
+        mock_sign: MagicMock,
+    ) -> None:
+        import httpx
+
+        from llm_gateway.bedrock import count_tokens_with_bedrock_mantle
+
+        mock_sign.return_value = {"anthropic-version": "2023-06-01"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=httpx.Response(status_code=200, json={"input_tokens": 88}))
+        mock_async_client_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await count_tokens_with_bedrock_mantle(
+            {"messages": [{"role": "user", "content": "Hello"}]},
+            "us.anthropic.claude-fable-5",
+            "us-east-1",
+            300.0,
+            product="llm_gateway",
+        )
+
+        assert result == 88
+        # fable-5 is retention-gated on mantle even for counting; the same-tokenizer opus-4-8
+        # id must go over the wire or the request 400s on the data-retention gate.
+        signed_body = json.loads(mock_sign.call_args.args[1])
+        assert signed_body["model"] == "anthropic.claude-opus-4-8"
 
     @pytest.mark.asyncio
     @patch("llm_gateway.bedrock._sign_bedrock_mantle_request")


### PR DESCRIPTION
## Problem

`claude-fable-5` requires the `provider_data_share` data-retention mode on Bedrock, and our account's effective mode is `default`. Its bedrock-mantle count_tokens fallback therefore always fails with `data retention mode 'default' is not available for this model`, so a transient first-party Anthropic error on `/v1/messages/count_tokens` turns into a client-facing 502 for fable traffic.

Separately, bedrock-runtime `CountTokens` only accepts dated `-v1:0` foundation-model ids. Every cross-region-inference-only model (Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, Fable 5) fails it with a `ValidationException` on every single request, paying a guaranteed-failing round trip and emitting an error-level "Bedrock CountTokens failed" log before falling back to mantle anyway.

## Changes

- Count `claude-fable-5` tokens on mantle under the `anthropic.claude-opus-4-8` id. Fable 5 and Opus 4.8 share the same tokenizer so the counts are identical, and Opus 4.8 is allowed under the `default` retention mode. This also keeps counting-only payloads out of provider-share scope, so the alias stays even after a `provider_data_share` mantle project exists for inference.
- Skip bedrock-runtime `CountTokens` for CRIS-only model ids (new `supports_runtime_count_tokens`: dated `-v1:0` ids only) and go straight to mantle, killing the per-request error-log noise.

> [!NOTE]
> Follow-up PRs make fable servable through a dedicated bedrock-mantle project for inference (fallback first, then optional primary). This PR is independent and shippable now.

## How did you test this code?

Automated only, no live AWS calls:

- `test_skips_runtime_count_tokens_for_cris_only_models` catches reintroducing the guaranteed-failing runtime call for CRIS-only models (fable + sonnet-4-6): asserts the runtime transport is never invoked and mantle serves the count.
- `test_aliases_fable_count_tokens_to_opus_tokenizer` catches fable count_tokens re-hitting the retention gate: asserts the signed mantle payload carries `anthropic.claude-opus-4-8`.
- Moved the generic count_tokens provider tests to a dated model id (`claude-sonnet-4-5`) so `test_falls_back_to_mantle_when_runtime_unsupported` still exercises the genuine runtime-failure to mantle fallback now that CRIS ids skip runtime.
- Full gateway suite: `uv run pytest tests/` in `services/llm-gateway`, 1168 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session) from an investigation handoff doc; Chris directed the scope and the routing decisions.
- Skills invoked: `/writing-tests` for the test gate, `claude-api` to verify the model facts (Fable 5 uses the same tokenizer as Opus 4.8; Fable 5 requires 30-day retention on every platform).
- Considered counting fable natively under a `provider_data_share` mantle project instead of the alias, rejected it: the alias works today with zero AWS-side changes and permanently keeps count-only prompts out of the provider-share scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
