### PR TITLE
fix(cdp): populate fetch response body with client-side error info

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -972,12 +972,19 @@ export class HogExecutorService {
             body = undefined
         }
 
+        // Keep the status 500 fallback so template guards like `if (res.status
+        // >= 400) throw` still fire on a client-side abort and prevent
+        // subsequent fetches in multi-step templates from running against
+        // broken assumptions. Populate body with the real client-side error
+        // name and message so the terminal log stops reading as "status 500"
+        // with an empty body and instead tells the customer what actually
+        // happened (connect timeout, socket abort, DNS failure, etc.).
         const hogVmResponse: {
             status: number
             body: unknown
         } = {
             status: fetchResponse?.status ?? 500,
-            body,
+            body: body ?? (fetchError ? `${fetchError.name}: ${fetchError.message}` : undefined),
         }
 
         // Finally we create the response object as the VM expects


### PR DESCRIPTION
## Summary

When a hog function fetch fails without receiving an HTTP response (connect timeout, socket abort, DNS failure, event-loop-saturation-driven client abort), the executor synthesizes a `{ status: 500, body: undefined }` response object and pushes it onto the VM stack as if the destination had actually responded with a 500. Template hog code then hits its `if (res.status >= 400) throw ...` branch and logs `Webhook failed with status 500: ` with an empty body.

Customers investigating one of these events trace the "status 500" back to their own endpoint and spend a long time investigating server errors that never happened. A recent customer support ticket documented this exact pattern by reconciling their receive logs against our failure logs and confirming their endpoint returned 2xx to every request we labelled as 500.

## Change

`nodejs/src/cdp/services/hog-executor.service.ts`

```
-            status: fetchResponse?.status ?? 500,
-            body,
+            status: fetchResponse?.status ?? 500,
+            body: body ?? (fetchError ? `${fetchError.name}: ${fetchError.message}` : undefined),
```

Only the body fallback changes. Status 500 fallback stays.

## Why keep the status 500 fallback

An earlier version of this PR changed the status fallback to 0 so the log line stopped saying "500". Greptile correctly flagged that this regresses multi-step templates: after a failed fetch the executor still pushes a response onto the VM stack and resumes execution. If `res.status = 0` no longer trips `if (res.status >= 400) throw`, templates like `hubspot`, `intercom`, `google_ads`, and others that chain fetch calls would proceed to fetch #2 with broken assumptions about the state established by fetch #1.

Keeping status 500 preserves that guard behavior. The improvement is scoped to the body content: instead of an empty string, the log now includes the actual client-side error name and message.

## Effect on the log line

- **Before:** `Webhook failed with status 500: `
- **After:** `Webhook failed with status 500: AbortError: The operation was aborted due to timeout`

Status number is still misleading in the strict sense, but the body now tells the customer the real cause so they don't chase phantom server 500s. A more thorough fix would require reworking the executor's dual-write pattern (setting `result.error` AND pushing a response to keep the VM alive) which is a bigger design change deferred to a follow-up.

## Test plan

- [ ] Existing tests still pass (`hogli test nodejs/src/cdp/services/hog-executor.service.test.ts`). The tests that assert `{ status: 500, ... }` use real mocked HTTP 500 responses from a mock server, not the null-fetchResponse fallback, so they are unaffected
- [ ] Manually verify with a webhook destination against an unreachable host that the log line now includes the client-side error info in the body rather than being empty

## 🤖 Agent context

Follow-up from customer support ticket investigating false-500 destination errors that turned out to be client-side aborts from event-loop saturation during traffic bursts. Companion infrastructure fixes for the underlying saturation are on the charts side (PostHog/charts#13133 landed, PostHog/charts#13177 and PostHog/charts#13179 open).

A targeted regression test for the null-fetchResponse body-population fallback would be a valid follow-up.