### PR TITLE
feat(autoresearch): add clone-test-db-for-xdist for per-worker test DBs

### DIFF
--- a/bin/clone-test-db-for-xdist
+++ b/bin/clone-test-db-for-xdist
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Clone the migrated test databases into per-worker copies for pytest-xdist.
+# pytest-django suffixes each worker's DB as <name>_gwN, and posthog/conftest.py
+# derives the persons DB as <name>_gwN_persons; cloning both via
+# CREATE DATABASE ... TEMPLATE skips re-running Django + sqlx migrations per
+# worker, so `pytest -n N --reuse-db` starts instantly on every worker.
+#
+# Usage: bin/clone-test-db-for-xdist <num_workers> [source_db]
+set -euo pipefail
+
+WORKERS="${1:?usage: clone-test-db-for-xdist <num_workers> [source_db]}"
+SOURCE_DB="${2:-test_posthog}"
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-posthog}"
+export PGPASSWORD="${PGPASSWORD:-posthog}"
+
+psql_admin() {
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d postgres -v ON_ERROR_STOP=1 -qAt -c "$1"
+}
+
+clone() {
+    local src="$1" dest="$2"
+    psql_admin "DROP DATABASE IF EXISTS ${dest};" > /dev/null
+    psql_admin "CREATE DATABASE ${dest} TEMPLATE ${src};" > /dev/null
+    echo "cloned ${src} -> ${dest}"
+}
+
+# Concurrent clones of the SAME template fail ("source database is being
+# accessed"), so clones are sequential per source — but the main and persons
+# streams use different templates, so they run concurrently.
+clone_stream() {
+    local src="$1" suffix="$2"
+    # TEMPLATE requires no active connections on the source DB.
+    psql_admin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${src}' AND pid <> pg_backend_pid();" > /dev/null
+    for i in $(seq 0 $((WORKERS - 1))); do
+        clone "${src}" "${SOURCE_DB}_gw${i}${suffix}"
+    done
+}
+
+clone_stream "${SOURCE_DB}" "" &
+MAIN_PID=$!
+PERSONS_PID=""
+if psql_admin "SELECT 1 FROM pg_database WHERE datname = '${SOURCE_DB}_persons'" | grep -q 1; then
+    clone_stream "${SOURCE_DB}_persons" "_persons" &
+    PERSONS_PID=$!
+fi
+wait "$MAIN_PID"
+[ -n "$PERSONS_PID" ] && wait "$PERSONS_PID"
+echo "done: ${WORKERS} worker database(s) per stream"

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1144,3 +1144,7 @@ environment:
         bin_script: ensure-local-setup
         description: Idempotent local-dev bootstrap (e.g. the wizard OAuth app); runs automatically on hogli start
         hidden: true
+    clone:test:db:for:xdist:
+        bin_script: clone-test-db-for-xdist
+        description: TEMPLATE-clone the migrated test DBs into per-worker copies for pytest-xdist
+        hidden: true


### PR DESCRIPTION
## Problem

Each backend CI Django shard runs pytest single-process even though depot runners have spare cores and `pytest-xdist` is already a dependency. The missing piece is provisioning: pytest-django suffixes each worker's DB (`test_posthog_gwN`), and without a pre-migrated copy every worker pays full Django + sqlx migrations. Per-worker isolation for Postgres, Redis (DB index), and ClickHouse (database suffix) already exists in settings via `PYTEST_XDIST_WORKER`.

Split out of [#70731](https://github.com/PostHog/posthog/pull/70731) so it can be tested in isolation. Created with Autoresearch.

## Changes

- `bin/clone-test-db-for-xdist <workers> [source_db]`: TEMPLATE-clones the migrated main DB into `test_posthog_gwN` and, when present, the sqlx-managed persons DB into `test_posthog_gwN_persons`. Concurrent clones of the *same* template fail in Postgres, so clones are sequential per source — but the main and persons streams use independent templates and run concurrently (~1.1s for 4 workers locally).
- Registers the script in the hogli manifest (`hogli meta:check` requires it).

This PR only adds the tool; wiring it into `ci-backend.yml` (gated behind a `DJANGO_XDIST_WORKERS` repo variable, fail-open to single-process) is a follow-up — the vetted workflow patch is attached to [#70731](https://github.com/PostHog/posthog/pull/70731#issuecomment-4969866829) since this session's tokens lack the `workflow` scope to push workflow files.

## How did you test this code?

I (Claude) ran the script and then a 320-test API benchmark under `pytest -n 4 --dist worksteal --reuse-db` — all green with workers starting instantly from the cloned DBs (21.2–21.9s vs ~23.5s single-process on the same set). Re-running the script is idempotent (drop-if-exists then clone).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal CI/dev tooling; usage is documented in the script header.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code autoresearch session. An earlier iteration validated that first-run xdist failures were DB-provisioning races, not test-correctness issues — this script is the fix. Split from #70731 at reviewers' request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
