### PR TITLE
feat(autoresearch): skip no-op django migrate on fully-migrated test DBs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -206,12 +206,72 @@ def _cheapen_freezegun_module_hash() -> None:
     api._get_module_attributes_hash = _fast_module_attributes_hash  # ty: ignore[invalid-assignment]
 
 
+def _skip_noop_migrate() -> None:
+    # pytest-django runs `migrate` per session even on a reused, fully-migrated DB
+    # (--reuse-db / schema cache in CI), paying ~1.3s of graph building and project
+    # state rendering just to conclude there is nothing to apply. Short-circuit the
+    # bare invocation when every migration on disk is already recorded as applied —
+    # one recorder query plus load_disk, no graph, no state render, no signals.
+    # Any targeted/fancy invocation (app label, --fake, --run-syncdb, --check, ...)
+    # and any error falls through to the original handler, so a cold DB, a PR's
+    # unapplied migrations, and migration-framework tests behave exactly as before.
+    from django.core.management.commands import migrate as migrate_cmd  # noqa: PLC0415 — deferred import
+
+    orig_handle = migrate_cmd.Command.handle
+
+    def handle(self, *args, **options):
+        if not args and not options.get("app_label"):
+            passthrough_flags = ("migration_name", "fake", "fake_initial", "run_syncdb", "check_unapplied", "prune")
+            if not any(options.get(flag) for flag in passthrough_flags):
+                try:
+                    import pkgutil  # noqa: PLC0415
+                    import importlib  # noqa: PLC0415
+
+                    from django.apps import apps  # noqa: PLC0415
+                    from django.db import connections  # noqa: PLC0415
+                    from django.db.migrations.loader import MigrationLoader  # noqa: PLC0415
+                    from django.db.migrations.recorder import MigrationRecorder  # noqa: PLC0415
+
+                    # Discover on-disk migration names with pkgutil (same rule as
+                    # MigrationLoader.load_disk: skip subpackages and _/~ prefixes)
+                    # without importing every migration module (~1s for our tree).
+                    disk_migrations = set()
+                    for app_config in apps.get_app_configs():
+                        module_name, _explicit = MigrationLoader.migrations_module(app_config.label)
+                        if module_name is None:
+                            continue
+                        try:
+                            module = importlib.import_module(module_name)
+                        except ModuleNotFoundError:
+                            continue
+                        # Namespace/odd packages: defer to the real migrate rather than guessing.
+                        if not hasattr(module, "__path__"):
+                            raise LookupError(f"unexpected migrations module shape for {app_config.label}")
+                        for _finder, name, is_pkg in pkgutil.iter_modules(module.__path__):
+                            if not is_pkg and name[0] not in "_~":
+                                disk_migrations.add((app_config.label, name))
+
+                    connection = connections[options["database"]]
+                    recorder = MigrationRecorder(connection)
+                    if recorder.has_table() and disk_migrations <= recorder.applied_migrations().keys():
+                        if options.get("verbosity", 1) >= 1:
+                            self.stdout.write("All disk migrations already applied — skipping migrate.")
+                        return
+                except Exception:
+                    pass
+        return orig_handle(self, *args, **options)
+
+    handle.__wrapped__ = orig_handle  # exposes the original for the canary tests
+    migrate_cmd.Command.handle = handle  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+
+
 def pytest_configure(config) -> None:
     _cache_reverse_rel_identity()
     _cache_select_masks()
     _cache_drf_field_info()
     _cache_url_resolution()
     _cheapen_freezegun_module_hash()
+    _skip_noop_migrate()
 
 
 def pytest_collection_finish() -> None:


### PR DESCRIPTION
## Problem

pytest-django runs `migrate` once per session even when the database is already fully migrated (`--reuse-db` locally, schema-cache-primed DBs in CI), paying ~1.3s of migration-graph building and project-state rendering just to conclude there is nothing to apply. That cost repeats on every one of the ~50 backend CI shards.

Split out of [#70731](https://github.com/PostHog/posthog/pull/70731) so it can be tested in isolation. Created with Autoresearch.

## Changes

Adds `_skip_noop_migrate()` to the root `conftest.py`: patches `migrate.Command.handle` to short-circuit the bare invocation when every on-disk migration — discovered via `pkgutil.iter_modules` without importing the migration modules — is already recorded as applied (one recorder query). Warm-path cost drops from ~1.3s to ~0.05s.

> [!NOTE]
> Fail-open by design: any targeted invocation (`app_label`, `--fake`, `--fake-initial`, `--run-syncdb`, `--check`, `--prune`, explicit migration name) and any error falls through to the original handler, so cold DBs, PR-delta migrations, and migration-framework tests behave exactly as before.

## How did you test this code?

I (Claude) verified locally: warm skip triggers (0.05s, notice printed), and un-recording one applied migration makes the next `migrate` fall through to the real executor and attempt application. The 320-test API benchmark stays green. Also validated on the combined branch, whose full Backend CI merge-gate matrix ran green (run 29340497622) — that run exercises this path on every shard against the schema-cache-restored DB.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — test-infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code autoresearch session. The patch follows the root conftest's existing pattern of session performance patches (`_cache_url_resolution`, `_cache_select_masks`, etc.), including the `__wrapped__` convention for canary tests. Split from #70731 at reviewers' request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
