### PR TITLE
feat(autoresearch): disable postgres durability for disposable dev/CI data

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -372,7 +372,9 @@ services:
         # (maybe only in Pycharm) keeps many idle transactions open
         # and eventually kills postgres, these settings aim to stop that happening.
         # They are only for DEV and should not be used in production.
-        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000 -c max_prepared_transactions=10
+        # fsync/synchronous_commit/full_page_writes off: dev and CI data is disposable,
+        # so commits skip WAL durability waits — a real win on CI runners with real disks.
+        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000 -c max_prepared_transactions=10 -c fsync=off -c synchronous_commit=off -c full_page_writes=off
 
     redis7:
         extends:


### PR DESCRIPTION
## Problem

The dev/CI Postgres (`db` service in `docker-compose.dev.yml`) runs with full durability, so every commit waits on a WAL flush. Test and dev data is disposable — those waits buy nothing. Profiling a warm backend test session showed psycopg connection waits as the top cost bucket, and on CI runners with real disks the durability overhead is a meaningful share of suite wall-clock.

Split out of [#70731](https://github.com/PostHog/posthog/pull/70731) so it can be tested in isolation. Created with Autoresearch.

## Changes

Adds `-c fsync=off -c synchronous_commit=off -c full_page_writes=off` to the `db` service command, alongside the existing dev-only flags.

> [!WARNING]
> This applies to local dev too, not just CI. Data in this container is disposable by design, but flag it in review if you know a reason local dev needs durable commits. Never applicable to production — this compose file is dev-only.

## How did you test this code?

I (Claude) recreated the container, confirmed all three settings report `off`, and ran the 320-test API benchmark green. On macOS/Docker Desktop the local delta is within noise (the VM absorbs fsyncs); the win materializes on Linux CI runners with real disks. The combined branch's full Backend CI merge-gate matrix ran green (run 29340497622).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — dev/CI infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code autoresearch session, including a same-session A/B (fsync on vs off, container recreate between) to confirm no local regression. Split from #70731 at reviewers' request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
