### PR TITLE
feat(llm-gateway): serve provider_data_share models via bedrock mantle

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -14,6 +14,7 @@ from fastapi.responses import StreamingResponse
 from llm_gateway.api.handler import (
     ANTHROPIC_CONFIG,
     BEDROCK_CONFIG,
+    BEDROCK_MANTLE_CONFIG,
     CLOUDFLARE_ANTHROPIC_CONFIG,
     ProviderError,
     _sanitize_request_data,
@@ -26,6 +27,13 @@ from llm_gateway.bedrock import (
     ensure_bedrock_configured,
     map_to_bedrock_model,
     supports_runtime_count_tokens,
+)
+from llm_gateway.bedrock_mantle import (
+    BedrockMantleMessages,
+    ensure_bedrock_mantle_project_configured,
+    is_bedrock_primary_model,
+    matched_mantle_model,
+    to_mantle_model_id,
 )
 from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
 from llm_gateway.cloudflare import (
@@ -44,12 +52,14 @@ from llm_gateway.metrics.prometheus import (
     BEDROCK_FALLBACK_SUCCESS,
     BEDROCK_FALLBACK_TRIGGERED,
     BEDROCK_PARAM_STRIPPED,
+    BEDROCK_PRIMARY_FALLBACK_TRIGGERED,
     REQUEST_COUNT,
     REQUEST_LATENCY,
 )
 from llm_gateway.models.anthropic import GATEWAY_ONLY_FIELDS, AnthropicCountTokensRequest, AnthropicMessagesRequest
 from llm_gateway.products.config import validate_product
 from llm_gateway.request_context import (
+    POSTHOG_PROVIDER_HEADER,
     apply_posthog_context_from_headers,
     extract_posthog_provider_from_headers,
     extract_posthog_use_bedrock_fallback_from_headers,
@@ -238,6 +248,50 @@ async def _send_cloudflare_messages(
     )
 
 
+async def _send_bedrock_mantle_messages(
+    request_data: dict[str, Any],
+    user: RateLimitedUser,
+    request: Request,
+    is_streaming: bool,
+    product: str,
+    attribution_model: str,
+) -> dict[str, Any] | StreamingResponse:
+    """Serve an Anthropic Messages request on the bedrock-mantle endpoint under the
+    provider_data_share project — the only working Bedrock path for models whose allowed
+    data-retention modes reject bedrock-runtime (e.g. claude-fable-5)."""
+    settings = get_settings()
+    bedrock_region_name = ensure_bedrock_configured(settings)
+    project_id = ensure_bedrock_mantle_project_configured(settings)
+
+    data = dict(request_data)
+    mantle_model = to_mantle_model_id(data["model"])
+    data["model"] = mantle_model
+
+    anthropic_beta = request.headers.get("anthropic-beta")
+    if anthropic_beta:
+        data["anthropic_beta"] = [h.strip() for h in anthropic_beta.split(",") if h.strip()]
+
+    # Conservative reuse of the runtime allowlist: mantle speaks the native Anthropic API, so
+    # some dropped params may actually be supported — BEDROCK_PARAM_STRIPPED is the signal to
+    # relax this per param once verified against the mantle surface.
+    data = sanitize_for_bedrock(data, model=mantle_model, product=product)
+
+    mantle_call = BedrockMantleMessages(
+        region_name=bedrock_region_name,
+        project_id=project_id,
+        attribution_model=attribution_model,
+    )
+    return await handle_llm_request(
+        request_data=data,
+        user=user,
+        model=mantle_model,
+        is_streaming=is_streaming,
+        provider_config=BEDROCK_MANTLE_CONFIG,
+        llm_call=mantle_call.acreate,
+        product=product,
+    )
+
+
 async def _send_bedrock_messages(
     request_data: dict[str, Any],
     user: RateLimitedUser,
@@ -246,6 +300,16 @@ async def _send_bedrock_messages(
     product: str,
 ) -> dict[str, Any] | StreamingResponse:
     settings = get_settings()
+
+    # Every Bedrock entry point (explicit provider header, circuit-breaker bypass, 1P-failure
+    # fallback) funnels through here, so this one branch routes provider_data_share-gated models
+    # to the mantle transport instead of the guaranteed-400 bedrock-runtime path.
+    mantle_model_name = matched_mantle_model(request_data["model"], settings)
+    if mantle_model_name is not None:
+        return await _send_bedrock_mantle_messages(
+            request_data, user, request, is_streaming, product, attribution_model=mantle_model_name
+        )
+
     bedrock_region_name = ensure_bedrock_configured(settings)
 
     data = dict(request_data)
@@ -420,6 +484,26 @@ async def _handle_anthropic_messages(
 
     if await _maybe_bypass_anthropic(breaker, body.model, product, use_bedrock_fallback=use_bedrock_fallback):
         return await _send_bedrock_messages(data, user, request, body.stream or False, product)
+
+    # Staged bedrock-primary: configured models try Bedrock first when the caller expressed no
+    # provider preference; an explicit `x-posthog-provider: anthropic` header stays a 1P escape
+    # hatch. Provider-side Bedrock failures (5xx, 429) fall through to the normal 1P path below;
+    # caller-side 4xx are raised as-is since Anthropic would reject them identically. Bedrock
+    # outcomes are never recorded on the Anthropic circuit breaker. Same pre-stream-only
+    # limitation as the 1P→Bedrock direction: a mid-stream failure is not replayable.
+    if request.headers.get(POSTHOG_PROVIDER_HEADER) is None and is_bedrock_primary_model(body.model, get_settings()):
+        try:
+            return await _send_bedrock_messages(data, user, request, body.stream or False, product)
+        except HTTPException as exc:
+            if _is_breaker_success(exc.status_code):
+                raise
+            BEDROCK_PRIMARY_FALLBACK_TRIGGERED.labels(model=body.model, product=product).inc()
+            logger.warning(
+                "Bedrock-primary request failed, falling back to Anthropic",
+                model=body.model,
+                product=product,
+                **_exception_log_fields(exc, prefix="bedrock"),
+            )
 
     litellm_data = {**data, "model": normalize_litellm_model_name(body.model, ANTHROPIC_CONFIG.name)}
 

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -82,6 +82,13 @@ BEDROCK_CONFIG = ProviderConfig(
     endpoint_name="bedrock_messages",
     extract_effort=effort_from_output_config,
 )
+# Same provider label as BEDROCK_CONFIG so provider-level dashboards aggregate both transports;
+# split endpoint label so a mantle-specific regression is distinguishable in metrics.
+BEDROCK_MANTLE_CONFIG = ProviderConfig(
+    name="bedrock",
+    endpoint_name="bedrock_mantle_messages",
+    extract_effort=effort_from_output_config,
+)
 OPENAI_CONFIG = ProviderConfig(
     name="openai",
     endpoint_name="chat_completions",

--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -354,13 +354,26 @@ def _strip_regional_inference_prefix(model: str) -> str:
     return model.replace("us.anthropic.", "anthropic.").replace("eu.anthropic.", "anthropic.")
 
 
+def get_bedrock_mantle_url(region_name: str, path: str) -> str:
+    return f"https://bedrock-mantle.{region_name}.api.aws{path}"
+
+
 def get_bedrock_mantle_count_tokens_url(region_name: str) -> str:
-    return f"https://bedrock-mantle.{region_name}.api.aws/anthropic/v1/messages/count_tokens"
+    return get_bedrock_mantle_url(region_name, "/anthropic/v1/messages/count_tokens")
 
 
-def _sign_bedrock_mantle_request(url: str, body: bytes, region_name: str) -> dict[str, str]:
+def _sign_bedrock_mantle_request(
+    url: str,
+    body: bytes,
+    region_name: str,
+    *,
+    extra_headers: dict[str, str] | None = None,
+) -> dict[str, str]:
     """SigV4-sign a bedrock-mantle request using the ambient AWS credentials (same IAM role
-    the bedrock-runtime client uses). The AWS SDKs don't expose a client for this endpoint."""
+    the bedrock-runtime client uses). The AWS SDKs don't expose a client for this endpoint.
+
+    extra_headers are merged before signing so they are part of the signature (e.g. the
+    mantle project header, anthropic-beta)."""
     credentials = get_bedrock_session().get_credentials()
     if credentials is None:
         raise HTTPException(
@@ -375,6 +388,7 @@ def _sign_bedrock_mantle_request(url: str, body: bytes, region_name: str) -> dic
         headers={
             "Content-Type": "application/json",
             "anthropic-version": BEDROCK_MANTLE_ANTHROPIC_VERSION,
+            **(extra_headers or {}),
         },
     )
     SigV4Auth(credentials.get_frozen_credentials(), BEDROCK_MANTLE_SIGV4_SERVICE, region_name).add_auth(request)

--- a/services/llm-gateway/src/llm_gateway/bedrock_mantle.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock_mantle.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import Any, Final
+
+import httpx
+import litellm
+import structlog
+from fastapi import HTTPException
+
+from llm_gateway.bedrock import (
+    BEDROCK_ANTHROPIC_MODEL_PREFIXES,
+    _sign_bedrock_mantle_request,
+    get_bedrock_mantle_url,
+)
+from llm_gateway.callbacks.base import InstrumentedCallback
+from llm_gateway.config import get_settings
+
+logger = structlog.get_logger(__name__)
+
+BEDROCK_MANTLE_MESSAGES_PATH: Final[str] = "/anthropic/v1/messages"
+# The OpenAI-compatible mantle surface selects a project with this header. Whether the
+# anthropic-native /anthropic/v1/* surface expects the same name or an "anthropic-project"
+# variant is unverified — confirm in dev and change this one constant if needed.
+BEDROCK_MANTLE_PROJECT_HEADER: Final[str] = "OpenAI-Project"
+
+
+def _short_model_name(model: str) -> str:
+    """Drop any Bedrock provider/routing prefix: "us.anthropic.claude-fable-5" -> "claude-fable-5"."""
+    for prefix in BEDROCK_ANTHROPIC_MODEL_PREFIXES:
+        if model.startswith(prefix):
+            return model[len(prefix) :]
+    return model
+
+
+def to_mantle_model_id(model: str) -> str:
+    """Mantle takes the bare foundation-model id ("anthropic.<model>"), never CRIS prefixes."""
+    return f"anthropic.{_short_model_name(model)}"
+
+
+def _configured_model_list(settings: object, field: str) -> list[str]:
+    # Defensive on type: the field is env-parsed config, and several tests stub settings with a
+    # bare MagicMock whose auto-created attributes must read as "feature off", not crash routing.
+    values = getattr(settings, field, None)
+    if not isinstance(values, list | tuple):
+        return []
+    return [value for value in values if isinstance(value, str)]
+
+
+def matched_mantle_model(model: str, settings: object) -> str | None:
+    """The configured short model name when `model` must be served via the mantle endpoint.
+
+    Models whose Bedrock `allowed_modes` is provider_data_share only (e.g. claude-fable-5)
+    reject every bedrock-runtime request, so the mantle endpoint with the dedicated project is
+    the only working Bedrock path for them. Accepts short, CRIS ("us."/"eu."/"global."), and
+    bare ("anthropic.") ids.
+    """
+    short = _short_model_name(model).lower()
+    for configured in _configured_model_list(settings, "bedrock_mantle_models"):
+        if configured.lower() == short:
+            return configured
+    return None
+
+
+def is_bedrock_primary_model(model: str, settings: object) -> bool:
+    """Whether this model should try Bedrock first when the caller expressed no provider."""
+    return model in _configured_model_list(settings, "bedrock_primary_models")
+
+
+def ensure_bedrock_mantle_project_configured(settings: object) -> str:
+    project_id = getattr(settings, "bedrock_mantle_project_id", None)
+    if isinstance(project_id, str) and project_id:
+        return project_id
+
+    logger.warning("Bedrock Mantle project not configured")
+    raise HTTPException(
+        status_code=503,
+        detail={"error": {"message": "Bedrock Mantle project not configured", "type": "configuration_error"}},
+    )
+
+
+class MantleAPIError(Exception):
+    """Anthropic-shaped provider error from the mantle endpoint.
+
+    Exposes status_code/message/type/code because handle_llm_request's generic error mapping
+    reads exactly those attributes when it re-raises the client-facing ProviderError — this is
+    how the upstream status (e.g. the data-retention 400) survives to the caller and to the
+    fallback logic that branches on it.
+    """
+
+    def __init__(self, status_code: int, body: bytes | str) -> None:
+        message = body.decode("utf-8", errors="replace") if isinstance(body, bytes) else body
+        error_type = "api_error"
+        code: str | None = None
+        try:
+            error = json.loads(message).get("error") or {}
+            message = str(error.get("message") or message)
+            error_type = str(error.get("type") or error_type)
+            code = error.get("code")
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        self.status_code = status_code
+        self.message = message
+        self.type = error_type
+        self.code = code
+        super().__init__(message)
+
+
+class MantleStreamAccumulator:
+    """Best-effort reconstruction of usage and content from a native Anthropic SSE stream.
+
+    Analytics-only: a parse failure degrades to whatever was captured so far and never
+    interrupts the byte passthrough to the client.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = b""
+        self._blocks: dict[int, dict[str, Any]] = {}
+        self._parse_failed = False
+        self.message: dict[str, Any] = {}
+        self.usage: dict[str, Any] = {}
+        self.saw_message_start = False
+
+    def feed(self, chunk: bytes) -> None:
+        if self._parse_failed:
+            return
+        try:
+            self._buffer += chunk
+            while b"\n" in self._buffer:
+                line, self._buffer = self._buffer.split(b"\n", 1)
+                self._handle_line(line.strip())
+        except Exception:
+            self._parse_failed = True
+            logger.warning("bedrock_mantle_stream_parse_failed", exc_info=True)
+
+    def _handle_line(self, line: bytes) -> None:
+        if not line.startswith(b"data:"):
+            return
+        payload = line[len(b"data:") :].strip()
+        if not payload or payload == b"[DONE]":
+            return
+        event = json.loads(payload)
+        event_type = event.get("type")
+
+        if event_type == "message_start":
+            self.saw_message_start = True
+            message = event.get("message") or {}
+            self.message = {key: message.get(key) for key in ("id", "type", "role", "model", "stop_reason")}
+            self.usage.update(message.get("usage") or {})
+        elif event_type == "content_block_start":
+            block = dict(event.get("content_block") or {})
+            block.setdefault("type", "text")
+            if block["type"] == "tool_use":
+                block["_partial_json"] = ""
+            self._blocks[int(event.get("index", 0))] = block
+        elif event_type == "content_block_delta":
+            block = self._blocks.get(int(event.get("index", 0)))
+            if block is None:
+                return
+            delta = event.get("delta") or {}
+            delta_type = delta.get("type")
+            if delta_type == "text_delta":
+                block["text"] = block.get("text", "") + delta.get("text", "")
+            elif delta_type == "thinking_delta":
+                block["thinking"] = block.get("thinking", "") + delta.get("thinking", "")
+            elif delta_type == "input_json_delta":
+                block["_partial_json"] = block.get("_partial_json", "") + delta.get("partial_json", "")
+            elif delta_type == "signature_delta":
+                block["signature"] = block.get("signature", "") + delta.get("signature", "")
+        elif event_type == "message_delta":
+            delta = event.get("delta") or {}
+            if delta.get("stop_reason") is not None:
+                self.message["stop_reason"] = delta["stop_reason"]
+            # usage carries running totals (output_tokens grows monotonically), so
+            # last-seen values are correct even when the stream is cut short.
+            self.usage.update(event.get("usage") or {})
+
+    def response_message(self) -> dict[str, Any] | None:
+        if not self.saw_message_start:
+            return None
+        content: list[dict[str, Any]] = []
+        for index in sorted(self._blocks):
+            block = dict(self._blocks[index])
+            partial_json = block.pop("_partial_json", None)
+            if partial_json is not None:
+                try:
+                    block["input"] = json.loads(partial_json) if partial_json else {}
+                except json.JSONDecodeError:
+                    block["input"] = {}
+            content.append(block)
+        return {**self.message, "content": content, "usage": dict(self.usage)}
+
+
+def compute_mantle_cost(model: str, usage: dict[str, Any]) -> tuple[float | None, dict[str, float]]:
+    """Per-side cost from litellm's cost map (fable is guaranteed present via MODEL_COST_OVERRIDES).
+
+    Returns (None, {}) when the core rates are missing so the rate-limit callback's
+    token-estimation/fallback path engages instead of recording a silent zero.
+    """
+    rates = litellm.model_cost.get(model) or {}
+    if rates.get("input_cost_per_token") is None or rates.get("output_cost_per_token") is None:
+        return None, {}
+
+    breakdown: dict[str, float] = {}
+    total = 0.0
+    for usage_key, rate_key, breakdown_key in (
+        ("input_tokens", "input_cost_per_token", "input_cost"),
+        ("output_tokens", "output_cost_per_token", "output_cost"),
+        ("cache_read_input_tokens", "cache_read_input_token_cost", "cache_read_cost"),
+        ("cache_creation_input_tokens", "cache_creation_input_token_cost", "cache_creation_cost"),
+    ):
+        rate = rates.get(rate_key)
+        if rate is None:
+            continue
+        cost = int(usage.get(usage_key) or 0) * float(rate)
+        breakdown[breakdown_key] = cost
+        total += cost
+    return total, breakdown
+
+
+def build_mantle_callback_kwargs(
+    *,
+    model: str,
+    request_data: dict[str, Any],
+    usage: dict[str, Any],
+    response_message: dict[str, Any] | None,
+    response_time: float,
+    is_streaming: bool,
+) -> dict[str, Any]:
+    """A litellm-mimicking callback payload for a hand-rolled mantle call.
+
+    The registered InstrumentedCallback subclasses (PostHog, rate limiting, Prometheus) read a
+    narrow field set from litellm's standard_logging_object; this synthesizes exactly those
+    fields with litellm's conventions (prompt_tokens is the cache-inclusive total, cache tokens
+    ride in metadata.usage_object, trace id in litellm_params.metadata).
+    """
+    input_tokens = int(usage.get("input_tokens") or 0)
+    cache_read = usage.get("cache_read_input_tokens")
+    cache_creation = usage.get("cache_creation_input_tokens")
+
+    usage_object: dict[str, Any] = {}
+    if cache_read is not None:
+        usage_object["cache_read_input_tokens"] = cache_read
+    if cache_creation is not None:
+        usage_object["cache_creation_input_tokens"] = cache_creation
+
+    response_cost, cost_breakdown = compute_mantle_cost(model, usage)
+
+    standard_logging_object: dict[str, Any] = {
+        "model": model,
+        "custom_llm_provider": "bedrock",
+        "messages": request_data.get("messages"),
+        "prompt_tokens": input_tokens + int(cache_read or 0) + int(cache_creation or 0),
+        "completion_tokens": int(usage.get("output_tokens") or 0),
+        "response_time": response_time,
+        "stream": is_streaming,
+        "metadata": {"usage_object": usage_object},
+    }
+    if response_cost is not None:
+        standard_logging_object["response_cost"] = response_cost
+        standard_logging_object["cost_breakdown"] = cost_breakdown
+    if response_message is not None:
+        standard_logging_object["response"] = response_message
+
+    return {
+        "standard_logging_object": standard_logging_object,
+        "litellm_params": {"metadata": request_data.get("metadata") or {}},
+    }
+
+
+async def _emit_callbacks(kwargs: dict[str, Any], *, success: bool, start_time: float, end_time: float) -> None:
+    # InstrumentedCallback swallows its own exceptions, so attribution can never fail a request.
+    for callback in litellm.callbacks:
+        if not isinstance(callback, InstrumentedCallback):
+            continue
+        if success:
+            await callback.async_log_success_event(kwargs, None, start_time, end_time)
+        else:
+            await callback.async_log_failure_event(kwargs, None, start_time, end_time)
+
+
+@functools.lru_cache
+def get_mantle_http_client() -> httpx.AsyncClient:
+    """Shared pooled client — a fresh TLS handshake per request would show up in TTFT."""
+    settings = get_settings()
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10.0, read=settings.request_timeout, write=30.0, pool=10.0),
+    )
+
+
+class BedrockMantleMessages:
+    """Anthropic-native Messages calls against the bedrock-mantle endpoint.
+
+    Fits handle_llm_request's llm_call contract: awaiting acreate(**request_data) returns a
+    parsed message dict (non-streaming) or an async iterator of raw SSE bytes (streaming —
+    mantle speaks native Anthropic SSE, so format_sse_stream's passthrough branch re-emits the
+    bytes unmodified). Because the call bypasses litellm, PostHog/cost/token attribution is
+    emitted explicitly via the registered callbacks.
+    """
+
+    def __init__(self, *, region_name: str, project_id: str, attribution_model: str) -> None:
+        self._region_name = region_name
+        self._project_id = project_id
+        # The user-facing model name ("claude-fable-5"): keys the cost map and keeps
+        # $ai_model consistent with the same model's first-party events.
+        self._attribution_model = attribution_model
+
+    async def acreate(self, **request_data: Any) -> Any:
+        data = dict(request_data)
+        extra_headers: dict[str, str] = {BEDROCK_MANTLE_PROJECT_HEADER: self._project_id}
+        anthropic_beta = data.pop("anthropic_beta", None)
+        if anthropic_beta:
+            extra_headers["anthropic-beta"] = (
+                ",".join(anthropic_beta) if isinstance(anthropic_beta, list) else str(anthropic_beta)
+            )
+        # The native surface takes the version as a header; the signer sets the public one.
+        data.pop("anthropic_version", None)
+
+        is_streaming = bool(data.get("stream"))
+        payload = json.dumps(data).encode("utf-8")
+        url = get_bedrock_mantle_url(self._region_name, BEDROCK_MANTLE_MESSAGES_PATH)
+        # Credential resolution can touch the network (e.g. role refresh), so sign off the event loop.
+        signed_headers = await asyncio.to_thread(
+            _sign_bedrock_mantle_request, url, payload, self._region_name, extra_headers=extra_headers
+        )
+
+        start_time = time.monotonic()
+        client = get_mantle_http_client()
+        http_request = client.build_request("POST", url, content=payload, headers=signed_headers)
+        response = await client.send(http_request, stream=True)
+
+        if response.status_code != 200:
+            body = await response.aread()
+            await response.aclose()
+            error = MantleAPIError(response.status_code, body)
+            await self._emit_failure(data, error, is_streaming)
+            raise error
+
+        if not is_streaming:
+            body = await response.aread()
+            await response.aclose()
+            parsed: dict[str, Any] = json.loads(body)
+            await self._emit_success(
+                data,
+                usage=parsed.get("usage") or {},
+                response_message=parsed,
+                response_time=time.monotonic() - start_time,
+                is_streaming=False,
+            )
+            return parsed
+
+        return self._stream(response, data, start_time)
+
+    async def _stream(
+        self, response: httpx.Response, request_data: dict[str, Any], start_time: float
+    ) -> AsyncIterator[bytes]:
+        accumulator = MantleStreamAccumulator()
+        error: Exception | None = None
+        try:
+            async for chunk in response.aiter_bytes():
+                accumulator.feed(chunk)
+                yield chunk
+        except asyncio.CancelledError:
+            # Client disconnect — already-streamed tokens are still billed upstream, so the
+            # usage captured so far must be recorded (finally below).
+            raise
+        except Exception as exc:
+            error = exc
+            raise
+        finally:
+            await response.aclose()
+            response_time = time.monotonic() - start_time
+            try:
+                if accumulator.saw_message_start:
+                    await self._emit_success(
+                        request_data,
+                        usage=accumulator.usage,
+                        response_message=accumulator.response_message(),
+                        response_time=response_time,
+                        is_streaming=True,
+                    )
+                elif error is not None:
+                    await self._emit_failure(request_data, error, True)
+            except Exception:
+                logger.exception("bedrock_mantle_attribution_failed", model=self._attribution_model)
+
+    async def _emit_success(
+        self,
+        request_data: dict[str, Any],
+        *,
+        usage: dict[str, Any],
+        response_message: dict[str, Any] | None,
+        response_time: float,
+        is_streaming: bool,
+    ) -> None:
+        kwargs = build_mantle_callback_kwargs(
+            model=self._attribution_model,
+            request_data=request_data,
+            usage=usage,
+            response_message=response_message,
+            response_time=response_time,
+            is_streaming=is_streaming,
+        )
+        end_time = time.time()
+        await _emit_callbacks(kwargs, success=True, start_time=end_time - response_time, end_time=end_time)
+
+    async def _emit_failure(self, request_data: dict[str, Any], error: Exception, is_streaming: bool) -> None:
+        kwargs = {
+            "standard_logging_object": {
+                "model": self._attribution_model,
+                "custom_llm_provider": "bedrock",
+                "stream": is_streaming,
+                "error_str": str(error),
+            },
+            "litellm_params": {"metadata": request_data.get("metadata") or {}},
+        }
+        now = time.time()
+        await _emit_callbacks(kwargs, success=False, start_time=now, end_time=now)

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -132,6 +132,16 @@ class Settings(BaseSettings):
 
     anthropic_api_key: str | None = None
     bedrock_region_name: str | None = None
+    # Bedrock Mantle project (proj_...) opted into the provider_data_share data retention mode.
+    # Required to serve bedrock_mantle_models; created out-of-band per AWS account (see
+    # posthog-cloud-infra scripts/bedrock-mantle-project.sh and docs/BEDROCK_MANTLE.md there).
+    bedrock_mantle_project_id: str | None = None
+    # Models that must be served via the mantle endpoint + project whenever the Bedrock path is
+    # taken: their Bedrock allowed data-retention modes gate them off bedrock-runtime entirely.
+    bedrock_mantle_models: list[str] = ["claude-fable-5"]
+    # Models routed to Bedrock first even without an x-posthog-provider header, with first-party
+    # Anthropic as the fallback. Empty by default — the staged bedrock-primary flip.
+    bedrock_primary_models: list[str] = []
     openai_api_key: str | None = None
     openai_api_base_url: str | None = None  # Used for regional endpoints
     # OpenAI organization ID. When set, forwarded to OpenAI on every request so

--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -243,6 +243,12 @@ BEDROCK_FALLBACK_FAILURE = Counter(
     labelnames=["model", "product"],
 )
 
+BEDROCK_PRIMARY_FALLBACK_TRIGGERED = Counter(
+    "llm_gateway_bedrock_primary_fallback_triggered_total",
+    "Times a bedrock-primary model fell back to first-party Anthropic after a Bedrock failure",
+    labelnames=["model", "product"],
+)
+
 BEDROCK_PARAM_STRIPPED = Counter(
     "llm_gateway_bedrock_param_stripped_total",
     "Top-level request params dropped before sending to Bedrock because they aren't in the "

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -873,6 +873,180 @@ class TestModelMapping:
         assert "Invalid product" in response.json()["detail"]
 
 
+def _mantle_settings(**overrides: Any) -> MagicMock:
+    settings = MagicMock()
+    settings.bedrock_region_name = "us-east-1"
+    settings.request_timeout = 300.0
+    settings.streaming_timeout = 300.0
+    settings.bedrock_mantle_project_id = "proj_test123"
+    settings.bedrock_mantle_models = ["claude-fable-5"]
+    settings.bedrock_primary_models = []
+    for key, value in overrides.items():
+        setattr(settings, key, value)
+    return settings
+
+
+class TestBedrockMantleRouting:
+    """Routing of provider_data_share-gated models to the mantle transport."""
+
+    @pytest.fixture
+    def mantle_response(self) -> dict[str, Any]:
+        return {
+            "id": "msg_mantle",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "model": "claude-fable-5",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            pytest.param("claude-fable-5", id="short_name"),
+            pytest.param("us.anthropic.claude-fable-5", id="cris_id"),
+        ],
+    )
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    @patch("llm_gateway.api.anthropic.BedrockMantleMessages")
+    @patch("llm_gateway.api.anthropic.get_settings")
+    def test_bedrock_provider_header_routes_mantle_model_to_mantle(
+        self,
+        mock_get_settings: MagicMock,
+        mock_mantle_cls: MagicMock,
+        mock_litellm: MagicMock,
+        authenticated_client: TestClient,
+        mantle_response: dict[str, Any],
+        model: str,
+    ) -> None:
+        mock_get_settings.return_value = _mantle_settings()
+        mock_mantle_cls.return_value.acreate = AsyncMock(return_value=mantle_response)
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json={"model": model, "messages": [{"role": "user", "content": "Hello"}]},
+            headers={"Authorization": "Bearer phx_test_key", "X-PostHog-Provider": "bedrock"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["id"] == "msg_mantle"
+        # fable never touches bedrock-runtime — it 400s there on the data-retention gate.
+        mock_litellm.assert_not_called()
+        assert mock_mantle_cls.call_args.kwargs["project_id"] == "proj_test123"
+        assert mock_mantle_cls.call_args.kwargs["attribution_model"] == "claude-fable-5"
+        acreate_kwargs = mock_mantle_cls.return_value.acreate.await_args.kwargs
+        assert acreate_kwargs["model"] == "anthropic.claude-fable-5"
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    @patch("llm_gateway.api.anthropic.BedrockMantleMessages")
+    @patch("llm_gateway.api.anthropic.get_settings")
+    def test_mantle_model_without_project_returns_configuration_error(
+        self,
+        mock_get_settings: MagicMock,
+        mock_mantle_cls: MagicMock,
+        mock_litellm: MagicMock,
+        authenticated_client: TestClient,
+    ) -> None:
+        mock_get_settings.return_value = _mantle_settings(bedrock_mantle_project_id=None)
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json={"model": "claude-fable-5", "messages": [{"role": "user", "content": "Hello"}]},
+            headers={"Authorization": "Bearer phx_test_key", "X-PostHog-Provider": "bedrock"},
+        )
+
+        # A loud 503, not a silent fall-through to bedrock-runtime's guaranteed retention 400.
+        assert response.status_code == 503
+        assert "Mantle project not configured" in response.json()["error"]["message"]
+        mock_mantle_cls.assert_not_called()
+        mock_litellm.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "mantle_status,expect_fallback,expected_status",
+        [
+            pytest.param(503, True, 200, id="provider_5xx_falls_back_to_anthropic"),
+            pytest.param(400, False, 400, id="caller_4xx_raised_without_fallback"),
+        ],
+    )
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    @patch("llm_gateway.api.anthropic.BedrockMantleMessages")
+    @patch("llm_gateway.api.anthropic.get_settings")
+    def test_bedrock_primary_model_falls_back_to_anthropic_on_provider_failure(
+        self,
+        mock_get_settings: MagicMock,
+        mock_mantle_cls: MagicMock,
+        mock_litellm: MagicMock,
+        authenticated_client: TestClient,
+        mantle_response: dict[str, Any],
+        mantle_status: int,
+        expect_fallback: bool,
+        expected_status: int,
+    ) -> None:
+        from llm_gateway.bedrock_mantle import MantleAPIError
+        from llm_gateway.metrics.prometheus import BEDROCK_PRIMARY_FALLBACK_TRIGGERED
+
+        mock_get_settings.return_value = _mantle_settings(bedrock_primary_models=["claude-fable-5"])
+        mock_mantle_cls.return_value.acreate = AsyncMock(
+            side_effect=MantleAPIError(
+                mantle_status,
+                json.dumps({"error": {"message": "mantle upstream error", "type": "api_error"}}),
+            )
+        )
+        mock_1p_response = MagicMock()
+        mock_1p_response.model_dump = MagicMock(return_value=mantle_response)
+        mock_litellm.return_value = mock_1p_response
+
+        fallbacks_before = BEDROCK_PRIMARY_FALLBACK_TRIGGERED.labels(
+            model="claude-fable-5", product="llm_gateway"
+        )._value.get()
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json={"model": "claude-fable-5", "messages": [{"role": "user", "content": "Hello"}]},
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
+
+        assert response.status_code == expected_status
+        fallbacks_after = BEDROCK_PRIMARY_FALLBACK_TRIGGERED.labels(
+            model="claude-fable-5", product="llm_gateway"
+        )._value.get()
+        if expect_fallback:
+            mock_litellm.assert_called_once()
+            assert fallbacks_after == fallbacks_before + 1
+        else:
+            # Anthropic would reject a caller-side 4xx identically — no wasted round trip.
+            mock_litellm.assert_not_called()
+            assert fallbacks_after == fallbacks_before
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    @patch("llm_gateway.api.anthropic.BedrockMantleMessages")
+    @patch("llm_gateway.api.anthropic.get_settings")
+    def test_explicit_anthropic_provider_header_skips_bedrock_primary(
+        self,
+        mock_get_settings: MagicMock,
+        mock_mantle_cls: MagicMock,
+        mock_litellm: MagicMock,
+        authenticated_client: TestClient,
+        mantle_response: dict[str, Any],
+    ) -> None:
+        mock_get_settings.return_value = _mantle_settings(bedrock_primary_models=["claude-fable-5"])
+        mock_1p_response = MagicMock()
+        mock_1p_response.model_dump = MagicMock(return_value=mantle_response)
+        mock_litellm.return_value = mock_1p_response
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json={"model": "claude-fable-5", "messages": [{"role": "user", "content": "Hello"}]},
+            headers={"Authorization": "Bearer phx_test_key", "X-PostHog-Provider": "anthropic"},
+        )
+
+        # The explicit anthropic header is the 1P escape hatch even for bedrock-primary models.
+        assert response.status_code == 200
+        mock_mantle_cls.assert_not_called()
+        mock_litellm.assert_called_once()
+
+
 class TestBedrockMantleCountTokens:
     """Unit tests for the bedrock-mantle count_tokens fallback transport."""
 

--- a/services/llm-gateway/tests/test_bedrock_mantle.py
+++ b/services/llm-gateway/tests/test_bedrock_mantle.py
@@ -1,0 +1,318 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import litellm
+import pytest
+
+from llm_gateway.bedrock_mantle import (
+    BedrockMantleMessages,
+    MantleAPIError,
+    MantleStreamAccumulator,
+)
+from llm_gateway.callbacks.base import InstrumentedCallback
+from llm_gateway.rate_limiting.model_cost_overrides import MODEL_COST_OVERRIDES
+from llm_gateway.streaming.sse import format_sse_stream
+
+FABLE_COST = MODEL_COST_OVERRIDES["claude-fable-5"]
+
+
+def _sse(event: dict[str, Any]) -> bytes:
+    return f"event: {event['type']}\ndata: {json.dumps(event)}\n\n".encode()
+
+
+_STREAM_CHUNKS = [
+    _sse(
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-fable-5",
+                "usage": {
+                    "input_tokens": 3,
+                    "cache_read_input_tokens": 100,
+                    "cache_creation_input_tokens": 10,
+                    "output_tokens": 1,
+                },
+            },
+        }
+    ),
+    _sse({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}),
+    _sse({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hel"}}),
+    _sse({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "lo"}}),
+    _sse({"type": "content_block_stop", "index": 0}),
+    _sse({"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 7}}),
+    _sse({"type": "message_stop"}),
+]
+
+
+class _FakeStreamResponse:
+    def __init__(self, status_code: int, chunks: list[bytes] | None = None, body: bytes = b"") -> None:
+        self.status_code = status_code
+        self._chunks = chunks or []
+        self._body = body
+        self.closed = False
+
+    async def aiter_bytes(self) -> Any:
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aread(self) -> bytes:
+        return self._body
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _fake_client(response: _FakeStreamResponse) -> MagicMock:
+    client = MagicMock()
+    client.build_request = MagicMock(return_value=MagicMock())
+    client.send = AsyncMock(return_value=response)
+    return client
+
+
+class _CaptureCallback(InstrumentedCallback):
+    callback_name = "capture"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.success_kwargs: list[dict[str, Any]] = []
+        self.failure_kwargs: list[dict[str, Any]] = []
+
+    async def _on_success(
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: float, end_time: float, end_user_id: str | None
+    ) -> None:
+        self.success_kwargs.append(kwargs)
+
+    async def _on_failure(
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: float, end_time: float, end_user_id: str | None
+    ) -> None:
+        self.failure_kwargs.append(kwargs)
+
+
+def _mantle_call() -> BedrockMantleMessages:
+    return BedrockMantleMessages(
+        region_name="us-east-1",
+        project_id="proj_test123",
+        attribution_model="claude-fable-5",
+    )
+
+
+class TestBedrockMantleMessages:
+    @pytest.mark.asyncio
+    @patch("llm_gateway.bedrock_mantle.get_mantle_http_client")
+    @patch("llm_gateway.bedrock_mantle._sign_bedrock_mantle_request")
+    async def test_non_streaming_posts_signed_payload_with_project_header(
+        self,
+        mock_sign: MagicMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        mock_sign.return_value = {"Authorization": "signed", "anthropic-version": "2023-06-01"}
+        message = {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hi"}],
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        }
+        response = _FakeStreamResponse(200, body=json.dumps(message).encode())
+        client = _fake_client(response)
+        mock_get_client.return_value = client
+
+        with patch.object(litellm, "callbacks", []):
+            result = await _mantle_call().acreate(
+                model="anthropic.claude-fable-5",
+                messages=[{"role": "user", "content": "Hello"}],
+                max_tokens=64,
+                anthropic_beta=["beta-1", "beta-2"],
+                anthropic_version="2023-06-01",
+            )
+
+        assert result == message
+        signed_url = mock_sign.call_args.args[0]
+        assert signed_url == "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages"
+        # The project header must be part of the signature — dropping it lands the request on
+        # the account-default project, where fable 400s on the data-retention gate.
+        extra_headers = mock_sign.call_args.kwargs["extra_headers"]
+        assert extra_headers["OpenAI-Project"] == "proj_test123"
+        assert extra_headers["anthropic-beta"] == "beta-1,beta-2"
+        signed_body = json.loads(mock_sign.call_args.args[1])
+        assert signed_body["model"] == "anthropic.claude-fable-5"
+        # The native surface takes the version as a header, not a body field.
+        assert "anthropic_version" not in signed_body
+        assert "anthropic_beta" not in signed_body
+        # The same signed payload bytes are what gets sent.
+        assert client.build_request.call_args.kwargs["content"] == mock_sign.call_args.args[1]
+        assert client.build_request.call_args.kwargs["headers"] == mock_sign.return_value
+
+    @pytest.mark.asyncio
+    @patch("llm_gateway.bedrock_mantle.get_mantle_http_client")
+    @patch("llm_gateway.bedrock_mantle._sign_bedrock_mantle_request")
+    async def test_streaming_passes_raw_sse_bytes_through_unmodified(
+        self,
+        mock_sign: MagicMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        mock_sign.return_value = {"Authorization": "signed"}
+        response = _FakeStreamResponse(200, chunks=list(_STREAM_CHUNKS))
+        mock_get_client.return_value = _fake_client(response)
+
+        with patch.object(litellm, "callbacks", []):
+            stream = await _mantle_call().acreate(
+                model="anthropic.claude-fable-5",
+                messages=[{"role": "user", "content": "Hello"}],
+                stream=True,
+            )
+            emitted = [chunk async for chunk in format_sse_stream(stream)]
+
+        # Mantle speaks native Anthropic SSE: the gateway must re-emit it byte-for-byte —
+        # no re-serialization and no OpenAI-style "data: [DONE]" appended.
+        assert emitted == _STREAM_CHUNKS
+        assert response.closed
+
+    @pytest.mark.asyncio
+    @patch("llm_gateway.bedrock_mantle.get_mantle_http_client")
+    @patch("llm_gateway.bedrock_mantle._sign_bedrock_mantle_request")
+    async def test_streaming_emits_callback_attribution_with_usage_and_cost(
+        self,
+        mock_sign: MagicMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        mock_sign.return_value = {"Authorization": "signed"}
+        response = _FakeStreamResponse(200, chunks=list(_STREAM_CHUNKS))
+        mock_get_client.return_value = _fake_client(response)
+        capture = _CaptureCallback()
+
+        with (
+            patch.object(litellm, "callbacks", [capture]),
+            patch.object(litellm, "model_cost", {"claude-fable-5": dict(FABLE_COST)}),
+        ):
+            stream = await _mantle_call().acreate(
+                model="anthropic.claude-fable-5",
+                messages=[{"role": "user", "content": "Hello"}],
+                stream=True,
+                metadata={"user_id": "trace-1"},
+            )
+            async for _ in stream:
+                pass
+
+        assert len(capture.success_kwargs) == 1
+        kwargs = capture.success_kwargs[0]
+        slo = kwargs["standard_logging_object"]
+        assert slo["model"] == "claude-fable-5"
+        assert slo["custom_llm_provider"] == "bedrock"
+        assert slo["stream"] is True
+        # litellm convention: prompt_tokens is the cache-inclusive total (3 + 100 + 10).
+        assert slo["prompt_tokens"] == 113
+        # message_delta usage is a running total — last-seen wins, not a sum.
+        assert slo["completion_tokens"] == 7
+        assert slo["metadata"]["usage_object"] == {
+            "cache_read_input_tokens": 100,
+            "cache_creation_input_tokens": 10,
+        }
+        expected_cost = (
+            3 * FABLE_COST["input_cost_per_token"]
+            + 7 * FABLE_COST["output_cost_per_token"]
+            + 100 * FABLE_COST["cache_read_input_token_cost"]
+            + 10 * FABLE_COST["cache_creation_input_token_cost"]
+        )
+        assert slo["response_cost"] == pytest.approx(expected_cost)
+        assert slo["cost_breakdown"]["cache_read_cost"] == pytest.approx(
+            100 * FABLE_COST["cache_read_input_token_cost"]
+        )
+        assert slo["response"]["content"] == [{"type": "text", "text": "Hello"}]
+        assert slo["response"]["stop_reason"] == "end_turn"
+        assert kwargs["litellm_params"]["metadata"] == {"user_id": "trace-1"}
+
+    @pytest.mark.asyncio
+    @patch("llm_gateway.bedrock_mantle.get_mantle_http_client")
+    @patch("llm_gateway.bedrock_mantle._sign_bedrock_mantle_request")
+    async def test_error_response_raises_mantle_api_error_with_status_and_type(
+        self,
+        mock_sign: MagicMock,
+        mock_get_client: MagicMock,
+    ) -> None:
+        mock_sign.return_value = {"Authorization": "signed"}
+        error_body = {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "data retention mode 'default' is not available for this model",
+            },
+        }
+        response = _FakeStreamResponse(400, body=json.dumps(error_body).encode())
+        mock_get_client.return_value = _fake_client(response)
+        capture = _CaptureCallback()
+
+        with patch.object(litellm, "callbacks", [capture]), pytest.raises(MantleAPIError) as exc_info:
+            await _mantle_call().acreate(
+                model="anthropic.claude-fable-5",
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+
+        # handle_llm_request's error mapping reads exactly these attributes to build the
+        # client-facing error, so the upstream status/type must survive verbatim.
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.type == "invalid_request_error"
+        assert "data retention mode" in exc_info.value.message
+        assert len(capture.failure_kwargs) == 1
+        failure_slo = capture.failure_kwargs[0]["standard_logging_object"]
+        assert failure_slo["custom_llm_provider"] == "bedrock"
+        assert "data retention mode" in failure_slo["error_str"]
+
+
+class TestMantleStreamAccumulator:
+    def test_reconstructs_tool_use_and_running_output_tokens_across_chunk_boundaries(self) -> None:
+        events = [
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-fable-5",
+                    "usage": {"input_tokens": 5, "output_tokens": 1},
+                },
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "tu_1", "name": "get_weather"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": '{"city": "S'},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": 'F"}'}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_delta", "delta": {}, "usage": {"output_tokens": 5}},
+            {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 9}},
+        ]
+        raw = b"".join(_sse(event) for event in events)
+        accumulator = MantleStreamAccumulator()
+        # Split mid-line so the accumulator has to buffer partial SSE lines across feeds.
+        split_at = raw.index(b"input_json_delta") + 5
+        accumulator.feed(raw[:split_at])
+        accumulator.feed(raw[split_at:])
+
+        assert accumulator.usage["output_tokens"] == 9
+        message = accumulator.response_message()
+        assert message is not None
+        assert message["stop_reason"] == "tool_use"
+        assert message["content"] == [
+            {"type": "tool_use", "id": "tu_1", "name": "get_weather", "input": {"city": "SF"}}
+        ]
+
+    def test_parse_failure_degrades_without_breaking_feed(self) -> None:
+        accumulator = MantleStreamAccumulator()
+        accumulator.feed(_sse({"type": "message_start", "message": {"usage": {"input_tokens": 2}}}))
+        accumulator.feed(b"data: {not json\n\n")
+        accumulator.feed(_sse({"type": "message_delta", "delta": {}, "usage": {"output_tokens": 4}}))
+
+        # Everything captured before the malformed line is kept; later events are skipped
+        # rather than raising into the byte passthrough.
+        assert accumulator.saw_message_start
+        assert accumulator.usage == {"input_tokens": 2}


### PR DESCRIPTION
## Problem

`claude-fable-5` only allows the `provider_data_share` data retention mode on Bedrock (`allowed_modes: ["provider_data_share"]`), and our accounts run at `default` — so every Bedrock request naming it fails with `data retention mode 'default' is not available for this model`. The Bedrock inference fallback for fable has never worked: during an Anthropic incident, opted-in fable traffic falls over to bedrock-runtime and hits a guaranteed 400 (that includes the circuit-breaker bypass, which today routes opted-in fable straight into that 400).

The fix on the AWS side is a dedicated Bedrock Mantle project opted into `provider_data_share` while the account stays at `default` ([PostHog/posthog-cloud-infra#9346](https://github.com/PostHog/posthog-cloud-infra/pull/9346)). This PR is the gateway half: an Anthropic-native transport against the mantle endpoint that targets that project.

Stacked on [#70768](https://github.com/PostHog/posthog/pull/70768) (count_tokens fixes).

## Changes

### Before

```mermaid
flowchart LR
    A{{Caller}} --> B[gateway]
    B -->|"provider: bedrock / breaker bypass / 1P-failure fallback"| C[litellm to bedrock-runtime]
    C -->|"opus, sonnet: OK"| D[response]
    C -->|"fable: retention 400, always"| E[error]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class B,C phBlue;
    class E phRed;
    class A,D phYellow;
```

### After

```mermaid
flowchart LR
    A{{Caller}} --> B[gateway]
    B -->|"any Bedrock entry point"| S{model gated behind provider_data_share?}
    S -->|no| C[litellm to bedrock-runtime]
    S -->|"yes (fable)"| M[mantle transport + project header]
    C --> D[response]
    M --> D
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class B,C,M phBlue;
    class S phGray;
    class A,D phYellow;
```

- **New `bedrock_mantle.py` transport.** SigV4-signed httpx calls to `https://bedrock-mantle.{region}.api.aws/anthropic/v1/messages`, reusing the existing mantle signer from the count_tokens path (extended so extra headers — the `OpenAI-Project` project header, forwarded `anthropic-beta` — are signed). Mantle speaks the native Anthropic Messages API with standard SSE, so streaming is a raw byte passthrough via `format_sse_stream`'s existing raw branch; non-streaming returns the parsed dict. Errors map to `MantleAPIError` exposing `status_code/message/type/code`, the exact attributes `handle_llm_request`'s error mapping already reads, so the upstream status survives to clients and to fallback logic.
- **Attribution without litellm.** The hand-rolled call bypasses litellm, which normally drives `$ai_generation`, cost-based rate limiting, and token/cost metrics. A stream accumulator captures usage (cache tokens from `message_start`, running `output_tokens` from `message_delta`) and reconstructs content, then a litellm-mimicking `standard_logging_object` is fed to every registered `InstrumentedCallback`. Cost comes from `litellm.model_cost` per side (input/output/cache read/cache write). `$ai_model` is the short name (`claude-fable-5`), matching the same model's first-party events for cost-parity dashboards. Attribution is emitted in the stream's `finally`, so disconnects/truncations still record the tokens Anthropic bills.
- **Routing seam.** All three Bedrock entry points (explicit `x-posthog-provider: bedrock`, circuit-breaker bypass, 1P-failure fallback) funnel through `_send_bedrock_messages`; a single check routes `LLM_GATEWAY_BEDROCK_MANTLE_MODELS` (default `["claude-fable-5"]`) to the mantle transport. Everything else stays on litellm/bedrock-runtime, byte-for-byte unchanged. If the project id isn't configured, mantle-gated models get a loud 503 `configuration_error` instead of the misleading retention 400.
- **Staged primary, off by default.** `LLM_GATEWAY_BEDROCK_PRIMARY_MODELS` (empty by default) routes listed models to Bedrock first when the caller sends no provider header; provider-side failures (5xx/429) fall back to first-party Anthropic with a new `llm_gateway_bedrock_primary_fallback_triggered_total` counter, caller-side 4xx raise as-is, an explicit `x-posthog-provider: anthropic` header remains a 1P escape hatch, and Bedrock outcomes never touch the Anthropic circuit breaker.

> [!WARNING]
> Behavior change even before any config is set in prod: once `LLM_GATEWAY_BEDROCK_MANTLE_PROJECT_ID` is deployed, fable's Bedrock fallback goes from guaranteed-400 to working (that's the point). Until the env var lands, the only change for fable on the Bedrock path is 400→503 with a clearer message.

> [!NOTE]
> Dev-time verification items (single-constant/comment-marked in code): the project header name on the anthropic-native surface (`OpenAI-Project` vs a possible `anthropic-project` variant), prompt-cache hits through mantle, and global-vs-regional routing of the bare model id. The runtime param allowlist (`sanitize_for_bedrock`) is reused conservatively; `BEDROCK_PARAM_STRIPPED` is the signal to relax it for mantle-native params.

## How did you test this code?

Automated only, no live AWS calls (the real-project end-to-end check happens in dev per the rollout plan):

- `test_non_streaming_posts_signed_payload_with_project_header` — catches dropping the project header (or signing after header injection), which would land fable on the default project and re-hit the retention 400.
- `test_streaming_passes_raw_sse_bytes_through_unmodified` — catches re-serialization or an appended `data: [DONE]` corrupting native Anthropic SSE for SDK clients, end-to-end through `format_sse_stream`.
- `test_streaming_emits_callback_attribution_with_usage_and_cost` — catches a billing/observability hole: asserts the synthetic callback payload carries cache-inclusive `prompt_tokens`, last-seen (not summed) `output_tokens`, per-side costs matching `MODEL_COST_OVERRIDES` rates, and reconstructed output content.
- `test_error_response_raises_mantle_api_error_with_status_and_type` — catches the upstream retention 400 degrading into an opaque 500 (fallback logic branches on the status).
- Accumulator unit tests — tool_use JSON split across chunk boundaries, running-total usage, and parse failures degrading without breaking the byte passthrough.
- Routing (`test_bedrock.py::TestBedrockMantleRouting`) — fable (short and CRIS ids) routes to mantle with litellm untouched; missing project id → 503; bedrock-primary falls back to 1P on 5xx but not on 4xx (counter asserted); explicit anthropic header skips primary. Existing suites pin that non-mantle models stay on bedrock-runtime.
- Full gateway suite: `uv run pytest tests/` in `services/llm-gateway`, 1180 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Gateway-internal; the operational runbook lives in posthog-cloud-infra (`docs/BEDROCK_MANTLE.md`, added in [PostHog/posthog-cloud-infra#9346](https://github.com/PostHog/posthog-cloud-infra/pull/9346)).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session); Chris directed the routing decisions (staged fallback → primary flip, mantle only for provider-share-required models — other CRIS models keep their working bedrock-runtime inference path; the broader CRIS→mantle rule applies only to count_tokens, shipped in #70768).
- Skills invoked: `/writing-tests`, `claude-api` (verified against Anthropic/AWS docs: mantle endpoint shape and SigV4 service name, project selection via the `OpenAI-Project` header on the OpenAI-compatible surface, fable's `allowed_modes`, retention resolution order project → account → model default).
- Transport decision: extended the existing hand-rolled httpx+SigV4 mantle client rather than adopting the anthropic SDK's `AnthropicBedrockMantle` — the pinned SDK (0.81.0, no bedrock extra) may not ship it, and a proxy wants raw SSE re-emission, which the SDK would parse and force us to re-serialize.
- Attribution design: rather than duplicating callback logic, the transport synthesizes litellm's `standard_logging_object` field conventions and invokes the registered `InstrumentedCallback`s directly; the attribution test pins those conventions so litellm upgrades or callback changes surface loudly.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
