### PR TITLE
feat(web-analytics): roll no-join fast paths to all us cloud teams

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1169,7 +1169,7 @@ WEB_ANALYTICS_NO_JOIN_TEAM_IDS: list[int] = [
 # 100 enrolls every team. Defaults to 50 on US Cloud (verified region); EU stays 0
 # until its ClickHouse upgrade converges and the fast paths are verified there.
 # Env var overrides in either direction and is the kill switch.
-_NO_JOIN_DEFAULT_ROLLOUT_PERCENT = 50 if (CLOUD_DEPLOYMENT or "").upper() == "US" and not TEST else 0
+_NO_JOIN_DEFAULT_ROLLOUT_PERCENT = 100 if (CLOUD_DEPLOYMENT or "").upper() == "US" and not TEST else 0
 WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT: int = get_from_env(
     "WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT", _NO_JOIN_DEFAULT_ROLLOUT_PERCENT, type_cast=int
 )


### PR DESCRIPTION
## Problem

The no-join fast paths (#70746) rolled to 50% of US Cloud teams via deterministic team bucketing (#70906). Production evidence after 14 hours at 50%:

| Metric | Pre-merge (join, eligible population, 24h) | Post-merge (no-join, 14h at 50%) |
|---|---|---|
| Paths tile p50 | 816ms | **384ms** (2.1x) |
| Paths tile p95 | 3.6s | **815ms** (4.4x) |
| Paths tile p99 | 7.3s | **2.3s** (3.2x) |
| Paths tile max memory | **33.4 GiB** | **741 MiB** (45x) |
| Overview max memory | 21.9 GiB | **196 MiB** (114x) |
| Teams served | - | **374** (674 paths servings + 100 overview) |
| Query-level fast-path failures | - | **0** (only anomaly: one team's 1-second burst into the pre-existing 30-concurrent-queries OFFLINE cap) |
| Out-of-bucket servings | - | **0** |

Coverage math: ~86% of user-facing web analytics queries reaching ClickHouse are unfiltered and therefore eligible; at 50% team bucketing roughly half of that population is served today, so this PR approximately doubles fast-path coverage to all eligible US traffic.

(Eligible population = user-facing, unfiltered, no test-account filtering - the class the fast path serves. The post p99 tail is bounded-memory queue contention on the dogfooding team, not query cost.)

## Changes

One line: the US Cloud default for `WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT` goes 50 → 100. Every US team's unfiltered overview and paths queries take the fast path on deploy. EU stays at 0 (pending its ClickHouse 26.6 upgrade convergence + separate verification), self-hosted and tests unaffected. The env var remains a two-way override and the kill switch.

## How did you test this code?

- Settings-only change; the bucketing/allowlist behavior is covered by `TestWebOverviewNoJoinRolloutPercent` (boundary-exact tests) from #70906.
- Production evidence above; monitoring continues via the `stats_table_no_join_*` / `web_overview_no_join_query` tags (#70934) and `web_analytics_no_join_served_total`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change (results parity verified; latency improves).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Final notch of the staged rollout Lucas directed (team 2 → 50% → 100%), backed by the fleet evidence table above collected via query_log monitoring.
- Skills invoked: /evaluating-web-analytics-performance.
