### PR TITLE
feat(slo): add billing objectives and burn alerts

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/alerts.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/alerts.tf
@@ -1,0 +1,180 @@
+locals {
+  billing_slo_operation_keys = ["billing_status", "usage_report_ingest"]
+  billing_slo_operation_regions = {
+    for key, operation in local.slo_operation_regions :
+    key => operation if contains(local.billing_slo_operation_keys, operation.operation)
+  }
+
+  # A 14.4x burn for one hour consumes roughly 2% of a 28-day error budget.
+  billing_slo_fast_burn_threshold = 14.4
+}
+
+# PostHog alerts currently require a TrendsQuery, while the dashboard burn-rate
+# insights use HogQL to correlate started/completed events. This alert-only insight
+# uses the same started-minus-successful-completed availability calculation over
+# hourly buckets. These operations complete within an hour, so the bucket boundary
+# does not materially change the signal.
+resource "posthog_insight" "billing_slo_fast_burn" {
+  for_each = local.billing_slo_operation_regions
+
+  name        = "SLO alert: 1h burn rate - ${each.value.name}${each.value.region_count > 1 ? " — ${each.value.region}" : ""}"
+  description = "Fast-burn alert source for the ${each.value.slo}% availability objective. Alert threshold: ${local.billing_slo_fast_burn_threshold}x the sustainable error-budget burn rate."
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [
+        {
+          kind        = "EventsNode"
+          event       = "slo_operation_started"
+          math        = "total"
+          custom_name = "Started"
+          properties = [
+            {
+              key      = "operation"
+              type     = "event"
+              value    = [each.value.operation]
+              operator = "exact"
+            },
+            {
+              key      = "region"
+              type     = "event"
+              value    = [each.value.region]
+              operator = "exact"
+            }
+          ]
+        },
+        {
+          kind        = "EventsNode"
+          event       = "slo_operation_completed"
+          math        = "total"
+          custom_name = "Successful completions"
+          properties = [
+            {
+              key      = "operation"
+              type     = "event"
+              value    = [each.value.operation]
+              operator = "exact"
+            },
+            {
+              key      = "region"
+              type     = "event"
+              value    = [each.value.region]
+              operator = "exact"
+            },
+            {
+              key      = "outcome"
+              type     = "event"
+              value    = ["success"]
+              operator = "exact"
+            }
+          ]
+        }
+      ]
+      version  = 2
+      interval = "hour"
+      dateRange = {
+        date_from = "-24h"
+      }
+      trendsFilter = {
+        display                 = "ActionsLineGraph"
+        decimalPlaces           = 2
+        showLegend              = true
+        showAlertThresholdLines = true
+        formulaNodes = [{
+          formula     = "(A-B)/A/${format("%.8f", (100 - each.value.slo) / 100)}"
+          custom_name = "1h burn rate"
+        }]
+      }
+      filterTestAccounts = false
+    }
+  })
+
+  tags = ["managed-by:terraform", "slo", "billing"]
+}
+
+resource "posthog_alert" "billing_slo_fast_burn" {
+  for_each = posthog_insight.billing_slo_fast_burn
+
+  name                   = "Billing SLO fast burn: ${local.billing_slo_operation_regions[each.key].name}${local.billing_slo_operation_regions[each.key].region_count > 1 ? " — ${local.billing_slo_operation_regions[each.key].region}" : ""}"
+  enabled                = true
+  calculation_interval   = "hourly"
+  condition_type         = "absolute_value"
+  threshold_type         = "absolute"
+  threshold_upper        = local.billing_slo_fast_burn_threshold
+  series_index           = 0
+  check_ongoing_interval = false
+  insight                = each.value.id
+  subscribed_users       = var.analytics_platform_alert_subscribed_user_ids
+}
+
+resource "posthog_hog_function" "billing_slo_slack_notification" {
+  for_each = posthog_alert.billing_slo_fast_burn
+
+  name        = "Post Billing SLO alert to Slack"
+  description = "Post a Billing SLO fast-burn alert to #team-billing"
+  type        = "internal_destination"
+  enabled     = true
+  hog         = "let res := fetch('https://slack.com/api/chat.postMessage', {\n  'body': {\n    'channel': inputs.channel,\n    'icon_emoji': inputs.icon_emoji,\n    'username': inputs.username,\n    'blocks': inputs.blocks,\n    'text': inputs.text\n  },\n  'method': 'POST',\n  'headers': {\n    'Authorization': f'Bearer {inputs.slack_workspace.access_token}',\n    'Content-Type': 'application/json'\n  }\n});\n\nif (res.status != 200 or res.body.ok == false) {\n  throw Error(f'Failed to post message to Slack: {res.status}: {res.body}');\n}"
+
+  inputs_json = jsonencode({
+    text = {
+      value      = "Billing SLO alert triggered: {event.properties.insight_name}"
+      templating = "hog"
+    }
+    blocks = {
+      value = [
+        {
+          text = {
+            text = "Billing SLO alert '{event.properties.alert_name}' is firing"
+            type = "plain_text"
+          }
+          type = "header"
+        },
+        {
+          text = { text = "{event.properties.breaches}", type = "plain_text" }
+          type = "section"
+        },
+        {
+          type     = "context"
+          elements = [{ text = "Project: <{project.url}|{project.name}>", type = "mrkdwn" }]
+        },
+        { type = "divider" },
+        {
+          type = "actions"
+          elements = [
+            {
+              url  = "{project.url}/insights/{event.properties.insight_id}"
+              text = { text = "View insight", type = "plain_text" }
+              type = "button"
+            },
+            {
+              url  = "{project.url}/insights/{event.properties.insight_id}/alerts?alert_id={event.properties.alert_id}"
+              text = { text = "View alert", type = "plain_text" }
+              type = "button"
+            }
+          ]
+        }
+      ]
+      templating = "hog"
+    }
+    channel         = { value = var.billing_slack_channel_id, templating = "hog" }
+    username        = { value = "Billing SLO monitor", templating = "hog" }
+    icon_emoji      = { value = ":hogzilla:", templating = "hog" }
+    slack_workspace = { value = var.analytics_platform_slack_workspace_id, templating = "hog" }
+  })
+
+  filters_json = jsonencode({
+    source = "events"
+    events = [{ id = "$insight_alert_firing", type = "events" }]
+    properties = [{
+      key      = "alert_id"
+      type     = "event"
+      value    = each.value.id
+      operator = "exact"
+    }]
+  })
+
+  template_id = "template-slack"
+  icon_url    = "/static/services/slack.png"
+}

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -40,6 +40,16 @@ locals {
       slo     = 99.95 # error budget = 0.05%
       regions = ["US", "EU"]
     }
+    billing_status = {
+      name    = "GET /api/billing"
+      slo     = 99.95 # error budget = 0.05%
+      regions = ["US"]
+    }
+    usage_report_ingest = {
+      name    = "Usage reports v2 intake"
+      slo     = 99.95 # error budget = 0.05%
+      regions = ["US", "EU"]
+    }
     query_service = {
       name    = "Query service"
       slo     = 99.95 # error budget = 0.05%

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -48,7 +48,7 @@ locals {
     usage_report_ingest = {
       name    = "Usage reports v2 intake"
       slo     = 99.95 # error budget = 0.05%
-      regions = ["US", "EU"]
+      regions = ["US", "EU", "UNKNOWN"]
     }
     query_service = {
       name    = "Query service"
@@ -266,7 +266,7 @@ resource "posthog_insight" "slo_burn_rate" {
       query = replace(
         replace(
           replace(local.slo_burn_rate_query, "{{OPERATION}}", each.value.operation),
-          "{{REGION}}", each.value.region),
+        "{{REGION}}", each.value.region),
         "{{ERROR_BUDGET}}", tostring((100 - each.value.slo) / 100)
       )
     }
@@ -283,7 +283,7 @@ resource "posthog_insight" "slo_burn_rate" {
       showLegend            = true
       goalLines = [
         { label = "Budget rate", value = 0.30, position = "start" },
-        { label = "100x burn",   value = 2.00, position = "start" }
+        { label = "100x burn", value = 2.00, position = "start" }
       ]
     }
     tableSettings = {
@@ -305,14 +305,14 @@ resource "posthog_insight" "slo_burn_rate" {
 resource "posthog_insight" "slo_duration" {
   for_each = local.slo_operation_regions
 
-  name        = "SLO: Duration - ${each.value.name}${each.value.region_count > 1 ? " — ${each.value.region}" : ""}"
+  name = "SLO: Duration - ${each.value.name}${each.value.region_count > 1 ? " — ${each.value.region}" : ""}"
   query_json = jsonencode({
     kind = "DataVisualizationNode"
     source = {
-      kind  = "HogQLQuery"
+      kind = "HogQLQuery"
       query = replace(
         replace(local.slo_duration_query, "{{OPERATION}}", each.value.operation),
-        "{{REGION}}", each.value.region)
+      "{{REGION}}", each.value.region)
     }
     display = "ActionsAreaGraph"
     chartSettings = {
@@ -345,7 +345,7 @@ resource "posthog_insight" "slo_duration" {
 # Combined 28d success rate (all operations on one chart).
 # ---------------------------------------------------------------------------
 resource "posthog_insight" "slo_success_rate" {
-  name        = "SLO: 28d Success Rate"
+  name = "SLO: 28d Success Rate"
   query_json = jsonencode({
     kind = "DataVisualizationNode"
     source = {

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
@@ -1,3 +1,16 @@
+locals {
+  slo_operation_layout_y = {
+    for op_idx, op_key in sort(keys(local.slo_operations)) :
+    op_key => 6 + sum(concat(
+      [0],
+      [
+        for previous_op_key in slice(sort(keys(local.slo_operations)), 0, op_idx) :
+        1 + length(local.slo_operations[previous_op_key].regions) * 3
+      ]
+    ))
+  }
+}
+
 resource "posthog_dashboard_layout" "slo_monitoring" {
   dashboard_id = posthog_dashboard.slo_monitoring.id
   tiles = concat(
@@ -7,7 +20,7 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
         insight_id = posthog_insight.slo_success_rate.id
         layouts_json = jsonencode({
           sm = {
-            h = 5, i = "success_rate", w = 8, x = 0, y = 0
+            h    = 5, i = "success_rate", w = 8, x = 0, y = 0
             minH = 2, minW = 2, moved = false, static = false
           }
         })
@@ -16,7 +29,7 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
         insight_id = posthog_insight.slo_volume.id
         layouts_json = jsonencode({
           sm = {
-            h = 5, i = "volume", w = 4, x = 8, y = 0
+            h    = 5, i = "volume", w = 4, x = 8, y = 0
             minH = 2, minW = 2, moved = false, static = false
           }
         })
@@ -25,7 +38,7 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
         text_body = "**Success rate** is a 28-day rolling window showing the percentage of successful operations. **Burn rate** shows how fast you're consuming your error budget on a logarithmic scale — the Budget rate line marks sustainable consumption, crossing 100x burn indicates an active incident. **Duration** shows p50/p95/p99 operation latency in seconds."
         layouts_json = jsonencode({
           sm = {
-            h = 1, i = "text", w = 12, x = 0, y = 5
+            h    = 1, i = "text", w = 12, x = 0, y = 5
             minH = 1, minW = 1, moved = false, static = false
           }
         })
@@ -34,16 +47,15 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
     # Per-operation sections: header + burn rate (left) + duration (right) per region.
     # Each section: header (h=1) + N regions * row_height (h=3).
     # Base y = 6 (after success rate h=5 + text h=1).
-    # NOTE: y offset formula assumes all operations have the same number of regions.
     flatten([
-      for op_idx, op_key in sort(keys(local.slo_operations)) : concat(
+      for op_key in sort(keys(local.slo_operations)) : concat(
         # Section header
         [{
           text_body = "## ${local.slo_operations[op_key].name}"
           layouts_json = jsonencode({
             sm = {
-              h = 1, i = "header_${op_key}", w = 12, x = 0,
-              y = 6 + op_idx * (1 + length(local.slo_operations[op_key].regions) * 3)
+              h    = 1, i = "header_${op_key}", w = 12, x = 0,
+              y    = local.slo_operation_layout_y[op_key]
               minH = 1, minW = 1, moved = false, static = false
             }
           })
@@ -54,8 +66,8 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
             insight_id = posthog_insight.slo_burn_rate["${op_key}_${lower(region)}"].id
             layouts_json = jsonencode({
               sm = {
-                h = 3, i = "burn_${op_key}_${lower(region)}", w = 6, x = 0,
-                y = 6 + op_idx * (1 + length(local.slo_operations[op_key].regions) * 3) + 1 + reg_idx * 3
+                h    = 3, i = "burn_${op_key}_${lower(region)}", w = 6, x = 0,
+                y    = local.slo_operation_layout_y[op_key] + 1 + reg_idx * 3
                 minH = 2, minW = 2, moved = false, static = false
               }
             })
@@ -67,8 +79,8 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
             insight_id = posthog_insight.slo_duration["${op_key}_${lower(region)}"].id
             layouts_json = jsonencode({
               sm = {
-                h = 3, i = "dur_${op_key}_${lower(region)}", w = 6, x = 6,
-                y = 6 + op_idx * (1 + length(local.slo_operations[op_key].regions) * 3) + 1 + reg_idx * 3
+                h    = 3, i = "dur_${op_key}_${lower(region)}", w = 6, x = 6,
+                y    = local.slo_operation_layout_y[op_key] + 1 + reg_idx * 3
                 minH = 2, minW = 2, moved = false, static = false
               }
             })

--- a/terraform/us/project-2/team-analytics-platform/terragrunt.hcl
+++ b/terraform/us/project-2/team-analytics-platform/terragrunt.hcl
@@ -15,4 +15,5 @@ inputs = {
   analytics_platform_slack_channel_id          = "C09S5802LMU"
   analytics_platform_slack_workspace_id        = 54567
   analytics_platform_alert_subscribed_user_ids = [339134]
+  billing_slack_channel_id                     = "C08ERRQT41E"
 }

--- a/terraform/us/project-2/team-analytics-platform/variables_team.tf.tpl
+++ b/terraform/us/project-2/team-analytics-platform/variables_team.tf.tpl
@@ -24,6 +24,12 @@ variable "analytics_platform_slack_workspace_id" {
   sensitive   = true
 }
 
+variable "billing_slack_channel_id" {
+  description = "Slack channel ID for Billing alert notifications"
+  type        = string
+  sensitive   = true
+}
+
 variable "analytics_platform_alert_subscribed_user_ids" {
   description = "List of PostHog user IDs subscribed to alerts"
   type        = list(number)


### PR DESCRIPTION
## Problem

[PostHog/billing#2052](https://github.com/PostHog/billing/pull/2052) emits SLO lifecycle events for billing status requests and usage reports v2 intake. The shared SLO dashboard does not yet define objectives or alert delivery for those operations.

Malformed usage report messages cannot always be attributed to `US` or `EU`. Without a catch-all series, those failures disappear from the regional burn-rate alerts.

## Changes

- Add 99.95% successful-completion objectives over 28 days for `billing_status` and `usage_report_ingest`.
- Add an `UNKNOWN` usage-report region so malformed messages remain in the intake SLO denominator.
- Add hourly fast-burn alerts at 14.4x the sustainable budget rate.
- Deliver firing alerts to the Billing team Slack channel.
- Support operations with different region counts in the generated dashboard layout.
- Use an alert-only Trends formula because PostHog alerts currently accept `TrendsQuery`, while the dashboard keeps its correlation-aware HogQL query.

## How did you test this code?

- Ran `terraform fmt -check` on the SLO monitoring configuration.
- Ran `./bin/hogli ci:preflight --strict`.
- Ran `git diff --check`.
- I did not run Terragrunt plan or apply.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No product documentation changes. The Billing repository owns the internal SLO objective notes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop prepared this PR in the current task. No public session link is available. Skills used: `/marce-development`, `/slo-instrumentation`, `/sending-notifications`, `/write-like-a-human`, and `/github:yeet`. The Slack connector was used only to resolve the stable Billing channel ID.

The main design choice was to keep the dashboard's correlation-aware HogQL calculation and create a small Trends formula only for alert evaluation, since alerts currently reject HogQL-backed insights.