### PR TITLE
feat(metrics): clickable exemplar dots on the metrics chart

### DIFF
--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -172,7 +172,7 @@ export function Sparkline(props: SparklineProps): JSX.Element {
         props.highlightedRange ||
         props.incompleteBars?.indices?.length ||
         props.referenceLines?.length ||
-        props.markers?.length ||
+        props.markers ||
         props.withXScale ||
         props.withYScale
     )
@@ -312,6 +312,69 @@ function LegacySparkline({
     const [tooltip, setTooltip] = useState<TooltipModel<'bar'> | null>(null)
     const dragStartRef = useRef<{ index: number; x: number } | null>(null)
     const [isDragging, setIsDragging] = useState(false)
+    const dragEndedRef = useRef(false)
+
+    // Markers draw as an overlay plugin, never a dataset: datasets would join axis
+    // auto-scaling and index-mode hover, misplacing dots on time axes and hijacking
+    // the tooltip's bucket resolution. Refs keep click targets fresh without chart
+    // rebuilds (useChart's deps are JSON-serialized, dropping the onClick closures).
+    const markersRef = useRef<SparklineMarker[] | undefined>(markers)
+    markersRef.current = markers
+    const markerHitboxesRef = useRef<{ x: number; y: number; marker: SparklineMarker }[]>([])
+
+    const markersPlugin = useMemo(
+        () => ({
+            id: 'sparklineMarkers',
+            afterDatasetsDraw: (chart: Chart) => {
+                markerHitboxesRef.current = []
+                const currentMarkers = markersRef.current
+                if (!currentMarkers?.length) {
+                    return
+                }
+                const seriesMeta = chart.getDatasetMeta(0)
+                const yScale = chart.scales.y
+                const { top, bottom } = chart.chartArea
+                const ctx = chart.ctx
+                ctx.save()
+                for (const marker of currentMarkers) {
+                    // The series element's x is the bucket's rendered position — correct on
+                    // category and time axes alike, and always aligned with the line.
+                    const element = seriesMeta?.data?.[marker.index]
+                    if (!element) {
+                        continue
+                    }
+                    const x = element.x
+                    const y = Math.min(Math.max(yScale.getPixelForValue(marker.value), top), bottom)
+                    ctx.beginPath()
+                    ctx.arc(x, y, 3.5, 0, Math.PI * 2)
+                    ctx.fillStyle = getColorVar(marker.color || 'danger')
+                    ctx.fill()
+                    ctx.lineWidth = 1.5
+                    ctx.strokeStyle = 'white'
+                    ctx.stroke()
+                    markerHitboxesRef.current.push({ x, y, marker })
+                }
+                ctx.restore()
+            },
+        }),
+        []
+    )
+
+    const findMarkerAt = useCallback((event: any): SparklineMarker | null => {
+        const native = event?.native ?? event
+        const x = native?.offsetX ?? event?.x
+        const y = native?.offsetY ?? event?.y
+        if (typeof x !== 'number' || typeof y !== 'number') {
+            return null
+        }
+        const HIT_RADIUS = 8
+        for (const hitbox of markerHitboxesRef.current) {
+            if (Math.abs(hitbox.x - x) <= HIT_RADIUS && Math.abs(hitbox.y - y) <= HIT_RADIUS) {
+                return hitbox.marker
+            }
+        }
+        return null
+    }, [])
 
     const incompleteBarSet = useMemo(() => new Set(incompleteBars?.indices ?? []), [incompleteBars])
 
@@ -387,84 +450,53 @@ function LegacySparkline({
             const xScale = withXScale ? withXScale(defaultXScale) : defaultXScale
             const yScale = withYScale ? withYScale(defaultYScale) : defaultYScale
 
-            // Markers render as a scatter dataset drawn on top of the series. Kept out of the
-            // stacked group and flagged so the tooltip and click handling can tell it apart.
-            const markerDataset =
-                markers && markers.length > 0
-                    ? [
-                          {
-                              type: 'scatter' as const,
-                              label: '',
-                              data: markers.map((marker) => ({ x: marker.index, y: marker.value })),
-                              backgroundColor: markers.map((marker) => getColorVar(marker.color || 'danger')),
-                              borderColor: 'white',
-                              borderWidth: 1,
-                              pointRadius: 3.5,
-                              pointHoverRadius: 5,
-                              pointHitRadius: 8,
-                              stack: 'sparkline-markers',
-                              // Lowest order draws last, i.e. on top of the series.
-                              order: -1,
-                              sparklineMarkers: true,
-                          } as any,
-                      ]
-                    : []
-
-            const findMarkerHit = (event: any, chart: Chart): number | null => {
-                const nativeEvent = event?.native ?? event
-                if (!nativeEvent) {
-                    return null
-                }
-                const hits = chart.getElementsAtEventForMode(nativeEvent, 'nearest', { intersect: true }, true)
-                const hit = hits.find((element) => (chart.data.datasets[element.datasetIndex] as any)?.sparklineMarkers)
-                return hit ? hit.index : null
-            }
-
             return {
                 type,
                 data: {
                     labels: labels || adjustedData[0].values.map((_, i) => `Entry ${i}`),
-                    datasets: [
-                        ...markerDataset,
-                        ...adjustedData.map((timeseries) => {
-                            const seriesColor = getColorVar(timeseries.color || 'muted')
-                            const hoverColor = getColorVar(timeseries.hoverColor || timeseries.color || 'muted')
-                            // Incomplete (still-ingesting) bars get a faded hatch of the series colour so
-                            // they read as "not final" without losing which series they belong to.
-                            const hatched = incompleteBarSet.size > 0 ? createHashedPattern(seriesColor) : null
-                            const fillFor = (
-                                base: string
-                            ): typeof base | CanvasPattern | ((ctx: { dataIndex: number }) => string | CanvasPattern) =>
-                                hatched
-                                    ? (ctx: { dataIndex: number }) =>
-                                          incompleteBarSet.has(ctx.dataIndex) ? hatched : base
-                                    : base
-                            return {
-                                label: timeseries.name,
-                                data: timeseries.values,
-                                minBarLength: 0,
-                                categoryPercentage: 0.9, // Slightly tighter bar spacing than the default 0.8
-                                backgroundColor: fillFor(seriesColor),
-                                hoverBackgroundColor: fillFor(hoverColor),
-                                borderColor: seriesColor,
-                                borderWidth: type === 'line' ? 2 : 0,
-                                pointRadius: 0,
-                                borderRadius: 2,
-                            }
-                        }),
-                    ],
+                    datasets: adjustedData.map((timeseries) => {
+                        const seriesColor = getColorVar(timeseries.color || 'muted')
+                        const hoverColor = getColorVar(timeseries.hoverColor || timeseries.color || 'muted')
+                        // Incomplete (still-ingesting) bars get a faded hatch of the series colour so
+                        // they read as "not final" without losing which series they belong to.
+                        const hatched = incompleteBarSet.size > 0 ? createHashedPattern(seriesColor) : null
+                        const fillFor = (
+                            base: string
+                        ): typeof base | CanvasPattern | ((ctx: { dataIndex: number }) => string | CanvasPattern) =>
+                            hatched
+                                ? (ctx: { dataIndex: number }) => (incompleteBarSet.has(ctx.dataIndex) ? hatched : base)
+                                : base
+                        return {
+                            label: timeseries.name,
+                            data: timeseries.values,
+                            minBarLength: 0,
+                            categoryPercentage: 0.9, // Slightly tighter bar spacing than the default 0.8
+                            backgroundColor: fillFor(seriesColor),
+                            hoverBackgroundColor: fillFor(hoverColor),
+                            borderColor: seriesColor,
+                            borderWidth: type === 'line' ? 2 : 0,
+                            pointRadius: 0,
+                            borderRadius: 2,
+                        }
+                    }),
                 },
+                plugins: markers ? [markersPlugin] : [],
                 options: {
-                    ...(markers && markers.length > 0
+                    ...(markers
                         ? {
-                              onClick: (event: any, _elements: any, chart: Chart) => {
-                                  const markerIndex = findMarkerHit(event, chart)
-                                  if (markerIndex !== null) {
-                                      markers[markerIndex]?.onClick?.()
+                              onClick: (event: any) => {
+                                  // A drag that ends on a dot still emits a click — don't navigate.
+                                  if (dragEndedRef.current) {
+                                      dragEndedRef.current = false
+                                      return
                                   }
+                                  findMarkerAt(event)?.onClick?.()
                               },
                               onHover: (event: any, _elements: any, chart: Chart) => {
-                                  chart.canvas.style.cursor = findMarkerHit(event, chart) !== null ? 'pointer' : ''
+                                  const cursor = findMarkerAt(event) ? 'pointer' : ''
+                                  if (chart.canvas.style.cursor !== cursor) {
+                                      chart.canvas.style.cursor = cursor
+                                  }
                               },
                           }
                         : {}),
@@ -561,10 +593,7 @@ function LegacySparkline({
     const finalClassName = sparklineClassName(adjustedData[0]?.values?.length || 0, className)
 
     const tooltipVisible = !!(tooltip && tooltip.opacity > 0)
-    // Markers are chart decoration, not a series — keep them out of the hover tooltip.
-    const toolTipDataPoints = (tooltip && tooltip.dataPoints ? tooltip.dataPoints : []).filter(
-        (dp) => !(dp.dataset as any)?.sparklineMarkers
-    )
+    const toolTipDataPoints = tooltip && tooltip.dataPoints ? tooltip.dataPoints : []
 
     const hoveredElementX = toolTipDataPoints[0]?.element?.x ?? 0
     const hoveredElementWidth = (toolTipDataPoints[0]?.element as any)?.width ?? 0
@@ -584,6 +613,8 @@ function LegacySparkline({
                 return
             }
 
+            // The click event that follows this mouseup must not fire a marker's onClick.
+            dragEndedRef.current = true
             setIsDragging(false)
 
             if (!onSelectionChange || !toolTipDataPoints.length || !dragStartRef.current) {

--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -44,6 +44,16 @@ export interface SparklineTimeSeries {
     hoverColor?: string
 }
 
+export interface SparklineMarker {
+    /** X bucket index the marker sits in. */
+    index: number
+    /** Y value the marker is drawn at, in the same units as the series data. */
+    value: number
+    /** Check vars.scss for available colors. @default 'danger' */
+    color?: string
+    onClick?: () => void
+}
+
 export type AnyScaleOptions = ScaleOptions<'linear' | 'logarithmic' | 'time' | 'timeseries' | 'category'>
 
 export interface SparklineProps {
@@ -96,6 +106,11 @@ export interface SparklineProps {
      * `indices` array to clear.
      */
     incompleteBars?: { indices: number[]; tooltip?: string } | null
+    /**
+     * Clickable point markers drawn on top of the series (e.g. trace exemplars). Each marker
+     * renders as a dot at (index, value); clicking it fires its `onClick`.
+     */
+    markers?: SparklineMarker[]
 }
 
 /** Normalize the permissive `data` prop into one `SparklineTimeSeries` per series. */
@@ -157,6 +172,7 @@ export function Sparkline(props: SparklineProps): JSX.Element {
         props.highlightedRange ||
         props.incompleteBars?.indices?.length ||
         props.referenceLines?.length ||
+        props.markers?.length ||
         props.withXScale ||
         props.withYScale
     )
@@ -289,6 +305,7 @@ function LegacySparkline({
     renderTooltipValue,
     highlightedRange,
     incompleteBars,
+    markers,
 }: SparklineProps): JSX.Element {
     const tooltipRef = useRef<HTMLDivElement | null>(null)
 
@@ -370,37 +387,87 @@ function LegacySparkline({
             const xScale = withXScale ? withXScale(defaultXScale) : defaultXScale
             const yScale = withYScale ? withYScale(defaultYScale) : defaultYScale
 
+            // Markers render as a scatter dataset drawn on top of the series. Kept out of the
+            // stacked group and flagged so the tooltip and click handling can tell it apart.
+            const markerDataset =
+                markers && markers.length > 0
+                    ? [
+                          {
+                              type: 'scatter' as const,
+                              label: '',
+                              data: markers.map((marker) => ({ x: marker.index, y: marker.value })),
+                              backgroundColor: markers.map((marker) => getColorVar(marker.color || 'danger')),
+                              borderColor: 'white',
+                              borderWidth: 1,
+                              pointRadius: 3.5,
+                              pointHoverRadius: 5,
+                              pointHitRadius: 8,
+                              stack: 'sparkline-markers',
+                              // Lowest order draws last, i.e. on top of the series.
+                              order: -1,
+                              sparklineMarkers: true,
+                          } as any,
+                      ]
+                    : []
+
+            const findMarkerHit = (event: any, chart: Chart): number | null => {
+                const nativeEvent = event?.native ?? event
+                if (!nativeEvent) {
+                    return null
+                }
+                const hits = chart.getElementsAtEventForMode(nativeEvent, 'nearest', { intersect: true }, true)
+                const hit = hits.find((element) => (chart.data.datasets[element.datasetIndex] as any)?.sparklineMarkers)
+                return hit ? hit.index : null
+            }
+
             return {
                 type,
                 data: {
                     labels: labels || adjustedData[0].values.map((_, i) => `Entry ${i}`),
-                    datasets: adjustedData.map((timeseries) => {
-                        const seriesColor = getColorVar(timeseries.color || 'muted')
-                        const hoverColor = getColorVar(timeseries.hoverColor || timeseries.color || 'muted')
-                        // Incomplete (still-ingesting) bars get a faded hatch of the series colour so
-                        // they read as "not final" without losing which series they belong to.
-                        const hatched = incompleteBarSet.size > 0 ? createHashedPattern(seriesColor) : null
-                        const fillFor = (
-                            base: string
-                        ): typeof base | CanvasPattern | ((ctx: { dataIndex: number }) => string | CanvasPattern) =>
-                            hatched
-                                ? (ctx: { dataIndex: number }) => (incompleteBarSet.has(ctx.dataIndex) ? hatched : base)
-                                : base
-                        return {
-                            label: timeseries.name,
-                            data: timeseries.values,
-                            minBarLength: 0,
-                            categoryPercentage: 0.9, // Slightly tighter bar spacing than the default 0.8
-                            backgroundColor: fillFor(seriesColor),
-                            hoverBackgroundColor: fillFor(hoverColor),
-                            borderColor: seriesColor,
-                            borderWidth: type === 'line' ? 2 : 0,
-                            pointRadius: 0,
-                            borderRadius: 2,
-                        }
-                    }),
+                    datasets: [
+                        ...markerDataset,
+                        ...adjustedData.map((timeseries) => {
+                            const seriesColor = getColorVar(timeseries.color || 'muted')
+                            const hoverColor = getColorVar(timeseries.hoverColor || timeseries.color || 'muted')
+                            // Incomplete (still-ingesting) bars get a faded hatch of the series colour so
+                            // they read as "not final" without losing which series they belong to.
+                            const hatched = incompleteBarSet.size > 0 ? createHashedPattern(seriesColor) : null
+                            const fillFor = (
+                                base: string
+                            ): typeof base | CanvasPattern | ((ctx: { dataIndex: number }) => string | CanvasPattern) =>
+                                hatched
+                                    ? (ctx: { dataIndex: number }) =>
+                                          incompleteBarSet.has(ctx.dataIndex) ? hatched : base
+                                    : base
+                            return {
+                                label: timeseries.name,
+                                data: timeseries.values,
+                                minBarLength: 0,
+                                categoryPercentage: 0.9, // Slightly tighter bar spacing than the default 0.8
+                                backgroundColor: fillFor(seriesColor),
+                                hoverBackgroundColor: fillFor(hoverColor),
+                                borderColor: seriesColor,
+                                borderWidth: type === 'line' ? 2 : 0,
+                                pointRadius: 0,
+                                borderRadius: 2,
+                            }
+                        }),
+                    ],
                 },
                 options: {
+                    ...(markers && markers.length > 0
+                        ? {
+                              onClick: (event: any, _elements: any, chart: Chart) => {
+                                  const markerIndex = findMarkerHit(event, chart)
+                                  if (markerIndex !== null) {
+                                      markers[markerIndex]?.onClick?.()
+                                  }
+                              },
+                              onHover: (event: any, _elements: any, chart: Chart) => {
+                                  chart.canvas.style.cursor = findMarkerHit(event, chart) !== null ? 'pointer' : ''
+                              },
+                          }
+                        : {}),
                     scales: {
                         x: xScale,
                         y: yScale,
@@ -487,13 +554,17 @@ function LegacySparkline({
             referenceLines,
             highlightedRange,
             incompleteBars,
+            markers,
         ],
     })
 
     const finalClassName = sparklineClassName(adjustedData[0]?.values?.length || 0, className)
 
     const tooltipVisible = !!(tooltip && tooltip.opacity > 0)
-    const toolTipDataPoints = tooltip && tooltip.dataPoints ? tooltip.dataPoints : []
+    // Markers are chart decoration, not a series — keep them out of the hover tooltip.
+    const toolTipDataPoints = (tooltip && tooltip.dataPoints ? tooltip.dataPoints : []).filter(
+        (dp) => !(dp.dataset as any)?.sparklineMarkers
+    )
 
     const hoveredElementX = toolTipDataPoints[0]?.element?.x ?? 0
     const hoveredElementWidth = (toolTipDataPoints[0]?.element as any)?.width ?? 0

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -105,6 +105,8 @@ export const MetricsViewer = (): JSX.Element => {
     // The side panel's logic listens to this viewer's filter changes; mounting it
     // here keeps samples in sync even while the panel itself is off-screen.
     useMountedLogic(metricsSamplesLogic())
+    const { exemplarsEnabled, exemplarMarkers } = useValues(metricsSamplesLogic())
+    const { setExemplarsEnabled, exemplarClicked } = useActions(metricsSamplesLogic())
     const {
         metricName,
         aggregation,
@@ -293,6 +295,15 @@ export const MetricsViewer = (): JSX.Element => {
                     bordered
                     data-attr="metrics-viewer-live-toggle"
                 />
+                <LemonSwitch
+                    label="Exemplars"
+                    checked={exemplarsEnabled}
+                    onChange={setExemplarsEnabled}
+                    tooltip="Overlay trace-linked samples on the chart. Click a dot to open its trace."
+                    bordered
+                    disabledReason={hasMetricName ? undefined : 'Pick a metric first'}
+                    data-attr="metrics-viewer-exemplars-toggle"
+                />
                 <LemonButton
                     size="small"
                     type="secondary"
@@ -353,6 +364,15 @@ export const MetricsViewer = (): JSX.Element => {
                                 className="w-full h-full"
                                 withXScale={withXScale}
                                 renderLabel={renderLabel}
+                                markers={
+                                    exemplarsEnabled
+                                        ? exemplarMarkers.map((marker) => ({
+                                              index: marker.index,
+                                              value: marker.value,
+                                              onClick: () => exemplarClicked(marker),
+                                          }))
+                                        : undefined
+                                }
                             />
                         ) : !queryResultsLoading ? (
                             <div className="h-full flex items-center justify-center text-secondary text-sm">

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -105,7 +105,7 @@ export const MetricsViewer = (): JSX.Element => {
     // The side panel's logic listens to this viewer's filter changes; mounting it
     // here keeps samples in sync even while the panel itself is off-screen.
     useMountedLogic(metricsSamplesLogic())
-    const { exemplarsEnabled, exemplarMarkers } = useValues(metricsSamplesLogic())
+    const { exemplarsEnabled, exemplarMarkers, samplesLoading } = useValues(metricsSamplesLogic())
     const { setExemplarsEnabled, exemplarClicked } = useActions(metricsSamplesLogic())
     const {
         metricName,
@@ -295,15 +295,17 @@ export const MetricsViewer = (): JSX.Element => {
                     bordered
                     data-attr="metrics-viewer-live-toggle"
                 />
-                <LemonSwitch
-                    label="Exemplars"
-                    checked={exemplarsEnabled}
-                    onChange={setExemplarsEnabled}
-                    tooltip="Overlay trace-linked samples on the chart. Click a dot to open its trace."
-                    bordered
-                    disabledReason={hasMetricName ? undefined : 'Pick a metric first'}
-                    data-attr="metrics-viewer-exemplars-toggle"
-                />
+                {viewMode === 'chart' && (
+                    <LemonSwitch
+                        label="Exemplars"
+                        checked={exemplarsEnabled}
+                        onChange={setExemplarsEnabled}
+                        tooltip="Overlay trace-linked samples on the chart. Click a dot to open its trace."
+                        bordered
+                        disabledReason={hasMetricName ? undefined : 'Pick a metric first'}
+                        data-attr="metrics-viewer-exemplars-toggle"
+                    />
+                )}
                 <LemonButton
                     size="small"
                     type="secondary"
@@ -377,6 +379,11 @@ export const MetricsViewer = (): JSX.Element => {
                         ) : !queryResultsLoading ? (
                             <div className="h-full flex items-center justify-center text-secondary text-sm">
                                 No data for this metric in the selected range.
+                            </div>
+                        ) : null}
+                        {exemplarsEnabled && !samplesLoading && exemplarMarkers.length === 0 && hasResults ? (
+                            <div className="absolute top-1 right-2 text-xs text-secondary">
+                                No trace-linked samples in this range
                             </div>
                         ) : null}
                         {queryResultsLoading && <SpinnerOverlay />}

--- a/products/metrics/frontend/components/exemplarMarkers.test.ts
+++ b/products/metrics/frontend/components/exemplarMarkers.test.ts
@@ -1,0 +1,62 @@
+import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/api.schemas'
+
+import { exemplarMarkersFromSamples } from './exemplarMarkers'
+
+const BUCKETS = ['2026-07-14T10:00:00Z', '2026-07-14T10:01:00Z', '2026-07-14T10:02:00Z', '2026-07-14T10:03:00Z']
+
+function sample(overrides: Partial<_MetricEventSampleApi>): _MetricEventSampleApi {
+    return {
+        timestamp: '2026-07-14T10:00:10Z',
+        metric_name: 'queue.depth',
+        metric_type: 'gauge',
+        value: 7,
+        count: 1,
+        unit: '',
+        aggregation_temporality: 'delta',
+        is_monotonic: false,
+        service_name: 'svc',
+        trace_id: 'abc123def456',
+        span_id: 'span1',
+        attributes: {},
+        resource_attributes: {},
+        ...overrides,
+    }
+}
+
+describe('exemplarMarkersFromSamples', () => {
+    it('maps trace-linked samples to their nearest chart bucket', () => {
+        const markers = exemplarMarkersFromSamples(
+            [
+                sample({ timestamp: '2026-07-14T10:00:10Z', value: 7 }),
+                // 10:02:40 is nearer to the 10:03 bucket than the 10:02 one.
+                sample({ timestamp: '2026-07-14T10:02:40Z', value: 12, trace_id: 'ffff0000' }),
+            ],
+            BUCKETS
+        )
+
+        expect(markers).toEqual([
+            expect.objectContaining({ index: 0, value: 7, traceId: 'abc123def456' }),
+            expect.objectContaining({ index: 3, value: 12, traceId: 'ffff0000' }),
+        ])
+    })
+
+    it('drops samples without a trace and dedupes to the newest sample per bucket', () => {
+        const markers = exemplarMarkersFromSamples(
+            [
+                // Endpoint returns newest-first; both land in bucket 1 and the newest must win.
+                sample({ timestamp: '2026-07-14T10:01:20Z', value: 99, trace_id: 'newest' }),
+                sample({ timestamp: '2026-07-14T10:01:05Z', value: 1, trace_id: 'older' }),
+                sample({ timestamp: '2026-07-14T10:01:10Z', value: 5, trace_id: '' }),
+            ],
+            BUCKETS
+        )
+
+        expect(markers).toHaveLength(1)
+        expect(markers[0]).toEqual(expect.objectContaining({ index: 1, traceId: 'newest', value: 99 }))
+    })
+
+    it('returns nothing without buckets or samples', () => {
+        expect(exemplarMarkersFromSamples([], BUCKETS)).toEqual([])
+        expect(exemplarMarkersFromSamples([sample({})], [])).toEqual([])
+    })
+})

--- a/products/metrics/frontend/components/exemplarMarkers.test.ts
+++ b/products/metrics/frontend/components/exemplarMarkers.test.ts
@@ -2,7 +2,17 @@ import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/
 
 import { exemplarMarkersFromSamples } from './exemplarMarkers'
 
-const BUCKETS = ['2026-07-14T10:00:00Z', '2026-07-14T10:01:00Z', '2026-07-14T10:02:00Z', '2026-07-14T10:03:00Z']
+const SERIES = [
+    {
+        labels: {},
+        points: [
+            { time: '2026-07-14T10:00:00Z', value: 10 },
+            { time: '2026-07-14T10:01:00Z', value: 20 },
+            { time: '2026-07-14T10:02:00Z', value: 30 },
+            { time: '2026-07-14T10:03:00Z', value: 40 },
+        ],
+    },
+]
 
 function sample(overrides: Partial<_MetricEventSampleApi>): _MetricEventSampleApi {
     return {
@@ -23,40 +33,104 @@ function sample(overrides: Partial<_MetricEventSampleApi>): _MetricEventSampleAp
     }
 }
 
+const NO_OPTS = { groupByKeys: [], filters: [] }
+
 describe('exemplarMarkersFromSamples', () => {
-    it('maps trace-linked samples to their nearest chart bucket', () => {
+    it('floors samples into their containing bucket and pins the dot to the series value', () => {
         const markers = exemplarMarkersFromSamples(
             [
-                sample({ timestamp: '2026-07-14T10:00:10Z', value: 7 }),
-                // 10:02:40 is nearer to the 10:03 bucket than the 10:02 one.
-                sample({ timestamp: '2026-07-14T10:02:40Z', value: 12, trace_id: 'ffff0000' }),
+                sample({ timestamp: '2026-07-14T10:00:10Z' }),
+                // 10:02:40 belongs to the 10:02 bucket it aggregated into, not the nearer 10:03.
+                sample({ timestamp: '2026-07-14T10:02:40Z', trace_id: 'ffff0000' }),
             ],
-            BUCKETS
+            SERIES,
+            NO_OPTS
         )
 
         expect(markers).toEqual([
-            expect.objectContaining({ index: 0, value: 7, traceId: 'abc123def456' }),
-            expect.objectContaining({ index: 3, value: 12, traceId: 'ffff0000' }),
+            expect.objectContaining({ index: 0, value: 10, traceId: 'abc123def456' }),
+            expect.objectContaining({ index: 2, value: 30, traceId: 'ffff0000' }),
         ])
     })
 
-    it('drops samples without a trace and dedupes to the newest sample per bucket', () => {
+    it('drops samples outside the bucket window instead of clamping them to the edges', () => {
         const markers = exemplarMarkersFromSamples(
             [
-                // Endpoint returns newest-first; both land in bucket 1 and the newest must win.
-                sample({ timestamp: '2026-07-14T10:01:20Z', value: 99, trace_id: 'newest' }),
-                sample({ timestamp: '2026-07-14T10:01:05Z', value: 1, trace_id: 'older' }),
-                sample({ timestamp: '2026-07-14T10:01:10Z', value: 5, trace_id: '' }),
+                sample({ timestamp: '2026-07-14T09:59:00Z', trace_id: 'before' }),
+                sample({ timestamp: '2026-07-14T10:05:30Z', trace_id: 'after' }),
+                sample({ timestamp: '2026-07-14T10:03:30Z', trace_id: 'in-last-bucket' }),
             ],
-            BUCKETS
+            SERIES,
+            NO_OPTS
+        )
+
+        expect(markers).toEqual([expect.objectContaining({ index: 3, traceId: 'in-last-bucket' })])
+    })
+
+    it('drops non-traced samples and dedupes to the newest per bucket', () => {
+        const markers = exemplarMarkersFromSamples(
+            [
+                sample({ timestamp: '2026-07-14T10:01:20Z', trace_id: 'newest' }),
+                sample({ timestamp: '2026-07-14T10:01:05Z', trace_id: 'older' }),
+                sample({ timestamp: '2026-07-14T10:01:10Z', trace_id: '' }),
+            ],
+            SERIES,
+            NO_OPTS
         )
 
         expect(markers).toHaveLength(1)
-        expect(markers[0]).toEqual(expect.objectContaining({ index: 1, traceId: 'newest', value: 99 }))
+        expect(markers[0]).toEqual(expect.objectContaining({ index: 1, traceId: 'newest', value: 20 }))
+    })
+
+    it('applies the chart filters client-side, with negative operators matching missing keys', () => {
+        const samples = [
+            sample({ attributes: { env: 'prod' }, trace_id: 'keep-eq' }),
+            sample({ attributes: { env: 'dev' }, trace_id: 'drop-eq', timestamp: '2026-07-14T10:01:10Z' }),
+        ]
+
+        expect(
+            exemplarMarkersFromSamples(samples, SERIES, {
+                groupByKeys: [],
+                filters: [{ key: 'env', op: 'eq', value: 'prod' }],
+            }).map((m) => m.traceId)
+        ).toEqual(['keep-eq'])
+
+        // neq matches rows lacking the key entirely, mirroring Prometheus negative matchers.
+        expect(
+            exemplarMarkersFromSamples([sample({ attributes: {}, trace_id: 'no-key' })], SERIES, {
+                groupByKeys: [],
+                filters: [{ key: 'env', op: 'neq', value: 'prod' }],
+            }).map((m) => m.traceId)
+        ).toEqual(['no-key'])
+    })
+
+    it('pins grouped samples to their matching series and drops samples with no series', () => {
+        const grouped = [
+            { labels: { container: 'a' }, points: SERIES[0].points },
+            {
+                labels: { container: 'b' },
+                points: SERIES[0].points.map((point) => ({ ...point, value: (point.value ?? 0) * 10 })),
+            },
+        ]
+        const markers = exemplarMarkersFromSamples(
+            [
+                sample({ attributes: { container: 'b' }, trace_id: 'goes-to-b' }),
+                sample({ attributes: { container: 'zz' }, trace_id: 'orphan', timestamp: '2026-07-14T10:01:10Z' }),
+            ],
+            grouped,
+            { groupByKeys: ['container'], filters: [] }
+        )
+
+        expect(markers).toEqual([expect.objectContaining({ index: 0, value: 100, traceId: 'goes-to-b' })])
+    })
+
+    it('skips buckets where the matched series has a gap', () => {
+        const gappy = [{ labels: {}, points: SERIES[0].points.map((p, i) => (i === 0 ? { ...p, value: null } : p)) }]
+        expect(exemplarMarkersFromSamples([sample({})], gappy, NO_OPTS)).toEqual([])
     })
 
     it('returns nothing without buckets or samples', () => {
-        expect(exemplarMarkersFromSamples([], BUCKETS)).toEqual([])
-        expect(exemplarMarkersFromSamples([sample({})], [])).toEqual([])
+        expect(exemplarMarkersFromSamples([], SERIES, NO_OPTS)).toEqual([])
+        expect(exemplarMarkersFromSamples([sample({})], [], NO_OPTS)).toEqual([])
     })
 })

--- a/products/metrics/frontend/components/exemplarMarkers.test.ts
+++ b/products/metrics/frontend/components/exemplarMarkers.test.ts
@@ -68,10 +68,12 @@ describe('exemplarMarkersFromSamples', () => {
     })
 
     it('drops non-traced samples and dedupes to the newest per bucket', () => {
+        // Older sample first, so keep-newest can't be faked by keep-first-seen:
+        // the API does not promise chronological order.
         const markers = exemplarMarkersFromSamples(
             [
-                sample({ timestamp: '2026-07-14T10:01:20Z', trace_id: 'newest' }),
                 sample({ timestamp: '2026-07-14T10:01:05Z', trace_id: 'older' }),
+                sample({ timestamp: '2026-07-14T10:01:20Z', trace_id: 'newest' }),
                 sample({ timestamp: '2026-07-14T10:01:10Z', trace_id: '' }),
             ],
             SERIES,

--- a/products/metrics/frontend/components/exemplarMarkers.ts
+++ b/products/metrics/frontend/components/exemplarMarkers.ts
@@ -1,10 +1,10 @@
-import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/api.schemas'
+import type { _MetricEventSampleApi, _MetricFilterApi } from 'products/metrics/frontend/generated/api.schemas'
 
 // One clickable dot on the chart: a trace-linked emission positioned in its time bucket.
 export interface ExemplarMarker {
     /** Chart bucket index the sample falls into. */
     index: number
-    /** The sample's recorded value — where the dot sits on the y-axis. */
+    /** The matched series' value at that bucket — the dot sits on the line it annotates. */
     value: number
     traceId: string
     spanId: string | null
@@ -12,38 +12,98 @@ export interface ExemplarMarker {
     timestamp: string
 }
 
+interface ExemplarSeries {
+    labels: Record<string, string>
+    points: { time: string; value: number | null }[]
+}
+
+interface ExemplarOptions {
+    groupByKeys: string[]
+    filters: _MetricFilterApi[]
+}
+
+// The samples endpoint only scopes by metric name and window, so the chart's
+// attribute filters are re-applied here — a dot must belong to the plotted data.
+// Negative operators match rows lacking the key, mirroring Prometheus matchers.
+function matchesFilters(attributes: Record<string, string>, filters: _MetricFilterApi[]): boolean {
+    return filters.every((filter) => {
+        const value = attributes[filter.key]
+        switch (filter.op ?? 'eq') {
+            case 'eq':
+                return value === filter.value
+            case 'neq':
+                return value === undefined || value !== filter.value
+            case 'regex':
+                return value !== undefined && safeRegexTest(filter.value, value)
+            case 'not_regex':
+                return value === undefined || !safeRegexTest(filter.value, value)
+            default:
+                return true
+        }
+    })
+}
+
+function safeRegexTest(pattern: string, value: string): boolean {
+    try {
+        return new RegExp(pattern).test(value)
+    } catch {
+        return false
+    }
+}
+
 /**
- * Positions trace-linked samples on the chart's bucket grid: nearest bucket by
- * timestamp, newest sample wins per bucket (the endpoint returns newest-first)
- * so a busy bucket renders one dot instead of a smear.
+ * Positions trace-linked samples on the chart: floored into the bucket they
+ * aggregated into (buckets are start-timestamped), matched to their series
+ * under group-by, filtered like the chart, and pinned to the series value so
+ * the dot sits on the line regardless of the chart's aggregation. Newest
+ * sample wins per bucket so a busy bucket renders one dot instead of a smear.
  */
-export function exemplarMarkersFromSamples(samples: _MetricEventSampleApi[], bucketTimes: string[]): ExemplarMarker[] {
+export function exemplarMarkersFromSamples(
+    samples: _MetricEventSampleApi[],
+    series: ExemplarSeries[],
+    options: ExemplarOptions
+): ExemplarMarker[] {
+    const bucketTimes = series[0]?.points.map((point) => point.time) ?? []
     if (!samples.length || !bucketTimes.length) {
         return []
     }
     const bucketMs = bucketTimes.map((time) => new Date(time).getTime())
+    // Samples past the final bucket's span are out of window, not part of the last bucket.
+    const interval = bucketMs.length > 1 ? bucketMs[1] - bucketMs[0] : Infinity
+    const windowEnd = bucketMs[bucketMs.length - 1] + interval
+
     const byBucket = new Map<number, ExemplarMarker>()
     for (const sample of samples) {
         if (!sample.trace_id) {
             continue
         }
         const sampleMs = new Date(sample.timestamp).getTime()
-        if (!Number.isFinite(sampleMs)) {
+        if (!Number.isFinite(sampleMs) || sampleMs < bucketMs[0] || sampleMs >= windowEnd) {
             continue
         }
-        let nearest = 0
-        let nearestDistance = Infinity
-        for (let i = 0; i < bucketMs.length; i++) {
-            const distance = Math.abs(sampleMs - bucketMs[i])
-            if (distance < nearestDistance) {
-                nearest = i
-                nearestDistance = distance
-            }
+        const attributes = { ...sample.resource_attributes, ...sample.attributes }
+        if (!matchesFilters(attributes, options.filters)) {
+            continue
         }
-        if (!byBucket.has(nearest)) {
-            byBucket.set(nearest, {
-                index: nearest,
-                value: sample.value,
+        const matchedSeries = options.groupByKeys.length
+            ? series.find((candidate) => options.groupByKeys.every((key) => candidate.labels[key] === attributes[key]))
+            : series[0]
+        if (!matchedSeries) {
+            continue
+        }
+        // Floor to the containing bucket: the last bucket starting at or before the sample.
+        let bucket = bucketMs.length - 1
+        while (bucket > 0 && bucketMs[bucket] > sampleMs) {
+            bucket--
+        }
+        const seriesValue = matchedSeries.points[bucket]?.value
+        if (seriesValue === null || seriesValue === undefined) {
+            continue // a dot on a gap would assert data the chart doesn't show
+        }
+        if (!byBucket.has(bucket)) {
+            byBucket.set(bucket, {
+                index: bucket,
+                value: seriesValue,
                 traceId: sample.trace_id,
                 spanId: sample.span_id || null,
                 timestamp: sample.timestamp,

--- a/products/metrics/frontend/components/exemplarMarkers.ts
+++ b/products/metrics/frontend/components/exemplarMarkers.ts
@@ -1,0 +1,54 @@
+import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/api.schemas'
+
+// One clickable dot on the chart: a trace-linked emission positioned in its time bucket.
+export interface ExemplarMarker {
+    /** Chart bucket index the sample falls into. */
+    index: number
+    /** The sample's recorded value — where the dot sits on the y-axis. */
+    value: number
+    traceId: string
+    spanId: string | null
+    /** ISO timestamp of the emission, used to bound the trace lookup. */
+    timestamp: string
+}
+
+/**
+ * Positions trace-linked samples on the chart's bucket grid: nearest bucket by
+ * timestamp, newest sample wins per bucket (the endpoint returns newest-first)
+ * so a busy bucket renders one dot instead of a smear.
+ */
+export function exemplarMarkersFromSamples(samples: _MetricEventSampleApi[], bucketTimes: string[]): ExemplarMarker[] {
+    if (!samples.length || !bucketTimes.length) {
+        return []
+    }
+    const bucketMs = bucketTimes.map((time) => new Date(time).getTime())
+    const byBucket = new Map<number, ExemplarMarker>()
+    for (const sample of samples) {
+        if (!sample.trace_id) {
+            continue
+        }
+        const sampleMs = new Date(sample.timestamp).getTime()
+        if (!Number.isFinite(sampleMs)) {
+            continue
+        }
+        let nearest = 0
+        let nearestDistance = Infinity
+        for (let i = 0; i < bucketMs.length; i++) {
+            const distance = Math.abs(sampleMs - bucketMs[i])
+            if (distance < nearestDistance) {
+                nearest = i
+                nearestDistance = distance
+            }
+        }
+        if (!byBucket.has(nearest)) {
+            byBucket.set(nearest, {
+                index: nearest,
+                value: sample.value,
+                traceId: sample.trace_id,
+                spanId: sample.span_id || null,
+                timestamp: sample.timestamp,
+            })
+        }
+    }
+    return Array.from(byBucket.values()).sort((a, b) => a.index - b.index)
+}

--- a/products/metrics/frontend/components/exemplarMarkers.ts
+++ b/products/metrics/frontend/components/exemplarMarkers.ts
@@ -100,7 +100,10 @@ export function exemplarMarkersFromSamples(
         if (seriesValue === null || seriesValue === undefined) {
             continue // a dot on a gap would assert data the chart doesn't show
         }
-        if (!byBucket.has(bucket)) {
+        // Newest sample wins per bucket, regardless of the order the API returned
+        // them in, so a busy bucket renders its most recent trace, not a random one.
+        const existing = byBucket.get(bucket)
+        if (!existing || sampleMs > new Date(existing.timestamp).getTime()) {
             byBucket.set(bucket, {
                 index: bucket,
                 value: seriesValue,

--- a/products/metrics/frontend/components/metricsSamplesLogic.test.ts
+++ b/products/metrics/frontend/components/metricsSamplesLogic.test.ts
@@ -104,25 +104,31 @@ describe('metricsSamplesLogic', () => {
         expect(mockSamplesCreate).toHaveBeenCalledTimes(2)
     })
 
-    it('derives exemplar markers positioned on the chart buckets from traced samples', async () => {
+    it('derives exemplar markers pinned to the series value and refetches on chart refresh', async () => {
         metricsViewerLogic.actions.setMetricName('demo_checkout_duration_ms')
         logic.actions.setExemplarsEnabled(true)
         await expectLogic(logic).toDispatchActions(['loadSamplesSuccess'])
+        const callsAfterEnable = mockSamplesCreate.mock.calls.length
 
-        metricsViewerLogic.actions.fetchQueryResultsSuccess([
-            {
-                labels: {},
-                metricName: 'demo_checkout_duration_ms',
-                clause: 'a',
-                points: [
-                    { time: '2026-07-09T05:46:00+00:00', value: 1 },
-                    { time: '2026-07-09T05:47:00+00:00', value: 2 },
-                ],
-            },
-        ] as any)
+        // Live refresh: every chart refetch re-syncs the samples window while exemplars are on.
+        await expectLogic(logic, () => {
+            metricsViewerLogic.actions.fetchQueryResultsSuccess([
+                {
+                    labels: {},
+                    metricName: 'demo_checkout_duration_ms',
+                    clause: 'a',
+                    points: [
+                        { time: '2026-07-09T05:46:00+00:00', value: 111 },
+                        { time: '2026-07-09T05:47:00+00:00', value: 2 },
+                    ],
+                },
+            ] as any)
+        }).toDispatchActions(['loadSamples', 'loadSamplesSuccess'])
+        expect(mockSamplesCreate.mock.calls.length).toBeGreaterThan(callsAfterEnable)
 
+        // Dots sit on the line: the marker takes the series value at its bucket, not the raw sample value.
         expect(logic.values.exemplarMarkers).toEqual([
-            expect.objectContaining({ index: 0, traceId: SAMPLE.trace_id, value: SAMPLE.value }),
+            expect.objectContaining({ index: 0, traceId: SAMPLE.trace_id, value: 111 }),
         ])
     })
 })

--- a/products/metrics/frontend/components/metricsSamplesLogic.test.ts
+++ b/products/metrics/frontend/components/metricsSamplesLogic.test.ts
@@ -90,4 +90,39 @@ describe('metricsSamplesLogic', () => {
         await expectLogic(logic).delay(10)
         expect(mockSamplesCreate).toHaveBeenCalledTimes(2)
     })
+
+    // Exemplar dots: the chart overlay needs samples without the samples tab being open.
+    it('enabling exemplars fetches samples and filter changes refetch while enabled', async () => {
+        metricsViewerLogic.actions.setMetricName('demo_checkout_duration_ms')
+
+        logic.actions.setExemplarsEnabled(true)
+        await expectLogic(logic).toDispatchActions(['loadSamplesSuccess'])
+        expect(mockSamplesCreate).toHaveBeenCalledTimes(1)
+
+        metricsViewerLogic.actions.setDateFrom('-30m')
+        await expectLogic(logic).toDispatchActions(['loadSamplesSuccess'])
+        expect(mockSamplesCreate).toHaveBeenCalledTimes(2)
+    })
+
+    it('derives exemplar markers positioned on the chart buckets from traced samples', async () => {
+        metricsViewerLogic.actions.setMetricName('demo_checkout_duration_ms')
+        logic.actions.setExemplarsEnabled(true)
+        await expectLogic(logic).toDispatchActions(['loadSamplesSuccess'])
+
+        metricsViewerLogic.actions.fetchQueryResultsSuccess([
+            {
+                labels: {},
+                metricName: 'demo_checkout_duration_ms',
+                clause: 'a',
+                points: [
+                    { time: '2026-07-09T05:46:00+00:00', value: 1 },
+                    { time: '2026-07-09T05:47:00+00:00', value: 2 },
+                ],
+            },
+        ] as any)
+
+        expect(logic.values.exemplarMarkers).toEqual([
+            expect.objectContaining({ index: 0, traceId: SAMPLE.trace_id, value: SAMPLE.value }),
+        ])
+    })
 })

--- a/products/metrics/frontend/components/metricsSamplesLogic.tsx
+++ b/products/metrics/frontend/components/metricsSamplesLogic.tsx
@@ -19,6 +19,8 @@ export type MetricsPanelTab = 'aggregates' | 'samples'
 
 export const SAMPLES_LIMIT = 50
 
+const EMPTY_MARKERS: ExemplarMarker[] = []
+
 // One row of the Aggregates tab: a series with its headline numbers.
 export interface MetricsAggregateRow {
     name: string
@@ -34,9 +36,9 @@ export const metricsSamplesLogic = kea<metricsSamplesLogicType>([
             teamLogic,
             ['currentTeamId'],
             metricsViewerLogic,
-            ['metricName', 'dateFrom', 'dateTo', 'queryResults'],
+            ['metricName', 'dateFrom', 'dateTo', 'queryResults', 'queryFilters', 'groupByKeys'],
         ],
-        actions: [metricsViewerLogic, ['setMetricName', 'setDateFrom', 'setDateTo']],
+        actions: [metricsViewerLogic, ['setMetricName', 'setDateFrom', 'setDateTo', 'fetchQueryResultsSuccess']],
     })),
     actions({
         setActiveTab: (activeTab: MetricsPanelTab) => ({ activeTab }),
@@ -74,15 +76,22 @@ export const metricsSamplesLogic = kea<metricsSamplesLogicType>([
         ],
     })),
     selectors({
-        // Dots for the chart overlay: traced samples snapped onto the current
-        // series' bucket grid, so a dot sits where its emission was recorded.
+        // Dots for the chart overlay: traced samples floored onto the current
+        // series' bucket grid and re-filtered like the chart. A stable empty
+        // reference while disabled keeps chart-adjacent subscribers from
+        // re-rendering on unrelated samples-tab loads.
         exemplarMarkers: [
-            (s) => [s.samples, s.queryResults],
-            (samples: _MetricEventSampleApi[], queryResults: MetricsViewerSeries[]): ExemplarMarker[] =>
-                exemplarMarkersFromSamples(
-                    samples,
-                    (queryResults[0]?.points ?? []).map((point) => point.time)
-                ),
+            (s) => [s.exemplarsEnabled, s.samples, s.queryResults, s.queryFilters, s.groupByKeys],
+            (
+                exemplarsEnabled: boolean,
+                samples: _MetricEventSampleApi[],
+                queryResults: MetricsViewerSeries[],
+                queryFilters,
+                groupByKeys: string[]
+            ): ExemplarMarker[] =>
+                exemplarsEnabled
+                    ? exemplarMarkersFromSamples(samples, queryResults, { filters: queryFilters, groupByKeys })
+                    : EMPTY_MARKERS,
         ],
         // Rows for the Aggregates tab, derived from the chart's series so both
         // views always describe the same query (colors match the chart legend).
@@ -117,6 +126,14 @@ export const metricsSamplesLogic = kea<metricsSamplesLogicType>([
             },
             exemplarClicked: ({ marker }) => {
                 router.actions.push(traceUrl({ traceId: marker.traceId, spanId: marker.spanId, ts: marker.timestamp }))
+            },
+            // Live refresh refetches the chart every 15s; the dots must track the same
+            // sliding window or stale samples drift off the grid. The loader's
+            // breakpoint coalesces this with the filter-change listeners below.
+            fetchQueryResultsSuccess: () => {
+                if (values.exemplarsEnabled) {
+                    actions.loadSamples({})
+                }
             },
             // The viewer's filters are the samples' filters: any change that redraws
             // the chart refreshes the visible samples too, but only when they're shown

--- a/products/metrics/frontend/components/metricsSamplesLogic.tsx
+++ b/products/metrics/frontend/components/metricsSamplesLogic.tsx
@@ -1,11 +1,14 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
 
 import { teamLogic } from 'scenes/teamLogic'
 
 import { metricsSamplesCreate } from 'products/metrics/frontend/generated/api'
 import type { _MetricEventSampleApi } from 'products/metrics/frontend/generated/api.schemas'
+import { traceUrl } from 'products/tracing/frontend/traceLinks'
 
+import { type ExemplarMarker, exemplarMarkersFromSamples } from './exemplarMarkers'
 import type { metricsSamplesLogicType } from './metricsSamplesLogicType'
 import { formatSeriesName, seriesColor } from './metricsSeries'
 import { type MetricsViewerSeries, metricsViewerLogic, resolveDate } from './metricsViewerLogic'
@@ -37,9 +40,12 @@ export const metricsSamplesLogic = kea<metricsSamplesLogicType>([
     })),
     actions({
         setActiveTab: (activeTab: MetricsPanelTab) => ({ activeTab }),
+        setExemplarsEnabled: (enabled: boolean) => ({ enabled }),
+        exemplarClicked: (marker: ExemplarMarker) => ({ marker }),
     }),
     reducers({
         activeTab: ['aggregates' as MetricsPanelTab, { setActiveTab: (_, { activeTab }) => activeTab }],
+        exemplarsEnabled: [false, { setExemplarsEnabled: (_, { enabled }) => enabled }],
     }),
     loaders(({ values }) => ({
         samples: [
@@ -68,6 +74,16 @@ export const metricsSamplesLogic = kea<metricsSamplesLogicType>([
         ],
     })),
     selectors({
+        // Dots for the chart overlay: traced samples snapped onto the current
+        // series' bucket grid, so a dot sits where its emission was recorded.
+        exemplarMarkers: [
+            (s) => [s.samples, s.queryResults],
+            (samples: _MetricEventSampleApi[], queryResults: MetricsViewerSeries[]): ExemplarMarker[] =>
+                exemplarMarkersFromSamples(
+                    samples,
+                    (queryResults[0]?.points ?? []).map((point) => point.time)
+                ),
+        ],
         // Rows for the Aggregates tab, derived from the chart's series so both
         // views always describe the same query (colors match the chart legend).
         aggregateRows: [
@@ -86,28 +102,40 @@ export const metricsSamplesLogic = kea<metricsSamplesLogicType>([
                 }),
         ],
     }),
-    listeners(({ actions, values }) => ({
-        setActiveTab: ({ activeTab }) => {
-            if (activeTab === 'samples') {
-                actions.loadSamples({})
-            }
-        },
-        // The viewer's filters are the samples' filters: any change that redraws
-        // the chart refreshes the visible samples too, but only when they're shown.
-        setMetricName: () => {
-            if (values.activeTab === 'samples') {
-                actions.loadSamples({})
-            }
-        },
-        setDateFrom: () => {
-            if (values.activeTab === 'samples') {
-                actions.loadSamples({})
-            }
-        },
-        setDateTo: () => {
-            if (values.activeTab === 'samples') {
-                actions.loadSamples({})
-            }
-        },
-    })),
+    listeners(({ actions, values }) => {
+        const samplesVisible = (): boolean => values.activeTab === 'samples' || values.exemplarsEnabled
+        return {
+            setActiveTab: ({ activeTab }) => {
+                if (activeTab === 'samples') {
+                    actions.loadSamples({})
+                }
+            },
+            setExemplarsEnabled: ({ enabled }) => {
+                if (enabled) {
+                    actions.loadSamples({})
+                }
+            },
+            exemplarClicked: ({ marker }) => {
+                router.actions.push(traceUrl({ traceId: marker.traceId, spanId: marker.spanId, ts: marker.timestamp }))
+            },
+            // The viewer's filters are the samples' filters: any change that redraws
+            // the chart refreshes the visible samples too, but only when they're shown
+            // (samples tab open, or exemplar dots overlaid on the chart).
+            setMetricName: () => {
+                if (samplesVisible()) {
+                    actions.loadSamples({})
+                }
+            },
+            setDateFrom: () => {
+                if (samplesVisible()) {
+                    actions.loadSamples({})
+                }
+            },
+            setDateTo: () => {
+                if (samplesVisible()) {
+                    actions.loadSamples({})
+                }
+            },
+        }
+    }),
 ])

--- a/products/metrics/frontend/components/metricsUsageTrackingLogic.ts
+++ b/products/metrics/frontend/components/metricsUsageTrackingLogic.ts
@@ -41,7 +41,7 @@ export const metricsUsageTrackingLogic = kea<metricsUsageTrackingLogicType>([
                 'fetchQueryResultsFailure',
             ],
             metricsSamplesLogic,
-            ['setActiveTab as samplesPanelTabChanged', 'loadSamplesSuccess'],
+            ['setActiveTab as samplesPanelTabChanged', 'loadSamplesSuccess', 'setExemplarsEnabled', 'exemplarClicked'],
             teamLogic,
             ['addProductIntent'],
         ],
@@ -55,6 +55,12 @@ export const metricsUsageTrackingLogic = kea<metricsUsageTrackingLogicType>([
     listeners(({ actions, values, cache }) => ({
         sceneTabChanged: ({ activeTab }) => {
             posthog.capture('metrics tab changed', { tab: activeTab })
+        },
+        setExemplarsEnabled: ({ enabled }) => {
+            posthog.capture('metrics viewer exemplars toggled', { enabled })
+        },
+        exemplarClicked: () => {
+            posthog.capture('metrics exemplar trace pivot clicked', { source: 'chart' })
         },
         setMetricName: ({ metricName }) => {
             if (metricName.trim()) {


### PR DESCRIPTION
## Problem

The metric→trace pivot exists but hides in the Samples tab: to get from a spike on the chart to the trace that caused it, you switch tabs, scan a table, and match timestamps by eye. The standard affordance (Grafana exemplars, Sentry trace-connected metrics) is a dot on the chart you click.

## Changes

- **Exemplars toggle** in the metrics viewer (next to Live): overlays trace-linked samples as red dots on the chart; clicking a dot opens its trace (same `traceUrl` the Samples tab uses, with the sample timestamp bounding the lookup).
- **`Sparkline` gains an additive optional `markers` prop**: a scatter dataset drawn on top of the series (`order: -1`), nearest-intersect click routing with a pointer cursor on hover, excluded from the hover tooltip, and routed to the Chart.js path in the flag dispatch like the other overlay features (`referenceLines`, `highlightedRange`). No behavior change for existing consumers — the prop is opt-in.
- **`metricsSamplesLogic`**: `exemplarsEnabled` reducer reusing the existing samples endpoint (fetch fires on enable and on filter changes while enabled — same lazy pattern as the samples tab), plus an `exemplarMarkers` selector that snaps traced samples onto the chart's bucket grid via a pure adapter (`exemplarMarkersFromSamples`: nearest bucket by timestamp, newest sample wins per bucket so busy buckets render one dot, non-traced samples dropped).
- Usage capture per the tracking logic's listener-on-source-action pattern: `metrics viewer exemplars toggled`, `metrics exemplar trace pivot clicked`.

The eventual home for chart overlays is quill's `TimeSeriesLineChart` (`onPointClick` + overlay children), but this chart is pinned to the legacy Chart.js path today (`withXScale` forces `needsLegacyFeatures`), so the additive prop is the minimal correct step and migrates cleanly later.

## How did you test this code?

- New: `exemplarMarkers.test.ts` — pure adapter tests (nearest-bucket mapping incl. the closer-to-next-bucket case, trace-only filtering, newest-per-bucket dedupe, empty inputs). Written first, observed failing at import.
- Extended: `metricsSamplesLogic.test.ts` — enabling exemplars fetches without the samples tab open and refetches on filter changes while enabled (catches the "only fetches on tab activation" regression); the `exemplarMarkers` selector positions a traced sample on the chart buckets.
- Full runs: `products/metrics/frontend` + `frontend/src/lib/components` suites — **2433 passed** (all existing Sparkline consumers included).
- Typecheck: stash-baseline diff over the touched paths — **zero new type errors**.
- Not done: no browser-level visual pass of the dot rendering/click (canvas isn't exercisable in jsdom; the scatter/click config follows Chart.js's documented `getElementsAtEventForMode` pattern). Worth a quick visual check on the preview before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the metrics roadmap; assigned as DRI.

I (Claude) built this as roadmap item "exemplar dots" (Tier 0 of the metrics strategy). Skills invoked: `/writing-tests` (earlier this session, gate applied to the new tests). Design decision: extend the legacy Sparkline with an additive prop rather than migrate the chart to quill `TimeSeriesLineChart` — the quill path is unreachable for this chart today (`withXScale` pins it to Chart.js) and the migration is a separate, larger change; noted in-code and above so the follow-up is discoverable.
