### PR TITLE
chore(eng-analytics): vary seeded flaky deltas between windows

### DIFF
--- a/products/engineering_analytics/backend/management/commands/seed_engineering_analytics.py
+++ b/products/engineering_analytics/backend/management/commands/seed_engineering_analytics.py
@@ -413,8 +413,10 @@ def _seed_trace_spans(team: Team) -> int:
             for day in range(_SPAN_DAYS):
                 is_current = day >= _SPAN_DAYS // 2
                 daily = current_daily if is_current else prior_daily
-                # ±1 wobble so trends read organic, never below zero.
-                daily = max(0, daily + ((day * 7 + test_index * 3) % 3) - 1)
+                # ±1 wobble so trends read organic, never below zero. A quiet window (0/day)
+                # stays truly quiet: one wobble span would qualify the test as flaky there
+                # (min_rerun_passes=1), flattening every roster delta to ±0.
+                daily = max(0, daily + ((day * 7 + test_index * 3) % 3) - 1) if daily else 0
                 for occurrence in range(daily):
                     span_index += 1
                     # Mix of outcomes: retries dominate, with failures (PR-attributed and


### PR DESCRIPTION
## Problem

The seed's ±1 wobble raised quiet (0/day) windows to nonzero, so every seeded test qualified as flaky in both windows (`min_rerun_passes=1`) and the teams roster's flaky-count deltas all read ±0%.

## Changes

- Quiet windows stay at true zero, so the seeded trend shapes (worsening, burst, recovered, flat) show up in the roster deltas

## How did you test this code?

- Re-seeded and read the roster through the real query path: replay 2→3, conversations 0→1, experiments 2→0, batch-exports flat

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; demo-seed tuning only, no production code paths