### PR TITLE
fix(nodejs): don't evaluate plugin-server config at logger import

### DIFF
--- a/nodejs/src/common/utils/logger.test.ts
+++ b/nodejs/src/common/utils/logger.test.ts
@@ -60,4 +60,38 @@ describe('Logger', () => {
             ]
         `)
     })
+
+    // Entrypoints without plugin-server database env (e.g. the recording rasterizer)
+    // import this module transitively. Guards against reintroducing a defaultConfig
+    // import, which throws at module load when that env is missing. NODE_ENV must be
+    // production here: in the test env, config falls back to a default DATABASE_URL,
+    // so the throw this test guards against would never fire.
+    it('loads without plugin-server database env', async () => {
+        const saved: Record<string, string | undefined> = {
+            NODE_ENV: process.env.NODE_ENV,
+            DEBUG: process.env.DEBUG,
+            DATABASE_URL: process.env.DATABASE_URL,
+            POSTHOG_DB_NAME: process.env.POSTHOG_DB_NAME,
+        }
+        process.env.NODE_ENV = 'production'
+        delete process.env.DEBUG
+        delete process.env.DATABASE_URL
+        delete process.env.POSTHOG_DB_NAME
+        let isolated: typeof import('./logger') | undefined
+        try {
+            jest.isolateModules(() => {
+                isolated = require('./logger')
+            })
+        } finally {
+            for (const [key, value] of Object.entries(saved)) {
+                if (value === undefined) {
+                    delete process.env[key]
+                } else {
+                    process.env[key] = value
+                }
+            }
+        }
+        expect(isolated!.logger).toBeInstanceOf(isolated!.Logger)
+        await isolated!.shutdownLogger()
+    })
 })

--- a/nodejs/src/common/utils/logger.ts
+++ b/nodejs/src/common/utils/logger.ts
@@ -1,9 +1,13 @@
 import pino from 'pino'
 
-import { LogLevel } from '~/types'
+import type { LogLevel } from '~/types'
 
-import { defaultConfig } from '../config/config'
-import { isProdEnv } from './env-utils'
+import { isProdEnv, isTestEnv } from './env-utils'
+
+// Read from env directly instead of defaultConfig: that module throws at import when
+// Postgres env vars are missing, and entrypoints without them (e.g. the recording
+// rasterizer) reach this logger transitively.
+const logLevel: LogLevel = (process.env.LOG_LEVEL as LogLevel) || (isTestEnv() ? 'warn' : 'info')
 
 export class Logger {
     private pino: ReturnType<typeof pino>
@@ -13,7 +17,6 @@ export class Logger {
 
     constructor(name: string) {
         this.prefix = `[${name.toUpperCase()}]`
-        const logLevel: LogLevel = defaultConfig.LOG_LEVEL
         if (isProdEnv()) {
             this.pino = pino({
                 // By default pino will log the level number. So we can easily unify
@@ -108,9 +111,7 @@ export class Logger {
     }
 }
 
-// TODO: remove defaultConfig import — it creates circular imports when config files
-// import anything that transitively reaches this module. The logger should not depend on config.
-export const logger = new Logger(defaultConfig.PLUGIN_SERVER_MODE ?? 'MAIN')
+export const logger = new Logger(process.env.PLUGIN_SERVER_MODE ?? 'MAIN')
 
 export function serializeError(error: unknown): Record<string, unknown> | unknown {
     if (error instanceof Error) {

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/otel-metrics.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/otel-metrics.test.ts
@@ -1,0 +1,35 @@
+// The rasterizer deployment has no plugin-server database env, so its whole import
+// graph must load without it. Guards the otlp metrics chain (shared instruments,
+// provider, exporter, logger) against reintroducing a module that evaluates
+// defaultConfig at load, which crashloops the worker at boot. NODE_ENV must be
+// production here: in the test env, config falls back to a default DATABASE_URL,
+// so the throw this test guards against would never fire.
+describe('otel-metrics import chain', () => {
+    it('loads without plugin-server database env', () => {
+        const saved: Record<string, string | undefined> = {
+            NODE_ENV: process.env.NODE_ENV,
+            DEBUG: process.env.DEBUG,
+            DATABASE_URL: process.env.DATABASE_URL,
+            POSTHOG_DB_NAME: process.env.POSTHOG_DB_NAME,
+        }
+        process.env.NODE_ENV = 'production'
+        delete process.env.DEBUG
+        delete process.env.DATABASE_URL
+        delete process.env.POSTHOG_DB_NAME
+        let mod: typeof import('../otel-metrics') | undefined
+        try {
+            jest.isolateModules(() => {
+                mod = require('../otel-metrics')
+            })
+        } finally {
+            for (const [key, value] of Object.entries(saved)) {
+                if (value === undefined) {
+                    delete process.env[key]
+                } else {
+                    process.env[key] = value
+                }
+            }
+        }
+        expect(mod!.initMetrics).toBeInstanceOf(Function)
+    })
+})


### PR DESCRIPTION
## Problem

The shared nodejs logger imports `defaultConfig` from `common/config/config.ts`,
which is evaluated at module load and throws when neither `DATABASE_URL` nor `POSTHOG_DB_NAME` is set.
Any entrypoint deployed without Postgres env therefore crashloops at boot the moment anything in its import graph reaches the logger.

That just happened to the recording rasterizer.
#70535 wired its metrics through the shared OTLP exporter, and the exporter imports the logger.
The rasterizer deployment has no Postgres env (it talks to recording-api over HTTP), so the new image crashlooped in dev and the deploy was only unblocked by a placeholder `DATABASE_URL` in the Helm values (PostHog/charts#13172).
The logger already carried a TODO saying its config dependency needed to go.

**Before** (rasterizer boot):

```mermaid
flowchart LR
    A[rasterizer otel-metrics] --> B[otlp-provider] --> C[otlp-json-exporter] --> D[common logger] --> E[config/config.ts]
    E --> F{{throws without DATABASE_URL}}
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C,D phGray;
    class E,F phRed;
```

**After**:

```mermaid
flowchart LR
    A[rasterizer otel-metrics] --> B[otlp-provider] --> C[otlp-json-exporter] --> D[common logger] --> E[LOG_LEVEL and PLUGIN_SERVER_MODE env vars]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C,D phGray;
    class E phBlue;
```

## Changes

- `common/utils/logger.ts` no longer imports `defaultConfig`.
  It reads `LOG_LEVEL` and `PLUGIN_SERVER_MODE` from the environment directly, with the same defaults the config module used (`warn` in tests, `info` otherwise, `MAIN` as the fallback logger name).
  These were the only two config values the logger consumed.
- The `LogLevel` import is now `import type`, so no build tool can ever keep it as a runtime dependency.
- Two regression tests lock the invariant (see below).

> [!NOTE]
> Backwards compatible by design: services that need config still import it themselves and keep the exact same fail-fast behavior.
> I verified the compiled output of the whole package is unchanged except `logger.js` (a three line semantic diff) and `logger.test.js`.
> Config validation of `PLUGIN_SERVER_MODE` still happens wherever config is actually loaded.

Once this ships in the rasterizer image, the placeholder `DATABASE_URL` from PostHog/charts#13172 can be reverted.

## How did you test this code?

Reproduced the exact production failure locally, on master and with the fix:

- built the package on master and ran `node dist/session-replay/recording-rasterizer/index.js` with no Postgres env: it throws the `You must specify either DATABASE_URL...` error at module load, matching the crashloop
- same command with the fix: the rasterizer boots, starts its metrics server, and connects to Temporal (it then stops on the expected missing local Chromium, same as any run outside the container)
- ran the plugin-server entrypoint (`dist/index.js`) with no Postgres env: it still fails fast with the identical error through its own config import, so fail-fast semantics are preserved for services that need config
- diffed the full compiled `dist/` trees (master build vs fixed build): only `logger.js` and `logger.test.js` differ
- audited consumers: only two `new Logger(` sites exist (the singleton and its test), no code mutates `LOG_LEVEL` at runtime, and every other `PLUGIN_SERVER_MODE` consumer reads config directly

Automated tests (all run locally):

- new test in `logger.test.ts`: the logger module loads without plugin-server database env. Catches anyone reintroducing a config import into the logger's graph, which no existing test covered
- new `recording-rasterizer/__tests__/otel-metrics.test.ts`: the rasterizer's OTLP metrics import chain (instruments, provider, exporter, logger) loads without plugin-server database env. Catches the incident class end to end even if the regression enters through a different module in the chain
- both tests validated against the unfixed logger: they fail with the exact incident error, and pass with the fix
- full rasterizer suite (16 suites, 265 tests), logger suite, and the common metrics suites pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal infra change, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Claude Fable 5) from the incident escalation.
Skills invoked: /writing-tests.
Decisions: fixed the logger's config dependency (resolving its existing TODO) instead of making the OTLP exporter avoid the logger, because it removes the whole failure class for any future config-less entrypoint and is a net smaller change.
The new tests set `NODE_ENV=production` during an isolated require because the test env injects a default `DATABASE_URL`, which would make the guard vacuous.
Verified the guard tests fail against the unfixed logger before trusting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
