### PR TITLE
feat(web-analytics): percentage-of-teams rollout for no-join fast paths

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1162,3 +1162,9 @@ WEB_ANALYTICS_NO_JOIN_TEAM_IDS: list[int] = [
     int(team_id)
     for team_id in get_list(get_from_env("WEB_ANALYTICS_NO_JOIN_TEAM_IDS", _LAZY_PRECOMPUTE_DEFAULT_TEAM_IDS))
 ]
+
+# Percentage-of-teams rollout for the no-join fast paths, on top of the explicit
+# allowlist above. Bucketing is deterministic per team (team_id % 100) so everyone
+# on a team sees numbers from the same code path. 0 disables (allowlist only),
+# 100 enrolls every team. Set per deployment — region rollouts are independent.
+WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT: int = get_from_env("WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT", 0, type_cast=int)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1166,5 +1166,10 @@ WEB_ANALYTICS_NO_JOIN_TEAM_IDS: list[int] = [
 # Percentage-of-teams rollout for the no-join fast paths, on top of the explicit
 # allowlist above. Bucketing is deterministic per team (team_id % 100) so everyone
 # on a team sees numbers from the same code path. 0 disables (allowlist only),
-# 100 enrolls every team. Set per deployment — region rollouts are independent.
-WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT: int = get_from_env("WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT", 0, type_cast=int)
+# 100 enrolls every team. Defaults to 50 on US Cloud (verified region); EU stays 0
+# until its ClickHouse upgrade converges and the fast paths are verified there.
+# Env var overrides in either direction and is the kill switch.
+_NO_JOIN_DEFAULT_ROLLOUT_PERCENT = 50 if (CLOUD_DEPLOYMENT or "").upper() == "US" and not TEST else 0
+WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT: int = get_from_env(
+    "WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT", _NO_JOIN_DEFAULT_ROLLOUT_PERCENT, type_cast=int
+)

--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview.py
@@ -1130,3 +1130,25 @@ class TestWebOverviewNoJoinFastPath(ClickhouseTestMixin, APIBaseTest):
         with override_settings(WEB_ANALYTICS_NO_JOIN_TEAM_IDS=[self.team.pk]):
             runner = self._make_runner(filterTestAccounts=True)
             assert not runner.should_skip_session_join
+
+
+class TestWebOverviewNoJoinRolloutPercent(ClickhouseTestMixin, APIBaseTest):
+    def _runner(self) -> WebOverviewQueryRunner:
+        query = WebOverviewQuery(dateRange=DateRange(date_from="-7d"), properties=[])
+        return WebOverviewQueryRunner(team=self.team, query=query)
+
+    def test_percent_rollout_buckets_deterministically_by_team(self):
+        bucket = self.team.pk % 100
+        cases = [
+            (0, False),
+            (bucket, False),
+            (bucket + 1, True),
+            (100, True),
+        ]
+        for percent, expected in cases:
+            with override_settings(WEB_ANALYTICS_NO_JOIN_TEAM_IDS=[], WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT=percent):
+                assert self._runner().should_skip_session_join == expected, f"percent={percent}"
+
+    def test_allowlist_wins_regardless_of_percent(self):
+        with override_settings(WEB_ANALYTICS_NO_JOIN_TEAM_IDS=[self.team.pk], WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT=0):
+            assert self._runner().should_skip_session_join

--- a/products/web_analytics/backend/hogql_queries/web_analytics_query_runner.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_query_runner.py
@@ -222,7 +222,7 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
         Runners that support a no-join query shape check this gate; anything not
         covered falls through to the join path untouched.
         """
-        if self.team.pk not in settings.WEB_ANALYTICS_NO_JOIN_TEAM_IDS:
+        if not self._team_in_no_join_rollout():
             return False
         if getattr(self.query, "conversionGoal", None):
             return False
@@ -239,6 +239,14 @@ class WebAnalyticsQueryRunner(AnalyticsQueryRunner[WAR], ABC):
         if sampling and (sampling.enabled or sampling.forceSamplingRate):
             return False
         return True
+
+    def _team_in_no_join_rollout(self) -> bool:
+        if self.team.pk in settings.WEB_ANALYTICS_NO_JOIN_TEAM_IDS:
+            return True
+        percent = settings.WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT
+        # Deterministic per-team bucketing: query results must come from one code
+        # path for everyone on a team, so the rollout unit is the team, not the user.
+        return percent > 0 and self.team.pk % 100 < percent
 
     @cached_property
     def filters_eligibility_hash(self) -> Optional[str]:


### PR DESCRIPTION
## Problem

The no-join fast paths from #70746 are gated on an explicit team allowlist (`WEB_ANALYTICS_NO_JOIN_TEAM_IDS`, currently the Cloud dogfooding team). Production verification on that team is clean - the 180d live-path probe served at 7.1s/439 MiB where the join path needed ~35s/20+ GiB, with zero non-cancellation exceptions since deploy. Widening team-by-team via allowlist doesn't scale to a general release, and a per-user percentage would be wrong for query results: two people on the same team would see numbers computed by different code paths.

## Changes

- `WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT` (0-100, default 0): enrolls teams by deterministic bucket (`team_id % 100 < percent`) on top of the existing allowlist. The rollout unit is the team, so everyone on a team gets one code path. Set per deployment, so region rollouts are independent - team ids are region-specific and the allowlist/percent for one region says nothing about the other.
- Percent 0 keeps today's behavior (allowlist only) and doubles as the kill switch; 100 enrolls everyone.

As merged, the default is **50 on US Cloud** (the verified region) and 0 everywhere else - EU stays at 0 until its ClickHouse 26.6 upgrade converges and the fast paths are verified there, self-hosted and tests are unaffected. The env var overrides in either direction and is the kill switch; next notch is 100 after a clean bake.

## How did you test this code?

- `test_percent_rollout_buckets_deterministically_by_team`: exercises the exact boundary (`percent == bucket` excluded, `bucket + 1` included) plus 0 and 100 - catches off-by-one or nondeterministic bucketing, which would flip teams in and out of the fast path between queries.
- `test_allowlist_wins_regardless_of_percent`: the explicit allowlist keeps working at percent 0.
- Existing no-join eligibility/parity suites still pass (18 tests across overview + stats table fast-path classes).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change at the default (percent 0).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Follow-up to #70746 from the rollout discussion: Lucas proposed releasing to everyone or a percentage of users; per-user bucketing was rejected because query results must be consistent within a team, so the mechanism buckets deterministically by team id.
- Skills invoked: /writing-tests.
- Patch coverage: the new gate branch is covered by the boundary tests above.
