### PR TITLE
feat(batch-exports): add snowflake integration support to frontend

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5211,9 +5211,9 @@ snapshots:
     scenes-app-batchexports--new-s-3-export--light:
         hash: v1.k794b7964.1778817ba915c967ed248359a721bb7359f6370dbca5b1e6fb34e8769b78cdba.yEseQ8plqcP182L5sJ8gnS3mPfFvpHzKjNTTsT8h23c
     scenes-app-batchexports--new-snowflake-export--dark:
-        hash: v1.k794b7964.0c7a5abf149ea9b77a64c7d74097874c5183b1dd4d95825af52a795903b570a6.c8gdKzLC8DEuvtlxQDOqrNagEITtUSCQjMxcpxkEKwA
+        hash: v1.k794b7964.e843d4755dc71856b6a979dc92ff55bf5b96aad73ae92fc84e75b4928db6a881.l71DgdgJKxvGClNwzNogGnHBQbp2KJLj0oMLs8-Htf4
     scenes-app-batchexports--new-snowflake-export--light:
-        hash: v1.k794b7964.d340fea11187663ae6943d9c7097fb82d6cd03a99194a97046593da89f63c8c8.uD1T5wfQtvHKTTbXS_ci3lZ7RxcJXKZshFJgtGv1B7A
+        hash: v1.k794b7964.1025c42527dc2156f4a19a8472783095203ac62a2b4dd8081c246a4d5a5b445b.ggdjfWosV1awfLqx-6Y3fw8u4Sogs1W3bnlOAn8q3VI
     scenes-app-batchexports--runs-empty--dark:
         hash: v1.k794b7964.8177c005d63cababb9abc801ea81b65535c143566c46768b5de465a9d0d53beb.Z_iUGxGBuja1U4pMXOJ99dvgsMUdovOKv-xiIZdsV-U
     scenes-app-batchexports--runs-empty--light:

--- a/frontend/src/lib/components/CyclotronJob/integrations/integrationSetups.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/integrationSetups.tsx
@@ -5,6 +5,7 @@ import { GitLabSetupModal } from 'scenes/integrations/gitlab/GitLabSetupModal'
 import { GoogleCloudServiceAccountSetupModal } from 'scenes/integrations/google-cloud-service-account/GoogleCloudServiceAccountSetupModal'
 import { PostgreSQLSetupModal } from 'scenes/integrations/postgresql/PostgreSQLSetupModal'
 import { S3CompatibleSetupModal } from 'scenes/integrations/s3-compatible/S3CompatibleSetupModal'
+import { SnowflakeSetupModal } from 'scenes/integrations/snowflake/SnowflakeSetupModal'
 import { urls } from 'scenes/urls'
 
 import { ChannelSetupModal } from 'products/workflows/frontend/Channels/ChannelSetupModal'
@@ -119,5 +120,16 @@ registerIntegrationSetup({
     }),
     SetupModal: ({ isOpen, integration, onComplete }) => (
         <S3CompatibleSetupModal isOpen={isOpen} integration={integration} onComplete={onComplete} />
+    ),
+})
+
+registerIntegrationSetup({
+    kind: 'snowflake',
+    menuItem: ({ openModal }) => ({
+        label: 'Configure new Snowflake connection',
+        onClick: () => openModal('snowflake'),
+    }),
+    SetupModal: ({ isOpen, integration, onComplete }) => (
+        <SnowflakeSetupModal isOpen={isOpen} integration={integration} onComplete={onComplete} />
     ),
 })

--- a/frontend/src/lib/integrations/utils.ts
+++ b/frontend/src/lib/integrations/utils.ts
@@ -32,6 +32,7 @@ import IconS3Compatible from 'public/services/s3-compatible.png'
 import IconSalesforce from 'public/services/salesforce.png'
 import IconSlack from 'public/services/slack.png'
 import IconSnapchat from 'public/services/snapchat.png'
+import IconSnowflake from 'public/services/snowflake.png'
 import IconStripe from 'public/services/stripe.png'
 import IconTikTok from 'public/services/tiktok.png'
 import IconTwilio from 'public/services/twilio.png'
@@ -75,6 +76,7 @@ export const ICONS: Record<IntegrationKind, any> = {
     postgresql: IconPostgres,
     'aws-s3': IconAwsS3,
     's3-compatible': IconS3Compatible,
+    snowflake: IconSnowflake,
 }
 
 // Brand marks that are solid black/monochrome on a transparent background — they vanish against a dark

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -26878,7 +26878,8 @@
                 "apns",
                 "postgresql",
                 "aws-s3",
-                "s3-compatible"
+                "s3-compatible",
+                "snowflake"
             ],
             "type": "string"
         },

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -444,8 +444,9 @@ describe('batchExportConfigFormLogic', () => {
                 fields: ['user', 'password', 'host', 'port', 'database', 'schema', 'table_name'],
             },
             {
+                // New Snowflake exports authenticate via an integration, not inline credentials.
                 service: 'Snowflake' as const,
-                fields: ['account', 'database', 'warehouse', 'user', 'password', 'schema', 'table_name'],
+                fields: ['integration_id', 'database', 'warehouse', 'schema', 'table_name'],
             },
             { service: 'BigQuery' as const, fields: ['integration_id', 'dataset_id', 'table_id'] },
             { service: 'HTTP' as const, fields: ['url', 'token'] },
@@ -745,7 +746,7 @@ describe('batchExportConfigFormLogic', () => {
             },
             {
                 service: 'Snowflake',
-                expected: { destination: 'Snowflake', authentication_type: 'password', paused: true, model: 'events' },
+                expected: { destination: 'Snowflake', paused: true, model: 'events' },
             },
             {
                 service: 'Redshift',
@@ -885,26 +886,23 @@ describe('batchExportConfigFormLogic', () => {
                 },
             },
             {
-                name: 'Snowflake (password)',
+                // New Snowflake exports authenticate via an integration; account/user/credentials live
+                // on it and must not leak into the payload.
+                name: 'Snowflake',
                 service: 'Snowflake' as const,
                 requiredValues: {
-                    account: 'sf-account',
+                    integration_id: 31,
                     database: 'sf-db',
                     warehouse: 'sf-wh',
-                    user: 'sf-user',
-                    password: 'sf-pass',
                     schema: 'public',
                     table_name: 'events',
                 },
                 expectedDestination: {
                     type: 'Snowflake',
+                    integration: 31,
                     config: {
-                        account: 'sf-account',
                         database: 'sf-db',
                         warehouse: 'sf-wh',
-                        user: 'sf-user',
-                        password: 'sf-pass',
-                        authentication_type: 'password',
                         schema: 'public',
                         table_name: 'events',
                     },

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/snowflake.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/snowflake.tsx
@@ -1,23 +1,38 @@
-import { LemonInput, LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonBanner, LemonInput, LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
 
+import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import type { DestinationDefinition } from './types'
 
+// New Snowflake exports must store credentials in a linked Integration. Exports created before
+// integrations existed keep their inline credentials (grandfathered), detected by integration_id.
 export const snowflakeDefinition: DestinationDefinition = {
     type: 'Snowflake',
-    defaults: () => ({
-        authentication_type: 'password',
-    }),
-    requiredFields: ({ isNew, formValues }) => [
-        'account',
+    usesIntegration: true,
+    defaults: () => ({}),
+    requiredFields: ({ isNew, formValues }) => {
+        if (isNew || formValues.integration_id) {
+            // New exports must pick an integration; existing integration-backed exports keep theirs.
+            return [...(isNew ? ['integration_id'] : []), 'database', 'warehouse', 'schema', 'table_name']
+        }
+        // Grandfathered inline-credential exports keep their original fields when edited.
+        return ['account', 'database', 'warehouse', 'schema', 'table_name']
+    },
+    // The credential keys remain allowlisted for grandfathered inline exports.
+    // TODO: clean up once fully migrated to integration-based credentials
+    configKeys: [
         'database',
         'warehouse',
-        ...(isNew ? ['user'] : []),
-        ...(isNew && formValues.authentication_type == 'password' ? ['password'] : []),
-        ...(isNew && formValues.authentication_type == 'keypair' ? ['private_key'] : []),
         'schema',
         'table_name',
+        'role',
+        'account',
+        'user',
+        'authentication_type',
+        'password',
+        'private_key',
+        'private_key_passphrase',
     ],
     eventTableOverrides: {
         setName: 'people_set',
@@ -32,53 +47,66 @@ export const snowflakeDefinition: DestinationDefinition = {
         },
     },
     Fields: function SnowflakeFields({ isNew, formValues }) {
+        const useIntegration = isNew || !!formValues.integration_id
+
         return (
             <>
-                <LemonField name="account" label="Account">
-                    <LemonInput placeholder="my-account" />
-                </LemonField>
-
-                <LemonField name="user" label="User">
-                    <LemonInput placeholder={isNew ? 'my-user' : 'Leave unchanged'} />
-                </LemonField>
-
-                <LemonField name="authentication_type" label="Authentication type" className="flex-1">
-                    <LemonSelect
-                        options={[
-                            { value: 'password', label: 'Password' },
-                            { value: 'keypair', label: 'Key pair' },
-                        ]}
-                    />
-                </LemonField>
-
-                {formValues.authentication_type != 'keypair' && (
-                    <LemonField name="password" label="Password">
-                        <LemonInput placeholder={isNew ? 'my-password' : 'Leave unchanged'} type="password" />
+                {useIntegration ? (
+                    <LemonField name="integration_id" label="Connection">
+                        {({ value, onChange }) => (
+                            <IntegrationChoice integration="snowflake" value={value} onChange={onChange} />
+                        )}
                     </LemonField>
-                )}
-
-                {formValues.authentication_type == 'keypair' && (
+                ) : (
                     <>
-                        <LemonField name="private_key" label="Private key">
-                            <LemonTextArea
-                                className="ph-ignore-input"
-                                placeholder={isNew ? 'my-private-key' : 'Leave unchanged'}
-                                minRows={4}
+                        <LemonBanner type="warning">
+                            Snowflake batch exports are moving to integration-based credentials. This export will be
+                            migrated automatically — no action required.
+                        </LemonBanner>
+
+                        <LemonField name="account" label="Account">
+                            <LemonInput placeholder="my-account" />
+                        </LemonField>
+
+                        <LemonField name="user" label="User">
+                            <LemonInput placeholder={isNew ? 'my-user' : 'Leave unchanged'} />
+                        </LemonField>
+
+                        <LemonField name="authentication_type" label="Authentication type" className="flex-1">
+                            <LemonSelect
+                                options={[
+                                    { value: 'password', label: 'Password' },
+                                    { value: 'keypair', label: 'Key pair' },
+                                ]}
                             />
                         </LemonField>
 
-                        <LemonField name="private_key_passphrase" label="Private key passphrase">
-                            <LemonInput placeholder={isNew ? 'my-passphrase' : 'Leave unchanged'} />
-                        </LemonField>
+                        {formValues.authentication_type != 'keypair' && (
+                            <LemonField name="password" label="Password">
+                                <LemonInput placeholder={isNew ? 'my-password' : 'Leave unchanged'} type="password" />
+                            </LemonField>
+                        )}
+
+                        {formValues.authentication_type == 'keypair' && (
+                            <>
+                                <LemonField name="private_key" label="Private key">
+                                    <LemonTextArea
+                                        className="ph-ignore-input"
+                                        placeholder={isNew ? 'my-private-key' : 'Leave unchanged'}
+                                        minRows={4}
+                                    />
+                                </LemonField>
+
+                                <LemonField name="private_key_passphrase" label="Private key passphrase">
+                                    <LemonInput placeholder={isNew ? 'my-passphrase' : 'Leave unchanged'} />
+                                </LemonField>
+                            </>
+                        )}
                     </>
                 )}
 
                 <LemonField name="database" label="Database">
                     <LemonInput placeholder="my-database" />
-                </LemonField>
-
-                <LemonField name="warehouse" label="Warehouse">
-                    <LemonInput placeholder="my-warehouse" />
                 </LemonField>
 
                 <LemonField name="schema" label="Schema">
@@ -87,6 +115,10 @@ export const snowflakeDefinition: DestinationDefinition = {
 
                 <LemonField name="table_name" label="Table name">
                     <LemonInput placeholder="events" />
+                </LemonField>
+
+                <LemonField name="warehouse" label="Warehouse">
+                    <LemonInput placeholder="my-warehouse" />
                 </LemonField>
 
                 <LemonField name="role" label="Role" showOptional>

--- a/frontend/src/scenes/integrations/snowflake/SnowflakeSetupModal.tsx
+++ b/frontend/src/scenes/integrations/snowflake/SnowflakeSetupModal.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
-import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonButton, LemonFileInput, LemonInput, LemonModal, LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
@@ -53,6 +53,13 @@ export const SnowflakeSetupModal = (props: SnowflakeSetupModalLogicProps): JSX.E
                 </LemonField>
                 {snowflakeIntegration.authentication_type === 'keypair' ? (
                     <>
+                        <LemonField
+                            name="private_key_file"
+                            label="Private key file"
+                            help="Upload the key file you generated, or paste its contents below."
+                        >
+                            <LemonFileInput accept=".p8,.pem,.key" multiple={false} />
+                        </LemonField>
                         <LemonField name="private_key" label="Private key">
                             <LemonTextArea className="ph-ignore-input" placeholder="my-private-key" minRows={8} />
                         </LemonField>

--- a/frontend/src/scenes/integrations/snowflake/SnowflakeSetupModal.tsx
+++ b/frontend/src/scenes/integrations/snowflake/SnowflakeSetupModal.tsx
@@ -1,0 +1,71 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTextArea } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { SnowflakeSetupModalLogicProps, snowflakeSetupModalLogic } from './snowflakeSetupModalLogic'
+
+export const SnowflakeSetupModal = (props: SnowflakeSetupModalLogicProps): JSX.Element => {
+    const { isSnowflakeIntegrationSubmitting, snowflakeIntegration } = useValues(snowflakeSetupModalLogic(props))
+    const { submitSnowflakeIntegration } = useActions(snowflakeSetupModalLogic(props))
+
+    return (
+        <LemonModal
+            isOpen={props.isOpen}
+            width={680}
+            title="Configure Snowflake connection"
+            description="Enter your Snowflake credentials to connect PostHog to your account. They are stored encrypted and can be reused across exports."
+            onClose={props.onComplete}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={() => props.onComplete()}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        loading={isSnowflakeIntegrationSubmitting}
+                        onClick={submitSnowflakeIntegration}
+                    >
+                        Save
+                    </LemonButton>
+                </>
+            }
+        >
+            <Form logic={snowflakeSetupModalLogic} formKey="snowflakeIntegration" className="flex flex-col gap-4">
+                <LemonField name="name" label="Name" info="A name to identify this connection across exports.">
+                    <LemonInput placeholder="e.g. Production Snowflake account" />
+                </LemonField>
+                <LemonField name="account" label="Account">
+                    <LemonInput placeholder="my-account" autoComplete="off" />
+                </LemonField>
+                <LemonField name="user" label="User">
+                    <LemonInput placeholder="my-user" autoComplete="off" />
+                </LemonField>
+                <LemonField name="authentication_type" label="Authentication type">
+                    <LemonSelect
+                        options={[
+                            { value: 'keypair', label: 'Key pair' },
+                            { value: 'password', label: 'Password' },
+                        ]}
+                    />
+                </LemonField>
+                {snowflakeIntegration.authentication_type === 'keypair' ? (
+                    <>
+                        <LemonField name="private_key" label="Private key">
+                            <LemonTextArea className="ph-ignore-input" placeholder="my-private-key" minRows={8} />
+                        </LemonField>
+                        <LemonField name="private_key_passphrase" label="Private key passphrase" showOptional>
+                            <LemonInput type="password" placeholder="my-passphrase" autoComplete="new-password" />
+                        </LemonField>
+                    </>
+                ) : (
+                    <LemonField name="password" label="Password">
+                        <LemonInput type="password" placeholder="my-password" autoComplete="new-password" />
+                    </LemonField>
+                )}
+            </Form>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/integrations/snowflake/snowflakeSetupModalLogic.ts
+++ b/frontend/src/scenes/integrations/snowflake/snowflakeSetupModalLogic.ts
@@ -1,0 +1,68 @@
+import { connect, kea, path, props } from 'kea'
+import { forms } from 'kea-forms'
+
+import api from 'lib/api'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+
+import { IntegrationType } from '~/types'
+
+import type { snowflakeSetupModalLogicType } from './snowflakeSetupModalLogicType'
+
+export interface SnowflakeSetupModalLogicProps {
+    isOpen: boolean
+    integration?: IntegrationType | null
+    onComplete: (integrationId?: number) => void
+}
+
+export const snowflakeSetupModalLogic = kea<snowflakeSetupModalLogicType>([
+    path(['integrations', 'snowflake', 'snowflakeSetupModalLogic']),
+    props({} as SnowflakeSetupModalLogicProps),
+    connect(() => ({
+        actions: [integrationsLogic, ['loadIntegrations']],
+    })),
+    forms(({ props, actions, values }) => ({
+        snowflakeIntegration: {
+            defaults: {
+                name: '',
+                account: '',
+                user: '',
+                authentication_type: 'keypair',
+                password: '',
+                private_key: '',
+                private_key_passphrase: '',
+            },
+            errors: ({ name, account, user, authentication_type, password, private_key }) => ({
+                name: name.trim() ? undefined : 'Name is required',
+                account: account.trim() ? undefined : 'Account is required',
+                user: user.trim() ? undefined : 'User is required',
+                password: authentication_type === 'password' && !password.trim() ? 'Password is required' : undefined,
+                private_key:
+                    authentication_type === 'keypair' && !private_key.trim() ? 'Private key is required' : undefined,
+            }),
+            submit: async () => {
+                const { snowflakeIntegration } = values
+                try {
+                    const integration = await api.integrations.create({
+                        kind: 'snowflake',
+                        config: {
+                            name: snowflakeIntegration.name,
+                            account: snowflakeIntegration.account,
+                            user: snowflakeIntegration.user,
+                            authentication_type: snowflakeIntegration.authentication_type,
+                            password: snowflakeIntegration.password,
+                            private_key: snowflakeIntegration.private_key,
+                            private_key_passphrase: snowflakeIntegration.private_key_passphrase,
+                        },
+                    })
+                    actions.loadIntegrations()
+                    lemonToast.success('Snowflake connection created successfully!')
+                    props.onComplete(integration.id)
+                } catch (error: any) {
+                    lemonToast.error(error.detail || 'Failed to create Snowflake connection')
+                    throw error
+                }
+            },
+        },
+    })),
+])

--- a/frontend/src/scenes/integrations/snowflake/snowflakeSetupModalLogic.ts
+++ b/frontend/src/scenes/integrations/snowflake/snowflakeSetupModalLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, path, props } from 'kea'
+import { connect, kea, listeners, path, props } from 'kea'
 import { forms } from 'kea-forms'
 
 import api from 'lib/api'
@@ -31,6 +31,8 @@ export const snowflakeSetupModalLogic = kea<snowflakeSetupModalLogicType>([
                 password: '',
                 private_key: '',
                 private_key_passphrase: '',
+                // Bound to the file input only — its contents are read into `private_key`, it isn't sent.
+                private_key_file: null as File[] | null,
             },
             errors: ({ name, account, user, authentication_type, password, private_key }) => ({
                 name: name.trim() ? undefined : 'Name is required',
@@ -63,6 +65,26 @@ export const snowflakeSetupModalLogic = kea<snowflakeSetupModalLogicType>([
                     throw error
                 }
             },
+        },
+    })),
+    listeners(({ actions }) => ({
+        setSnowflakeIntegrationValue: async ({ name, value }) => {
+            // When a key file is uploaded, read its contents into the private_key field so users
+            // following Snowflake's key-pair workflow can upload the generated file instead of pasting.
+            const fieldName = Array.isArray(name) ? name[0] : name
+            if (fieldName === 'private_key_file' && value?.[0]) {
+                try {
+                    const contents: string = await new Promise((resolve, reject) => {
+                        const reader = new FileReader()
+                        reader.onload = (e) => resolve(e.target?.result as string)
+                        reader.onerror = (e) => reject(e)
+                        reader.readAsText(value[0])
+                    })
+                    actions.setSnowflakeIntegrationValue('private_key', contents)
+                } catch {
+                    actions.setSnowflakeIntegrationManualErrors({ private_key_file: 'Could not read the key file' })
+                }
+            }
         },
     })),
 ])

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5429,6 +5429,7 @@ export const INTEGRATION_KINDS = [
     'postgresql',
     'aws-s3',
     's3-compatible',
+    'snowflake',
 ] as const
 
 export type IntegrationKind = (typeof INTEGRATION_KINDS)[number]
@@ -6491,6 +6492,7 @@ export type BatchExportServicePostgres = {
 
 export type BatchExportServiceSnowflake = {
     type: 'Snowflake'
+    integration?: number
     config: {
         account: string
         database: string

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2343,6 +2343,7 @@ class IntegrationKind(StrEnum):
     POSTGRESQL = "postgresql"
     AWS_S3 = "aws-s3"
     S3_COMPATIBLE = "s3-compatible"
+    SNOWFLAKE = "snowflake"
 
 
 class IntervalType(StrEnum):

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -4510,6 +4510,7 @@ export const IntegrationKindApi = {
     Postgresql: 'postgresql',
     AwsS3: 'aws-s3',
     S3Compatible: 's3-compatible',
+    Snowflake: 'snowflake',
 } as const
 
 export interface ErrorTrackingExternalReferenceIntegrationApi {

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -3863,6 +3863,7 @@ export const IntegrationKindApi = {
     Postgresql: 'postgresql',
     AwsS3: 'aws-s3',
     S3Compatible: 's3-compatible',
+    Snowflake: 'snowflake',
 } as const
 
 export interface ErrorTrackingExternalReferenceIntegrationApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -5494,6 +5494,7 @@ export namespace Schemas {
       Postgresql: 'postgresql',
       AwsS3: 'aws-s3',
       S3Compatible: 's3-compatible',
+      Snowflake: 'snowflake',
     } as const;
 
     export interface ErrorTrackingExternalReferenceIntegration {


### PR DESCRIPTION
## Problem

The Snowflake backend support for Integrations is already merged ([#70481](https://github.com/PostHog/posthog/pull/70481)); this is the frontend to match, mirroring the S3 work in [#66359](https://github.com/PostHog/posthog/pull/66359).

## Changes

- Add `snowflake` as an integration kind (`INTEGRATION_KINDS`, `IntegrationKind`) with its icon, and an `integration` field on `BatchExportServiceSnowflake`.
- New `SnowflakeSetupModal` + logic to create a snowflake Integration (name, account, user, and either key pair or password auth). Key pair is the default.
- Wire the Snowflake destination form to the integration picker for new exports. Exports created before integrations existed keep their inline credential fields (grandfathered), with a banner noting they'll be migrated automatically.

## How did you test this code?

Automated tests:

- `batchExportConfigFormLogic.test.ts` (67 cases pass). Updated the Snowflake cases to assert the new integration flow: required fields are now `integration_id` + `database`/`warehouse`/`schema`/`table_name`, the create payload carries `destination.integration` with no leaked credentials, and `authentication_type` no longer defaults into the config. The existing password/keypair round-trip fixtures already guard grandfathered inline exports.

Manual testing via the local stack:

- tested creation of a new Snowflake batch export using an Integration
- tested an existing Snowflake batch export still works without an Integration (legacy inline credentials still work)

## Screenshots

### New modal

<img width="709" height="977" alt="image" src="https://github.com/user-attachments/assets/563eb129-4a0a-4c65-b0ba-ed35f004c043" />

### Warning for legacy exports

<img width="1691" height="390" alt="image" src="https://github.com/user-attachments/assets/cc824604-2f6d-4ba2-9ff0-a753dbb102ca" />


## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams? No

## Docs update

We should update the docs for Snowflake batch exports to mention the new flow using integrations, as was done for S3 recently.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude (PostHog Code). Ross directed the work: scope it as a frontend mirror of the S3 integration PR, then a few refinements (key pair as the default auth, modal width tuning for pasting private keys).

Notes for reviewers:

- Structurally this follows `postgres.tsx` more than the S3 files. Snowflake defines its `Fields` inline like Postgres, whereas the three S3 destinations share `S3FamilyFields`.
- Dropped the `authentication_type: 'password'` default on the destination. New exports use the picker and never render the inline auth field, so a default would only leak the key into `config`, which the backend rejects as unknown.
- Skills invoked: `/writing-tests` (before touching the test file) and `/user-skills:create-pr` (this PR).
- The kea `*LogicType.ts` files are gitignored and regenerated in CI, so they're not in the diff.

---

_Created with [PostHog Code](https://posthog.com/code?ref=pr)_