### PR TITLE
chore(aio): make the eval engine swappable behind neutral interfaces

### DIFF
--- a/.agents/skills/writing-evals/SKILL.md
+++ b/.agents/skills/writing-evals/SKILL.md
@@ -112,13 +112,11 @@ Follow this split (and the constants-shared-by-all-three pattern) when seeding a
 
 Two patterns, each with exactly **one** implemented branch — never both `_run_eval_sync` and `_run_eval_async` (see the Scorers section of `harness/AGENTS.md`):
 
-**Deterministic** — subclass `Scorer`, implement `_run_eval_sync` only. The base class supplies the async path Braintrust uses.
+**Deterministic** — subclass `Scorer`, implement `_run_eval_sync` only. The base class supplies the async path the engine uses.
 
 ```python
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import LogParser
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 
 class MyCheck(Scorer):

--- a/products/posthog_ai/eval_harness/README.md
+++ b/products/posthog_ai/eval_harness/README.md
@@ -34,7 +34,7 @@ python -m products.posthog_ai.eval_harness.harness [SELECTOR ...] [flags]
 No manual env sourcing is needed on either path.
 The harness loads the repo-root `.env` itself (shell values win), and `hogli evals` additionally layers in `.env.local` / `.env.development` / `.env.services` through hogli's standard env loading — including 1Password resolution when `.env.local` holds `op://` references.
 Before any infrastructure boots, a preflight validates that the required variables are set and fails with a one-line fix per missing variable.
-Which variables are required depends on the selected suites' kinds: every run needs `BRAINTRUST_API_KEY`; sandboxed suites add `SANDBOX_JWT_PRIVATE_KEY` and `LLM_GATEWAY_ANTHROPIC_API_KEY`; one-shot suites add `LLM_GATEWAY_ANTHROPIC_API_KEY` (used directly, no gateway).
+Which variables are required depends on the eval engine and the selected suites' kinds: the braintrust engine (the default, and only one today) requires `BRAINTRUST_API_KEY` on every run — it is the engine's own `required_env()`, not a core harness variable; sandboxed suites add `SANDBOX_JWT_PRIVATE_KEY` and `LLM_GATEWAY_ANTHROPIC_API_KEY`; one-shot suites add `LLM_GATEWAY_ANTHROPIC_API_KEY` (used directly, no gateway).
 
 Selectors are substrings matched against a suite id of the form `<domain>/<module>::<fn>`, for example `experiments`, `sql`, or `eval_lifecycle_skills`.
 Omit them to run every suite.

--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -8,13 +8,11 @@ from collections.abc import Sequence
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
-from braintrust import EvalCase, EvalHooks
-
 from .acp_log import ParsedLog, parse_log
 from .config import AgentArtifacts, BaseEvalCase, SandboxedEvalCase
 from .engines.base import EvalEngine
 from .engines.braintrust import BraintrustEngine
-from .engines.types import ExperimentResult
+from .engines.types import CaseHooks, CaseSpec, ExperimentResult, ExperimentSpec, SpanKind
 from .log_sink import append_case_scores, build_case_dir, write_case_logs
 from .runner import EvalCaseResult, run_eval_case
 from .scorers import ExitCodeZero, wrap_scorers
@@ -38,7 +36,7 @@ def _get_last_assistant_text(parsed: ParsedLog) -> str:
     return ""
 
 
-def _log_conversation_spans(hooks: EvalHooks, parsed: ParsedLog) -> None:
+def _log_conversation_spans(hooks: CaseHooks, parsed: ParsedLog) -> None:
     """Log each conversation message as a child span so Braintrust renders a trace tree.
 
     Uses the same Anthropic-format messages as PostHog trace capture.
@@ -68,6 +66,7 @@ def _log_conversation_spans(hooks: EvalHooks, parsed: ParsedLog) -> None:
         else:
             display_content = str(content)
 
+        span_type: SpanKind
         if role == "assistant":
             # Check if this message contains tool_use blocks
             has_tool_use = isinstance(content, list) and any(
@@ -85,7 +84,7 @@ def _log_conversation_spans(hooks: EvalHooks, parsed: ParsedLog) -> None:
             span_type = "function"
             name = role
 
-        with hooks.span.start_span(name=name, span_attributes={"type": span_type}) as span:
+        with hooks.start_span(name, span_type) as span:
             if role == "user":
                 span.log(input=display_content)
             elif role == "assistant":
@@ -95,7 +94,7 @@ def _log_conversation_spans(hooks: EvalHooks, parsed: ParsedLog) -> None:
 
     # Also log non-AI spans (console, errors)
     for span_desc in parsed.spans:
-        with hooks.span.start_span(name=span_desc.span_name, span_attributes={"type": "function"}) as span:
+        with hooks.start_span(span_desc.span_name, "function") as span:
             span.log(metadata={"message": span_desc.content})
 
 
@@ -171,15 +170,15 @@ class _BaseEvalRun:
         """The JSON-safe ``input`` dict a case round-trips through Braintrust as."""
         return {"name": case.name, "prompt": case.prompt}
 
-    def _build_eval_cases(self) -> list[EvalCase]:
-        eval_cases: list[EvalCase] = []
+    def _build_eval_cases(self) -> list[CaseSpec]:
+        eval_cases: list[CaseSpec] = []
         for case in self.cases:
             if self.case_filter and self.case_filter not in case.name:
                 continue
-            eval_cases.append(EvalCase(input=self._case_input(case), expected=case.expected, metadata=case.metadata))
+            eval_cases.append(CaseSpec(input=self._case_input(case), expected=case.expected, metadata=case.metadata))
         return eval_cases
 
-    async def _execute_case(self, input: dict[str, Any], hooks: EvalHooks) -> dict[str, Any]:
+    async def _execute_case(self, input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
         """Run one case and return the scorer ``output`` dict.
 
         Owns the case's concurrency slot and its ``asyncio.wait_for`` budget;
@@ -198,7 +197,7 @@ class _BaseEvalRun:
     def _experiment_metadata(self) -> dict[str, Any]:
         return {"agent_model": self.ctx.agent_model}
 
-    async def _task(self, input: dict[str, Any], hooks: EvalHooks) -> dict[str, Any] | None:
+    async def _task(self, input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any] | None:
         case_started = time.monotonic()
         case_name = input.get("name", "?")
         status: Literal["ok", "timeout", "error"] = "ok"
@@ -288,16 +287,18 @@ class _BaseEvalRun:
         await self.ctx.reporter.experiment_started(self.experiment_name, planned_cases, self.run_log_dir)
 
         result = await self.engine.run_experiment(
-            project_name=self._project_name(),
-            cases=eval_cases,
-            task=self._task,
-            scorers=self.active_scorers,
-            trial_count=self.ctx.trials,
-            is_public=self.is_public,
-            no_send_logs=self.no_send_logs,
-            # Experiment names stay runtime/model-agnostic so history lines up across
-            # runs; the metadata is what lets Braintrust filter or compare by them.
-            metadata=self._experiment_metadata(),
+            ExperimentSpec(
+                project_name=self._project_name(),
+                cases=eval_cases,
+                task=self._task,
+                scorers=self.active_scorers,
+                trial_count=self.ctx.trials,
+                is_public=self.is_public,
+                no_send_logs=self.no_send_logs,
+                # Experiment names stay runtime/model-agnostic so history lines up across
+                # runs; the metadata is what lets an engine filter or compare by them.
+                metadata=self._experiment_metadata(),
+            )
         )
 
         await self._finalize(result)
@@ -383,7 +384,7 @@ class _SandboxedEvalRun(_BaseEvalRun):
     async def _post_process(
         self,
         eval_case: SandboxedEvalCase,
-        hooks: EvalHooks,
+        hooks: CaseHooks,
         result: EvalCaseResult,
         seed_result: dict[str, Any],
     ) -> dict[str, Any]:
@@ -448,7 +449,7 @@ class _SandboxedEvalRun(_BaseEvalRun):
             "prompt": eval_case.prompt,
         }
 
-    async def _execute_case(self, input: dict[str, Any], hooks: EvalHooks) -> dict[str, Any]:
+    async def _execute_case(self, input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
         eval_case = SandboxedEvalCase(
             name=input["name"],
             prompt=input["prompt"],

--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from .acp_log import ParsedLog, parse_log
 from .config import AgentArtifacts, BaseEvalCase, SandboxedEvalCase
 from .engines.base import EvalEngine
-from .engines.braintrust import BraintrustEngine
 from .engines.types import CaseHooks, CaseSpec, ExperimentResult, ExperimentSpec, SpanKind
 from .log_sink import append_case_scores, build_case_dir, write_case_logs
 from .runner import EvalCaseResult, run_eval_case
@@ -127,9 +126,9 @@ class _BaseEvalRun:
         self.ctx = ctx
         self.is_public = is_public
         self.no_send_logs = no_send_logs
-        # The execution/reporting backend. Braintrust is the only one today; the
-        # seam lets a PostHog-native engine slot in later (see engines/base.py).
-        self.engine = engine or BraintrustEngine()
+        # The execution/reporting backend, resolved once per run and shared via
+        # ctx.engine; an explicit engine (in tests) overrides it.
+        self.engine = engine or ctx.engine
 
         # Generate a unique experiment ID per eval run
         self.experiment_id = str(uuid.uuid4())

--- a/products/posthog_ai/eval_harness/base.py
+++ b/products/posthog_ai/eval_harness/base.py
@@ -9,12 +9,12 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
 from braintrust import EvalCase, EvalHooks
-from braintrust.framework import EvalResultWithSummary
 
 from .acp_log import ParsedLog, parse_log
 from .config import AgentArtifacts, BaseEvalCase, SandboxedEvalCase
 from .engines.base import EvalEngine
 from .engines.braintrust import BraintrustEngine
+from .engines.types import ExperimentResult
 from .log_sink import append_case_scores, build_case_dir, write_case_logs
 from .runner import EvalCaseResult, run_eval_case
 from .scorers import ExitCodeZero, wrap_scorers
@@ -226,7 +226,7 @@ class _BaseEvalRun:
                 status=status,
             )
 
-    async def _finalize(self, result: EvalResultWithSummary) -> None:
+    async def _finalize(self, result: ExperimentResult) -> None:
         """Append scores to local summaries, emit PostHog evaluation/trace-root
         events, and hand the summary to the reporter — after scoring completes."""
         # Append final scores to local summary files for every case we wrote.
@@ -279,7 +279,7 @@ class _BaseEvalRun:
         error_count = sum(1 for r in result.results if r.error is not None)
         await self.ctx.reporter.record_summary(self.experiment_name, result.summary, error_count=error_count)
 
-    async def run(self) -> EvalResultWithSummary:
+    async def run(self) -> ExperimentResult:
         eval_cases = self._build_eval_cases()
 
         # Register the case total (post-filter, times trials) so the reporter can
@@ -479,7 +479,7 @@ async def SandboxedEval(
     ctx: EvalContext,
     is_public: bool = False,
     no_send_logs: bool = True,
-) -> EvalResultWithSummary:
+) -> ExperimentResult:
     """Run a sandboxed agent evaluation suite via Braintrust.
 
     For each ``SandboxedEvalCase``, creates a Task, triggers the temporal workflow

--- a/products/posthog_ai/eval_harness/engines/base.py
+++ b/products/posthog_ai/eval_harness/engines/base.py
@@ -13,7 +13,8 @@ from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Protocol
 
 from braintrust import EvalCase, EvalHooks
-from braintrust.framework import EvalResultWithSummary
+
+from .types import ExperimentResult
 
 EvalTaskFn = Callable[[dict[str, Any], EvalHooks], Awaitable[dict[str, Any] | None]]
 """The per-case task the engine drives: it takes the JSON-safe case input and the
@@ -41,7 +42,8 @@ class EvalEngine(Protocol):
         is_public: bool,
         no_send_logs: bool,
         metadata: dict[str, Any],
-    ) -> EvalResultWithSummary:
+    ) -> ExperimentResult:
         """Run every case (``trial_count`` times each) through ``task`` and
-        ``scorers``, and return the result plus its per-scorer summary."""
+        ``scorers``, and return the engine-neutral result plus its per-scorer
+        summary."""
         ...

--- a/products/posthog_ai/eval_harness/engines/base.py
+++ b/products/posthog_ai/eval_harness/engines/base.py
@@ -9,16 +9,13 @@ the run base or any suite.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, Protocol
+from typing import Protocol
 
-from braintrust import EvalCase, EvalHooks
+from .types import EvalTaskFn, ExperimentResult, ExperimentSpec
 
-from .types import ExperimentResult
-
-EvalTaskFn = Callable[[dict[str, Any], EvalHooks], Awaitable[dict[str, Any] | None]]
-"""The per-case task the engine drives: it takes the JSON-safe case input and the
-Braintrust hooks and returns the scorer ``output`` dict (or ``None``)."""
+# Re-exported for callers that import ``EvalTaskFn`` from the engine seam; it now
+# lives in ``types`` (retargeted at the neutral ``CaseHooks``).
+__all__ = ["EvalEngine", "EvalTaskFn"]
 
 
 class EvalEngine(Protocol):
@@ -31,19 +28,8 @@ class EvalEngine(Protocol):
     the same interface, without changing the run base or any suite.
     """
 
-    async def run_experiment(
-        self,
-        *,
-        project_name: str,
-        cases: Sequence[EvalCase],
-        task: EvalTaskFn,
-        scorers: Sequence[Any],
-        trial_count: int,
-        is_public: bool,
-        no_send_logs: bool,
-        metadata: dict[str, Any],
-    ) -> ExperimentResult:
-        """Run every case (``trial_count`` times each) through ``task`` and
-        ``scorers``, and return the engine-neutral result plus its per-scorer
+    async def run_experiment(self, spec: ExperimentSpec) -> ExperimentResult:
+        """Run every case in ``spec`` (``trial_count`` times each) through the task
+        and scorers, and return the engine-neutral result plus its per-scorer
         summary."""
         ...

--- a/products/posthog_ai/eval_harness/engines/base.py
+++ b/products/posthog_ai/eval_harness/engines/base.py
@@ -9,9 +9,9 @@ the run base or any suite.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import ClassVar, Protocol
 
-from .types import EvalTaskFn, ExperimentResult, ExperimentSpec
+from .types import EnvVarSpec, EvalTaskFn, ExperimentResult, ExperimentSpec
 
 # Re-exported for callers that import ``EvalTaskFn`` from the engine seam; it now
 # lives in ``types`` (retargeted at the neutral ``CaseHooks``).
@@ -26,7 +26,24 @@ class EvalEngine(Protocol):
     future ``PostHogEvalsEngine`` — recording datasets, experiments, and scores
     into PostHog's own LLM analytics as the system of record — can slot in behind
     the same interface, without changing the run base or any suite.
+
+    Obligations (documented on the implementation and pinned by the conformance
+    suite): never throttle or budget the task; persist ``hooks.metadata`` onto
+    ``CaseResult.metadata``; a task exception becomes ``CaseResult.error`` and is
+    excluded from aggregates; ``None`` scores are preserved per-case and excluded
+    from the means.
     """
+
+    name: ClassVar[str]
+    """Stable engine identifier; ``reporting`` renders ``name.title()`` as the label."""
+
+    supports_public_experiments: ClassVar[bool]
+    """Whether the engine has a notion of a public experiment (``is_public``)."""
+
+    @classmethod
+    def required_env(cls) -> tuple[EnvVarSpec, ...]:
+        """The environment variables this engine needs, validated in preflight."""
+        ...
 
     async def run_experiment(self, spec: ExperimentSpec) -> ExperimentResult:
         """Run every case in ``spec`` (``trial_count`` times each) through the task

--- a/products/posthog_ai/eval_harness/engines/braintrust.py
+++ b/products/posthog_ai/eval_harness/engines/braintrust.py
@@ -9,6 +9,7 @@ from braintrust import EvalAsync, EvalCase
 from braintrust.framework import EvalResultWithSummary, Evaluator, ReporterDef
 
 from .base import EvalTaskFn
+from .types import AggregateScore, CaseResult, EvalSummary, ExperimentResult
 
 
 def _quiet_report_eval(evaluator: Evaluator, result: EvalResultWithSummary, verbose: bool, jsonl: bool) -> bool:
@@ -62,8 +63,8 @@ class BraintrustEngine:
         is_public: bool,
         no_send_logs: bool,
         metadata: dict[str, Any],
-    ) -> EvalResultWithSummary:
-        return await EvalAsync(
+    ) -> ExperimentResult:
+        result = await EvalAsync(
             project_name,
             data=list(cases),
             task=task,
@@ -87,4 +88,36 @@ class BraintrustEngine:
             # Experiment names stay runtime/model-agnostic so history lines up
             # across runs; the metadata is what lets Braintrust filter or compare.
             metadata=metadata,
+        )
+        return self._translate(result)
+
+    def _translate(self, result: EvalResultWithSummary) -> ExperimentResult:
+        """Map braintrust's ``EvalResultWithSummary`` onto the neutral model.
+
+        ``score=None`` is preserved per-case (braintrust drops it from the
+        aggregate); a task exception becomes ``CaseResult.error`` as a string so
+        callers never re-handle a live ``Exception``; ``summary.raw`` is the
+        braintrust summary's ``as_dict()`` so the jsonl export round-trips
+        byte-for-byte through ``EvalSummary.as_json()``.
+        """
+        summary = result.summary
+        return ExperimentResult(
+            summary=EvalSummary(
+                engine_name="braintrust",
+                experiment_name=summary.experiment_name,
+                scores={name: AggregateScore(name=s.name, score=s.score) for name, s in summary.scores.items()},
+                experiment_url=summary.experiment_url,
+                raw=summary.as_dict(),
+            ),
+            results=[
+                CaseResult(
+                    input=case.input,
+                    output=case.output,
+                    scores=dict(case.scores or {}),
+                    expected=case.expected,
+                    metadata=dict(case.metadata or {}),
+                    error=None if case.error is None else str(case.error),
+                )
+                for case in result.results
+            ],
         )

--- a/products/posthog_ai/eval_harness/engines/braintrust.py
+++ b/products/posthog_ai/eval_harness/engines/braintrust.py
@@ -6,10 +6,27 @@ from collections.abc import Sequence
 from typing import Any
 
 from braintrust import EvalAsync, EvalCase
-from braintrust.framework import EvalResultWithSummary
+from braintrust.framework import EvalResultWithSummary, Evaluator, ReporterDef
 
-from ..harness.reporting import QUIET_REPORTER
 from .base import EvalTaskFn
+
+
+def _quiet_report_eval(evaluator: Evaluator, result: EvalResultWithSummary, verbose: bool, jsonl: bool) -> bool:
+    return True
+
+
+def _quiet_report_run(results: list[bool], verbose: bool, jsonl: bool) -> bool:
+    return True
+
+
+QUIET_REPORTER: ReporterDef = ReporterDef(
+    name="quiet",
+    report_eval=_quiet_report_eval,
+    report_run=_quiet_report_run,
+)
+"""Reporter that keeps Braintrust's per-experiment tables out of the shared stream.
+
+Its callbacks are called synchronously by ``EvalAsync`` and must not be coroutines."""
 
 
 class BraintrustEngine:

--- a/products/posthog_ai/eval_harness/engines/braintrust.py
+++ b/products/posthog_ai/eval_harness/engines/braintrust.py
@@ -9,7 +9,7 @@ from typing import Any
 from braintrust import EvalAsync, EvalCase, EvalHooks
 from braintrust.framework import EvalResultWithSummary, Evaluator, ReporterDef
 
-from .types import AggregateScore, CaseResult, EvalSummary, ExperimentResult, ExperimentSpec, SpanKind
+from .types import AggregateScore, CaseResult, EnvVarSpec, EvalSummary, ExperimentResult, ExperimentSpec, SpanKind
 
 
 def _quiet_report_eval(evaluator: Evaluator, result: EvalResultWithSummary, verbose: bool, jsonl: bool) -> bool:
@@ -74,6 +74,13 @@ class BraintrustEngine:
       lines up across runs; updating keeps that history rather than forking it.
     """
 
+    name = "braintrust"
+    supports_public_experiments = True
+
+    @classmethod
+    def required_env(cls) -> tuple[EnvVarSpec, ...]:
+        return (EnvVarSpec("BRAINTRUST_API_KEY", "records experiments and scores to Braintrust"),)
+
     async def run_experiment(self, spec: ExperimentSpec) -> ExperimentResult:
         async def bridged_task(input: dict[str, Any], hooks: EvalHooks) -> dict[str, Any] | None:
             # Wrap braintrust's hooks so the suite task only ever sees neutral CaseHooks.
@@ -119,7 +126,7 @@ class BraintrustEngine:
         summary = result.summary
         return ExperimentResult(
             summary=EvalSummary(
-                engine_name="braintrust",
+                engine_name=self.name,
                 experiment_name=summary.experiment_name,
                 scores={name: AggregateScore(name=s.name, score=s.score) for name, s in summary.scores.items()},
                 experiment_url=summary.experiment_url,

--- a/products/posthog_ai/eval_harness/engines/braintrust.py
+++ b/products/posthog_ai/eval_harness/engines/braintrust.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
-from braintrust import EvalAsync, EvalCase
+from braintrust import EvalAsync, EvalCase, EvalHooks
 from braintrust.framework import EvalResultWithSummary, Evaluator, ReporterDef
 
-from .base import EvalTaskFn
-from .types import AggregateScore, CaseResult, EvalSummary, ExperimentResult
+from .types import AggregateScore, CaseResult, EvalSummary, ExperimentResult, ExperimentSpec, SpanKind
 
 
 def _quiet_report_eval(evaluator: Evaluator, result: EvalResultWithSummary, verbose: bool, jsonl: bool) -> bool:
@@ -28,6 +28,28 @@ QUIET_REPORTER: ReporterDef = ReporterDef(
 """Reporter that keeps Braintrust's per-experiment tables out of the shared stream.
 
 Its callbacks are called synchronously by ``EvalAsync`` and must not be coroutines."""
+
+
+class _BraintrustCaseHooks:
+    """Adapts braintrust's ``EvalHooks`` to the neutral ``CaseHooks``.
+
+    ``metadata`` is a write-through onto the braintrust hooks (so mutations land
+    on the eventual ``CaseResult.metadata``); ``start_span`` maps the neutral
+    ``(name, kind)`` onto braintrust's ``start_span(name=, span_attributes=)`` and
+    yields the braintrust ``Span``, whose ``.log`` already matches ``SpanHandle``.
+    """
+
+    def __init__(self, hooks: EvalHooks) -> None:
+        self._hooks = hooks
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return self._hooks.metadata
+
+    @contextmanager
+    def start_span(self, name: str, kind: SpanKind) -> Iterator[Any]:
+        with self._hooks.span.start_span(name=name, span_attributes={"type": kind}) as span:
+            yield span
 
 
 class BraintrustEngine:
@@ -52,28 +74,22 @@ class BraintrustEngine:
       lines up across runs; updating keeps that history rather than forking it.
     """
 
-    async def run_experiment(
-        self,
-        *,
-        project_name: str,
-        cases: Sequence[EvalCase],
-        task: EvalTaskFn,
-        scorers: Sequence[Any],
-        trial_count: int,
-        is_public: bool,
-        no_send_logs: bool,
-        metadata: dict[str, Any],
-    ) -> ExperimentResult:
+    async def run_experiment(self, spec: ExperimentSpec) -> ExperimentResult:
+        async def bridged_task(input: dict[str, Any], hooks: EvalHooks) -> dict[str, Any] | None:
+            # Wrap braintrust's hooks so the suite task only ever sees neutral CaseHooks.
+            return await spec.task(input, _BraintrustCaseHooks(hooks))
+
+        cases = [EvalCase(input=case.input, expected=case.expected, metadata=case.metadata) for case in spec.cases]
         result = await EvalAsync(
-            project_name,
-            data=list(cases),
-            task=task,
-            scores=list(scorers),
-            trial_count=trial_count,
+            spec.project_name,
+            data=cases,
+            task=bridged_task,
+            scores=list(spec.scorers),
+            trial_count=spec.trial_count,
             # Our global concurrency semaphores are the only limiters that should
             # bind. Braintrust's own per-suite limiter must never gate, so let it
             # admit every case at once — across all trials.
-            max_concurrency=max(len(cases) * trial_count, 1),
+            max_concurrency=max(len(cases) * spec.trial_count, 1),
             # Braintrust's timeout wraps the whole task invocation, including any
             # time a case spends queued on our concurrency semaphores — so a queued
             # case would be killed before it ever started. The real budget is the
@@ -83,11 +99,11 @@ class BraintrustEngine:
             # from dumping its own score table into the interleaved stream.
             reporter=QUIET_REPORTER,
             update=True,
-            is_public=is_public,
-            no_send_logs=no_send_logs,
+            is_public=spec.is_public,
+            no_send_logs=spec.no_send_logs,
             # Experiment names stay runtime/model-agnostic so history lines up
             # across runs; the metadata is what lets Braintrust filter or compare.
-            metadata=metadata,
+            metadata=spec.metadata,
         )
         return self._translate(result)
 

--- a/products/posthog_ai/eval_harness/engines/registry.py
+++ b/products/posthog_ai/eval_harness/engines/registry.py
@@ -1,0 +1,27 @@
+"""Engine registry: resolve an ``EvalEngine`` by name.
+
+There is no ``--engine`` CLI flag yet — the default is the only entry until a
+second engine exists — but ``EvalContext.engine`` and preflight both resolve
+through here, so adding one is a one-line change.
+"""
+
+from __future__ import annotations
+
+from .base import EvalEngine
+from .braintrust import BraintrustEngine
+
+_ENGINES: dict[str, type[EvalEngine]] = {
+    BraintrustEngine.name: BraintrustEngine,
+}
+
+DEFAULT_ENGINE = BraintrustEngine.name
+
+
+def resolve_engine(name: str = DEFAULT_ENGINE) -> EvalEngine:
+    """Return a fresh engine instance for ``name`` (the Braintrust engine by default)."""
+    try:
+        engine_cls = _ENGINES[name]
+    except KeyError:
+        known = ", ".join(sorted(_ENGINES))
+        raise ValueError(f"Unknown eval engine '{name}'; known engines: {known}") from None
+    return engine_cls()

--- a/products/posthog_ai/eval_harness/engines/types.py
+++ b/products/posthog_ai/eval_harness/engines/types.py
@@ -1,0 +1,69 @@
+"""Engine-neutral types at the harness/engine boundary.
+
+Stdlib-only on purpose: no braintrust, no Django, no pydantic. ``env_preflight``
+imports ``EnvVarSpec`` from here, and it sits on the Django-free ``__main__``
+import chain (see ``harness/AGENTS.md``), so nothing here may pull in a heavier
+dependency.
+
+Each ``EvalEngine`` translates its native result shapes into these so the run
+base, reporting, and trace emission never see a braintrust type.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class CaseResult:
+    """One scored case (or case × trial): the engine-neutral ``EvalResult``.
+
+    ``scores`` maps scorer name to its per-case score; ``None`` means the scorer
+    skipped this case (excluded from aggregates). ``error`` is non-``None`` when
+    the task itself raised — an infra failure the engine excludes from score
+    averages rather than scoring 0.
+    """
+
+    input: dict[str, Any]
+    output: Any
+    scores: dict[str, float | None]
+    expected: Any = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class AggregateScore:
+    """A scorer's mean over the cases where it produced a non-``None`` score."""
+
+    name: str
+    score: float | None
+
+
+@dataclass
+class EvalSummary:
+    """The per-experiment summary the reporting path consumes.
+
+    ``raw`` is the engine-native summary payload; ``as_json`` passes it straight
+    through so the ``eval_results.jsonl`` export stays byte-identical to what the
+    engine would have written itself.
+    """
+
+    engine_name: str
+    experiment_name: str
+    scores: dict[str, AggregateScore]
+    experiment_url: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def as_json(self) -> str:
+        return json.dumps(self.raw)
+
+
+@dataclass
+class ExperimentResult:
+    """What ``EvalEngine.run_experiment`` returns: the summary plus every case."""
+
+    summary: EvalSummary
+    results: list[CaseResult]

--- a/products/posthog_ai/eval_harness/engines/types.py
+++ b/products/posthog_ai/eval_harness/engines/types.py
@@ -1,12 +1,12 @@
 """Engine-neutral types at the harness/engine boundary.
 
-Stdlib-only on purpose: no braintrust, no Django, no pydantic. ``env_preflight``
+Stdlib-only on purpose: no Braintrust, no Django, no pydantic. ``env_preflight``
 imports ``EnvVarSpec`` from here, and it sits on the Django-free ``__main__``
 import chain (see ``harness/AGENTS.md``), so nothing here may pull in a heavier
 dependency.
 
 Each ``EvalEngine`` translates its native result shapes into these so the run
-base, reporting, and trace emission never see a braintrust type.
+base, reporting, and trace emission never see an engine-specific type.
 """
 
 from __future__ import annotations

--- a/products/posthog_ai/eval_harness/engines/types.py
+++ b/products/posthog_ai/eval_harness/engines/types.py
@@ -12,8 +12,87 @@ base, reporting, and trace emission never see a braintrust type.
 from __future__ import annotations
 
 import json
+from collections.abc import Awaitable, Callable, Iterator, Sequence
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, Protocol
+
+
+@dataclass(frozen=True)
+class CaseSpec:
+    """An engine-neutral eval case: JSON-safe ``input`` plus ``expected`` and
+    ``metadata``. Each engine translates this to its native case type; the
+    harness keeps callable rebinding (a case's ``setup`` hook) in ``cases_by_name``."""
+
+    input: dict[str, Any]
+    expected: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+SpanKind = Literal["llm", "function", "task", "score"]
+
+
+class SpanHandle(Protocol):
+    """A single span the task logs onto; the engine renders it into its own trace."""
+
+    def log(self, *, input: Any = None, output: Any = None, metadata: dict[str, Any] | None = None) -> None: ...
+
+
+class CaseHooks(Protocol):
+    """The per-case handle the engine passes to the task.
+
+    ``metadata`` is a mutable dict the engine must persist onto
+    ``CaseResult.metadata``; ``start_span`` opens a child span the task logs onto.
+    """
+
+    @property
+    def metadata(self) -> dict[str, Any]: ...
+
+    def start_span(self, name: str, kind: SpanKind) -> AbstractContextManager[SpanHandle]: ...
+
+
+EvalTaskFn = Callable[[dict[str, Any], CaseHooks], Awaitable[dict[str, Any] | None]]
+"""The per-case task the engine drives: it takes the JSON-safe case input and the
+neutral ``CaseHooks`` and returns the scorer ``output`` dict (or ``None``)."""
+
+
+class _NullSpanHandle:
+    def log(self, *, input: Any = None, output: Any = None, metadata: dict[str, Any] | None = None) -> None:
+        return None
+
+
+class NullCaseHooks:
+    """A concrete no-op ``CaseHooks`` for tests and span-less engines.
+
+    Replaces the old ``hooks=None`` sentinel: ``metadata`` is a real (discarded)
+    dict and ``start_span`` yields a span that swallows every ``log``.
+    """
+
+    def __init__(self) -> None:
+        self._metadata: dict[str, Any] = {}
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return self._metadata
+
+    @contextmanager
+    def start_span(self, name: str, kind: SpanKind) -> Iterator[SpanHandle]:
+        yield _NullSpanHandle()
+
+
+@dataclass(frozen=True)
+class ExperimentSpec:
+    """The single argument to ``run_experiment``. Bundling the knobs in one frozen
+    spec means a new field (e.g. a baseline experiment id) breaks no engine or stub."""
+
+    project_name: str
+    cases: Sequence[CaseSpec]
+    task: EvalTaskFn
+    scorers: Sequence[Any]  # duck-typed: eval_async(output, expected, **kwargs) + _name()
+    trial_count: int
+    is_public: bool
+    no_send_logs: bool
+    metadata: dict[str, Any]
 
 
 @dataclass

--- a/products/posthog_ai/eval_harness/engines/types.py
+++ b/products/posthog_ai/eval_harness/engines/types.py
@@ -146,3 +146,15 @@ class ExperimentResult:
 
     summary: EvalSummary
     results: list[CaseResult]
+
+
+@dataclass(frozen=True)
+class EnvVarSpec:
+    """One environment variable an engine requires, surfaced in the preflight error.
+
+    ``name`` is the literal variable name; ``description`` says what it is for so a
+    missing variable reads as a one-line fix.
+    """
+
+    name: str
+    description: str

--- a/products/posthog_ai/eval_harness/harness/AGENTS.md
+++ b/products/posthog_ai/eval_harness/harness/AGENTS.md
@@ -8,7 +8,7 @@ Verify a change with `python -m products.posthog_ai.eval_harness.harness --list`
 ## Import ordering
 
 `__main__.py` calls `setup_django()` **before** importing `lifecycle`, and `lifecycle` is what pulls in everything that touches Django settings, the ORM, or the `products.tasks` facade.
-Anything reachable from `__main__`'s top-level imports must therefore stay Django-free: today that is `cli.py`, `providers.py`, `tunnels.py`, `ports.py`, `env_preflight.py`, `requirements.py`, `transcript.py`, `log_sink.py`, and `django_env.py` itself.
+Anything reachable from `__main__`'s top-level imports must therefore stay Django-free: today that is `cli.py`, `providers.py`, `tunnels.py`, `ports.py`, `env_preflight.py`, `requirements.py`, `transcript.py`, `log_sink.py`, and `django_env.py` itself, plus [`../engines/types.py`](../engines/types.py) — the stdlib-only neutral types `env_preflight` imports `EnvVarSpec` from. Keep `types.py` free of braintrust, Django, and pydantic for that reason.
 
 This is why the port constants live in `ports.py` rather than in `services.py`, which imports Django.
 If you add an import to one of those modules, check that `--list` still runs.
@@ -23,6 +23,22 @@ The Braintrust-specific knobs below (`timeout`, `max_concurrency`, `QUIET_REPORT
 - Hold `ctx.team_setup_slots` across both the demo-data clone and optional case setup hook. Some setup hooks write directly to ClickHouse, so releasing it between those phases defeats the RAM guard.
 - Keep scoring, log parsing, and span building _outside_ the slot. A sandbox that is being scored is a sandbox that someone else could be using.
 - Every sync Django ORM call reached from async code goes through `asyncio.to_thread`. Do not set `DJANGO_ALLOW_ASYNC_UNSAFE` to make an error go away.
+
+## Engines
+
+`_BaseEvalRun.run()` builds an `ExperimentSpec` (cases, task, scorers, flags, metadata) and hands it to `ctx.engine.run_experiment`, which returns an engine-neutral `ExperimentResult` ([`../engines/types.py`](../engines/types.py)).
+The engine is resolved once per run by `engines/registry.resolve_engine()` and shared via `EvalContext.engine`; there is no `--engine` flag until a second engine exists.
+`BraintrustEngine` ([`../engines/braintrust.py`](../engines/braintrust.py)) is the only implementation and the sole runtime module that knows braintrust exists, alongside the deferred autoevals judge substrate in `../scorers/`.
+
+Every engine owes the run base these obligations, pinned by the conformance suite ([`../test/test_engine_conformance.py`](../test/test_engine_conformance.py)):
+
+- Never throttle or budget the task — the harness's own semaphores and `asyncio.wait_for` are the only limiters. The braintrust `timeout`/`max_concurrency` knobs above are how `BraintrustEngine` honors this.
+- Persist `hooks.metadata` mutations onto `CaseResult.metadata`.
+- Turn a task exception into `CaseResult.error` (a string) and exclude that case from aggregates.
+- Preserve `score=None` per-case and exclude it from the means — `None` is "skipped", `0.0` is "failed".
+- Print nothing to the shared stdout (braintrust's `QUIET_REPORTER` is how it stays quiet), and accumulate history under a stable `project_name`.
+
+A new engine implements the `EvalEngine` protocol ([`../engines/base.py`](../engines/base.py)) — `name`, `supports_public_experiments`, `required_env()`, `run_experiment(spec)` — registers in `engines/registry.py`, joins the conformance fixture list, and must pass it unchanged.
 
 ## Terminal output
 
@@ -108,7 +124,7 @@ Env loading follows the same before-`django.setup()` rule: `__main__` loads the 
 The explicit `SANDBOX_PROVIDER` / `PERSONHOG_ADDR` assignments come after the load, so they trump any env file on every path.
 
 `setup_django()` also forces `SELF_CAPTURE=0` before `django.setup()`. The ASGI app must not re-enable the global SDK with the local development personal API key during evals; eval trace emission uses the harness's explicit regional client instead.
-Required variables are then validated by `env_preflight.validate_eval_env()` at the top of `lifecycle.run()`, before any infrastructure boots — add new hard env requirements to the per-kind env models there (`CoreEvalEnv`, `SandboxEvalEnv`, `OneShotEvalEnv`), not as ad-hoc checks scattered through bootstrap.
+Required variables are then validated by `env_preflight.validate_eval_env()` at the top of `lifecycle.run()`, before any infrastructure boots — add new hard env requirements to the per-kind env models there (`SandboxEvalEnv`, `OneShotEvalEnv`), or, for engine-specific keys, to the engine's `required_env()` (`BRAINTRUST_API_KEY` lives on `BraintrustEngine`), which `lifecycle` threads in via the `engine_env` argument — not as ad-hoc checks scattered through bootstrap.
 
 ## pytest
 

--- a/products/posthog_ai/eval_harness/harness/README.md
+++ b/products/posthog_ai/eval_harness/harness/README.md
@@ -13,7 +13,7 @@ Wall-clock was dominated by suites queueing behind each other while sandbox capa
 
 The harness boots the same infrastructure once, then runs every suite concurrently on a single event loop and bounds sandbox and team-setup load with shared semaphores.
 Braintrust remains the eval engine and reporting backend; it just no longer controls scheduling.
-The `EvalAsync` call itself lives behind an `EvalEngine` seam (`../engines/`): `_BaseEvalRun.run()` hands cases, task, scorers, and metadata to `BraintrustEngine`, so a future PostHog-native engine can slot in without touching the run base or any suite.
+The `EvalAsync` call itself lives behind an `EvalEngine` seam (`../engines/`): `_BaseEvalRun.run()` hands a neutral `ExperimentSpec` to the engine resolved by `engines/registry.resolve_engine()` (shared via `EvalContext.engine`) and gets back a neutral `ExperimentResult` (`engines/types.py`), so a future PostHog-native engine can slot in behind the same interface — implementing the `EvalEngine` protocol and passing the conformance suite — without touching the run base or any suite.
 
 Not every suite is sandboxed anymore: each suite declares a `SUITE_KIND` (`requirements.py`), the kind maps to a set of `Infra` requirements, and the harness boots only the union of what the selected suites need.
 A run of one-shot suites never pays for — or fails preflight on — the sandbox provider, Temporal, the live server, the LLM gateway, or the MCP server.

--- a/products/posthog_ai/eval_harness/harness/README.md
+++ b/products/posthog_ai/eval_harness/harness/README.md
@@ -20,25 +20,25 @@ A run of one-shot suites never pays for — or fails preflight on — the sandbo
 
 ## Modules
 
-| Module             | Role                                                                                                                 |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `__main__.py`      | Entry point. Parses args, starts the transcript, configures Django, then hands off to `lifecycle`.                   |
-| `cli.py`           | `HarnessOptions` and the argparse builder. Resolves per-provider defaults.                                           |
-| `env_preflight.py` | Loads the repo-root `.env` (stdlib parser, shell wins) and validates per-kind env vars via pydantic models.          |
-| `ports.py`         | The six port constants. Deliberately free of Django imports.                                                         |
-| `providers.py`     | `SandboxProviderStrategy` and its docker/modal implementations: preflight, settings overrides, sandbox TTL, cleanup. |
-| `tunnels.py`       | `NgrokTunnels`. Modal only: generates an ngrok config, starts the agent, waits for public URLs.                      |
-| `requirements.py`  | `SuiteKind`, `Infra`, and the kind → infrastructure mapping (with implication closure).                              |
-| `django_env.py`    | `setup_django()`, the `NullDbBlocker` shim, and `EvalDatabase` (test database lifecycle).                            |
-| `live_server.py`   | `EvalLiveServer`, a session-lifetime Uvicorn server for PostHog's full ASGI application.                             |
-| `services.py`      | Starts the LLM gateway, MCP server, and personhog subprocesses; builds local skills.                                 |
-| `temporal_env.py`  | Local Temporal dev server, stale-workflow cleanup, and the worker thread.                                            |
-| `demo_data.py`     | `SandboxedDemoData`: seeds the master Hedgebox team once, then mints an isolated team per case.                      |
-| `discovery.py`     | Walks the tree for `eval_*.py` and collects `eval_*` coroutines into `EvalSuite` objects.                            |
-| `context.py`       | `EvalContext`, the single object every suite receives.                                                               |
-| `reporting.py`     | `ProgressReporter`, the final summary table, and the quiet Braintrust reporter.                                      |
-| `transcript.py`    | Mirrors stdout and stderr to one run log, then publishes its absolute path as the final line.                        |
-| `lifecycle.py`     | `SandboxedEvalHarness`: orchestrates bootstrap, the run, and teardown.                                               |
+| Module             | Role                                                                                                                              |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `__main__.py`      | Entry point. Parses args, starts the transcript, configures Django, then hands off to `lifecycle`.                                |
+| `cli.py`           | `HarnessOptions` and the argparse builder. Resolves per-provider defaults.                                                        |
+| `env_preflight.py` | Loads the repo-root `.env` (stdlib parser, shell wins) and validates per-kind env vars via pydantic models.                       |
+| `ports.py`         | The six port constants. Deliberately free of Django imports.                                                                      |
+| `providers.py`     | `SandboxProviderStrategy` and its docker/modal implementations: preflight, settings overrides, sandbox TTL, cleanup.              |
+| `tunnels.py`       | `NgrokTunnels`. Modal only: generates an ngrok config, starts the agent, waits for public URLs.                                   |
+| `requirements.py`  | `SuiteKind`, `Infra`, and the kind → infrastructure mapping (with implication closure).                                           |
+| `django_env.py`    | `setup_django()`, the `NullDbBlocker` shim, and `EvalDatabase` (test database lifecycle).                                         |
+| `live_server.py`   | `EvalLiveServer`, a session-lifetime Uvicorn server for PostHog's full ASGI application.                                          |
+| `services.py`      | Starts the LLM gateway, MCP server, and personhog subprocesses; builds local skills.                                              |
+| `temporal_env.py`  | Local Temporal dev server, stale-workflow cleanup, and the worker thread.                                                         |
+| `demo_data.py`     | `SandboxedDemoData`: seeds the master Hedgebox team once, then mints an isolated team per case.                                   |
+| `discovery.py`     | Walks the tree for `eval_*.py` and collects `eval_*` coroutines into `EvalSuite` objects.                                         |
+| `context.py`       | `EvalContext`, the single object every suite receives.                                                                            |
+| `reporting.py`     | `ProgressReporter` and the final summary table. The quiet Braintrust reporter lives with the engine (`../engines/braintrust.py`). |
+| `transcript.py`    | Mirrors stdout and stderr to one run log, then publishes its absolute path as the final line.                                     |
+| `lifecycle.py`     | `SandboxedEvalHarness`: orchestrates bootstrap, the run, and teardown.                                                            |
 
 ## Boot sequence
 

--- a/products/posthog_ai/eval_harness/harness/context.py
+++ b/products/posthog_ai/eval_harness/harness/context.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from posthoganalytics import Posthog
 
+from ..engines.base import EvalEngine
 from .demo_data import SandboxedDemoData
 from .providers import SandboxProvider, SandboxProviderStrategy
 from .reporting import ProgressReporter
@@ -63,6 +64,9 @@ class EvalContext:
 
     reporter: ProgressReporter
     """Owns all terminal output and the ``eval_results.jsonl`` export."""
+
+    engine: EvalEngine
+    """The execution/reporting backend every suite runs on, resolved once per run."""
 
     per_case_timeout_seconds: int
     """Budget for the agent run, started after team setup so queueing cannot consume it."""

--- a/products/posthog_ai/eval_harness/harness/env_preflight.py
+++ b/products/posthog_ai/eval_harness/harness/env_preflight.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from ..engines.types import EnvVarSpec
 from .providers import PreflightError
 from .requirements import SuiteKind
 
@@ -20,24 +21,6 @@ REPO_ROOT = Path(__file__).parents[4]
 
 _ASSIGNMENT_RE = re.compile(r"^\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>.*)$")
 _ESCAPES = {"n": "\n", "r": "\r", "t": "\t", '"': '"', "'": "'", "\\": "\\"}
-
-
-class CoreEvalEnv(BaseModel):
-    """Environment variables every eval run needs, regardless of suite kind.
-
-    Field names are the literal environment variable names; each description is
-    surfaced in the preflight error so a missing variable says what it is for.
-    Provider-specific prerequisites with non-env fallbacks (Modal tokens vs
-    ``~/.modal.toml``, ``NGROK_AUTHTOKEN`` vs the ngrok config file) stay in the
-    provider strategies' ``preflight()``.
-    """
-
-    model_config = ConfigDict(extra="ignore")
-
-    BRAINTRUST_API_KEY: str = Field(
-        min_length=1,
-        description="records experiments and scores to Braintrust",
-    )
 
 
 class SandboxEvalEnv(BaseModel):
@@ -152,15 +135,22 @@ def load_env_file() -> None:
         os.environ.setdefault(key, value)
 
 
-def validate_eval_env(agent_runtime: str = "claude", *, kinds: Collection[SuiteKind] = (SuiteKind.SANDBOXED,)) -> None:
+def validate_eval_env(
+    agent_runtime: str = "claude",
+    *,
+    kinds: Collection[SuiteKind] = (SuiteKind.SANDBOXED,),
+    engine_env: Collection[EnvVarSpec] = (),
+) -> None:
     """Fail fast, before any infrastructure boots, if a required variable is unset.
 
-    Only the env models for the selected suites' kinds are checked, so a run
-    without sandboxed suites doesn't demand sandbox credentials. Without this a
-    missing key surfaces minutes into a run as an opaque mid-case failure
-    (gateway 401s, Braintrust login errors) instead of a one-line fix.
+    ``engine_env`` is the selected engine's ``required_env()`` (e.g. the Braintrust
+    engine's ``BRAINTRUST_API_KEY``). Only the env models for the selected suites'
+    kinds are checked, so a run without sandboxed suites doesn't demand sandbox
+    credentials. Without this a missing key surfaces minutes into a run as an
+    opaque mid-case failure (gateway 401s, engine login errors) instead of a
+    one-line fix.
     """
-    models: list[type[BaseModel]] = [CoreEvalEnv]
+    models: list[type[BaseModel]] = []
     for kind, kind_models in ENV_MODELS_BY_KIND.items():
         if kind in kinds:
             models.extend(kind_models)
@@ -169,6 +159,13 @@ def validate_eval_env(agent_runtime: str = "claude", *, kinds: Collection[SuiteK
 
     lines = []
     seen: set[str] = set()
+    # Engine env first, so its line (e.g. BRAINTRUST_API_KEY) leads the report as
+    # the core CoreEvalEnv field used to.
+    for spec in engine_env:
+        if spec.name in seen or os.environ.get(spec.name):
+            continue
+        seen.add(spec.name)
+        lines.append(f"  - {spec.name}: {spec.description}")
     for model in models:
         try:
             model.model_validate(dict(os.environ))

--- a/products/posthog_ai/eval_harness/harness/lifecycle.py
+++ b/products/posthog_ai/eval_harness/harness/lifecycle.py
@@ -19,6 +19,8 @@ from posthog.ph_client import get_client
 
 from products.tasks.backend.temporal.process_task.utils import get_reasoning_effort_error
 
+from ..engines.base import EvalEngine
+from ..engines.registry import resolve_engine
 from .cli import DEFAULT_ONE_SHOT_CONCURRENCY, TEAM_SETUP_CONCURRENCY, HarnessOptions
 from .context import EvalContext
 from .demo_data import SandboxedDemoData, ensure_demo_ready
@@ -61,6 +63,9 @@ class SandboxedEvalHarness:
     def __init__(self, options: HarnessOptions) -> None:
         self.options = options
         self.provider: SandboxProviderStrategy | None = None
+        # The execution/reporting backend for this run. No --engine flag yet, so
+        # this is the registry default; it feeds preflight and every suite's run.
+        self._engine: EvalEngine = resolve_engine()
         self._stack = ExitStack()
         self._database: EvalDatabase | None = None
         self._live_server: EvalLiveServer | None = None
@@ -99,7 +104,7 @@ class SandboxedEvalHarness:
         results: list[SuiteRunResult] | None = None
         interrupted = False
         try:
-            validate_eval_env(self.options.agent_runtime, kinds=kinds)
+            validate_eval_env(self.options.agent_runtime, kinds=kinds, engine_env=self._engine.required_env())
             if Infra.SANDBOX in required:
                 self.provider = build_provider(
                     self.options.provider,
@@ -295,6 +300,7 @@ class SandboxedEvalHarness:
             team_setup_slots=asyncio.Semaphore(TEAM_SETUP_CONCURRENCY),
             one_shot_slots=asyncio.Semaphore(DEFAULT_ONE_SHOT_CONCURRENCY),
             reporter=reporter,
+            engine=self._engine,
             per_case_timeout_seconds=self.options.per_case_timeout_seconds,
             trials=self.options.trials,
         )

--- a/products/posthog_ai/eval_harness/harness/reporting.py
+++ b/products/posthog_ai/eval_harness/harness/reporting.py
@@ -214,7 +214,7 @@ class ProgressReporter:
         posthog_url = self._posthog_urls.get(experiment_name)
         if posthog_url:
             lines.append(f"  PostHog: {posthog_url}")
-        lines.append(f"  Braintrust: {summary.experiment_url or '(local run, not uploaded)'}")
+        lines.append(f"  {summary.engine_name.title()}: {summary.experiment_url or '(local run, not uploaded)'}")
         log_dir = self._log_dirs.get(experiment_name)
         if log_dir:
             lines.append(f"  Agent logs: {log_dir}")

--- a/products/posthog_ai/eval_harness/harness/reporting.py
+++ b/products/posthog_ai/eval_harness/harness/reporting.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from braintrust.logger import ExperimentSummary
+from ..engines.types import EvalSummary
 
 EVAL_RESULTS_JSONL = "eval_results.jsonl"
 """Machine-readable per-experiment summary export, opt-in via ``EXPORT_EVAL_RESULTS``."""
@@ -42,7 +42,7 @@ class ProgressReporter:
         self._total_suites = total_suites
         self._lock = asyncio.Lock()
         self._finished_suites = 0
-        self._summaries: dict[str, ExperimentSummary] = {}
+        self._summaries: dict[str, EvalSummary] = {}
         self._case_counts: dict[str, int] = defaultdict(int)
         self._case_durations: dict[str, float] = defaultdict(float)
         self._case_statuses: dict[str, Counter[str]] = defaultdict(Counter)
@@ -110,7 +110,7 @@ class ProgressReporter:
                 f"{_format_duration(result.duration_seconds)}"
             )
 
-    async def record_summary(self, experiment_name: str, summary: ExperimentSummary, *, error_count: int = 0) -> None:
+    async def record_summary(self, experiment_name: str, summary: EvalSummary, *, error_count: int = 0) -> None:
         async with self._lock:
             self._summaries[experiment_name] = summary
             self._summary_error_counts[experiment_name] = error_count
@@ -195,7 +195,7 @@ class ProgressReporter:
             combined["error"] += max(statuses["error"], self._summary_error_counts[experiment_name])
         return combined
 
-    def _experiment_block(self, experiment_name: str, summary: ExperimentSummary) -> list[str]:
+    def _experiment_block(self, experiment_name: str, summary: EvalSummary) -> list[str]:
         statuses = self._case_statuses[experiment_name]
         error_count = max(statuses["error"], self._summary_error_counts[experiment_name])
         lines = [

--- a/products/posthog_ai/eval_harness/harness/reporting.py
+++ b/products/posthog_ai/eval_harness/harness/reporting.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from braintrust.framework import EvalResultWithSummary, Evaluator, ReporterDef
 from braintrust.logger import ExperimentSummary
 
 EVAL_RESULTS_JSONL = "eval_results.jsonl"
@@ -258,19 +257,3 @@ def _format_duration(seconds: float) -> str:
         return f"{int(minutes)}m {remaining:.1f}s"
     hours, minutes = divmod(int(minutes), 60)
     return f"{hours}h {minutes}m {remaining:.1f}s"
-
-
-def _quiet_report_eval(evaluator: Evaluator, result: EvalResultWithSummary, verbose: bool, jsonl: bool) -> bool:
-    return True
-
-
-def _quiet_report_run(results: list[bool], verbose: bool, jsonl: bool) -> bool:
-    return True
-
-
-QUIET_REPORTER: ReporterDef = ReporterDef(
-    name="quiet",
-    report_eval=_quiet_report_eval,
-    report_run=_quiet_report_run,
-)
-"""Reporter that keeps Braintrust's per-experiment tables out of the shared stream."""

--- a/products/posthog_ai/eval_harness/one_shot.py
+++ b/products/posthog_ai/eval_harness/one_shot.py
@@ -16,11 +16,9 @@ from collections.abc import Awaitable, Callable, Sequence
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
-from braintrust import EvalHooks
-
 from .base import _BaseEvalRun
 from .config import BaseEvalCase
-from .engines.types import ExperimentResult
+from .engines.types import CaseHooks, ExperimentResult
 from .log_sink import write_case_logs
 
 if TYPE_CHECKING:
@@ -63,7 +61,7 @@ class _OneShotEvalRun(_BaseEvalRun):
         )
         self._task_fn = task_fn
 
-    async def _execute_case(self, input: dict[str, Any], hooks: EvalHooks) -> dict[str, Any]:
+    async def _execute_case(self, input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
         # Re-bind the original case object: it carries what Braintrust's JSON
         # round-trip drops, and the task fn may want `expected`/`metadata`.
         case = self.cases_by_name.get(input["name"]) or BaseEvalCase(name=input["name"], prompt=input.get("prompt", ""))

--- a/products/posthog_ai/eval_harness/one_shot.py
+++ b/products/posthog_ai/eval_harness/one_shot.py
@@ -17,10 +17,10 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from braintrust import EvalHooks
-from braintrust.framework import EvalResultWithSummary
 
 from .base import _BaseEvalRun
 from .config import BaseEvalCase
+from .engines.types import ExperimentResult
 from .log_sink import write_case_logs
 
 if TYPE_CHECKING:
@@ -105,7 +105,7 @@ async def OneShotEval(
     ctx: EvalContext,
     is_public: bool = False,
     no_send_logs: bool = True,
-) -> EvalResultWithSummary:
+) -> ExperimentResult:
     """Run a one-shot evaluation suite via Braintrust.
 
     For each ``BaseEvalCase``, invokes ``task(case, ctx)`` once under the global

--- a/products/posthog_ai/eval_harness/scorers/contract.py
+++ b/products/posthog_ai/eval_harness/scorers/contract.py
@@ -1,0 +1,35 @@
+"""The PostHog-owned scorer contract.
+
+Ships as a shim today: ``Score`` re-exports braintrust's and ``Scorer`` is an
+empty subclass of braintrust's base — zero behavior change. Both still satisfy
+braintrust's duck-typed dispatch (``hasattr(scorer, "eval_async")``) and score
+check (``name``/``score``/``metadata``/``as_dict``), so scorers written against
+this module stay directly consumable by ``BraintrustEngine`` with no adapter.
+
+A later flip replaces these with pure PostHog classes carrying the same surface
+(``eval_async(output, expected, **kwargs)``, ``_name()``, ``Score.name/score/
+metadata/as_dict``) — a single-file change that no scorer has to follow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from braintrust import Score as Score
+from braintrust_core.score import Scorer as _UpstreamScorer
+
+
+class Scorer(_UpstreamScorer):
+    """PostHog's scorer base. An empty subclass of braintrust's base for now."""
+
+
+class AsyncOnlyScorerMixin:
+    """Marks a scorer as async-only; the sync branch is unreachable in the harness.
+
+    The harness runs every scorer through the engine, which dispatches via
+    ``eval_async``, so async-only scorers turn the never-used sync branch into an
+    explicit error instead of a silently divergent code path.
+    """
+
+    def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        raise NotImplementedError(f"{type(self).__name__} is async-only; call eval_async()")

--- a/products/posthog_ai/eval_harness/scorers/deterministic.py
+++ b/products/posthog_ai/eval_harness/scorers/deterministic.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import LogParser
+
+from .contract import Score, Scorer
 
 
 class ExitCodeZero(Scorer):

--- a/products/posthog_ai/eval_harness/scorers/judged.py
+++ b/products/posthog_ai/eval_harness/scorers/judged.py
@@ -11,7 +11,17 @@ from __future__ import annotations
 from typing import Any
 
 from autoevals.llm import LLMClassifier
-from braintrust import Score
+
+from .contract import AsyncOnlyScorerMixin, Score
+
+# Re-exported for back-compat: AsyncOnlyScorerMixin now lives in the scorer contract.
+__all__ = [
+    "BINARY_CHOICE_SCORES",
+    "GRADED_ALIGNMENT_CHOICE_SCORES",
+    "JUDGE_MODEL",
+    "AsyncOnlyScorerMixin",
+    "JudgedScorer",
+]
 
 BINARY_CHOICE_SCORES = {"yes": 1.0, "no": 0.0}
 
@@ -25,13 +35,6 @@ GRADED_ALIGNMENT_CHOICE_SCORES = {
 }
 
 JUDGE_MODEL = "gpt-5.4"
-
-
-class AsyncOnlyScorerMixin:
-    """Marks a scorer as async-only; the sync branch is unreachable in the harness."""
-
-    def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
-        raise NotImplementedError(f"{type(self).__name__} is async-only; call eval_async()")
 
 
 class JudgedScorer(AsyncOnlyScorerMixin, LLMClassifier):

--- a/products/posthog_ai/eval_harness/scorers/tracing.py
+++ b/products/posthog_ai/eval_harness/scorers/tracing.py
@@ -16,11 +16,10 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
-from braintrust_core.score import Scorer
 from posthoganalytics import Posthog
 
 from ..trace_events import DISTINCT_ID
-from .judged import AsyncOnlyScorerMixin
+from .contract import AsyncOnlyScorerMixin, Scorer
 
 # Context var for injecting per-scorer-invocation trace properties
 # into the traced OpenAI client's ``create()`` calls.

--- a/products/posthog_ai/eval_harness/test/test_braintrust_engine.py
+++ b/products/posthog_ai/eval_harness/test/test_braintrust_engine.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any
+
+from braintrust.framework import EvalResult, EvalResultWithSummary
+from braintrust.logger import ExperimentSummary, ScoreSummary
+
+from products.posthog_ai.eval_harness.engines.braintrust import BraintrustEngine
+
+
+def _summary(**overrides: Any) -> ExperimentSummary:
+    defaults: dict[str, Any] = {
+        "project_name": "p",
+        "project_id": None,
+        "experiment_id": None,
+        "experiment_name": "exp",
+        "project_url": None,
+        "experiment_url": None,
+        "comparison_experiment_name": None,
+        "scores": {"acc": ScoreSummary("acc", 3, 0.5, None, None)},
+        "metrics": {},
+    }
+    defaults.update(overrides)
+    return ExperimentSummary(**defaults)
+
+
+def test_translate_preserves_none_scores_and_stringifies_errors() -> None:
+    result: EvalResultWithSummary = EvalResultWithSummary(
+        summary=_summary(experiment_url="https://bt.example/e"),
+        results=[
+            EvalResult(input={"name": "a"}, output={"v": 1}, scores={"acc": 1.0}, expected={"e": 1}, metadata={"m": 1}),
+            EvalResult(input={"name": "skip"}, output={}, scores={"acc": None}, metadata={}),
+            EvalResult(input={"name": "boom"}, output=None, scores={}, error=ValueError("infra boom")),
+        ],
+    )
+
+    translated = BraintrustEngine()._translate(result)
+
+    assert [r.scores for r in translated.results] == [{"acc": 1.0}, {"acc": None}, {}]
+    assert translated.results[2].error == "infra boom"
+    assert translated.results[0].error is None
+    assert translated.results[0].input == {"name": "a"}
+    assert translated.results[0].expected == {"e": 1}
+    assert translated.results[0].metadata == {"m": 1}
+    assert translated.summary.engine_name == "braintrust"
+    assert translated.summary.experiment_url == "https://bt.example/e"
+    assert translated.summary.scores["acc"].score == 0.5
+
+
+def test_translate_summary_raw_round_trips_as_json() -> None:
+    summary = _summary()
+    translated = BraintrustEngine()._translate(EvalResultWithSummary(summary=summary, results=[]))
+
+    # The jsonl export must stay byte-identical to what braintrust would write.
+    assert translated.summary.as_json() == summary.as_json()

--- a/products/posthog_ai/eval_harness/test/test_braintrust_engine.py
+++ b/products/posthog_ai/eval_harness/test/test_braintrust_engine.py
@@ -5,7 +5,7 @@ from typing import Any
 from braintrust.framework import EvalResult, EvalResultWithSummary
 from braintrust.logger import ExperimentSummary, ScoreSummary
 
-from products.posthog_ai.eval_harness.engines.braintrust import BraintrustEngine
+from products.posthog_ai.eval_harness.engines.braintrust import BraintrustEngine, _BraintrustCaseHooks
 
 
 def _summary(**overrides: Any) -> ExperimentSummary:
@@ -53,3 +53,49 @@ def test_translate_summary_raw_round_trips_as_json() -> None:
 
     # The jsonl export must stay byte-identical to what braintrust would write.
     assert translated.summary.as_json() == summary.as_json()
+
+
+class _FakeSpan:
+    def __init__(self) -> None:
+        self.logs: list[dict[str, Any]] = []
+
+    def log(self, **kwargs: Any) -> None:
+        self.logs.append(kwargs)
+
+    def __enter__(self) -> _FakeSpan:
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+
+class _FakeSpanFactory:
+    def __init__(self) -> None:
+        self.started: list[tuple[str, dict[str, Any], _FakeSpan]] = []
+
+    def start_span(self, *, name: str, span_attributes: dict[str, Any]) -> _FakeSpan:
+        span = _FakeSpan()
+        self.started.append((name, span_attributes, span))
+        return span
+
+
+class _FakeEvalHooks:
+    def __init__(self) -> None:
+        self.metadata: dict[str, Any] = {}
+        self.span = _FakeSpanFactory()
+
+
+def test_case_hooks_adapter_writes_through_metadata_and_translates_spans() -> None:
+    hooks = _FakeEvalHooks()
+    adapter = _BraintrustCaseHooks(hooks)  # type: ignore[arg-type]
+
+    adapter.metadata["trace_id"] = "t1"
+    # Write-through: mutations must land on the underlying braintrust hooks.
+    assert hooks.metadata == {"trace_id": "t1"}
+
+    with adapter.start_span("agent", "llm") as span:
+        span.log(output="hi")
+
+    name, attrs, started_span = hooks.span.started[0]
+    assert (name, attrs) == ("agent", {"type": "llm"})
+    assert started_span.logs == [{"output": "hi"}]

--- a/products/posthog_ai/eval_harness/test/test_engine_conformance.py
+++ b/products/posthog_ai/eval_harness/test/test_engine_conformance.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+import braintrust.framework as bt_framework
+from braintrust import Score
+from braintrust.framework import EvalResultWithSummary, Evaluator
+from braintrust.logger import ExperimentSummary, ScoreSummary
+from braintrust_core.score import Scorer
+
+from products.posthog_ai.eval_harness.engines.braintrust import BraintrustEngine
+from products.posthog_ai.eval_harness.engines.types import CaseHooks, CaseSpec, ExperimentResult, ExperimentSpec
+
+# Every ``EvalEngine`` must satisfy these obligations; a future ``PostHogEvalsEngine``
+# joins this parameter list and must pass the same suite unchanged.
+pytestmark = pytest.mark.parametrize("engine", ["braintrust"], indirect=True)
+
+
+def _none_safe_local_summary(
+    evaluator: Evaluator[Any, Any], results: Sequence[EvalResultWithSummary[Any, Any]]
+) -> ExperimentSummary:
+    """A None-aware replacement for braintrust's offline ``build_local_summary``.
+
+    The stock offline path sums ``None`` scores and crashes (a local-mode bug the
+    authenticated path doesn't have — the real harness always runs authenticated).
+    This shim excludes ``None`` from the mean, matching authenticated behavior, so
+    the offline fixture can exercise the None-exclusion the engine contract promises.
+    """
+    by_name: dict[str, tuple[float, int]] = defaultdict(lambda: (0.0, 0))
+    for result in results:
+        for name, score in result.scores.items():
+            if score is None:
+                continue
+            total, count = by_name[name]
+            by_name[name] = (total + score, count + 1)
+    longest = max((len(name) for name in by_name), default=0)
+    scores = {
+        name: ScoreSummary(
+            name=name,
+            _longest_score_name=longest,
+            score=(total / count if count else 0.0),
+            improvements=0,
+            regressions=0,
+        )
+        for name, (total, count) in by_name.items()
+    }
+    return ExperimentSummary(
+        project_name=evaluator.project_name,
+        project_id=None,
+        experiment_id=None,
+        experiment_name=evaluator.experiment_name,
+        project_url=None,
+        experiment_url=None,
+        comparison_experiment_name=None,
+        scores=scores,
+        metrics={},
+    )
+
+
+@pytest.fixture
+def engine(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> BraintrustEngine:
+    if request.param == "braintrust":
+        # Keep the run fully offline: no API key means no login and no network.
+        monkeypatch.delenv("BRAINTRUST_API_KEY", raising=False)
+        monkeypatch.setattr(bt_framework, "build_local_summary", _none_safe_local_summary)
+        return BraintrustEngine()
+    raise AssertionError(f"unknown engine fixture: {request.param}")
+
+
+class _MaybeNoneScorer(Scorer):
+    """Scores 1.0/0.0 by the ``good`` flag, but skips (``None``) when ``skip`` is set."""
+
+    def _name(self) -> str:
+        return "maybe"
+
+    def _run_eval_sync(self, output: dict[str, Any] | None, expected: Any = None, **kwargs: Any) -> Score:
+        if output and output.get("skip"):
+            return Score(name="maybe", score=None)
+        return Score(name="maybe", score=1.0 if (output and output.get("good")) else 0.0)
+
+
+def _spec(
+    task: Any,
+    cases: list[CaseSpec],
+    *,
+    scorers: list[Any] | None = None,
+    trial_count: int = 1,
+) -> ExperimentSpec:
+    return ExperimentSpec(
+        project_name="conformance",
+        cases=cases,
+        task=task,
+        scorers=scorers if scorers is not None else [_MaybeNoneScorer()],
+        trial_count=trial_count,
+        is_public=False,
+        no_send_logs=True,
+        metadata={},
+    )
+
+
+def _run(engine: BraintrustEngine, spec: ExperimentSpec) -> ExperimentResult:
+    return asyncio.run(engine.run_experiment(spec))
+
+
+def test_one_result_per_case_and_trial(engine: BraintrustEngine) -> None:
+    async def task(input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
+        return {"good": True}
+
+    cases = [CaseSpec(input={"name": name}) for name in ("a", "b", "c")]
+    result = _run(engine, _spec(task, cases, trial_count=2))
+
+    assert len(result.results) == 6
+
+
+def test_input_round_trips(engine: BraintrustEngine) -> None:
+    async def task(input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
+        return {"good": True}
+
+    cases = [CaseSpec(input={"name": name}) for name in ("a", "b")]
+    result = _run(engine, _spec(task, cases))
+
+    assert sorted(r.input["name"] for r in result.results) == ["a", "b"]
+
+
+def test_hooks_metadata_persisted(engine: BraintrustEngine) -> None:
+    async def task(input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
+        hooks.metadata["seen"] = input["name"]
+        return {"good": True}
+
+    result = _run(engine, _spec(task, [CaseSpec(input={"name": "a"})]))
+
+    assert result.results[0].metadata.get("seen") == "a"
+
+
+def test_task_exception_becomes_error_and_is_excluded_from_aggregate(engine: BraintrustEngine) -> None:
+    async def task(input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
+        if input["name"] == "boom":
+            raise ValueError("infra boom")
+        return {"good": True}
+
+    cases = [CaseSpec(input={"name": name}) for name in ("a", "boom", "b")]
+    result = _run(engine, _spec(task, cases))
+
+    by_name = {r.input["name"]: r for r in result.results}
+    assert by_name["boom"].error is not None
+    assert by_name["boom"].scores == {}
+    assert by_name["a"].error is None
+    # boom is excluded: the mean is over the two successful 1.0 scores.
+    assert result.summary.scores["maybe"].score == 1.0
+
+
+def test_none_score_preserved_per_case_and_excluded_from_aggregate(engine: BraintrustEngine) -> None:
+    async def task(input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
+        if input["name"] == "skip":
+            return {"skip": True}
+        return {"good": input["name"] == "hit"}
+
+    cases = [CaseSpec(input={"name": name}) for name in ("hit", "skip", "miss")]
+    result = _run(engine, _spec(task, cases))
+
+    by_name = {r.input["name"]: r for r in result.results}
+    assert by_name["skip"].scores == {"maybe": None}
+    # None is excluded, so the mean is over hit (1.0) and miss (0.0).
+    assert result.summary.scores["maybe"].score == 0.5
+
+
+def test_engine_does_not_throttle_concurrency(engine: BraintrustEngine) -> None:
+    active = 0
+    peak = 0
+
+    async def task(input: dict[str, Any], hooks: CaseHooks) -> dict[str, Any]:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return {"good": True}
+
+    cases = [CaseSpec(input={"name": str(i)}) for i in range(5)]
+    _run(engine, _spec(task, cases))
+
+    # The engine must admit every case at once; only the harness's own semaphores gate.
+    assert peak == 5

--- a/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
+++ b/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from products.posthog_ai.eval_harness.config import BaseEvalCase
+from products.posthog_ai.eval_harness.engines.registry import resolve_engine
 from products.posthog_ai.eval_harness.engines.types import EvalSummary, ExperimentResult, ExperimentSpec, NullCaseHooks
 from products.posthog_ai.eval_harness.harness.context import EvalContext
 from products.posthog_ai.eval_harness.one_shot import _OneShotEvalRun
@@ -52,6 +53,7 @@ def _build_ctx(timeout_seconds: int = 30, one_shot_slots: int = 2, case_filter: 
         team_setup_slots=asyncio.Semaphore(1),
         one_shot_slots=asyncio.Semaphore(one_shot_slots),
         reporter=_StubReporter(),  # type: ignore[arg-type]
+        engine=resolve_engine(),
         per_case_timeout_seconds=timeout_seconds,
         trials=1,
     )

--- a/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
+++ b/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
@@ -7,8 +7,7 @@ from typing import Any
 import pytest
 
 from products.posthog_ai.eval_harness.config import BaseEvalCase
-from products.posthog_ai.eval_harness.engines.base import EvalTaskFn
-from products.posthog_ai.eval_harness.engines.types import EvalSummary, ExperimentResult
+from products.posthog_ai.eval_harness.engines.types import EvalSummary, ExperimentResult, ExperimentSpec, NullCaseHooks
 from products.posthog_ai.eval_harness.harness.context import EvalContext
 from products.posthog_ai.eval_harness.one_shot import _OneShotEvalRun
 
@@ -32,23 +31,10 @@ class _StubReporter:
 class _StubEngine:
     def __init__(self, result: ExperimentResult) -> None:
         self.result = result
-        self.calls: list[dict[str, Any]] = []
+        self.calls: list[ExperimentSpec] = []
 
-    async def run_experiment(
-        self,
-        *,
-        project_name: str,
-        cases: Any,
-        task: EvalTaskFn,
-        scorers: Any,
-        trial_count: int,
-        is_public: bool,
-        no_send_logs: bool,
-        metadata: dict[str, Any],
-    ) -> ExperimentResult:
-        self.calls.append(
-            {"project_name": project_name, "cases": list(cases), "trial_count": trial_count, "metadata": metadata}
-        )
+    async def run_experiment(self, spec: ExperimentSpec) -> ExperimentResult:
+        self.calls.append(spec)
         return self.result
 
 
@@ -90,7 +76,7 @@ def test_execute_case_backfills_prompt_and_writes_logs(tmp_path: Path, monkeypat
 
     ctx = _build_ctx()
     run = _build_run(tmp_path, monkeypatch, ctx, task)
-    output = asyncio.run(run._execute_case({"name": "c1", "prompt": "the prompt"}, hooks=None))
+    output = asyncio.run(run._execute_case({"name": "c1", "prompt": "the prompt"}, hooks=NullCaseHooks()))
 
     assert output["answer"] == 42
     assert output["prompt"] == "the prompt"
@@ -104,7 +90,7 @@ def test_task_scores_timeout_as_output_not_error(tmp_path: Path, monkeypatch: py
 
     ctx = _build_ctx(timeout_seconds=1)
     run = _build_run(tmp_path, monkeypatch, ctx, task)
-    output = asyncio.run(run._task({"name": "c1", "prompt": "the prompt"}, hooks=None))
+    output = asyncio.run(run._task({"name": "c1", "prompt": "the prompt"}, hooks=NullCaseHooks()))
 
     assert output == {"timeout": True, "error": "case timeout after 1s"}
     assert ctx.reporter.done == [("c1", "timeout")]  # type: ignore[attr-defined]
@@ -117,7 +103,7 @@ def test_task_reraises_infra_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     ctx = _build_ctx()
     run = _build_run(tmp_path, monkeypatch, ctx, task)
     with pytest.raises(ValueError):
-        asyncio.run(run._task({"name": "c1", "prompt": "the prompt"}, hooks=None))
+        asyncio.run(run._task({"name": "c1", "prompt": "the prompt"}, hooks=NullCaseHooks()))
     assert ctx.reporter.done == [("c1", "error")]  # type: ignore[attr-defined]
 
 
@@ -138,8 +124,8 @@ def test_one_shot_slots_bound_concurrency(tmp_path: Path, monkeypatch: pytest.Mo
 
     async def run_both() -> None:
         await asyncio.gather(
-            run._execute_case({"name": "c1", "prompt": "the prompt"}, hooks=None),
-            run._execute_case({"name": "c2", "prompt": "other"}, hooks=None),
+            run._execute_case({"name": "c1", "prompt": "the prompt"}, hooks=NullCaseHooks()),
+            run._execute_case({"name": "c2", "prompt": "other"}, hooks=NullCaseHooks()),
         )
 
     asyncio.run(run_both())
@@ -172,9 +158,9 @@ def test_run_routes_through_the_engine(tmp_path: Path, monkeypatch: pytest.Monke
     assert returned is canned
     assert len(engine.calls) == 1
     call = engine.calls[0]
-    assert call["project_name"] == "one-shot-test"
-    assert [case.input["name"] for case in call["cases"]] == ["c1", "c2"]
-    assert call["metadata"] == {"agent_model": "claude-test"}
+    assert call.project_name == "one-shot-test"
+    assert [case.input["name"] for case in call.cases] == ["c1", "c2"]
+    assert call.metadata == {"agent_model": "claude-test"}
     reporter = ctx.reporter
     assert reporter.started == [("one-shot-test", 2)]  # type: ignore[attr-defined]
     assert reporter.summaries == [("one-shot-test", canned.summary, 0)]  # type: ignore[attr-defined]

--- a/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
+++ b/products/posthog_ai/eval_harness/test/test_one_shot_runner.py
@@ -6,10 +6,9 @@ from typing import Any
 
 import pytest
 
-from braintrust.framework import EvalResultWithSummary
-
 from products.posthog_ai.eval_harness.config import BaseEvalCase
 from products.posthog_ai.eval_harness.engines.base import EvalTaskFn
+from products.posthog_ai.eval_harness.engines.types import EvalSummary, ExperimentResult
 from products.posthog_ai.eval_harness.harness.context import EvalContext
 from products.posthog_ai.eval_harness.one_shot import _OneShotEvalRun
 
@@ -31,7 +30,7 @@ class _StubReporter:
 
 
 class _StubEngine:
-    def __init__(self, result: EvalResultWithSummary) -> None:
+    def __init__(self, result: ExperimentResult) -> None:
         self.result = result
         self.calls: list[dict[str, Any]] = []
 
@@ -46,7 +45,7 @@ class _StubEngine:
         is_public: bool,
         no_send_logs: bool,
         metadata: dict[str, Any],
-    ) -> EvalResultWithSummary:
+    ) -> ExperimentResult:
         self.calls.append(
             {"project_name": project_name, "cases": list(cases), "trial_count": trial_count, "metadata": metadata}
         )
@@ -159,7 +158,10 @@ def test_run_routes_through_the_engine(tmp_path: Path, monkeypatch: pytest.Monke
     async def task(case: BaseEvalCase, ctx: EvalContext) -> dict[str, Any]:
         raise AssertionError("the engine is stubbed, so the task must not run")
 
-    canned = EvalResultWithSummary(summary=object(), results=[])
+    canned = ExperimentResult(
+        summary=EvalSummary(engine_name="stub", experiment_name="one-shot-test", scores={}),
+        results=[],
+    )
     engine = _StubEngine(canned)
     ctx = _build_ctx()
     run = _build_run(tmp_path, monkeypatch, ctx, task)

--- a/products/posthog_ai/eval_harness/test/test_sandboxed_experiment_scorers.py
+++ b/products/posthog_ai/eval_harness/test/test_sandboxed_experiment_scorers.py
@@ -11,8 +11,7 @@ import json
 
 import pytest
 
-from braintrust import Score
-
+from products.posthog_ai.eval_harness.scorers.contract import Score
 from products.posthog_ai.evals.experiments.scorers import (
     FirstUpdateMetricShape,
     validate_ratio_revenue_metric,

--- a/products/posthog_ai/eval_harness/test/test_sandboxed_harness_output.py
+++ b/products/posthog_ai/eval_harness/test/test_sandboxed_harness_output.py
@@ -63,13 +63,13 @@ async def test_reporter_output_is_labeled_and_reserves_pass_for_the_run(
     await reporter.record_summary(
         "sandboxed-cli-mcp-verify-event-cli",
         EvalSummary(
-            engine_name="braintrust",
+            engine_name="Braintrust",
             experiment_name="sandboxed-cli-mcp-verify-event-cli",
             scores={
                 "exit_code_zero": AggregateScore("exit_code_zero", 1.0),
                 "called_target_tool": AggregateScore("called_target_tool", 0.0),
             },
-            experiment_url="https://braintrust.example/experiment",
+            experiment_url="https://experiments.example/e",
         ),
     )
     await reporter.record_posthog_evaluations_url(
@@ -108,7 +108,7 @@ async def test_reporter_output_is_labeled_and_reserves_pass_for_the_run(
     assert "exit_code_zero: 100.0%" in output
     assert "called_target_tool: 0.0%" in output
     assert "PostHog: https://us.posthog.com/" in output
-    assert "Braintrust: https://braintrust.example/experiment" in output
+    assert "Braintrust: https://experiments.example/e" in output
     assert f"Agent logs: {tmp_path}" in output
     assert output.count("PASS") == 1
 

--- a/products/posthog_ai/eval_harness/test/test_sandboxed_harness_output.py
+++ b/products/posthog_ai/eval_harness/test/test_sandboxed_harness_output.py
@@ -6,9 +6,8 @@ from pathlib import Path
 import pytest
 from unittest.mock import MagicMock
 
-from braintrust.logger import ExperimentSummary, ScoreSummary
-
 from products.posthog_ai.eval_harness import base
+from products.posthog_ai.eval_harness.engines.types import AggregateScore, EvalSummary
 from products.posthog_ai.eval_harness.harness.reporting import ProgressReporter, SuiteRunResult
 from products.posthog_ai.eval_harness.harness.transcript import RunTranscript
 from products.posthog_ai.eval_harness.scorers import ExitCodeZero
@@ -63,19 +62,14 @@ async def test_reporter_output_is_labeled_and_reserves_pass_for_the_run(
     )
     await reporter.record_summary(
         "sandboxed-cli-mcp-verify-event-cli",
-        ExperimentSummary(
-            project_name="project",
-            project_id="project-id",
-            experiment_id="experiment-id",
+        EvalSummary(
+            engine_name="braintrust",
             experiment_name="sandboxed-cli-mcp-verify-event-cli",
-            project_url="https://braintrust.example/project",
-            experiment_url="https://braintrust.example/experiment",
-            comparison_experiment_name=None,
             scores={
-                "exit_code_zero": ScoreSummary("exit_code_zero", 20, 1.0, None, None),
-                "called_target_tool": ScoreSummary("called_target_tool", 20, 0.0, None, None),
+                "exit_code_zero": AggregateScore("exit_code_zero", 1.0),
+                "called_target_tool": AggregateScore("called_target_tool", 0.0),
             },
-            metrics={},
+            experiment_url="https://braintrust.example/experiment",
         ),
     )
     await reporter.record_posthog_evaluations_url(

--- a/products/posthog_ai/eval_harness/test/test_scorer_contract.py
+++ b/products/posthog_ai/eval_harness/test/test_scorer_contract.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+from braintrust.score import is_score
+
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
+
+
+def test_contract_scorer_is_dispatchable_by_braintrust() -> None:
+    class _S(Scorer):
+        def _name(self) -> str:
+            return "s"
+
+        def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+            return Score(name="s", score=1.0)
+
+    # braintrust's EvalAsync only runs a scorer if it exposes eval_async; the
+    # later pure-class flip must keep that surface, or every scorer stops firing.
+    assert hasattr(_S(), "eval_async")
+
+
+def test_contract_score_passes_braintrust_is_score() -> None:
+    # is_score is braintrust's duck check (name/score/metadata/as_dict); a Score
+    # that fails it is silently dropped from every experiment's results.
+    assert is_score(Score(name="s", score=1.0))

--- a/products/posthog_ai/eval_harness/test/test_suite_requirements.py
+++ b/products/posthog_ai/eval_harness/test/test_suite_requirements.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from products.posthog_ai.eval_harness.engines.registry import resolve_engine
 from products.posthog_ai.eval_harness.harness.env_preflight import validate_eval_env
 from products.posthog_ai.eval_harness.harness.providers import PreflightError
 from products.posthog_ai.eval_harness.harness.requirements import INFRA_BY_KIND, Infra, SuiteKind, expand, infra_union
@@ -127,3 +128,16 @@ def test_validate_eval_env_by_kind(
         assert message.count(name) == 1
     for name in set(ALL_ENV_VARS) - set(expect_missing) - set(env):
         assert name not in message
+
+
+def test_validate_eval_env_reports_missing_engine_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ALL_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("LLM_GATEWAY_ANTHROPIC_API_KEY", "x")
+
+    with pytest.raises(PreflightError) as exc_info:
+        validate_eval_env("claude", kinds={SuiteKind.ONE_SHOT}, engine_env=resolve_engine().required_env())
+
+    # The Braintrust engine's requirement is reported with the same line the core
+    # env model used to emit, so a missing key reads identically to before.
+    assert "  - BRAINTRUST_API_KEY: records experiments and scores to Braintrust" in str(exc_info.value)

--- a/products/posthog_ai/eval_harness/test/test_warehouse_scorers.py
+++ b/products/posthog_ai/eval_harness/test/test_warehouse_scorers.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import json
 
-from braintrust import Score
-
+from products.posthog_ai.eval_harness.scorers.contract import Score
 from products.posthog_ai.evals.data_warehouse.scorers import (
     AgenticSearchUsed,
     AnswerQueryRanWhenExpected,

--- a/products/posthog_ai/eval_harness/trace_events.py
+++ b/products/posthog_ai/eval_harness/trace_events.py
@@ -16,6 +16,7 @@ from typing import Any
 from posthoganalytics import Posthog
 
 from .acp_log import GenerationDescriptor, ParsedLog, SpanDescriptor
+from .engines.types import CaseResult
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +277,7 @@ def emit_evaluation_events(
     client: Posthog,
     experiment_id: str,
     experiment_name: str,
-    eval_results: list,
+    eval_results: list[CaseResult],
     scorer_traces: dict[tuple[str, str], str] | None = None,
 ) -> None:
     """Emit ``$ai_evaluation`` events for each scorer result in each eval case.

--- a/products/posthog_ai/evals/cli_mcp/scorers.py
+++ b/products/posthog_ai/evals/cli_mcp/scorers.py
@@ -32,10 +32,8 @@ from __future__ import annotations
 
 import re
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import EXEC_TOOL_NAME, INFO_SYNTHETIC_PREFIX, LogParser, ToolCall
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 __all__ = [
     "CalledTargetTool",

--- a/products/posthog_ai/evals/cohorts/scorers.py
+++ b/products/posthog_ai/evals/cohorts/scorers.py
@@ -17,10 +17,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import LogParser
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 __all__ = [
     "COHORTS_ADD_PERSONS_TOOL",

--- a/products/posthog_ai/evals/data_warehouse/scorers.py
+++ b/products/posthog_ai/evals/data_warehouse/scorers.py
@@ -16,11 +16,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import LogParser, ToolCall
 from products.posthog_ai.eval_harness.scorers import GRADED_ALIGNMENT_CHOICE_SCORES, JUDGE_MODEL, JudgedScorer
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 from products.posthog_ai.evals.product_analytics.scorers import parser_for, user_prompt
 from products.posthog_ai.evals.sql.scorers import _truncate_result_for_judge, extract_last_execute_sql_call
 

--- a/products/posthog_ai/evals/error_tracking/scorers.py
+++ b/products/posthog_ai/evals/error_tracking/scorers.py
@@ -20,11 +20,9 @@ import re
 import json
 from typing import Any
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import LogParser, ToolCall
 from products.posthog_ai.eval_harness.scorers import BINARY_CHOICE_SCORES, JUDGE_MODEL, JudgedScorer
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 __all__ = [
     "BINARY_CHOICE_SCORES",

--- a/products/posthog_ai/evals/experiments/scorers.py
+++ b/products/posthog_ai/evals/experiments/scorers.py
@@ -58,10 +58,9 @@ from __future__ import annotations
 from typing import Any
 
 from autoevals.llm import LLMClassifier
-from braintrust import Score
-from braintrust_core.score import Scorer
 
 from products.posthog_ai.eval_harness.scorers import BINARY_CHOICE_SCORES, AsyncOnlyScorerMixin, JudgedScorer, LogParser
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 # Not the shared JUDGE_MODEL: these judges were baselined on gpt-4.1, and
 # swapping the model resets their Braintrust history.

--- a/products/posthog_ai/evals/product_analytics/scorers.py
+++ b/products/posthog_ai/evals/product_analytics/scorers.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
-from braintrust import Score
-from braintrust_core.score import Scorer
 from pydantic import BaseModel
 
 from posthog.schema import AssistantFunnelsQuery, AssistantRetentionQuery, AssistantTrendsQuery
@@ -29,6 +27,7 @@ from products.posthog_ai.eval_harness.scorers import (
     JUDGE_MODEL,
     JudgedScorer,
 )
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 QUERY_TRENDS_TOOL_NAME = "query-trends"
 QUERY_RETENTION_TOOL_NAME = "query-retention"

--- a/products/posthog_ai/evals/retrieval/scorers.py
+++ b/products/posthog_ai/evals/retrieval/scorers.py
@@ -34,10 +34,8 @@ import re
 import json
 from typing import Any
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import INFO_SYNTHETIC_PREFIX, LogParser
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 __all__ = ["InfoCalledBeforeTool", "InformationSchemaBeforeSql", "LookupIdInOutput", "SkillLoaded"]
 

--- a/products/posthog_ai/evals/sql/scorers.py
+++ b/products/posthog_ai/evals/sql/scorers.py
@@ -24,10 +24,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.scorers import GRADED_ALIGNMENT_CHOICE_SCORES, JUDGE_MODEL, JudgedScorer
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 from products.posthog_ai.evals.product_analytics.scorers import GRADED_ALIGNMENT_RUBRIC, parser_for, user_prompt
 
 QUERY_SQL_TOOL_NAME = "execute-sql"

--- a/products/posthog_ai/evals/surveys/scorers.py
+++ b/products/posthog_ai/evals/surveys/scorers.py
@@ -6,11 +6,9 @@ import re
 import json
 from typing import Any
 
-from braintrust import Score
-from braintrust_core.score import Scorer
-
 from products.posthog_ai.eval_harness.log_parser import LogParser, ToolCall
 from products.posthog_ai.eval_harness.scorers import GRADED_ALIGNMENT_CHOICE_SCORES, JUDGE_MODEL, JudgedScorer
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
 
 SURVEY_CREATE_TOOL_NAME = "survey-create"
 SURVEY_FORBIDDEN_WRITE_TOOLS = frozenset(


### PR DESCRIPTION
## Problem

The eval harness has a first engine seam (`EvalEngine` Protocol + `BraintrustEngine`), but it isolates only the `EvalAsync(...)` call. Braintrust types still leak through everything around it: the task/hooks contract (`braintrust.EvalHooks`, span trees), case construction (`braintrust.EvalCase`), the result shapes consumed by finalize/reporting (`EvalResultWithSummary`, `ExperimentSummary`), the scorer hierarchy (every scorer subclasses `braintrust_core.score.Scorer`), and env preflight (`BRAINTRUST_API_KEY` hard-coded for every run). Swapping the engine — say to a future PostHog-native one that records datasets, experiments, and scores into PostHog LLM analytics — would mean touching the run base, reporting, trace emission, and every suite.

## Changes

**Before** — the seam covers one call, braintrust types flow through everything else:

```mermaid
flowchart LR
    S[suites + scorers<br/>braintrust Scorer/Score] --> RB[run base<br/>braintrust EvalCase/EvalHooks]
    RB --> E[EvalEngine seam] --> BT[EvalAsync]
    BT -->|EvalResultWithSummary| RB
    RB -->|ExperimentSummary| REP[reporting + traces]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class S,RB,E phBlue;
    class BT phRed;
    class REP phGray;
```

**After** — engine-neutral types at every boundary; one module knows braintrust exists:

```mermaid
flowchart LR
    S[suites + scorers<br/>scorers.contract] --> RB[run base<br/>CaseSpec/CaseHooks]
    RB -->|ExperimentSpec| E[EvalEngine<br/>+ registry/manifest]
    E --> BE[BraintrustEngine<br/>hooks adapter + translate]
    BE --> BT[EvalAsync]
    BE -->|ExperimentResult| RB
    RB -->|EvalSummary| REP[reporting + traces]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class S,RB,E phBlue;
    class BE phYellow;
    class BT phRed;
    class REP phGray;
```

Behavior-preserving throughout, in five shippable phases (one-or-two commits each):

- **Neutral types** (`engines/types.py`, stdlib-only): `CaseSpec` in, `ExperimentResult`/`CaseResult`/`EvalSummary`/`AggregateScore` out, and `ExperimentSpec` as the single `run_experiment` argument so future fields break no implementation. `EvalSummary.raw` carries the engine-native summary so the `eval_results.jsonl` export stays byte-identical (pinned by a round-trip test against `ExperimentSummary.as_json()`).
- **Neutral hooks** (`CaseHooks`/`SpanHandle` Protocols + concrete `NullCaseHooks`): exactly the two capabilities tasks actually use — a persisted `metadata` dict and nested `start_span(name, kind)`. `BraintrustEngine` adapts them onto `EvalHooks` with a small write-through wrapper.
- **Scorer contract re-homing** (`scorers/contract.py`): PostHog-owned `Score`/`Scorer`/`AsyncOnlyScorerMixin` names, shipped as a zero-behavior shim over braintrust's classes. Braintrust duck-types scorers (`hasattr(scorer, "eval_async")`) and scores (`name`/`score`/`metadata`/`as_dict`) — verified against the SDK source and pinned by a test — so the later flip to pure PostHog classes is a single-file change no scorer has to follow. The 9 domain scorer files migrated with an import-line change each, zero body changes.
- **Engine manifest, env, registry**: engines declare `name`, `supports_public_experiments`, and `required_env()`; `BRAINTRUST_API_KEY` moved out of the always-required env model into `BraintrustEngine.required_env()`, threaded into preflight with identical error text. `engines/registry.py` + `EvalContext.engine` replace the hard-coded default (no `--engine` flag until a second engine exists).
- **Engine conformance suite** (`test_engine_conformance.py`), parameterized over engines: one result per case×trial, input round-trip, hooks-metadata persistence, task exception → errored case excluded from aggregates, `None`-score preservation + exclusion from means, and no engine-side throttling. A future `PostHogEvalsEngine` joins the fixture list and must pass unchanged.

> [!NOTE]
> Deliberately deferred: the autoevals judge substrate (`JudgedScorer` stays an `LLMClassifier` subclass behind its `_prepare` facade — a separate "judge backend" seam), the `ee/hogai/eval/{ci,offline}` pytest trees, and the actual `PostHogEvalsEngine` implementation for which this is the landing pad.

## How did you test this code?

- `hogli test products/posthog_ai/eval_harness/test/` — 189 tests pass (+12 new). New coverage: braintrust result translation (`None` scores preserved, errors stringified, `raw` round-trips `as_json` byte-for-byte — the regression would be a silently changed jsonl export), the hooks adapter (span kwargs mapping, metadata write-through), the scorer-contract duck-type pin (the safety net for the future pure flip), and the engine conformance suite above. The conformance fixture runs `EvalAsync` fully offline (no API key, no network); braintrust's offline-only summary builder crashes aggregating `None` scores, so the fixture patches in a `None`-safe equivalent matching authenticated behavior (documented in the fixture).
- `python -m products.posthog_ai.eval_harness.harness --list` — exit 0 after every phase; the Django-free `__main__` import chain is intact (`engines/types.py` is stdlib-only).
- Live sandboxed run `... harness sql/eval_sql --eval sql_pageviews_by_browser` — passes end to end through the new path: spans built via the `CaseHooks` adapter, scorers through the contract shim, Braintrust upload with experiment URL, reporting output unchanged (98.6% mean; the sole sub-100 score is the usual judge variance on `sql_schema_alignment`).
- Grep gate: `braintrust|autoevals` imports in `products/posthog_ai/` are now confined to `engines/braintrust.py`, `engines/registry.py` (only the concrete-engine import), the `scorers/contract.py` shim, the deferred judge substrate (`scorers/judged.py`, `scorers/tracing.py`, `evals/experiments/scorers.py`), and the tests that pin the shim.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated in this PR: `eval_harness/harness/AGENTS.md` (engine obligations, Django-free list), `eval_harness/harness/README.md` (engine seam), `eval_harness/README.md` (per-engine env requirement), and the `writing-evals` skill (scorer imports from `scorers.contract`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code ([session](https://claude.ai/code/session_01JKPqfzxCAML8eVNs6LpxWS)); skills invoked: `/writing-evals`, `/writing-tests`. The design started from a full coupling inventory of the harness (what leaks braintrust semantics where), validated the load-bearing enabler against the installed SDK source (braintrust duck-types scorers and scores, which is what makes the shim-then-flip scorer strategy free of adapters), and was reviewed and approved by the human driver as a 6-concept interface set with a 5-phase migration. Implementation was delegated to a Claude Opus subagent working from the approved plan; the main session verified every phase independently (tests, import chain, grep gate, and the live sandboxed run). Rejected along the way: a neutral scorer Protocol with per-engine runtime adapters (dead layer given duck-typing), keeping braintrust as the permanent scorer authoring base (chains every future engine to it), and an `engine.experiment_url()` capability method (the URL is per-run result data, so it lives on `EvalSummary`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKPqfzxCAML8eVNs6LpxWS
