### PR TITLE
chore(ci): name failing tests in the django gate

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -21,6 +21,10 @@
 #   Trunk posting from a non-blocking timing trial — and so also omits the test
 #   steps' continue-on-error and that verdict step, letting each shard's test
 #   exit code be the verdict directly)
+# - Per-test failure rollup: canonical's django_tests gate uploads product JUnit and, when a
+#   test job fails, downloads that shard's JUnit to list the actual failing tests. The shadow
+#   strips artifact uploads (above), so it has nothing to download and keeps the plain
+#   dependency-result table — depot-exempt for the same reason as the other uploads.
 # - OpenAPI types: the check-openapi-types job is folded into check-migrations as a
 #   check-only step (drift still fails the run); only its auto-commit side effect is dropped
 # - actions/cache reads/writes route to Depot Cache, not GitHub Actions Cache,

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -856,6 +856,7 @@ jobs:
                   name: product-junit-results-${{ strategy.job-index }}
                   path: junit-staging/junit-product-*.xml
                   if-no-files-found: ignore
+                  overwrite: true # artifacts are immutable per run; re-run shards would 409 otherwise
 
             - name: Upload timing data
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -3008,7 +3009,7 @@ jobs:
                       out = ["### Failing backend & product tests", "", f"{len(rows)} failing test(s):",
                              "", "| Shard | Test | Message |", "| --- | --- | --- |"]
                       for shard, nodeid, _f, msg in rows[:100]:
-                          out.append(f"| {shard} | `{nodeid}` | {msg.replace('|', r'\|')} |")
+                          out.append(f"| {shard} | `{nodeid.replace('|', r'\|')}` | {msg.replace('|', r'\|')} |")
                       if len(rows) > 100:
                           out += ["", f"…and {len(rows) - 100} more."]
                       text = "\n".join(out) + "\n"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -835,6 +835,28 @@ jobs:
               shell: bash
               run: exit 1
 
+            # Feeds the django_tests gate's per-test failure rollup. Rename each file to carry
+            # its product so the name survives upload-artifact's least-common-ancestor path
+            # collapse (same trick as "Stage product coverage" below).
+            - name: Stage product JUnit
+              if: always()
+              shell: bash
+              run: |
+                  mkdir -p junit-staging
+                  for f in products/*/junit-product.xml; do
+                      [ -f "$f" ] || continue
+                      cp "$f" "junit-staging/junit-product-$(basename "$(dirname "$f")").xml"
+                  done
+            # Separate prefix from junit-results-backend-* on purpose: those are consumed by
+            # test-selection-verdict (snob shadow) and report-test-timings, not product tests.
+            - name: Upload product test results
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: always()
+              with:
+                  name: product-junit-results-${{ strategy.job-index }}
+                  path: junit-staging/junit-product-*.xml
+                  if-no-files-found: ignore
+
             - name: Upload timing data
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               if: ${{ github.ref == 'refs/heads/master' }}
@@ -2896,7 +2918,8 @@ jobs:
             ]
         name: Django Tests Pass
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        # Headroom for downloading every shard's JUnit for the failure rollup.
+        timeout-minutes: 8
         if: always()
         steps:
             - name: Summarize dependency results
@@ -2925,8 +2948,82 @@ jobs:
                     fi
                   } | tee -a "$GITHUB_STEP_SUMMARY"
 
+            # Per-test failure rollup: only when a test job actually failed, download that
+            # shard's JUnit so "Check dependency results" can list the failing tests. Skipped
+            # on green runs (the common case) to avoid pulling ~50 artifacts for nothing.
+            # continue-on-error so a flaky fetch can't fail this required gate.
+            - name: Download shard JUnit results
+              if: always() && (needs.django.result != 'success' || needs.turbo-tests.result != 'success')
+              continue-on-error: true
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  pattern: '{junit-results-backend,product-junit-results}-*'
+                  path: /tmp/junit-gate/
             - name: Check dependency results
               run: |
+                  # Per-test failure rollup, emitted from THIS step because GitHub only
+                  # auto-expands the failed step in the log view. Best-effort via `|| true`
+                  # so a parser hiccup never changes the verdict computed below.
+                  python3 <<'PY' || true
+                  import glob, os, xml.etree.ElementTree as ET
+
+                  ROOT = "/tmp/junit-gate"
+                  rows = []  # (shard, nodeid, repo_file, message)
+
+                  def clean(s):
+                      # Collapse newlines so PR-authored test names can't inject ::workflow-commands::
+                      return " ".join((s or "").split())
+
+                  for path in glob.glob(os.path.join(ROOT, "**", "junit-*.xml"), recursive=True):
+                      artifact = os.path.relpath(path, ROOT).split(os.sep)[0]
+                      base = os.path.basename(path)
+                      # Product JUnit is staged as junit-product-<name>.xml; backend keeps its key.
+                      product = base[len("junit-product-"):-len(".xml")] if base.startswith("junit-product-") else ""
+                      shard = f"products/{product}" if product else artifact.removeprefix("junit-results-backend-")
+                      with open(path, "rb") as fh:
+                          raw = fh.read()
+                      # Refuse DTD/entity payloads (XXE, billion-laughs). pytest JUnit has neither,
+                      # so real failures are never dropped; a crafted file is simply skipped.
+                      if b"<!DOCTYPE" in raw or b"<!ENTITY" in raw:
+                          continue
+                      try:
+                          tree = ET.fromstring(raw)
+                      except ET.ParseError:
+                          continue
+                      for tc in tree.iter("testcase"):
+                          bad = tc.find("failure")
+                          if bad is None:
+                              bad = tc.find("error")
+                          if bad is None:
+                              continue
+                          name = tc.get("name", "")
+                          file_ = tc.get("file", "") or tc.get("classname", "")
+                          repo_file = f"products/{product}/{file_}" if product and file_ else file_
+                          nodeid = clean("::".join(p for p in (repo_file, name) if p))
+                          msg = clean(bad.get("message") or bad.text or "")[:200]
+                          rows.append((clean(shard), nodeid, clean(repo_file), msg))
+
+                  # Print only when something failed; on a green gate this stays silent.
+                  if rows:
+                      out = ["### Failing backend & product tests", "", f"{len(rows)} failing test(s):",
+                             "", "| Shard | Test | Message |", "| --- | --- | --- |"]
+                      for shard, nodeid, _f, msg in rows[:100]:
+                          out.append(f"| {shard} | `{nodeid}` | {msg.replace('|', r'\|')} |")
+                      if len(rows) > 100:
+                          out += ["", f"…and {len(rows) - 100} more."]
+                      text = "\n".join(out) + "\n"
+                      summary = os.environ.get("GITHUB_STEP_SUMMARY")
+                      if summary:
+                          with open(summary, "a") as fh:
+                              fh.write(text)
+                      print(text)
+                      for shard, nodeid, repo_file, msg in rows[:30]:
+                          title = f"Backend test failed ({shard})"
+                          body = f"{nodeid}: {msg}" if msg else nodeid
+                          loc = f"file={repo_file}," if repo_file else ""
+                          print(f"::error {loc}title={title}::{body}")
+                  PY
+
                   deterministic_failure=false
                   failed=false
 


### PR DESCRIPTION
## Problem

The "Django Tests Pass" gate tells you which *job* failed, not which *test*. Product test failures can't even be named, because their JUnit never gets uploaded. On [this run](https://github.com/PostHog/posthog/actions/runs/29346326136/job/87134551266) it just says the product matrix failed, so you're left digging through the shard by hand.

## Changes

- When a test job fails, the gate downloads that shard's JUnit and lists the failing tests. It prints them from the failing `Check dependency results` step (GitHub only auto-expands the step that failed), and also writes a job-summary table plus file-linked `::error::` annotations.
- Product tests now upload their JUnit, staged as `junit-product-<name>.xml` under a `product-junit-results-*` prefix so it stays out of the snob shadow verdict and the timing reporter.
- All of it is best effort (`|| true`) and skipped on green runs, so it never touches the pass/fail result.

**Before**
```mermaid
flowchart LR
  D[Django shards] --> G{{Django Tests Pass}}
  P[Product shards] --> G
  G --> R[Reports which JOB failed]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class G phBlue;
  class R phYellow;
  class D,P phGray;
```
**After**
```mermaid
flowchart LR
  D[Django shards] -->|result| G{{Django Tests Pass}}
  P[Product shards] -->|result| G
  D -. JUnit .-> A[(Artifacts)]
  P -. JUnit .-> A
  A -. "download (on failure)" .-> G
  G --> R[Reports which TEST failed + file annotations]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class G phBlue;
  class R phYellow;
  class D,P,A phGray;
```

<details><summary><b>Live proof</b>: <a href="https://github.com/PostHog/posthog/actions/runs/29355647745/job/87166929076">a run</a> where a test was failed on purpose, then reverted</summary>

| Shard | Test | Message |
| --- | --- | --- |
| core-18 | `posthog/test/test_datetime.py::test_ci_rollup_demo_remove_before_merge` | AssertionError: ci rollup demo failure ... assert 1 == 2 |

Plus a file-linked annotation on the Checks tab. That run predates the current step layout and staged product upload, but uses the same parser, validated locally for backend, product, green-silent, and the XXE guard. The failing test was a throwaway and has been reverted.

</details>

> [!NOTE]
> No change to test behavior. The verdict is untouched; this only adds detail on failure.

## How did you test this code?

- The live run above named the failing test and shard in the summary and as an annotation.
- Ran the parser against backend and product JUnit fixtures: correct labels, repo-relative links, pipe-escaped output, silent on green, DTD/entity payloads refused. Also exercised the staging shell loop.
- `hogli lint:workflows` 6/6, `actionlint` 0 new, `ci:preflight --strict` green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Confirmed the rollup gate still exists (it does: `django_tests`, [strengthened recently](https://github.com/PostHog/posthog/pull/68003)) before building this out. Claude (Opus 4.8) wrote the first pass and a `/simplify` run tightened it.

- Print from the failing step, since GitHub only auto-expands the step that failed and a separate green step would hide the detail.
- Stage product JUnit as `junit-product-<name>.xml` so it survives upload-artifact's path collapse (same trick as the coverage step); the name is parsed back out of the filename.
- Download artifacts only when a test job failed, to avoid pulling ~50 artifacts on green runs.
- Use a separate `product-junit-results-*` prefix so `test-selection-verdict` and `report-test-timings` don't ingest product results.
- Inline stdlib parser (the gate holds no secrets); XXE handled by refusing DTD/entity files rather than pulling in `defusedxml`.
- Depot shadow strips artifact uploads, so this is canonical-only, documented as an intentional delta.
