### PR TITLE
fix(data-imports): honor Anthropic Retry-After on 429s

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/anthropic.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/anthropic.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 
 import requests
 from structlog.types import FilteringBoundLogger
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -30,7 +30,37 @@ DEFAULT_STARTING_AT = datetime(2023, 1, 1, tzinfo=UTC)
 
 
 class AnthropicRetryableError(Exception):
-    pass
+    def __init__(self, message: str, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        # Seconds the server asked us to wait (from a 429 `Retry-After`), or None to back off blindly.
+        self.retry_after = retry_after
+
+
+# The report endpoints (usage_report/cost_report) are strictly rate limited and return a `Retry-After`
+# on 429. Cap the honored value so a pathological header can't pin the worker; the pipeline retries the
+# activity above us if the window is genuinely longer.
+_MAX_RETRY_AFTER_SECONDS = 60
+_fallback_wait = wait_exponential_jitter(initial=1, max=30)
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a `Retry-After` header expressed as delta-seconds (Anthropic's form). Returns None for a
+    missing, non-numeric, or negative value so the caller falls back to exponential backoff."""
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    return seconds if seconds >= 0 else None
+
+
+def _wait_anthropic(retry_state: RetryCallState) -> float:
+    """Honor the server's `Retry-After` on 429s (capped), else fall back to exponential jitter."""
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if isinstance(exc, AnthropicRetryableError) and exc.retry_after is not None:
+        return min(exc.retry_after, _MAX_RETRY_AFTER_SECONDS)
+    return _fallback_wait(retry_state)
 
 
 @dataclasses.dataclass
@@ -84,14 +114,18 @@ def _build_url(path: str, params: dict[str, Any], multi_params: dict[str, list[s
         )
     ),
     stop=stop_after_attempt(5),
-    wait=wait_exponential_jitter(initial=1, max=30),
+    wait=_wait_anthropic,
     reraise=True,
 )
 def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
     response = session.get(url, headers=headers, timeout=60)
 
     if response.status_code == 429 or response.status_code >= 500:
-        raise AnthropicRetryableError(f"Anthropic API error (retryable): status={response.status_code}, url={url}")
+        retry_after = _parse_retry_after(response.headers.get("retry-after")) if response.status_code == 429 else None
+        raise AnthropicRetryableError(
+            f"Anthropic API error (retryable): status={response.status_code}, url={url}",
+            retry_after=retry_after,
+        )
 
     if not response.ok:
         logger.error(f"Anthropic API error: status={response.status_code}, body={response.text}, url={url}")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/tests/test_anthropic.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/tests/test_anthropic.py
@@ -1,11 +1,12 @@
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from unittest.mock import MagicMock, patch
 
 import requests
 from parameterized import parameterized
+from tenacity import RetryCallState
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic import anthropic
 from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic.anthropic import (
@@ -357,15 +358,15 @@ class TestRetryAfter:
         assert exc_info.value.retry_after == 45.0
 
     def test_wait_honors_retry_after_capped(self) -> None:
-        assert _wait_anthropic(_FakeRetryState(AnthropicRetryableError("rate limited", retry_after=45.0))) == 45.0
+        state = _FakeRetryState(AnthropicRetryableError("rate limited", retry_after=45.0))
+        assert _wait_anthropic(cast(RetryCallState, state)) == 45.0
         # A server asking for longer than the cap is clamped so it can't wedge the worker.
-        assert (
-            _wait_anthropic(_FakeRetryState(AnthropicRetryableError("rate limited", retry_after=6000.0)))
-            == _MAX_RETRY_AFTER_SECONDS
-        )
+        capped = _FakeRetryState(AnthropicRetryableError("rate limited", retry_after=6000.0))
+        assert _wait_anthropic(cast(RetryCallState, capped)) == _MAX_RETRY_AFTER_SECONDS
 
     def test_wait_falls_back_when_no_retry_after(self) -> None:
         # No header (e.g. a 5xx) → blind exponential backoff, never a crash on the missing value.
-        wait = _wait_anthropic(_FakeRetryState(AnthropicRetryableError("server error"), attempt_number=1))
+        state = _FakeRetryState(AnthropicRetryableError("server error"), attempt_number=1)
+        wait = _wait_anthropic(cast(RetryCallState, state))
         assert isinstance(wait, float)
         assert wait >= 0

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/tests/test_anthropic.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/tests/test_anthropic.py
@@ -9,12 +9,16 @@ from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic import anthropic
 from products.warehouse_sources.backend.temporal.data_imports.sources.anthropic.anthropic import (
+    _MAX_RETRY_AFTER_SECONDS,
     AnthropicResumeConfig,
+    AnthropicRetryableError,
     _build_url,
     _flatten_cost_result,
     _flatten_usage_result,
+    _parse_retry_after,
     _report_params,
     _row_id,
+    _wait_anthropic,
     get_rows,
     validate_credentials,
 )
@@ -317,3 +321,51 @@ class TestFetchPage:
         with pytest.raises(requests.HTTPError):
             anthropic._fetch_page(session, "https://api.anthropic.com/v1/organizations/users", {}, MagicMock())
         assert session.get.call_count == 1
+
+
+class _FakeRetryState:
+    def __init__(self, exc: Exception | None, attempt_number: int = 1) -> None:
+        self.outcome = MagicMock()
+        self.outcome.exception.return_value = exc
+        self.attempt_number = attempt_number
+
+
+class TestRetryAfter:
+    @parameterized.expand(
+        [
+            ("delta_seconds", "45", 45.0),
+            ("zero", "0", 0.0),
+            ("missing", None, None),
+            ("non_numeric", "in a while", None),
+            ("negative", "-5", None),
+        ]
+    )
+    def test_parse_retry_after(self, _name: str, header: str | None, expected: float | None) -> None:
+        assert _parse_retry_after(header) == expected
+
+    def test_fetch_page_attaches_retry_after_from_header(self) -> None:
+        # The rate-limited report endpoints tell us exactly when the window resets; that value must
+        # survive onto the exception so the wait strategy can honor it instead of guessing.
+        response = MagicMock(status_code=429, ok=False, headers={"retry-after": "45"})
+        session = MagicMock()
+        session.get.return_value = response
+        with patch.object(anthropic._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
+            with pytest.raises(AnthropicRetryableError) as exc_info:
+                anthropic._fetch_page(
+                    session, "https://api.anthropic.com/v1/organizations/cost_report", {}, MagicMock()
+                )
+        assert exc_info.value.retry_after == 45.0
+
+    def test_wait_honors_retry_after_capped(self) -> None:
+        assert _wait_anthropic(_FakeRetryState(AnthropicRetryableError("rate limited", retry_after=45.0))) == 45.0
+        # A server asking for longer than the cap is clamped so it can't wedge the worker.
+        assert (
+            _wait_anthropic(_FakeRetryState(AnthropicRetryableError("rate limited", retry_after=6000.0)))
+            == _MAX_RETRY_AFTER_SECONDS
+        )
+
+    def test_wait_falls_back_when_no_retry_after(self) -> None:
+        # No header (e.g. a 5xx) → blind exponential backoff, never a crash on the missing value.
+        wait = _wait_anthropic(_FakeRetryState(AnthropicRetryableError("server error"), attempt_number=1))
+        assert isinstance(wait, float)
+        assert wait >= 0


### PR DESCRIPTION
## Problem

Error tracking surfaced `AnthropicRetryableError` (status 429) firing from the Anthropic data-warehouse import, raised in `_fetch_page` at `products/warehouse_sources/backend/temporal/data_imports/sources/anthropic/anthropic.py`. It hit the `cost_report` / `usage_report` endpoints, which are the strictly rate-limited paginated report endpoints.

The Anthropic Admin API returns a `Retry-After` header on 429s telling us exactly when the rate-limit window resets. The in-source retry ignored it: it backed off with a `wait_exponential_jitter(initial=1, max=30)` capped at 30s. When Anthropic asks for a longer wait, we retry too early, burn all 5 attempts inside the window, and reraise — hard-failing the sync on a condition that a correctly-timed retry would clear.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f61a1-9658-7f80-9105-4edcec472626

## Changes

A 429 is transient and should stay retryable, so this is not a NonRetryableError. Instead I made the retry actually effective:

- `AnthropicRetryableError` now carries an optional `retry_after`.
- On a 429, `_fetch_page` parses the `Retry-After` header (delta-seconds) and attaches it.
- A custom tenacity `wait` honors that value (capped at 60s so a pathological header can't wedge the worker), falling back to the existing exponential jitter when there's no header (e.g. 5xx).

Scoped to this source's retry path. Global retry policy is untouched.

## How did you test this code?

Automated only (I'm an agent and did not run the live import). Added a `TestRetryAfter` class in `test_anthropic.py`:

- `_parse_retry_after` handles delta-seconds, zero, missing, non-numeric, and negative values.
- `_fetch_page` on a 429 attaches the header value to the raised exception.
- the wait strategy honors `Retry-After`, clamps it to the cap, and falls back to jitter with no crash when it's absent.

These catch the regression where the parsing or honoring is dropped and 429s revert to the blind <=30s backoff that caused this issue. No existing test exercised `Retry-After` (the old `_fetch_page` test used a mock header that yielded no value).

`hogli test` on the file: 35 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (PostHog Code). Invoked the `/writing-tests` skill before adding the regression tests. Considered adding the 429 to `get_non_retryable_errors` and rejected it: a rate limit is transient and must stay retryable per the pipeline's retry conventions; the real defect was the backoff ignoring the server's `Retry-After`. Kept the change to this source only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
