### PR TITLE
chore(clickhouse): drop retired shufflehog NodeRole

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -27,7 +27,6 @@ class NodeRole(StrEnum):
     INGESTION_EVENTS = "events"
     INGESTION_SMALL = "small"
     INGESTION_MEDIUM = "medium"
-    SHUFFLEHOG = "shufflehog"
     ENDPOINTS = "endpoints"
     LOGS = "logs"
 

--- a/posthog/clickhouse/migrations/0139_add_custom_metric_test_ingestion_layer.py
+++ b/posthog/clickhouse/migrations/0139_add_custom_metric_test_ingestion_layer.py
@@ -5,10 +5,10 @@ from posthog.clickhouse.custom_metrics import CUSTOM_METRICS_INGESTION_LAYER_VIE
 operations = [
     run_sql_with_exceptions(
         CUSTOM_METRICS_TEST_VIEW(),
-        node_roles=[NodeRole.INGESTION_EVENTS, NodeRole.SHUFFLEHOG],
+        node_roles=[NodeRole.INGESTION_EVENTS],
     ),
     run_sql_with_exceptions(
         CUSTOM_METRICS_INGESTION_LAYER_VIEW(),
-        node_roles=[NodeRole.INGESTION_EVENTS, NodeRole.SHUFFLEHOG],
+        node_roles=[NodeRole.INGESTION_EVENTS],
     ),
 ]

--- a/posthog/clickhouse/migrations/AGENTS.md
+++ b/posthog/clickhouse/migrations/AGENTS.md
@@ -32,10 +32,6 @@ The main cluster is:
 
 Additionally, on k8s we have stateless nodes:
 
-## ShuffleHog nodes
-
-It shuffles data between Kafka partitions.
-
 ## Ingestion nodes
 
 It ingests data from Kafka to a proper ClickHouse shard.


### PR DESCRIPTION
## Problem

The `shufflehog` ClickHouse node role no longer has any nodes behind it. The `NodeRole.SHUFFLEHOG` enum value and its lone usage are now dead references.

## Changes

- Remove `SHUFFLEHOG` from the `NodeRole` enum in `posthog/clickhouse/client/connection.py`.
- Drop `NodeRole.SHUFFLEHOG` from the two `node_roles` lists in migration `0139_add_custom_metric_test_ingestion_layer.py`, leaving `[NodeRole.INGESTION_EVENTS]`. This migration already ran and the shufflehog SQL is no longer applied, so editing it is safe. The reference has to go regardless, since removing the enum member would otherwise break the module import.
- Remove the now-empty "ShuffleHog nodes" section from the migrations `AGENTS.md` (its `CLAUDE.md` symlink follows automatically).

## How did you test this code?

`hogli ci:preflight --fix` passes (ruff lint/format, markdown format, migration conflict check). Confirmed no remaining `shufflehog` references under `posthog/clickhouse` and that both edited Python files compile.
