### PR TITLE
fix(integrations): classify reddit dead-grant refresh failures as invalid_grant

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -114,12 +114,17 @@ REFRESH_FAILURE_REASON_HTTP_5XX = "http_5xx"
 REFRESH_FAILURE_REASON_OTHER = "other"
 
 
-def oauth_refresh_failure_reason(status_code: int, body: dict) -> str:
+def oauth_refresh_failure_reason(status_code: int, body: dict, kind: str | None = None) -> str:
     error = body.get("error")
     if error == REFRESH_FAILURE_REASON_INVALID_GRANT:
         return REFRESH_FAILURE_REASON_INVALID_GRANT
     if error == REFRESH_FAILURE_REASON_INVALID_CLIENT:
         return REFRESH_FAILURE_REASON_INVALID_CLIENT
+    # Reddit reports a dead grant as `{"message": "Bad Request", "error": 400}` with no OAuth
+    # error code. Our refresh request shape is fixed and succeeds fleet-wide, so a 400 on this
+    # endpoint means the grant, not the request - match that exact shape for reddit only.
+    if kind == "reddit-ads" and status_code == 400 and error == 400:
+        return REFRESH_FAILURE_REASON_INVALID_GRANT
     if status_code >= 500:
         return REFRESH_FAILURE_REASON_HTTP_5XX
     return REFRESH_FAILURE_REASON_OTHER
@@ -1357,7 +1362,7 @@ class OauthIntegration:
         if res.status_code != 200 or not config.get("access_token"):
             logger.warning(f"Failed to refresh token for {self}", response=res.text)
             self.integration.errors = ERROR_TOKEN_REFRESH_FAILED
-            reason = oauth_refresh_failure_reason(res.status_code, config)
+            reason = oauth_refresh_failure_reason(res.status_code, config, kind=self.integration.kind)
             attempt = record_refresh_failure(self.integration, reason=reason)
             oauth_refresh_counter.labels(
                 kind=self.integration.kind, result="failed", reason=reason, attempt=attempt
@@ -3281,7 +3286,7 @@ class MetaAdsIntegration:
         if res.status_code != 200 or not config.get("access_token"):
             logger.warning(f"Failed to refresh token for {self}", response=res.text)
             self.integration.errors = ERROR_TOKEN_REFRESH_FAILED
-            reason = oauth_refresh_failure_reason(res.status_code, config)
+            reason = oauth_refresh_failure_reason(res.status_code, config, kind=self.integration.kind)
             attempt = record_refresh_failure(self.integration, reason=reason)
             oauth_refresh_counter.labels(
                 kind=self.integration.kind, result="failed", reason=reason, attempt=attempt

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -770,15 +770,19 @@ class TestOauthIntegrationModel(BaseTest):
 
     @parameterized.expand(
         [
-            ("invalid_grant", 400, {"error": "invalid_grant"}, "invalid_grant"),
-            ("invalid_client", 401, {"error": "invalid_client"}, "invalid_client"),
-            ("server_error", 502, {}, "http_5xx"),
-            ("other_4xx", 400, {"error": "temporarily_unavailable"}, "other"),
-            ("non_string_error", 400, {"error": {"code": 1}}, "other"),
+            ("invalid_grant", 400, {"error": "invalid_grant"}, None, "invalid_grant"),
+            ("invalid_client", 401, {"error": "invalid_client"}, None, "invalid_client"),
+            ("server_error", 502, {}, None, "http_5xx"),
+            ("other_4xx", 400, {"error": "temporarily_unavailable"}, None, "other"),
+            ("non_string_error", 400, {"error": {"code": 1}}, None, "other"),
+            ("reddit_dead_grant_shape", 400, {"message": "Bad Request", "error": 400}, "reddit-ads", "invalid_grant"),
+            ("reddit_shape_on_other_kind", 400, {"message": "Bad Request", "error": 400}, "hubspot", "other"),
+            ("reddit_5xx", 502, {"message": "Bad Gateway", "error": 502}, "reddit-ads", "http_5xx"),
+            ("reddit_oauth_error_code", 400, {"error": "invalid_grant"}, "reddit-ads", "invalid_grant"),
         ]
     )
-    def test_oauth_refresh_failure_reason(self, _name, status_code, body, expected):
-        assert oauth_refresh_failure_reason(status_code, body) == expected
+    def test_oauth_refresh_failure_reason(self, _name, status_code, body, kind, expected):
+        assert oauth_refresh_failure_reason(status_code, body, kind=kind) == expected
 
     @patch("posthog.models.integration.requests.post")
     def test_reconnect_clears_backoff_state(self, mock_post):


### PR DESCRIPTION
## Problem

Reddit's token endpoint reports a dead or revoked refresh token as `{"message": "Bad Request", "error": 400}` rather than the standard OAuth `{"error": "invalid_grant"}` code. Since #70492, `invalid_grant` is the only failure reason that can take an integration to the terminal state (5 unbroken strikes and the refresh sweep stops retrying). Reddit's nonstandard shape classifies as `other`, so a fleet of dead reddit-ads integrations retries once an hour forever instead of going terminal and falling silent - they are the dominant share of the residual refresh-failure noise now that the backoff has collapsed the floor.

### Evidence that this 400 means a dead grant

Reddit doesn't document its revoked-refresh-token response body, so this classification is grounded in production telemetry rather than a spec:

- **The body is uniform.** Over a 24h window, 99.96% of failed reddit-ads refresh log lines carry the exact JSON `{"message": "Bad Request", "error": 400}`.
- **It is not rate limiting.** The only other response Reddit sent in that window was its HTML 429 "Too Many Requests" page, and every instance predates the #70492 backoff, when the sweep was retrying broken rows on every run. After the backoff cut retry volume to roughly hourly, the 429s vanished entirely while the 400s persisted - Reddit's rate limiting is loud and visibly different.
- **It is per-row and permanent, not per-request.** Healthy reddit-ads integrations refresh successfully through this exact code path in the same window, so the request shape, content type, and platform credentials are fine. Sampled failing rows fail at exactly the hourly backoff cadence with zero successful refreshes over the past week. A 400 that recurs indefinitely for one row while its neighbors succeed is a per-row credential failure - only a re-auth can fix it, which is precisely what `invalid_grant` means.
- **Community corroboration.** PRAW/prawcore (the canonical Reddit client) surfaces a revoked refresh token as a 400 `BadRequest` from this endpoint ([refresh token docs](https://praw.readthedocs.io/en/latest/tutorials/refresh_token.html)).

## Changes

- `oauth_refresh_failure_reason` now accepts the integration `kind` and maps reddit-ads' dead-grant shape (HTTP 400 with `error: 400` and no OAuth error code) to `invalid_grant`. The same shape on any other kind still classifies as `other`, and reddit 5xx responses still classify as `http_5xx`.
- Both call sites (the generic OAuth refresh and the Facebook token-exchange path) now pass `kind`.

> [!NOTE]
> The theoretical risk of the mapping: if we ever ship a malformed reddit refresh request, affected rows would streak to terminal within about an hour. Those rows would be broken either way, and reconnecting the integration fully resets the state.

## How did you test this code?

Extended the existing parameterized `test_oauth_refresh_failure_reason` with four cases: the reddit dead-grant shape classifies as `invalid_grant`, the identical shape on another kind stays `other` (guards against the mapping leaking across kinds), reddit 5xx stays `http_5xx`, and a standard `invalid_grant` code on reddit still classifies directly. All existing backoff/terminal tests pass unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Found while verifying #70492's deploy in Grafana: the new `reason` label showed the residual failure noise was dominated by reddit-ads rows classified `other`, and Loki sampling showed Reddit's nonstandard 400 body. Kept the mapping kind-scoped rather than treating any `error: 400` as a dead grant, since other providers may use that shape for genuinely malformed requests. Skills invoked: /writing-tests.
