### PR TITLE
fix(data-warehouse): debounce active-query decoration in SQL editor

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -669,13 +669,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             // subquery, which is too expensive to do on every arrow key.
             cache.cursorDisposable?.dispose()
             cache.cursorDisposable = props.editor.onDidChangeCursorPosition(() => {
-                if (cache.activeQueryDecorationDebounceTimeout) {
-                    window.clearTimeout(cache.activeQueryDecorationDebounceTimeout)
-                }
-                cache.activeQueryDecorationDebounceTimeout = window.setTimeout(() => {
-                    cache.activeQueryDecorationDebounceTimeout = null
-                    cache.updateActiveQueryDecoration?.()
-                }, 150)
+                cache.scheduleActiveQueryDecoration?.()
             })
 
             // Set up the active-query outline overlay. We render a single `div` parented
@@ -2046,8 +2040,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             // everything whenever the editor content changes.
             cache.subqueryValidationCache?.clear()
 
-            // Decorations are cheap and visual — update immediately for responsiveness.
-            cache.updateActiveQueryDecoration?.()
+            // Debounced — updating decorations parses the AST and can hit the metadata endpoint,
+            // which is too expensive to run on every keystroke.
+            cache.scheduleActiveQueryDecoration?.()
 
             // Skip re-parsing if the text hasn't changed since the last parse.
             if (cache.lastParsedQueryInput === queryInput && cache.lastParsedQueryResult !== undefined) {
@@ -2618,6 +2613,19 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         cache.lastSelectedConnectionId = values.selectedConnectionId
         cache.activeQueryDecorationIds = [] as string[]
         cache.decorationGeneration = 0
+
+        // Debounce the active-query decoration. It parses the HogQL AST (WASM, main thread) and
+        // can fire a HogQLMetadata request, so running it on every keystroke or arrow key stalls
+        // typing on long queries. Cursor moves and content changes both schedule through here.
+        cache.scheduleActiveQueryDecoration = (): void => {
+            if (cache.activeQueryDecorationDebounceTimeout) {
+                window.clearTimeout(cache.activeQueryDecorationDebounceTimeout)
+            }
+            cache.activeQueryDecorationDebounceTimeout = window.setTimeout(() => {
+                cache.activeQueryDecorationDebounceTimeout = null
+                cache.updateActiveQueryDecoration?.()
+            }, 150)
+        }
 
         cache.updateActiveQueryDecoration = async (): Promise<void> => {
             // Bump the generation counter so any still-running invocation bails out before

--- a/playwright/e2e/sql-editor-typing-perf.spec.ts
+++ b/playwright/e2e/sql-editor-typing-perf.spec.ts
@@ -1,0 +1,186 @@
+import { Page } from '@playwright/test'
+
+import { SqlInsight } from '../page-models/insights/sqlInsight'
+import { expect, PlaywrightWorkspaceSetupResult, test } from '../utils/workspace-test-base'
+
+// Manual performance benchmark for typing latency in the SQL editor on a long query.
+// Not part of the CI suite (perf numbers are machine-dependent and would be flaky as an
+// assertion) — gated behind RUN_PERF_BENCH so it is skipped unless run explicitly:
+//
+//   RUN_PERF_BENCH=1 BASE_URL='http://localhost:8010' \
+//     pnpm --filter=@posthog/playwright exec playwright test sql-editor-typing-perf --workers 1
+//
+// It types a fixed burst of keystrokes into a large query and reports main-thread long-task
+// time via PerformanceObserver. To compare before/after a change, run it, `git stash` the
+// change, run again, then `git stash pop` — the printed numbers are the result, not pass/fail.
+
+// A recognizable, autocomplete-safe run of characters (no spaces/dots) typed into a comment.
+const TYPE_MARKER = 'perfbenchmark'
+const TYPE_CHARS = TYPE_MARKER.repeat(6) // 78 keystrokes
+const TYPE_DELAY_MS = 40 // faster than the 150ms decoration debounce, so coalescing is visible
+
+interface TypingStats {
+    // Primary: main-thread jank. A requestAnimationFrame loop runs during the burst; whenever a
+    // frame is delayed past 16.7ms the main thread was too busy to paint. frameBlockedMs sums
+    // that overflow across the burst — it captures the many small per-keystroke parses the
+    // unfixed code runs, which the coarse longtask (>50ms) API misses entirely.
+    frameBlockedMs: number
+    maxFrameGapMs: number
+    frames: number
+    // Secondary: worst single interaction latency + long-task count.
+    eventMaxMs: number
+    longTasks: number
+}
+
+// Build a deterministic, large, deeply-nested query: 12 chained CTEs plus a 20-level nested
+// subquery tail. This is what makes the per-keystroke HogQL parse expensive.
+function buildLargeQuery(): string {
+    const ctes: string[] = []
+    for (let i = 0; i < 12; i++) {
+        const cols = Array.from({ length: 8 }, (_, j) => `col_${i}_${j} AS c${j}`).join(',\n        ')
+        const aggs = Array.from({ length: 5 }, (_, j) => `sum(metric_${i}_${j}) AS a${j}`).join(',\n        ')
+        const groupBy = Array.from({ length: 8 }, (_, j) => `c${j}`).join(', ')
+        ctes.push(
+            `cte_${i} AS (\n    SELECT\n        ${cols},\n        ${aggs}\n    FROM events\n` +
+                `    WHERE col_${i}_0 > ${i * 100}\n        AND timestamp > now() - INTERVAL ${i + 1} DAY\n` +
+                `    GROUP BY ${groupBy}\n)`
+        )
+    }
+
+    let nested = 'SELECT base AS v, sum(x0) AS m FROM events GROUP BY v'
+    for (let d = 1; d <= 20; d++) {
+        nested = `SELECT v, m, max(y${d}) AS m${d} FROM (\n${nested}\n) sub_${d} WHERE m > ${d} GROUP BY v, m`
+    }
+
+    const joins = Array.from(
+        { length: 11 },
+        (_, i) => `    LEFT JOIN cte_${i + 1} ON cte_${i + 1}.c0 = cte_0.c${(i + 1) % 8}`
+    ).join('\n')
+    const finalCols = Array.from({ length: 12 }, (_, i) => `    cte_${i}.a${i % 5} AS metric_${i}`).join(',\n')
+
+    return [
+        '-- perf benchmark query',
+        'WITH\n' + ctes.join(',\n'),
+        `SELECT\n${finalCols}\nFROM cte_0\n${joins}\nLIMIT 100;`,
+        '-- nested tail',
+        nested + ';',
+    ].join('\n')
+}
+
+async function startMeasuring(page: Page): Promise<void> {
+    await page.evaluate(() => {
+        const w = window as any
+        w.__frames = []
+        w.__events = []
+        w.__longTasks = []
+        const loop = (t: number): void => {
+            w.__frames.push(t)
+            w.__raf = requestAnimationFrame(loop)
+        }
+        w.__raf = requestAnimationFrame(loop)
+        w.__evObs = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+                w.__events.push(entry.duration)
+            }
+        })
+        w.__evObs.observe({ type: 'event', durationThreshold: 16 })
+        w.__ltObs = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+                w.__longTasks.push(entry.duration)
+            }
+        })
+        w.__ltObs.observe({ type: 'longtask' })
+    })
+}
+
+async function stopMeasuring(page: Page): Promise<TypingStats> {
+    return await page.evaluate(() => {
+        const w = window as any
+        cancelAnimationFrame(w.__raf)
+        w.__evObs?.disconnect()
+        w.__ltObs?.disconnect()
+
+        const frames: number[] = w.__frames || []
+        const FRAME_BUDGET = 1000 / 60 // 16.7ms
+        let blocked = 0
+        let maxGap = 0
+        for (let i = 1; i < frames.length; i++) {
+            const gap = frames[i] - frames[i - 1]
+            blocked += Math.max(0, gap - FRAME_BUDGET)
+            maxGap = Math.max(maxGap, gap)
+        }
+        const events: number[] = w.__events || []
+        return {
+            frameBlockedMs: Math.round(blocked),
+            maxFrameGapMs: Math.round(maxGap),
+            frames: frames.length,
+            eventMaxMs: Math.round(events.length ? Math.max(...events) : 0),
+            longTasks: (w.__longTasks || []).length,
+        }
+    })
+}
+
+async function goToSqlEditor(page: Page): Promise<void> {
+    await page.goto('/sql')
+    await expect(page).toHaveURL(/\/sql(?:[?#].*)?$/)
+    await expect(page.getByTestId('editor-scene')).toBeVisible({ timeout: 60000 })
+    await expect(page.getByTestId('hogql-query-editor')).toBeVisible()
+    await expect(page.getByText('Loading...', { exact: true })).toHaveCount(0, { timeout: 60000 })
+    await page
+        .getByRole('button', { name: 'Minimize' })
+        .click({ timeout: 1000 })
+        .catch(() => {})
+}
+
+test.describe('SQL editor typing performance', () => {
+    test.describe.configure({ mode: 'serial' })
+    test.setTimeout(180000)
+    test.skip(!process.env.RUN_PERF_BENCH, 'Perf benchmark — run manually with RUN_PERF_BENCH=1')
+
+    let workspace: PlaywrightWorkspaceSetupResult | null = null
+
+    test.beforeAll(async ({ playwrightSetup }) => {
+        workspace = await playwrightSetup.createWorkspace({
+            skip_onboarding: true,
+            use_current_time: true,
+        })
+    })
+
+    test.beforeEach(async ({ page, playwrightSetup }) => {
+        await playwrightSetup.loginAndNavigateToTeam(page, workspace!)
+        await goToSqlEditor(page)
+    })
+
+    test('measure main-thread blocking while typing in a long query', async ({ page }, testInfo) => {
+        const sqlInsight = new SqlInsight(page)
+        const editorArea = page.getByTestId('hogql-query-editor')
+
+        await test.step('load the long query into the editor', async () => {
+            await sqlInsight.writeQuery(buildLargeQuery())
+            // Let the initial parse + metadata request settle so warm-up cost is not measured.
+            await page.waitForTimeout(2000)
+        })
+
+        await test.step('type a burst inside the leading comment and measure long tasks', async () => {
+            await editorArea.click()
+            await page.keyboard.press('ControlOrMeta+Home')
+            await page.keyboard.press('End') // end of the first comment line — no autocomplete here
+
+            await startMeasuring(page)
+            await page.keyboard.type(TYPE_CHARS, { delay: TYPE_DELAY_MS })
+            await page.waitForTimeout(600) // let any trailing debounced work run
+            const stats = await stopMeasuring(page)
+
+            // Prove the keystrokes actually landed in the editor.
+            await expect(editorArea).toContainText(TYPE_MARKER)
+
+            const summary =
+                `keystrokes=${TYPE_CHARS.length} ` +
+                `frameBlockedMs=${stats.frameBlockedMs} maxFrameGapMs=${stats.maxFrameGapMs} ` +
+                `frames=${stats.frames} eventMaxMs=${stats.eventMaxMs} longTasks=${stats.longTasks}`
+            testInfo.annotations.push({ type: 'typing-perf', description: summary })
+            // eslint-disable-next-line no-console
+            console.log(`\n[SQL editor typing perf] ${summary}\n`)
+        })
+    })
+})


### PR DESCRIPTION
## Problem

Editing a long query in the SQL editor lags badly while typing. Every keystroke feels like it stutters, which makes working with big HogQL queries painful.

## Changes

The root cause is in `sqlEditorLogic`. The `queryInput` subscription fired on every keystroke and immediately called `updateActiveQueryDecoration()`. Despite an inline comment calling it "cheap and visual", it isn't: it parses the HogQL AST in WASM on the main thread (`findInnermostSelectAtOffset`) and can fire a `HogQLMetadata` request, whose cache was being wiped on every keystroke anyway.

Cursor moves already debounced that exact call at 150ms, precisely because "each run can fire a HogQLMetadata request... too expensive to do on every arrow key". Content changes just didn't get the same treatment. This shares one debounced scheduler between both paths, reusing the existing `activeQueryDecorationDebounceTimeout` (so teardown in `beforeUnmount` is already handled).

Net effect: the parse and metadata validation run at most once per ~150ms pause instead of once per keystroke. The active-subquery outline and squiggle still update shortly after you stop typing, same as cursor moves already behaved.

> [!NOTE]
> No change to the parse/validation logic itself or the error-squiggle metadata path (`codeEditorLogic`, its own 300ms debounce). This only changes *when* the existing decoration work runs.

## How did you test this code?

I (Claude, driving as PostHog Code) added a gated Playwright benchmark, `playwright/e2e/sql-editor-typing-perf.spec.ts`, and ran it against a local stack. It loads a large deterministic query (12 chained CTEs + a 20-level nested subquery tail), types a fixed 78-keystroke burst inside the leading comment, and measures main-thread jank with a `requestAnimationFrame` probe (sum of frame gaps beyond 16.7ms during the burst).

The benchmark is gated behind `RUN_PERF_BENCH=1` so it is skipped in CI (perf numbers are machine-dependent and would be flaky as an assertion). It asserts only that keystrokes landed, and prints the metrics. Run it with:

```bash
RUN_PERF_BENCH=1 BASE_URL='http://localhost:8010' \
  pnpm --filter=@posthog/playwright exec playwright test sql-editor-typing-perf --workers 1
```

A/B on the same machine (`git stash` the fix, run, pop, run):

| | frameBlockedMs (total jank during burst) | shape |
| --- | --- | --- |
| Before fix | ~344 avg (316–384) | jank spread across many frames while typing |
| After fix | ~225 avg (217–233) | one parse *after* typing stops; typing itself smooth |

About 35% less main-thread blocking, and the shape shifts from "a parse on nearly every keystroke" to "a single deferred parse once you pause". 10/10 passing on `--repeat-each 10`, and confirmed it skips cleanly without the env var.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tools: PostHog Code (Claude Opus 4.8). Skill invoked: `/playwright-test` for the benchmark harness mechanics.

Worth flagging one dead end for reviewers: the first version of the benchmark measured `longtask` (>50ms tasks) and showed *no* before/after difference. That was a false negative, because the unfixed code does many small (~20-40ms) per-keystroke parses that each fall under the 50ms long-task threshold. Switching to the rAF jank probe surfaced the real signal. That is why the final spec uses frame timing rather than the Long Tasks API.

The debounce itself reuses the existing 150ms timer and its `beforeUnmount` cleanup rather than introducing a new resource, so there is no new teardown path to get wrong.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
