### PR TITLE
fix(data-warehouse): guide users when the new-source table step finds no tables

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
@@ -98,6 +98,12 @@ export default function SchemaForm(): JSX.Element {
     const showRows = databaseSchema.some((schema) => schema.rows != null)
     const hasManySchemas = databaseSchema.length > 10
 
+    // Shown when the schema fetch returned zero tables. That can be transient — some sources
+    // are still listing their tables just after connecting — or a credentials/permissions
+    // problem, so point at both instead of dead-ending on "No tables found".
+    const noTablesMessage =
+        'No tables found. If you just connected, the source may still be listing its tables, so go back a step and try again. Otherwise, check the source credentials, permissions, and configuration.'
+
     const warehouseColumns = [
         {
             width: 0,
@@ -526,7 +532,9 @@ export default function SchemaForm(): JSX.Element {
                                 />
                             </div>
                         ) : (
-                            <div className="border rounded px-4 py-8 text-center text-muted-alt">No tables found</div>
+                            <div className="border rounded px-4 py-8 text-center text-muted-alt">
+                                {noTablesMessage}
+                            </div>
                         )
                     ) : groupedDatabaseSchema.length > 1 ? (
                         <div className="border rounded bg-bg-light">
@@ -575,7 +583,7 @@ export default function SchemaForm(): JSX.Element {
                         </div>
                     ) : (
                         <LemonTable
-                            emptyState={schemaNameFilter ? `No tables match "${schemaNameFilter}"` : 'No schemas found'}
+                            emptyState={schemaNameFilter ? `No tables match "${schemaNameFilter}"` : noTablesMessage}
                             dataSource={filteredDatabaseSchema}
                             pagination={{ pageSize: 100, hideOnSinglePage: true }}
                             columns={[

--- a/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SchemaForm.tsx
@@ -532,9 +532,7 @@ export default function SchemaForm(): JSX.Element {
                                 />
                             </div>
                         ) : (
-                            <div className="border rounded px-4 py-8 text-center text-muted-alt">
-                                {noTablesMessage}
-                            </div>
+                            <div className="border rounded px-4 py-8 text-center text-muted-alt">{noTablesMessage}</div>
                         )
                     ) : groupedDatabaseSchema.length > 1 ? (
                         <div className="border rounded bg-bg-light">


### PR DESCRIPTION
## Problem

In the data warehouse new-source wizard, the table-selection step renders only after schema discovery finishes. When that call comes back with zero tables, the step showed a bare "No tables found" (or "No schemas found") with nowhere to go.

Two things land users here:
- A transient empty result. Some sources are still listing their tables in the moment right after you connect, so the first fetch legitimately returns nothing.
- A real credentials or permissions problem where the connected account can't see any tables.

Either way the dead-end message doesn't say which, so people bounce back and forth between steps or give up on the connection.

## Changes

Replace the two empty-state strings in the wizard's table step with one message that covers both causes and names the next action:

> No tables found. If you just connected, the source may still be listing its tables, so go back a step and try again. Otherwise, check the source credentials, permissions, and configuration.

Going back a step and re-submitting re-runs schema discovery, so the retry hint is accurate. The credentials half mirrors copy the source-detail views already use for the same empty state.

Copy-only change. No behavior, sync, or schema changes.

## How did you test this code?

No automated tests added. This is a static copy change to an existing empty state, gated by the same conditions as before. I (Claude) could not run the frontend linters or typecheck in this environment because `node_modules` isn't installed. CI covers lint, format, and typecheck.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude while reviewing onboarding-friction signals from data-warehouse new-source sessions. The recurring pattern was users reaching the table step, seeing an empty list, and bouncing between steps or abandoning, most clearly on sources whose schema listing takes a moment to populate after connecting.

I looked at whether this needed a loading state instead, but the step already only mounts after the fetch resolves, so the empty state genuinely means "the fetch returned zero rows" rather than "still loading". That made a copy fix the right, self-contained scope. Left broader items (per-connector schema-listing latency, the table step's lack of progress feedback on import) as recommendations rather than folding them in here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
