### PR TITLE
feat(eng-analytics): enable team ci activity mcp tool

### DIFF
--- a/products/engineering_analytics/mcp/tools.yaml
+++ b/products/engineering_analytics/mcp/tools.yaml
@@ -169,7 +169,24 @@ tools:
         feature_flag: engineering-analytics
     engineering-analytics-team-ci-activity:
         operation: engineering_analytics_team_ci_activity
-        enabled: false
+        enabled: true
+        scopes:
+            - engineering_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: One team's CI test activity
+        description: >
+            One team's CI test-health detail over a window (date_from default -14d, maximum 30 days): the daily
+            signal series (failed/error, pass-on-retry, and quarantined-but-still-failing counts per day) plus
+            per-test current-vs-prior signal pairs (signal_count vs signal_count_prior over equal-length windows),
+            capped at test_limit with truncated_tests set when more qualified. Call it after the team-ci-health
+            roster points at a team, passing owner_team exactly as the roster returned it (including the literal
+            'unowned', which holds spans with no ownership stamp). Each test row carries the pytest nodeid and a
+            runnable selector for reproducing locally. Counts are absolute signal, never rates: fast passing runs
+            are not emitted, so there is no honest denominator.
+        feature_flag: engineering-analytics
     engineering-analytics-team-ci-health:
         operation: engineering_analytics_team_ci_health
         enabled: true

--- a/products/engineering_analytics/mcp/tools.yaml
+++ b/products/engineering_analytics/mcp/tools.yaml
@@ -178,14 +178,14 @@ tools:
             idempotent: true
         title: One team's CI test activity
         description: >
-            One team's CI test-health detail over a window (date_from default -14d, maximum 30 days): the daily
-            signal series (failed/error, pass-on-retry, and quarantined-but-still-failing counts per day) plus
-            per-test current-vs-prior signal pairs (signal_count vs signal_count_prior over equal-length windows),
-            capped at test_limit with truncated_tests set when more qualified. Call it after the team-ci-health
-            roster points at a team, passing owner_team exactly as the roster returned it (including the literal
-            'unowned', which holds spans with no ownership stamp). Each test row carries the pytest nodeid and a
-            runnable selector for reproducing locally. Counts are absolute signal, never rates: fast passing runs
-            are not emitted, so there is no honest denominator.
+            One team's CI test-health detail over a window (date_from default -14d, maximum 30 days): the daily signal
+            series (failed/error, pass-on-retry, and quarantined-but-still-failing counts per day) plus per-test
+            current-vs-prior signal pairs (signal_count vs signal_count_prior over equal-length windows), capped at
+            test_limit with truncated_tests set when more qualified. Call it after the team-ci-health roster points at a
+            team, passing owner_team exactly as the roster returned it (including the literal 'unowned', which holds
+            spans with no ownership stamp). Each test row carries the pytest nodeid and a runnable selector for
+            reproducing locally. Counts are absolute signal, never rates: fast passing runs are not emitted, so there is
+            no honest denominator.
         feature_flag: engineering-analytics
     engineering-analytics-team-ci-health:
         operation: engineering_analytics_team_ci_health

--- a/products/engineering_analytics/skills/diagnosing-ci-and-merge-bottlenecks/SKILL.md
+++ b/products/engineering_analytics/skills/diagnosing-ci-and-merge-bottlenecks/SKILL.md
@@ -5,9 +5,11 @@ description: >
   pull-requests (PR list with CI status), workflow-health (per-workflow CI trends), and pr-lifecycle (a single PR's
   timeline). Use when asked whether CI is getting faster or slower, which GitHub Actions workflow is the slow or
   flaky long-pole, how long PRs take from open to merge, how an author's merge time compares to the cohort, which
-  open PRs have failing or pending CI, or where a specific pull request is stuck. Triggers on "engineering
-  analytics", "is CI getting slower", "slow workflow", "flaky CI", "time to merge", "cycle time", "PR throughput",
-  "failing checks", "where is PR <n> stuck", "CI long pole", "what's holding up this PR".
+  open PRs have failing or pending CI, or where a specific pull request is stuck. Also routes CI health to owning
+  teams: which team owns the flakiest test surfaces, and whether one team's CI signal is getting better or worse.
+  Triggers on "engineering analytics", "is CI getting slower", "slow workflow", "flaky CI", "time to merge",
+  "cycle time", "PR throughput", "failing checks", "where is PR <n> stuck", "CI long pole", "what's holding up
+  this PR", "which team owns", "team CI health".
 ---
 
 # Diagnosing CI and merge bottlenecks
@@ -44,6 +46,18 @@ autonomous agents (e.g. PostHog Code) reasoning about their own PRs.
   flaky right now" and picks quarantine candidates; `xfailed_count > 0` means already quarantined but still
   failing. Counts are absolute signal, never rates — passing runs are mostly not emitted, so there is no honest
   denominator.
+- **`engineering-analytics-team-ci-health`**: the per-owning-team roster over a window (`date_from` default
+  `-14d`, max 30 days): flaky-test count (the leaderboard's qualification bar applied per team), failed/error
+  and pass-on-retry span counts, each with an equal-length previous-window twin (`*_prior`) for honest deltas.
+  Answers "which team owns the flakiest surfaces" and routes a CI finding to its owning team. Ownership is
+  stamped on each test span at CI emission time from the repo's ownership map (products/\*/product.yaml +
+  CODEOWNERS); a nonempty `unowned` row means ownership gaps, not a real team. Teams own code surfaces, never
+  authors.
+- **`engineering-analytics-team-ci-activity`**: one team's drill-down: the daily signal series over the window
+  plus per-test current-vs-prior signal pairs, capped at `test_limit` (`truncated_tests` set when more
+  qualified). Answers "is this team's CI health getting better or worse, and which tests moved". Pass
+  `owner_team` exactly as the roster returned it (including `unowned`); each test row carries the pytest nodeid
+  and a runnable selector.
 
 There is no aggregate time-to-merge tool and no "counts" tool — derive those from `pull-requests` (the stuck/failing
 counts, the merge-time percentiles).
@@ -68,17 +82,23 @@ These are structural limits of today's snapshot data — state them, don't paper
   match, and there is no repo or limit filter to narrow the call. When `truncated` is `true`, any percentile or
   count you derive covers only the newest page — not the whole window — so say so and shrink `date_from` until the
   real set fits under the cap.
+- **Team attribution is capture-time ownership.** Test spans are stamped with the owning team when CI emits them,
+  so a test is attributed to whoever owned it when it ran, and spans emitted before the stamp existed (or from
+  paths with no owner) aggregate under `unowned`. Report a growing `unowned` row as an ownership gap to fix, never
+  as a team.
 
 ## Choosing a tool
 
-| The question                                           | Tool                                | How                                                                                                                                                                                                                                                                                            |
-| ------------------------------------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Is CI getting slower? Which workflow is the long pole? | `workflow-health`                   | Call over two adjacent windows (e.g. `date_from=-14d`, then `date_from=-28d` `date_to=-14d`); compare `p50_seconds` and `p95_seconds` per workflow. Lead with the median but always check p95 separately — they move independently.                                                            |
-| Which open PRs have failing or pending CI?             | `pull-requests`                     | Keep rows where `ci.failing > 0` or `ci.pending > 0`. `pending` means unsettled (or stale) — not a settled failure.                                                                                                                                                                            |
-| Which PRs are stuck open longest?                      | `pull-requests`                     | Keep `state = open`, not `is_draft`, not `author.is_bot`; sort by `created_at` ascending (oldest first).                                                                                                                                                                                       |
-| How long are PRs taking to merge? Per author?          | `pull-requests`                     | Over merged rows (`merged_at` set, not bot, not draft), aggregate `open_to_merge_seconds` — median and p95. Group by `author.handle` for **cohort context, not a ranking** (per-developer surveillance is an explicit non-goal). Trend it by calling with two `date_from` windows.             |
-| Where is PR N stuck?                                   | `pr-lifecycle`                      | Walk the sorted events: `opened → first CI started`, the CI span (first start → last finish; one pair per workflow), `last CI finished → merged`. The largest gap is the bottleneck. A long open→merge with quick CI points at review/idle time the `partial` data can't itemize yet — say so. |
-| Which tests are flaky? What should be quarantined?     | `engineering-analytics-flaky-tests` | Default window is `-7d`; rows are already ranked by `rerun_passed_count` + `failed_pr_count`. Report counts, never rates. A no-rerun lane surfaces flakes as plain failures — that's what `failed_pr_count` catches.                                                                           |
+| The question                                           | Tool                                     | How                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Is CI getting slower? Which workflow is the long pole? | `workflow-health`                        | Call over two adjacent windows (e.g. `date_from=-14d`, then `date_from=-28d` `date_to=-14d`); compare `p50_seconds` and `p95_seconds` per workflow. Lead with the median but always check p95 separately — they move independently.                                                            |
+| Which open PRs have failing or pending CI?             | `pull-requests`                          | Keep rows where `ci.failing > 0` or `ci.pending > 0`. `pending` means unsettled (or stale) — not a settled failure.                                                                                                                                                                            |
+| Which PRs are stuck open longest?                      | `pull-requests`                          | Keep `state = open`, not `is_draft`, not `author.is_bot`; sort by `created_at` ascending (oldest first).                                                                                                                                                                                       |
+| How long are PRs taking to merge? Per author?          | `pull-requests`                          | Over merged rows (`merged_at` set, not bot, not draft), aggregate `open_to_merge_seconds` — median and p95. Group by `author.handle` for **cohort context, not a ranking** (per-developer surveillance is an explicit non-goal). Trend it by calling with two `date_from` windows.             |
+| Where is PR N stuck?                                   | `pr-lifecycle`                           | Walk the sorted events: `opened → first CI started`, the CI span (first start → last finish; one pair per workflow), `last CI finished → merged`. The largest gap is the bottleneck. A long open→merge with quick CI points at review/idle time the `partial` data can't itemize yet — say so. |
+| Which tests are flaky? What should be quarantined?     | `engineering-analytics-flaky-tests`      | Default window is `-7d`; rows are already ranked by `rerun_passed_count` + `failed_pr_count`. Report counts, never rates. A no-rerun lane surfaces flakes as plain failures — that's what `failed_pr_count` catches.                                                                           |
+| Which team owns the flakiest CI surfaces?              | `engineering-analytics-team-ci-health`   | Default window is `-14d`. Rank by `flaky_test_count` + `failed_count`; compare each figure to its `*_prior` twin for the trend. Report a nonempty `unowned` row as an ownership gap, not a team.                                                                                               |
+| Is team X's CI getting better or worse? What moved?    | `engineering-analytics-team-ci-activity` | Pass `owner_team` from the roster verbatim. Compare `signal_count` vs `signal_count_prior` per test; the daily series shows when it moved. Use each row's selector to run the test locally.                                                                                                    |
 
 ## The high-value chain
 
@@ -92,6 +112,17 @@ workflow-health  (find the slow/flaky long-pole workflow)
 
 "CI median rose because `e2e-playwright` p95 doubled; that workflow is the long pole on PR #1234, which sat 47m in
 CI before merging."
+
+For routing flaky-test health to owners, the chain runs roster to drill-down:
+
+```text
+team-ci-health  (which team owns the flakiest surfaces; is 'unowned' growing)
+   → team-ci-activity  (that team's daily trend and the specific tests that moved)
+      → engineering-analytics-flaky-tests  (cross-team context for the same tests)
+```
+
+"batch-exports holds 4 of the top 10 flaky tests, flat vs the prior window; team-replay is the mover, 2 to 3
+qualifying tests, driven by test_snapshot_batching (9 signal spans vs 2 prior)."
 
 ## Output expectations
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2696,6 +2696,21 @@
         },
         "feature_flag": "engineering-analytics"
     },
+    "engineering-analytics-team-ci-activity": {
+        "description": "One team's CI test-health detail over a window (date_from default -14d, maximum 30 days): the daily signal series (failed/error, pass-on-retry, and quarantined-but-still-failing counts per day) plus per-test current-vs-prior signal pairs (signal_count vs signal_count_prior over equal-length windows), capped at test_limit with truncated_tests set when more qualified. Call it after the team-ci-health roster points at a team, passing owner_team exactly as the roster returned it (including the literal 'unowned', which holds spans with no ownership stamp). Each test row carries the pytest nodeid and a runnable selector for reproducing locally. Counts are absolute signal, never rates: fast passing runs are not emitted, so there is no honest denominator.",
+        "category": "Engineering analytics",
+        "feature": "engineering_analytics",
+        "summary": "One team's CI test activity",
+        "title": "One team's CI test activity",
+        "required_scopes": ["engineering_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "engineering-analytics"
+    },
     "engineering-analytics-team-ci-health": {
         "description": "Per-owning-team rollup of the CI test surfaces each team owns, over a window (date_from default -14d, maximum 30 days): flaky-test count (same qualification bar as the flaky-test leaderboard), failed/error span count, and pass-on-retry count, each with an equal-length previous-window twin (*_prior) for honest deltas. Use this for \"which team owns the flakiest surfaces right now\" and to route a flaky-test or CI Signal to its owning team. Ownership is stamped on the spans at CI emission time from the repo's ownership map (products/*/product.yaml + CODEOWNERS); spans without a stamp aggregate under the literal team 'unowned' (a nonempty 'unowned' row means ownership gaps, not a real team). Teams are organizational owners of code surfaces, never authors. Read all counts as absolute signal, never rates: fast passing runs are not emitted, so there is no honest denominator.",
         "category": "Engineering analytics",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2739,6 +2739,21 @@
         },
         "feature_flag": "engineering-analytics"
     },
+    "engineering-analytics-team-ci-activity": {
+        "description": "One team's CI test-health detail over a window (date_from default -14d, maximum 30 days): the daily signal series (failed/error, pass-on-retry, and quarantined-but-still-failing counts per day) plus per-test current-vs-prior signal pairs (signal_count vs signal_count_prior over equal-length windows), capped at test_limit with truncated_tests set when more qualified. Call it after the team-ci-health roster points at a team, passing owner_team exactly as the roster returned it (including the literal 'unowned', which holds spans with no ownership stamp). Each test row carries the pytest nodeid and a runnable selector for reproducing locally. Counts are absolute signal, never rates: fast passing runs are not emitted, so there is no honest denominator.",
+        "category": "Engineering analytics",
+        "feature": "engineering_analytics",
+        "summary": "One team's CI test activity",
+        "title": "One team's CI test activity",
+        "required_scopes": ["engineering_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "engineering-analytics"
+    },
     "engineering-analytics-team-ci-health": {
         "description": "Per-owning-team rollup of the CI test surfaces each team owns, over a window (date_from default -14d, maximum 30 days): flaky-test count (same qualification bar as the flaky-test leaderboard), failed/error span count, and pass-on-retry count, each with an equal-length previous-window twin (*_prior) for honest deltas. Use this for \"which team owns the flakiest surfaces right now\" and to route a flaky-test or CI Signal to its owning team. Ownership is stamped on the spans at CI emission time from the repo's ownership map (products/*/product.yaml + CODEOWNERS); spans without a stamp aggregate under the literal team 'unowned' (a nonempty 'unowned' row means ownership gaps, not a real team). Teams are organizational owners of code surfaces, never authors. Read all counts as absolute signal, never rates: fast passing runs are not emitted, so there is no honest denominator.",
         "category": "Engineering analytics",

--- a/services/mcp/src/generated/engineering_analytics/api.ts
+++ b/services/mcp/src/generated/engineering_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 12 enabled ops
+ * PostHog API - MCP 13 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -186,6 +186,42 @@ export const EngineeringAnalyticsSourcesParams = /* @__PURE__ */ zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
+})
+
+/**
+ * One owning team's CI test activity: the daily signal series over the window plus per-test current-vs-prior signal pairs (the before/after comparison behind a slope chart). Signal = failed + error + pass-on-retry spans on the team's owned tests. All figures are absolute counts, never rates: fast passing runs are not emitted, so denominators are biased. Pass-on-retry counts only flow from CI lanes running with reruns enabled; in other lanes a flake surfaces as a plain failure, which the distinct-PR count catches.
+ */
+export const EngineeringAnalyticsTeamCiActivityParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const EngineeringAnalyticsTeamCiActivityQueryParams = /* @__PURE__ */ zod.object({
+    date_from: zod
+        .string()
+        .optional()
+        .describe(
+            "Window start: relative ('-14d', '-7d') or ISO8601. Defaults to -14d; the window may span at most 30 days. An equal-length prior window feeds the *_prior twins."
+        ),
+    date_to: zod.string().optional().describe('Window end: relative or ISO8601. Defaults to now.'),
+    owner_team: zod
+        .string()
+        .describe(
+            "Owning team slug to scope to (as returned by team_ci_health), e.g. 'team-replay', or the literal 'unowned' for tests with no ownership stamp."
+        ),
+    source_id: zod
+        .string()
+        .optional()
+        .describe(
+            'Connected GitHub data warehouse source to read from. Defaults to the oldest connected GitHub source when the team has more than one.'
+        ),
+    test_limit: zod
+        .number()
+        .optional()
+        .describe('Maximum number of per-test signal rows to return (1-100). Defaults to 25.'),
 })
 
 /**

--- a/services/mcp/src/tools/generated/engineering_analytics.ts
+++ b/services/mcp/src/tools/generated/engineering_analytics.ts
@@ -10,6 +10,7 @@ import {
     EngineeringAnalyticsPrLifecycleQueryParams,
     EngineeringAnalyticsPullRequestsQueryParams,
     EngineeringAnalyticsRunFailureLogsQueryParams,
+    EngineeringAnalyticsTeamCiActivityQueryParams,
     EngineeringAnalyticsTeamCiHealthQueryParams,
     EngineeringAnalyticsWorkflowHealthQueryParams,
     EngineeringAnalyticsWorkflowJobsQueryParams,
@@ -146,6 +147,31 @@ const engineeringAnalyticsSources = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/engineering_analytics/sources/`,
         })
         return await withPostHogUrl(context, result, '/engineering-analytics')
+    },
+})
+
+const EngineeringAnalyticsTeamCiActivitySchema = EngineeringAnalyticsTeamCiActivityQueryParams
+
+const engineeringAnalyticsTeamCiActivity = (): ToolBase<
+    typeof EngineeringAnalyticsTeamCiActivitySchema,
+    Schemas.TeamCIActivity
+> => ({
+    name: 'engineering-analytics-team-ci-activity',
+    schema: EngineeringAnalyticsTeamCiActivitySchema,
+    handler: async (context: Context, params: z.infer<typeof EngineeringAnalyticsTeamCiActivitySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.TeamCIActivity>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/engineering_analytics/team_ci_activity/`,
+            query: {
+                date_from: params.date_from,
+                date_to: params.date_to,
+                owner_team: params.owner_team,
+                source_id: params.source_id,
+                test_limit: params.test_limit,
+            },
+        })
+        return result
     },
 })
 
@@ -307,6 +333,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'engineering-analytics-pr-cost': engineeringAnalyticsPrCost,
     'engineering-analytics-run-failure-logs': engineeringAnalyticsRunFailureLogs,
     'engineering-analytics-sources': engineeringAnalyticsSources,
+    'engineering-analytics-team-ci-activity': engineeringAnalyticsTeamCiActivity,
     'engineering-analytics-team-ci-health': engineeringAnalyticsTeamCiHealth,
     'engineering-analytics-workflow-jobs': engineeringAnalyticsWorkflowJobs,
     'engineering-analytics-workflow-runner-costs': engineeringAnalyticsWorkflowRunnerCosts,


### PR DESCRIPTION
## Problem

The `team-ci-health` roster tool routes a CI finding to its owning team, but its drill-down (`team_ci_activity`) was disabled and the skill taught neither, so agents fell back to the unscoped flaky-test leaderboard.

## Changes

- Enable `engineering-analytics-team-ci-activity` (read-only annotations; the description carries the absolute-counts and `unowned` caveats)
- The `diagnosing-ci-and-merge-bottlenecks` skill now teaches both team tools, the capture-time-ownership caveat, and the roster→drill-down routing chain

## How did you test this code?

- MCP consistency tests (4) pass; tool codegen regenerated from `tools.yaml`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- Skill doc updated in the same PR

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; enabling the drill-down keeps the MCP surface consistent with the already-enabled roster