### PR TITLE
fix(slo): trustworthy delivery metric and NUL-safe snapshot writes

### DIFF
--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -73,6 +73,8 @@ async def _persist_content_snapshot(
     @database_sync_to_async(thread_sensitive=False)
     def _merge() -> None:
         delivery = SubscriptionDelivery.objects.get(pk=delivery_id)
+        # insight_snapshots must already be NUL-scrubbed at its source (build_insight_delivery_snapshot
+        # → _serialize_insight_result); a NUL reaching content_snapshot fails this save with a DataError.
         delivery.content_snapshot = {
             **(delivery.content_snapshot or {}),
             "total_insight_count": total_insight_count,

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/activities.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/activities.py
@@ -28,8 +28,8 @@ from products.exports.backend.temporal.subscriptions.delivery_common import (
     auto_disable_and_return,
     deliver_email,
     deliver_slack,
+    strip_null_bytes,
 )
-from products.exports.backend.temporal.subscriptions.insight_snapshot import strip_null_bytes
 from products.exports.backend.temporal.subscriptions.types import (
     AI_REPORT_DIAGNOSTICS_KEY,
     AI_REPORT_PROMPT_SNAPSHOT_KEY,

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/activities.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/activities.py
@@ -29,6 +29,7 @@ from products.exports.backend.temporal.subscriptions.delivery_common import (
     deliver_email,
     deliver_slack,
 )
+from products.exports.backend.temporal.subscriptions.insight_snapshot import strip_null_bytes
 from products.exports.backend.temporal.subscriptions.types import (
     AI_REPORT_DIAGNOSTICS_KEY,
     AI_REPORT_PROMPT_SNAPSHOT_KEY,
@@ -105,13 +106,15 @@ async def _persist_ai_report(delivery_id: uuid.UUID, result: AiReportResult, pro
         # No DoesNotExist guard: create_delivery_record always writes this row before
         # generation runs, so a missing row is a wiring bug — let it raise loudly.
         delivery = SubscriptionDelivery.objects.get(pk=delivery_id)
+        # LLM output and the user prompt can carry NUL bytes that Postgres text/jsonb reject;
+        # scrub them here (payloads are small) as they are the untrusted inputs on this write path.
         delivery.content_snapshot = {
             **(delivery.content_snapshot or {}),
-            AI_REPORT_SNAPSHOT_KEY: result.markdown,
-            AI_REPORT_DIAGNOSTICS_KEY: [dataclasses.asdict(d) for d in result.diagnostics],
+            AI_REPORT_SNAPSHOT_KEY: strip_null_bytes(result.markdown),
+            AI_REPORT_DIAGNOSTICS_KEY: strip_null_bytes([dataclasses.asdict(d) for d in result.diagnostics]),
             AI_REPORT_WINDOW_END_KEY: result.window_end_utc,
             # prompt is None for non-AI subs; "" if cleared — omit either.
-            **({AI_REPORT_PROMPT_SNAPSHOT_KEY: prompt} if prompt else {}),
+            **({AI_REPORT_PROMPT_SNAPSHOT_KEY: strip_null_bytes(prompt)} if prompt else {}),
         }
         delivery.save(update_fields=["content_snapshot", "last_updated_at"])
 

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_activities.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_activities.py
@@ -94,6 +94,31 @@ async def test_persist_ai_report_writes_markdown_query_diagnostics_and_prompt(te
     assert snapshot[AI_REPORT_PROMPT_SNAPSHOT_KEY] == "weekly adoption + reliability report"
 
 
+async def test_persist_ai_report_strips_null_bytes(team, user) -> None:
+    # Regression witness: LLM output, diagnostics, and the prompt are untrusted NUL sources. Without
+    # the scrub, the NUL reaches content_snapshot and Postgres rejects the whole save with a DataError,
+    # so this test would fail on the write itself; with it, the NULs are gone and the rest survives.
+    delivery = await _create_delivery(team, user)
+
+    await _persist_ai_report(
+        delivery.id,
+        AiReportResult(
+            markdown="# Weekly\x00 report",
+            window_end_utc=_WINDOW_END_UTC,
+            diagnostics=(
+                QueryStepDiagnostic(description="adop\x00tion", hogql="SELECT co\x00unt()", ok=True, error_type=None),
+            ),
+        ),
+        prompt="weekly\x00 report",
+    )
+
+    snapshot = await _snapshot(delivery.id)
+    assert snapshot[AI_REPORT_SNAPSHOT_KEY] == "# Weekly report"
+    assert snapshot[AI_REPORT_DIAGNOSTICS_KEY][0]["description"] == "adoption"
+    assert snapshot[AI_REPORT_DIAGNOSTICS_KEY][0]["hogql"] == "SELECT count()"
+    assert snapshot[AI_REPORT_PROMPT_SNAPSHOT_KEY] == "weekly report"
+
+
 @pytest.mark.parametrize("prompt", [None, ""])
 async def test_persist_ai_report_omits_blank_prompt(team, user, prompt) -> None:
     # A non-AI sub passes prompt=None and a cleared prompt passes ""; neither should write the key

--- a/products/exports/backend/temporal/subscriptions/delivery_common.py
+++ b/products/exports/backend/temporal/subscriptions/delivery_common.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from slack_sdk.errors import SlackApiError
 from structlog import get_logger
@@ -25,6 +26,26 @@ from ee.tasks.subscriptions.auto_disable import (
 from ee.tasks.subscriptions.slack_subscriptions import SlackDeliveryResult, get_slack_integration_for_team
 
 LOGGER = get_logger(__name__)
+
+
+def strip_null_bytes(value: Any) -> Any:
+    """Recursively remove NUL (\\x00) from strings — Postgres text/jsonb columns cannot store it.
+
+    Anything written to ``SubscriptionDelivery.content_snapshot`` that originates outside a Postgres
+    text column (ClickHouse query results, LLM output, user-supplied prompts) must pass through this
+    first, or the NUL surfaces as a unicode escape that fails the whole delivery write with a DataError.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, list):
+        return [strip_null_bytes(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(strip_null_bytes(v) for v in value)
+    if isinstance(value, dict):
+        # Strip keys too: a Map(String, …) column can produce data-derived keys carrying NUL,
+        # and Postgres rejects it in a jsonb key just as it does in a value.
+        return {strip_null_bytes(k): strip_null_bytes(v) for k, v in value.items()}
+    return value
 
 
 async def auto_disable_and_return(

--- a/products/exports/backend/temporal/subscriptions/insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/insight_snapshot.py
@@ -28,32 +28,19 @@ from posthog.models import Team, User
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.exports.backend.models.subscription import Subscription
+from products.exports.backend.temporal.subscriptions.delivery_common import strip_null_bytes
 from products.product_analytics.backend.models.insight import Insight
 
 logger = structlog.get_logger(__name__)
+
+# strip_null_bytes now lives in delivery_common (a general-purpose sanitizer shared across delivery
+# paths); imported here for the query-result scrub below and so existing
+# `insight_snapshot.strip_null_bytes` importers keep resolving.
 
 
 def _json_safe_value(val: Any) -> Any:
     """Coerce to JSONField-safe Python (dict/list/scalars); unknown types use fallback, not pass-through."""
     return to_jsonable_python(val, fallback=lambda x: str(x))
-
-
-def strip_null_bytes(value: Any) -> Any:
-    """Recursively remove NUL (\\x00) from strings — Postgres text/jsonb columns cannot store it.
-
-    Anything written to ``SubscriptionDelivery.content_snapshot`` that originates outside a Postgres
-    text column (ClickHouse query results, LLM output, user-supplied prompts) must pass through this
-    first, or the NUL surfaces as a unicode escape that fails the whole delivery write with a DataError.
-    """
-    if isinstance(value, str):
-        return value.replace("\x00", "")
-    if isinstance(value, list):
-        return [strip_null_bytes(v) for v in value]
-    if isinstance(value, dict):
-        # Strip keys too: a Map(String, …) column can produce data-derived keys carrying NUL,
-        # and Postgres rejects it in a jsonb key just as it does in a value.
-        return {strip_null_bytes(k): strip_null_bytes(v) for k, v in value.items()}
-    return value
 
 
 def build_initial_content_snapshot(subscription: Subscription) -> dict[str, Any]:

--- a/products/exports/backend/temporal/subscriptions/insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/insight_snapshot.py
@@ -33,10 +33,6 @@ from products.product_analytics.backend.models.insight import Insight
 
 logger = structlog.get_logger(__name__)
 
-# strip_null_bytes now lives in delivery_common (a general-purpose sanitizer shared across delivery
-# paths); imported here for the query-result scrub below and so existing
-# `insight_snapshot.strip_null_bytes` importers keep resolving.
-
 
 def _json_safe_value(val: Any) -> Any:
     """Coerce to JSONField-safe Python (dict/list/scalars); unknown types use fallback, not pass-through."""
@@ -91,10 +87,19 @@ def _serialize_insight_result(result: InsightResult) -> dict[str, Any]:
         default=str,
     )
     parsed = orjson.loads(dumped)
-    # Query results can carry NUL bytes from upstream data. Django's JSONField serializes a NUL to
-    # a unicode escape that Postgres text/jsonb columns reject, which fails the whole delivery write.
-    # orjson emits that same escape sequence for a real NUL, so gate the (rare) recursive strip on
-    # its presence to avoid walking multi-MB payloads on every delivery.
+    # Query results can carry NUL bytes from upstream data, and Django's JSONField serializes a NUL
+    # to a unicode escape that Postgres text/jsonb columns reject — failing the whole delivery write
+    # with a DataError. So we strip NUL before returning, but only when one is actually present:
+    #
+    # - Cost: result.result is arbitrary ClickHouse output and can reach several MB; strip_null_bytes
+    #   rebuilds the entire dict/list tree, so running it on every delivery (nearly none carry a NUL)
+    #   would be pure waste. The gate is a single byte scan over the buffer we already serialized.
+    # - Correctness: orjson always emits a real NUL as an escape sequence (JSON forbids a raw control
+    #   byte), including inside object keys, so the check never misses a genuine NUL. It can only
+    #   over-trigger on literal escape text in the data, which is harmless — the walk then finds none.
+    #
+    # The AI-report path scrubs unconditionally instead, since those payloads are small (see
+    # delivery_common.strip_null_bytes callers).
     if b"\\u0000" in dumped:
         parsed = strip_null_bytes(parsed)
     return parsed

--- a/products/exports/backend/temporal/subscriptions/insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/insight_snapshot.py
@@ -50,7 +50,9 @@ def strip_null_bytes(value: Any) -> Any:
     if isinstance(value, list):
         return [strip_null_bytes(v) for v in value]
     if isinstance(value, dict):
-        return {k: strip_null_bytes(v) for k, v in value.items()}
+        # Strip keys too: a Map(String, …) column can produce data-derived keys carrying NUL,
+        # and Postgres rejects it in a jsonb key just as it does in a value.
+        return {strip_null_bytes(k): strip_null_bytes(v) for k, v in value.items()}
     return value
 
 

--- a/products/exports/backend/temporal/subscriptions/insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/insight_snapshot.py
@@ -38,14 +38,19 @@ def _json_safe_value(val: Any) -> Any:
     return to_jsonable_python(val, fallback=lambda x: str(x))
 
 
-def _strip_null_bytes(value: Any) -> Any:
-    """Recursively remove NUL (\\x00) from strings — Postgres text/jsonb columns cannot store it."""
+def strip_null_bytes(value: Any) -> Any:
+    """Recursively remove NUL (\\x00) from strings — Postgres text/jsonb columns cannot store it.
+
+    Anything written to ``SubscriptionDelivery.content_snapshot`` that originates outside a Postgres
+    text column (ClickHouse query results, LLM output, user-supplied prompts) must pass through this
+    first, or the NUL surfaces as a unicode escape that fails the whole delivery write with a DataError.
+    """
     if isinstance(value, str):
         return value.replace("\x00", "")
     if isinstance(value, list):
-        return [_strip_null_bytes(v) for v in value]
+        return [strip_null_bytes(v) for v in value]
     if isinstance(value, dict):
-        return {k: _strip_null_bytes(v) for k, v in value.items()}
+        return {k: strip_null_bytes(v) for k, v in value.items()}
     return value
 
 
@@ -102,7 +107,7 @@ def _serialize_insight_result(result: InsightResult) -> dict[str, Any]:
     # orjson emits that same escape sequence for a real NUL, so gate the (rare) recursive strip on
     # its presence to avoid walking multi-MB payloads on every delivery.
     if b"\\u0000" in dumped:
-        parsed = _strip_null_bytes(parsed)
+        parsed = strip_null_bytes(parsed)
     return parsed
 
 

--- a/products/exports/backend/temporal/subscriptions/insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/insight_snapshot.py
@@ -38,6 +38,17 @@ def _json_safe_value(val: Any) -> Any:
     return to_jsonable_python(val, fallback=lambda x: str(x))
 
 
+def _strip_null_bytes(value: Any) -> Any:
+    """Recursively remove NUL (\\x00) from strings — Postgres text/jsonb columns cannot store it."""
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, list):
+        return [_strip_null_bytes(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _strip_null_bytes(v) for k, v in value.items()}
+    return value
+
+
 def build_initial_content_snapshot(subscription: Subscription) -> dict[str, Any]:
     """Skeleton ``content_snapshot`` persisted when a delivery row is created.
 
@@ -71,22 +82,28 @@ def _serialize_insight_result(result: InsightResult) -> dict[str, Any]:
     # json.dumps (Django JSONField's default encoder) emits for non-finite floats.
     # `default=str` covers types orjson doesn't serialize natively (notably Decimal) the way
     # DjangoJSONEncoder would have, so switching encoders is a no-op for non-finite-float payloads.
-    return orjson.loads(
-        orjson.dumps(
-            {
-                "result": result.result,
-                "columns": result.columns,
-                "types": result.types,
-                "resolved_date_range": _json_safe_value(result.resolved_date_range),
-                "last_refresh": result.last_refresh.isoformat() if result.last_refresh else None,
-                "is_cached": result.is_cached,
-                "timezone": result.timezone,
-                "has_more": result.has_more,
-                "query_status": _json_safe_value(result.query_status),
-            },
-            default=str,
-        )
+    dumped = orjson.dumps(
+        {
+            "result": result.result,
+            "columns": result.columns,
+            "types": result.types,
+            "resolved_date_range": _json_safe_value(result.resolved_date_range),
+            "last_refresh": result.last_refresh.isoformat() if result.last_refresh else None,
+            "is_cached": result.is_cached,
+            "timezone": result.timezone,
+            "has_more": result.has_more,
+            "query_status": _json_safe_value(result.query_status),
+        },
+        default=str,
     )
+    parsed = orjson.loads(dumped)
+    # Query results can carry NUL bytes from upstream data. Django's JSONField serializes a NUL to
+    # a unicode escape that Postgres text/jsonb columns reject, which fails the whole delivery write.
+    # orjson emits that same escape sequence for a real NUL, so gate the (rare) recursive strip on
+    # its presence to avoid walking multi-MB payloads on every delivery.
+    if b"\\u0000" in dumped:
+        parsed = _strip_null_bytes(parsed)
+    return parsed
 
 
 def _insight_snapshot_base_metadata(*, insight: Insight, tile: DashboardTile | None) -> dict[str, Any]:

--- a/products/exports/backend/temporal/subscriptions/insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/insight_snapshot.py
@@ -215,7 +215,8 @@ def _execute_and_serialize_insight_query(
         return {
             "query_results": None,
             "cache_key": None,
-            "query_error": {"type": type(e).__name__, "message": str(e)},
+            # str(e) can echo offending query data, so scrub it like the result payload.
+            "query_error": {"type": type(e).__name__, "message": strip_null_bytes(str(e))},
         }
 
     if isinstance(insight_result, NothingInCacheResult):

--- a/products/exports/backend/temporal/subscriptions/test_insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/test_insight_snapshot.py
@@ -74,6 +74,25 @@ def test_serialize_insight_result_non_finite_floats_become_null():
     ]
 
 
+def test_serialize_insight_result_strips_null_bytes():
+    # Regression witness: ClickHouse result strings can carry NUL (\x00). Django's JSONField
+    # serializes it to a unicode escape that Postgres text/jsonb reject, failing the whole
+    # subscription delivery write. The NUL must be stripped while the rest of the string survives.
+    result = _build_insight_result(
+        result=[["Success?\x00 Yes: Env", "clean value"], ["\x00leading", "trailing\x00"]],
+        columns=["label\x00", "value"],
+        types=["String", "String"],
+    )
+
+    serialized = _serialize_insight_result(result)
+
+    # Round-trip through stdlib json (what JSONField uses) must not raise and must be NUL-free.
+    reparsed = json.loads(json.dumps(serialized))
+    assert reparsed["result"] == [["Success? Yes: Env", "clean value"], ["leading", "trailing"]]
+    assert reparsed["columns"] == ["label", "value"]
+    assert "\x00" not in json.dumps(serialized)
+
+
 def test_serialize_insight_result_handles_decimal_and_date():
     # Regression witness: orjson raises on Decimal without a default= hook, and stdlib json
     # raises on bare date. Both used to live on the ClickHouse result path for revenue /

--- a/products/exports/backend/temporal/subscriptions/test_insight_snapshot.py
+++ b/products/exports/backend/temporal/subscriptions/test_insight_snapshot.py
@@ -79,7 +79,8 @@ def test_serialize_insight_result_strips_null_bytes():
     # serializes it to a unicode escape that Postgres text/jsonb reject, failing the whole
     # subscription delivery write. The NUL must be stripped while the rest of the string survives.
     result = _build_insight_result(
-        result=[["Success?\x00 Yes: Env", "clean value"], ["\x00leading", "trailing\x00"]],
+        # A Map(String, …) column deserializes to a dict, so NUL can land in a key too.
+        result=[["Success?\x00 Yes: Env", {"la\x00bel": "val\x00ue"}], ["\x00leading", "trailing\x00"]],
         columns=["label\x00", "value"],
         types=["String", "String"],
     )
@@ -88,7 +89,7 @@ def test_serialize_insight_result_strips_null_bytes():
 
     # Round-trip through stdlib json (what JSONField uses) must not raise and must be NUL-free.
     reparsed = json.loads(json.dumps(serialized))
-    assert reparsed["result"] == [["Success? Yes: Env", "clean value"], ["leading", "trailing"]]
+    assert reparsed["result"] == [["Success? Yes: Env", {"label": "value"}], ["leading", "trailing"]]
     assert reparsed["columns"] == ["label", "value"]
     assert "\x00" not in json.dumps(serialized)
 

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -341,36 +341,69 @@ resource "posthog_insight" "slo_success_rate" {
     source = {
       kind  = "HogQLQuery"
       query = <<-SQL
-        -- No correlation_id needed: daily buckets have negligible cross-bucket issues.
-        -- Sampled operations are reweighted by 1/sample_rate so the rate reflects
-        -- true volume; events without the property coalesce to 1.0 (no sampling).
+        -- Pair starts to completions by correlation_id (same as the burn rate query) so an
+        -- operation that starts late in a day and finishes after midnight is attributed to its
+        -- start day, not miscounted as a failure on the start day and dropped on the next.
+        -- Uncorrelated events (cid = '') fall back to per-day bucket counting with a clamp.
+        -- Sampled operations are reweighted by 1/sample_rate so the rate reflects true volume;
+        -- events without the property coalesce to 1.0 (no sampling).
         WITH weighted_events AS (
             SELECT
                 event,
                 timestamp,
                 properties.operation AS operation,
+                coalesce(nullIf(properties.correlation_id, ''), '') AS correlation_id,
                 properties.outcome AS outcome,
+                coalesce(toFloat(properties.sample_rate), 1.0) AS sample_rate,
                 1.0 / coalesce(toFloat(properties.sample_rate), 1.0) AS weight
             FROM events
             WHERE event IN ('slo_operation_started', 'slo_operation_completed')
               AND properties.operation IN (${local.slo_operation_list})
               AND timestamp >= now() - INTERVAL 56 DAY
         ),
-        daily AS (
+        per_cid_day AS (
             SELECT
-                toDate(timestamp) AS date,
                 operation,
-                sumIf(weight, event = 'slo_operation_started') AS total,
-                greatest(
-                    sumIf(weight, event = 'slo_operation_started')
-                      - sumIf(weight, event = 'slo_operation_completed' AND outcome = 'success'),
-                    0.0
-                ) AS failures
+                correlation_id AS cid,
+                toDate(timestamp) AS event_date,
+                sumIf(weight, event = 'slo_operation_started') AS starts,
+                sumIf(weight, event = 'slo_operation_completed' AND outcome = 'success') AS successes,
+                max(sample_rate) AS cid_sample_rate,
+                min(if(event = 'slo_operation_started', timestamp, NULL)) AS first_start
             FROM weighted_events
-            GROUP BY date, operation
+            GROUP BY operation, cid, event_date
+        ),
+        daily AS (
+            SELECT operation, date, sum(total) AS total, sum(failures) AS failures
+            FROM (
+                -- Uncorrelated: starts/successes already weighted; 1 row per (operation, day).
+                SELECT
+                    operation,
+                    event_date AS date,
+                    starts AS total,
+                    greatest(starts - successes, 0.0) AS failures
+                FROM per_cid_day
+                WHERE cid = ''
+
+                UNION ALL
+
+                -- Correlated: collapse across days per (operation, cid), attribute to start day.
+                SELECT
+                    operation,
+                    toDate(min(first_start)) AS date,
+                    1.0 / max(cid_sample_rate) AS total,
+                    if(max(successes) > 0, 0.0, 1.0 / max(cid_sample_rate)) AS failures
+                FROM per_cid_day
+                WHERE cid != ''
+                GROUP BY operation, cid
+                HAVING date IS NOT NULL
+            )
+            GROUP BY operation, date
         ),
         date_range AS (
-            SELECT toDate(now()) - number AS date FROM numbers(28)
+            -- 28 displayed days + 28 days of look-back so every displayed point has a full
+            -- 28-day rolling window (avoids the warm-up ramp at the left edge of the chart).
+            SELECT toDate(now()) - number AS date FROM numbers(56)
         ),
         operations AS (
             SELECT arrayJoin([${local.slo_operation_list}]) AS operation
@@ -398,6 +431,7 @@ resource "posthog_insight" "slo_success_rate" {
             operation,
             if(t28 > 0, round((t28 - f28) / t28 * 100, 2), NULL) AS success_rate
         FROM rolling
+        WHERE date >= toDate(now()) - INTERVAL 27 DAY
         ORDER BY date ASC, operation ASC
         LIMIT ${local.slo_success_rate_limit}
       SQL

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -354,7 +354,6 @@ resource "posthog_insight" "slo_success_rate" {
                 properties.operation AS operation,
                 coalesce(nullIf(properties.correlation_id, ''), '') AS correlation_id,
                 properties.outcome AS outcome,
-                coalesce(toFloat(properties.sample_rate), 1.0) AS sample_rate,
                 1.0 / coalesce(toFloat(properties.sample_rate), 1.0) AS weight
             FROM events
             WHERE event IN ('slo_operation_started', 'slo_operation_completed')
@@ -368,7 +367,8 @@ resource "posthog_insight" "slo_success_rate" {
                 toDate(timestamp) AS event_date,
                 sumIf(weight, event = 'slo_operation_started') AS starts,
                 sumIf(weight, event = 'slo_operation_completed' AND outcome = 'success') AS successes,
-                max(sample_rate) AS cid_sample_rate,
+                -- One operation per cid, so all its events share a weight; max() collapses them.
+                max(weight) AS cid_weight,
                 min(if(event = 'slo_operation_started', timestamp, NULL)) AS first_start
             FROM weighted_events
             GROUP BY operation, cid, event_date
@@ -391,8 +391,8 @@ resource "posthog_insight" "slo_success_rate" {
                 SELECT
                     operation,
                     toDate(min(first_start)) AS date,
-                    1.0 / max(cid_sample_rate) AS total,
-                    if(max(successes) > 0, 0.0, 1.0 / max(cid_sample_rate)) AS failures
+                    max(cid_weight) AS total,
+                    if(max(successes) > 0, 0.0, max(cid_weight)) AS failures
                 FROM per_cid_day
                 WHERE cid != ''
                 GROUP BY operation, cid


### PR DESCRIPTION
## Problem

The **SLO Monitoring** dashboard's "28d Success Rate" insight could misrepresent subscription-delivery health in two ways:

- **Warm-up ramp.** The 28-day rolling window was computed over only 28 base rows, so the earliest ~27 points had partial windows and rendered as an artificial ramp on the left edge of the chart — easy to misread as a recent decline when the current value is actually healthy.
- **Day-boundary phantom failures.** Success/failure was bucketed by calendar day (`greatest(daily_starts − daily_successes, 0)`), so a delivery that started late in a day and finished after midnight was counted as a failure on the start day and dropped on the next. For batch-heavy operations this manufactured a large number of phantom failures.

Separately, a subscription delivery could **fail its entire write** when snapshot content contained a NUL byte (`\x00`): Django's JSONField serializes NUL to a unicode escape that Postgres text/jsonb columns reject, raising a `DataError`. This affected insight query results, and — unguarded — AI report markdown, step diagnostics, the user prompt, and query-error messages.

## Changes

- **SLO success-rate query** (`slo-monitoring/insights.tf`): pair starts to completions by `correlation_id` (the approach the burn-rate query on the same dashboard already uses) so cross-midnight deliveries are attributed to their start day; compute over 56 days but display only the fully-warmed last 28. Uncorrelated events keep the per-day fallback. Also dropped a redundant `sample_rate` round-trip (`weight` is already `1/sample_rate`).
- **NUL scrubbing**: a shared recursive `strip_null_bytes` helper (keys and values) applied at every untrusted ingress that reaches `content_snapshot` — insight results, query-error messages, AI markdown/diagnostics, and the user prompt. The large insight payload stays behind a cheap byte-level gate so clean deliveries skip the walk.

**Why:** the dashboard metric was firing on artifacts rather than real regressions, and the NUL `DataError` was failing real deliveries outright.

## How did you test this code?

- Added `test_serialize_insight_result_strips_null_bytes` covering NUL in result strings, map-derived dict keys, and columns; it round-trips through stdlib `json` (what JSONField uses) and asserts the output is NUL-free.
- Verified the `strip_null_bytes` algorithm (keys + values at all nesting depths, plus the escape-detection gate) with a standalone simulation.
- Validated the rewritten HogQL query against live data: the warm-up ramp is gone and the day-boundary phantom failures no longer appear, while genuine failures are still reflected; the `sample_rate`→`weight` simplification is result-identical.
- Ran `ruff format` / `ruff check` on all changed Python.
- I was **not** able to run the pytest suite in this environment (test dependencies weren't installed here); the new test should be run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI assigned as the PR assignee.

Investigation started from an SLO snapshot report that flagged a subscription-delivery success-rate drop. Digging into the data showed the "drop" was mostly the dashboard metric's warm-up + day-boundary artifacts (true per-operation success rate is high), which motivated the query rewrite; the NUL `DataError` surfaced as a recurring real delivery failure in the same data.

- Skills invoked: `/simplify` (removed the redundant `sample_rate` round-trip; promoted the NUL helper to a shared function and applied it on the AI-report path) and `/code-review` (high effort). The review caught that `strip_null_bytes` scrubbed dict values but not keys — a NUL in a `Map(String, …)` key would still fail the write — now fixed and tested. A confirmation pass then flagged that query-error messages bypassed the scrub; closed at the source.
- Decision: scrub at each untrusted ingress (gated for the large insight payload) rather than one blanket pre-save walk, to avoid re-walking multi-MB payloads on every delivery.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9A53J8RF/p1784094998253529?thread_ts=1784094998.253529&cid=C0B9A53J8RF)*
