### PR TITLE
feat(mcp-store): add Linear to the MCP server catalog

### DIFF
--- a/products/mcp_store/backend/catalog.py
+++ b/products/mcp_store/backend/catalog.py
@@ -164,6 +164,14 @@ MCP_SERVER_CATALOG: list[CatalogEntry] = [
         icon_domain="launchdarkly.com",
     ),
     CatalogEntry(
+        name="Linear",
+        url="https://mcp.linear.app/mcp",
+        description="Manage Linear issues, projects, and team workflows.",
+        auth_type="oauth",
+        category="productivity",
+        icon_domain="linear.app",
+    ),
+    CatalogEntry(
         name="Neon",
         url="https://mcp.neon.tech/mcp",
         description="Manage Neon serverless Postgres projects, branches, and databases.",


### PR DESCRIPTION
## Problem

Linear is a common issue tracker for product and engineering teams, but it wasn't in the MCP store catalog, so users couldn't connect it from Settings → MCP servers.

## Changes

Adds one `CatalogEntry` for Linear to `products/mcp_store/backend/catalog.py` (alphabetically, between LaunchDarkly and Neon):

```python
CatalogEntry(
    name="Linear",
    url="https://mcp.linear.app/mcp",
    description="Manage Linear issues, projects, and team workflows.",
    auth_type="oauth",
    category="productivity",
    icon_domain="linear.app",
),
```

Linear speaks OAuth with Dynamic Client Registration, so the entry ships as `auth_type="oauth"` and activates automatically on merge. No operator provisioning, no icon assets (the logo resolves from `linear.app` via logo.dev at render time).

I picked `productivity` to match the closest catalog analog (Atlassian/Jira). It could arguably sit under `dev`.

> [!NOTE]
> This stacks on #70163, which introduces `catalog.py` (the file doesn't exist on master yet). Base is `claude/mcp-store-5-skill`, not master. Rebase onto master once #70163 merges.

## How did you test this code?

Probe against the live endpoint:

```
DEBUG=1 python manage.py probe_mcp_server https://mcp.linear.app/mcp
```

```
speaks_mcp: true
auth_flavor: "oauth_dcr"
dcr_registered: true
authorize_endpoint_ok: true
passed_activation_gate: true
```

`hogli test products/mcp_store/backend/test/test_catalog_sync.py` → 10 passed (includes `test_catalog_entries_are_valid`).

Verification tier 2: probe passed. I (Claude) did not complete a real OAuth install end to end because I don't have a Linear account in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Chris directed this via PostHog Code (Claude Opus 4.8). I invoked the repo `/adding-mcp-store-servers` skill and followed its workflow: found Linear's remote MCP endpoint, probed it, authored the catalog entry, and ran the catalog-sync test. The only judgment call was `category`: `productivity` (matching Atlassian) vs `dev` — flagged above for the reviewer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
