### PR TITLE
feat(autoresearch): skip sqlx spawns when persons test DB is migrated

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -185,6 +185,30 @@ def reset_clickhouse_tables():
     run_clickhouse_statement_in_parallel(list(CREATE_DATA_QUERIES()))
 
 
+def _persons_migrations_current(database_url: str, migrations_path: str) -> bool:
+    """True when every migration file on disk is already recorded in _sqlx_migrations.
+
+    One short psycopg query instead of two sqlx subprocess spawns (~0.5s per pytest
+    session, and per xdist worker). Fail-open: any error means "not current" and the
+    real sqlx path runs.
+    """
+    import psycopg  # noqa: PLC0415 — deferred so conftest import stays cheap
+
+    try:
+        disk_versions = {
+            int(name.split("_", 1)[0])
+            for name in os.listdir(migrations_path)
+            if name.endswith(".sql") and name.split("_", 1)[0].isdigit()
+        }
+        if not disk_versions:
+            return False
+        with psycopg.connect(database_url, connect_timeout=3) as conn:
+            applied = {row[0] for row in conn.execute("SELECT version FROM _sqlx_migrations").fetchall()}
+        return disk_versions <= applied
+    except Exception:
+        return False
+
+
 def run_persons_sqlx_migrations(keepdb: bool = False):
     """Run sqlx migrations for persons tables in separate test_posthog_persons database.
 
@@ -212,6 +236,9 @@ def run_persons_sqlx_migrations(keepdb: bool = False):
     # conftest.py is at posthog/conftest.py, go up one level to repo root
     migrations_path = os.path.join(os.path.dirname(__file__), "..", "rust", "persons_migrations")
     migrations_path = os.path.abspath(migrations_path)
+
+    if keepdb and _persons_migrations_current(database_url, migrations_path):
+        return
 
     env = {**os.environ, "DATABASE_URL": database_url}
 


### PR DESCRIPTION
## Problem

`run_persons_sqlx_migrations(keepdb=True)` spawns two sqlx subprocesses (`database create` + `migrate run`, ~0.5s) in every pytest session — including every CI shard and every future xdist worker — even when the persons DB is already fully migrated.

Split out of [#70731](https://github.com/PostHog/posthog/pull/70731) so it can be tested in isolation. Created with Autoresearch.

## Changes

Adds `_persons_migrations_current()` to `posthog/conftest.py`: one short psycopg query compares the on-disk migration versions in `rust/persons_migrations/` against the `_sqlx_migrations` table, and skips both subprocess spawns when nothing is pending (~0.5s → ~0.02s). Fail-open: any mismatch, missing DB, or error runs the real sqlx path, and `keepdb=False` (fresh-DB) runs are untouched.

## How did you test this code?

I (Claude) verified locally: warm skip (~0.02s), fall-through when the persons DB doesn't exist, and the 320-test API benchmark green. Also validated on the combined branch, whose full Backend CI merge-gate matrix ran green (run 29340497622).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — test-infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code autoresearch session. Split from #70731 at reviewers' request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
