### PR TITLE
feat(autoresearch): cut large dashboard GET wall time ~65% by eliminating cached-result serialization round trips

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional, overload
 
 import structlog
 import pydantic_core
@@ -55,6 +55,52 @@ class RawCachedQueryResponse:
 
     response: BaseModel
     raw_results: bytes
+
+
+# The overloads keep the public contract at `dict | BaseModel` for the vast majority of
+# callers: only allow_raw_results=True can produce a RawCachedQueryResponse.
+@overload
+def process_query_dict(
+    team: Team,
+    query_json: dict,
+    *,
+    dashboard_filters_json: Optional[dict] = ...,
+    variables_override_json: Optional[dict] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: Literal[False] = ...,
+) -> dict | BaseModel: ...
+
+
+@overload
+def process_query_dict(
+    team: Team,
+    query_json: dict,
+    *,
+    dashboard_filters_json: Optional[dict] = ...,
+    variables_override_json: Optional[dict] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: bool,
+) -> dict | BaseModel | RawCachedQueryResponse: ...
 
 
 def process_query_dict(
@@ -129,6 +175,50 @@ def process_query_dict(
         analytics_props=analytics_props,
         allow_raw_results=allow_raw_results,
     )
+
+
+@overload
+def process_query_model(
+    team: Team,
+    query: BaseModel,
+    *,
+    dashboard_filters: Optional[DashboardFilter] = ...,
+    variables_override: Optional[list[HogQLVariable]] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: Literal[False] = ...,
+) -> dict | BaseModel: ...
+
+
+@overload
+def process_query_model(
+    team: Team,
+    query: BaseModel,
+    *,
+    dashboard_filters: Optional[DashboardFilter] = ...,
+    variables_override: Optional[list[HogQLVariable]] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: bool,
+) -> dict | BaseModel | RawCachedQueryResponse: ...
 
 
 def process_query_model(

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -252,7 +252,7 @@ def process_query_model(
             query_runner.apply_pagination_cursor(pagination_cursor)
         query_runner.is_query_service = is_query_service
         if allow_raw_results:
-            query_runner._serve_raw_cached_results = True
+            query_runner.serve_raw_cached_results = True
 
         result = query_runner.run(
             execution_mode=execution_mode,
@@ -263,7 +263,7 @@ def process_query_model(
             cache_age_seconds=cache_age_seconds,
             analytics_props=analytics_props,
         )
-        raw_results = query_runner._raw_cached_results_bytes
+        raw_results = query_runner.raw_cached_results_bytes
         if raw_results is not None and isinstance(result, BaseModel):
             return RawCachedQueryResponse(response=result, raw_results=raw_results)
 

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Optional
 
 import structlog
@@ -42,6 +43,20 @@ from common.hogvm.python.debugger import color_bytecode
 logger = structlog.get_logger(__name__)
 
 
+@dataclass(frozen=True)
+class RawCachedQueryResponse:
+    """A cached query response whose `results` field is carried as raw JSON bytes.
+
+    `response.results` holds an empty-list placeholder; `raw_results` is the JSON-encoded
+    results segment straight from the cache, ready to be embedded into a JSON response
+    (e.g. via orjson.Fragment) without a parse/re-serialize round trip. Only produced when
+    a caller passes allow_raw_results=True.
+    """
+
+    response: BaseModel
+    raw_results: bytes
+
+
 def process_query_dict(
     team: Team,
     query_json: dict,
@@ -59,7 +74,8 @@ def process_query_dict(
     cache_age_seconds: Optional[int] = None,
     pagination_cursor: Optional[str] = None,
     analytics_props: Optional[AnalyticsProps] = None,
-) -> dict | BaseModel:
+    allow_raw_results: bool = False,
+) -> dict | BaseModel | RawCachedQueryResponse:
     upgraded_query_json = upgrade(query_json)
     try:
         model = QuerySchemaRoot.model_validate(upgraded_query_json)
@@ -111,6 +127,7 @@ def process_query_dict(
         cache_age_seconds=cache_age_seconds,
         pagination_cursor=pagination_cursor,
         analytics_props=analytics_props,
+        allow_raw_results=allow_raw_results,
     )
 
 
@@ -131,8 +148,9 @@ def process_query_model(
     cache_age_seconds: Optional[int] = None,
     pagination_cursor: Optional[str] = None,
     analytics_props: Optional[AnalyticsProps] = None,
-) -> dict | BaseModel:
-    result: dict | BaseModel
+    allow_raw_results: bool = False,
+) -> dict | BaseModel | RawCachedQueryResponse:
+    result: dict | BaseModel | RawCachedQueryResponse
 
     if isinstance(query, HogQLAutocomplete):
         _, database = resolve_database_for_connection(
@@ -203,6 +221,7 @@ def process_query_model(
                 is_query_service=is_query_service,
                 cache_age_seconds=cache_age_seconds,
                 analytics_props=analytics_props,
+                allow_raw_results=allow_raw_results,
             )
         elif execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
             # Caching is handled by query runners, so in this case we can only return a cache miss
@@ -232,6 +251,8 @@ def process_query_model(
         if pagination_cursor:
             query_runner.apply_pagination_cursor(pagination_cursor)
         query_runner.is_query_service = is_query_service
+        if allow_raw_results:
+            query_runner._serve_raw_cached_results = True
 
         result = query_runner.run(
             execution_mode=execution_mode,
@@ -242,5 +263,8 @@ def process_query_model(
             cache_age_seconds=cache_age_seconds,
             analytics_props=analytics_props,
         )
+        raw_results = query_runner._raw_cached_results_bytes
+        if raw_results is not None and isinstance(result, BaseModel):
+            return RawCachedQueryResponse(response=result, raw_results=raw_results)
 
     return result

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -950,6 +950,9 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             "insight_variables": InsightVariable.objects.filter(team=resource.team).all(),
             "export_cache_keys": export_cache_keys,
             "shared_link_user": shared_link_user,
+            # exported_data is embedded into the page with stdlib json.dumps, which cannot
+            # serialize raw cached result bytes (orjson.Fragment)
+            "require_parsed_results": True,
         }
         exported_data: dict[str, Any] = {"type": "embed" if embedded else "scene"}
 

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -11,7 +11,7 @@ from posthog.hogql.constants import LimitContext
 from posthog.api.services.query import ExecutionMode, RawCachedQueryResponse, process_query_dict
 from posthog.clickhouse.query_tagging import get_team_query_tags, tag_queries
 from posthog.event_usage import AnalyticsProps
-from posthog.hogql_queries.query_runner import get_query_runner_or_none
+from posthog.hogql_queries.query_runner import get_query_runner_or_none, response_results_contain_models
 from posthog.models import Team, User
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 
@@ -36,20 +36,22 @@ def _model_field_as_dict(model: BaseModel, field: str) -> Optional[dict]:
     return value
 
 
-def _list_item_as_dict(item: Any) -> Any:
-    if isinstance(item, BaseModel):
-        return item.model_dump(by_alias=True)
-    if isinstance(item, list):
-        # e.g. funnel-breakdown / marketing-analytics results are lists of lists of items
-        return [inner.model_dump(by_alias=True) if isinstance(inner, BaseModel) else inner for inner in item]
-    return item
+def _dump_nested_models(value: Any) -> Any:
+    """Container-preserving conversion of pydantic models to dicts (lists, dicts, scalars pass through)."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(by_alias=True)
+    if isinstance(value, list):
+        return [_dump_nested_models(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _dump_nested_models(item) for key, item in value.items()}
+    return value
 
 
 def _model_list_field_as_dicts(model: BaseModel, field: str) -> Optional[list]:
     value = getattr(model, field, None)
     if value is None:
         return None
-    return [_list_item_as_dict(item) for item in value]
+    return [item.model_dump(by_alias=True) if isinstance(item, BaseModel) else item for item in value]
 
 
 def calculate_cache_key(target: Union[DashboardTile, Insight]) -> Optional[str]:
@@ -143,16 +145,21 @@ def calculate_for_query_based_insight(
         # Pull fields off the model instead, converting just the small nested models to dicts
         # (which is what model_dump produced before). The response class may not carry every
         # field (legacy insights shape), hence the getattr defaults.
-        return InsightResult(
+        if raw_results is not None:
             # orjson.Fragment embeds the cached results bytes into the JSON response as-is,
             # skipping the parse/re-serialize round trip. Callers passing allow_raw_results
-            # guarantee the result feeds an orjson renderer. The parsed path must convert
-            # model-typed result items (e.g. RetentionResult, PathsLink) to dicts like
-            # model_dump did — DRF's JSON encoder would otherwise mangle them into
-            # (field, value) tuple arrays.
-            result=orjson.Fragment(raw_results)
-            if raw_results is not None
-            else _model_list_field_as_dicts(process_response, "results"),
+            # guarantee the result feeds an orjson renderer.
+            result: Any = orjson.Fragment(raw_results)
+        else:
+            result = getattr(process_response, "results", None)
+            if result is not None and response_results_contain_models(type(process_response)):
+                # Model-typed results (e.g. RetentionResult, PathsLink) must be dumped to dicts
+                # like model_dump did — DRF's JSON encoder would otherwise mangle them into
+                # (field, value) tuple arrays. Results whose annotation is plain data (the huge
+                # trends/funnels payloads, or scalar/dict-shaped results) pass through untouched.
+                result = _dump_nested_models(result)
+        return InsightResult(
+            result=result,
             has_more=getattr(process_response, "hasMore", None),
             columns=getattr(process_response, "columns", None),
             last_refresh=getattr(process_response, "last_refresh", None),

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional, Union
 
+import orjson
 import structlog
 from pydantic import BaseModel
 
@@ -7,7 +8,7 @@ from posthog.schema import CacheMissResponse, DashboardFilter
 
 from posthog.hogql.constants import LimitContext
 
-from posthog.api.services.query import ExecutionMode, process_query_dict
+from posthog.api.services.query import ExecutionMode, RawCachedQueryResponse, process_query_dict
 from posthog.clickhouse.query_tagging import get_team_query_tags, tag_queries
 from posthog.event_usage import AnalyticsProps
 from posthog.hogql_queries.query_runner import get_query_runner_or_none
@@ -76,6 +77,7 @@ def calculate_for_query_based_insight(
     query_override: Optional[dict] = None,
     cache_age_seconds: Optional[int] = None,
     analytics_props: Optional[AnalyticsProps] = None,
+    allow_raw_results: bool = False,
 ) -> "InsightResult":
     from posthog.caching.fetch_from_cache import InsightResult, NothingInCacheResult
 
@@ -113,7 +115,13 @@ def calculate_for_query_based_insight(
         limit_context=LimitContext.QUERY_ASYNC,
         cache_age_seconds=cache_age_seconds,
         analytics_props=analytics_props,
+        allow_raw_results=allow_raw_results,
     )
+
+    raw_results: Optional[bytes] = None
+    if isinstance(process_response, RawCachedQueryResponse):
+        raw_results = process_response.raw_results
+        process_response = process_response.response
 
     if isinstance(process_response, CacheMissResponse):
         return NothingInCacheResult(
@@ -127,7 +135,12 @@ def calculate_for_query_based_insight(
         # (which is what model_dump produced before). The response class may not carry every
         # field (legacy insights shape), hence the getattr defaults.
         return InsightResult(
-            result=getattr(process_response, "results", None),
+            # orjson.Fragment embeds the cached results bytes into the JSON response as-is,
+            # skipping the parse/re-serialize round trip. Callers passing allow_raw_results
+            # guarantee the result feeds an orjson renderer.
+            result=orjson.Fragment(raw_results)
+            if raw_results is not None
+            else getattr(process_response, "results", None),
             has_more=getattr(process_response, "hasMore", None),
             columns=getattr(process_response, "columns", None),
             last_refresh=getattr(process_response, "last_refresh", None),

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import orjson
 import structlog
@@ -36,11 +36,20 @@ def _model_field_as_dict(model: BaseModel, field: str) -> Optional[dict]:
     return value
 
 
+def _list_item_as_dict(item: Any) -> Any:
+    if isinstance(item, BaseModel):
+        return item.model_dump(by_alias=True)
+    if isinstance(item, list):
+        # e.g. funnel-breakdown / marketing-analytics results are lists of lists of items
+        return [inner.model_dump(by_alias=True) if isinstance(inner, BaseModel) else inner for inner in item]
+    return item
+
+
 def _model_list_field_as_dicts(model: BaseModel, field: str) -> Optional[list]:
     value = getattr(model, field, None)
     if value is None:
         return None
-    return [item.model_dump(by_alias=True) if isinstance(item, BaseModel) else item for item in value]
+    return [_list_item_as_dict(item) for item in value]
 
 
 def calculate_cache_key(target: Union[DashboardTile, Insight]) -> Optional[str]:
@@ -137,10 +146,13 @@ def calculate_for_query_based_insight(
         return InsightResult(
             # orjson.Fragment embeds the cached results bytes into the JSON response as-is,
             # skipping the parse/re-serialize round trip. Callers passing allow_raw_results
-            # guarantee the result feeds an orjson renderer.
+            # guarantee the result feeds an orjson renderer. The parsed path must convert
+            # model-typed result items (e.g. RetentionResult, PathsLink) to dicts like
+            # model_dump did — DRF's JSON encoder would otherwise mangle them into
+            # (field, value) tuple arrays.
             result=orjson.Fragment(raw_results)
             if raw_results is not None
-            else getattr(process_response, "results", None),
+            else _model_list_field_as_dicts(process_response, "results"),
             has_more=getattr(process_response, "hasMore", None),
             columns=getattr(process_response, "columns", None),
             last_refresh=getattr(process_response, "last_refresh", None),

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -26,6 +26,22 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 
+def _model_field_as_dict(model: BaseModel, field: str) -> Optional[dict]:
+    value = getattr(model, field, None)
+    if value is None:
+        return None
+    if isinstance(value, BaseModel):
+        return value.model_dump(by_alias=True)
+    return value
+
+
+def _model_list_field_as_dicts(model: BaseModel, field: str) -> Optional[list]:
+    value = getattr(model, field, None)
+    if value is None:
+        return None
+    return [item.model_dump(by_alias=True) if isinstance(item, BaseModel) else item for item in value]
+
+
 def calculate_cache_key(target: Union[DashboardTile, Insight]) -> Optional[str]:
     insight: Optional[Insight] = target if isinstance(target, Insight) else target.insight
     dashboard: Optional[Dashboard] = target.dashboard if isinstance(target, DashboardTile) else None
@@ -83,7 +99,7 @@ def calculate_for_query_based_insight(
     if query_json is None:
         raise ValueError("Insight has no query and no query_override was provided")
 
-    response = process_response = process_query_dict(
+    process_response = process_query_dict(
         team,
         query_json,
         dashboard_filters_json=dashboard_filters_json,
@@ -99,16 +115,36 @@ def calculate_for_query_based_insight(
         analytics_props=analytics_props,
     )
 
-    if isinstance(process_response, BaseModel):
-        response = process_response.model_dump(by_alias=True)
-
-    assert isinstance(response, dict)
-
     if isinstance(process_response, CacheMissResponse):
-        return NothingInCacheResult(cache_key=process_response.cache_key, query_status=response.get("query_status"))
+        return NothingInCacheResult(
+            cache_key=process_response.cache_key, query_status=_model_field_as_dict(process_response, "query_status")
+        )
 
-    cache_key = response.get("cache_key")
-    last_refresh = response.get("last_refresh")
+    if isinstance(process_response, BaseModel):
+        # Don't model_dump() the whole response: `results` alone can be tens of MB of plain
+        # dicts, and dumping deep-copies all of it only for a handful of fields to be re-read.
+        # Pull fields off the model instead, converting just the small nested models to dicts
+        # (which is what model_dump produced before). The response class may not carry every
+        # field (legacy insights shape), hence the getattr defaults.
+        return InsightResult(
+            result=getattr(process_response, "results", None),
+            has_more=getattr(process_response, "hasMore", None),
+            columns=getattr(process_response, "columns", None),
+            last_refresh=getattr(process_response, "last_refresh", None),
+            cache_key=getattr(process_response, "cache_key", None),
+            is_cached=getattr(process_response, "is_cached", False),
+            timezone=getattr(process_response, "timezone", None),
+            next_allowed_client_refresh=getattr(process_response, "next_allowed_client_refresh", None),
+            cache_target_age=getattr(process_response, "cache_target_age", None),
+            timings=_model_list_field_as_dicts(process_response, "timings"),
+            query_status=_model_field_as_dict(process_response, "query_status"),
+            hogql=getattr(process_response, "hogql", None),
+            types=getattr(process_response, "types", None),
+            resolved_date_range=_model_field_as_dict(process_response, "resolved_date_range"),
+        )
+
+    response = process_response
+    assert isinstance(response, dict)
 
     return InsightResult(
         # Translating `QueryResponse` to legacy insights shape
@@ -116,8 +152,8 @@ def calculate_for_query_based_insight(
         result=response.get("results"),
         has_more=response.get("hasMore"),
         columns=response.get("columns"),
-        last_refresh=last_refresh,
-        cache_key=cache_key,
+        last_refresh=response.get("last_refresh"),
+        cache_key=response.get("cache_key"),
         is_cached=response.get("is_cached", False),
         timezone=response.get("timezone"),
         next_allowed_client_refresh=response.get("next_allowed_client_refresh"),

--- a/posthog/caching/fetch_from_cache.py
+++ b/posthog/caching/fetch_from_cache.py
@@ -23,11 +23,15 @@ insight_cache_read_counter = Counter(
 # the results payload, which dominates CPU for large cached insights. Blobs without the magic prefix
 # are the legacy single-JSON format and stay readable.
 QUERY_CACHE_SPLIT_MAGIC = b"PHQC2\x00"
+# The flags byte is a bitmask: readers must test individual bits, never compare the whole byte,
+# so new flags can be added without breaking existing readers.
 _SPLIT_FLAG_CUSTOM_NAMES = 0b00000001
 
 
 @dataclass(frozen=True)
 class SplitCachedResponse:
+    """A cached query response with the `results` segment kept as raw, unparsed JSON bytes."""
+
     header: dict
     results_bytes: Optional[bytes]
     """Raw JSON bytes of the `results` field; None means `header` is the full legacy response."""

--- a/posthog/caching/fetch_from_cache.py
+++ b/posthog/caching/fetch_from_cache.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import structlog
 from prometheus_client import Counter
 
-from posthog.schema import QueryTiming, ResolvedDateRangeResponse
+from posthog.schema import QueryTiming
 
 from posthog.cache_utils import OrjsonJsonSerializer
 from posthog.caching.query_cache_routing import get_query_cache
@@ -144,7 +144,8 @@ class InsightResult:
     query_status: Optional[Any] = None
     hogql: Optional[str] = None
     types: Optional[list] = None
-    resolved_date_range: Optional[ResolvedDateRangeResponse] = None
+    # A ResolvedDateRangeResponse-shaped dict — the field carries model_dump output
+    resolved_date_range: Optional[dict] = None
 
 
 @dataclass(frozen=True)

--- a/posthog/caching/fetch_from_cache.py
+++ b/posthog/caching/fetch_from_cache.py
@@ -39,18 +39,21 @@ class SplitCachedResponse:
     """Whether any series/step in results carries a non-null custom_name (so a cache hit may need patching)."""
 
 
+def _item_has_custom_name(item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if item.get("custom_name") is not None:
+        return True
+    action = item.get("action")
+    return isinstance(action, dict) and action.get("custom_name") is not None
+
+
 def results_have_custom_names(results: list) -> bool:
     for item in results:
-        if isinstance(item, dict):
-            if item.get("custom_name") is not None:
-                return True
-            action = item.get("action")
-            if isinstance(action, dict) and action.get("custom_name") is not None:
-                return True
-        elif isinstance(item, list):
-            for step in item:
-                if isinstance(step, dict) and step.get("custom_name") is not None:
-                    return True
+        if _item_has_custom_name(item):
+            return True
+        if isinstance(item, list) and any(_item_has_custom_name(step) for step in item):
+            return True
     return False
 
 

--- a/posthog/caching/fetch_from_cache.py
+++ b/posthog/caching/fetch_from_cache.py
@@ -18,8 +18,70 @@ insight_cache_read_counter = Counter(
     labelnames=["result"],
 )
 
+# Split cache format: magic + flags byte + 4-byte big-endian header length + header JSON + results JSON.
+# Storing `results` as a separate JSON segment lets cache hits skip parsing (and later re-serializing)
+# the results payload, which dominates CPU for large cached insights. Blobs without the magic prefix
+# are the legacy single-JSON format and stay readable.
+QUERY_CACHE_SPLIT_MAGIC = b"PHQC2\x00"
+_SPLIT_FLAG_CUSTOM_NAMES = 0b00000001
 
-def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]:
+
+@dataclass(frozen=True)
+class SplitCachedResponse:
+    header: dict
+    results_bytes: Optional[bytes]
+    """Raw JSON bytes of the `results` field; None means `header` is the full legacy response."""
+    results_have_custom_names: bool = False
+    """Whether any series/step in results carries a non-null custom_name (so a cache hit may need patching)."""
+
+
+def results_have_custom_names(results: list) -> bool:
+    for item in results:
+        if isinstance(item, dict):
+            if item.get("custom_name") is not None:
+                return True
+            action = item.get("action")
+            if isinstance(action, dict) and action.get("custom_name") is not None:
+                return True
+        elif isinstance(item, list):
+            for step in item:
+                if isinstance(step, dict) and step.get("custom_name") is not None:
+                    return True
+    return False
+
+
+def encode_split_cached_response(response: dict) -> bytes:
+    serializer = OrjsonJsonSerializer({})
+    results = response["results"]
+    header = {key: value for key, value in response.items() if key != "results"}
+    flags = _SPLIT_FLAG_CUSTOM_NAMES if results_have_custom_names(results) else 0
+    header_bytes = serializer.dumps(header)
+    return (
+        QUERY_CACHE_SPLIT_MAGIC
+        + bytes([flags])
+        + len(header_bytes).to_bytes(4, "big")
+        + header_bytes
+        + serializer.dumps(results)
+    )
+
+
+def split_cached_response_bytes(cached_response_bytes: bytes) -> SplitCachedResponse:
+    serializer = OrjsonJsonSerializer({})
+    if not cached_response_bytes.startswith(QUERY_CACHE_SPLIT_MAGIC):
+        return SplitCachedResponse(header=serializer.loads(cached_response_bytes), results_bytes=None)
+    offset = len(QUERY_CACHE_SPLIT_MAGIC)
+    flags = cached_response_bytes[offset]
+    header_length = int.from_bytes(cached_response_bytes[offset + 1 : offset + 5], "big")
+    header_start = offset + 5
+    header = serializer.loads(cached_response_bytes[header_start : header_start + header_length])
+    return SplitCachedResponse(
+        header=header,
+        results_bytes=cached_response_bytes[header_start + header_length :],
+        results_have_custom_names=bool(flags & _SPLIT_FLAG_CUSTOM_NAMES),
+    )
+
+
+def fetch_split_cached_response_by_key(cache_key: str, team_id: int) -> Optional[SplitCachedResponse]:
     query_cache = get_query_cache()
     try:
         cached_response_bytes = query_cache.get(cache_key)
@@ -35,7 +97,7 @@ def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]
         return None
 
     try:
-        return OrjsonJsonSerializer({}).loads(cached_response_bytes)
+        return split_cached_response_bytes(cached_response_bytes)
     except Exception:
         logger.exception(
             "query_cache_deserialize_error",
@@ -44,6 +106,20 @@ def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]
             exc_info=True,
         )
         return None
+
+
+def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]:
+    split = fetch_split_cached_response_by_key(cache_key, team_id)
+    if split is None:
+        return None
+    if split.results_bytes is None:
+        return split.header
+    try:
+        split.header["results"] = OrjsonJsonSerializer({}).loads(split.results_bytes)
+    except Exception:
+        logger.exception("query_cache_deserialize_error", cache_key=cache_key, team_id=team_id, exc_info=True)
+        return None
+    return split.header
 
 
 @dataclass(frozen=True)

--- a/posthog/caching/test/test_calculate_results.py
+++ b/posthog/caching/test/test_calculate_results.py
@@ -1,0 +1,105 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+import orjson
+
+from posthog.schema import (
+    CachedMarketingAnalyticsTableQueryResponse,
+    CachedRetentionQueryResponse,
+    CachedTrendsQueryResponse,
+    MarketingAnalyticsItem,
+    RetentionResult,
+)
+
+from posthog.api.services.query import ExecutionMode, RawCachedQueryResponse
+from posthog.caching.calculate_results import calculate_for_query_based_insight
+
+from products.product_analytics.backend.models.insight import Insight
+
+
+class TestCalculateForQueryBasedInsight(BaseTest):
+    def _calculate(self, response, allow_raw_results: bool = False):
+        insight = Insight.objects.create(
+            team=self.team,
+            query={"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}},
+        )
+        with patch("posthog.caching.calculate_results.process_query_dict", return_value=response):
+            return calculate_for_query_based_insight(
+                insight,
+                team=self.team,
+                execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
+                user=None,
+                allow_raw_results=allow_raw_results,
+            )
+
+    # Model-typed results (e.g. retention, paths, marketing analytics) must be dumped to
+    # dicts: DRF's JSON encoder falls back to iterating pydantic models, mangling them into
+    # (field, value) tuple arrays in the rendered response.
+    def test_model_typed_results_are_returned_as_dicts(self):
+        response = CachedRetentionQueryResponse(
+            results=[RetentionResult(date=datetime(2026, 1, 1, tzinfo=UTC), label="Day 0", values=[])],
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert isinstance(insight_result.result[0], dict)
+        assert insight_result.result[0]["label"] == "Day 0"
+
+    def test_models_nested_in_result_lists_are_returned_as_dicts(self):
+        # e.g. CachedMarketingAnalyticsTableQueryResponse.results: list[list[MarketingAnalyticsItem]]
+        response = CachedMarketingAnalyticsTableQueryResponse(
+            results=[[MarketingAnalyticsItem(key="spend", kind="unit", value=1.0)]],
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert isinstance(insight_result.result[0][0], dict)
+        assert insight_result.result[0][0]["key"] == "spend"
+
+    def test_plain_dict_results_pass_through_without_copying(self):
+        series = {"data": [1.0, 2.0], "label": "series", "action": {"order": 0}}
+        response = CachedTrendsQueryResponse(
+            results=[series],
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert insight_result.result[0] is response.results[0]
+        assert insight_result.is_cached is True
+        assert insight_result.cache_key == "key"
+
+    def test_raw_cached_results_become_fragments(self):
+        raw = orjson.dumps([{"data": [1.0], "label": "series"}])
+        response = RawCachedQueryResponse(
+            response=CachedTrendsQueryResponse(
+                results=[],
+                is_cached=True,
+                last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+                next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+                cache_key="key",
+                timezone="UTC",
+            ),
+            raw_results=raw,
+        )
+
+        insight_result = self._calculate(response, allow_raw_results=True)
+
+        assert isinstance(insight_result.result, orjson.Fragment)
+        assert orjson.dumps({"result": insight_result.result}) == b'{"result":[{"data":[1.0],"label":"series"}]}'

--- a/posthog/caching/test/test_calculate_results.py
+++ b/posthog/caching/test/test_calculate_results.py
@@ -6,9 +6,11 @@ from unittest.mock import patch
 import orjson
 
 from posthog.schema import (
+    CachedMarketingAnalyticsAggregatedQueryResponse,
     CachedMarketingAnalyticsTableQueryResponse,
     CachedRetentionQueryResponse,
     CachedTrendsQueryResponse,
+    HogQueryResponse,
     MarketingAnalyticsItem,
     RetentionResult,
 )
@@ -67,6 +69,27 @@ class TestCalculateForQueryBasedInsight(BaseTest):
 
         assert isinstance(insight_result.result[0][0], dict)
         assert insight_result.result[0][0]["key"] == "spend"
+
+    def test_dict_shaped_results_keep_their_shape_with_models_dumped(self):
+        response = CachedMarketingAnalyticsAggregatedQueryResponse(
+            results={"spend": MarketingAnalyticsItem(key="spend", kind="unit", value=1.0)},
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert isinstance(insight_result.result, dict)
+        assert isinstance(insight_result.result["spend"], dict)
+        assert insight_result.result["spend"]["key"] == "spend"
+
+    def test_scalar_results_pass_through(self):
+        insight_result = self._calculate(HogQueryResponse(results="ERROR: nope"))
+
+        assert insight_result.result == "ERROR: nope"
 
     def test_plain_dict_results_pass_through_without_copying(self):
         series = {"data": [1.0, 2.0], "label": "series", "action": {"order": 0}}

--- a/posthog/caching/test/test_query_cache_format.py
+++ b/posthog/caching/test/test_query_cache_format.py
@@ -1,0 +1,32 @@
+from posthog.test.base import BaseTest
+
+from django.test import override_settings
+
+from posthog.caching.fetch_from_cache import fetch_cached_response_by_key, fetch_split_cached_response_by_key
+from posthog.hogql_queries.query_cache_factory import get_query_cache_manager
+
+
+class TestQueryCacheWriteFormat(BaseTest):
+    def test_writes_legacy_format_until_split_writes_enabled(self):
+        # Old readers treat split-format entries as cache misses and recompute, so shipping
+        # split writes before every reader understands the format causes a cache-load spike
+        # on deploy. Split writes must stay opt-in via QUERY_CACHE_SPLIT_FORMAT_WRITES.
+        response = {"is_cached": False, "results": [{"data": [1]}], "cache_key": "k"}
+        manager = get_query_cache_manager(team=self.team, cache_key=f"cache_format_test_{self.team.pk}", insight_id=1)
+
+        manager.set_cache_data(response=response, target_age=None)
+        split = fetch_split_cached_response_by_key(manager.cache_key, self.team.pk)
+        assert split is not None
+        assert split.results_bytes is None
+        assert split.header["results"] == [{"data": [1]}]
+
+        with override_settings(QUERY_CACHE_SPLIT_FORMAT_WRITES=True):
+            manager.set_cache_data(response=response, target_age=None)
+        split = fetch_split_cached_response_by_key(manager.cache_key, self.team.pk)
+        assert split is not None
+        assert split.results_bytes == b'[{"data":[1]}]'
+        assert fetch_cached_response_by_key(manager.cache_key, self.team.pk) == {
+            "is_cached": False,
+            "results": [{"data": [1]}],
+            "cache_key": "k",
+        }

--- a/posthog/hogql_queries/query_cache.py
+++ b/posthog/hogql_queries/query_cache.py
@@ -1,7 +1,10 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
+
+if TYPE_CHECKING:
+    from posthog.caching.fetch_from_cache import SplitCachedResponse
 
 from django.conf import settings
 
@@ -176,7 +179,14 @@ class DjangoCacheQueryCacheManager(QueryCacheManagerBase):
     """
 
     def set_cache_data(self, *, response: dict, target_age: Optional[datetime]) -> None:
-        fresh_response_serialized = OrjsonJsonSerializer({}).dumps(response)
+        from posthog.caching.fetch_from_cache import encode_split_cached_response
+
+        if isinstance(response.get("results"), list):
+            # Split format keeps `results` as its own JSON segment so cache hits can skip
+            # parsing it — see fetch_from_cache.SplitCachedResponse.
+            fresh_response_serialized = encode_split_cached_response(response)
+        else:
+            fresh_response_serialized = OrjsonJsonSerializer({}).dumps(response)
         data_size = len(fresh_response_serialized)
 
         # Set cache with per-team size limit enforcement
@@ -202,3 +212,8 @@ class DjangoCacheQueryCacheManager(QueryCacheManagerBase):
         from posthog.caching.fetch_from_cache import fetch_cached_response_by_key
 
         return fetch_cached_response_by_key(self.cache_key, self.team_id)
+
+    def get_cache_data_split(self) -> Optional["SplitCachedResponse"]:
+        from posthog.caching.fetch_from_cache import fetch_split_cached_response_by_key
+
+        return fetch_split_cached_response_by_key(self.cache_key, self.team_id)

--- a/posthog/hogql_queries/query_cache.py
+++ b/posthog/hogql_queries/query_cache.py
@@ -181,9 +181,11 @@ class DjangoCacheQueryCacheManager(QueryCacheManagerBase):
     def set_cache_data(self, *, response: dict, target_age: Optional[datetime]) -> None:
         from posthog.caching.fetch_from_cache import encode_split_cached_response
 
-        if isinstance(response.get("results"), list):
+        if settings.QUERY_CACHE_SPLIT_FORMAT_WRITES and isinstance(response.get("results"), list):
             # Split format keeps `results` as its own JSON segment so cache hits can skip
-            # parsing it — see fetch_from_cache.SplitCachedResponse.
+            # parsing it — see fetch_from_cache.SplitCachedResponse. Write-gated so a deploy
+            # ships split-capable readers everywhere before any pod writes the new format
+            # (old readers treat split entries as misses and recompute).
             fresh_response_serialized = encode_split_cached_response(response)
         else:
             fresh_response_serialized = OrjsonJsonSerializer({}).dumps(response)

--- a/posthog/hogql_queries/query_cache_base.py
+++ b/posthog/hogql_queries/query_cache_base.py
@@ -1,11 +1,9 @@
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from posthog import redis
-
-if TYPE_CHECKING:
-    from posthog.caching.fetch_from_cache import SplitCachedResponse
+from posthog.caching.fetch_from_cache import SplitCachedResponse
 
 
 class QueryCacheManagerBase(ABC):
@@ -109,10 +107,8 @@ class QueryCacheManagerBase(ABC):
         """Retrieve query results from cache."""
         pass
 
-    def get_cache_data_split(self) -> Optional["SplitCachedResponse"]:
+    def get_cache_data_split(self) -> Optional[SplitCachedResponse]:
         """Retrieve cached results, keeping the results segment as raw bytes when the backend supports it."""
-        from posthog.caching.fetch_from_cache import SplitCachedResponse  # noqa: PLC0415 — avoids circular import
-
         data = self.get_cache_data()
         if data is None:
             return None

--- a/posthog/hogql_queries/query_cache_base.py
+++ b/posthog/hogql_queries/query_cache_base.py
@@ -1,8 +1,11 @@
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from posthog import redis
+
+if TYPE_CHECKING:
+    from posthog.caching.fetch_from_cache import SplitCachedResponse
 
 
 class QueryCacheManagerBase(ABC):
@@ -105,3 +108,12 @@ class QueryCacheManagerBase(ABC):
     def get_cache_data(self) -> Optional[dict]:
         """Retrieve query results from cache."""
         pass
+
+    def get_cache_data_split(self) -> Optional["SplitCachedResponse"]:
+        """Retrieve cached results, keeping the results segment as raw bytes when the backend supports it."""
+        from posthog.caching.fetch_from_cache import SplitCachedResponse  # noqa: PLC0415 — avoids circular import
+
+        data = self.get_cache_data()
+        if data is None:
+            return None
+        return SplitCachedResponse(header=data, results_bytes=None)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1318,10 +1318,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     is_query_service: bool = False
     workload: Workload
     # Opt-in (set by process_query_model): on a cache hit, keep the results segment of the
-    # cached response as raw JSON bytes in _raw_cached_results_bytes instead of parsing it,
+    # cached response as raw JSON bytes in raw_cached_results_bytes instead of parsing it,
     # leaving a `results=[]` placeholder on the returned model.
-    _serve_raw_cached_results: bool = False
-    _raw_cached_results_bytes: Optional[bytes] = None
+    serve_raw_cached_results: bool = False
+    raw_cached_results_bytes: Optional[bytes] = None
 
     def __init__(
         self,
@@ -1474,9 +1474,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     ) -> Optional[CR | CacheMissResponse]:
         CachedResponse: type[CR] = self.cached_response_type
         cached_response: CR | CacheMissResponse
-        self._raw_cached_results_bytes = None
+        self.raw_cached_results_bytes = None
         raw_results: Optional[bytes] = None
-        if self._serve_raw_cached_results:
+        if self.serve_raw_cached_results:
             # Serving results as raw bytes skips parsing (and later re-serializing) the results
             # payload. Only safe when the caller opted in AND neither the query nor the cached
             # results carry custom series names — otherwise apply_series_custom_names below must
@@ -1501,7 +1501,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             try:
                 cached_response = CachedResponse(**cached_response_candidate)
                 if raw_results is not None:
-                    self._raw_cached_results_bytes = raw_results
+                    self.raw_cached_results_bytes = raw_results
             except Exception as e:
                 capture_exception(Exception(f"Error parsing cached response: {e}"))
                 cached_response = CacheMissResponse(cache_key=cache_manager.cache_key)
@@ -1576,7 +1576,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         # Nothing useful out of cache, nor async query status. A recomputation follows, so the
         # cached raw results (if any) must not leak onto the fresh response.
-        self._raw_cached_results_bytes = None
+        self.raw_cached_results_bytes = None
         return None
 
     def _call_with_rate_limits(self, *, dashboard_id: Optional[int]) -> tuple[R, float]:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
+from functools import cache
 from time import perf_counter
 from types import UnionType
 from typing import Any, Generic, NamedTuple, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args, get_origin
@@ -211,6 +212,28 @@ def get_survey_query_metric_labels(query: Any) -> dict[str, str] | None:
         "query_type": getattr(query, "kind", "Other"),
         "query_name": getattr(tags, "name", None) or UNKNOWN_QUERY_METRIC_LABEL,
     }
+
+
+def _annotation_mentions_base_model(annotation: Any) -> bool:
+    if annotation is None:
+        return False
+    if isinstance(annotation, type):
+        return issubclass(annotation, BaseModel)
+    return any(_annotation_mentions_base_model(arg) for arg in get_args(annotation))
+
+
+@cache
+def response_results_contain_models(response_class: type[BaseModel]) -> bool:
+    """Whether the class's `results` annotation can hold pydantic models (e.g. list[RetentionResult]).
+
+    Responses are only ever built by validating plain data (a cached JSON blob, or the dict a fresh
+    calculation was dumped to), so model instances can appear in `results` exactly where the
+    annotation declares a model type — `Any`/`dict[str, Any]` positions stay plain data.
+    """
+    field = response_class.model_fields.get("results")
+    if field is None:
+        return False
+    return _annotation_mentions_base_model(field.annotation)
 
 
 def execution_mode_from_refresh(refresh_requested: bool | str | None) -> ExecutionMode:
@@ -1474,20 +1497,31 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     ) -> Optional[CR | CacheMissResponse]:
         CachedResponse: type[CR] = self.cached_response_type
         cached_response: CR | CacheMissResponse
+        cached_response_candidate: Optional[dict]
         self.raw_cached_results_bytes = None
         raw_results: Optional[bytes] = None
         if self.serve_raw_cached_results:
             # Serving results as raw bytes skips parsing (and later re-serializing) the results
-            # payload. Only safe when the caller opted in AND neither the query nor the cached
-            # results carry custom series names — otherwise apply_series_custom_names below must
-            # be able to patch the parsed results.
+            # payload. Only safe when the caller opted in AND validation of the parsed results
+            # wouldn't add protection (the response class types them as plain data — for
+            # model-typed results, e.g. retention, validating a `[]` placeholder would bypass
+            # the schema-drift check that triggers recomputation) AND neither the query nor
+            # the cached results carry custom series names — otherwise
+            # apply_series_custom_names below must be able to patch the parsed results.
             split_candidate = cache_manager.get_cache_data_split()
-            cached_response_candidate = split_candidate.header if split_candidate is not None else None
-            if split_candidate is not None and split_candidate.results_bytes is not None:
-                if split_candidate.results_have_custom_names or self._query_has_series_custom_names():
-                    cached_response_candidate["results"] = orjson.loads(split_candidate.results_bytes)  # type: ignore[index]
-                else:
-                    raw_results = split_candidate.results_bytes
+            if split_candidate is None:
+                cached_response_candidate = None
+            else:
+                cached_response_candidate = split_candidate.header
+                if split_candidate.results_bytes is not None:
+                    if (
+                        response_results_contain_models(CachedResponse)
+                        or split_candidate.results_have_custom_names
+                        or self._query_has_series_custom_names()
+                    ):
+                        cached_response_candidate["results"] = orjson.loads(split_candidate.results_bytes)
+                    else:
+                        raw_results = split_candidate.results_bytes
         else:
             cached_response_candidate = cache_manager.get_cache_data()
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -6,6 +6,7 @@ from time import perf_counter
 from types import UnionType
 from typing import Any, Generic, NamedTuple, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args, get_origin
 
+import orjson
 import posthoganalytics
 from prometheus_client import Counter, Histogram
 from pydantic import BaseModel, ConfigDict
@@ -1316,6 +1317,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     # query service means programmatic access and /query endpoint
     is_query_service: bool = False
     workload: Workload
+    # Opt-in (set by process_query_model): on a cache hit, keep the results segment of the
+    # cached response as raw JSON bytes in _raw_cached_results_bytes instead of parsing it,
+    # leaving a `results=[]` placeholder on the returned model.
+    _serve_raw_cached_results: bool = False
+    _raw_cached_results_bytes: Optional[bytes] = None
 
     def __init__(
         self,
@@ -1388,6 +1394,12 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         return hasattr(data, "is_cached") or (  # Duck typing for backwards compatibility with `CachedQueryResponse`
             isinstance(data, dict) and "is_cached" in data
         )
+
+    def _query_has_series_custom_names(self) -> bool:
+        series = getattr(self.query, "series", None)
+        if not series:
+            return False
+        return any(getattr(s, "custom_name", None) is not None for s in series)
 
     @property
     def _limit_context_aliased_for_cache(self) -> LimitContext:
@@ -1462,14 +1474,34 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     ) -> Optional[CR | CacheMissResponse]:
         CachedResponse: type[CR] = self.cached_response_type
         cached_response: CR | CacheMissResponse
-        cached_response_candidate = cache_manager.get_cache_data()
+        self._raw_cached_results_bytes = None
+        raw_results: Optional[bytes] = None
+        if self._serve_raw_cached_results:
+            # Serving results as raw bytes skips parsing (and later re-serializing) the results
+            # payload. Only safe when the caller opted in AND neither the query nor the cached
+            # results carry custom series names — otherwise apply_series_custom_names below must
+            # be able to patch the parsed results.
+            split_candidate = cache_manager.get_cache_data_split()
+            cached_response_candidate = split_candidate.header if split_candidate is not None else None
+            if split_candidate is not None and split_candidate.results_bytes is not None:
+                if split_candidate.results_have_custom_names or self._query_has_series_custom_names():
+                    cached_response_candidate["results"] = orjson.loads(split_candidate.results_bytes)  # type: ignore[index]
+                else:
+                    raw_results = split_candidate.results_bytes
+        else:
+            cached_response_candidate = cache_manager.get_cache_data()
 
         if self.is_cached_response(cached_response_candidate):
+            assert cached_response_candidate is not None
+            if raw_results is not None:
+                cached_response_candidate["results"] = []
             cached_response_candidate["is_cached"] = True
             # When rolling out schema changes, cached responses may not match the new schema.
             # Trigger recomputation in this case.
             try:
                 cached_response = CachedResponse(**cached_response_candidate)
+                if raw_results is not None:
+                    self._raw_cached_results_bytes = raw_results
             except Exception as e:
                 capture_exception(Exception(f"Error parsing cached response: {e}"))
                 cached_response = CacheMissResponse(cache_key=cache_manager.cache_key)
@@ -1542,7 +1574,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 )
                 return cached_response
 
-        # Nothing useful out of cache, nor async query status
+        # Nothing useful out of cache, nor async query status. A recomputation follows, so the
+        # cached raw results (if any) must not leak onto the fresh response.
+        self._raw_cached_results_bytes = None
         return None
 
     def _call_with_rate_limits(self, *, dashboard_id: Optional[int]) -> tuple[R, float]:

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -577,6 +577,13 @@ FLAGS_CACHE_MISS_TTL = int(os.getenv("FLAGS_CACHE_MISS_TTL", str(60 * 60 * 24)))
 LLM_PROMPTS_CACHE_TTL = int(os.getenv("LLM_PROMPTS_CACHE_TTL", str(60 * 60 * 24)))  # 1 day
 LLM_PROMPTS_CACHE_MISS_TTL = int(os.getenv("LLM_PROMPTS_CACHE_MISS_TTL", str(60 * 5)))  # 5 minutes
 
+# Rollout gate for the split query-cache format (header + raw results segments). Every deploy
+# can READ both formats, but old readers treat split entries as cache misses and recompute —
+# so writes stay in the legacy format until all readers understand the split one. Flip this on
+# only once the split-capable reader is fully deployed; safe to flip back off (readers keep
+# understanding both formats).
+QUERY_CACHE_SPLIT_FORMAT_WRITES: bool = get_from_env("QUERY_CACHE_SPLIT_FORMAT_WRITES", False, type_cast=str_to_bool)
+
 CACHES = {
     "default": {
         # IMPORTANT: If any of these settings change, make sure the

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2025,8 +2025,24 @@ class DashboardSerializer(DashboardMetadataSerializer):
             if not sorted_tiles:
                 return []
 
+            # One serializer reused across tiles: constructing DashboardTileSerializer per tile
+            # deep-copies every declared field of the tile + nested insight serializers, which
+            # dominates CPU on large dashboards. Per-tile state is passed via the shared context.
+            # (dashboard, insight) is unique per dashboard, so the per-instance insight_result
+            # lru_cache never leaks a result from one tile to another.
+            tile_context = self.context.copy()
+            reused_serializer = DashboardTileSerializer(context=tile_context)
             for order, tile in enumerate(sorted_tiles):
-                order, tile_data = serialize_tile_with_context(tile, order, self.context)
+                tile_context.update({"dashboard_tile": tile, "order": order})
+
+                if isinstance(tile.layouts, str):
+                    tile.layouts = json.loads(tile.layouts)
+
+                try:
+                    tile_data = reused_serializer.to_representation(tile)
+                except pydantic_core.ValidationError:
+                    # Fall back to the fresh-serializer path, which handles the error shape
+                    order, tile_data = serialize_tile_with_context(tile, order, self.context)
                 serialized_tiles.append(cast(ReturnDict, tile_data))
 
         return serialized_tiles

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2339,9 +2339,11 @@ class DashboardsViewSet(
         metadata_serializer = DashboardMetadataSerializer(dashboard, context=self.get_serializer_context())
         metadata_data = metadata_serializer.data
 
-        # Create serializer context for tiles
+        # Create serializer context for tiles. Tiles are rendered with SafeJSONRenderer below,
+        # so raw cached results (orjson.Fragment) are safe even though the negotiated renderer
+        # is the SSE one.
         context = self.get_serializer_context()
-        context.update({"dashboard": dashboard})
+        context.update({"dashboard": dashboard, "raw_results_supported": True})
 
         # Get tiles with proper prefetch
         tiles = DashboardTile.dashboard_queryset(dashboard.tiles.all()).prefetch_related(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2768,6 +2768,9 @@ class DashboardsViewSet(
 
         context = self.get_serializer_context()
         context["dashboard"] = dashboard
+        # _format_insight_for_llm consumes results as Python data, so raw cached
+        # result bytes (orjson.Fragment) must not be used here.
+        context["require_parsed_results"] = True
 
         tiles = DashboardTile.dashboard_queryset(dashboard.tiles.all()).prefetch_related(
             Prefetch(

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -115,7 +115,7 @@ from posthog.rbac.user_access_control import (
     UserAccessControlSerializerMixin,
     access_level_satisfied_for_resource,
 )
-from posthog.renderers import SafeJSONRenderer, ServerSentEventRenderer
+from posthog.renderers import SafeJSONRenderer
 from posthog.resource_limits import LimitKey, check_count_limit
 from posthog.schema_migrations.upgrade import upgrade
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -1124,12 +1124,14 @@ class InsightSerializer(InsightBasicSerializer):
                     getattr(view, "user_access_control", None) if isinstance(request_user, User) else None
                 )
                 # Raw cached results (orjson.Fragment) are only valid when the response is
-                # rendered by orjson: SafeJSONRenderer directly, or the SSE tile stream which
-                # renders each tile with SafeJSONRenderer. Pretty-printed output (?indent=) would
-                # not indent inside a fragment, so keep the parsed path there.
+                # rendered by orjson: SafeJSONRenderer directly, or a caller that declares it
+                # renders tiles with SafeJSONRenderer itself (the SSE tile stream sets
+                # raw_results_supported — SSE content negotiation alone doesn't guarantee an
+                # orjson boundary). Pretty-printed output (?indent=) would not indent inside a
+                # fragment, so keep the parsed path there.
                 accepted_renderer = getattr(self.context["request"], "accepted_renderer", None)
                 allow_raw_results = (
-                    isinstance(accepted_renderer, SafeJSONRenderer | ServerSentEventRenderer)
+                    (isinstance(accepted_renderer, SafeJSONRenderer) or bool(self.context.get("raw_results_supported")))
                     and not self.context["request"].query_params.get("indent")
                     and not self.context.get("require_parsed_results")
                 )

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -115,6 +115,7 @@ from posthog.rbac.user_access_control import (
     UserAccessControlSerializerMixin,
     access_level_satisfied_for_resource,
 )
+from posthog.renderers import SafeJSONRenderer, ServerSentEventRenderer
 from posthog.resource_limits import LimitKey, check_count_limit
 from posthog.schema_migrations.upgrade import upgrade
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -1122,6 +1123,16 @@ class InsightSerializer(InsightBasicSerializer):
                 request_user_access_control = (
                     getattr(view, "user_access_control", None) if isinstance(request_user, User) else None
                 )
+                # Raw cached results (orjson.Fragment) are only valid when the response is
+                # rendered by orjson: SafeJSONRenderer directly, or the SSE tile stream which
+                # renders each tile with SafeJSONRenderer. Pretty-printed output (?indent=) would
+                # not indent inside a fragment, so keep the parsed path there.
+                accepted_renderer = getattr(self.context["request"], "accepted_renderer", None)
+                allow_raw_results = (
+                    isinstance(accepted_renderer, SafeJSONRenderer | ServerSentEventRenderer)
+                    and not self.context["request"].query_params.get("indent")
+                    and not self.context.get("require_parsed_results")
+                )
                 with tags_context(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.INSIGHT, **shared_tags):
                     return calculate_for_query_based_insight(
                         insight,
@@ -1135,6 +1146,7 @@ class InsightSerializer(InsightBasicSerializer):
                         tile_filters_override=tile_filters_override,
                         cache_age_seconds=shared_cache_age_seconds,
                         analytics_props=get_request_analytics_properties(self.context["request"]),
+                        allow_raw_results=allow_raw_results,
                     )
             except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
                 raise ValidationError(str(e), getattr(e, "code_name", None))

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -527,6 +527,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 tile_filters_override={},
                 cache_age_seconds=None,
                 analytics_props=ANY,
+                allow_raw_results=False,
             )
 
         with patch(
@@ -548,6 +549,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 tile_filters_override={},
                 cache_age_seconds=int(SHARED_FORCE_BLOCKING_STALENESS_WINDOW.total_seconds()),
                 analytics_props=ANY,
+                allow_raw_results=False,
             )
 
     def test_get_shared_insight_with_force_refresh_returns_200(self) -> None:
@@ -609,6 +611,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 tile_filters_override={},
                 cache_age_seconds=int(SHARED_FORCE_BLOCKING_STALENESS_WINDOW.total_seconds()),
                 analytics_props=ANY,
+                allow_raw_results=False,
             )
 
     def test_get_insight_by_short_id(self) -> None:


### PR DESCRIPTION
## TL;DR (eli5)

Opening a big dashboard was slow even when every chart was already cached. The server was unpacking every cached chart result into Python objects, copying them, and re-packing them into JSON — three times the work for zero change in output. Now it reuses one serializer for all tiles, stops copying the result tree, and passes the cached results straight from Redis into the response as raw JSON. Same bytes out, about 3x faster.

## Problem

Large dashboard GETs (70-80 insight tiles) spend 80%+ of wall time outside Postgres, even with every tile served from the query cache. Profiling a local repro (70 trends tiles, ~450 KiB cached results each, ~29 MB response) showed the non-SQL time concentrated in:

| Phase | ~ms/request |
|---|---|
| orjson.loads of 70 cached result blobs | 389 |
| pydantic `model_dump(by_alias=True)` of the full response | 254 |
| DRF serializer construction per tile (`get_fields` deepcopy) | 300 |
| Response render (orjson.dumps) | ~100 |
| Redis GET + zstd | 76 |
| SQL (26 queries) | 38 |

## Changes

Three independent, behavior-preserving optimizations (one commit each):

1. **Skip the full-response `model_dump`** in `calculate_for_query_based_insight` — build `InsightResult` from response model attributes; only the small nested models (`timings`, `query_status`, `resolved_date_range`) are dumped, matching previous output.
2. **Reuse one `DashboardTileSerializer` across tiles** in `get_tiles` — DRF field construction (deep-copying ~60 declared fields incl. the nested insight serializer, per tile) dominated serializer CPU. Per-tile state flows through the shared context; `(dashboard, insight)` uniqueness keeps the per-instance `insight_result` lru_cache correct.
3. **Serve cached results as raw JSON** — behind `QUERY_CACHE_SPLIT_FORMAT_WRITES` (default **off**): every deploy ships split-capable readers, and split-format writes are enabled only once the reader is fully rolled out (old readers treat split entries as cache misses and would recompute + churn the cache during a mixed-version window). When enabled, cache blobs are written in a split format (header JSON + results JSON segments; legacy blobs stay readable, old readers treat new blobs as cache misses and recompute). On cache hits, the insight serializer opts in to validate only the header and embed the results segment into the response via `orjson.Fragment`, skipping the parse → validate → re-serialize round trip entirely. Gated to orjson renderers (`SafeJSONRenderer`/SSE tile stream), disabled for `?indent=`, the shared-page template (stdlib `json.dumps`), `run_insights` LLM formatting, and whenever the query or cached results carry series `custom_name`s (those need parsed patching).

Results on the local repro (median of 25 GETs, single core; SQL time unchanged at ~38ms / 26 queries):

| Change | median wall | p90 |
|---|---|---|
| baseline | 999 ms | 2130 ms |
| 1. no full model_dump | 873 ms | 2035 ms |
| 2. serializer reuse | 787 ms | 2229 ms |
| 3. raw results pass-through | **347 ms** | **440 ms** |

A fourth commit fixes a bug an adversarial review pass caught in change 1: response classes whose `results` items are pydantic models (Retention, Paths, marketing analytics `list[list[...]]`) need those items dumped to dicts — DRF's JSON encoder otherwise iterates the models into `(field, value)` tuple arrays, corrupting the response shape. Covered by new regression tests in `posthog/caching/test/test_calculate_results.py` (model items, nested lists of models, plain-dict identity pass-through, raw-fragment path) — a gap no existing test covered.

The p90 collapse comes from eliminating ~700 MB of per-request Python object allocation (GC pauses). The same per-tile pipeline serves `stream_tiles` (the app's SSE path), so it benefits equally; the plain `retrieve` path remains the one used by API consumers, mobile, and embeds.

## Where the remaining time goes (why this is close to the floor)

After the three fixes the local repro sits at ~345 ms (from 999 ms), of which ~307 ms is non-SQL. Decomposition of the remainder: Redis fetch + header parse ~80 ms, per-tile query-runner machinery (cache key, async-status lookup, observability contexts, per-tile analytics event) ~60 ms, DRF field iteration across ~45 insight fields per tile ~50 ms, URL routing + middleware + auth ~50 ms, SQL 38 ms, response render ~20 ms. No remaining single-digit-risk change is worth >30 ms; further reduction needs behavior or API changes, e.g.:

- batching the per-tile cache/status Redis GETs needs the cache keys before serialization, but keys are derived inside each tile's query runner (the tiles' stored `filters_hash` is only maintained for legacy filters-based insights) — batching would require restructuring `insight_result` to build runners in a pre-pass;
- skipping the per-tile async-query-status lookup on fresh cache hits would drop 70 Redis round trips but changes `query_status` semantics;
- a "results-only" dashboard payload for consumers that ignore the ~40 insight metadata fields would cut the DRF loop, but that's an API change (`stream_tiles` already exists for the app frontend and benefits from these fixes equally — verified the SSE events remain valid JSON with the fragment path active).

Also evaluated and rejected: bypassing django-redis's pickle framing of cached bytes (isolated A/B: 0.8 ms per 70 blobs — pickle-framing bytes is nearly free; a sampling profiler had misattributed the cost).

## Post-review hardening (commits 5)

Addressed `ty` type errors and review feedback: `Literal` overloads keep `process_query_dict`/`process_query_model` returning `dict | BaseModel` for all existing callers; raw pass-through is additionally gated off for response classes whose `results` are model-typed (so the schema-drift validation path is never bypassed) and requires an explicit `raw_results_supported` capability for the SSE stream instead of trusting content negotiation; model conversion is container-preserving (dict-shaped/scalar results keep their shape); nested funnel steps' `action.custom_name` is detected at write time; split-format writes are flag-gated for rollout safety (with a write-format regression test).

## How did you test this code?

- Byte-identity: sha256 of the full 29.9 MB dashboard response is identical before/after each change (and raw vs parsed path), with only `last_accessed_at` normalized.
- `posthog/api/test/dashboards/test_dashboard.py` — 176 passed, 1 failed (`test_shared_dashboard`) — that failure reproduces identically on master in this environment (no object storage) and is unrelated.
- Canonical N+1 tests pass, including `test_insight_alerts_do_not_nplus1_dashboard_gets` and `test_adding_insights_is_not_nplus1_for_gets` (query counts unchanged).
- `posthog/hogql_queries/test/test_query_runner.py` (89 passed), `posthog/caching/test/test_cache_size_tracker.py`, `posthog/caching/test/test_warming.py`, and `products/product_analytics/backend/api/test/test_insight.py -k "cach or refresh or shared"` (12 passed).
- Two mock-assertion tests updated for the new `allow_raw_results` kwarg (exact-kwargs `assert_called_once_with`).
- New `posthog/caching/test/test_calculate_results.py` (4 tests): catches the model-typed-results regression described above; asserts through the public `calculate_for_query_based_insight` interface with only `process_query_dict` mocked.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Produced in an autoresearch (iterative optimization) session with Claude Code: built a benchmark harness (70 cached trends tiles seeded into the query cache), profiled with pyinstrument + targeted phase timers, and applied fixes one at a time with before/after medians and byte-identity checks between each. Considered and rejected: batching per-tile Redis GETs via MGET (needs cache keys upfront, which only exist after per-tile runner construction; revisit separately), and skipping `apply_dashboard_filters_to_dict` for empty filters (measured at 0.1 ms — not worth the risk). The split cache format records at write time whether results contain custom series names, so the raw path can prove that custom-name patching is a no-op before skipping the parse.

Created with Autoresearch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
