### PR TITLE
feat(autoresearch): defer google.genai and openai imports in setup wizard

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -10,14 +10,6 @@ from django.utils.crypto import get_random_string
 
 import posthoganalytics
 from drf_spectacular.utils import extend_schema
-from google.genai.types import GenerateContentConfig, Schema
-from openai.types.chat import (
-    ChatCompletionMessageParam,
-    ChatCompletionSystemMessageParam,
-    ChatCompletionUserMessageParam,
-)
-from posthoganalytics.ai.gemini import genai
-from posthoganalytics.ai.openai import OpenAI
 from prometheus_client import Counter
 from rest_framework import exceptions, response, serializers, viewsets
 from rest_framework.decorators import action
@@ -255,6 +247,12 @@ class SetupWizardViewSet(viewsets.ViewSet):
         )
 
         if model in GEMINI_SUPPORTED_MODELS:
+            # noqa comments: keep the google.genai import (~1s of pydantic model
+            # construction) off the router import path — it loads with the wizard
+            # module in every Django process and pytest session otherwise.
+            from google.genai.types import GenerateContentConfig, Schema  # noqa: PLC0415
+            from posthoganalytics.ai.gemini import genai  # noqa: PLC0415
+
             api_key = settings.GEMINI_API_KEY
             if not api_key:
                 error = exceptions.ValidationError(ERROR_GEMINI_API_KEY_NOT_CONFIGURED)
@@ -309,6 +307,15 @@ class SetupWizardViewSet(viewsets.ViewSet):
             response_data = response.parsed
 
         elif model in OPENAI_SUPPORTED_MODELS:
+            # noqa comments: keep the openai SDK import off the router import path
+            # (loads with the wizard module in every Django process otherwise).
+            from openai.types.chat import (  # noqa: PLC0415
+                ChatCompletionMessageParam,
+                ChatCompletionSystemMessageParam,
+                ChatCompletionUserMessageParam,
+            )
+            from posthoganalytics.ai.openai import OpenAI  # noqa: PLC0415
+
             system_message = ChatCompletionSystemMessageParam(
                 role="system",
                 content=system_prompt,

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -42,7 +42,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.data["host"] == "http://localhost:8010"
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_requires_hash_header(self, mock_openai):
         response = self.client.post(
             self.query_url,
@@ -55,7 +55,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     @patch("django.conf.settings.DEBUG", False)
     def test_query_endpoint_rate_limit(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
@@ -86,7 +86,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_invalid_hash(self, mock_openai):
         response = self.client.post(
             self.query_url,
@@ -99,7 +99,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
         mock_openai_instance.chat.completions.create.return_value = MagicMock(
@@ -118,7 +118,7 @@ class SetupWizardTests(APIBaseTest):
         assert response.json() == {"data": {"foo": "bar"}}
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_uses_default_model(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
         mock_openai_instance.chat.completions.create.return_value = MagicMock(
@@ -143,7 +143,7 @@ class SetupWizardTests(APIBaseTest):
         mock_openai_instance.chat.completions.create.assert_called_once()
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_accepts_valid_openai_model(self, mock_openai):
         mock_openai_instance = mock_openai.return_value
         mock_openai_instance.chat.completions.create.return_value = MagicMock(
@@ -168,7 +168,7 @@ class SetupWizardTests(APIBaseTest):
         mock_openai_instance.chat.completions.create.assert_called_once()
 
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.genai.Client")
+    @patch("posthoganalytics.ai.gemini.genai.Client")
     @patch("django.conf.settings.GEMINI_API_KEY", "test-key")
     def test_query_endpoint_accepts_valid_gemini_model(self, mock_genai_client):
         mock_client_instance = mock_genai_client.return_value
@@ -213,7 +213,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", True)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_mock_wizard_data_in_debug_with_fixture_header(self, mock_openai):
         """Test that mock wizard data is used when DEBUG=True and X-PostHog-Wizard-Fixture-Generation header is present"""
         mock_openai_instance = mock_openai.return_value
@@ -248,7 +248,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", True)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_mock_wizard_data_overrides_existing_cache(self, mock_openai):
         """Test that mock wizard data overrides existing cache data when conditions are met"""
         mock_openai_instance = mock_openai.return_value
@@ -284,7 +284,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", False)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_no_mock_when_debug_false(self, mock_openai):
         """Test that mock wizard data is NOT used when DEBUG=False even with fixture header"""
         # Clear any existing cache data
@@ -307,7 +307,7 @@ class SetupWizardTests(APIBaseTest):
 
     @patch("django.conf.settings.DEBUG", True)
     @patch("posthog.api.wizard.http.posthoganalytics.default_client", MagicMock())
-    @patch("posthog.api.wizard.http.OpenAI")
+    @patch("posthoganalytics.ai.openai.OpenAI")
     def test_query_endpoint_no_mock_without_fixture_header(self, mock_openai):
         """Test that mock wizard data is NOT used when DEBUG=True but fixture header is missing"""
         # Clear any existing cache data

--- a/posthog/api/wizard/utils.py
+++ b/posthog/api/wizard/utils.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from google.genai.types import Type
+if TYPE_CHECKING:
+    from google.genai.types import Type
 
 
 def get_type_enum(json_type: str) -> Type:
     """Convert JSON Schema type to Gemini Type enum"""
+    from google.genai.types import (
+        Type,  # noqa: PLC0415 — keeps the heavy google.genai import off the router import path
+    )
+
     type_mapping = {
         "string": Type.STRING,
         "number": Type.NUMBER,


### PR DESCRIPTION
## Problem

`posthog/api/wizard/http.py` imports the `google.genai` types module (~1s of pydantic model construction) and the `openai` SDK at module level. The wizard module loads via the DRF router in every Django process and pytest session, so every process pays that import cost even though only the wizard `query` endpoint ever calls those APIs.

Split out of [#70731](https://github.com/PostHog/posthog/pull/70731) so it can be tested in isolation. Created with Autoresearch.

## Changes

- Moves the `google.genai` / `posthoganalytics.ai.gemini` imports into the Gemini branch of `query()`, and the `openai` imports into the OpenAI branch (`# noqa: PLC0415` with justification, per the repo's deferred-import convention).
- `posthog/api/wizard/utils.py`: `Type` becomes a `TYPE_CHECKING` import with the runtime import inside `get_type_enum()`.
- Test mocks now patch the SDK source modules (`posthoganalytics.ai.openai.OpenAI`, `posthoganalytics.ai.gemini.genai.Client`) instead of the wizard module attributes, since the names no longer live there.

## How did you test this code?

I (Claude) ran all 35 wizard tests (`posthog/api/wizard/`) green, and verified `wizard.http` now imports in 0.01s with neither SDK in `sys.modules`. The combined branch's full Backend CI merge-gate matrix ran green (run 29340497622).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code autoresearch session; found by tracing lazy imports triggered during API test runs. Split from #70731 at reviewers' request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
