### PR TITLE
feat(cymbal): set posthog-php wire-order cutoff at 4.11.0

### DIFF
--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -98,8 +98,8 @@ fn lib_rules() -> &'static [LibRule] {
                 canonical_since: match lib {
                     // posthog-rs ships the flip in 0.19.0 (PostHog/posthog-rs#176).
                     "posthog-rs" => Some(Version::new(0, 19, 0)),
-                    // posthog-php ships the flip in 4.10.0 (PostHog/posthog-php#200).
-                    "posthog-php" => Some(Version::new(4, 10, 0)),
+                    // posthog-php ships the flip in 4.11.0 (PostHog/posthog-php#200).
+                    "posthog-php" => Some(Version::new(4, 11, 0)),
                     _ => None,
                 },
             })
@@ -319,9 +319,9 @@ mod test {
 
     #[test]
     fn php_cutoff_gates_normalization_by_version() {
-        // Below the 4.10.0 cutoff (and unparseable versions): crash-first on
+        // Below the 4.11.0 cutoff (and unparseable versions): crash-first on
         // the wire, frames reverse, legacy snapshot returned.
-        for version in [Some("4.9.0"), Some("3.0.0"), Some("dev-main"), None] {
+        for version in [Some("4.10.0"), Some("4.9.0"), Some("dev-main"), None] {
             let mut list: ExceptionList =
                 vec![exception_with_frames("Boom", &["main", "boom"])].into();
             let legacy = normalize_wire_order(&mut list, Some("posthog-php"), version);
@@ -330,7 +330,7 @@ mod test {
         }
 
         // At/above the cutoff: canonical on the wire, untouched.
-        for version in ["4.10.0", "4.10.1", "4.11.0", "5.0.0"] {
+        for version in ["4.11.0", "4.11.1", "4.12.0", "5.0.0"] {
             let mut list: ExceptionList =
                 vec![exception_with_frames("Boom", &["main", "boom"])].into();
             let legacy = normalize_wire_order(&mut list, Some("posthog-php"), Some(version));

--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -98,6 +98,8 @@ fn lib_rules() -> &'static [LibRule] {
                 canonical_since: match lib {
                     // posthog-rs ships the flip in 0.19.0 (PostHog/posthog-rs#176).
                     "posthog-rs" => Some(Version::new(0, 19, 0)),
+                    // posthog-php ships the flip in 4.10.0 (PostHog/posthog-php#200).
+                    "posthog-php" => Some(Version::new(4, 10, 0)),
                     _ => None,
                 },
             })
@@ -313,6 +315,35 @@ mod test {
         // Natively-canonical SDKs have no legacy order.
         assert!(legacy_wire_order(Some("posthog-node"), &canonical).is_none());
         assert!(legacy_wire_order(None, &canonical).is_none());
+    }
+
+    #[test]
+    fn php_cutoff_gates_normalization_by_version() {
+        // Below the 4.10.0 cutoff (and unparseable versions): crash-first on
+        // the wire, frames reverse, legacy snapshot returned.
+        for version in [Some("4.9.0"), Some("3.0.0"), Some("dev-main"), None] {
+            let mut list: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-php"), version);
+            assert!(legacy.is_some(), "{version:?} should normalize");
+            assert_eq!(frame_names(&list[0]), vec!["boom", "main"]);
+        }
+
+        // At/above the cutoff: canonical on the wire, untouched.
+        for version in ["4.10.0", "4.10.1", "4.11.0", "5.0.0"] {
+            let mut list: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-php"), Some(version));
+            assert!(legacy.is_none(), "{version} should pass through");
+            assert_eq!(frame_names(&list[0]), vec!["main", "boom"]);
+        }
+
+        // Legacy hashing still reconstructs pre-flip order post-cutoff.
+        let canonical: ExceptionList =
+            vec![exception_with_frames("Boom", &["main", "boom"])].into();
+        let legacy = legacy_wire_order(Some("posthog-php"), &canonical)
+            .expect("reconstruction must ignore the cutoff");
+        assert_eq!(frame_names(&legacy[0]), vec!["boom", "main"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Second SDK flip of the wire-order standardization (PostHog/sdk-specs#11): posthog-php ships canonical bottom-up frames in **4.11.0** (PostHog/posthog-php#200, latest release 4.10.0 + that PR's lone minor changeset). The normalization gate must stop reordering php payloads at that version.

The rust flip (#69837 + posthog-rs 0.19.1) validated the full mechanism in prod: post-flip events pass the gate untouched (stored order verified canonical on live traffic), no split wave, legacy matching healthy. PHP is next by the smallest-blast-radius ordering (~40k exception events/day, 52 teams) and is mechanically the cleanest crash-first SDK — no resolution reshaping, so legacy-order reconstruction is byte-exact even after the flip.

## Changes

- `posthog-php` gets `canonical_since: Some(4.11.0)` in the normalization table; everything below (or unparseable, e.g. `dev-main`) keeps normalizing.
- Mirror of the rs cutoff test: 4.10.0 / 4.9.0 / `dev-main` / missing versions still normalize; 4.11.x, 4.12.0, 5.0.0 pass through; legacy-order reconstruction ignores the cutoff (continuity for pre-flip-keyed issues).

## Merge sequencing — do not merge out of order

1. Merge this, wait for cymbal autodeploy.
2. Then merge PostHog/posthog-php#200 and release as 4.11.0.
3. No other posthog-php minor may release between the two steps; 4.10.x patches are fine.

Watch on the `et-wire-order-launch` dashboard as with rs.

## How did you test this code?

Automated only: new `php_cutoff_gates_normalization_by_version` unit test; full `cargo test -p cymbal` 306 passed, 0 failed (DB-backed tests against local Postgres + Kafka); clippy `-D warnings` and fmt clean. The change is a mechanical clone of the reviewed rs cutoff (#69837).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Rollout process documented in the sdk-specs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this under my direction, step 2 of the per-SDK flip rollout, following the sequencing contract established in #69837. Target version derived from posthog-php's latest release plus #200's pending changeset (verified no other changesets are queued).

