### PR TITLE
fix(devex): bound OTel trace flush at process exit

### DIFF
--- a/posthog/otel_instrumentation.py
+++ b/posthog/otel_instrumentation.py
@@ -1,4 +1,5 @@
 import os
+import atexit
 import typing
 import logging
 
@@ -101,11 +102,21 @@ def initialize_otel():
             source_module="otel_instrumentation",
         )
 
-        provider = TracerProvider(resource=resource)
+        # shutdown_on_exit=False: the SDK's own atexit hook calls provider.shutdown(),
+        # which joins the BatchSpanProcessor export thread WITHOUT a timeout. If the
+        # OTLP collector is unreachable, that thread sits in the gRPC exporter's
+        # retry/backoff loop (~63s of sleeps per batch, and the exporter's shutdown
+        # flag is only set after the join returns), so every process exit hangs until
+        # SIGKILL — under granian this turns each worker stop into a
+        # "refused to gracefully stop" hard kill. A bounded force_flush gives spans
+        # their best shot at export and then lets the process exit; the export thread
+        # is a daemon, so skipping shutdown() leaks nothing at exit.
+        provider = TracerProvider(resource=resource, shutdown_on_exit=False)
         otlp_exporter = OTLPSpanExporter()  # Assumes OTLP endpoint is configured via env vars
         processor = BatchSpanProcessor(otlp_exporter)
         provider.add_span_processor(processor)
         trace.set_tracer_provider(provider)
+        atexit.register(lambda: provider.force_flush(timeout_millis=5_000))
         logger.info(
             "otel_core_components_initialized_successfully",
             service_name=service_name,


### PR DESCRIPTION
## Problem

The OTel SDK's default atexit hook calls `TracerProvider.shutdown()`, which joins the `BatchSpanProcessor` export thread **without a timeout**. If the OTLP collector is unreachable, that thread sits in the gRPC exporter's retry/backoff loop (~63s of sleeps per queued batch in opentelemetry 1.33.1), and the exporter's own shutdown flag is only set *after* the join returns — an ordering deadlock, so process exit blocks indefinitely.

Under granian this means: collector outage → every worker stop fleet-wide hangs until it's SIGKILLed after `GRANIAN_WORKERS_KILL_TIMEOUT` ("Killing worker-N after it refused to gracefully stop"), severing whatever requests the worker still held, and pods eat their full termination grace period, slowing rollouts and scale-downs to a crawl.

Found while investigating drain behavior on the granian pools; proven with a faulthandler dump of a hung worker (main thread in `threading.join` ← `BatchSpanProcessor.shutdown` ← atexit; export thread in `exporter.py _export` retry).

## Changes

- `TracerProvider(shutdown_on_exit=False)` — drop the SDK's unbounded atexit join.
- Register our own atexit doing `provider.force_flush(timeout_millis=5000)` — spans still get flushed on clean exits, but bounded. The export thread is a daemon, so skipping `shutdown()` leaks nothing at exit.

## How did you test this code?

Drain repro on the current prod image (granian WSGI, real boot path):
- Unreachable collector, 100% sampling, unpatched: worker hangs indefinitely, SIGKILL after kill timeout — every time.
- Same setup with this patch: worker exits in ~10s (5s bounded flush + the in-progress retry sleep).
- Healthy collector with this patch: graceful exit in 2-5s, spans flushed.

`ruff check` / `ruff format` clean. `initialize_otel` early-returns under `TEST=1`, so test runs are unaffected.
