### PR TITLE
fix(eng-analytics): fail closed on none-level source access

### DIFF
--- a/products/engineering_analytics/backend/logic/sources.py
+++ b/products/engineering_analytics/backend/logic/sources.py
@@ -20,9 +20,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 
 from posthog.models.team import Team
+from posthog.rbac.user_access_control import NO_ACCESS_LEVEL
 
 from products.engineering_analytics.backend.facade.contracts import GitHubSource, GitHubSourceNotConnectedError
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
@@ -157,9 +158,15 @@ def _github_sources(team: Team, user_access_control: "UserAccessControl | None" 
     if user_access_control is not None:
         sources = user_access_control.filter_queryset_by_access_level(sources)
         if not user_access_control.has_resource_access("external_data_source"):
-            # "none" resource-level access: the platform filter applies only explicit object grants
-            # and, with no grants at all, nothing — restrict to self-created so this fails closed.
-            sources = sources.filter(created_by=user_access_control.user)
+            # "none" resource-level access: the platform filter drops nothing when the user holds no
+            # object grants, so fail closed here to self-created or explicitly granted sources.
+            granted_ids = [
+                source.id
+                for source in sources
+                if (level := user_access_control.access_level_for_object(source, explicit=True))
+                and level != NO_ACCESS_LEVEL
+            ]
+            sources = sources.filter(Q(created_by=user_access_control.user) | Q(id__in=granted_ids))
     return sources
 
 

--- a/products/engineering_analytics/backend/logic/sources.py
+++ b/products/engineering_analytics/backend/logic/sources.py
@@ -156,6 +156,10 @@ def _github_sources(team: Team, user_access_control: "UserAccessControl | None" 
     )
     if user_access_control is not None:
         sources = user_access_control.filter_queryset_by_access_level(sources)
+        if not user_access_control.has_resource_access("external_data_source"):
+            # "none" resource-level access: the platform filter applies only explicit object grants
+            # and, with no grants at all, nothing — restrict to self-created so this fails closed.
+            sources = sources.filter(created_by=user_access_control.user)
     return sources
 
 

--- a/products/engineering_analytics/backend/tests/test_views.py
+++ b/products/engineering_analytics/backend/tests/test_views.py
@@ -8,12 +8,15 @@ import pandas as pd
 
 from posthog.hogql.query import execute_hogql_query
 
+from posthog.constants import AvailableFeature
 from posthog.models.team import Team
+from posthog.rbac.user_access_control import UserAccessControl
 
 from products.engineering_analytics.backend.logic.sources import (
     PULL_REQUESTS_SCHEMA,
     WORKFLOW_RUNS_SCHEMA,
     GitHubTables,
+    list_github_sources,
 )
 from products.engineering_analytics.backend.logic.views import pull_requests, workflow_runs
 from products.engineering_analytics.backend.logic.views.source_schema import (
@@ -23,6 +26,8 @@ from products.engineering_analytics.backend.logic.views.source_schema import (
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema, ExternalDataSource
 from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 from products.warehouse_sources.backend.test.utils import create_data_warehouse_table_from_csv
+
+from ee.models.rbac.access_control import AccessControl
 
 TEST_BUCKET = "test_storage_bucket-posthog.products.engineering_analytics.views"
 
@@ -158,6 +163,33 @@ def _run_row(
         "pull_requests": f'[{{"number": {pr_number}}}]' if pr_number is not None else None,
         "repository": f'{{"full_name": "{full_name}"}}',
     }
+
+
+class TestListGithubSourcesAccessControl(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+
+    def test_none_resource_access_fails_closed_to_self_created_sources(self) -> None:
+        # filter_queryset_by_access_level returns the queryset UNFILTERED for a user with "none"
+        # resource access and no object grants — without the guard, such a user enumerates every
+        # GitHub source on the team.
+        mine = create_github_source(self.team, prefix="mine_", source_id="gh-mine")
+        mine.created_by = self.user
+        mine.save()
+        create_github_source(self.team, prefix="theirs_", source_id="gh-theirs")
+        access_control = UserAccessControl(user=self.user, team=self.team)
+
+        assert len(list_github_sources(team=self.team, user_access_control=access_control)) == 2
+
+        AccessControl.objects.create(team=self.team, resource="external_data_source", access_level="none")
+        visible = list_github_sources(
+            team=self.team, user_access_control=UserAccessControl(user=self.user, team=self.team)
+        )
+        assert [source.id for source in visible] == [str(mine.id)]
 
 
 class TestEngineeringAnalyticsViews(ClickhouseTestMixin, BaseTest):

--- a/products/engineering_analytics/backend/tests/test_views.py
+++ b/products/engineering_analytics/backend/tests/test_views.py
@@ -180,7 +180,7 @@ class TestListGithubSourcesAccessControl(BaseTest):
         mine = create_github_source(self.team, prefix="mine_", source_id="gh-mine")
         mine.created_by = self.user
         mine.save()
-        create_github_source(self.team, prefix="theirs_", source_id="gh-theirs")
+        theirs = create_github_source(self.team, prefix="theirs_", source_id="gh-theirs")
         access_control = UserAccessControl(user=self.user, team=self.team)
 
         assert len(list_github_sources(team=self.team, user_access_control=access_control)) == 2
@@ -190,6 +190,15 @@ class TestListGithubSourcesAccessControl(BaseTest):
             team=self.team, user_access_control=UserAccessControl(user=self.user, team=self.team)
         )
         assert [source.id for source in visible] == [str(mine.id)]
+
+        # An explicit object grant survives the fail-closed guard.
+        AccessControl.objects.create(
+            team=self.team, resource="external_data_source", resource_id=str(theirs.id), access_level="editor"
+        )
+        visible = list_github_sources(
+            team=self.team, user_access_control=UserAccessControl(user=self.user, team=self.team)
+        )
+        assert {source.id for source in visible} == {str(mine.id), str(theirs.id)}
 
 
 class TestEngineeringAnalyticsViews(ClickhouseTestMixin, BaseTest):


### PR DESCRIPTION
## Problem

We're about to point an hourly, userless sweep at GitHub warehouse data ([CI signals](https://github.com/PostHog/posthog/pull/67117)), which forced the question of who is actually allowed to read which sources. Auditing that turned up a gap that's live on master today, independent of the sweep:

- `filter_queryset_by_access_level` returns the queryset **unfiltered** for a user with "none" `external_data_source` access and no object grants
- Engineering analytics resolves GitHub sources through it, so such a user can enumerate every source on the team

## Changes

- `_github_sources` (the product's access chokepoint): callers without resource-level access see only self-created or explicitly granted sources
- Root cause is the platform filter's none-branch; flagged for the RBAC owners

## How did you test this code?

- New test: a none-level member sees only their own source, and an explicit object grant survives — catches the unfiltered passthrough regressing (needs the `ACCESS_CONTROL` feature, matching how it manifests)
- Engineering-analytics backend suite green

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Extracted by Claude Code from a security sweep of the CI signals stack.

