### PR TITLE
chore(ide): exclude services/llm-gateway/.venv from JetBrains indexing

### DIFF
--- a/.idea/posthog.iml
+++ b/.idea/posthog.iml
@@ -4,7 +4,6 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/.flox/cache/venv/lib/python3.11/site-packages/loginas/tests" />
       <sourceFolder url="file://$MODULE_DIR$/.flox/cache/venv/lib/python3.11/site-packages/loginas/tests" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.flox/cache/venv" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
@@ -74,6 +73,7 @@
       <excludeFolder url="file://$MODULE_DIR$/staticfiles/rest_framework" />
       <excludeFolder url="file://$MODULE_DIR$/staticfiles/services" />
       <excludeFolder url="file://$MODULE_DIR$/staticfiles/transformations" />
+      <excludeFolder url="file://$MODULE_DIR$/services/llm-gateway/.venv" />
       <excludePattern pattern="*node_modules*" />
     </content>
     <orderEntry type="inheritedJdk" />


### PR DESCRIPTION
## Problem

`.idea/posthog.iml` is the one tracked JetBrains file, and it doesn't exclude the llm-gateway venv, so the IDE indexes it.

## Changes

adds `services/llm-gateway/.venv` to the exclude list (and dedupes a repeated loginas sourceFolder line the IDE churned).

## How did you test this code?

n/a, IDE config only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

split out of the setup-review branch (#70681) to keep that PR clean.