### PR TITLE
fix(data-warehouse): use resolved partition keys for all repartition batches

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition.py
@@ -359,11 +359,14 @@ async def _rewrite_into_temp(
         if PARTITION_KEY in table.column_names:
             table = table.drop([PARTITION_KEY])
 
+        # After the first batch resolves, later batches must use the *resolved* keys too: datetime
+        # auto-detect swaps the key from the primary key to the detected timestamp column, and pairing
+        # the resolved mode with the original (e.g. UUID) key would fail to parse it as a date.
         result = append_partition_key_to_table(
             table=table,
             partition_count=target.partition_count,
             partition_size=target.partition_size,
-            partition_keys=target.partition_keys,
+            partition_keys=resolved.partition_keys if resolved else target.partition_keys,
             partition_mode=resolved.partition_mode if resolved else target.partition_mode,
             partition_format=resolved.partition_format if resolved else target.partition_format,
             logger=logger,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition.py
@@ -262,6 +262,37 @@ class TestRewriteIntoTemp:
         # created_at is a timestamp column named like a datetime key → auto-detects datetime mode.
         assert resolved.partition_mode == "datetime"
 
+    def test_resolved_keys_apply_to_batches_after_the_first(self, tmp_path):
+        # Auto-detect swaps the target's primary key (a UUID string) for the detected timestamp
+        # column. Batches after the first must use the resolved key — pairing the resolved
+        # datetime mode with the original UUID key raised ParserError mid-rewrite in production.
+        rows = 10
+        table = pa.table(
+            {
+                "id": pa.array([f"0198d931-1efe-73b9-aad5-feb84ed767{i:02d}" for i in range(rows)], type=pa.string()),
+                "created_at": pa.array(
+                    [datetime.datetime(2024, 1, (i % 27) + 1) for i in range(rows)], type=pa.timestamp("us")
+                ),
+            }
+        )
+        deltalake.write_deltalake(str(tmp_path / "src"), table)
+        old_delta = deltalake.DeltaTable(str(tmp_path / "src"))
+
+        rows_written, resolved = asyncio.run(
+            _rewrite_into_temp(
+                old_delta=old_delta,
+                temp_uri=str(tmp_path / "tmp"),
+                storage_options={},
+                target=RepartitionTarget(partition_keys=["id"], trigger_reason="test", partition_mode=None),
+                batch_size=3,  # force batches after the resolving first one
+                logger=logger,
+            )
+        )
+
+        assert rows_written == rows
+        assert resolved.partition_mode == "datetime"
+        assert resolved.partition_keys == ["created_at"]
+
 
 class _FakeS3CM:
     """Minimal async-context-manager stand-in for `aget_s3_client()`."""


### PR DESCRIPTION
## Problem

The auto-repartition controller has been producing a steady stream of `warehouse_repartition_failed` events with `error_type=ParserError` and messages like `Unknown string format: 0198d931-1efe-73b9-aad5-feb84ed767f5` — UUID/cuid values being fed into `dateutil.parser.parse`. Every affected table burns through its 3 repartition attempts and never gets repartitioned, so the OOM pressure the controller exists to relieve stays unresolved.

Root cause: when an *unpartitioned* table is flagged (either trigger), the target carries the schema's primary keys (e.g. a UUID `id`) with `partition_mode=None`. `_rewrite_into_temp` auto-detects on the first batch — resolving `datetime` mode keyed on the detected timestamp column (e.g. `created_at`) — but every subsequent batch was called with the resolved `datetime` **mode** paired with the **original UUID key**. Auto-detection is skipped once a mode is set, so batch 2 tries to parse the UUID as a date and raises `ParserError`. Any table larger than one 50k-row batch with a non-numeric string primary key and a detectable timestamp column fails deterministically.

## Changes

One-line fix in `_rewrite_into_temp`: thread `resolved.partition_keys` (not `target.partition_keys`) into batches after the first, matching how the resolved mode and format were already threaded.

## How did you test this code?

- Reproduced the exact production error in isolation (unpartitioned Delta table, UUID string `id` primary key, `created_at` timestamp column, `batch_size` forcing multiple batches): `ParserError: Unknown string format: <uuid>` on the second batch before the fix; clean rewrite with `resolved.partition_keys == ["created_at"]` after.
- Added `test_resolved_keys_apply_to_batches_after_the_first` — it fails with the ParserError on the unfixed code (verified) and passes with the fix. No existing test caught this because the multi-batch tests all pass `partition_keys=["created_at"]`, which coincidentally equals the resolved key.
- Full `test_repartition.py` suite: 51 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal controller behavior only — no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: diagnosed from the "Recent repartition failures" dashboard (ParserError rows across US/EU teams), traced the throw site to the datetime branch of `append_partition_key_to_table`, then to the unresolved-keys threading in `_rewrite_into_temp`.
- Skills invoked: /writing-tests.
- Verified the buggy call site is identical on current master before porting the fix from an older worktree base.
