### PR TITLE
fix(google-ads): actionable error on permission-denied validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
@@ -345,6 +345,18 @@ class GoogleAdsSource(
                     "Your Google Ads connection is no longer available — it may have been disconnected. "
                     "Please reconnect your Google Ads account.",
                 )
+            # A gRPC PERMISSION_DENIED ("The caller does not have permission") means the connected Google
+            # login can't access this customer ID — the wrong customer/manager (MCC) account, or access
+            # that was never granted. list_accessible_customers raises it as a raw _InactiveRpcError whose
+            # str() is a protobuf dump (with a per-request peer IP) the user can't act on, so surface an
+            # actionable prompt instead of leaking it, mirroring the MCC USER_PERMISSION_DENIED message.
+            if "PERMISSION_DENIED" in error_message or "caller does not have permission" in error_message:
+                return (
+                    False,
+                    "PostHog doesn't have permission to access this Google Ads account. Verify the "
+                    "customer ID (and manager account, if using an MCC) is accessible to the connected "
+                    "Google login, then reconnect your Google Ads account.",
+                )
             # A transient Google-side blip (INTERNAL / UNAVAILABLE) stringifies as a raw gRPC status and
             # protobuf failure dump the user can't act on. The sync rides these out in-process; here on
             # the interactive create path we surface a clean retry prompt instead of leaking the dump.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -377,6 +377,27 @@ class TestValidateCredentials:
         assert ok is False
         assert "reconnect your Google Ads account" in (message or "")
 
+    def test_permission_denied_returns_actionable_message(self):
+        # A connected login that can't access the customer ID surfaces as a raw gRPC PERMISSION_DENIED
+        # dump (with a per-request peer IP) at validate time. Surface a clean, actionable prompt rather
+        # than leaking the protobuf dump to the wizard.
+        config = GoogleAdsSourceConfig(customer_id="1234567890", google_ads_integration_id=1)
+        client = mock.Mock()
+        client.get_service.return_value.list_accessible_customers.side_effect = Exception(
+            'status = StatusCode.PERMISSION_DENIED\n\tdetails = "The caller does not have permission"\n\t'
+            'debug_error_string = "peer_address:ipv4:216.239.36.223:443"'
+        )
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
+            return_value=client,
+        ):
+            ok, message = GoogleAdsSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert "reconnect your Google Ads account" in (message or "")
+        assert "216.239.36.223" not in (message or "")
+        assert "StatusCode" not in (message or "")
+
     def test_transient_google_side_error_returns_retry_message(self):
         # A transient INTERNAL/UNAVAILABLE blip from Google stringifies as a raw gRPC status plus a
         # protobuf failure dump. Surface a clean retry prompt instead of leaking that to the wizard.


### PR DESCRIPTION
## Problem

Connecting a Google Ads source failed at credential-validation time with a raw gRPC dump surfaced directly in the setup wizard — a `PERMISSION_DENIED` `_InactiveRpcError` stringified as a protobuf blob (status text plus a per-request peer IP and timestamp) with nothing the user could act on.

`validate_credentials` already maps several failures (missing integration, transient blips) to clean messages, but a permission-denied from `list_accessible_customers` fell through to the generic `Error validating credentials: {raw}` fallback. This happens when the connected Google login can't access the configured customer ID — the wrong customer/manager (MCC) account, or access that was never granted.

This is the create/link-time counterpart to the sync-time permission handling in [#66221](https://github.com/PostHog/posthog/pull/66221) (which maps `get_non_retryable_errors`) and mirrors the UNAUTHENTICATED validate-time handling in [#67538](https://github.com/PostHog/posthog/pull/67538); neither covers create-time `PERMISSION_DENIED`.

## Changes

- Map a create-time gRPC `PERMISSION_DENIED` ("The caller does not have permission") in `validate_credentials` to an actionable message telling the user to verify the customer ID / manager account and reconnect, instead of leaking the raw dump.

## How did you test this code?

I'm an agent. Added `test_permission_denied_returns_actionable_message` to `TestValidateCredentials` in `test_google_ads_source.py` — it feeds a raw `StatusCode.PERMISSION_DENIED` dump into `list_accessible_customers` and asserts the returned message is the reconnect prompt and that neither the peer IP nor the raw `StatusCode` leaks. No existing test covered the permission-denied validate path. Ran the class locally: passed. Linted the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Opus 4.8) while triaging warehouse source-creation failures. Scoped narrowly to the create-time validate path so it doesn't overlap the sync-path fix in #66221 or the UNAUTHENTICATED validate fix in #67538. No `/`-skills shaped the code beyond `/writing-tests` for the test gate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
