### PR TITLE
feat(autoresearch): disable pytest unraisable/thread exception plugins

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,11 @@ junit_family = xunit1
 # nothing in this repo uses the `faker` fixture or the library (faker is a transitive dep)
 # -p pytest_boot_gc opens the boot GC window (gc.disable) before pytest-django runs
 # django.setup(), which happens before conftest files load; the root conftest closes it
-addopts = -p no:warnings -p no:tach -p no:langsmith_plugin -p no:faker -p pytest_boot_gc --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
+# -p no:unraisableexception -p no:threadexception: both plugins run gc_collect_harder()
+# (several full gc.collect passes over the whole heap, seconds per session at our heap sizes)
+# during cleanup to surface __del__/thread exceptions as warnings — but with -p no:warnings
+# those warnings can never escalate to failures here, so the collections are pure teardown cost
+addopts = -p no:warnings -p no:tach -p no:langsmith_plugin -p no:faker -p no:unraisableexception -p no:threadexception -p pytest_boot_gc --reuse-db --pytest-durations=0 --ignore=posthog/user_scripts --ignore=services/llm-gateway --ignore=services/stripe-mock --ignore=common/ingestion/acceptance_tests --ignore=tools/hogli --ignore=tools/hogli-commands --ignore=tools/traffic-sim --ignore=tools/query-performance-ai
 
 markers =
     ee


### PR DESCRIPTION
## Problem

Every backend pytest session (and every CI shard) pays several full-heap `gc.collect()` passes at session cleanup, run by pytest's `unraisableexception` and `threadexception` plugins purely to surface `__del__`/thread exceptions as warnings. With `-p no:warnings` already in our addopts, those warnings can never escalate to failures, so the passes (~3s per session at our heap sizes, measured under cProfile) are pure teardown cost.

Split out of [#70731](https://github.com/PostHog/posthog/pull/70731) so it can be tested in isolation. Created with Autoresearch.

## Changes

Adds `-p no:unraisableexception -p no:threadexception` to `pytest.ini` addopts, with a comment explaining why they're safe to disable here.

## How did you test this code?

I (Claude) ran a fixed 320-test benchmark (`posthog/api/test/{test_organization.py,test_team.py,notebooks}`) locally before/after: 24.7s → 21.8s, all green. Also validated as part of the combined branch, whose full Backend CI merge-gate matrix ran green (all Django shards, run 29340497622).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code autoresearch session; identified via cProfile of a warm test session (gc_collect_harder dominated teardown). Split from #70731 at reviewers' request so each optimization lands independently.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
