### PR TITLE
feat(data-warehouse): add copy button to sync error tooltip

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceScene/syncErrorTooltip.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/syncErrorTooltip.tsx
@@ -1,0 +1,20 @@
+import { IconCopy } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
+
+/** Tooltip content for a failed sync: the error text plus a one-click copy button. */
+export function syncErrorTooltip(error: string): JSX.Element {
+    return (
+        <div className="flex items-start gap-1">
+            <span className="whitespace-pre-wrap">{error}</span>
+            <LemonButton
+                size="xsmall"
+                icon={<IconCopy />}
+                noPadding
+                tooltip="Copy error"
+                onClick={() => void copyToClipboard(error, 'error message')}
+            />
+        </div>
+    )
+}

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -36,6 +36,7 @@ import {
     ExternalDataSourceSchema,
 } from '~/types'
 
+import { syncErrorTooltip } from 'products/data_warehouse/frontend/scenes/SourceScene/syncErrorTooltip'
 import { splitQualifiedTableName } from 'products/data_warehouse/frontend/shared/components/forms/schemaGroupingUtils'
 import { DATA_WAREHOUSE_APP_SOURCE } from 'products/data_warehouse/frontend/shared/components/metrics/DataWarehouseMetrics'
 import {
@@ -422,7 +423,7 @@ function ManagedSchemaTable({
                             </LemonTag>
                         )
                         return schema.latest_error && schema.status === 'Failed' ? (
-                            <Tooltip title={schema.latest_error} interactive>
+                            <Tooltip title={syncErrorTooltip(schema.latest_error)} interactive>
                                 {tagContent}
                             </Tooltip>
                         ) : (

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SyncsTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SyncsTab.tsx
@@ -14,6 +14,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { ExternalDataJob, ExternalDataJobStatus, LogEntryLevel } from '~/types'
 
+import { syncErrorTooltip } from '../syncErrorTooltip'
 import { sourceSettingsLogic } from './sourceSettingsLogic'
 
 const StatusTagSetting: Record<ExternalDataJob['status'], LemonTagType> = {
@@ -128,7 +129,7 @@ export const SyncsTab = ({ id }: SyncsTabProps): JSX.Element => {
                                 <LemonTag type={StatusTagSetting[job.status] || 'default'}>{job.status}</LemonTag>
                             )
                             return job.latest_error && job.status === ExternalDataJobStatus.Failed ? (
-                                <Tooltip title={job.latest_error} interactive>
+                                <Tooltip title={syncErrorTooltip(job.latest_error)} interactive>
                                     {tagContent}
                                 </Tooltip>
                             ) : (


### PR DESCRIPTION
## Problem

When a data warehouse source sync fails, the error surfaces inside a hover tooltip on the red "Failed" status tag. Today the only way to grab that text is to hover, keep the tooltip open, and hand-select it. For long stack traces that is fiddly and easy to get wrong. People copying an error into a support thread or a search deserve a one-click grab.

## Changes

Added a copy-to-clipboard button inside the error tooltip. It shows up in both places that render the failed-sync tooltip:

- Schemas tab (`SchemasTab.tsx`) - per-schema `latest_error`
- Syncs tab (`SyncsTab.tsx`) - per-job `latest_error`

Both tooltips were already `interactive`, so the button is clickable without the tooltip dismissing. The two call sites now share a small `syncErrorTooltip(error)` helper that renders the error text (with `whitespace-pre-wrap` so long traces stay readable) plus an `IconCopy` `LemonButton`. Copy itself reuses the existing `copyToClipboard` util, which handles the clipboard write and the success toast.

No backend or serializer change, so no generated types were touched.

## How did you test this code?

I (Claude) did not run the app for this change. What I verified:

- Confirmed the two call sites and that `latest_error` (not the status tag) is the error text being copied.
- Scoped format via lint-staged on the three changed files.
- `hogli ci:preflight --strict` on push passed (no CI-failure classes triggered).

Manual verification still owed by a human: open a source with a failed sync, hover the "Failed" tag on the Schemas and Syncs tabs, click the copy icon, and confirm the full error lands on the clipboard with the success toast, and that the tooltip stays open while moving onto the button.

No automated test added - this is a small presentational addition reusing an existing util, and I couldn't name a regression a test would uniquely catch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kyle drove this; I (Claude, via PostHog Code) wrote the code. The ask was simply to add a copy button to the sync-error hover popover.

Notable moment worth flagging for reviewers: while formatting I initially ran the repo-wide `pnpm --filter=@posthog/frontend format` script, which runs `oxlint --fix --fix-dangerously --fix-suggestions` across the whole tree and rewrote ~68 unrelated files (including semantic changes like dropping a `useMemo` dependency). I reverted all of that and re-formatted only the three touched files. This PR contains just those three.

I considered reusing `CopyToClipboardInline` but it applies `truncate`/`break-all` to its child, which would clip a long multi-line error inside the tooltip, so I hand-rolled the text + copy button instead. Kept the existing LemonUI `Tooltip` rather than switching component families, matching the surrounding code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
