### PR TITLE
feat(data-warehouse): promote bing ads source to ga

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldOauthAccountSelectConfig,
     SourceFieldOauthConfig,
@@ -140,7 +141,7 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             keywords=["microsoft ads", "microsoft advertising"],
             label="Bing Ads",
             caption="Ensure you have granted PostHog access to your Bing Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/bing-ads).",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/bing-ads.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/bing-ads",
             fields=cast(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest import mock
 
-from posthog.schema import SourceFieldOauthAccountSelectConfig, SourceFieldOauthConfig
+from posthog.schema import ReleaseStatus, SourceFieldOauthAccountSelectConfig, SourceFieldOauthConfig
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.bing_ads.source import BingAdsSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.bing_ads.utils import BingAdsResumeConfig
@@ -32,7 +32,7 @@ class TestBingAdsSource:
 
         assert config.name.value == "BingAds"
         assert config.label == "Bing Ads"
-        assert config.releaseStatus == "beta"
+        assert config.releaseStatus == ReleaseStatus.GA
         assert config.iconPath == "/static/services/bing-ads.svg"
         assert len(config.fields) == 2
 


### PR DESCRIPTION
## Problem

The Bing Ads (`BingAds`) data warehouse source has been shipping under a `beta` label. It now clears our GA bar, so the label should reflect that it's generally available.

Current 7-day metrics:

| Metric | Threshold | Current |
| --- | --- | --- |
| Adoption | 100+ teams **or** 3+ months live | 106 teams, live ~7.6 months |
| Import error rate | < 2.5% | 1.5% |

## Changes

- Set `releaseStatus` on the `BingAds` source config from `beta` to `ga`.
- Switched from the bare `"beta"` string literal to the `ReleaseStatus.GA` enum, matching the convention every other source follows (and what the `implementing-warehouse-sources` skill requires).
- Updated the source config test to assert the new value via the enum.

This is a status-only promotion. No connector behavior, schemas, or sync logic changed. No gating flag was present (`unreleasedSource` was already absent, no `featureFlag`), so nothing else needed touching.

## How did you test this code?

Ran `ruff check` and `ruff format` on the changed files (clean). The dev environment here has no Django installed, so I could not run the pytest suite. The only test touched is the existing `test_get_source_config` assertion, updated in lockstep with the config change. `py_compile` passes on both files.

## Docs update

No user-facing docs change needed. `docsUrl` still points at the existing Bing Ads doc.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Promotion done by Claude (Opus 4.8) via PostHog Code. Invoked the `/implementing-warehouse-sources` skill to confirm where release status lives and the enum-over-string-literal convention. Verified there was no existing open PR doing the same promotion (searched by source name, `releaseStatus`, and the maintainer's own open PRs). Chose `ReleaseStatus.GA` over omitting `releaseStatus` to keep an explicit, greppable status consistent with peers like Klaviyo, GitHub, and Google Ads.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
