### PR TITLE
fix(experiments): add fairness key

### DIFF
--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -1047,7 +1047,10 @@ class EnterpriseExperimentsViewSet(
                 asyncio.run(
                     temporal.start_workflow(
                         "experiment-metrics-recalculation-workflow",
-                        MetricsRecalcInputs(recalculation_id=recalculation_id),
+                        MetricsRecalcInputs(
+                            recalculation_id=recalculation_id,
+                            fairness_key=str(experiment.team.organization_id),
+                        ),
                         id=f"experiment-metrics-recalculation-{recalculation_id}",
                         task_queue=settings.EXPERIMENTS_RECALCULATION_TASK_QUEUE,
                     )

--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -39,6 +39,9 @@ class ExperimentMetricsRecalculationWorkflowInputs:
     """Input to the batch metrics recalculation workflow."""
 
     recalculation_id: str  # UUID as string
+    # Task-queue fairness key for the calc activities (the org id, matching the app_per_org limiter scope).
+    # None falls back to default dispatch order.
+    fairness_key: str | None = None
 
 
 @dataclasses.dataclass

--- a/products/experiments/backend/temporal/recalculation_workflow.py
+++ b/products/experiments/backend/temporal/recalculation_workflow.py
@@ -2,7 +2,7 @@ import asyncio
 from datetime import timedelta
 
 import temporalio.workflow
-from temporalio.common import RetryPolicy
+from temporalio.common import Priority, RetryPolicy
 from temporalio.exceptions import ApplicationError
 
 from posthog.temporal.common.base import PostHogWorkflow
@@ -122,6 +122,9 @@ class ExperimentMetricsRecalculationWorkflow(PostHogWorkflow):
                     ],
                     start_to_close_timeout=timedelta(seconds=METRIC_CALC_ACTIVITY_TIMEOUT_SECONDS),
                     retry_policy=calc_retry_policy,
+                    # Round-robin dispatch across orgs under backlog; a no-op on namespaces without
+                    # fairness support.
+                    priority=Priority(fairness_key=inputs.fairness_key),
                 )
                 for metric in metrics
             ],


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Stacked on #70801, and closes the last gap left by removing the workflow's concurrency pool in #70793: dispatch ordering. A run now schedules every metric activity up front, and the task queue serves them FIFO, so one org's large run queued first occupies the queue head while another org's small run waits behind it until autoscaling adds pods. The old per-run fan-out cap limited this incidentally; nothing replaced it at the dispatch layer.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Dispatches the calc activities with a Temporal task-queue fairness key set to the org id:

- New optional `fairness_key` on `ExperimentMetricsRecalculationWorkflowInputs`, passed by the trigger endpoint as the experiment's organization id, and applied per calc activity via `Priority(fairness_key=...)`. Under backlog, the task queue round-robins dispatch across keys instead of FIFO, so no org's burst can queue-starve another's.
- The key scope deliberately matches the `app_per_org` ClickHouse limiter (#70801): dispatch fairness and query quota act on the same boundary. Interleaving orgs at dispatch also spreads a single org's wave of activities over time, which softens how hard it slams its own quota.
- On a namespace without task-queue fairness support the field is ignored and ordering stays FIFO, so this degrades to a safe no-op. The key is applied on the activities, not the workflow, because activity slots are the contended resource.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/13280d87-c155-45ec-a51a-c860a5532f63)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Fable 5
Manually refactored: **yes**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Fairness key is the org id rather than the team id or run id, so dispatch fairness shares a boundary with the per-org query limiter; a per-run key would give a bursty org more aggregate share.
- Verified the installed temporalio SDK (1.24.0) supports `Priority(fairness_key=...)` on `execute_activity`, and that unsupported namespaces silently ignore it, before building on the feature.
- No dedicated test: the change is pass-through plumbing into Temporal's dispatcher, and asserting the call kwargs would be a change-detector test with no observable behavior to pin locally.