### PR TITLE
fix(dashboards): prefetch alert threshold and subscribers on read paths

### DIFF
--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -2260,9 +2260,17 @@
          "posthog_user"."onboarding_delegated_to_organization_id",
          "posthog_user"."onboarding_delegation_accepted_at",
          "posthog_user"."events_column_config",
-         "posthog_user"."email_opt_in"
+         "posthog_user"."email_opt_in",
+         "posthog_threshold"."created_by_id",
+         "posthog_threshold"."created_at",
+         "posthog_threshold"."id",
+         "posthog_threshold"."team_id",
+         "posthog_threshold"."insight_id",
+         "posthog_threshold"."name",
+         "posthog_threshold"."configuration"
   FROM "posthog_alertconfiguration"
   LEFT OUTER JOIN "posthog_user" ON ("posthog_alertconfiguration"."created_by_id" = "posthog_user"."id")
+  LEFT OUTER JOIN "posthog_threshold" ON ("posthog_alertconfiguration"."threshold_id" = "posthog_threshold"."id")
   WHERE "posthog_alertconfiguration"."insight_id" IN (1,
                                                       2,
                                                       3,
@@ -7730,9 +7738,17 @@
          "posthog_user"."onboarding_delegated_to_organization_id",
          "posthog_user"."onboarding_delegation_accepted_at",
          "posthog_user"."events_column_config",
-         "posthog_user"."email_opt_in"
+         "posthog_user"."email_opt_in",
+         "posthog_threshold"."created_by_id",
+         "posthog_threshold"."created_at",
+         "posthog_threshold"."id",
+         "posthog_threshold"."team_id",
+         "posthog_threshold"."insight_id",
+         "posthog_threshold"."name",
+         "posthog_threshold"."configuration"
   FROM "posthog_alertconfiguration"
   LEFT OUTER JOIN "posthog_user" ON ("posthog_alertconfiguration"."created_by_id" = "posthog_user"."id")
+  LEFT OUTER JOIN "posthog_threshold" ON ("posthog_alertconfiguration"."threshold_id" = "posthog_threshold"."id")
   WHERE "posthog_alertconfiguration"."insight_id" IN (1,
                                                       2,
                                                       3,

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -33,8 +33,10 @@ from posthog.models.project import Project
 from posthog.models.quick_filter import QuickFilter
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.signals import mute_selected_signals
+from posthog.test.db_context_capturing import capture_db_queries
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
 
+from products.alerts.backend.models.alert import AlertConfiguration, AlertSubscription, Threshold
 from products.dashboards.backend.api.dashboard import DashboardSerializer
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import ButtonTile, DashboardTile, Text
@@ -680,6 +682,45 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
         with self.assertNumQueries(baseline + 11 + 9):
             self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
+
+    def test_insight_alerts_do_not_nplus1_dashboard_gets(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+
+        def _add_insight_with_alerts() -> None:
+            insight_id, _ = self.dashboard_api.create_insight({"dashboards": [dashboard_id]})
+            threshold = Threshold.objects.create(
+                team=self.team,
+                insight_id=insight_id,
+                created_by=self.user,
+                configuration={"type": "absolute", "bounds": {"upper": 1}},
+            )
+            # one threshold alert and one detector alert — AlertSerializer emits threshold and
+            # subscribed_users per alert, the two relations that regress to per-alert queries
+            for alert_threshold in (threshold, None):
+                alert = AlertConfiguration.objects.create(
+                    team=self.team,
+                    insight_id=insight_id,
+                    created_by=self.user,
+                    name="alert",
+                    threshold=alert_threshold,
+                    condition={"type": "absolute_value"},
+                    config={"type": "TrendsAlertConfig", "series_index": 0},
+                    detector_config=None if alert_threshold else {"type": "zscore", "threshold": 3},
+                )
+                AlertSubscription.objects.create(user=self.user, alert_configuration=alert, created_by=self.user)
+
+        def _dashboard_query_count() -> int:
+            with capture_db_queries() as ctx:
+                self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
+            return len(ctx.captured_queries)
+
+        _add_insight_with_alerts()
+        _dashboard_query_count()  # warmup: absorbs one-off writes like last_accessed_at
+        baseline = _dashboard_query_count()
+
+        _add_insight_with_alerts()
+        _add_insight_with_alerts()
+        self.assertEqual(_dashboard_query_count(), baseline)
 
     @snapshot_postgres_queries
     def test_listing_dashboards_is_not_nplus1(self) -> None:

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1996,7 +1996,11 @@ class DashboardSerializer(DashboardMetadataSerializer):
             ),
             Prefetch(
                 "insight__alertconfiguration_set",
-                queryset=AlertConfiguration.objects.select_related("created_by"),
+                # AlertSerializer emits threshold and subscribed_users per alert; without these,
+                # every alert on the dashboard costs two extra queries
+                queryset=AlertConfiguration.objects.select_related("created_by", "threshold").prefetch_related(
+                    "subscribed_users"
+                ),
                 to_attr="_prefetched_alerts",
             ),
         )

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1555,7 +1555,11 @@ class InsightViewSet(
                 ),
                 Prefetch(
                     "alertconfiguration_set",
-                    queryset=AlertConfiguration.objects.select_related("created_by"),
+                    # AlertSerializer emits threshold and subscribed_users per alert; without these,
+                    # every alert in the list costs two extra queries
+                    queryset=AlertConfiguration.objects.select_related("created_by", "threshold").prefetch_related(
+                        "subscribed_users"
+                    ),
                     to_attr="_prefetched_alerts",
                 ),
             )

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -54,7 +54,7 @@ from posthog.models.project import Project
 from posthog.test.db_context_capturing import capture_db_queries
 from posthog.test.persons import create_person
 
-from products.alerts.backend.models.alert import AlertConfiguration
+from products.alerts.backend.models.alert import AlertConfiguration, AlertSubscription, Threshold
 from products.cohorts.backend.models.cohort import Cohort
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile, Text
@@ -1078,6 +1078,51 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             assert len(ctx.captured_queries) == baseline_query_count, (
                 f"n={n}: {len(ctx.captured_queries)} queries vs baseline {baseline_query_count}; "
                 f"adding insights should not grow the per-request query count."
+            )
+
+    @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
+    def test_listing_insights_with_alerts_does_not_nplus1(self) -> None:
+        url = f"/api/projects/{self.team.id}/insights/?saved=true&limit=30"
+
+        def _create_insight_with_alerts(short_id: str) -> None:
+            insight_id, _ = self.dashboard_api.create_insight(
+                data={"short_id": short_id, "filters": {"events": [{"id": "$pageview"}]}}
+            )
+            threshold = Threshold.objects.create(
+                team=self.team,
+                insight_id=insight_id,
+                created_by=self.user,
+                configuration={"type": "absolute", "bounds": {"upper": 1}},
+            )
+            # one threshold alert and one detector alert — AlertSerializer emits threshold and
+            # subscribed_users per alert, the two relations that regress to per-alert queries
+            for alert_threshold in (threshold, None):
+                alert = AlertConfiguration.objects.create(
+                    team=self.team,
+                    insight_id=insight_id,
+                    created_by=self.user,
+                    name="alert",
+                    threshold=alert_threshold,
+                    condition={"type": "absolute_value"},
+                    config={"type": "TrendsAlertConfig", "series_index": 0},
+                    detector_config=None if alert_threshold else {"type": "zscore", "threshold": 3},
+                )
+                AlertSubscription.objects.create(user=self.user, alert_configuration=alert, created_by=self.user)
+
+        _create_insight_with_alerts("first")
+        with capture_db_queries() as ctx:
+            assert self.client.get(url).status_code == status.HTTP_200_OK
+        baseline = len(ctx.captured_queries)
+
+        for n in range(2, 5):
+            _create_insight_with_alerts(f"insight-{n}")
+            with capture_db_queries() as ctx:
+                response = self.client.get(url)
+                assert response.status_code == status.HTTP_200_OK
+                assert len(response.json()["results"]) == n
+            assert len(ctx.captured_queries) == baseline, (
+                f"n={n}: {len(ctx.captured_queries)} queries vs baseline {baseline}; "
+                f"adding insights with alerts should not grow the per-request query count."
             )
 
     def test_listing_insights_shows_legacy_and_hogql_ones(self) -> None:


### PR DESCRIPTION
## TL;DR (eli5)

When a dashboard has alerts on its insights, opening it made the server ask the database two extra questions for *every single alert* (who's subscribed? what's the threshold?). A dashboard with lots of alerted insights asked hundreds of tiny questions one by one. Now it asks once for all of them upfront — same answer, a fraction of the round trips.

## Problem

`AlertSerializer` serializes `threshold` and `subscribed_users` for every alert, but the alert prefetch on dashboard GET (`DashboardSerializer.get_tiles`) and insight list only does `select_related("created_by")`. Each alert on the page costs two extra Postgres queries, so alert-heavy dashboards degrade to O(alerts) queries per load. Found while benchmarking dashboard loads against real dashboards: an alert-per-insight dashboard paid ~3 extra queries per tile, dwarfing its fixed query cost.

**Why:** follow-up from the query benchmarking of #70085 — the biggest per-tile query multiplier on dashboard load turned out to be alerts, not the fixed costs that PR addresses.

## Changes

- Both alert prefetch sites now use `select_related("created_by", "threshold")` + `prefetch_related("subscribed_users")`.
- Measured on a 30-tile dashboard with two alerts per insight (one threshold, one detector, one subscriber each): **176 → 27 queries, wall time −72%**; query count is now flat as tile count grows.

## How did you test this code?

- `test_insight_alerts_do_not_nplus1_dashboard_gets` (dashboard GET) and `test_listing_insights_with_alerts_does_not_nplus1` (insight list): constant-query-count tests that create insights with threshold + detector alerts and assert the per-request query count doesn't grow with more insights. Each catches the regression of dropping `threshold`/`subscribed_users` from its endpoint's prefetch — no existing test creates alerts on dashboard/listed insights, so this N+1 was invisible to the suite. Both fail on the previous prefetch and pass with this change (verified locally by stashing the fix).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change; no docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: /improving-drf-endpoints, /writing-tests. The N+1 was located by benchmarking dashboard GETs per-commit for #70085, then diffing captured SQL against production dashboards; the repeating statements were per-alert `posthog_user` (subscribed_users, serialized twice per alert) and `posthog_threshold` selects. Fix validated with a standalone query-count benchmark (176 → 27 queries at 30 tiles) and the two new regression tests, run locally against Postgres + ClickHouse.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
