### PR TITLE
feat(tasks): staff read-only task visibility for support and debugging

### DIFF
--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -141,15 +141,6 @@ export const tasksLogic = kea<tasksLogicType>([
     selectors({
         // The "all team" filter is staff-only; expose it so the menu can conditionally show it.
         isStaffUser: [(s) => [s.user], (user): boolean => !!user?.is_staff],
-        // Query params to carry onto a task's detail URL. In the staff "all team" view, this is the
-        // ph_debug opt-in so the detail page and its run logs load for tasks the viewer doesn't own
-        // (the backend honors it for staff). Empty otherwise. Every navigation into a task detail —
-        // the openTask listener and the list-row links — must apply this, or the detail 404s.
-        taskDetailQueryParams: [
-            (s) => [s.assigneeFilter, s.user],
-            (assigneeFilter, user): Record<string, string> =>
-                assigneeFilter === 'all_team' && user?.is_staff ? { ph_debug: 'true' } : {},
-        ],
         // Combined list filters: search term + the assignee toggle. "For you" scopes to the current
         // user's own tasks; "team scouts" scopes to autonomous Signals Scout tasks; "all team" (staff
         // only) lists every task on the team, letting the server bypass the per-user visibility filter.
@@ -172,7 +163,7 @@ export const tasksLogic = kea<tasksLogicType>([
 
     listeners(({ actions, values }) => ({
         openTask: ({ taskId }) => {
-            router.actions.push(`/tasks/${taskId}`, values.taskDetailQueryParams)
+            router.actions.push(`/tasks/${taskId}`)
         },
         // Debounce typing before hitting the server; the loader's own `breakpoint` then drops any
         // response that a newer query has already superseded.

--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -141,6 +141,15 @@ export const tasksLogic = kea<tasksLogicType>([
     selectors({
         // The "all team" filter is staff-only; expose it so the menu can conditionally show it.
         isStaffUser: [(s) => [s.user], (user): boolean => !!user?.is_staff],
+        // Query params to carry onto a task's detail URL. In the staff "all team" view, this is the
+        // ph_debug opt-in so the detail page and its run logs load for tasks the viewer doesn't own
+        // (the backend honors it for staff). Empty otherwise. Every navigation into a task detail —
+        // the openTask listener and the list-row links — must apply this, or the detail 404s.
+        taskDetailQueryParams: [
+            (s) => [s.assigneeFilter, s.user],
+            (assigneeFilter, user): Record<string, string> =>
+                assigneeFilter === 'all_team' && user?.is_staff ? { ph_debug: 'true' } : {},
+        ],
         // Combined list filters: search term + the assignee toggle. "For you" scopes to the current
         // user's own tasks; "team scouts" scopes to autonomous Signals Scout tasks; "all team" (staff
         // only) lists every task on the team, letting the server bypass the per-user visibility filter.
@@ -163,13 +172,7 @@ export const tasksLogic = kea<tasksLogicType>([
 
     listeners(({ actions, values }) => ({
         openTask: ({ taskId }) => {
-            // From the staff "all team" view, carry the ph_debug opt-in so the detail page and its run
-            // logs load for tasks the viewer doesn't own (the backend honors it for staff).
-            if (values.assigneeFilter === 'all_team' && values.isStaffUser) {
-                router.actions.push(`/tasks/${taskId}`, { ph_debug: 'true' })
-                return
-            }
-            router.actions.push(`/tasks/${taskId}`)
+            router.actions.push(`/tasks/${taskId}`, values.taskDetailQueryParams)
         },
         // Debounce typing before hitting the server; the loader's own `breakpoint` then drops any
         // response that a newer query has already superseded.

--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -139,21 +139,36 @@ export const tasksLogic = kea<tasksLogicType>([
     }),
 
     selectors({
+        // The "all team" filter is staff-only; expose it so the menu can conditionally show it.
+        isStaffUser: [(s) => [s.user], (user): boolean => !!user?.is_staff],
         // Combined list filters: search term + the assignee toggle. "For you" scopes to the current
-        // user's own tasks; "team scouts" scopes to autonomous Signals Scout tasks.
+        // user's own tasks; "team scouts" scopes to autonomous Signals Scout tasks; "all team" (staff
+        // only) lists every task on the team, letting the server bypass the per-user visibility filter.
         taskListParams: [
             (s) => [s.searchQuery, s.assigneeFilter, s.user],
-            (searchQuery, assigneeFilter, user): TaskListParams => ({
-                search: searchQuery || undefined,
-                ...(assigneeFilter === 'for_you'
-                    ? { created_by: user?.id }
-                    : { origin_product: OriginProduct.SIGNALS_SCOUT }),
-            }),
+            (searchQuery, assigneeFilter, user): TaskListParams => {
+                const base: TaskListParams = { search: searchQuery || undefined }
+                // Guard here too: a non-staff user must never send `all_team_tasks` (the server ignores
+                // it, but this keeps the request honest and falls back to their own tasks).
+                if (assigneeFilter === 'all_team' && user?.is_staff) {
+                    return { ...base, all_team_tasks: true }
+                }
+                if (assigneeFilter === 'team_scouts') {
+                    return { ...base, origin_product: OriginProduct.SIGNALS_SCOUT }
+                }
+                return { ...base, created_by: user?.id }
+            },
         ],
     }),
 
     listeners(({ actions, values }) => ({
         openTask: ({ taskId }) => {
+            // From the staff "all team" view, carry the ph_debug opt-in so the detail page and its run
+            // logs load for tasks the viewer doesn't own (the backend honors it for staff).
+            if (values.assigneeFilter === 'all_team' && values.isStaffUser) {
+                router.actions.push(`/tasks/${taskId}`, { ph_debug: 'true' })
+                return
+            }
             router.actions.push(`/tasks/${taskId}`)
         },
         // Debounce typing before hitting the server; the loader's own `breakpoint` then drops any

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskAssigneeFilterMenu.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskAssigneeFilterMenu.tsx
@@ -15,7 +15,7 @@ import { tasksLogic } from '../../../logics/tasksLogic'
 import { TaskAssigneeFilter } from '../../../types/taskTypes'
 
 export function TaskAssigneeFilterMenu(): JSX.Element {
-    const { assigneeFilter } = useValues(tasksLogic)
+    const { assigneeFilter, isStaffUser } = useValues(tasksLogic)
     const { setAssigneeFilter } = useActions(tasksLogic)
 
     return (
@@ -35,6 +35,9 @@ export function TaskAssigneeFilterMenu(): JSX.Element {
                 >
                     <DropdownMenuRadioItem value="for_you">For you</DropdownMenuRadioItem>
                     <DropdownMenuRadioItem value="team_scouts">Team scouts</DropdownMenuRadioItem>
+                    {isStaffUser && (
+                        <DropdownMenuRadioItem value="all_team">All team tasks (staff)</DropdownMenuRadioItem>
+                    )}
                 </DropdownMenuRadioGroup>
             </DropdownMenuContent>
         </DropdownMenu>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskListItem.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskListItem.tsx
@@ -1,5 +1,5 @@
-import { useActions } from 'kea'
-import { router } from 'kea-router'
+import { useActions, useValues } from 'kea'
+import { combineUrl, router } from 'kea-router'
 import { memo } from 'react'
 
 import { IconArchive } from '@posthog/icons'
@@ -37,23 +37,27 @@ export const TaskListItem = memo(function TaskListItem({
     isActive: boolean
 }): JSX.Element {
     const { deleteTask } = useActions(tasksLogic)
+    const { taskDetailQueryParams } = useValues(tasksLogic)
 
     const displayTitle = task.title || task.slug
     // "Started" reflects when the latest run began; fall back to creation for never-run tasks.
     const startedAt = task.latest_run?.created_at ?? task.created_at
+    // Carry any active detail opt-in (e.g. staff ph_debug) onto the link so it survives cmd/ctrl-click
+    // (native new-tab) as well as the SPA push below.
+    const detailUrl = combineUrl(urls.taskDetail(task.id), taskDetailQueryParams).url
 
     return (
         <LinkListItem.Root>
             <LinkListItem.Group>
                 <Link
-                    to={urls.taskDetail(task.id)}
+                    to={detailUrl}
                     onClick={(e) => {
                         // Let cmd/ctrl/middle-click open a new tab natively.
                         if (e.metaKey || e.ctrlKey || e.button === 1) {
                             return
                         }
                         e.preventDefault()
-                        router.actions.push(urls.taskDetail(task.id))
+                        router.actions.push(urls.taskDetail(task.id), taskDetailQueryParams)
                     }}
                     buttonProps={{
                         active: isActive,

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskListItem.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskListItem.tsx
@@ -1,5 +1,5 @@
-import { useActions, useValues } from 'kea'
-import { combineUrl, router } from 'kea-router'
+import { useActions } from 'kea'
+import { router } from 'kea-router'
 import { memo } from 'react'
 
 import { IconArchive } from '@posthog/icons'
@@ -37,27 +37,23 @@ export const TaskListItem = memo(function TaskListItem({
     isActive: boolean
 }): JSX.Element {
     const { deleteTask } = useActions(tasksLogic)
-    const { taskDetailQueryParams } = useValues(tasksLogic)
 
     const displayTitle = task.title || task.slug
     // "Started" reflects when the latest run began; fall back to creation for never-run tasks.
     const startedAt = task.latest_run?.created_at ?? task.created_at
-    // Carry any active detail opt-in (e.g. staff ph_debug) onto the link so it survives cmd/ctrl-click
-    // (native new-tab) as well as the SPA push below.
-    const detailUrl = combineUrl(urls.taskDetail(task.id), taskDetailQueryParams).url
 
     return (
         <LinkListItem.Root>
             <LinkListItem.Group>
                 <Link
-                    to={detailUrl}
+                    to={urls.taskDetail(task.id)}
                     onClick={(e) => {
                         // Let cmd/ctrl/middle-click open a new tab natively.
                         if (e.metaKey || e.ctrlKey || e.button === 1) {
                             return
                         }
                         e.preventDefault()
-                        router.actions.push(urls.taskDetail(task.id), taskDetailQueryParams)
+                        router.actions.push(urls.taskDetail(task.id))
                     }}
                     buttonProps={{
                         active: isActive,

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -1,5 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
+import { userLogic } from 'scenes/userLogic'
+
 import { runInteractionLogic, type RunInteractionLogicProps } from 'products/posthog_ai/frontend/api/logics'
 import { Composer, QueuedMessageList } from 'products/posthog_ai/frontend/api/primitives'
 // Eager, NOT the lazy `api/readableRun` facade: the runner scene is already a route-split chunk and the run
@@ -34,7 +36,11 @@ export interface TaskRunChatProps {
  */
 export function TaskRunChat({ taskId, runId, streamKey, onRunStarted }: TaskRunChatProps): JSX.Element {
     const { setSelectedRunId, loadTaskRuns } = useActions(taskDetailSceneLogic({ taskId }))
-    const { selectedRun } = useValues(taskDetailSceneLogic({ taskId }))
+    const { selectedRun, task } = useValues(taskDetailSceneLogic({ taskId }))
+    const { user } = useValues(userLogic)
+    // Staff can view tasks they don't own (support/debugging); those are read-only — hide the composer so
+    // they can't try to drive a run they can't control (the backend rejects the write anyway).
+    const readOnly = !!user?.is_staff && !!task?.created_by && task.created_by.id !== user.id
     const logicProps: RunInteractionLogicProps = {
         taskId,
         runId,
@@ -52,12 +58,18 @@ export function TaskRunChat({ taskId, runId, streamKey, onRunStarted }: TaskRunC
 
     return (
         <BindLogic logic={runInteractionLogic} props={logicProps}>
-            <TaskRunChatContent logicProps={logicProps} />
+            <TaskRunChatContent logicProps={logicProps} readOnly={readOnly} />
         </BindLogic>
     )
 }
 
-function TaskRunChatContent({ logicProps }: { logicProps: RunInteractionLogicProps }): JSX.Element {
+function TaskRunChatContent({
+    logicProps,
+    readOnly,
+}: {
+    logicProps: RunInteractionLogicProps
+    readOnly: boolean
+}): JSX.Element {
     return (
         // `RunSurface.Root` and `runInteractionLogic` deliberately share the same stream key (`streamKey ?? runId`,
         // resolved inside each): the composer slot's gating must read the exact stream the thread renders. The
@@ -70,12 +82,15 @@ function TaskRunChatContent({ logicProps }: { logicProps: RunInteractionLogicPro
         >
             <div className="@container/thread flex flex-col h-full -mx-4">
                 <RunSurface.Thread className="flex-1 min-h-0" listClassName="py-4" rowClassName="px-4" />
-                <RunSurface.Composer>
-                    <RunSurface.Resources />
-                    {/* The composer owns the per-keystroke draft in an isolated child so typing never re-renders
-                    the thread/virtualizer rendered as its sibling above — that cascade is what made the input lag. */}
-                    <LiveComposer logicProps={logicProps} />
-                </RunSurface.Composer>
+                {/* Stay live (stream keeps flowing) but omit the composer entirely for a read-only viewer. */}
+                {!readOnly && (
+                    <RunSurface.Composer>
+                        <RunSurface.Resources />
+                        {/* The composer owns the per-keystroke draft in an isolated child so typing never re-renders
+                        the thread/virtualizer rendered as its sibling above — that cascade is what made the input lag. */}
+                        <LiveComposer logicProps={logicProps} />
+                    </RunSurface.Composer>
+                )}
             </div>
         </RunSurface.Root>
     )

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -1,7 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
-import { userLogic } from 'scenes/userLogic'
-
 import { runInteractionLogic, type RunInteractionLogicProps } from 'products/posthog_ai/frontend/api/logics'
 import { Composer, QueuedMessageList } from 'products/posthog_ai/frontend/api/primitives'
 // Eager, NOT the lazy `api/readableRun` facade: the runner scene is already a route-split chunk and the run
@@ -36,11 +34,9 @@ export interface TaskRunChatProps {
  */
 export function TaskRunChat({ taskId, runId, streamKey, onRunStarted }: TaskRunChatProps): JSX.Element {
     const { setSelectedRunId, loadTaskRuns } = useActions(taskDetailSceneLogic({ taskId }))
-    const { selectedRun, task } = useValues(taskDetailSceneLogic({ taskId }))
-    const { user } = useValues(userLogic)
-    // Staff can view tasks they don't own (support/debugging); those are read-only — hide the composer so
-    // they can't try to drive a run they can't control (the backend rejects the write anyway).
-    const readOnly = !!user?.is_staff && !!task?.created_by && task.created_by.id !== user.id
+    // `isReadOnlyViewer` (a viewer who may watch but not drive this task — e.g. a staff support read)
+    // hides the composer; the control rule itself lives in the logic, mirroring the backend.
+    const { selectedRun, isReadOnlyViewer } = useValues(taskDetailSceneLogic({ taskId }))
     const logicProps: RunInteractionLogicProps = {
         taskId,
         runId,
@@ -58,7 +54,7 @@ export function TaskRunChat({ taskId, runId, streamKey, onRunStarted }: TaskRunC
 
     return (
         <BindLogic logic={runInteractionLogic} props={logicProps}>
-            <TaskRunChatContent logicProps={logicProps} readOnly={readOnly} />
+            <TaskRunChatContent logicProps={logicProps} readOnly={isReadOnlyViewer} />
         </BindLogic>
     )
 }

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskDetailSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskDetailSceneLogic.ts
@@ -4,12 +4,13 @@ import { router } from 'kea-router'
 
 import api from 'lib/api'
 import { isUUIDLike } from 'lib/utils/guards'
+import { userLogic } from 'scenes/userLogic'
 
 import { isApiNotFound, loadErrorMessage } from '../../lib/load-error'
 import { phDebugQueryParams } from '../../lib/ph-debug'
 import { TaskLogicProps, taskLogic } from '../../logics/taskLogic'
 import { tasksLogic } from '../../logics/tasksLogic'
-import { TaskRun } from '../../types/taskTypes'
+import { TEAM_CONTROLLABLE_ORIGIN_PRODUCTS, TaskRun } from '../../types/taskTypes'
 import type { taskDetailSceneLogicType } from './taskDetailSceneLogicType'
 
 export type TaskDetailSceneLogicProps = TaskLogicProps
@@ -20,7 +21,7 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
     key((props) => props.taskId),
 
     connect((props: TaskDetailSceneLogicProps) => ({
-        values: [taskLogic(props), ['task', 'taskLoading', 'taskNotFound', 'taskError']],
+        values: [taskLogic(props), ['task', 'taskLoading', 'taskNotFound', 'taskError'], userLogic, ['user']],
         actions: [
             taskLogic(props),
             ['loadTask', 'loadTaskSuccess', 'runTask', 'runTaskSuccess', 'deleteTask', 'updateTask'],
@@ -144,6 +145,25 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
             (s) => [s.task],
             (task): string => {
                 return task?.title || task?.slug || 'Task'
+            },
+        ],
+        // Mirrors the backend control rule (`task_control_q` in products/tasks/backend/visibility.py):
+        // a task is drivable by its creator, by anyone when it has no creator, and by any team member
+        // when its origin product is team-scoped. Non-controllable views (a staff support read, a
+        // teammate's public-channel task) hide the composer — the backend rejects their writes anyway.
+        // While the task is still loading, only staff default to read-only: they may be opening someone
+        // else's task by URL, and the composer must not flash in and then vanish.
+        isReadOnlyViewer: [
+            (s) => [s.task, s.user],
+            (task, user): boolean => {
+                if (!task) {
+                    return !!user?.is_staff
+                }
+                const canControl =
+                    !task.created_by ||
+                    task.created_by.id === user?.id ||
+                    TEAM_CONTROLLABLE_ORIGIN_PRODUCTS.includes(task.origin_product)
+                return !canControl
             },
         ],
     }),

--- a/products/posthog_ai/frontend/types/taskTypes.ts
+++ b/products/posthog_ai/frontend/types/taskTypes.ts
@@ -22,8 +22,11 @@ export enum OriginProduct {
     POSTHOG_AI = 'posthog_ai',
 }
 
-/** TaskTracker list filter: the current user's own tasks vs. team scout tasks. */
-export type TaskAssigneeFilter = 'for_you' | 'team_scouts'
+/**
+ * TaskTracker list filter: the current user's own tasks, team scout tasks, or — staff only —
+ * every task on the team.
+ */
+export type TaskAssigneeFilter = 'for_you' | 'team_scouts' | 'all_team'
 
 export enum TaskRunStatus {
     NOT_STARTED = 'not_started',
@@ -107,6 +110,8 @@ export interface TaskListParams {
     internal?: 'true' | 'false' | 'all'
     search?: string
     status?: TaskRunStatus
+    /** Staff-only. List every task on the team, bypassing the per-user visibility filter. Ignored server-side for non-staff. */
+    all_team_tasks?: boolean
     /** Page size (LimitOffset pagination); the viewset caps it at 100. */
     limit?: number
     offset?: number

--- a/products/posthog_ai/frontend/types/taskTypes.ts
+++ b/products/posthog_ai/frontend/types/taskTypes.ts
@@ -20,7 +20,23 @@ export enum OriginProduct {
     // Tasks created autonomously by the headless Signals Scout — team-scoped, visible to everyone.
     SIGNALS_SCOUT = 'signals_scout',
     POSTHOG_AI = 'posthog_ai',
+    // The "Set up PostHog" wizard task — team-scoped so anyone can pick up the setup.
+    ONBOARDING = 'onboarding',
+    // HogDesk support-desk Code threads — team-scoped so any agent on the ticket resumes the thread.
+    HOGDESK = 'hogdesk',
 }
+
+/**
+ * Origin products whose tasks are team-scoped rather than personal: any team member may view AND
+ * drive them regardless of who `created_by` points at. Mirrors `TEAM_VISIBLE_ORIGIN_PRODUCTS` in
+ * products/tasks/backend/visibility.py — keep the two lists in sync.
+ */
+export const TEAM_CONTROLLABLE_ORIGIN_PRODUCTS: OriginProduct[] = [
+    OriginProduct.SIGNAL_REPORT,
+    OriginProduct.SIGNALS_SCOUT,
+    OriginProduct.ONBOARDING,
+    OriginProduct.HOGDESK,
+]
 
 /**
  * TaskTracker list filter: the current user's own tasks, team scout tasks, or — staff only —

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -3243,9 +3243,11 @@ async def select_repository_for_message(team_id: int, user_id: int, message: str
     )
 
 
-def _list_tasks_queryset(team_id: int, user_id: int | None, *, filters: dict) -> QuerySet[Task]:
+def _list_tasks_queryset(
+    team_id: int, user_id: int | None, *, filters: dict, bypass_visibility: bool = False
+) -> QuerySet[Task]:
     latest_run = TaskRun.objects.filter(task=OuterRef("pk"), team_id=team_id).order_by("-created_at", "-id")
-    qs = _visible_task_qs(team_id, user_id).order_by("-created_at", "-id")
+    qs = _visible_task_qs(team_id, user_id, bypass_visibility=bypass_visibility).order_by("-created_at", "-id")
 
     origin_product = filters.get("origin_product")
     if origin_product:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1247,6 +1247,14 @@ class TaskListQuerySerializer(serializers.Serializer):
         ),
     )
     channel = serializers.UUIDField(required=False, help_text="Filter tasks to a channel's feed.")
+    all_team_tasks = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text=(
+            "Staff-only. When true, list every task on the team regardless of creator or channel, "
+            "bypassing the per-user visibility filter. Ignored for non-staff users."
+        ),
+    )
 
 
 class ChannelSerializer(DataclassSerializer):

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -22,6 +22,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.mixins import validated_request
@@ -29,6 +30,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.streaming import sse_streaming_response
 from posthog.api.utils import ServerTimingsGathered
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.cloud_utils import is_cloud
 from posthog.permissions import APIScopePermission
 from posthog.rate_limit import CodeInviteThrottle
 from posthog.renderers import ServerSentEventRenderer
@@ -150,17 +152,29 @@ def _is_internal_debug_team(team_id: int | None) -> bool:
     return team_id == 2 and settings.CLOUD_DEPLOYMENT == "US"
 
 
-def _can_bypass_visibility(request, team_id: int | None) -> bool:
-    """Whether this request may READ tasks/runs it doesn't own (never write — control stays creator-scoped).
+def _is_staff_visibility_bypass(request: Request) -> bool:
+    """Cloud PostHog staff may READ tasks/runs they don't own, on any team (support/debugging).
 
-    - Staff users: unconditionally, on any team (support/debugging). No opt-in needed, so staff don't hit
-      the per-creator 404 when opening a task by URL or streaming its run logs — the frontend can't reliably
-      thread a query param through every read (the SSE stream doesn't carry one).
-    - Internal-debug teams: keep the narrower, explicit ``?ph_debug=true`` opt-in (dev/debug workflow).
+    No opt-in needed, so staff don't hit the per-creator 404 when opening a task by URL or streaming its
+    run logs — the frontend can't reliably thread a query param through every read (the SSE stream doesn't
+    carry one). Gated to cloud: on self-hosted instances ``is_staff`` marks the instance admin (the first
+    signup gets it automatically), not PostHog support, and must not unlock other members' tasks.
     """
-    if bool(getattr(request.user, "is_staff", False)):
-        return True
+    return is_cloud() and bool(getattr(request.user, "is_staff", False))
+
+
+def _is_internal_debug_visibility_bypass(request: Request, team_id: int | None) -> bool:
+    """Internal-debug teams get a narrower, explicit ``?ph_debug=true`` read opt-in (dev/debug workflow).
+
+    Unlike the staff bypass this is available to non-staff members of the internal-debug team, so callers
+    gate it to a deliberately small action surface (see ``TaskRunViewSet._PH_DEBUG_READ_ACTIONS``).
+    """
     return _is_internal_debug_team(team_id) and request.query_params.get("ph_debug") == "true"
+
+
+def _can_bypass_visibility(request: Request, team_id: int | None) -> bool:
+    """Whether this request may READ tasks/runs it doesn't own (never write — control stays creator-scoped)."""
+    return _is_staff_visibility_bypass(request) or _is_internal_debug_visibility_bypass(request, team_id)
 
 
 class _SchemaAwareLimitOffsetPagination(LimitOffsetPagination):
@@ -249,9 +263,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         filters["archived"] = getattr(request, "validated_query_data", {}).get("archived")
         filters["channel"] = getattr(request, "validated_query_data", {}).get("channel")
         # Staff can opt into seeing every team task; re-check server-side so a client can't
-        # forge the flag to bypass the per-user visibility gate.
+        # forge the flag to bypass the per-user visibility gate. Staff-only (matching the
+        # serializer help text): the ph_debug opt-in never unlocked list enumeration.
         all_team_tasks = bool(getattr(request, "validated_query_data", {}).get("all_team_tasks"))
-        bypass_visibility = all_team_tasks and _can_bypass_visibility(request, self.team_id)
+        bypass_visibility = all_team_tasks and _is_staff_visibility_bypass(request)
         tasks = tasks_facade._list_tasks_queryset(
             self.team_id, self._user_id(), filters=filters, bypass_visibility=bypass_visibility
         )
@@ -799,15 +814,30 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         "artifacts_download",
     )
 
+    # The ph_debug bypass is reachable by non-staff members of the internal-debug team, so it gets a
+    # smaller action surface than the staff bypass: no artifact egress (presign/download).
+    _PH_DEBUG_READ_ACTIONS = (
+        "list",
+        "retrieve",
+        "logs",
+        "session_logs",
+        "stream",
+        "stream_token",
+    )
+
     def _ensure_task_accessible(self) -> str:
         """Gate access to the parent task, mirroring the old ``safely_get_queryset``.
 
-        Staff users (and internal-debug teams via ``?ph_debug=true``) may read another member's runs
-        through the read-only actions; the bypass never applies to control actions.
+        Staff users may read another member's runs through any read-only action; internal-debug teams
+        (via ``?ph_debug=true``) through ``_PH_DEBUG_READ_ACTIONS`` only. The bypass never applies to
+        control actions.
         """
         task_id = self._task_id()
         is_read_only = self.action in self._READ_ONLY_ACTIONS
-        bypass_visibility = is_read_only and _can_bypass_visibility(self.request, self.team_id)
+        bypass_visibility = (is_read_only and _is_staff_visibility_bypass(self.request)) or (
+            self.action in self._PH_DEBUG_READ_ACTIONS
+            and _is_internal_debug_visibility_bypass(self.request, self.team_id)
+        )
         if not tasks_facade.task_accessible_for_run_view(
             task_id,
             self.team_id,

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -151,11 +151,16 @@ def _is_internal_debug_team(team_id: int | None) -> bool:
 
 
 def _can_bypass_visibility(request, team_id: int | None) -> bool:
-    """Whether this request may read tasks it doesn't own, when it opts in via ``?ph_debug=true``.
+    """Whether this request may READ tasks/runs it doesn't own (never write — control stays creator-scoped).
 
-    Granted to staff users (support/debugging any team) and to members of an internal-debug team.
+    - Staff users: unconditionally, on any team (support/debugging). No opt-in needed, so staff don't hit
+      the per-creator 404 when opening a task by URL or streaming its run logs — the frontend can't reliably
+      thread a query param through every read (the SSE stream doesn't carry one).
+    - Internal-debug teams: keep the narrower, explicit ``?ph_debug=true`` opt-in (dev/debug workflow).
     """
-    return bool(getattr(request.user, "is_staff", False)) or _is_internal_debug_team(team_id)
+    if bool(getattr(request.user, "is_staff", False)):
+        return True
+    return _is_internal_debug_team(team_id) and request.query_params.get("ph_debug") == "true"
 
 
 class _SchemaAwareLimitOffsetPagination(LimitOffsetPagination):
@@ -262,9 +267,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         description="Retrieve a single task by ID.",
     )
     def retrieve(self, request, pk=None, **kwargs):
-        bypass_visibility = (
-            _can_bypass_visibility(request, self.team_id) and request.query_params.get("ph_debug") == "true"
-        )
+        bypass_visibility = _can_bypass_visibility(request, self.team_id)
         task = tasks_facade.get_task_detail(pk, self.team_id, self._user_id(), bypass_visibility=bypass_visibility)
         if task is None:
             raise NotFound()
@@ -799,29 +802,17 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def _ensure_task_accessible(self) -> str:
         """Gate access to the parent task, mirroring the old ``safely_get_queryset``.
 
-        ``?ph_debug=true`` lets staff users and internal-debug teams read other members' runs
-        through read-only actions.
+        Staff users (and internal-debug teams via ``?ph_debug=true``) may read another member's runs
+        through the read-only actions; the bypass never applies to control actions.
         """
         task_id = self._task_id()
         is_read_only = self.action in self._READ_ONLY_ACTIONS
-        is_debug_read = (
-            _can_bypass_visibility(self.request, self.team_id)
-            and self.action
-            in (
-                "list",
-                "retrieve",
-                "logs",
-                "session_logs",
-                "stream",
-                "stream_token",
-            )
-            and self.request.query_params.get("ph_debug") == "true"
-        )
+        bypass_visibility = is_read_only and _can_bypass_visibility(self.request, self.team_id)
         if not tasks_facade.task_accessible_for_run_view(
             task_id,
             self.team_id,
             self._user_id(),
-            bypass_visibility=is_debug_read,
+            bypass_visibility=bypass_visibility,
             for_control=not is_read_only,
         ):
             raise NotFound("Task not found")

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2037,13 +2037,10 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
     def _ensure_task_accessible(self) -> str:
         """Gate access to the parent task, mirroring ``TaskRunViewSet._ensure_task_accessible``."""
         task_id = self._task_id()
-        is_internal_debug_read = (
-            _is_internal_debug_team(self.team_id)
-            and self.action in ("list", "retrieve")
-            and self.request.query_params.get("ph_debug") == "true"
-        )
+        is_read = self.action in ("list", "retrieve")
+        bypass_visibility = is_read and _can_bypass_visibility(self.request, self.team_id)
         if not tasks_facade.task_accessible_for_run_view(
-            task_id, self.team_id, getattr(self.request.user, "id", None), bypass_visibility=is_internal_debug_read
+            task_id, self.team_id, getattr(self.request.user, "id", None), bypass_visibility=bypass_visibility
         ):
             raise NotFound("Task not found")
         return task_id

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -150,6 +150,14 @@ def _is_internal_debug_team(team_id: int | None) -> bool:
     return team_id == 2 and settings.CLOUD_DEPLOYMENT == "US"
 
 
+def _can_bypass_visibility(request, team_id: int | None) -> bool:
+    """Whether this request may read tasks it doesn't own, when it opts in via ``?ph_debug=true``.
+
+    Granted to staff users (support/debugging any team) and to members of an internal-debug team.
+    """
+    return bool(getattr(request.user, "is_staff", False)) or _is_internal_debug_team(team_id)
+
+
 class _SchemaAwareLimitOffsetPagination(LimitOffsetPagination):
     """LimitOffsetPagination subclass that surfaces `default_limit`/`max_limit` in the OpenAPI schema."""
 
@@ -235,7 +243,13 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         filters["internal"] = getattr(request, "validated_query_data", {}).get("internal")
         filters["archived"] = getattr(request, "validated_query_data", {}).get("archived")
         filters["channel"] = getattr(request, "validated_query_data", {}).get("channel")
-        tasks = tasks_facade._list_tasks_queryset(self.team_id, self._user_id(), filters=filters)
+        # Staff can opt into seeing every team task; re-check server-side so a client can't
+        # forge the flag to bypass the per-user visibility gate.
+        all_team_tasks = bool(getattr(request, "validated_query_data", {}).get("all_team_tasks"))
+        bypass_visibility = all_team_tasks and _can_bypass_visibility(request, self.team_id)
+        tasks = tasks_facade._list_tasks_queryset(
+            self.team_id, self._user_id(), filters=filters, bypass_visibility=bypass_visibility
+        )
         page = self.paginate_queryset(tasks)
         assert page is not None, "TaskViewSet list requires an active paginator"
         return self.get_paginated_response(
@@ -248,7 +262,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         description="Retrieve a single task by ID.",
     )
     def retrieve(self, request, pk=None, **kwargs):
-        bypass_visibility = _is_internal_debug_team(self.team_id) and request.query_params.get("ph_debug") == "true"
+        bypass_visibility = (
+            _can_bypass_visibility(request, self.team_id) and request.query_params.get("ph_debug") == "true"
+        )
         task = tasks_facade.get_task_detail(pk, self.team_id, self._user_id(), bypass_visibility=bypass_visibility)
         if task is None:
             raise NotFound()
@@ -783,13 +799,13 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def _ensure_task_accessible(self) -> str:
         """Gate access to the parent task, mirroring the old ``safely_get_queryset``.
 
-        ``?ph_debug=true`` lets internal-debug teams read other members' runs through read-only
-        actions.
+        ``?ph_debug=true`` lets staff users and internal-debug teams read other members' runs
+        through read-only actions.
         """
         task_id = self._task_id()
         is_read_only = self.action in self._READ_ONLY_ACTIONS
-        is_internal_debug_read = (
-            _is_internal_debug_team(self.team_id)
+        is_debug_read = (
+            _can_bypass_visibility(self.request, self.team_id)
             and self.action
             in (
                 "list",
@@ -805,7 +821,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             task_id,
             self.team_id,
             self._user_id(),
-            bypass_visibility=is_internal_debug_read,
+            bypass_visibility=is_debug_read,
             for_control=not is_read_only,
         ):
             raise NotFound("Task not found")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -747,6 +747,78 @@ class TestTaskVisibilityInternalDebugTeamBypass(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
+class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
+    """Staff users get the same visibility bypass as internal-debug teams, on any team:
+    the ``all_team_tasks=true`` list filter and the ``?ph_debug=true`` read opt-in for a
+    single task/run. Non-staff users can't reach either, and writes stay creator-scoped.
+    The internal-debug-team path is covered by ``TestTaskVisibilityInternalDebugTeamBypass``."""
+
+    def setUp(self):
+        super().setUp()
+        # self.user is the authenticated requester (it resolves `@current`); make it staff and
+        # attribute the tasks under test to a different member so they're "not mine".
+        self.user.is_staff = True
+        self.user.save(update_fields=["is_staff"])
+        self.other_user = self.create_organization_user("teammate")
+
+    def test_staff_all_team_tasks_filter_includes_other_user_tasks(self):
+        theirs = self.create_task("Theirs", created_by=self.other_user)
+
+        response = self.client.get("/api/projects/@current/tasks/?all_team_tasks=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item["id"] for item in response.json()["results"]}
+        assert str(theirs.id) in ids
+
+    def test_staff_list_without_filter_still_excludes_other_user_tasks(self):
+        # The filter is opt-in — the default list stays creator-scoped even for staff.
+        theirs = self.create_task("Theirs", created_by=self.other_user)
+
+        response = self.client.get("/api/projects/@current/tasks/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item["id"] for item in response.json()["results"]}
+        assert str(theirs.id) not in ids
+
+    def test_non_staff_all_team_tasks_filter_is_ignored(self):
+        self.user.is_staff = False
+        self.user.save(update_fields=["is_staff"])
+        theirs = self.create_task("Theirs", created_by=self.other_user)
+
+        response = self.client.get("/api/projects/@current/tasks/?all_team_tasks=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item["id"] for item in response.json()["results"]}
+        assert str(theirs.id) not in ids
+
+    def test_staff_retrieve_other_user_task_with_ph_debug(self):
+        task = self.create_task(created_by=self.other_user)
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/?ph_debug=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], str(task.id))
+
+    def test_staff_retrieve_other_user_task_without_ph_debug_still_404s(self):
+        task = self.create_task(created_by=self.other_user)
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_staff_list_runs_for_other_user_task_with_ph_debug(self):
+        task = self.create_task(created_by=self.other_user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/?ph_debug=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {item["id"] for item in response.json()["results"]}
+        self.assertEqual(ids, {str(run.id)})
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_staff_write_on_other_user_task_still_404s(self, _mock_workflow):
+        # ph_debug is a read-only opt-in — staff still can't drive another member's task.
+        task = self.create_task(created_by=self.other_user)
+
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/?ph_debug=true")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
 class TestTaskVisibilityInternalDebugRegionGate(BaseTaskAPITest):
     """The internal-debug bypass keys on team-id 2 — but that's only meaningful in
     the US-prod DB. On EU prod, self-hosted, and dev, team-id 2 belongs to some

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -748,10 +748,11 @@ class TestTaskVisibilityInternalDebugTeamBypass(BaseTaskAPITest):
 
 
 class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
-    """Staff users get the same visibility bypass as internal-debug teams, on any team:
-    the ``all_team_tasks=true`` list filter and the ``?ph_debug=true`` read opt-in for a
-    single task/run. Non-staff users can't reach either, and writes stay creator-scoped.
-    The internal-debug-team path is covered by ``TestTaskVisibilityInternalDebugTeamBypass``."""
+    """Staff users can READ any task/run on the team, unconditionally — no ``?ph_debug=true`` opt-in
+    (unlike internal-debug teams), because the frontend can't reliably thread a query param through
+    every read (the SSE stream carries none). The ``all_team_tasks=true`` list filter stays opt-in so
+    the default list is unchanged. Non-staff users can't reach either, and writes stay creator-scoped.
+    The internal-debug-team ``?ph_debug=true`` path is covered by ``TestTaskVisibilityInternalDebugTeamBypass``."""
 
     def setUp(self):
         super().setUp()
@@ -788,34 +789,37 @@ class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
         ids = {item["id"] for item in response.json()["results"]}
         assert str(theirs.id) not in ids
 
-    def test_staff_retrieve_other_user_task_with_ph_debug(self):
+    def test_staff_retrieve_other_user_task_needs_no_ph_debug(self):
+        # No opt-in param — a staff user opening a teammate's task by URL just works.
         task = self.create_task(created_by=self.other_user)
 
-        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/?ph_debug=true")
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["id"], str(task.id))
 
-    def test_staff_retrieve_other_user_task_without_ph_debug_still_404s(self):
+    def test_non_staff_retrieve_other_user_task_still_404s(self):
+        self.user.is_staff = False
+        self.user.save(update_fields=["is_staff"])
         task = self.create_task(created_by=self.other_user)
 
         response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_staff_list_runs_for_other_user_task_with_ph_debug(self):
+    def test_staff_list_runs_for_other_user_task_needs_no_ph_debug(self):
         task = self.create_task(created_by=self.other_user)
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 
-        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/?ph_debug=true")
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         ids = {item["id"] for item in response.json()["results"]}
         self.assertEqual(ids, {str(run.id)})
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_staff_write_on_other_user_task_still_404s(self, _mock_workflow):
-        # ph_debug is a read-only opt-in — staff still can't drive another member's task.
+        # Read-only bypass — staff still can't drive another member's task.
         task = self.create_task(created_by=self.other_user)
 
-        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/?ph_debug=true")
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -723,6 +723,21 @@ class TestTaskVisibilityInternalDebugTeamBypass(BaseTaskAPITest):
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_artifact_presign_on_other_user_run_still_404s_with_ph_debug(self):
+        # Artifact egress (presign/download) is outside the ph_debug action list — the opt-in is
+        # reachable by non-staff members of the internal-debug team, so it must not mint download
+        # URLs for another member's run artifacts.
+        other_user = self.create_organization_user("teammate")
+        task = self.create_task(created_by=other_user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/artifacts/presign/?ph_debug=true",
+            {"storage_path": "task_runs/some/artifact"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_write_action_on_other_user_task_still_returns_404(self, _mock_workflow):
         # POST /tasks/<id>/run/ is a write — bypass must NOT fire even when the
@@ -747,13 +762,13 @@ class TestTaskVisibilityInternalDebugTeamBypass(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
+# Cloud staff can READ any task/run on the team with no `?ph_debug=true` opt-in (the frontend can't
+# thread a query param through every read — the SSE stream carries none), while writes stay
+# creator-scoped and the `all_team_tasks=true` list filter stays opt-in. The bypass is cloud-only:
+# on self-hosted, `is_staff` marks the instance admin, not PostHog support. The internal-debug-team
+# `?ph_debug=true` path is covered by `TestTaskVisibilityInternalDebugTeamBypass`.
+@override_settings(CLOUD_DEPLOYMENT="US")
 class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
-    """Staff users can READ any task/run on the team, unconditionally — no ``?ph_debug=true`` opt-in
-    (unlike internal-debug teams), because the frontend can't reliably thread a query param through
-    every read (the SSE stream carries none). The ``all_team_tasks=true`` list filter stays opt-in so
-    the default list is unchanged. Non-staff users can't reach either, and writes stay creator-scoped.
-    The internal-debug-team ``?ph_debug=true`` path is covered by ``TestTaskVisibilityInternalDebugTeamBypass``."""
-
     def setUp(self):
         super().setUp()
         # self.user is the authenticated requester (it resolves `@current`); make it staff and
@@ -762,13 +777,26 @@ class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
         self.user.save(update_fields=["is_staff"])
         self.other_user = self.create_organization_user("teammate")
 
-    def test_staff_all_team_tasks_filter_includes_other_user_tasks(self):
+    def _set_staff(self, is_staff: bool) -> None:
+        self.user.is_staff = is_staff
+        self.user.save(update_fields=["is_staff"])
+
+    @parameterized.expand(
+        [
+            ("staff", True, True),
+            ("non_staff", False, False),
+        ]
+    )
+    def test_all_team_tasks_filter_lists_other_user_tasks_only_for_staff(
+        self, _name: str, is_staff: bool, expect_theirs: bool
+    ) -> None:
+        self._set_staff(is_staff)
         theirs = self.create_task("Theirs", created_by=self.other_user)
 
         response = self.client.get("/api/projects/@current/tasks/?all_team_tasks=true")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         ids = {item["id"] for item in response.json()["results"]}
-        assert str(theirs.id) in ids
+        self.assertEqual(str(theirs.id) in ids, expect_theirs)
 
     def test_staff_list_without_filter_still_excludes_other_user_tasks(self):
         # The filter is opt-in — the default list stays creator-scoped even for staff.
@@ -779,31 +807,36 @@ class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
         ids = {item["id"] for item in response.json()["results"]}
         assert str(theirs.id) not in ids
 
-    def test_non_staff_all_team_tasks_filter_is_ignored(self):
-        self.user.is_staff = False
-        self.user.save(update_fields=["is_staff"])
-        theirs = self.create_task("Theirs", created_by=self.other_user)
-
-        response = self.client.get("/api/projects/@current/tasks/?all_team_tasks=true")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        ids = {item["id"] for item in response.json()["results"]}
-        assert str(theirs.id) not in ids
-
-    def test_staff_retrieve_other_user_task_needs_no_ph_debug(self):
+    @parameterized.expand(
+        [
+            ("staff", True, status.HTTP_200_OK),
+            ("non_staff", False, status.HTTP_404_NOT_FOUND),
+        ]
+    )
+    def test_retrieve_other_user_task_succeeds_only_for_staff(
+        self, _name: str, is_staff: bool, expected_status: int
+    ) -> None:
         # No opt-in param — a staff user opening a teammate's task by URL just works.
+        self._set_staff(is_staff)
         task = self.create_task(created_by=self.other_user)
 
         response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["id"], str(task.id))
+        self.assertEqual(response.status_code, expected_status)
 
-    def test_non_staff_retrieve_other_user_task_still_404s(self):
-        self.user.is_staff = False
-        self.user.save(update_fields=["is_staff"])
+    @parameterized.expand(
+        [
+            ("eu_prod", "EU", status.HTTP_200_OK),
+            ("self_hosted", None, status.HTTP_404_NOT_FOUND),
+        ]
+    )
+    def test_staff_bypass_is_cloud_only(self, _name: str, deployment: str | None, expected_status: int) -> None:
+        # On self-hosted, the auto-granted first-user `is_staff` flag must not unlock other
+        # members' tasks; on any cloud region it must.
         task = self.create_task(created_by=self.other_user)
 
-        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        with override_settings(CLOUD_DEPLOYMENT=deployment):
+            response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
+        self.assertEqual(response.status_code, expected_status)
 
     def test_staff_list_runs_for_other_user_task_needs_no_ph_debug(self):
         task = self.create_task(created_by=self.other_user)
@@ -815,8 +848,8 @@ class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
         self.assertEqual(ids, {str(run.id)})
 
     def test_staff_list_living_artifacts_for_other_user_run(self):
-        # Living artifacts are a separate run-read viewset whose gate previously required an
-        # internal-debug team — staff must reach it on any team too.
+        # Living artifacts are gated by a separate run-read viewset — the staff bypass must
+        # cover it too, or the task page half-renders for staff.
         task = self.create_task(created_by=self.other_user)
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -814,6 +814,15 @@ class TestTaskStaffVisibilityBypass(BaseTaskAPITest):
         ids = {item["id"] for item in response.json()["results"]}
         self.assertEqual(ids, {str(run.id)})
 
+    def test_staff_list_living_artifacts_for_other_user_run(self):
+        # Living artifacts are a separate run-read viewset whose gate previously required an
+        # internal-debug team — staff must reach it on any team too.
+        task = self.create_task(created_by=self.other_user)
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/living_artifacts/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_staff_write_on_other_user_task_still_404s(self, _mock_workflow):
         # Read-only bypass — staff still can't drive another member's task.

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -2717,6 +2717,10 @@ export type TaskMentionsListParams = {
 
 export type TasksListParams = {
     /**
+     * Staff-only. When true, list every task on the team regardless of creator or channel, bypassing the per-user visibility filter. Ignored for non-staff users.
+     */
+    all_team_tasks?: boolean
+    /**
      * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
      *
      * * `true` - true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -74236,6 +74236,10 @@ export namespace Schemas {
 
     export type TasksListParams = {
     /**
+     * Staff-only. When true, list every task on the team regardless of creator or channel, bypassing the per-user visibility filter. Ignored for non-staff users.
+     */
+    all_team_tasks?: boolean;
+    /**
      * Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.
      *
      * * `true` - true

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -20,6 +20,7 @@ export const TasksListParams = /* @__PURE__ */ zod.object({
         ),
 })
 
+export const tasksListQueryAllTeamTasksDefault = false
 export const tasksListQueryLimitDefault = 50
 export const tasksListQueryLimitMax = 100
 
@@ -27,6 +28,12 @@ export const tasksListQueryOffsetDefault = 0
 export const tasksListQueryOffsetMin = 0
 
 export const TasksListQueryParams = /* @__PURE__ */ zod.object({
+    all_team_tasks: zod
+        .boolean()
+        .default(tasksListQueryAllTeamTasksDefault)
+        .describe(
+            'Staff-only. When true, list every task on the team regardless of creator or channel, bypassing the per-user visibility filter. Ignored for non-staff users.'
+        ),
     archived: zod
         .enum(['true', 'false', 'all'])
         .optional()

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -25,6 +25,7 @@ const tasksList = (): ToolBase<typeof TasksListSchema, WithPostHogUrl<Schemas.Pa
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/`,
             query: {
+                all_team_tasks: params.all_team_tasks,
                 archived: params.archived,
                 channel: params.channel,
                 created_by: params.created_by,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-list.json
@@ -1,6 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "all_team_tasks": {
+            "default": false,
+            "description": "Staff-only. When true, list every task on the team regardless of creator or channel, bypassing the per-user visibility filter. Ignored for non-staff users.",
+            "type": "boolean"
+        },
         "archived": {
             "description": "Filter by archived state. Defaults to excluding archived tasks. Use 'true' to list only archived tasks, 'false' for the default, or 'all' to include both.\n\n* `true` - true\n* `false` - false\n* `all` - all",
             "enum": ["true", "false", "all"],


### PR DESCRIPTION
## Problem

Support and debugging often require a PostHog staff member to look at a customer-reported task: its detail page, run logs, live stream, and artifacts. Task visibility is creator-scoped, so staff opening a task by URL hit a 404 unless they were on the internal-debug team and threaded `?ph_debug=true` through every request — which the frontend can't do reliably (the SSE stream carries no query params).

## Changes

**Backend**

- Cloud staff users can now READ any task/run on a team with no opt-in: `retrieve`, run list/detail, logs, session logs, stream, stream token, artifact presign/download, and living artifacts. Writes stay creator-scoped — staff cannot drive another member's task.
- The bypass is gated on `is_cloud()`: on self-hosted instances `is_staff` marks the instance admin (auto-granted to the first signup), not PostHog support, so it must not unlock other members' tasks there.
- New staff-only `all_team_tasks=true` list filter lists every task on the team; the default list stays creator-scoped.
- The pre-existing non-staff `?ph_debug=true` internal-debug bypass keeps its historical six-action list (`_PH_DEBUG_READ_ACTIONS`) — it deliberately excludes artifact presign/download, since that path is reachable by non-staff members of the internal-debug team.

**Frontend**

- The task list gets an "All team tasks (staff)" filter option, shown only to staff.
- The run chat hides the composer for read-only viewers via a new `isReadOnlyViewer` selector on `taskDetailSceneLogic` that mirrors the backend control rule (`task_control_q`): creator, creator-less tasks, and team-scoped origins (scouts, onboarding, HogDesk) keep the composer; a staff support view of someone else's personal task doesn't. While the task is still loading, staff default to read-only so the composer doesn't flash in and vanish.

## How did you test this code?

Ran the four task-visibility test classes locally (53 tests, all passing): `TestTaskStaffVisibilityBypass`, `TestTaskVisibilityInternalDebugTeamBypass`, `TestTaskVisibilityInternalDebugRegionGate`, `TestTaskCreatorScoping`.

New/changed tests and the regressions they catch:

- `test_staff_bypass_is_cloud_only` — a self-hosted instance admin (auto-staff first signup) regaining read access to teammates' private tasks if the `is_cloud()` gate is dropped.
- `test_artifact_presign_on_other_user_run_still_404s_with_ph_debug` — the ph_debug bypass silently widening to artifact egress if it's ever keyed on `_READ_ONLY_ACTIONS`.
- Staff/non-staff pairs for the list filter and retrieve are parameterized; existing internal-debug tests cover that `?ph_debug=true` behavior is unchanged.

The sandbox couldn't run the full frontend typecheck (unbuilt workspace packages); kea typegen for the edited logic generates the expected types, and CI runs the authoritative check. I was not able to manually test the UI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal, staff-only behavior — no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code (remote session). Skills invoked: `/code-review`, `/improving-drf-endpoints`, `/writing-tests`, `/setup-web-tests`.
- An 8-angle `/code-review medium` pass with adversarial verification ran on the branch; the confirmed findings were then fixed on request. Key decisions: gate the staff bypass on `is_cloud()` (mirroring `SingleTenancyOrAdmin`'s pattern) rather than leaving `is_staff` global; keep the ph_debug arm on its own explicit action list instead of `_READ_ONLY_ACTIONS` so the two bypass policies can diverge; scope the `all_team_tasks` list bypass to staff only so the serializer help text stays truthful; and gate the composer via a logic selector mirroring `task_control_q` instead of an inline `is_staff && created_by !== me` heuristic, which had wrongly removed the composer from team-scoped scout tasks staff are allowed to drive. A server-provided `can_control` field on the task serializer was considered as the deeper fix but deferred to keep this PR focused; the frontend list is annotated to stay in sync with `TEAM_VISIBLE_ORIGIN_PRODUCTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Td64275Sg3TUenreAGr6wD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Td64275Sg3TUenreAGr6wD)_