### PR TITLE
feat(workflows): expose an in-flight run count for hog flows

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -15,7 +15,7 @@ import { UUIDT } from '~/common/utils/utils'
 
 import { createCdpConsumerDeps } from '../../tests/helpers/cdp'
 import { forSnapshot } from '../../tests/helpers/snapshots'
-import { getFirstTeam, resetTestDatabase } from '../../tests/helpers/sql'
+import { createTeam, getFirstTeam, resetTestDatabase } from '../../tests/helpers/sql'
 import { Hub, Team } from '../types'
 import { FixtureHogFlowBuilder } from './_tests/builders/hogflow.builder'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from './_tests/examples'
@@ -1219,6 +1219,18 @@ describe('CDP API', () => {
 
             expect(res.status).toEqual(404)
             expect(res.body.error).toEqual('Workflow not found')
+        })
+
+        it("errors when requesting another team's hog flow", async () => {
+            const otherTeamId = await createTeam(hub.postgres, team.organization_id)
+
+            const res = await supertest(app).get(
+                `/api/projects/${otherTeamId}/hog_flows/${countHogFlow.id}/in_flight_count`
+            )
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Workflow not found')
+            expect(mockCountInFlightJobs).not.toHaveBeenCalled()
         })
 
         it('errors if the cyclotron producer is not configured', async () => {

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -914,6 +914,7 @@ describe('CDP API', () => {
             const createJobMock = jest.fn().mockResolvedValue('resolver-job-id')
             api['batchResolverProducer'] = {
                 createJob: createJobMock,
+                countInFlightJobs: jest.fn().mockResolvedValue(0),
                 disconnect: jest.fn().mockResolvedValue(undefined),
             }
 
@@ -1000,6 +1001,7 @@ describe('CDP API', () => {
             const createJobMock = jest.fn().mockResolvedValue('resolver-job-id')
             api['batchResolverProducer'] = {
                 createJob: createJobMock,
+                countInFlightJobs: jest.fn().mockResolvedValue(0),
                 disconnect: jest.fn().mockResolvedValue(undefined),
             }
 
@@ -1060,6 +1062,7 @@ describe('CDP API', () => {
             const createJobMock = jest.fn().mockResolvedValue('resolver-job-id')
             api['batchResolverProducer'] = {
                 createJob: createJobMock,
+                countInFlightJobs: jest.fn().mockResolvedValue(0),
                 disconnect: jest.fn().mockResolvedValue(undefined),
             }
 

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -1168,6 +1168,67 @@ describe('CDP API', () => {
         })
     })
 
+    describe('hogflow in-flight count', () => {
+        let countHogFlow: HogFlow
+        let mockCountInFlightJobs: jest.Mock
+
+        beforeEach(async () => {
+            mockCountInFlightJobs = jest.fn().mockResolvedValue(3)
+            api['batchResolverProducer'] = {
+                createJob: jest.fn(),
+                disconnect: jest.fn(),
+                countInFlightJobs: mockCountInFlightJobs,
+            }
+
+            countHogFlow = await insertHogFlow({
+                id: new UUIDT().toString(),
+                name: 'test in-flight count hog flow',
+                status: 'active',
+                version: 1,
+                exit_condition: 'exit_on_conversion',
+                edges: [],
+                actions: [],
+                trigger: {
+                    type: 'event',
+                    filters: {},
+                },
+            })
+        })
+
+        afterEach(() => {
+            api['batchResolverProducer'] = null
+        })
+
+        it('returns the in-flight job count for a workflow', async () => {
+            const res = await supertest(app).get(
+                `/api/projects/${countHogFlow.team_id}/hog_flows/${countHogFlow.id}/in_flight_count`
+            )
+
+            expect(res.status).toEqual(200)
+            expect(res.body).toEqual({ count: 3 })
+            expect(mockCountInFlightJobs).toHaveBeenCalledWith(countHogFlow.team_id, countHogFlow.id)
+        })
+
+        it('errors if missing hog flow', async () => {
+            const res = await supertest(app).get(
+                `/api/projects/${countHogFlow.team_id}/hog_flows/${new UUIDT().toString()}/in_flight_count`
+            )
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Workflow not found')
+        })
+
+        it('errors if the cyclotron producer is not configured', async () => {
+            api['batchResolverProducer'] = null
+
+            const res = await supertest(app).get(
+                `/api/projects/${countHogFlow.team_id}/hog_flows/${countHogFlow.id}/in_flight_count`
+            )
+
+            expect(res.status).toEqual(503)
+        })
+    })
+
     // The test panel POSTs to /hog_flows/:id/invocations and runs the executor in-process —
     // it never enqueues into cyclotron. If the executor routes an email action onto the
     // dedicated email queue, nothing services that job and the workflow stalls on a

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -238,6 +238,7 @@ export class CdpApi {
             asyncHandler(this.postRerunInvocations('hog_function'))
         )
         router.post('/api/projects/:team_id/hog_flows/:id/rerun', asyncHandler(this.postRerunInvocations('hog_flow')))
+        router.get('/api/projects/:team_id/hog_flows/:id/in_flight_count', asyncHandler(this.getHogFlowInFlightCount))
         router.get('/api/projects/:team_id/hog_functions/:id/status', asyncHandler(this.getFunctionStatus()))
         router.patch('/api/projects/:team_id/hog_functions/:id/status', asyncHandler(this.patchFunctionStatus()))
         router.get('/api/hog_functions/states', asyncHandler(this.getFunctionStates()))
@@ -798,6 +799,37 @@ export class CdpApi {
                 res.status(500).json({ error: e instanceof Error ? e.message : String(e) })
             }
         }
+
+    // How many of this workflow's runs are still in flight (parked on waits/delays or actively
+    // executing). Django calls this to show publish/edit impact before a live workflow changes.
+    private getHogFlowInFlightCount = async (req: ModifiedRequest, res: express.Response): Promise<any> => {
+        try {
+            if (!this.batchResolverProducer) {
+                return res.status(503).json({
+                    error: 'Cyclotron producer not initialized (CYCLOTRON_NODE_DATABASE_URL unset)',
+                })
+            }
+
+            const { team_id, id } = req.params
+            const team = await this.deps.teamManager.getTeam(parseInt(team_id)).catch(() => null)
+            if (!team) {
+                return res.status(404).json({ error: 'Team not found' })
+            }
+
+            const hogFlow = await this.hogFlowManager.getHogFlow(id)
+            if (!hogFlow || hogFlow.team_id !== team.id) {
+                return res.status(404).json({ error: 'Workflow not found' })
+            }
+
+            const count = await this.batchResolverProducer.countInFlightJobs(team.id, id)
+            return res.json({ count })
+        } catch (e) {
+            logger.error('Error counting in-flight hog flow jobs', {
+                error: e instanceof Error ? e.message : String(e),
+            })
+            return res.status(500).json({ error: e instanceof Error ? e.message : String(e) })
+        }
+    }
 
     private postHogFlowBatchInvocation = async (req: ModifiedRequest, res: express.Response): Promise<any> => {
         try {

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -254,6 +254,21 @@ describe('Cyclotron V2', () => {
             }
         )
 
+        it('countInFlightJobs counts available and running jobs for one team and function', async () => {
+            const functionId = uuidv7()
+            const otherFunctionId = uuidv7()
+            await manager.createJob({ teamId: 1, queueName: QUEUE, functionId })
+            const runningId = await manager.createJob({ teamId: 1, queueName: QUEUE, functionId })
+            await assertPool.query(`UPDATE cyclotron_jobs SET status = 'running' WHERE id = $1`, [runningId])
+            // Not counted: terminal status, other function, other team
+            const completedId = await manager.createJob({ teamId: 1, queueName: QUEUE, functionId })
+            await assertPool.query(`UPDATE cyclotron_jobs SET status = 'completed' WHERE id = $1`, [completedId])
+            await manager.createJob({ teamId: 1, queueName: QUEUE, functionId: otherFunctionId })
+            await manager.createJob({ teamId: 2, queueName: QUEUE, functionId })
+
+            expect(await manager.countInFlightJobs(1, functionId)).toBe(2)
+        })
+
         it('backpressure throws when queue depth exceeds limit', async () => {
             const smallManager = createManager({ depthLimit: 2, depthCheckIntervalMs: 0 })
             await smallManager.connect()

--- a/nodejs/src/cdp/services/cyclotron-v2/manager.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/manager.ts
@@ -391,6 +391,17 @@ export class CyclotronV2Manager {
         return dequeueSeqs
     }
 
+    // "In flight" = jobs still owned by the queue: parked waits/delays ('available' with a future
+    // scheduled time) and jobs a worker currently holds ('running'). Terminal rows don't count.
+    async countInFlightJobs(teamId: number, functionId: string): Promise<number> {
+        const result = await this.pool.query<{ count: number }>(
+            `SELECT COUNT(*)::int AS count FROM cyclotron_jobs
+             WHERE team_id = $1 AND function_id = $2 AND status IN ('available', 'running')`,
+            [teamId, functionId]
+        )
+        return result.rows[0].count
+    }
+
     async disconnect(): Promise<void> {
         await this.pool.end()
     }

--- a/nodejs/src/cdp/services/cyclotron-v2/types.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.ts
@@ -101,6 +101,7 @@ export type CyclotronV2ManagerConfig = {
  */
 export interface CyclotronV2JobProducer {
     createJob(input: CyclotronV2JobInit): Promise<string>
+    countInFlightJobs(teamId: number, functionId: string): Promise<number>
     disconnect(): Promise<void>
 }
 

--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -107,6 +107,13 @@ def create_hog_flow_scheduled_invocation(
     )
 
 
+def get_hog_flow_in_flight_count(team_id: int, hog_flow_id: str) -> requests.Response:
+    return internal_requests.get(
+        CDP_API_URL + f"/api/projects/{team_id}/hog_flows/{hog_flow_id}/in_flight_count",
+        headers=get_internal_api_headers(),
+    )
+
+
 def get_hog_function_status(team_id: int, hog_function_id: UUIDT) -> requests.Response:
     return internal_requests.get(
         CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status",


### PR DESCRIPTION
## Problem

Live edits to an active workflow reach runs already in flight - parked on waits and delays or mid-execution - but nothing in the API layer can say how many runs that is.
For the workflows draft → test → publish cycle (step 1 of #66380), publish needs to echo a crude "N runs in flight" so nothing publishes blind.
In-flight runs live in the cyclotron jobs table, which only the node CDP service can reach, so Django has no way to ask today.

## Changes

- `countInFlightJobs(teamId, functionId)` on `CyclotronV2Manager` and the `CyclotronV2JobProducer` interface: one indexed count of `available`/`running` jobs by team and function (`idx_queue_function_id` covers the lookup).
- `GET /api/projects/:team_id/hog_flows/:id/in_flight_count` on the CDP API, returning `{count}`.
  Guards mirror the rerun endpoint: 503 when `CYCLOTRON_NODE_DATABASE_URL` is unset, 404 for unknown team or workflow (including cross-team lookups).
- `get_hog_flow_in_flight_count()` in `posthog/plugins/plugin_server_api.py`, same shape as its sibling client helpers.

No callers yet - the publish endpoint that consumes this lands in a follow-up PR.

## How did you test this code?

- `cyclotron-v2.test.ts`: new case proving the count includes available and running jobs and excludes terminal statuses, other functions, and other teams - catches anyone loosening the status or scoping filters.
- `cdp-api.test.ts`: three route cases - 200 with the count and correct `(team_id, function_id)` args (catches a param swap), 404 for an unknown workflow, 503 when the producer isn't configured (locks in fail-on-request rather than fail-at-boot for local dev).

Both suites run green locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None - internal service endpoint, no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as PR 1 of 3 for the draft → test → publish cycle in #66380.
Skills invoked: /writing-tests.
Tests were written first against the real cyclotron test database and the supertest app.
The count method went on the existing `CyclotronV2JobProducer` surface (already injected into `CdpApi` for batch dispatch) rather than a new pool or a dedicated manager - the interface is documented as the place API entrypoints grow producer-side needs.