### PR TITLE
fix(cal_com): cap bookings page size to the 100 API maximum

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/cal_com.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/cal_com.py
@@ -17,9 +17,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.htt
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 CAL_COM_BASE_URL = "https://api.cal.com/v2"
-# Bookings `limit` and webhooks `take` are documented with a 250 maximum; the largest page
-# minimizes round trips against the 120 req/min default rate limit.
-PAGE_LIMIT = 250
 REQUEST_TIMEOUT_SECONDS = 60
 # Cheap single-object endpoint used to confirm an API key is genuine. The key is account-wide, so
 # one probe validates access to every list endpoint.
@@ -152,7 +149,7 @@ def _get_cursor_rows(
         logger.debug(f"Cal.com: resuming {config.name} from cursor {cursor}")
 
     while True:
-        params = {**base_params, "limit": PAGE_LIMIT}
+        params = {**base_params, "limit": config.page_size}
         if cursor is not None:
             params["cursor"] = cursor
 
@@ -186,17 +183,17 @@ def _get_offset_rows(
         logger.debug(f"Cal.com: resuming {config.name} from offset {skip}")
 
     while True:
-        params = {**base_params, "take": PAGE_LIMIT, "skip": skip}
+        params = {**base_params, "take": config.page_size, "skip": skip}
         body = _fetch_page(session, url, params, logger)
         items = _rows_from_body(body, config, url)
         if items:
             yield items
 
         # These endpoints return no pagination metadata; a short (or empty) page means we're done.
-        if len(items) < PAGE_LIMIT:
+        if len(items) < config.page_size:
             break
 
-        skip += PAGE_LIMIT
+        skip += config.page_size
         resumable_source_manager.save_state(CalComResumeConfig(skip=skip))
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/settings.py
@@ -39,6 +39,9 @@ class CalComEndpointConfig:
     # Maps an incremental field name to the server-side query param that filters on it.
     incremental_param_by_field: dict[str, str] = field(default_factory=dict)
     default_incremental_field: Optional[str] = None
+    # Max items per page. Cal.com caps this per endpoint and rejects larger values with 400: the
+    # bookings `limit` maxes at 100, while the webhooks `take` allows up to 250.
+    page_size: int = 100
 
 
 # Cal.com API v2 list endpoints (https://cal.com/docs/api-reference/v2/introduction). Only bookings
@@ -76,6 +79,7 @@ CAL_COM_ENDPOINTS: dict[str, CalComEndpointConfig] = {
         name="webhooks",
         path="/webhooks",
         pagination="offset",
+        page_size=250,
     ),
     "me": CalComEndpointConfig(
         name="me",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/tests/test_cal_com.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cal_com/tests/test_cal_com.py
@@ -10,7 +10,6 @@ from parameterized import parameterized
 from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com import cal_com
 from products.warehouse_sources.backend.temporal.data_imports.sources.cal_com.cal_com import (
     CAL_COM_BASE_URL,
-    PAGE_LIMIT,
     CalComResumeConfig,
     CalComRetryableError,
     cal_com_source,
@@ -83,8 +82,9 @@ class TestBookingsCursorPagination:
         manager = _FakeResumableManager()
         rows, calls = _collect(manager, self._pages, "bookings")
         assert rows == [{"id": 1}, {"id": 2}]
-        assert calls[0]["params"] == {"limit": PAGE_LIMIT}
-        assert calls[1]["params"] == {"limit": PAGE_LIMIT, "cursor": "c2"}
+        # Bookings `limit` maxes at 100; a larger value is rejected with 400 Bad Request.
+        assert calls[0]["params"] == {"limit": 100}
+        assert calls[1]["params"] == {"limit": 100, "cursor": "c2"}
         # State is saved once — after the first page, pointing at the next cursor — then we stop.
         assert [s.cursor for s in manager.saved] == ["c2"]
 
@@ -165,15 +165,18 @@ class TestBookingsCursorPagination:
 class TestWebhooksOffsetPagination:
     def test_advances_skip_until_short_page(self) -> None:
         manager = _FakeResumableManager()
-        full_page = [{"id": i} for i in range(PAGE_LIMIT)]
+        page_size = CAL_COM_ENDPOINTS["webhooks"].page_size
+        full_page = [{"id": i} for i in range(page_size)]
 
         def pages(url: str, params: dict[str, Any]) -> dict[str, Any]:
             return {"data": full_page if params["skip"] == 0 else [{"id": "last"}]}
 
         rows, calls = _collect(manager, pages, "webhooks")
-        assert len(rows) == PAGE_LIMIT + 1
-        assert [c["params"]["skip"] for c in calls] == [0, PAGE_LIMIT]
-        assert [s.skip for s in manager.saved] == [PAGE_LIMIT]
+        assert len(rows) == page_size + 1
+        # Webhooks `take` maxes at 250; a larger value is rejected with 400 Bad Request.
+        assert calls[0]["params"]["take"] == 250
+        assert [c["params"]["skip"] for c in calls] == [0, page_size]
+        assert [s.skip for s in manager.saved] == [page_size]
 
     def test_resumes_from_saved_offset(self) -> None:
         manager = _FakeResumableManager(CalComResumeConfig(skip=500))


### PR DESCRIPTION
## Problem

Cal.com error tracking surfaced a recurring `HTTPError` from the `cal_com` data-warehouse import source:

> `400 Client Error: Bad Request for url: https://api.cal.com/v2/bookings`

Raised in `cal_com.py` `_fetch_page`. [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019f639b-f49b-7d93-b42c-4160b5b77b89) — it fired across several distinct sources within the same short window, which pointed at a systemic request problem rather than one customer's config.

Root cause: the bookings list endpoint (`cal-api-version: 2026-05-01`) documents a `limit` [maximum of 100](https://cal.com/docs/api-reference/v2/bookings/get-all-bookings), but our shared page-size constant sent `limit=250`. Cal.com validates the parameter and rejects it with a 400, so every bookings sync failed on its very first page. The old code comment even claimed a 250 maximum for bookings, which is wrong — that cap belongs to the webhooks `take` parameter.

## Changes

Moved page size out of the single shared `PAGE_LIMIT` constant and into the per-endpoint config:

- **bookings** `limit` now caps at 100 (the documented maximum).
- **webhooks** `take` keeps its 250 maximum.

Both the request value and the offset short-page detection read from `config.page_size`, so each endpoint stays within its own documented cap.

## How did you test this code?

Automated tests only (I'm an agent and did not exercise a live Cal.com sync):

- Updated `test_follows_next_cursor_until_has_more_false` to assert bookings requests send `limit=100`. This is the regression guard — it fails if anyone sends a value above the API's documented max again, which is exactly the bug that caused the 400.
- Added a `take == 250` assertion to the webhooks offset test; nothing previously pinned the webhooks page size, so the per-endpoint cap is now locked in on both sides.
- Ran the full `cal_com` suite: `test_cal_com.py` (45 passed) and `test_cal_com_source.py` (19 passed).

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (PostHog Code). Confirmed the failure originated in the `cal_com` source (`_fetch_page`, top in-app frame), read the implementation, and checked the Cal.com API reference to confirm the bookings `limit` cap is 100 while webhooks `take` allows 250. Classified as a fixable bad-request-param bug (not a user/upstream auth error), so the fix corrects the request rather than extending `NonRetryableErrors`. Invoked `/writing-tests` before touching the tests. No open PR already addressed this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
