### PR TITLE
feat(autoresearch): drop stale temporal.ai preload from rest_router

### DIFF
--- a/posthog/api/rest_router.py
+++ b/posthog/api/rest_router.py
@@ -6,8 +6,6 @@ from django.apps import apps
 from rest_framework import decorators, exceptions, viewsets
 from rest_framework_extensions.routers import NestedRegistryItem
 
-# Preload to work around circular imports in `ee.hogai.{core.agent_modes,chat_agent,tools}`.
-import posthog.temporal.ai  # noqa: F401
 from posthog.api import data_color_theme, metalytics, my_notifications, project, user_integration, user_push_token
 from posthog.api.csp_reporting import CSPReportingViewSet
 from posthog.api.js_snippet import JsSnippetViewSet


### PR DESCRIPTION
## Problem

`posthog/api/rest_router.py` carries a `import posthog.temporal.ai` preload added as a circular-import workaround for `ee.hogai.{core.agent_modes,chat_agent,tools}`. That preload drags the langgraph/chat-agent import stack (~4.6s, dominated by pydantic model construction) into every Django process that touches the DRF router — web workers, celery, every pytest session, every CI shard.

Split out of [#70731](https://github.com/PostHog/posthog/pull/70731) so it can be tested in isolation. Created with Autoresearch.

## Changes

Removes the preload and its comment. The circular-import problem it worked around no longer exists.

## How did you test this code?

I (Claude) verified all previously-circular import orders resolve without it: `ee.hogai.core.agent_modes`, `ee.hogai.tools`, `ee.hogai.chat_agent.graph` — both router-first and graph-first orders — plus `posthog.temporal.ai` itself. The 320-test API benchmark stays green, and the combined branch's full Backend CI merge-gate matrix ran green (run 29340497622).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — no behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code autoresearch session; found by tracing which heavy modules load during `django.setup()` + router import. Split from #70731 at reviewers' request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
