### PR TITLE
fix(experiments): reverts retries to be idiomatic temporal

### DIFF
--- a/products/experiments/backend/temporal/recalculation_activities.py
+++ b/products/experiments/backend/temporal/recalculation_activities.py
@@ -8,6 +8,7 @@ and lets the logic be unit-tested without the activity decorator.
 import temporalio.activity
 
 from products.experiments.backend.temporal.models import (
+    MAX_METRIC_ATTEMPTS,
     ExperimentMetricToRecalculate,
     MetricRecalculationResult,
     RecalculationProgressUpdate,
@@ -41,7 +42,6 @@ async def calculate_experiment_metric_for_recalculation(
     recalculation_id: str,
     query_to: str,
     metric_type: str = "primary",
-    is_final_attempt: bool = True,
 ) -> MetricRecalculationResult:
     """Calculate one metric, write its recalc-fingerprinted result to ExperimentMetricResult, and fold the
     progress update (counter + error) into the same job atomically. query_to is the run's shared data-window end.
@@ -50,11 +50,12 @@ async def calculate_experiment_metric_for_recalculation(
     PostHog event so the capture path doesn't have to re-query the saved-metric M2M to resolve it. Defaults to
     "primary" so existing call sites and tests that don't pass it remain valid.
 
-    is_final_attempt is owned by the workflow's requeue loop (the activity runs with maximum_attempts=1, so it
-    can't infer this from activity.info().attempt). On the final attempt a transient failure is persisted rather
-    than re-raised silently, so the row reflects the real outcome once the workflow stops retrying. Defaults to
-    True so callers that don't pass it persist failures eagerly.
+    Finality is derived from activity.info().attempt against MAX_METRIC_ATTEMPTS, the same constant the
+    workflow's RetryPolicy is built from, so both sides agree on which attempt is the last. On the final
+    attempt a transient failure is persisted rather than re-raised silently, so the row reflects the real
+    outcome once Temporal stops retrying.
     """
+    is_final_attempt = temporalio.activity.info().attempt >= MAX_METRIC_ATTEMPTS
     return await _calculate_experiment_metric_for_recalculation_sync(
         experiment_id, metric_uuid, recalculation_id, query_to, metric_type, is_final_attempt
     )

--- a/products/experiments/backend/temporal/recalculation_workflow.py
+++ b/products/experiments/backend/temporal/recalculation_workflow.py
@@ -1,7 +1,5 @@
 import asyncio
-import dataclasses
-from collections import deque
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import temporalio.workflow
 from temporalio.common import RetryPolicy
@@ -14,7 +12,6 @@ with temporalio.workflow.unsafe.imports_passed_through():
         MAX_METRIC_ATTEMPTS,
         METRIC_CALC_ACTIVITY_TIMEOUT_SECONDS,
         ExperimentMetricsRecalculationWorkflowInputs,
-        ExperimentMetricToRecalculate,
         RecalculationProgressUpdate,
     )
     from products.experiments.backend.temporal.recalculation_activities import (
@@ -24,22 +21,18 @@ with temporalio.workflow.unsafe.imports_passed_through():
     )
     from products.experiments.backend.temporal.recalculation_metrics import increment_workflow_finished
 
-# Per-run metric fan-out: how many metric activities one run keeps in flight. Sized so two concurrent runs
-# from the same org fit exactly inside the per-org ClickHouse app-query limit (DEFAULT_APP_ORG_CONCURRENT_QUERIES
-# = 20 in posthog/clickhouse/client/limit.py); a third same-org run bounces off that limiter. Cross-run worker
-# load is bounded separately by the dedicated recalc worker's activity-slot cap (MAX_CONCURRENT_ACTIVITIES).
-MAX_CONCURRENT_METRICS = 10
-
 
 @temporalio.workflow.defn(name="experiment-metrics-recalculation-workflow")
 class ExperimentMetricsRecalculationWorkflow(PostHogWorkflow):
     """Recalculate all metrics for an experiment on demand.
 
-    Each run discovers all metrics, marks the job in_progress (which also pins the single data-window end), then
-    runs a pool of MAX_CONCURRENT_METRICS workers draining a requeue queue (one activity attempt at a time;
-    transient failures requeue with backoff, the workflow owns retries), and finalizes the job status. Per-metric
-    progress counters and errors are folded into the calc activity itself, so the workflow only writes progress
-    at start and finish.
+    Each run discovers all metrics, marks the job in_progress (which also pins the single data-window end),
+    schedules one calc activity per metric all at once, and finalizes the job status. The workflow imposes no
+    concurrency of its own, pacing is owned by the layers that actually constrain it: worker activity slots
+    (MAX_CONCURRENT_ACTIVITIES, autoscaled on task queue backlog) bound compute, and the per-org ClickHouse
+    app-query limiter bounds query fan-out. Scheduling every metric up front also keeps the task queue backlog
+    honest for the autoscaler. Per-metric progress counters and errors are folded into the calc activity
+    itself, so the workflow only writes progress at start and finish.
     """
 
     @staticmethod
@@ -111,101 +104,33 @@ class ExperimentMetricsRecalculationWorkflow(PostHogWorkflow):
 
         temporalio.workflow.logger.info(f"running recalc {recalculation_id} with {len(metrics)} metrics")
 
-        # Worker pool over a requeue queue. Retries are owned by the workflow, not the activity's retry policy,
-        # so a failing attempt frees its concurrency slot the moment it fails instead of holding it through the
-        # whole backoff chain (which would starve healthy metrics behind it). Each activity runs with
-        # maximum_attempts=1; on a transient failure (the activity raises) the metric is requeued at the BACK
-        # with a not-before delay, so other metrics run before its next attempt. A metric is permanently failed
-        # only after MAX_METRIC_ATTEMPTS trips. Permanent failures (StatisticError/ZeroDivisionError) are
-        # returned with success=False, not raised, so they terminate on the first trip.
-        #
-        # Determinism: all time comes from temporalio.workflow.now() (recorded by Temporal, stable on replay)
-        # and waits use temporalio.workflow.sleep(); no wall-clock, no Math.random, no host state.
-        @dataclasses.dataclass
-        class _QueuedMetric:
-            metric: ExperimentMetricToRecalculate
-            attempts: int  # attempts already made (0 on first enqueue)
-            not_before: datetime  # earliest workflow time this item may run
-
-        def _backoff(attempts: int) -> timedelta:
-            # Same schedule the old activity retry policy used: 5s, 10s, 20s, 40s, capped at 60s.
-            return timedelta(seconds=min(5.0 * (2.0 ** (attempts - 1)), 60.0))
-
-        start_now = temporalio.workflow.now()
-        queue: deque[_QueuedMetric] = deque(_QueuedMetric(metric=m, attempts=0, not_before=start_now) for m in metrics)
-        succeeded = 0
-        failed = 0
-        in_flight = 0
-
-        # Re-evaluated by Temporal until true: either an item is queued again (a sibling requeued a retry) or
-        # all in-flight work has drained (so this worker can exit). Defined once, not per loop iteration.
-        def _queue_changed() -> bool:
-            return bool(queue) or in_flight == 0
-
-        async def _worker() -> None:
-            nonlocal succeeded, failed, in_flight
-            while queue or in_flight:
-                if not queue:
-                    # Work is still running in a sibling worker but nothing is runnable here yet. Wait on the
-                    # in-flight work rather than busy-spin; it will requeue or finish, then re-check.
-                    await temporalio.workflow.wait_condition(_queue_changed)
-                    continue
-
-                item = queue.popleft()
-                wait = (item.not_before - temporalio.workflow.now()).total_seconds()
-                if wait > 0:
-                    # Not due yet. Requeue and, if every queued item is also not yet due, sleep until this one
-                    # is (bounded by its own not_before) so we neither busy-spin nor oversleep past a due item.
-                    queue.append(item)
-                    if all((q.not_before - temporalio.workflow.now()).total_seconds() > 0 for q in queue):
-                        await temporalio.workflow.sleep(timedelta(seconds=wait))
-                    continue
-
-                attempt_number = item.attempts + 1
-                is_final_attempt = attempt_number >= MAX_METRIC_ATTEMPTS
-                in_flight += 1
-                try:
-                    result = await temporalio.workflow.execute_activity(
-                        calculate_experiment_metric_for_recalculation,
-                        args=[
-                            item.metric.experiment_id,
-                            item.metric.metric_uuid,
-                            recalculation_id,
-                            query_to,
-                            item.metric.metric_type,
-                            is_final_attempt,
-                        ],
-                        # No heartbeat: the activity's only long-running step is one blocking ClickHouse query
-                        # with no progress hooks, so start_to_close_timeout is the real per-attempt ceiling.
-                        # The query's ClickHouse max_execution_time is capped below this (see models.py) so
-                        # slow queries fail typed inside the activity instead of being killed from outside.
-                        start_to_close_timeout=timedelta(seconds=METRIC_CALC_ACTIVITY_TIMEOUT_SECONDS),
-                        # One attempt per invocation; the workflow owns requeue + backoff (see block comment).
-                        retry_policy=RetryPolicy(maximum_attempts=1),
-                    )
-                except Exception:
-                    # Transient failure (the activity raised). Requeue at the back with a backoff delay unless
-                    # this was the final attempt — in which case the activity already persisted the failure.
-                    if is_final_attempt:
-                        failed += 1
-                    else:
-                        queue.append(
-                            _QueuedMetric(
-                                metric=item.metric,
-                                attempts=attempt_number,
-                                not_before=temporalio.workflow.now() + _backoff(attempt_number),
-                            )
-                        )
-                else:
-                    # Returned a result: success, or a permanent failure recorded with success=False.
-                    if result.success:
-                        succeeded += 1
-                    else:
-                        failed += 1
-                finally:
-                    in_flight -= 1
-
-        await asyncio.gather(*[_worker() for _ in range(MAX_CONCURRENT_METRICS)])
+        calc_retry_policy = RetryPolicy(
+            initial_interval=timedelta(seconds=5),
+            maximum_interval=timedelta(seconds=60),
+            maximum_attempts=MAX_METRIC_ATTEMPTS,
+        )
+        results = await asyncio.gather(
+            *[
+                temporalio.workflow.execute_activity(
+                    calculate_experiment_metric_for_recalculation,
+                    args=[
+                        metric.experiment_id,
+                        metric.metric_uuid,
+                        recalculation_id,
+                        query_to,
+                        metric.metric_type,
+                    ],
+                    start_to_close_timeout=timedelta(seconds=METRIC_CALC_ACTIVITY_TIMEOUT_SECONDS),
+                    retry_policy=calc_retry_policy,
+                )
+                for metric in metrics
+            ],
+            return_exceptions=True,
+        )
+        # An exception here means retries were exhausted; the activity already persisted the FAILED row on its
+        # final attempt. A returned result carries success=False for permanent failures recorded without retry.
+        succeeded = sum(1 for result in results if not isinstance(result, BaseException) and result.success)
+        failed = len(results) - succeeded
 
         # Any failure marks the run as "failed"; the succeeded/failed counts carry the partial-vs-total nuance
         # for consumers that need it (the UI shows "N succeeded, M failed" alongside the status). A status-only

--- a/products/experiments/backend/temporal/test_recalculation_workflow.py
+++ b/products/experiments/backend/temporal/test_recalculation_workflow.py
@@ -18,6 +18,7 @@ from products.experiments.backend.temporal.models import (
     MetricRecalculationResult,
     RecalculationProgressUpdate,
 )
+from products.experiments.backend.temporal.recalculation_activities import calculate_experiment_metric_for_recalculation
 from products.experiments.backend.temporal.recalculation_workflow import ExperimentMetricsRecalculationWorkflow
 
 _START_QUERY_TO = "2026-05-29T12:00:00+00:00"
@@ -53,7 +54,6 @@ def _make_mock_activities(
         recalculation_id: str,
         query_to: str,
         metric_type: str = "primary",
-        is_final_attempt: bool = True,
     ) -> MetricRecalculationResult:
         calculate_calls.append((experiment_id, metric_uuid, recalculation_id, query_to, metric_type))
         return metric_results.get(metric_uuid, MetricRecalculationResult(metric_uuid=metric_uuid, success=True))
@@ -126,10 +126,10 @@ class TestExperimentMetricsRecalculationWorkflow:
         assert progress_updates[-1].status == expected_final_status
         assert progress_updates[-1].mark_completed is True
 
-    async def test_transient_failure_is_requeued_and_retried_until_it_succeeds(self):
-        # A raised activity is a transient failure: the workflow requeues the metric and retries it, freeing
-        # the slot in between. m2 raises on its first two attempts, then succeeds on the third; m1 succeeds
-        # immediately. The run ends fully succeeded, and m2 was invoked three times.
+    async def test_transient_failure_is_retried_until_it_succeeds(self):
+        # A raised activity is a transient failure: Temporal's retry policy re-dispatches it. m2 raises on
+        # its first two attempts, then succeeds on the third; m1 succeeds immediately. The run ends fully
+        # succeeded, and m2 was invoked three times.
         metrics = [_metric("m1"), _metric("m2")]
         attempts: dict[str, int] = {}
 
@@ -148,7 +148,6 @@ class TestExperimentMetricsRecalculationWorkflow:
             recalculation_id: str,
             query_to: str,
             metric_type: str = "primary",
-            is_final_attempt: bool = True,
         ) -> MetricRecalculationResult:
             attempts[metric_uuid] = attempts.get(metric_uuid, 0) + 1
             if metric_uuid == "m2" and attempts[metric_uuid] <= 2:
@@ -161,43 +160,44 @@ class TestExperimentMetricsRecalculationWorkflow:
         assert attempts["m1"] == 1
         assert attempts["m2"] == 3
 
-    async def test_transient_failure_is_marked_failed_after_max_attempts(self):
-        # A metric that raises on every attempt is requeued until MAX_METRIC_ATTEMPTS is exhausted, then
-        # counted as failed (the final attempt persists the failure inside the real activity).
-        metrics = [_metric("m1")]
-        attempts: dict[str, int] = {}
-        # is_final_attempt is the only signal that tells the real activity to persist the failure. Track it
-        # per call so we can assert the workflow flips it to True exactly on the last attempt; otherwise a
-        # run would be counted failed here while the metric row stayed in its loading state forever.
-        is_final_attempt_log: list[bool] = []
+    async def test_exhausted_retries_mark_failed_and_finality_derives_from_attempt_count(self):
+        # A metric that raises on every attempt is retried by the activity retry policy until
+        # MAX_METRIC_ATTEMPTS is exhausted, then counted as failed. Runs the REAL activity wrapper (with the
+        # DB-touching sync implementation patched out) because the wrapper derives is_final_attempt from
+        # activity.info().attempt against the same constant the retry policy is built from — if those two
+        # sides drift, the FAILED row never persists and the metric row stays in its loading state forever.
+        recorded_flags: list[bool] = []
 
         @activity.defn(name="discover_experiment_metrics")
         async def mock_discover(recalculation_id: str) -> list[ExperimentMetricToRecalculate]:
-            return metrics
+            return [_metric("m1")]
 
         @activity.defn(name="update_recalculation_progress")
         async def mock_update_progress(update: RecalculationProgressUpdate) -> str | None:
             return _START_QUERY_TO if update.mark_started else None
 
-        @activity.defn(name="calculate_experiment_metric_for_recalculation")
-        async def mock_calculate(
+        async def failing_sync(
             experiment_id: int,
             metric_uuid: str,
             recalculation_id: str,
             query_to: str,
-            metric_type: str = "primary",
-            is_final_attempt: bool = True,
+            metric_type: str,
+            is_final_attempt: bool,
         ) -> MetricRecalculationResult:
-            attempts[metric_uuid] = attempts.get(metric_uuid, 0) + 1
-            is_final_attempt_log.append(is_final_attempt)
+            recorded_flags.append(is_final_attempt)
             raise RuntimeError("always fails")
 
-        result = await _run_workflow([mock_discover, mock_update_progress, mock_calculate])
+        with patch(
+            "products.experiments.backend.temporal.recalculation_activities._calculate_experiment_metric_for_recalculation_sync",
+            new=failing_sync,
+        ):
+            result = await _run_workflow(
+                [mock_discover, mock_update_progress, calculate_experiment_metric_for_recalculation]
+            )
 
         assert result == {"total": 1, "succeeded": 0, "failed": 1}
-        assert attempts["m1"] == MAX_METRIC_ATTEMPTS
         # Only the final attempt is flagged final; earlier attempts must not be, or they'd persist early.
-        assert is_final_attempt_log == [False] * (MAX_METRIC_ATTEMPTS - 1) + [True]
+        assert recorded_flags == [False] * (MAX_METRIC_ATTEMPTS - 1) + [True]
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Stacked on #69836. The recalc worker pool is moving to KEDA autoscaling driven by Temporal task queue backlog (PostHog/charts#13049), and the workflow's own design fights that setup.

The workflow runs a hand-rolled concurrency pool: `MAX_CONCURRENT_METRICS` coroutines draining a requeue deque, with activities forced to `maximum_attempts=1` and retries reimplemented in workflow code (backoff math, not-before timestamps, requeue-at-the-back ordering). Two consequences:

- Metrics beyond the fan-out cap hide inside workflow state. The task queue backlog the autoscaler watches, and the queue-wait histogram #69836 adds, only ever see a slice of a run's real demand.
- About a hundred lines of scheduling and retry logic duplicate what Temporal does natively, and every future change (quota handling, fairness) would have to be built into that custom loop.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Deletes the pool and hands scheduling and retries to Temporal. The workflow now schedules one calc activity per metric, all at once, and counts results:

- Pacing moves to the layers that actually own capacity: worker activity slots (`MAX_CONCURRENT_ACTIVITIES`) bound compute, and the per-org ClickHouse app-query limiter bounds query fan-out. As one activity finishes, the next starts on whatever pod has a free slot, so a run with more metrics than slots drains naturally and the queue backlog reflects true demand.
- Retries are Temporal-owned via `RetryPolicy(initial 5s, max 60s, maximum_attempts=MAX_METRIC_ATTEMPTS)`, reproducing the old 5/10/20/40/60s schedule with the same attempt budget (3). A retrying activity holds no worker slot during backoff; the server re-dispatches the next attempt through the queue, which was the original motivation for workflow-owned requeues and no longer applies.
- Finality inverts: instead of the workflow passing `is_final_attempt` into the activity, the activity derives it from `activity.info().attempt >= MAX_METRIC_ATTEMPTS`, the same constant the retry policy is built from. The parameter disappears from the activity signature; the logic layer keeps it unchanged.

> [!NOTE]
> Workflow runs in flight when this deploys will fail replay (the workflow body is rewritten). Runs are minutes-long and user-retriggerable, so the blast radius is a handful of runs that can simply be re-run.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/27258072-7628-492f-81ce-d1979f17fb6e)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Fable 5
Manually refactored: **yes**

Skills used:

- /writing-pull-requests (local)
- /writing-tests (local)

Relevant decisions:

- Kept this PR behavior-preserving on purpose: identical retry schedule and attempt budget as the old requeue loop. The behavior changes (larger attempt budget, quota-aware retry delays, org fairness keys) land as separate stacked PRs.
- Inverted `is_final_attempt` instead of deleting it: the logic layer keeps the parameter so its whole test suite survives, and a new workflow test runs the real activity wrapper against a patched sync implementation to pin the retry-policy/finality constant agreement.
- Verified that Temporal activity retries release the worker slot during backoff (the server re-dispatches attempts through the task queue), which removed the stated rationale for the workflow-owned requeue design.