### PR TITLE
feat(sdk-health): support posthog-kmp

### DIFF
--- a/frontend/src/scenes/onboarding/shared/sdkHealth/sdkConstants.ts
+++ b/frontend/src/scenes/onboarding/shared/sdkHealth/sdkConstants.ts
@@ -13,6 +13,7 @@ export const SDK_TYPE_READABLE_NAME: Record<SdkType, string> = {
     'posthog-go': 'Go',
     'posthog-flutter': 'Flutter',
     'posthog-react-native': 'React Native',
+    'posthog-kmp': 'Kotlin Multiplatform',
     'posthog-dotnet': '.NET',
     'posthog-elixir': 'Elixir',
 }
@@ -65,6 +66,10 @@ export const SDK_DOCS_LINKS: Record<SdkType, { releases: string; docs: string }>
     'posthog-react-native': {
         releases: 'https://github.com/PostHog/posthog-js/blob/main/packages/react-native/CHANGELOG.md',
         docs: 'https://posthog.com/docs/libraries/react-native',
+    },
+    'posthog-kmp': {
+        releases: 'https://github.com/PostHog/posthog-kmp/releases',
+        docs: 'https://github.com/PostHog/posthog-kmp',
     },
     'posthog-dotnet': {
         releases: 'https://github.com/PostHog/posthog-dotnet/releases',

--- a/products/growth/backend/constants.py
+++ b/products/growth/backend/constants.py
@@ -31,6 +31,7 @@ SdkTypes = Literal[
     "posthog-go",
     "posthog-flutter",
     "posthog-react-native",
+    "posthog-kmp",
     "posthog-dotnet",
     "posthog-elixir",
 ]
@@ -47,6 +48,7 @@ SDK_TYPES: list[SdkTypes] = [
     "posthog-go",
     "posthog-flutter",
     "posthog-react-native",
+    "posthog-kmp",
     "posthog-dotnet",
     "posthog-elixir",
 ]

--- a/products/growth/backend/sdk_health.py
+++ b/products/growth/backend/sdk_health.py
@@ -32,6 +32,7 @@ MOBILE_SDKS: frozenset[str] = frozenset(
         "posthog-android",
         "posthog-flutter",
         "posthog-react-native",
+        "posthog-kmp",
     }
 )
 
@@ -63,6 +64,7 @@ SDK_READABLE_NAME: dict[str, str] = {
     "posthog-server": "Java",
     "posthog-flutter": "Flutter",
     "posthog-react-native": "React Native",
+    "posthog-kmp": "Kotlin Multiplatform",
     "posthog-dotnet": ".NET",
     "posthog-elixir": "Elixir",
 }

--- a/products/growth/backend/tests/test_sdk_health.py
+++ b/products/growth/backend/tests/test_sdk_health.py
@@ -322,13 +322,14 @@ class TestAssessSdkTrafficAlerts(SimpleTestCase):
         # Primary (first) is fresh, so SDK not marked outdated
         assert result.is_outdated is False
 
-    def test_mobile_never_gets_traffic_alerts(self):
+    @parameterized.expand([("posthog-ios",), ("posthog-kmp",)])
+    def test_mobile_never_gets_traffic_alerts(self, sdk_type: str):
         # Even at high traffic, mobile SDKs shouldn't trigger traffic alerts (users don't auto-update)
         entries = [
             _entry("2.0.0", 10, days_ago=5, is_latest=True),
             _entry("1.0.0", 90, days_ago=200),
         ]
-        result = assess_sdk("posthog-ios", "2.0.0", entries, now=NOW)
+        result = assess_sdk(sdk_type, "2.0.0", entries, now=NOW)
         assert result is not None
         assert result.outdated_traffic_alerts == []
 

--- a/products/growth/backend/tests/test_sdk_health.py
+++ b/products/growth/backend/tests/test_sdk_health.py
@@ -322,7 +322,15 @@ class TestAssessSdkTrafficAlerts(SimpleTestCase):
         # Primary (first) is fresh, so SDK not marked outdated
         assert result.is_outdated is False
 
-    @parameterized.expand([("posthog-ios",), ("posthog-kmp",)])
+    @parameterized.expand(
+        [
+            ("posthog-ios",),
+            ("posthog-android",),
+            ("posthog-flutter",),
+            ("posthog-react-native",),
+            ("posthog-kmp",),
+        ]
+    )
     def test_mobile_never_gets_traffic_alerts(self, sdk_type: str):
         # Even at high traffic, mobile SDKs shouldn't trigger traffic alerts (users don't auto-update)
         entries = [

--- a/products/growth/dags/github_sdk_versions.py
+++ b/products/growth/dags/github_sdk_versions.py
@@ -32,6 +32,7 @@ SDK_FETCH_FUNCTIONS: dict[SdkTypes, Callable[[], dict[str, Any]]] = {
     "posthog-node": lambda: fetch_node_sdk_data(),
     "posthog-react-native": lambda: fetch_react_native_sdk_data(),
     "posthog-flutter": lambda: fetch_flutter_sdk_data(),
+    "posthog-kmp": lambda: fetch_kmp_sdk_data(),
     "posthog-ios": lambda: fetch_ios_sdk_data(),
     "posthog-android": lambda: fetch_android_sdk_data(),
     "posthog-java": lambda: fetch_java_sdk_data(),
@@ -233,6 +234,11 @@ def fetch_flutter_sdk_data() -> dict[str, Any]:
 def fetch_ios_sdk_data() -> dict[str, Any]:
     """Fetch iOS SDK data from GitHub releases API"""
     return fetch_sdk_data_from_releases("PostHog/posthog-ios")
+
+
+def fetch_kmp_sdk_data() -> dict[str, Any]:
+    """Fetch Kotlin Multiplatform SDK data from GitHub releases API"""
+    return fetch_sdk_data_from_releases("PostHog/posthog-kmp", tag_prefixes=["v"])
 
 
 def fetch_android_sdk_data() -> dict[str, Any]:

--- a/products/growth/dags/tests/test_github_sdk_versions.py
+++ b/products/growth/dags/tests/test_github_sdk_versions.py
@@ -9,6 +9,7 @@ from products.growth.dags.github_sdk_versions import (
     fetch_dotnet_sdk_data,
     fetch_elixir_sdk_data,
     fetch_flutter_sdk_data,
+    fetch_github_data_for_sdk,
     fetch_go_sdk_data,
     fetch_ios_sdk_data,
     fetch_java_sdk_data,
@@ -188,6 +189,30 @@ class TestFetchFlutterSdkData(TestFetchSdkDataBase):
 
         # `flutter` included a leading `v` prefix on some tags, let's make sure it's removed
         assert not any(version.startswith("v") for version in result["releaseDates"].keys())
+
+
+class TestFetchKmpSdkData(TestFetchSdkDataBase):
+    @patch("posthog.egress.transport.transport.requests.request")
+    def test_fetch_kmp_sdk_data_success(self, mock_get: MagicMock) -> None:
+        self.setup_ok_json_mock(
+            mock_get,
+            [
+                {
+                    "tag_name": "v0.0.1",
+                    "created_at": "2026-07-14T18:03:29Z",
+                    "draft": False,
+                    "prerelease": False,
+                }
+            ],
+        )
+
+        result = fetch_github_data_for_sdk("posthog-kmp")
+
+        assert result == {
+            "latestVersion": "0.0.1",
+            "releaseDates": {"0.0.1": "2026-07-14T18:03:29Z"},
+        }
+        assert "/repos/PostHog/posthog-kmp/releases" in mock_get.call_args_list[0].args[1]
 
 
 class TestFetchIosSdkData(TestFetchSdkDataBase):

--- a/products/growth/dags/tests/test_github_sdk_versions.py
+++ b/products/growth/dags/tests/test_github_sdk_versions.py
@@ -9,11 +9,11 @@ from products.growth.dags.github_sdk_versions import (
     fetch_dotnet_sdk_data,
     fetch_elixir_sdk_data,
     fetch_flutter_sdk_data,
-    fetch_github_data_for_sdk,
     fetch_go_sdk_data,
     fetch_ios_sdk_data,
     fetch_java_sdk_data,
     fetch_java_server_sdk_data,
+    fetch_kmp_sdk_data,
     fetch_node_sdk_data,
     fetch_php_sdk_data,
     fetch_python_sdk_data,
@@ -206,7 +206,7 @@ class TestFetchKmpSdkData(TestFetchSdkDataBase):
             ],
         )
 
-        result = fetch_github_data_for_sdk("posthog-kmp")
+        result = fetch_kmp_sdk_data()
 
         assert result == {
             "latestVersion": "0.0.1",

--- a/products/growth/frontend/generated/api.schemas.ts
+++ b/products/growth/frontend/generated/api.schemas.ts
@@ -267,6 +267,7 @@ export const HealthEnumApi = {
  * * `posthog-go` - posthog-go
  * * `posthog-flutter` - posthog-flutter
  * * `posthog-react-native` - posthog-react-native
+ * * `posthog-kmp` - posthog-kmp
  * * `posthog-dotnet` - posthog-dotnet
  * * `posthog-elixir` - posthog-elixir
  */
@@ -285,6 +286,7 @@ export const LibEnumApi = {
     PosthogGo: 'posthog-go',
     PosthogFlutter: 'posthog-flutter',
     PosthogReactNative: 'posthog-react-native',
+    PosthogKmp: 'posthog-kmp',
     PosthogDotnet: 'posthog-dotnet',
     PosthogElixir: 'posthog-elixir',
 } as const
@@ -363,6 +365,7 @@ export interface SdkAssessmentApi {
      * * `posthog-go` - posthog-go
      * * `posthog-flutter` - posthog-flutter
      * * `posthog-react-native` - posthog-react-native
+     * * `posthog-kmp` - posthog-kmp
      * * `posthog-dotnet` - posthog-dotnet
      * * `posthog-elixir` - posthog-elixir */
     lib: LibEnumApi

--- a/products/growth/frontend/generated/api.zod.schemas.ts
+++ b/products/growth/frontend/generated/api.zod.schemas.ts
@@ -472,11 +472,12 @@ export const LibEnumApi = zod
         'posthog-go',
         'posthog-flutter',
         'posthog-react-native',
+        'posthog-kmp',
         'posthog-dotnet',
         'posthog-elixir',
     ])
     .describe(
-        '\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir'
+        '\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-kmp` - posthog-kmp\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir'
     )
 
 export type LibEnumApi = zod.input<typeof LibEnumApi>
@@ -557,14 +558,15 @@ export const SdkAssessmentApi = zod.object({
             'posthog-go',
             'posthog-flutter',
             'posthog-react-native',
+            'posthog-kmp',
             'posthog-dotnet',
             'posthog-elixir',
         ])
         .describe(
-            '\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir'
+            '\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-kmp` - posthog-kmp\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir'
         )
         .describe(
-            "SDK identifier, e.g. 'web', 'posthog-python', 'posthog-node', 'posthog-ios'.\n\n\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir"
+            "SDK identifier, e.g. 'web', 'posthog-python', 'posthog-node', 'posthog-ios'.\n\n\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-kmp` - posthog-kmp\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir"
         ),
     readable_name: zod
         .string()
@@ -693,14 +695,15 @@ export const SdkHealthReportApi = zod.object({
                         'posthog-go',
                         'posthog-flutter',
                         'posthog-react-native',
+                        'posthog-kmp',
                         'posthog-dotnet',
                         'posthog-elixir',
                     ])
                     .describe(
-                        '\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir'
+                        '\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-kmp` - posthog-kmp\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir'
                     )
                     .describe(
-                        "SDK identifier, e.g. 'web', 'posthog-python', 'posthog-node', 'posthog-ios'.\n\n\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir"
+                        "SDK identifier, e.g. 'web', 'posthog-python', 'posthog-node', 'posthog-ios'.\n\n\* `web` - web\n\* `posthog-ios` - posthog-ios\n\* `posthog-android` - posthog-android\n\* `posthog-java` - posthog-java\n\* `posthog-server` - posthog-server\n\* `posthog-node` - posthog-node\n\* `posthog-python` - posthog-python\n\* `posthog-php` - posthog-php\n\* `posthog-ruby` - posthog-ruby\n\* `posthog-go` - posthog-go\n\* `posthog-flutter` - posthog-flutter\n\* `posthog-react-native` - posthog-react-native\n\* `posthog-kmp` - posthog-kmp\n\* `posthog-dotnet` - posthog-dotnet\n\* `posthog-elixir` - posthog-elixir"
                     ),
                 readable_name: zod
                     .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33061,6 +33061,7 @@ export namespace Schemas {
      * * `posthog-go` - posthog-go
      * * `posthog-flutter` - posthog-flutter
      * * `posthog-react-native` - posthog-react-native
+     * * `posthog-kmp` - posthog-kmp
      * * `posthog-dotnet` - posthog-dotnet
      * * `posthog-elixir` - posthog-elixir
      */
@@ -33080,6 +33081,7 @@ export namespace Schemas {
       PosthogGo: 'posthog-go',
       PosthogFlutter: 'posthog-flutter',
       PosthogReactNative: 'posthog-react-native',
+      PosthogKmp: 'posthog-kmp',
       PosthogDotnet: 'posthog-dotnet',
       PosthogElixir: 'posthog-elixir',
     } as const;
@@ -54757,6 +54759,7 @@ export namespace Schemas {
        * * `posthog-go` - posthog-go
        * * `posthog-flutter` - posthog-flutter
        * * `posthog-react-native` - posthog-react-native
+       * * `posthog-kmp` - posthog-kmp
        * * `posthog-dotnet` - posthog-dotnet
        * * `posthog-elixir` - posthog-elixir */
       lib: LibEnum;


### PR DESCRIPTION
## Problem

SDK Health does not recognize the Kotlin Multiplatform SDK. Events emitted with `$lib = "posthog-kmp"` are excluded from SDK detection, and the KMP release stream is not cached for version assessment.

```mermaid
flowchart LR
    A[KMP events] --> B[SDK type filter]
    B --> C[Excluded from SDK Health]
    D[KMP releases] --> E[No release fetcher]
    E --> C
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phYellow;
    class B,E phGray;
    class C phRed;
```

## Changes

I added `posthog-kmp` as an ordinary, independent SDK Health type. SDK Health now detects its versioned traffic, caches releases from `PostHog/posthog-kmp` using `v*` tags, applies the existing mobile SDK assessment rules, and displays Kotlin Multiplatform with repository and release links.

```mermaid
flowchart LR
    A[KMP events] --> B[Registered SDK type]
    D[KMP v* releases] --> E[Independent release cache]
    B --> F[SDK Health assessment]
    E --> F
    F --> G[Report and UI]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phYellow;
    class B,F phBlue;
    class E phGray;
    class G phYellow;
```

There is no migration path or versionless exception for KMP.

## How did you test this code?

- `hogli test products/growth/backend/tests/test_sdk_health.py` – 102 passed. The changed mobile-SDK regression now catches KMP being assessed with mobile traffic-alert behavior.
- `pytest -q --noconftest products/growth/dags/tests/test_github_sdk_versions.py` – 19 passed. The KMP regression catches missing dispatcher registration, incorrect repository routing, and failure to normalize the `v0.0.1` tag.
- Focused Ruff, oxfmt, oxlint, and `git diff --check` checks passed.
- `TEST=1 hogli build:openapi` completed with no generated diff.
- `hogli ci:preflight --strict` passed its checks and reported the expected OpenAPI advisory for the changed constants file. OpenAPI generation was run and left the tree clean.
- The database-backed API test could not run locally because PostgreSQL was unavailable. The existing API round-trip regression was adapted to assert the KMP identifier and readable name, and CI will run it with services available.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No product docs change is needed. The KMP repository README is the current integration documentation and is linked from SDK Health.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed Pi worker and reviewer subagents to implement and review this change. The implementation used `/writing-tests`, `/pi-subagents`, `/pre-pr-review-loop`, `/code-review`, `/running-ci-preflight`, and `/pr`. Two review cycles converged after strengthening the release regression to exercise the production dispatcher.

The implementation keeps KMP independent, reads its own `v*` release stream, uses the existing mobile assessment path, and deliberately adds no migration, versionless, alias, or shared-release behavior.
