### PR TITLE
chore(rust): bump posthog-rs to 0.19.2

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7918,9 +7918,9 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b19b9f71d36b4f2bd5c6b4db79a1d62c11b7ecf6772294aa5128711ca961f0b"
+checksum = "00dc758929b9fac69336c971480a409cb55eed413a4a4cbaf06aa25776442d72"
 dependencies = [
  "backtrace",
  "brotli 7.0.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -201,7 +201,7 @@ aws-smithy-runtime-api = { version = "1.11.5", features = ["client"] }
 aws-smithy-http-client = { version = "1.1.11", features = ["rustls-aws-lc"] }
 mockall = "0.13.0"
 moka = { version = "0.12.15", features = ["sync", "future"] }
-posthog-rs = { version = "0.19.1", features = ["async-client", "capture-v1"] }
+posthog-rs = { version = "0.19.2", features = ["async-client", "capture-v1"] }
 redis = { version = "0.32.7", features = [
   "tokio-comp",
   "cluster",


### PR DESCRIPTION
## Problem

The Rust workspace pins posthog-rs 0.19.1. The 0.19.2 patch release fixes default in-app frame classification for error tracking:

- Cargo dependency sources are recognized by cargo's on-disk layouts under any `CARGO_HOME` (e.g. `/usr/local/cargo` in the official Rust Docker images), not just `~/.cargo`, so dependency frames stop being marked as app code in containers.
- Crate-denylist matching strips trailing generic arguments before extracting the crate name, so DWARF-derived names like `poll_future<tokio::runtime::...>` classify correctly.
- Fileless thread/process bootstrap symbols (`__clone`, `start_thread`, `_start`, etc.) are classified as not in-app.

Release notes: https://github.com/PostHog/posthog-rs/blob/main/CHANGELOG.md

## Changes

- Bump `posthog-rs` from 0.19.1 to 0.19.2 in `rust/Cargo.toml` and `rust/Cargo.lock`. No API changes.

## How did you test this code?

- `cargo check -p posthog -p cymbal -p batch-import-worker` (the three crates consuming posthog-rs) passes.
