### PR TITLE
fix(insights): fill metric card in exported/shared insights

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2260,6 +2260,10 @@ snapshots:
         hash: v1.k794b7964.9e1bd66437108d2ae7be66826ebffdc276aa0e5d774aec80cc21f412e64bd88c.MHWc22XT82IGcvrDumZrv_AGDtt8aFuowT9zTB7TCxk
     exporter-other--sql-insight-no-results--light:
         hash: v1.k794b7964.61d2bc9e86a0f575ed9653d7a8591219e402a06f6e53021eee8efcc7eb87d644._4TYA0cVTREdm7CEPknXXiutaQB4rZKngjK1MrAGE-Y
+    exporter-trends--trends-metric-insight--dark:
+        hash: v1.k794b7964.5888bc8efe3994a6f6de72dc564dd209797d995747398bbe0f8cf489f4d72df2.WJEQf5G2g5LwsaQVobnxkbS2SiYJxDbaadzeIyamrlY
+    exporter-trends--trends-metric-insight--light:
+        hash: v1.k794b7964.12f7c6fa526a6c940fa5138db6ba1066ece183e5feb87f52f8a48d1470c4cd57.VWm4tXCvu-q1PRelHAug4e69-DB9Tt5fpKG_kbwJuS0
     exporter-trends--trends-pie-insight--dark:
         hash: v1.k794b7964.e5e7c9e36ec62680c87794152b474fcd8ae0061bc7e8145416512ee745e05d21.uVeV9IUiset22yU0BtIEzyXgbkadZEoT1M-mMbalaVw
     exporter-trends--trends-pie-insight--light:

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -42,6 +42,7 @@
 
         .ExportedInsight__content {
             flex: 0 0 auto;
+
             // `min-height: 0` overrides the flex-item `auto` floor so the aspect-ratio governs the height
             // instead of the content's min-content height stretching the box taller than a square.
             min-height: 0;

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -42,6 +42,9 @@
 
         .ExportedInsight__content {
             flex: 0 0 auto;
+            // `min-height: 0` overrides the flex-item `auto` floor so the aspect-ratio governs the height
+            // instead of the content's min-content height stretching the box taller than a square.
+            min-height: 0;
             aspect-ratio: 1 / 1;
         }
     }

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -32,6 +32,20 @@
         border-radius: 0 0 var(--radius) var(--radius);
     }
 
+    // A metric card renders best as a square chart under the title bar rather than stretched to the full
+    // exporter height. Size the card to its content and make the content area square (its height derives
+    // from the export width via aspect-ratio) so the filling sparkline hugs the bottom of a square, not a
+    // tall sliver.
+    &--metric {
+        flex: 0 0 auto;
+        height: auto;
+
+        .ExportedInsight__content {
+            flex: 0 0 auto;
+            aspect-ratio: 1 / 1;
+        }
+    }
+
     .LemonTable {
         --lemon-table-background-color: var(--color-bg-surface-primary);
     }

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -32,21 +32,21 @@
         border-radius: 0 0 var(--radius) var(--radius);
     }
 
-    // A metric card renders best as a square chart under the title bar rather than stretched to the full
-    // exporter height. Size the card to its content and make the content area square (its height derives
-    // from the export width via aspect-ratio) so the filling sparkline hugs the bottom of a square, not a
-    // tall sliver.
+    // A metric card renders best as a square card — header plus chart, proportioned like a dashboard
+    // tile on a 2x2 grid — rather than stretched to the full exporter height. The aspect-ratio derives
+    // the card's height from the export width, and the content flex-fills the space under the header so
+    // the filling sparkline hugs the bottom of the card.
     &--metric {
         flex: 0 0 auto;
         height: auto;
+        aspect-ratio: 1 / 1;
 
         .ExportedInsight__content {
-            flex: 0 0 auto;
+            flex: 1 1 0;
 
-            // `min-height: 0` overrides the flex-item `auto` floor so the aspect-ratio governs the height
-            // instead of the content's min-content height stretching the box taller than a square.
+            // `min-height: 0` overrides the flex-item `auto` floor so the aspect-ratio governs the card's
+            // height instead of the content's min-content height stretching it taller than a square.
             min-height: 0;
-            aspect-ratio: 1 / 1;
         }
     }
 

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -64,8 +64,6 @@ export function ExportedInsight({
     const trendsDisplay =
         isInsightVizNode(query) && isTrendsQuery(query.source) ? query.source.trendsFilter?.display : undefined
     const isBoxPlot = trendsDisplay === ChartDisplayType.BoxPlot
-    // A metric has no intrinsically tall content, so give it a square footprint (see ExportedInsight.scss)
-    // instead of letting the filling sparkline stretch to the full exporter height.
     const isMetric = trendsDisplay === ChartDisplayType.Metric
     const showLegend =
         legend &&

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -64,6 +64,9 @@ export function ExportedInsight({
     const trendsDisplay =
         isInsightVizNode(query) && isTrendsQuery(query.source) ? query.source.trendsFilter?.display : undefined
     const isBoxPlot = trendsDisplay === ChartDisplayType.BoxPlot
+    // A metric has no intrinsically tall content, so give it a square footprint (see ExportedInsight.scss)
+    // instead of letting the filling sparkline stretch to the full exporter height.
+    const isMetric = trendsDisplay === ChartDisplayType.Metric
     const showLegend =
         legend &&
         isInsightVizNode(query) &&
@@ -79,7 +82,7 @@ export function ExportedInsight({
 
     return (
         <BindLogic logic={insightLogic} props={insightLogicProps}>
-            <div className="ExportedInsight">
+            <div className={clsx('ExportedInsight', isMetric && 'ExportedInsight--metric')}>
                 {!noHeader && (
                     <div className="ExportedInsight__header">
                         <div>

--- a/frontend/src/exporter/Exporter.scss
+++ b/frontend/src/exporter/Exporter.scss
@@ -16,6 +16,12 @@ body.ExporterBody {
         max-height: 100vh;
     }
 
+    // A metric export is a square card, not a full-page insight — drop the viewport-height floor so the
+    // exporter wraps the card tightly instead of padding it out to 100vh.
+    &--metric {
+        min-height: 0;
+    }
+
     &--heatmap {
         padding: 0;
 

--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -18,6 +18,8 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { ExporterLogin } from '~/exporter/ExporterLogin'
 import { ExportType, ExportedData } from '~/exporter/types'
+import { isInsightVizNode, isTrendsQuery } from '~/queries/utils'
+import { ChartDisplayType } from '~/types'
 
 import { exporterViewLogic } from './exporterViewLogic'
 
@@ -66,6 +68,14 @@ export function Exporter(props: ExportedData): JSX.Element {
     const { whitelabel, showInspector = false } = exportOptions
     const forcedTheme = resolveForcedTheme(exportOptions.theme)
 
+    // A metric insight sizes to a square card rather than filling the viewport, so drop the 100vh floor
+    // that would otherwise leave empty space below it (see Exporter.scss and ExportedInsight.scss).
+    const isMetricInsight =
+        !!insight &&
+        isInsightVizNode(insight.query) &&
+        isTrendsQuery(insight.query.source) &&
+        insight.query.source.trendsFilter?.display === ChartDisplayType.Metric
+
     const { currentTeam } = useValues(teamLogic)
     const { ref: elementRef, height, width } = useResizeObserver()
 
@@ -109,6 +119,7 @@ export function Exporter(props: ExportedData): JSX.Element {
             <div
                 className={clsx('Exporter', {
                     'Exporter--insight': !!insight,
+                    'Exporter--metric': isMetricInsight,
                     'Exporter--dashboard': !!dashboard,
                     'Exporter--recording': !!recording,
                     'Exporter--notebook': !!notebook,

--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -70,11 +70,13 @@ export function Exporter(props: ExportedData): JSX.Element {
 
     // A metric insight sizes to a square card rather than filling the viewport, so drop the 100vh floor
     // that would otherwise leave empty space below it (see Exporter.scss and ExportedInsight.scss).
-    const isMetricInsight =
-        !!insight &&
+    const metric =
+        insight &&
         isInsightVizNode(insight.query) &&
         isTrendsQuery(insight.query.source) &&
         insight.query.source.trendsFilter?.display === ChartDisplayType.Metric
+            ? insight
+            : undefined
 
     const { currentTeam } = useValues(teamLogic)
     const { ref: elementRef, height, width } = useResizeObserver()
@@ -119,7 +121,7 @@ export function Exporter(props: ExportedData): JSX.Element {
             <div
                 className={clsx('Exporter', {
                     'Exporter--insight': !!insight,
-                    'Exporter--metric': isMetricInsight,
+                    'Exporter--metric': !!metric,
                     'Exporter--dashboard': !!dashboard,
                     'Exporter--recording': !!recording,
                     'Exporter--notebook': !!notebook,

--- a/frontend/src/exporter/stories/ExporterTrends.stories.tsx
+++ b/frontend/src/exporter/stories/ExporterTrends.stories.tsx
@@ -10,6 +10,7 @@ import __trendsBarBreakdown from '../../mocks/fixtures/api/projects/team_id/insi
 import __trendsLine from '../../mocks/fixtures/api/projects/team_id/insights/trendsLine.json'
 import __trendsLineBreakdown from '../../mocks/fixtures/api/projects/team_id/insights/trendsLineBreakdown.json'
 import __trendsLineMulti from '../../mocks/fixtures/api/projects/team_id/insights/trendsLineMulti.json'
+import __trendsMetric from '../../mocks/fixtures/api/projects/team_id/insights/trendsMetric.json'
 import __trendsNumber from '../../mocks/fixtures/api/projects/team_id/insights/trendsNumber.json'
 import __trendsPie from '../../mocks/fixtures/api/projects/team_id/insights/trendsPie.json'
 import __trendsTable from '../../mocks/fixtures/api/projects/team_id/insights/trendsTable.json'
@@ -140,6 +141,19 @@ export const TrendsAreaBreakdownInsight: Story = {
 export const TrendsNumberInsight: Story = {
     args: { insight: __trendsNumber as any },
     tags: ['test-skip'], // doesn't produce a helpful reference image, as canvas can't be captured
+}
+
+/** The Metric sparkline is SVG/canvas, so it captures cleanly and guards against the exported card
+ * collapsing to a fixed-height sparkline that floats mid-card instead of filling and hugging the bottom. */
+export const TrendsMetricInsight: Story = {
+    args: { insight: __trendsMetric as any },
+    parameters: {
+        mockDate: '2022-04-01',
+        testOptions: {
+            snapshotBrowsers: ['chromium'],
+            waitForSelector: '.Metric canvas',
+        },
+    },
 }
 
 export const TrendsTableInsight: Story = {

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -87,7 +87,9 @@ export function TrendInsight({ view, context, embedded, inSharedMode, editMode }
     const commonProps = {
         showPersonsModal,
         context,
-        inCardView: embedded && !inSharedMode,
+        // Fill the card in every embedded surface (dashboard tiles and shared/exported insights alike) so the
+        // Metric sparkline stretches and hugs the bottom instead of collapsing to a fixed height mid-card.
+        inCardView: embedded,
         inSharedMode,
     }
 

--- a/products/exports/backend/tasks/image_exporter.py
+++ b/products/exports/backend/tasks/image_exporter.py
@@ -18,7 +18,7 @@ from playwright.sync_api import (
 )
 from prometheus_client import Counter, Histogram
 
-from posthog.schema import FunnelLayout, NodeKind
+from posthog.schema import ChartDisplayType, FunnelLayout, NodeKind
 
 from posthog.caching.calculate_results import calculate_for_query_based_insight
 from posthog.event_usage import AnalyticsProps, EventSource
@@ -130,7 +130,7 @@ MEASURE_CONTENT_WIDTH_JS = f"""
             return null;
         """
 
-ScreenWidth = Literal[800, 1920, 1400, 4000]
+ScreenWidth = Literal[600, 800, 1920, 1400, 4000]
 CSSSelector = Literal[".InsightCard", ".ExportedInsight", ".replayer-wrapper", ".heatmap-exporter"]
 
 
@@ -192,10 +192,21 @@ def _export_to_png(
             funnels_filter = source.get("funnelsFilter") or {}
             funnel_layout = funnels_filter.get("layout")
             is_left_to_right_funnel = is_funnel and (funnel_layout is None or funnel_layout == FunnelLayout.VERTICAL)
+            # A metric renders as a square card whose height derives from the viewport width, so a
+            # narrower viewport keeps it at dashboard-tile size instead of an 800px-tall square.
+            trends_filter = source.get("trendsFilter") or {}
+            is_metric = source.get("kind") == NodeKind.TRENDS_QUERY and (
+                trends_filter.get("display") == ChartDisplayType.METRIC
+            )
             # Set initial window size large enough for wide content like left-to-right funnels with many steps
             # Small funnels will be constrained later.
             # The higher the number, the more RAM will be required by the Chromium driver.
-            screenshot_width = 4000 if is_left_to_right_funnel else 800
+            if is_left_to_right_funnel:
+                screenshot_width = 4000
+            elif is_metric:
+                screenshot_width = 600
+            else:
+                screenshot_width = 800
         elif exported_asset.dashboard is not None:
             cache_keys_param = _build_cache_keys_param(insight_cache_keys)
             url_to_render = absolute_uri(f"/exporter?token={access_token}{cache_keys_param}")

--- a/products/exports/backend/tasks/image_exporter.py
+++ b/products/exports/backend/tasks/image_exporter.py
@@ -194,9 +194,13 @@ def _export_to_png(
             is_left_to_right_funnel = is_funnel and (funnel_layout is None or funnel_layout == FunnelLayout.VERTICAL)
             # A metric renders as a square card whose height derives from the viewport width, so a
             # narrower viewport keeps it at dashboard-tile size instead of an 800px-tall square.
+            # Mirrors the frontend's check (InsightVizNode wrapper required), which gates the square
+            # metric CSS — a bare TrendsQuery gets neither, so it must keep the default viewport.
             trends_filter = source.get("trendsFilter") or {}
-            is_metric = source.get("kind") == NodeKind.TRENDS_QUERY and (
-                trends_filter.get("display") == ChartDisplayType.METRIC
+            is_metric = (
+                query.get("kind") == NodeKind.INSIGHT_VIZ_NODE
+                and source.get("kind") == NodeKind.TRENDS_QUERY
+                and trends_filter.get("display") == ChartDisplayType.METRIC
             )
             # Set initial window size large enough for wide content like left-to-right funnels with many steps
             # Small funnels will be constrained later.


### PR DESCRIPTION
## Problem

Metric insights render weirdly in exported/shared insight images (e.g. subscription screenshots): lots of empty space, and the sparkline sits mid-card at a fixed height instead of filling the card and hugging the bottom the way it does in the web app. Raised in [this Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1784043735142029?thread_ts=1784043735.142029&cid=C0368RPHLQH).

## Changes

The Metric display type only stretches its sparkline (`flex-1` + `sparklineFill`) when `inCardView` is true. In `TrendInsight` that flag was derived as `embedded && !inSharedMode`. The exporter renders insights with `inSharedMode`, so `inCardView` was `false`: the sparkline fell back to its fixed 120px height and the card sized to its content, floating at the top of the tall exporter container with empty space below.

- Derive `inCardView` from `embedded` alone, matching how `BoxPlot` and `InsightVizDisplay` already do it. Shared-mode interactivity is gated separately via `showPersonsModal`, and `BoldNumber` (the other consumer of these common props) ignores `inCardView`, so only the Metric layout changes.
- Size the exported metric card as a square (header + chart together, proportioned like a dashboard tile on a 2x2 grid) instead of stretching it to the full exporter height, drop the exporter's viewport-height floor for metric exports, and render metric image exports at a 600px viewport (instead of the default 800px) so the square card comes out at dashboard-tile size.
- Add an exporter Storybook snapshot for the Metric display type to lock in the filled layout.

## How did you test this code?

Added an `Exporter/Trends` Storybook story (`TrendsMetricInsight`) that renders the Metric display type through the exporter, so visual regression captures the filled-card layout. Dependencies were not installed in the agent sandbox, so the frontend formatter, typecheck, and the snapshot run were not executed locally — please rely on CI for those.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread report. Traced the divergence between the dashboard/web render path and the exporter path: both pass `embedded`, differing only on `inSharedMode`, which flowed into `inCardView` in `frontend/src/scenes/trends/Trends.tsx` and disabled the Metric card's fill behavior. Considered adding a separate export-specific flag but chose to align `inCardView` with the existing `embedded`-based convention used elsewhere, since the interactivity concern `inSharedMode` guards is already covered by `showPersonsModal`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1784043735142029?thread_ts=1784043735.142029&cid=C0368RPHLQH)*


