### PR TITLE
fix(data-warehouse): shrink new-source wizard payload and gzip it

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -842,7 +842,7 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/?api/(environments|projects)/\\d+/query/?$",
                 # Deploy-static source catalog (no user input or secrets reflected): several
                 # hundred KB of JSON that compresses ~7x.
-                "^/?api/(environments|projects)/\\d+/external_data_sources/wizard/?$",
+                "^/?api/(environments|projects)/(\\d+|@current)/external_data_sources/wizard/?$",
                 "^/?api/instance_status/?$",
                 "^/array/.*$",
             ]

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -840,6 +840,9 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/api/organizations/@current/plugins/?$",
                 "^api/(environments|projects)/@current/feature_flags/my_flags/?$",
                 "^/?api/(environments|projects)/\\d+/query/?$",
+                # Deploy-static source catalog (no user input or secrets reflected): several
+                # hundred KB of JSON that compresses ~7x.
+                "^/?api/(environments|projects)/\\d+/external_data_sources/wizard/?$",
                 "^/?api/instance_status/?$",
                 "^/array/.*$",
             ]

--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -4161,7 +4161,9 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
     )
     @action(methods=["GET"], detail=False)
     def wizard(self, request: Request, *arg: Any, **kwargs: Any):
-        configs = build_source_configs()
+        # The documented-tables catalog is only consumed by the posthog.com docs build (via the
+        # public endpoint) — skipping it here cuts ~40% off an already >1 MB response.
+        configs = build_source_configs(include_tables=False)
 
         requested = request.query_params.get("source_type")
         if requested:

--- a/products/data_warehouse/backend/presentation/views/public_source_configs.py
+++ b/products/data_warehouse/backend/presentation/views/public_source_configs.py
@@ -1,3 +1,5 @@
+import functools
+
 import structlog
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, status, viewsets
@@ -11,12 +13,18 @@ from products.warehouse_sources.backend.facade.source_management import SourceRe
 logger = structlog.get_logger(__name__)
 
 
-def build_source_configs() -> dict[str, dict]:
+@functools.cache
+def build_source_configs(*, include_tables: bool = True) -> dict[str, dict]:
     """Build the source-config catalog returned by both the public endpoint and the wizard.
 
-    Each entry is the source's ``SourceConfig`` augmented with ``supportsColumnSelection`` and a
-    credential-free ``tables`` catalog (empty for SQL/file sources with user-defined schemas). Kept
-    in one place so the two endpoints can never drift (see ``test_matches_wizard_response``).
+    Each entry is the source's ``SourceConfig`` augmented with ``supportsColumnSelection`` and,
+    when ``include_tables`` is set, a credential-free ``tables`` catalog (empty for SQL/file
+    sources with user-defined schemas). ``tables`` exists for the posthog.com docs build; the
+    in-app wizard skips it because nothing in the app reads it and it is ~40% of the payload.
+    Kept in one place so the two endpoints can never drift (see ``test_matches_wizard_response``).
+
+    The catalog is deploy-static (it only changes when source code ships), so the result is
+    memoized per process — callers must treat it as read-only.
     """
     sources = SourceRegistry.get_all_sources()
 
@@ -24,12 +32,13 @@ def build_source_configs() -> dict[str, dict]:
     for source_type, source in sources.items():
         config = source.get_source_config.model_dump()
         config["supportsColumnSelection"] = bool(source.supports_column_selection)
-        # Per-source guard: a single misbehaving source must never break the whole catalog.
-        try:
-            config["tables"] = source.get_documented_tables()
-        except Exception:
-            logger.exception("build_source_configs: get_documented_tables failed", source_type=str(source_type))
-            config["tables"] = []
+        if include_tables:
+            # Per-source guard: a single misbehaving source must never break the whole catalog.
+            try:
+                config["tables"] = source.get_documented_tables()
+            except Exception:
+                logger.exception("build_source_configs: get_documented_tables failed", source_type=str(source_type))
+                config["tables"] = []
         results[str(source_type)] = config
 
     return results

--- a/products/data_warehouse/backend/tests/api/test_public_source_configs.py
+++ b/products/data_warehouse/backend/tests/api/test_public_source_configs.py
@@ -19,14 +19,22 @@ class TestPublicSourceConfigs(APIBaseTest):
         assert "fields" in first_config
 
     def test_matches_wizard_response(self):
-        """Public endpoint should return the same data as the authenticated /wizard endpoint."""
+        """Public endpoint returns the same data as the authenticated /wizard endpoint, plus the
+        docs-only `tables` catalog the wizard deliberately omits to keep its payload small."""
         response = self.client.get("/api/public_source_configs/")
         assert response.status_code == status.HTTP_200_OK
 
         wizard_response = self.client.get("/api/environments/@current/external_data_sources/wizard/")
         assert wizard_response.status_code == status.HTTP_200_OK
 
-        assert response.json() == wizard_response.json()
+        wizard_data = wizard_response.json()
+        assert not any("tables" in config for config in wizard_data.values())
+
+        public_without_tables = {
+            source_type: {k: v for k, v in config.items() if k != "tables"}
+            for source_type, config in response.json().items()
+        }
+        assert public_without_tables == wizard_data
 
     def test_accessible_without_authentication(self):
         self.client.logout()


### PR DESCRIPTION
## Problem

The new-source wizard page (`/pipeline/new/source`) blocks on `GET /api/environments/:id/external_data_sources/wizard/`, which returned **1.22 MB of uncompressed JSON** describing all 761 registered sources. Two compounding issues:

1. **43% of the payload (521 KB) was dead weight.** The `tables` key is the credential-free documented-table catalog built for the posthog.com docs build (served by the public `/api/public_source_configs/` endpoint). Nothing on the app path reads it: the frontend `SourceConfig` type has no `tables` field, and the MCP tool's response projection (`pickResponseFields` in `services/mcp`) only passes through `name`, `caption`, `docsUrl`, `featured`, `unreleasedSource`, and `fields`.
2. **The response shipped uncompressed.** PostHog gzips API responses via a scoped allowlist (`ScopedGZipMiddleware`), and this path wasn't on it.

Server CPU was not the bottleneck (catalog build is ~35 ms warm), transfer was.

## Changes

| | before | after |
|---|---|---|
| wizard response (raw) | 1,218 KB | 688 KB |
| over the wire | 1,218 KB (no gzip) | **86 KB** (gzip) |
| catalog build per request | ~35 ms | ~0 ms (memoized) |

- `build_source_configs()` gains a keyword-only `include_tables` flag and is memoized with `functools.cache` (the catalog is deploy-static, it only changes when source code ships)
- the wizard action calls it with `include_tables=False`; the public docs endpoint is unchanged and keeps `tables`
- the wizard path is added to `GZIP_RESPONSE_ALLOW_LIST`. BREACH-safe: the response reflects no user input and contains no secrets
- the endpoint drift test now asserts public == wizard + `tables`, and that the wizard response carries no `tables` key

No frontend change needed, and the OpenAPI spec is unchanged (`tables` was never part of the `SourceConfig` schema, it was bolted onto the dict).

### Estimated impact

Pages that fetch this endpoint (the new-source wizard, the source connect scene, and the source configuration tab) get roughly 14k loads per month across US and EU Cloud combined. That works out to about 16.7 GB/month of uncompressed transfer before, ~1.2 GB/month after, so **~15.5 GB/month saved (93%)**. At typical cloud egress rates that's only a couple of dollars a month, so the dollar savings are negligible. The real win is page load time (1.2 MB of JSON on a slow connection is seconds of blocking spinner) plus a small per-request CPU saving on the web workers.

### Is the MCP tool affected?

No. The generated `external-data-sources-wizard` MCP tool fetches this endpoint and then applies an include-list projection before returning anything to the model. `tables` was fetched over the internal network and immediately discarded, so the tool's output is byte-identical after this change. The tool also declares its response as `unknown` (no zod validation of the response body), so removing a key cannot break parsing. Side benefit: the MCP service now downloads 688 KB instead of 1.22 MB for unfiltered calls.

## How did you test this code?

Automated (run locally, all green):

- `products/data_warehouse/backend/tests/api/test_public_source_configs.py` (7 passed), including the updated drift test — it now catches both regressions this change creates room for: the two endpoints drifting on shared fields, and someone re-adding `tables` to the wizard response and doubling the payload
- `products/data_warehouse/backend/tests/api/test_external_data_source.py -k wizard` (15 passed)
- `posthog/test/test_gzip_middleware.py` — 2 passed, 2 pre-existing failures that fail identically on a clean tree (local env can't render the home page), unrelated to this change
- payload sizes and the gzip allowlist regex verified with a local script against the real registry (761 sources): pattern matches `/api/environments/2/external_data_sources/wizard/` and `/api/projects/2/external_data_sources/wizard` and nothing else on that router

I (Claude) did not manually test the page in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference the wizard endpoint payload shape; the public docs endpoint that posthog.com consumes is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Fable 5) in a Claude Code session, directed by Daniel. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`.
- Investigated three options the driver raised (new endpoint, smaller response, caching) and landed on trimming + memoizing + gzip on the existing endpoint: a new endpoint would duplicate the catalog builder for no extra saving, and HTTP-level ETag/304 caching was considered and dropped as low-value once the wire size is 86 KB (would also need conditional-GET wiring this stack doesn't have today).
- Verified the two consumers of the removed field before cutting it: frontend `SourceConfig` type (no `tables` field, no `.tables` reads in app code) and the generated MCP tool (include-list projection drops it).
- Monthly load and transfer estimates come from querying pageviews of the three scenes that mount `availableSourcesLogic`, then multiplying by measured payload sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)