### PR TITLE
feat(llm-gateway): drop posthog_code free valve to $20

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -63,9 +63,9 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
 }
 
 FREE_PLAN_COST_LIMIT = UserCostLimit(
-    burst_limit_usd=75.0,
+    burst_limit_usd=20.0,
     burst_window_seconds=86400,
-    sustained_limit_usd=75.0,
+    sustained_limit_usd=20.0,
     sustained_window_seconds=2592000,
 )
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1279,24 +1279,24 @@ class TestRateLimitPoisoningPrevention:
 
 class TestPlanAwareThrottling:
     @pytest.mark.asyncio
-    async def test_free_user_gets_limit_of_75(self) -> None:
+    async def test_free_user_gets_limit_of_20(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="posthog_code", plan_key=None, seat_created_at="2026-01-01T00:00:00+00:00")
 
-        await throttle.record_cost(context, 75.0)
+        await throttle.record_cost(context, 20.0)
         result = await throttle.allow_request(context)
         assert result.allowed is False
 
     @pytest.mark.asyncio
-    async def test_free_user_gets_sustained_limit_of_75(self) -> None:
+    async def test_free_user_gets_sustained_limit_of_20(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
         context = make_context(product="posthog_code", plan_key=None, seat_created_at="2026-01-01T00:00:00+00:00")
 
-        await throttle.record_cost(context, 75.0)
+        await throttle.record_cost(context, 20.0)
         result = await throttle.allow_request(context)
         assert result.allowed is False
 
@@ -1318,7 +1318,7 @@ class TestPlanAwareThrottling:
         throttle = UserCostSustainedThrottle(redis=None)
         context = make_context(product="posthog_code", plan_key=None, seat_created_at="2025-01-01T00:00:00+00:00")
 
-        await throttle.record_cost(context, 49.0)
+        await throttle.record_cost(context, 19.0)
         result = await throttle.allow_request(context)
         assert result.allowed is True
 
@@ -1385,7 +1385,7 @@ class TestPlanAwareThrottling:
     @pytest.mark.parametrize(
         ("seat_missing", "expected_allowed"),
         [
-            # Confirmed no seat (404) → free cap: $80 spent exceeds the $75 limit.
+            # Confirmed no seat (404) → free cap: $80 spent exceeds the $20 limit.
             (True, False),
             # Plan resolution failed → default limits ($500/day): fail loose so an
             # outage never clamps paying users whose plan couldn't be resolved.
@@ -1414,7 +1414,7 @@ class TestPlanAwareThrottling:
         ("seat_missing", "code_usage_billed", "expected_allowed"),
         [
             # Seatless + org-billed Code usage: bills to the org - no per-user cap.
-            # $600 spent clears both the $75 free cap and the $500/day default.
+            # $600 spent clears both the $20 free cap and the $500/day default.
             (True, True, True),
             # Seatless + not billed: the free cap holds (this pair pins that the
             # bypass never leaks to orgs that would get the usage for free).


### PR DESCRIPTION
## Problem

Free-tier posthog_code users are capped at $75/day. Under usage-based billing the org-level free allowance is $20/month, enforced through the quota pipeline within ~20 minutes, so the per-user cap only has to bound burn inside that window. $75 is far past the thing it protects.

## Changes

`FREE_PLAN_COST_LIMIT` drops to $20 burst/day and $20 sustained/30d, matching the org allowance so one user can't burn past an org's month alone. Takes effect for free-tier users on deploy.

## How did you test this code?

Existing free-cap boundary tests moved to the new value ($20 blocks, $19 sustained allowed). Full gateway suite green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code session (Claude). Skill: /writing-tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
