### PR TITLE
fix(algolia): actionable error when validation returns 404

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/algolia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/algolia.py
@@ -259,7 +259,31 @@ def validate_credentials(
             return True, None
         return False, f"Your Algolia API key is missing the ACL required to sync '{schema_name}'"
 
-    return False, f"Algolia API returned status {response.status_code}"
+    # Any other status is unexpected for a credential probe. Surface Algolia's own message when it
+    # sends one, and give the common 404 an actionable hint, rather than echoing a bare status code
+    # the user can't act on.
+    api_message = ""
+    try:
+        api_message = response.json().get("message", "")
+    except ValueError:
+        pass
+
+    if response.status_code == 404:
+        target = f"index '{index_name}'" if index_name else "requested resource"
+        detail = f" Algolia said: {api_message}." if api_message else ""
+        return (
+            False,
+            f"Algolia couldn't find the {target} (status 404). Check that your Application ID is "
+            f"correct and the index exists, then try again.{detail}",
+        )
+
+    if api_message:
+        return False, f"Algolia rejected the request (status {response.status_code}): {api_message}"
+    return (
+        False,
+        f"Algolia returned an unexpected status ({response.status_code}). Check your Application ID "
+        "and API key, then try again.",
+    )
 
 
 def algolia_source(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia.py
@@ -308,3 +308,20 @@ class TestValidateCredentials:
         assert valid is False
         assert error is not None
         assert "Application ID" in error and "index" in error
+
+    def test_unexpected_status_surfaces_algolia_message(self) -> None:
+        # A non-404 error carrying an Algolia message should surface it so the user isn't left with
+        # only a status code.
+        resp = _response({"message": "Request rejected"}, status_code=400)
+        valid, error = self._run(resp, index_name="idx")
+        assert valid is False
+        assert error is not None and "Request rejected" in error
+
+    def test_non_json_error_body_does_not_crash(self) -> None:
+        # A non-JSON error body (e.g. an HTML 502 page) must not blow up validation; fall back to a
+        # status-based message.
+        resp = _response({}, status_code=502)
+        resp.json.side_effect = ValueError("no json")
+        valid, error = self._run(resp, index_name="idx")
+        assert valid is False
+        assert error is not None and "502" in error

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/algolia/tests/test_algolia.py
@@ -299,3 +299,12 @@ class TestValidateCredentials:
         valid, error = self._run(_response({}, status_code=500), index_name="idx")
         assert valid is False
         assert error is not None and "500" in error
+
+    def test_not_found_returns_actionable_message(self) -> None:
+        # A 404 means the probed index (or application ID) doesn't exist. Give the user something to
+        # act on instead of a bare "returned status 404".
+        resp = _response({"message": "Index does not exist"}, status_code=404)
+        valid, error = self._run(resp, index_name="idx")
+        assert valid is False
+        assert error is not None
+        assert "Application ID" in error and "index" in error


### PR DESCRIPTION
## Problem

Connecting an Algolia source failed credential validation with a bare `Algolia API returned status 404` — a raw status code the user can't act on. A 404 from the probe means the index being validated (or the application ID) doesn't exist, but the message gave no hint about which to check.

## Changes

- Replace the bare status-code fallback in `validate_credentials` with an actionable message: a 404 now points at the Application ID and index name, and other unexpected statuses surface Algolia's own message when it sends one. Existing 401/403 (bad-credentials / missing-ACL) handling is unchanged.

## How did you test this code?

I'm an agent. Added `test_not_found_returns_actionable_message` to `TestValidateCredentials` in `test_algolia.py` — asserts a 404 response yields a message naming both the Application ID and the index rather than a bare status. The existing `test_unexpected_status_returns_message` (500) still covers the generic branch. Ran the class locally: passed. Linted the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Opus 4.8) while triaging warehouse source-creation failures. The 404 branch names the index because the index-scoped browse probe is the likely source of a 404 at create time; other statuses keep a generic prompt plus Algolia's message. `/writing-tests` was invoked for the test gate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
