### PR TITLE
feat(web-analytics): skip fresh teams and fail loudly on empty audience in eager backfill

### DIFF
--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -468,6 +468,24 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext, config: EagerWar
     team_ids, gate_reason, diagnostics = _resolve_eager_audience(
         active_teams_pct=config.active_teams_pct, active_lookback_hours=config.active_lookback_hours
     )
+    # The active-audience fetch is best-effort ([] on any ClickHouse error) so the
+    # hourly warmer never skips a cycle. For the backfill that leniency is wrong: a
+    # transient cluster error would silently shrink a fleet-wide run to the static
+    # lists and the run would report SUCCESS having warmed nothing (this happened —
+    # an ALL_CONNECTION_TRIES_FAILED blip produced a 14-minute no-op "backfill").
+    # Fail loudly instead so the launcher knows to relaunch.
+    if (
+        job_name == "web_analytics_eager_backfill"
+        and config.active_teams_pct > 0
+        and not diagnostics.get("active_teams")
+    ):
+        raise dagster.Failure(
+            description=(
+                f"active-audience fetch returned no teams (active_teams_pct={config.active_teams_pct}) — "
+                "likely a transient ClickHouse error during the query_log scan; relaunch the backfill"
+            ),
+            metadata=diagnostics,
+        )
     # Captured before the ramp enrollment below mutates the setting — this set is
     # what "statically enrolled" means for the priority sort further down.
     static_ids = {

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -443,6 +443,14 @@ class EagerWarmConfig(dagster.Config):
     # None = use WARM_TEAM_CONCURRENCY (resolved at run time, so tests patching the
     # constant still control the pool).
     team_concurrency: int | None = pydantic.Field(default=None, ge=1, le=25)
+    # Skip teams whose latest READY job in the baseline window is fresher than this
+    # many hours, instead of merely sorting them last. Without it, a fleet-scale run
+    # spends hours re-verifying the tile matrix of thousands of already-warm teams
+    # before reaching the never-warmed tail — in the worst case never getting there
+    # within max_runtime. Teams with no precompute jobs at all are never skipped.
+    # None = process every eligible team (the hourly job's behavior — its static
+    # audience is small and should always be topped up).
+    skip_fresh_hours: int | None = pydantic.Field(default=None, ge=1, le=168)
 
 
 @dagster.op
@@ -549,6 +557,25 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext, config: EagerWar
             .values_list("team_id", "last")
         )
         never_computed = datetime.min.replace(tzinfo=UTC)
+
+        if config.skip_fresh_hours is not None:
+            # Teams with no READY jobs in the window have no `last_computed` entry
+            # and are therefore never skipped — they're the audience this exists for.
+            fresh_cutoff = datetime.now(UTC) - timedelta(hours=config.skip_fresh_hours)
+            fresh_ids = {t.pk for t in eligible if (last_computed.get(t.pk) or never_computed) >= fresh_cutoff}
+            if fresh_ids:
+                eligible = [t for t in eligible if t.pk not in fresh_ids]
+                skipped += len(fresh_ids)
+                context.log.info(
+                    f"eager_baseline_warming_skipped_fresh count={len(fresh_ids)} "
+                    f"skip_fresh_hours={config.skip_fresh_hours} remaining={len(eligible)}"
+                )
+                logger.info(
+                    "eager_baseline_warming_skipped_fresh",
+                    count=len(fresh_ids),
+                    skip_fresh_hours=config.skip_fresh_hours,
+                    remaining=len(eligible),
+                )
         # Two tiers: statically enrolled teams first (stalest first within the tier),
         # then the ramp audience. A large `active_teams_pct` audience is mostly
         # never-warmed, and a flat staleness sort would push the always-enrolled teams
@@ -687,7 +714,13 @@ def _fail_on_concurrent_run(context: dagster.OpExecutionContext) -> None:
         "relaunching skips them and continues the tail. Safe to run alongside the hourly "
         "schedule — the pending-job unique index dedupes concurrent window builds."
     ),
-    config={"ops": {"warm_eager_baseline_op": {"config": {"active_teams_pct": 100, "active_lookback_hours": 168}}}},
+    config={
+        "ops": {
+            "warm_eager_baseline_op": {
+                "config": {"active_teams_pct": 100, "active_lookback_hours": 168, "skip_fresh_hours": 24}
+            }
+        }
+    },
     tags={
         "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
         "dagster/max_runtime": str(24 * 60 * 60),

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -175,6 +175,21 @@ BASELINE_BREAKDOWNS: tuple[WebStatsBreakdown, ...] = (
 )
 
 
+# Full tile matrix size per team: WebOverview + WebGoals + WebVitalsPathBreakdown
+# plus one WebStatsTableQuery per baseline breakdown. A team's warm pass is
+# "complete" only when exactly this many tiles ran without error.
+BASELINE_TILE_COUNT = 3 + len(BASELINE_BREAKDOWNS)
+
+
+# Dagster run-storage KV key recording when a team last completed a *full* warm
+# pass (every tile in the matrix, zero failures). `skip_fresh_hours` trusts only
+# this marker — never the shared `PreaggregationJob` table, where a single recent
+# job from an interrupted run, an on-demand read, or another product would make
+# a cold team look freshly warmed.
+def _warm_complete_kv_key(team_id: int) -> str:
+    return f"web_analytics_eager_warm_complete:{team_id}"
+
+
 EAGER_PRECOMPUTE_BASELINE_WARMED = Counter(
     "web_analytics_eager_precompute_baseline_warmed_total",
     "Total baseline queries warmed by the eager web analytics precompute job, labeled by query kind.",
@@ -203,13 +218,15 @@ EAGER_PRECOMPUTE_BASELINE_NOT_PRECOMPUTED = Counter(
 ACTIVE_AUDIENCE_MAX_TEAMS = 20000
 
 
-def _fetch_active_wa_team_ids(limit: int, lookback_hours: int = 24) -> list[int]:
+def _fetch_active_wa_team_ids(limit: int, lookback_hours: int = 24) -> list[int] | None:
     """Top teams by deliberate WA dashboard activity (stats-table tile queries),
     most active first. Powers the warm-audience ramp experiment via the job's
     run config (`active_teams_pct`).
 
-    Best-effort: any failure returns [] so the warmer falls back to the static
-    lists rather than skipping a run."""
+    Returns None on failure so callers can tell a broken fetch apart from a
+    legitimately empty audience — the hourly warmer treats both as "fall back
+    to the static lists", but the backfill must fail loudly on the former and
+    proceed on the latter."""
     from posthog.clickhouse.client import sync_execute  # noqa: PLC0415 — keep dagster import path light
 
     try:
@@ -233,7 +250,7 @@ def _fetch_active_wa_team_ids(limit: int, lookback_hours: int = 24) -> list[int]
         return [int(row[0]) for row in rows]
     except Exception:
         logger.exception("eager_warm_active_audience_fetch_failed")
-        return []
+        return None
 
 
 def _resolve_eager_audience(active_teams_pct: int = 0, active_lookback_hours: int = 24) -> tuple[list[int], str, dict]:
@@ -254,8 +271,12 @@ def _resolve_eager_audience(active_teams_pct: int = 0, active_lookback_hours: in
     # baseline warmed — otherwise its reads land on cold on-demand inserts.
     # dict.fromkeys preserves order and dedupes teams in both lists.
     active_team_ids: list[int] = []
+    active_fetch_failed = False
     if active_teams_pct > 0:
         all_active = _fetch_active_wa_team_ids(ACTIVE_AUDIENCE_MAX_TEAMS, lookback_hours=active_lookback_hours)
+        if all_active is None:
+            active_fetch_failed = True
+            all_active = []
         take = max(1, len(all_active) * min(active_teams_pct, 100) // 100) if all_active else 0
         active_team_ids = all_active[:take]
 
@@ -274,6 +295,7 @@ def _resolve_eager_audience(active_teams_pct: int = 0, active_lookback_hours: in
         "teams_configured": len(team_ids),
         "active_teams_pct": active_teams_pct,
         "active_teams": len(active_team_ids),
+        "active_fetch_failed": int(active_fetch_failed),
     }
     if not team_ids:
         return [], "no_teams_configured", diag
@@ -443,13 +465,14 @@ class EagerWarmConfig(dagster.Config):
     # None = use WARM_TEAM_CONCURRENCY (resolved at run time, so tests patching the
     # constant still control the pool).
     team_concurrency: int | None = pydantic.Field(default=None, ge=1, le=25)
-    # Skip teams whose latest READY job in the baseline window is fresher than this
-    # many hours, instead of merely sorting them last. Without it, a fleet-scale run
-    # spends hours re-verifying the tile matrix of thousands of already-warm teams
-    # before reaching the never-warmed tail — in the worst case never getting there
-    # within max_runtime. Teams with no precompute jobs at all are never skipped.
-    # None = process every eligible team (the hourly job's behavior — its static
-    # audience is small and should always be topped up).
+    # Skip teams whose full tile matrix completed within this many hours (per the
+    # run-storage completion marker), instead of merely sorting them last. Without
+    # it, a fleet-scale run spends hours re-verifying the tile matrix of thousands
+    # of already-warm teams before reaching the never-warmed tail — in the worst
+    # case never getting there within max_runtime. Teams without a fresh marker
+    # (never warmed, interrupted mid-matrix, or marker predates this feature) are
+    # never skipped. None = process every eligible team (the hourly job's behavior
+    # — its static audience is small and should always be topped up).
     skip_fresh_hours: int | None = pydantic.Field(default=None, ge=1, le=168)
 
 
@@ -468,20 +491,18 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext, config: EagerWar
     team_ids, gate_reason, diagnostics = _resolve_eager_audience(
         active_teams_pct=config.active_teams_pct, active_lookback_hours=config.active_lookback_hours
     )
-    # The active-audience fetch is best-effort ([] on any ClickHouse error) so the
-    # hourly warmer never skips a cycle. For the backfill that leniency is wrong: a
-    # transient cluster error would silently shrink a fleet-wide run to the static
-    # lists and the run would report SUCCESS having warmed nothing (this happened —
-    # an ALL_CONNECTION_TRIES_FAILED blip produced a 14-minute no-op "backfill").
-    # Fail loudly instead so the launcher knows to relaunch.
-    if (
-        job_name == "web_analytics_eager_backfill"
-        and config.active_teams_pct > 0
-        and not diagnostics.get("active_teams")
-    ):
+    # The active-audience fetch is best-effort (falls back to the static lists) so
+    # the hourly warmer never skips a cycle. For the backfill that leniency is
+    # wrong: a transient cluster error would silently shrink a fleet-wide run to
+    # the static lists and the run would report SUCCESS having warmed nothing
+    # (this happened — an ALL_CONNECTION_TRIES_FAILED blip produced a 14-minute
+    # no-op "backfill"). Fail loudly on fetch *errors* so the launcher knows to
+    # relaunch; a fetch that succeeded but found no active teams proceeds with
+    # the static lists like any other run.
+    if job_name == "web_analytics_eager_backfill" and diagnostics.get("active_fetch_failed"):
         raise dagster.Failure(
             description=(
-                f"active-audience fetch returned no teams (active_teams_pct={config.active_teams_pct}) — "
+                f"active-audience fetch failed (active_teams_pct={config.active_teams_pct}) — "
                 "likely a transient ClickHouse error during the query_log scan; relaunch the backfill"
             ),
             metadata=diagnostics,
@@ -577,10 +598,23 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext, config: EagerWar
         never_computed = datetime.min.replace(tzinfo=UTC)
 
         if config.skip_fresh_hours is not None:
-            # Teams with no READY jobs in the window have no `last_computed` entry
-            # and are therefore never skipped — they're the audience this exists for.
+            # Skip only teams whose *own* full warm completed recently, recorded by
+            # the completion marker `_warm` writes. Teams with no marker — never
+            # warmed, interrupted mid-matrix, or only touched by other products'
+            # jobs in the shared table — are never skipped.
             fresh_cutoff = datetime.now(UTC) - timedelta(hours=config.skip_fresh_hours)
-            fresh_ids = {t.pk for t in eligible if (last_computed.get(t.pk) or never_computed) >= fresh_cutoff}
+            markers = context.instance.run_storage.get_cursor_values({_warm_complete_kv_key(t.pk) for t in eligible})
+
+            def _marker_fresh(team: Team) -> bool:
+                raw = markers.get(_warm_complete_kv_key(team.pk))
+                if not raw:
+                    return False
+                try:
+                    return datetime.fromisoformat(raw) >= fresh_cutoff
+                except ValueError:
+                    return False
+
+            fresh_ids = {t.pk for t in eligible if _marker_fresh(t)}
             if fresh_ids:
                 eligible = [t for t in eligible if t.pk not in fresh_ids]
                 skipped += len(fresh_ids)
@@ -618,6 +652,19 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext, config: EagerWar
                 # out of `pool.map`, abort the teams not yet iterated, and discard the
                 # counts of teams that already warmed. Contain it so the pool drains.
                 logger.exception("eager_baseline_warming_team_errored", team_id=team.pk)
+            else:
+                if team_failed == 0 and team_warmed == BASELINE_TILE_COUNT:
+                    # Full matrix warmed cleanly — record it so `skip_fresh_hours`
+                    # can trust this team is genuinely covered. Written per team
+                    # (not batched at run end) so a run killed by max_runtime keeps
+                    # the markers for everything it finished. Best-effort: a marker
+                    # write failure only costs a redundant re-verify next run.
+                    try:
+                        context.instance.run_storage.set_cursor_values(
+                            {_warm_complete_kv_key(team.pk): datetime.now(UTC).isoformat()}
+                        )
+                    except Exception:
+                        logger.exception("eager_baseline_warming_marker_write_failed", team_id=team.pk)
             finally:
                 # Each pool thread holds its own Django DB connections; close them on
                 # the way out so the run doesn't leak one connection per team.

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -10,6 +10,7 @@ from django.test import override_settings
 from django.utils import timezone
 
 import dagster
+from dagster import DagsterInstance
 from parameterized import parameterized
 from structlog.testing import capture_logs
 
@@ -25,6 +26,7 @@ from products.web_analytics.dags.eager_web_analytics_precompute import (
     EagerWarmConfig,
     _resolve_eager_audience,
     _warm_baseline_for_team,
+    _warm_complete_kv_key,
     warm_eager_baseline_op,
     web_analytics_eager_backfill_job,
     web_analytics_eager_baseline_warming_job,
@@ -69,7 +71,7 @@ class TestResolveEagerAudience:
         team_ids, reason, diag = _resolve_eager_audience()
         assert team_ids == [2, 7]
         assert reason == "ok"
-        assert diag == {"teams_configured": 2, "active_teams_pct": 0, "active_teams": 0}
+        assert diag == {"teams_configured": 2, "active_teams_pct": 0, "active_teams": 0, "active_fetch_failed": 0}
 
     def test_returns_empty_on_self_hosted(self, _is_cloud):
         _is_cloud.return_value = False
@@ -100,7 +102,12 @@ class TestResolveEagerAudience:
             team_ids, reason, diag = _resolve_eager_audience()
         assert team_ids == expected
         assert reason == "ok"
-        assert diag == {"teams_configured": len(expected), "active_teams_pct": 0, "active_teams": 0}
+        assert diag == {
+            "teams_configured": len(expected),
+            "active_teams_pct": 0,
+            "active_teams": 0,
+            "active_fetch_failed": 0,
+        }
 
     @parameterized.expand(
         [
@@ -123,7 +130,12 @@ class TestResolveEagerAudience:
             team_ids, reason, diag = _resolve_eager_audience(active_teams_pct=pct)
         assert team_ids == expected
         assert reason == "ok"
-        assert diag == {"teams_configured": len(expected), "active_teams_pct": pct, "active_teams": expected_active}
+        assert diag == {
+            "teams_configured": len(expected),
+            "active_teams_pct": pct,
+            "active_teams": expected_active,
+            "active_fetch_failed": 0,
+        }
 
 
 @patch("products.web_analytics.dags.eager_web_analytics_precompute.is_cloud", return_value=True)
@@ -192,37 +204,72 @@ class TestWarmEagerBaselineOp(APIBaseTest):
 
     @parameterized.expand(
         [
-            # skip_fresh_hours=24: the freshly-warmed team is dropped from the walk;
-            # the stale and never-warmed teams are still processed (never-warmed must
-            # survive the filter — it has no last_computed entry).
-            ("skip_enabled", 24, {"never", "stale"}, 1),
+            # skip_fresh_hours=24: only the team with a fresh completion marker is
+            # dropped. `partial` has a recent PreaggregationJob row but no marker —
+            # the shared-table case (interrupted run, on-demand read, another
+            # product's job) that must NOT hide a cold team.
+            ("skip_enabled", 24, {"never", "stale", "partial"}, 1),
             # None (hourly-job default): every team is processed, nothing skipped.
-            ("skip_disabled", None, {"never", "stale", "fresh"}, 0),
+            ("skip_disabled", None, {"never", "stale", "partial", "fresh"}, 0),
         ]
     )
     @patch(f"{_EAGER_MODULE}.WARM_TEAM_CONCURRENCY", 1)
     @patch(f"{_EAGER_MODULE}.tag_queries")
     @patch(f"{_EAGER_MODULE}.get_query_runner")
-    def test_skip_fresh_hours_drops_only_freshly_warmed_teams(
+    def test_skip_fresh_hours_drops_only_marker_complete_teams(
         self, _name, skip_fresh_hours, expected_processed, expected_skipped, get_runner, _tag, _is_cloud
     ):
-        never, stale, fresh = self._enroll_teams(count=3)
-        labels = {never.pk: "never", stale.pk: "stale", fresh.pk: "fresh"}
+        never, stale, fresh, partial = self._enroll_teams(count=4)
+        labels = {never.pk: "never", stale.pk: "stale", fresh.pk: "fresh", partial.pk: "partial"}
         now = timezone.now()
-        _make_preagg_job(fresh, computed_at=now - timedelta(hours=1))
-        _make_preagg_job(stale, computed_at=now - timedelta(days=2))
+        instance = DagsterInstance.ephemeral()
+        instance.run_storage.set_cursor_values({_warm_complete_kv_key(fresh.pk): now.isoformat()})
+        instance.run_storage.set_cursor_values({_warm_complete_kv_key(stale.pk): (now - timedelta(days=2)).isoformat()})
+        _make_preagg_job(partial, computed_at=now)
         get_runner.return_value = Mock(
             run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
         )
 
-        with _eager_audience([never.pk, stale.pk, fresh.pk]):
+        with _eager_audience([never.pk, stale.pk, fresh.pk, partial.pk]):
             result = warm_eager_baseline_op(
-                dagster.build_op_context(), EagerWarmConfig(skip_fresh_hours=skip_fresh_hours)
+                dagster.build_op_context(instance=instance), EagerWarmConfig(skip_fresh_hours=skip_fresh_hours)
             )
 
         processed = {labels[(call.kwargs.get("team") or call.args[1]).pk] for call in get_runner.call_args_list}
         assert processed == expected_processed
         assert result["skipped"] == expected_skipped
+
+    @parameterized.expand(
+        [
+            # A clean full warm writes the completion marker, so a second run with
+            # skip_fresh_hours skips the team without touching the runners.
+            ("clean_warm_marks_complete", False, 1, 0),
+            # A warm with a failing tile must NOT write the marker — the second run
+            # re-processes the team instead of hiding the hole.
+            ("failed_tile_blocks_marker", True, 0, _QUERIES_PER_TEAM),
+        ]
+    )
+    @patch(f"{_EAGER_MODULE}.tag_queries")
+    @patch(f"{_EAGER_MODULE}.get_query_runner")
+    def test_completion_marker_round_trip(
+        self, _name, tile_fails, expected_skipped, expected_second_run_calls, get_runner, _tag, _is_cloud
+    ):
+        ok_result = Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE)
+        get_runner.return_value = Mock(
+            run=Mock(side_effect=Exception("tile blew up") if tile_fails else None, return_value=ok_result)
+        )
+        instance = DagsterInstance.ephemeral()
+
+        with _eager_audience([self.team.pk]):
+            warm_eager_baseline_op(dagster.build_op_context(instance=instance))
+            get_runner.return_value.run.side_effect = None
+            get_runner.reset_mock()
+            result = warm_eager_baseline_op(
+                dagster.build_op_context(instance=instance), EagerWarmConfig(skip_fresh_hours=24)
+            )
+
+        assert result["skipped"] == expected_skipped
+        assert get_runner.return_value.run.call_count == expected_second_run_calls
 
     @patch(f"{_EAGER_MODULE}.tag_queries")
     @patch(f"{_EAGER_MODULE}.get_query_runner")
@@ -287,20 +334,33 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         assert result == {"teams": 1, "warmed": 0, "failed": 0, "skipped": 1}
         get_runner.assert_not_called()
 
+    @parameterized.expand(
+        [
+            # Fetch errored (None): the backfill must fail loudly instead of
+            # silently shrinking to the static lists and reporting SUCCESS —
+            # the production incident this guards against.
+            ("fetch_error_fails_run", None, False),
+            # Fetch succeeded but found no active teams ([]): a legitimate
+            # result — the run proceeds and warms the static lists.
+            ("legitimately_empty_proceeds", [], True),
+        ]
+    )
     @patch(f"{_EAGER_MODULE}.tag_queries")
     @patch(f"{_EAGER_MODULE}.get_query_runner")
-    @patch(f"{_EAGER_MODULE}._fetch_active_wa_team_ids", return_value=[])
-    def test_backfill_fails_when_active_audience_fetch_returns_nothing(self, _fetch, get_runner, _tag, _is_cloud):
-        # The fetch is best-effort ([] on ClickHouse errors) so the hourly warmer
-        # never skips a cycle — but a backfill run that gets [] would silently warm
-        # only the static lists and report SUCCESS. It must fail instead.
+    def test_backfill_distinguishes_fetch_error_from_empty_audience(
+        self, _name, fetch_result, expected_success, get_runner, _tag, _is_cloud
+    ):
         get_runner.return_value = Mock(
             run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
         )
-        with _eager_audience([self.team.pk]):
+        with (
+            _eager_audience([self.team.pk]),
+            patch(f"{_EAGER_MODULE}._fetch_active_wa_team_ids", return_value=fetch_result),
+        ):
             result = web_analytics_eager_backfill_job.execute_in_process(raise_on_error=False)
-        assert not result.success
-        get_runner.assert_not_called()
+        assert result.success == expected_success
+        if not expected_success:
+            get_runner.assert_not_called()
 
 
 class TestWarmBaselineForTeam(APIBaseTest):

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -22,6 +22,7 @@ from products.analytics_platform.backend.models.preaggregation_job import Preagg
 from products.web_analytics.dags.eager_web_analytics_precompute import (
     BASELINE_BREAKDOWNS,
     BASELINE_WINDOW_DAYS,
+    EagerWarmConfig,
     _resolve_eager_audience,
     _warm_baseline_for_team,
     warm_eager_baseline_op,
@@ -187,6 +188,40 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         # Both noise teams are treated as never-warmed (front); the genuinely warm team is last.
         assert seen[-1] == genuine.pk
         assert set(seen[:2]) == {noise_window.pk, noise_status.pk}
+
+    @parameterized.expand(
+        [
+            # skip_fresh_hours=24: the freshly-warmed team is dropped from the walk;
+            # the stale and never-warmed teams are still processed (never-warmed must
+            # survive the filter — it has no last_computed entry).
+            ("skip_enabled", 24, {"never", "stale"}, 1),
+            # None (hourly-job default): every team is processed, nothing skipped.
+            ("skip_disabled", None, {"never", "stale", "fresh"}, 0),
+        ]
+    )
+    @patch(f"{_EAGER_MODULE}.WARM_TEAM_CONCURRENCY", 1)
+    @patch(f"{_EAGER_MODULE}.tag_queries")
+    @patch(f"{_EAGER_MODULE}.get_query_runner")
+    def test_skip_fresh_hours_drops_only_freshly_warmed_teams(
+        self, _name, skip_fresh_hours, expected_processed, expected_skipped, get_runner, _tag, _is_cloud
+    ):
+        never, stale, fresh = self._enroll_teams(count=3)
+        labels = {never.pk: "never", stale.pk: "stale", fresh.pk: "fresh"}
+        now = timezone.now()
+        _make_preagg_job(fresh, computed_at=now - timedelta(hours=1))
+        _make_preagg_job(stale, computed_at=now - timedelta(days=2))
+        get_runner.return_value = Mock(
+            run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
+        )
+
+        with _eager_audience([never.pk, stale.pk, fresh.pk]):
+            result = warm_eager_baseline_op(
+                dagster.build_op_context(), EagerWarmConfig(skip_fresh_hours=skip_fresh_hours)
+            )
+
+        processed = {labels[(call.kwargs.get("team") or call.args[1]).pk] for call in get_runner.call_args_list}
+        assert processed == expected_processed
+        assert result["skipped"] == expected_skipped
 
     @patch(f"{_EAGER_MODULE}.tag_queries")
     @patch(f"{_EAGER_MODULE}.get_query_runner")

--- a/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/tests/test_eager_web_analytics_precompute.py
@@ -26,6 +26,7 @@ from products.web_analytics.dags.eager_web_analytics_precompute import (
     _resolve_eager_audience,
     _warm_baseline_for_team,
     warm_eager_baseline_op,
+    web_analytics_eager_backfill_job,
     web_analytics_eager_baseline_warming_job,
 )
 
@@ -284,6 +285,21 @@ class TestWarmEagerBaselineOp(APIBaseTest):
         # setting is updated; the run should not crash.
         result = warm_eager_baseline_op(dagster.build_op_context())
         assert result == {"teams": 1, "warmed": 0, "failed": 0, "skipped": 1}
+        get_runner.assert_not_called()
+
+    @patch(f"{_EAGER_MODULE}.tag_queries")
+    @patch(f"{_EAGER_MODULE}.get_query_runner")
+    @patch(f"{_EAGER_MODULE}._fetch_active_wa_team_ids", return_value=[])
+    def test_backfill_fails_when_active_audience_fetch_returns_nothing(self, _fetch, get_runner, _tag, _is_cloud):
+        # The fetch is best-effort ([] on ClickHouse errors) so the hourly warmer
+        # never skips a cycle — but a backfill run that gets [] would silently warm
+        # only the static lists and report SUCCESS. It must fail instead.
+        get_runner.return_value = Mock(
+            run=Mock(return_value=Mock(preComputeStrategy=WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE))
+        )
+        with _eager_audience([self.team.pk]):
+            result = web_analytics_eager_backfill_job.execute_in_process(raise_on_error=False)
+        assert not result.success
         get_runner.assert_not_called()
 
 


### PR DESCRIPTION
## Problem

Two backfill-run failure modes surfaced while running `web_analytics_eager_backfill` across the full active-WA audience:

1. **A relaunched backfill spends hours re-walking already-warm teams.** The op sorts eligible teams by staleness but still processes every one of them — each warm team costs a full tile-matrix verification pass (~24 read queries) before the run reaches the never-warmed tail. At fleet scale that's thousands of teams of pure verification, and in the worst case the runtime budget expires before the cold tail is reached at all.
2. **A transient ClickHouse error silently turns a backfill into a no-op.** The active-audience fetch is best-effort (returns `[]` on any error) so the hourly warmer never skips a cycle — but a backfill run that gets `[]` warms only the small static list and reports SUCCESS. This happened in production: an `ALL_CONNECTION_TRIES_FAILED` blip during the audience scan produced a 14-minute "successful" backfill that warmed nothing (`active_teams=0` in the run's output metadata).

## Changes

- New `skip_fresh_hours` config on `EagerWarmConfig` (default `None` = current behavior): teams whose latest READY `PreaggregationJob` in the baseline window is fresher than the threshold are dropped from the walk instead of merely sorted last. Teams with no precompute jobs at all are never skipped — they're the audience the backfill exists for. The backfill job's default config sets it to 24h; the hourly warmer keeps `None` (its static audience is small and should always be topped up).
- The backfill job now raises `dagster.Failure` when `active_teams_pct > 0` and the audience fetch returns no teams, so a transient ClickHouse error produces a visible failed run to relaunch instead of a silent no-op success. The hourly job's best-effort behavior is unchanged.

## How did you test this code?

- `test_skip_fresh_hours_drops_only_freshly_warmed_teams` (parameterized): with the flag on, a freshly-warmed team is skipped while stale and never-warmed teams still process (guards the sentinel regression where never-warmed teams would be silently skipped, no-opping the backfill); with `None`, all teams process — pins the hourly job's unchanged behavior.
- `test_backfill_fails_when_active_audience_fetch_returns_nothing`: executes the backfill job in-process with the fetch patched to `[]` and asserts the run fails without warming — the exact production incident.
- Full dag suite: 25 passed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built during live monitoring of the full-fleet backfill; both failure modes were observed in production runs (the silent no-op via `active_teams=0` in run output metadata, the slow warm-team walk via query_log insert/verify ratios).
- Skills invoked: /writing-tests.
