### PR TITLE
fix(flags): show pending-approval warning for single flag copy

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1,10 +1,17 @@
-import { MOCK_DEFAULT_BASIC_USER, MOCK_DEFAULT_PROJECT, MOCK_TEAM_ID } from 'lib/api.mock'
+import {
+    MOCK_DEFAULT_BASIC_USER,
+    MOCK_DEFAULT_PROJECT,
+    MOCK_DEFAULT_TEAM,
+    MOCK_ORGANIZATION_ID,
+    MOCK_TEAM_ID,
+} from 'lib/api.mock'
 
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
 import { dayjs } from 'lib/dayjs'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { urls } from 'scenes/urls'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
@@ -44,6 +51,15 @@ import {
     validateFeatureFlagKey,
 } from './featureFlagLogic'
 import { featureFlagsLogic } from './featureFlagsLogic'
+
+// jest.config.ts sets clearMocks: true, so these mock.fn() call histories reset before every test.
+jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
+    lemonToast: {
+        success: jest.fn(),
+        error: jest.fn(),
+        warning: jest.fn(),
+    },
+}))
 
 const MOCK_FEATURE_FLAG = {
     ...NEW_FLAG,
@@ -1333,6 +1349,72 @@ describe('featureFlagLogic', () => {
             expect(dialogProps.title).toBe('Disable feature flag "test-flag"?')
             expect(dialogProps.primaryButton?.children).toBe('Disable flag')
             dialogOpenSpy.mockRestore()
+        })
+    })
+
+    describe('copyFlagSuccess', () => {
+        const copyFlagsUrl = `/api/organizations/${MOCK_ORGANIZATION_ID}/feature_flags/copy_flags/`
+
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    // Hit by the loadProjectsWithCurrentFlag() the listener always triggers afterward.
+                    [`/api/organizations/${MOCK_ORGANIZATION_ID}/feature_flags/${MOCK_FEATURE_FLAG.key}/`]: () => [
+                        200,
+                        [],
+                    ],
+                },
+            })
+            logic.actions.setCopyDestinationProject(MOCK_TEAM_ID)
+        })
+
+        it('shows a pending-approval warning, not a raw error, when the target project gates the write', async () => {
+            useMocks({
+                post: {
+                    [copyFlagsUrl]: () => [
+                        200,
+                        {
+                            success: [],
+                            failed: [
+                                {
+                                    project_id: MOCK_TEAM_ID,
+                                    error_message: 'Approval required',
+                                    approval_pending: true,
+                                    change_request_id: 'cr-1',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            })
+
+            logic.actions.copyFlag()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.warning).toHaveBeenCalledWith(
+                `A change request was created for ${MOCK_DEFAULT_TEAM.name}; the copy will apply once approved.`
+            )
+            expect(lemonToast.error).not.toHaveBeenCalled()
+        })
+
+        it('shows a plain error toast for a hard failure', async () => {
+            useMocks({
+                post: {
+                    [copyFlagsUrl]: () => [
+                        200,
+                        {
+                            success: [],
+                            failed: [{ project_id: MOCK_TEAM_ID, error_message: 'Project not found.' }],
+                        },
+                    ],
+                },
+            })
+
+            logic.actions.copyFlag()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Error while copying feature flag: Project not found.')
+            expect(lemonToast.warning).not.toHaveBeenCalled()
         })
     })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -2189,9 +2189,24 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 ])
                 warnings.forEach((warning) => lemonToast.warning(warning))
             } else {
-                const errorMessage = JSON.stringify(featureFlagCopy?.failed) || featureFlagCopy
-                lemonToast.error(`Error while saving feature flag: ${errorMessage}`)
-                eventUsageLogic.actions.reportFeatureFlagCopyFailure(errorMessage)
+                // This flow copies to a single target project, so at most one failure entry comes back.
+                const failure = featureFlagCopy?.failed[0]
+                if (failure?.approval_pending) {
+                    const projectName = values.currentOrganization?.teams.find(
+                        (team) => team.id === (failure.project_id ?? values.copyDestinationProject)
+                    )?.name
+                    lemonToast.warning(
+                        `A change request was created for ${
+                            projectName ?? 'the destination project'
+                        }; the copy will apply once approved.`
+                    )
+                    eventUsageLogic.actions.reportFeatureFlagCopyFailure(failure.error_message ?? 'Approval pending')
+                } else {
+                    const errorMessage =
+                        failure?.error_message ?? JSON.stringify(featureFlagCopy?.failed ?? featureFlagCopy)
+                    lemonToast.error(`Error while copying feature flag: ${errorMessage}`)
+                    eventUsageLogic.actions.reportFeatureFlagCopyFailure(errorMessage)
+                }
             }
 
             actions.loadProjectsWithCurrentFlag()


### PR DESCRIPTION
## Problem

Follow-up to #69044, which added the bulk-copy modal and made `copy_flags` return a structured `approval_pending` entry when a target project's approval policy gates the write, instead of raising. That PR fixed the toast for the new bulk-copy modal, but the older single-flag copy on a flag's Projects tab still ran the raw `JSON.stringify(failed)` path in `copyFlagSuccess`, so copying one flag into an approval-gated project showed a JSON blob in an error toast even though the copy actually succeeded in creating a change request.

## Changes

`copyFlagSuccess` in `featureFlagLogic.ts` now checks the first (and only, since this flow targets a single project) entry in `failed` for `approval_pending`. When set, it shows a `lemonToast.warning` naming the destination project, matching the wording the bulk-copy modal already uses for the same case. Any other failure still shows `lemonToast.error`, now built from the failure's `error_message` instead of stringifying the whole array.

## How did you test this code?

- Added two tests to `featureFlagLogic.test.ts`: one for the pending-approval warning branch, one for the plain-error branch, both asserting on the exact toast call.
- Manually verified against a real approval policy: granted the org the `approvals` feature and created an `ApprovalPolicy` (`feature_flag.enable`, quorum 1) on a second local project, then copied a flag into it from the Projects tab. Saw the warning toast "A change request was created for Bulk Copy Target; the copy will apply once approved." and confirmed a real `pending` `ChangeRequest` row was created while the target flag stayed unapplied.
- Confirmed the hard-failure path (no approval policy involved) still shows a plain error toast, not a warning.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update