### PR TITLE
chore(nodejs): anchor jest dev-folder ignore pattern to the repo root

### DIFF
--- a/nodejs/jest.config.js
+++ b/nodejs/jest.config.js
@@ -21,8 +21,9 @@ module.exports = {
         '<rootDir>/.tmp/',
         '<rootDir>/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/',
     ],
-    // `dev/` folders hold dev-only benchmarks/scripts, never CI tests.
-    testPathIgnorePatterns: ['/node_modules/', '/dev/'],
+    // `dev/` folders hold dev-only benchmarks/scripts, never CI tests. Anchored to rootDir:
+    // an unanchored '/dev/' also matches checkout paths like ~/dev/posthog and ignores every test.
+    testPathIgnorePatterns: ['/node_modules/', '<rootDir>/(src|tests)/.*/dev/'],
 
     // NOTE: This should be kept in sync with tsconfig.json
     moduleNameMapper: {

--- a/nodejs/jest.config.js
+++ b/nodejs/jest.config.js
@@ -23,7 +23,7 @@ module.exports = {
     ],
     // `dev/` folders hold dev-only benchmarks/scripts, never CI tests. Anchored to rootDir:
     // an unanchored '/dev/' also matches checkout paths like ~/dev/posthog and ignores every test.
-    testPathIgnorePatterns: ['/node_modules/', '<rootDir>/(src|tests)/.*/dev/'],
+    testPathIgnorePatterns: ['/node_modules/', '<rootDir>/(src|tests)(/.*)?/dev/'],
 
     // NOTE: This should be kept in sync with tsconfig.json
     moduleNameMapper: {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,7 +8,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
-        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; jest --runInBand --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL --testPathIgnorePatterns='postgres-parity|service-e2e|/dev/'",
+        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; jest --runInBand --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL --testPathIgnorePatterns='postgres-parity|service-e2e|<rootDir>/(src|tests)/.*/dev/'",
         "test:rust-ingestion-e2e": "jest --runInBand --forceExit --testPathPatterns='service-e2e/rust-ingestion-consumer.test.ts'",
         "test:postgres-parity": "jest --runInBand --forceExit --testPathPatterns='postgres-parity'",
         "start": "pnpm start:dev",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,7 +8,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
-        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; jest --runInBand --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL --testPathIgnorePatterns='postgres-parity|service-e2e|<rootDir>/(src|tests)/.*/dev/'",
+        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; jest --runInBand --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL --testPathIgnorePatterns='postgres-parity|service-e2e|<rootDir>/(src|tests)(/.*)?/dev/'",
         "test:rust-ingestion-e2e": "jest --runInBand --forceExit --testPathPatterns='service-e2e/rust-ingestion-consumer.test.ts'",
         "test:postgres-parity": "jest --runInBand --forceExit --testPathPatterns='postgres-parity'",
         "start": "pnpm start:dev",


### PR DESCRIPTION
## Problem

`nodejs/jest.config.js` ignores test paths matching `/dev/` - meant for the in-repo `dev/` benchmark folders. But jest matches ignore patterns against **absolute** paths, so any checkout under a dev-named directory (`~/dev/posthog`) silently ignores the entire suite: raw `jest` reports "No tests found" for all 489 test files. CI never notices because runner paths don't contain `/dev/`.

## Changes

Anchor the pattern to the repo root so it only matches in-repo `dev/` folders:

```diff
-    testPathIgnorePatterns: ['/node_modules/', '/dev/'],
+    testPathIgnorePatterns: ['/node_modules/', '<rootDir>/(src|tests)(/.*)?/dev/'],
```

Same fix in the `test` script in `nodejs/package.json`, which repeats the pattern inline.

## How did you test this code?

From a `~/dev/posthog` checkout: before the change, `pnpm exec jest --testPathPatterns='hogflow-executor'` reports "No tests found" (0 matches with 489 testMatch hits); after, the suite is found and runs. In-repo `dev/` folders remain excluded, including direct `src/dev/` / `tests/dev/` children (the `(/.*)?` per Greptile's review).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None - local tooling behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Found while running the hogflow executor suite from a `~/dev` checkout during work on #70740; split out as its own PR to keep that one surgical.

