### PR TITLE
fix(cdp): remove non-functional disable toggle from hog function mappings

### DIFF
--- a/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
+++ b/frontend/src/scenes/hog-functions/mapping/HogFunctionMappings.tsx
@@ -12,7 +12,6 @@ import {
     LemonInput,
     LemonLabel,
     LemonSelect,
-    LemonTag,
     Tooltip,
 } from '@posthog/lemon-ui'
 
@@ -76,7 +75,6 @@ export const MappingSummary = memo(function MappingSummary({
                       : humanize(firstInputValue)}
             </span>
             <span className="flex-1" />
-            {mapping.disabled ? <LemonTag type="danger">Disabled</LemonTag> : null}
         </span>
     )
 })
@@ -99,18 +97,6 @@ export function HogFunctionMapping({
     return (
         <>
             <div className="p-3 pl-10 deprecated-space-y-2">
-                {mapping.disabled ? (
-                    <LemonBanner
-                        type="warning"
-                        className="p-2"
-                        action={{
-                            children: 'Enable',
-                            onClick: () => onChange({ ...mapping, disabled: false }),
-                        }}
-                    >
-                        This mapping is disabled. It will not trigger the function.
-                    </LemonBanner>
-                ) : null}
                 {!hideEventFilter && (
                     <>
                         <LemonLabel>Match events and actions</LemonLabel>
@@ -260,13 +246,6 @@ export function HogFunctionMappings(): JSX.Element | null {
                     }
                 }
 
-                const toggleDisabled = (mapping: HogFunctionMappingType): void => {
-                    const index = mappingsValue.findIndex((m) => m === mapping)
-                    if (index !== -1) {
-                        onChange(mappingsValue.map((m, i) => (i === index ? { ...m, disabled: !m.disabled } : m)))
-                    }
-                }
-
                 const renameMapping = (mapping: HogFunctionMappingType): void => {
                     LemonDialog.openForm({
                         title: 'Rename mapping',
@@ -336,11 +315,6 @@ export function HogFunctionMappings(): JSX.Element | null {
                                                         dropdown: {
                                                             overlay: (
                                                                 <div className="deprecated-space-y-px">
-                                                                    <LemonButton
-                                                                        onClick={() => toggleDisabled(mapping)}
-                                                                    >
-                                                                        {mapping.disabled ? 'Enable' : 'Disable'}
-                                                                    </LemonButton>
                                                                     <LemonButton onClick={() => renameMapping(mapping)}>
                                                                         Rename
                                                                     </LemonButton>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7032,7 +7032,6 @@ export type CyclotronJobInputType = CyclotronInputType
 
 export interface HogFunctionMappingType {
     name: string
-    disabled?: boolean
     inputs_schema?: CyclotronJobInputSchemaType[]
     inputs?: Record<string, CyclotronInputType> | null
     filters?: CyclotronJobFiltersType | null

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionMappings.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/HogFlowFunctionMappings.tsx
@@ -85,13 +85,6 @@ export function HogFlowFunctionMappings({
         }
     }
 
-    const toggleDisabled = (mapping: HogFunctionMappingType): void => {
-        const index = mappingsValue.findIndex((m) => m === mapping)
-        if (index !== -1) {
-            onChange(mappingsValue.map((m, i) => (i === index ? { ...m, disabled: !m.disabled } : m)))
-        }
-    }
-
     const renameMapping = (mapping: HogFunctionMappingType): void => {
         LemonDialog.openForm({
             title: 'Rename mapping',
@@ -156,9 +149,6 @@ export function HogFlowFunctionMappings({
                                             dropdown: {
                                                 overlay: (
                                                     <div className="deprecated-space-y-px">
-                                                        <LemonButton onClick={() => toggleDisabled(mapping)}>
-                                                            {mapping.disabled ? 'Enable' : 'Disable'}
-                                                        </LemonButton>
                                                         <LemonButton onClick={() => renameMapping(mapping)}>
                                                             Rename
                                                         </LemonButton>


### PR DESCRIPTION
## Problem

The per-mapping **Disable** button in CDP destinations (Pinterest, TikTok, Meta CAPI, etc.) has never actually worked. You'd click Disable, the row would show a **Disabled** tag, and after Save the tag would disappear — because the mapping was never really disabled, just held in local UI state until the API round-trip cleared it. Meanwhile the mapping kept firing for every matching event. The UI lied about the outcome.

Root cause: `MappingsSerializer` in `posthog/cdp/validation.py` never declared a `disabled` field, so DRF silently dropped it on every save. The Node.js executor at `nodejs/src/cdp/services/hog-executor.service.ts` also never checked `mapping.disabled` when iterating mappings, so even if the field had been persisted the disabled mapping would still have invoked. The feature was frontend-only from the day it shipped in [#27172](https://github.com/PostHog/posthog/pull/27172) (2025-01-15).

## Changes

Rather than wire disable properly across serializer, generated types, executor, and both mapping UI variants, this PR removes the misleading toggle. **Delete** already covers the "make this mapping stop firing" use case, and unlike the fake disable, it actually works.

Removed:
- The row-level **Disabled** `LemonTag` in `HogFunctionMappings.tsx`
- The in-editor warning banner with the "Enable" call to action
- The Enable/Disable menu item in the mapping row's overflow menu
- The `toggleDisabled` handler
- The `disabled?: boolean` field on the `HogFunctionMappingType` interface
- The same Enable/Disable menu item in the HogFlow variant (`HogFlowFunctionMappings.tsx`) which shared the same broken pattern

The row menu still has Rename, Duplicate, and Delete.

> [!NOTE]
> No backend changes are needed. The field was never persisted, so no user has a stored `disabled: true` mapping that this could regress. Anyone who thought they'd disabled a mapping was actually still sending events to that destination — this PR does not change that runtime behavior, only stops the UI from claiming otherwise.

## Trade-off

The only capability we lose is **temporary pause without data loss**. If someone wants to stop a mapping for a weekend and flip it back on, they now have to delete it and re-add it from the template dropdown — fine for mappings using template defaults, more friction if the mapping has customized filters or input values. The top-level `hogFunction.enabled` toggle still pauses the whole destination.

If real user demand exists for per-mapping pause, the follow-up is small: add `disabled` to `MappingsSerializer`, add the field to the Node.js `HogFunctionMappingType`, and short-circuit disabled mappings in the executor loop.

## How did you test this code?

- Manually verified the diff: the `disabled` field and every reference to it is gone from both mapping UIs and the shared type
- Confirmed no other files in `frontend/src` or `products/` reference `mapping.disabled` or `toggleDisabled`
- Did not run the dev server or open the UI in a browser — reviewers should smoke-test the mapping row menu in a CDP destination edit view before merging

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs referenced the per-mapping disable toggle.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Meikel flagged the bug from real usage (Pinterest CAPI). I (Claude) traced the root cause across three layers (Python serializer strips the field, Node.js executor never checks it, frontend UI lies about the outcome), confirmed via git history that the feature had never worked end to end since #27172, and after discussing the trade-off with Meikel — properly wire disable across four files, versus remove the misleading UI and lean on delete — we chose to remove. No skills were invoked beyond the built-in Explore agent for the initial cross-file trace.