### PR TITLE
feat(web-analytics): tag no-join overview executions with their own query type

### DIFF
--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview.py
@@ -1152,3 +1152,22 @@ class TestWebOverviewNoJoinRolloutPercent(ClickhouseTestMixin, APIBaseTest):
     def test_allowlist_wins_regardless_of_percent(self):
         with override_settings(WEB_ANALYTICS_NO_JOIN_TEAM_IDS=[self.team.pk], WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT=0):
             assert self._runner().should_skip_session_join
+
+    def test_no_join_executions_emit_their_own_query_type_tag(self):
+        from posthog.hogql import query as hogql_query_module
+
+        with override_settings(WEB_ANALYTICS_NO_JOIN_TEAM_IDS=[self.team.pk], WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT=0):
+            with patch(
+                "products.web_analytics.backend.hogql_queries.web_overview.execute_hogql_query",
+                wraps=hogql_query_module.execute_hogql_query,
+            ) as spy:
+                self._runner().calculate()
+        assert spy.call_args.kwargs["query_type"] == "web_overview_no_join_query"
+
+        with override_settings(WEB_ANALYTICS_NO_JOIN_TEAM_IDS=[], WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT=0):
+            with patch(
+                "products.web_analytics.backend.hogql_queries.web_overview.execute_hogql_query",
+                wraps=hogql_query_module.execute_hogql_query,
+            ) as spy:
+                self._runner().calculate()
+        assert spy.call_args.kwargs["query_type"] == "web_overview_query"

--- a/products/web_analytics/backend/hogql_queries/web_overview.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview.py
@@ -252,7 +252,9 @@ CROSS JOIN {sessions_agg} AS sessions_agg
 
         response = (
             execute_hogql_query(
-                query_type="web_overview_query",
+                # Distinct tag for the fast path so query_log analysis doesn't need
+                # to text-match the SQL shape (see /evaluating-web-analytics-performance).
+                query_type="web_overview_no_join_query" if self.should_skip_session_join else "web_overview_query",
                 query=self.to_query(),
                 team=self.team,
                 user=self.user,

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -112,11 +112,12 @@ def queries_to_keep_fresh(
                 AND team_id = %(team_id)s
                 AND (
                     startsWith(query_type, 'stats_table_')
+                    -- Overview strategy variants get their own tags (no_join today,
+                    -- two_phase next); prefix-match like stats_table_ so new variants
+                    -- can't silently fall out of warming.
+                    OR startsWith(query_type, 'web_overview_')
                     OR query_type IN (
                     'web_goals_query',
-                    'web_overview_preaggregated_query',
-                    'web_overview_query',
-                    'web_overview_lazy_query',
                     'web_stats_paths_lazy_query',
                     'web_vitals_path_breakdown_query',
                     'web_vitals_paths_lazy_query',


### PR DESCRIPTION
## Problem

The paths-tile no-join strategies emit distinct `query_type` tags (`stats_table_no_join_path_bounce_query`), but the overview fast path from #70746 shares `web_overview_query` with the join path. Rollout monitoring has to detect it by text-matching the generated SQL (`query LIKE '%CROSS JOIN%sessions_agg%'`), which is fragile and easy to forget.

## Changes

`WebOverviewQueryRunner._calculate` tags fast-path executions as `web_overview_no_join_query`; the join path keeps `web_overview_query`. One conditional, no query changes.

## How did you test this code?

- `test_no_join_executions_emit_their_own_query_type_tag`: asserts the tag for an allowlisted team and the unchanged tag otherwise. The regression it catches is the tag silently reverting to the shared name, which would blind the query_log-based rollout monitoring that the team's evaluation workflow depends on.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None (internal observability tag).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Follow-up from monitoring the #70746/#70906 rollout: Lucas flagged that the overview fast path should have had its own tag from the start. Query_log data before this merges still needs the SQL text-match; after, the tag is authoritative.
- Skills invoked: /writing-tests, /evaluating-web-analytics-performance (whose tag vocabulary this feeds).