### PR TITLE
feat(eng-analytics): add prs merged trend to repo overview

### DIFF
--- a/products/engineering_analytics/backend/facade/contracts.py
+++ b/products/engineering_analytics/backend/facade/contracts.py
@@ -1008,6 +1008,19 @@ class OpenToMergeBucket:
 
 
 @dataclass(frozen=True)
+class MergedPRBucket:
+    """One time bucket of merge throughput: pull requests merged in this bucket, all authors and bots
+    included (the same population as the overview's headline ``merged_pr_count``, so the series sums to
+    the tile). Zero-filled: a bucket where nothing merged is a true 0, not a gap.
+    """
+
+    # Bucket start, aligned to the granularity (top of hour / midnight / Monday). Keyed on merge time.
+    bucket_start: datetime
+    # PRs merged in this bucket, all authors and bots included. 0 when nothing merged.
+    merged_count: int
+
+
+@dataclass(frozen=True)
 class RepoOverview:
     """Repo-level headline aggregates for the landing page, each with its previous-window twin
     so the UI renders honest deltas. The previous window has the same length as the current one
@@ -1057,6 +1070,11 @@ class RepoOverview:
     open_to_merge_series: list[OpenToMergeBucket]
     # Bucket width of `open_to_merge_series`, chosen to fit the window: 'hour', 'day', or 'week'.
     open_to_merge_series_granularity: str
+    # Merge-throughput trend: PRs merged per bucket (all authors, bots included; the headline
+    # `merged_pr_count` population), oldest first, zero-filled, bucketed by `merged_pr_series_granularity`.
+    merged_pr_series: list[MergedPRBucket]
+    # Bucket width of `merged_pr_series`, chosen to fit the window: 'hour', 'day', or 'week'.
+    merged_pr_series_granularity: str
 
 
 @dataclass(frozen=True)

--- a/products/engineering_analytics/backend/logic/queries/repo_overview.py
+++ b/products/engineering_analytics/backend/logic/queries/repo_overview.py
@@ -5,7 +5,7 @@ every headline number ships with its previous-window twin and the UI can render 
 honest delta instead of a server-baked percentage. The PR medians (bots and drafts
 excluded, per the locked cycle-time recipe) come from the PR snapshot the same way.
 
-The four chart series are a separate concern with a separate producer
+The chart series are a separate concern with a separate producer
 (``query_repo_series``): every series query computes unconditionally, the shared
 bucket granularity is decided exactly once, and a headline-only consumer composes
 ``query_repo_overview`` with ``empty_repo_series`` instead of flag-switching what
@@ -19,6 +19,7 @@ from posthog.hogql import ast
 
 from products.engineering_analytics.backend.facade.contracts import (
     CostPerMergeBucket,
+    MergedPRBucket,
     OpenToMergeBucket,
     PassRateBucket,
     RepoOverview,
@@ -128,6 +129,48 @@ _OPEN_TO_MERGE_SERIES_SELECT = """
 """
 
 
+# PRs merged per bucket, all authors and bots included: the headline merged_pr_count population,
+# so the series sums to the tile. A bucket where nothing merged is a true 0, not a gap.
+_MERGED_PR_SERIES_SELECT = """
+    SELECT
+        __BUCKET_FN__ AS bucket_start,
+        count() AS merged_count
+    FROM __PR_SOURCE__ AS pr
+    WHERE merged_at IS NOT NULL AND merged_at >= {date_from} __DATE_TO_MERGED__
+    GROUP BY bucket_start
+    LIMIT 40000
+"""
+
+
+def query_merged_pr_series(
+    *,
+    curated: CuratedGitHubSource,
+    date_from: datetime,
+    date_to: datetime | None,
+    granularity: Granularity,
+) -> list[MergedPRBucket]:
+    """PRs merged per bucket across the window, oldest first, all authors and bots included (the
+    headline merged_pr_count population). Zero-filled: no merges in a bucket is honestly 0."""
+    placeholders: dict[str, ast.Expr] = {"date_from": ast.Constant(value=date_from)}
+    date_to_clause = "AND merged_at <= {date_to}" if date_to is not None else ""
+    if date_to is not None:
+        placeholders["date_to"] = ast.Constant(value=date_to)
+    sql = (
+        _MERGED_PR_SERIES_SELECT.replace("__PR_SOURCE__", curated.pr_source())
+        .replace("__DATE_TO_MERGED__", date_to_clause)
+        .replace("__BUCKET_FN__", bucket_expr(granularity, "merged_at"))
+    )
+    response = curated.run(sql, query_type="engineering_analytics.merged_pr_series", placeholders=placeholders)
+    count_by_bucket = {
+        normalize_bucket(bucket_start, granularity): int(merged_count or 0)
+        for bucket_start, merged_count in response.results or []
+    }
+    return [
+        MergedPRBucket(bucket_start=bucket, merged_count=count_by_bucket.get(bucket, 0))
+        for bucket in window_buckets(date_from, date_to, granularity)
+    ]
+
+
 def query_success_rate_series(
     *,
     curated: CuratedGitHubSource,
@@ -191,10 +234,10 @@ def query_open_to_merge_series(
 
 @dataclass(frozen=True)
 class RepoSeries:
-    """The repo hub's four chart series over one window, on one shared bucket granularity.
+    """The repo hub's chart series over one window, on one shared bucket granularity.
 
     Internal to the read layer: ``RepoOverview`` flattens it into the contract's per-series
-    fields. Produced by ``query_repo_series`` (four bucketed scans) or ``empty_repo_series``
+    fields. Produced by ``query_repo_series`` (one bucketed scan per series) or ``empty_repo_series``
     (no scans — the headline-only shape), so callers compose which one they pay for instead
     of the query layer flag-switching what it computes.
     """
@@ -204,6 +247,7 @@ class RepoSeries:
     time_to_green: list[TimeToGreenBucket]
     success_rate: list[PassRateBucket]
     open_to_merge: list[OpenToMergeBucket]
+    merged: list[MergedPRBucket]
 
 
 def query_repo_series(
@@ -212,7 +256,7 @@ def query_repo_series(
     date_from: datetime,
     date_to: datetime | None,
 ) -> RepoSeries:
-    """All four chart series across the window — the one place their shared granularity is decided."""
+    """All chart series across the window — the one place their shared granularity is decided."""
     granularity = pick_granularity(date_from, date_to)
     return RepoSeries(
         granularity=granularity,
@@ -228,6 +272,7 @@ def query_repo_series(
         open_to_merge=query_open_to_merge_series(
             curated=curated, date_from=date_from, date_to=date_to, granularity=granularity
         ),
+        merged=query_merged_pr_series(curated=curated, date_from=date_from, date_to=date_to, granularity=granularity),
     )
 
 
@@ -240,6 +285,7 @@ def empty_repo_series(*, date_from: datetime, date_to: datetime | None) -> RepoS
         time_to_green=[],
         success_rate=[],
         open_to_merge=[],
+        merged=[],
     )
 
 
@@ -326,4 +372,6 @@ def query_repo_overview(
         success_rate_series_granularity=series.granularity,
         open_to_merge_series=series.open_to_merge,
         open_to_merge_series_granularity=series.granularity,
+        merged_pr_series=series.merged,
+        merged_pr_series_granularity=series.granularity,
     )

--- a/products/engineering_analytics/backend/logic/queries/repo_overview.py
+++ b/products/engineering_analytics/backend/logic/queries/repo_overview.py
@@ -142,35 +142,6 @@ _MERGED_PR_SERIES_SELECT = """
 """
 
 
-def query_merged_pr_series(
-    *,
-    curated: CuratedGitHubSource,
-    date_from: datetime,
-    date_to: datetime | None,
-    granularity: Granularity,
-) -> list[MergedPRBucket]:
-    """PRs merged per bucket across the window, oldest first, all authors and bots included (the
-    headline merged_pr_count population). Zero-filled: no merges in a bucket is honestly 0."""
-    placeholders: dict[str, ast.Expr] = {"date_from": ast.Constant(value=date_from)}
-    date_to_clause = "AND merged_at <= {date_to}" if date_to is not None else ""
-    if date_to is not None:
-        placeholders["date_to"] = ast.Constant(value=date_to)
-    sql = (
-        _MERGED_PR_SERIES_SELECT.replace("__PR_SOURCE__", curated.pr_source())
-        .replace("__DATE_TO_MERGED__", date_to_clause)
-        .replace("__BUCKET_FN__", bucket_expr(granularity, "merged_at"))
-    )
-    response = curated.run(sql, query_type="engineering_analytics.merged_pr_series", placeholders=placeholders)
-    count_by_bucket = {
-        normalize_bucket(bucket_start, granularity): int(merged_count or 0)
-        for bucket_start, merged_count in response.results or []
-    }
-    return [
-        MergedPRBucket(bucket_start=bucket, merged_count=count_by_bucket.get(bucket, 0))
-        for bucket in window_buckets(date_from, date_to, granularity)
-    ]
-
-
 def query_success_rate_series(
     *,
     curated: CuratedGitHubSource,
@@ -228,6 +199,35 @@ def query_open_to_merge_series(
     }
     return [
         OpenToMergeBucket(bucket_start=bucket, p50_seconds=p50_by_bucket.get(bucket))
+        for bucket in window_buckets(date_from, date_to, granularity)
+    ]
+
+
+def query_merged_pr_series(
+    *,
+    curated: CuratedGitHubSource,
+    date_from: datetime,
+    date_to: datetime | None,
+    granularity: Granularity,
+) -> list[MergedPRBucket]:
+    """PRs merged per bucket across the window, oldest first, all authors and bots included (the
+    headline merged_pr_count population). Zero-filled: no merges in a bucket is honestly 0."""
+    placeholders: dict[str, ast.Expr] = {"date_from": ast.Constant(value=date_from)}
+    date_to_clause = "AND merged_at <= {date_to}" if date_to is not None else ""
+    if date_to is not None:
+        placeholders["date_to"] = ast.Constant(value=date_to)
+    sql = (
+        _MERGED_PR_SERIES_SELECT.replace("__PR_SOURCE__", curated.pr_source())
+        .replace("__DATE_TO_MERGED__", date_to_clause)
+        .replace("__BUCKET_FN__", bucket_expr(granularity, "merged_at"))
+    )
+    response = curated.run(sql, query_type="engineering_analytics.merged_pr_series", placeholders=placeholders)
+    count_by_bucket = {
+        normalize_bucket(bucket_start, granularity): int(merged_count or 0)
+        for bucket_start, merged_count in response.results or []
+    }
+    return [
+        MergedPRBucket(bucket_start=bucket, merged_count=count_by_bucket.get(bucket, 0))
         for bucket in window_buckets(date_from, date_to, granularity)
     ]
 

--- a/products/engineering_analytics/backend/presentation/serializers/workflows.py
+++ b/products/engineering_analytics/backend/presentation/serializers/workflows.py
@@ -6,6 +6,7 @@ from products.engineering_analytics.backend.facade.contracts import (
     CostPerMergeBucket,
     CurrentBranchHealth,
     MasterFailureGroup,
+    MergedPRBucket,
     OpenToMergeBucket,
     PassRateBucket,
     RepoOverview,
@@ -295,6 +296,20 @@ class OpenToMergeBucketSerializer(DataclassSerializer):
         }
 
 
+class MergedPRBucketSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = MergedPRBucket
+        extra_kwargs = {
+            "bucket_start": {
+                "help_text": "Bucket start, aligned to merged_pr_series_granularity (top of hour, midnight, or Monday)."
+            },
+            "merged_count": {
+                "help_text": "PRs merged in this bucket, all authors and bots included (the headline "
+                "merged_pr_count population). 0 when nothing merged; a true zero, not a gap."
+            },
+        }
+
+
 class RepoOverviewSerializer(DataclassSerializer):
     cost_series = CostPerMergeBucketSerializer(
         many=True,
@@ -318,6 +333,12 @@ class RepoOverviewSerializer(DataclassSerializer):
         help_text="Median time-to-merge (p50 open_to_merge_seconds, bots/drafts excluded) per bucket across "
         "the window, oldest first, bucketed by open_to_merge_series_granularity. Empty buckets carry null; "
         "the whole series is empty when include_series=false.",
+    )
+    merged_pr_series = MergedPRBucketSerializer(
+        many=True,
+        help_text="PRs merged per bucket across the window (all authors, bots included; the headline "
+        "merged_pr_count population), oldest first, zero-filled, bucketed by merged_pr_series_granularity. "
+        "Empty when include_series=false.",
     )
 
     class Meta:
@@ -382,6 +403,9 @@ class RepoOverviewSerializer(DataclassSerializer):
             },
             "open_to_merge_series_granularity": {
                 "help_text": "Bucket width of the open_to_merge_series trend: 'hour', 'day', or 'week'."
+            },
+            "merged_pr_series_granularity": {
+                "help_text": "Bucket width of the merged_pr_series trend: 'hour', 'day', or 'week'."
             },
         }
 

--- a/products/engineering_analytics/backend/presentation/views/workflows.py
+++ b/products/engineering_analytics/backend/presentation/views/workflows.py
@@ -346,8 +346,8 @@ class WorkflowActionsMixin(EngineeringAnalyticsViewSetBase):
                 location=OpenApiParameter.QUERY,
                 required=False,
                 description="Set false to skip the chart series (cost_series, time_to_green_series, "
-                "success_rate_series, open_to_merge_series return empty) and their query cost — for "
-                "headline-only consumers like the weekly digest. Defaults to true.",
+                "success_rate_series, open_to_merge_series, merged_pr_series return empty) and their "
+                "query cost — for headline-only consumers like the weekly digest. Defaults to true.",
             ),
             _SOURCE_ID,
             _REPO,

--- a/products/engineering_analytics/backend/tests/test_logic_workflows.py
+++ b/products/engineering_analytics/backend/tests/test_logic_workflows.py
@@ -214,10 +214,10 @@ class TestWorkflowEndpointsWarehouse(_EndpointsWarehouseMixin, BaseTest):
 
     def test_repo_overview_headlines_and_series_toggle(self) -> None:
         # The weekly digest's whole read path: headline aggregates with include_series=False must
-        # still carry every number the digest renders — merged counts over ALL merged PRs (bots
-        # included: the merge population that triggered the spend) while the median keeps the
-        # locked bots/drafts-excluded recipe, plus job-backed billable minutes — with all four
-        # chart series empty. The default call keeps the series for the UI.
+        # still carry every number the digest renders (merged counts over ALL merged PRs, bots
+        # included: the merge population that triggered the spend; the median keeps the locked
+        # bots/drafts-excluded recipe; job-backed billable minutes) with every chart series
+        # empty. The default call keeps the series for the UI.
         self._create_table(
             "github_pull_requests",
             PULL_REQUESTS_COLUMNS,
@@ -256,11 +256,17 @@ class TestWorkflowEndpointsWarehouse(_EndpointsWarehouseMixin, BaseTest):
         assert overview.time_to_green_series == []
         assert overview.success_rate_series == []
         assert overview.open_to_merge_series == []
+        assert overview.merged_pr_series == []
         assert overview.cost_series_granularity == "day"  # the grain the series would have used
 
         with_series = api.get_repo_overview(team=self.team)
         assert len(with_series.cost_series) > 0  # zero-filled spine across the default -30d window
         assert len(with_series.success_rate_series) > 0
+        # Merge throughput is keyed on merged_at (not created_at) over ALL merged PRs: the bot PR 81
+        # counts, 82 merged before the window doesn't, and the series sums to the headline tile.
+        assert sum(b.merged_count for b in with_series.merged_pr_series) == overview.merged_pr_count
+        merged_days = {b.bucket_start.date() for b in with_series.merged_pr_series if b.merged_count}
+        assert merged_days == {_dt(_ago(2)).date(), _dt(_ago(3)).date()}
 
     def test_workflow_health_aggregates(self) -> None:
         self._seed()

--- a/products/engineering_analytics/backend/tests/test_presentation.py
+++ b/products/engineering_analytics/backend/tests/test_presentation.py
@@ -146,6 +146,8 @@ def _repo_overview() -> contracts.RepoOverview:
         success_rate_series_granularity="day",
         open_to_merge_series=[],
         open_to_merge_series_granularity="day",
+        merged_pr_series=[contracts.MergedPRBucket(bucket_start=datetime(2026, 1, 20, tzinfo=UTC), merged_count=42)],
+        merged_pr_series_granularity="day",
     )
 
 

--- a/products/engineering_analytics/frontend/generated/api.schemas.ts
+++ b/products/engineering_analytics/frontend/generated/api.schemas.ts
@@ -845,6 +845,13 @@ export interface OpenToMergeBucketApi {
     p50_seconds: number | null
 }
 
+export interface MergedPRBucketApi {
+    /** Bucket start, aligned to merged_pr_series_granularity (top of hour, midnight, or Monday). */
+    bucket_start: string
+    /** PRs merged in this bucket, all authors and bots included (the headline merged_pr_count population). 0 when nothing merged; a true zero, not a gap. */
+    merged_count: number
+}
+
 export interface RepoOverviewApi {
     /** CI cost per merged PR across the window, oldest first, zero-filled, bucketed by cost_series_granularity. Empty when the job-level source isn't synced or include_series=false. */
     cost_series: CostPerMergeBucketApi[]
@@ -854,6 +861,8 @@ export interface RepoOverviewApi {
     success_rate_series: PassRateBucketApi[]
     /** Median time-to-merge (p50 open_to_merge_seconds, bots/drafts excluded) per bucket across the window, oldest first, bucketed by open_to_merge_series_granularity. Empty buckets carry null; the whole series is empty when include_series=false. */
     open_to_merge_series: OpenToMergeBucketApi[]
+    /** PRs merged per bucket across the window (all authors, bots included; the headline merged_pr_count population), oldest first, zero-filled, bucketed by merged_pr_series_granularity. Empty when include_series=false. */
+    merged_pr_series: MergedPRBucketApi[]
     /** Workflow runs started in the window, all branches and workflows. */
     run_count: number
     /** Same count over the equal-length window immediately before date_from — the delta baseline. */
@@ -918,6 +927,8 @@ export interface RepoOverviewApi {
     success_rate_series_granularity: string
     /** Bucket width of the open_to_merge_series trend: 'hour', 'day', or 'week'. */
     open_to_merge_series_granularity: string
+    /** Bucket width of the merged_pr_series trend: 'hour', 'day', or 'week'. */
+    merged_pr_series_granularity: string
 }
 
 export interface WorkflowRunActivityPointApi {
@@ -1449,7 +1460,7 @@ export type EngineeringAnalyticsRepoOverviewParams = {
      */
     date_to?: string
     /**
-     * Set false to skip the chart series (cost_series, time_to_green_series, success_rate_series, open_to_merge_series return empty) and their query cost — for headline-only consumers like the weekly digest. Defaults to true.
+     * Set false to skip the chart series (cost_series, time_to_green_series, success_rate_series, open_to_merge_series, merged_pr_series return empty) and their query cost — for headline-only consumers like the weekly digest. Defaults to true.
      */
     include_series?: boolean
     /**

--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.stories.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.stories.tsx
@@ -61,6 +61,12 @@ const OVERVIEW: RepoOverviewApi = {
         })
     ),
     open_to_merge_series_granularity: 'day',
+    // Sums to merged_pr_count so the card's headline tile and its bars agree.
+    merged_pr_series: [6, 9, 12, 7, 8, 10, 4].map((merged_count, i) => ({
+        bucket_start: `2026-06-${25 + i}T00:00:00Z`,
+        merged_count,
+    })),
+    merged_pr_series_granularity: 'day',
 }
 
 const ACTIVITY: WorkflowRunActivityApi = {

--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
@@ -33,7 +33,7 @@ import { githubCommitUrl } from '../lib/github'
 import { HUB_PREVIEW_MAX } from '../lib/preview'
 import { withCurrentScope, withScope } from '../lib/scope'
 import { engineeringAnalyticsLogic } from './engineeringAnalyticsLogic'
-import { repoOverviewLogic } from './repoOverviewLogic'
+import { bucketGranularity, repoOverviewLogic } from './repoOverviewLogic'
 
 function withSource(url: string, sourceId: string | null): string {
     return withCurrentScope(url, sourceId)
@@ -433,8 +433,6 @@ export function RepoOverviewScene(): JSX.Element {
                                     type="bar"
                                     maximumIndicator={false}
                                     className="h-16 w-full"
-                                    renderLabel={(label) => label}
-                                    renderTooltipValue={(value) => humanFriendlyNumber(value)}
                                 />
                             </>
                         ) : (
@@ -443,13 +441,8 @@ export function RepoOverviewScene(): JSX.Element {
                             </div>
                         )}
                         <div className="mt-2 border-t border-primary pt-2 text-[11px] text-tertiary">
-                            Pull requests merged per{' '}
-                            {overview?.merged_pr_series_granularity === 'hour'
-                                ? 'hour'
-                                : overview?.merged_pr_series_granularity === 'week'
-                                  ? 'week'
-                                  : 'day'}
-                            , bots included. Total for the window vs the one before it.
+                            Pull requests merged per {bucketGranularity(overview?.merged_pr_series_granularity)}, bots
+                            included. Total for the window vs the one before it.
                         </div>
                     </LemonCard>
 

--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
@@ -7,6 +7,7 @@ import { router } from 'kea-router'
 import { LemonButton, LemonCard, LemonSkeleton, LemonTable, LemonTag, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 import { TimeSeriesLineChart, useChartTheme } from '@posthog/quill-charts'
 
+import { Sparkline } from 'lib/components/Sparkline'
 import { TZLabel } from 'lib/components/TZLabel'
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
@@ -17,6 +18,7 @@ import { CIAnalyticsLoadError } from '../components/CIAnalyticsLoadError'
 import { ConnectGitHubSource } from '../components/ConnectGitHubSource'
 import { RepoEntityHeader } from '../components/EntityHeader'
 import { FailureLogGroups } from '../components/FailureLogs'
+import { DeltaBadge, percentChange } from '../components/MetricTile'
 import { PullRequestTable } from '../components/PullRequestTable'
 import { formatAxisMinutes, hasEnoughRunActivity } from '../components/RunActivityChart'
 import { RunActivityMiniBars } from '../components/RunActivityMiniBars'
@@ -244,6 +246,7 @@ export function RepoOverviewScene(): JSX.Element {
         timeToGreenSeries,
         passRateSeries,
         openToMergeSeries,
+        mergedPrSeries,
         jobsAvailable,
         overviewDefaultBranch,
         currentDefaultBranch,
@@ -405,11 +408,56 @@ export function RepoOverviewScene(): JSX.Element {
                         caption="Median created-to-merged time, bots and drafts excluded. Coarse: draft and ready time are fused."
                     />
 
-                    {/* CI cost per merged PR — the headline economic trend, so it earns a full quill line
-                        chart (axes + tooltip) rather than a sparkline. costPerMergeSeries carries ISO labels
-                        plus its interval; the chart owns tick/tooltip date formatting. Card chrome mirrors
-                        TrendCard so it sits flush in the grid. */}
+                    {/* Merge throughput: how much shipped. Unlike the TrendCards, the headline is the window
+                        total with its honest prior-window delta (the last bucket is usually partial, so a
+                        latest-bucket headline would read misleadingly low). Bars, not a line: counts per
+                        bucket are discrete sums. */}
                     <LemonCard hoverEffect={false} className="flex flex-col p-4">
+                        <h3 className="mb-1 text-xs font-semibold text-secondary">PRs merged</h3>
+                        {overviewPending ? (
+                            <LemonSkeleton className="h-20 w-full" />
+                        ) : mergedPrSeries ? (
+                            <>
+                                <div className="mb-1 flex items-baseline gap-2">
+                                    <span className="text-2xl font-semibold leading-none tabular-nums">
+                                        {humanFriendlyNumber(overview?.merged_pr_count ?? 0)}
+                                    </span>
+                                    <DeltaBadge
+                                        value={percentChange(overview?.merged_pr_count, overview?.merged_pr_count_prev)}
+                                    />
+                                </div>
+                                <Sparkline
+                                    data={mergedPrSeries.values}
+                                    labels={mergedPrSeries.labels}
+                                    name="PRs merged"
+                                    type="bar"
+                                    maximumIndicator={false}
+                                    className="h-16 w-full"
+                                    renderLabel={(label) => label}
+                                    renderTooltipValue={(value) => humanFriendlyNumber(value)}
+                                />
+                            </>
+                        ) : (
+                            <div className="flex h-20 items-center text-xs text-secondary">
+                                No merge data in the window yet.
+                            </div>
+                        )}
+                        <div className="mt-2 border-t border-primary pt-2 text-[11px] text-tertiary">
+                            Pull requests merged per{' '}
+                            {overview?.merged_pr_series_granularity === 'hour'
+                                ? 'hour'
+                                : overview?.merged_pr_series_granularity === 'week'
+                                  ? 'week'
+                                  : 'day'}
+                            , bots included. Total for the window vs the one before it.
+                        </div>
+                    </LemonCard>
+
+                    {/* CI cost per merged PR — the headline economic trend, so it earns a full-width quill
+                        line chart (axes + tooltip) rather than a sparkline. costPerMergeSeries carries ISO
+                        labels plus its interval; the chart owns tick/tooltip date formatting. Card chrome
+                        mirrors TrendCard so it sits flush in the grid. */}
+                    <LemonCard hoverEffect={false} className="flex flex-col p-4 md:col-span-2">
                         <h3 className="mb-1 text-xs font-semibold text-secondary">Cost per merged PR</h3>
                         {overviewPending ? (
                             <LemonSkeleton className="h-20 w-full" />

--- a/products/engineering_analytics/frontend/scenes/repoOverviewLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/repoOverviewLogic.ts
@@ -540,6 +540,23 @@ export const repoOverviewLogic = kea<repoOverviewLogicType>([
                 return { values, labels: trimmed.map((bucket) => dayjs(bucket.bucket_start).format(fmt)) }
             },
         ],
+        // Merge throughput per bucket (all authors, bots included: the headline merged_pr_count
+        // population). Zero-filled by the backend, and a bucket with no merges is a true 0, so no
+        // carry-forward or trimming. Null when the series is absent (include_series=false).
+        mergedPrSeries: [
+            (s) => [s.overview],
+            (overview): { values: number[]; labels: string[] } | null => {
+                const series = overview?.merged_pr_series ?? []
+                if (!series.length) {
+                    return null
+                }
+                const fmt = overview?.merged_pr_series_granularity === 'hour' ? 'MMM D HH:mm' : 'MMM D'
+                return {
+                    values: series.map((bucket) => bucket.merged_count),
+                    labels: series.map((bucket) => dayjs(bucket.bucket_start).format(fmt)),
+                }
+            },
+        ],
         // Time-to-merge trend in seconds (median open→merge, bots/drafts excluded). Same carry-forward +
         // trim as time-to-green: a gap means "nothing merged", not instant merges, so zero-filling would
         // draw a false dip. Null when no bucket had a qualifying merge.

--- a/products/engineering_analytics/frontend/scenes/repoOverviewLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/repoOverviewLogic.ts
@@ -32,6 +32,11 @@ const MASTER_FAILURES_WINDOW = '-24h'
 
 const TOP_COST_WORKFLOWS = 5
 
+/** A series' bucket width as one of the three the backend picks; anything unexpected reads as a day. */
+export function bucketGranularity(granularity: string | undefined): 'hour' | 'day' | 'week' {
+    return granularity === 'hour' || granularity === 'week' ? granularity : 'day'
+}
+
 export interface CostShareRow {
     workflowName: string | null
     costUsd: number
@@ -76,6 +81,10 @@ export interface repoOverviewLogicValues {
     jobsAvailable: boolean
     masterFailures: MasterFailureGroupApi[]
     masterFailuresLoading: boolean
+    mergedPrSeries: {
+        labels: string[]
+        values: number[]
+    } | null
     openToMergeSeries: {
         labels: string[]
         values: number[]
@@ -220,6 +229,10 @@ export interface repoOverviewLogicMeta {
             values: number[]
         } | null
         passRateSeries: (overview: RepoOverviewApi | null) => {
+            labels: string[]
+            values: number[]
+        } | null
+        mergedPrSeries: (overview: RepoOverviewApi | null) => {
             labels: string[]
             values: number[]
         } | null
@@ -485,11 +498,10 @@ export const repoOverviewLogic = kea<repoOverviewLogicType>([
                 if (firstData === -1) {
                     return null
                 }
-                const granularity = overview?.cost_series_granularity
                 return {
                     values: series.map((bucket) => bucket.cost_per_merge_usd ?? 0),
                     labels: series.map((bucket) => bucket.bucket_start),
-                    interval: granularity === 'hour' ? 'hour' : granularity === 'week' ? 'week' : 'day',
+                    interval: bucketGranularity(overview?.cost_series_granularity),
                 }
             },
         ],
@@ -545,7 +557,7 @@ export const repoOverviewLogic = kea<repoOverviewLogicType>([
         // carry-forward or trimming. Null when the series is absent (include_series=false).
         mergedPrSeries: [
             (s) => [s.overview],
-            (overview): { values: number[]; labels: string[] } | null => {
+            (overview: RepoOverviewApi | null): { values: number[]; labels: string[] } | null => {
                 const series = overview?.merged_pr_series ?? []
                 if (!series.length) {
                     return null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -38341,6 +38341,13 @@ export namespace Schemas {
       scraping_status?: ScrapingStatusEnum | BlankEnum | null;
     }
 
+    export interface MergedPRBucket {
+      /** Bucket start, aligned to merged_pr_series_granularity (top of hour, midnight, or Monday). */
+      bucket_start: string;
+      /** PRs merged in this bucket, all authors and bots included (the headline merged_pr_count population). 0 when nothing merged; a true zero, not a gap. */
+      merged_count: number;
+    }
+
     export type MessageContextualTools = { [key: string]: unknown };
 
     /**
@@ -58121,6 +58128,8 @@ export namespace Schemas {
       success_rate_series: PassRateBucket[];
       /** Median time-to-merge (p50 open_to_merge_seconds, bots/drafts excluded) per bucket across the window, oldest first, bucketed by open_to_merge_series_granularity. Empty buckets carry null; the whole series is empty when include_series=false. */
       open_to_merge_series: OpenToMergeBucket[];
+      /** PRs merged per bucket across the window (all authors, bots included; the headline merged_pr_count population), oldest first, zero-filled, bucketed by merged_pr_series_granularity. Empty when include_series=false. */
+      merged_pr_series: MergedPRBucket[];
       /** Workflow runs started in the window, all branches and workflows. */
       run_count: number;
       /** Same count over the equal-length window immediately before date_from — the delta baseline. */
@@ -58185,6 +58194,8 @@ export namespace Schemas {
       success_rate_series_granularity: string;
       /** Bucket width of the open_to_merge_series trend: 'hour', 'day', or 'week'. */
       open_to_merge_series_granularity: string;
+      /** Bucket width of the merged_pr_series trend: 'hour', 'day', or 'week'. */
+      merged_pr_series_granularity: string;
     }
 
     export type ReportPriority = typeof ReportPriority[keyof typeof ReportPriority];
@@ -73466,7 +73477,7 @@ export namespace Schemas {
      */
     date_to?: string;
     /**
-     * Set false to skip the chart series (cost_series, time_to_green_series, success_rate_series, open_to_merge_series return empty) and their query cost — for headline-only consumers like the weekly digest. Defaults to true.
+     * Set false to skip the chart series (cost_series, time_to_green_series, success_rate_series, open_to_merge_series, merged_pr_series return empty) and their query cost — for headline-only consumers like the weekly digest. Defaults to true.
      */
     include_series?: boolean;
     /**


### PR DESCRIPTION
## Problem

Repo overview trends cover pass rate, time to green, open→merge, and cost, but not throughput (PRs merged over time).

## Changes

- `merged_pr_series` on `repo_overview`: PRs merged per bucket, keyed on `merged_at`, zero-filled, same all-merged population as the headline tile
- "PRs merged" card: window total with prior-window delta over per-bucket bars (the latest bucket is usually partial, so the headline is the window total); the cost chart now spans the full row
- Regenerated OpenAPI/frontend/MCP types; drops a redundant Teams banner sentence

![prs merged card](https://raw.githubusercontent.com/PostHog/pr-assets/b130c117151b2e5d8ac2b668b48a1aca139fcd7d/2026/07/79616eb0-dc46-43ee-8c75-291a247a1493.png)

## How did you test this code?

- Extended `test_repo_overview_headlines_and_series_toggle`: the series sums to the headline, buckets key on `merged_at` not `created_at`, empty with `include_series=false`
- Verified in the seeded app (screenshot); typescript check green

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; skills: /improving-drf-endpoints, /writing-tests, dataviz