### PR TITLE
fix(aio): route count-triggered eval report checks to offline clickhouse

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/activities.py
@@ -10,6 +10,7 @@ from structlog import get_logger
 
 from posthog.hogql import ast
 
+from posthog.clickhouse.client.connection import Workload
 from posthog.sync import database_sync_to_async
 from posthog.temporal.ai_observability.eval_reports.types import (
     CheckCountTriggeredEvalReportInput,
@@ -180,8 +181,10 @@ def _count_eval_results_for_report(report: "EvaluationReport", since: dt.datetim
             "since": ast.Constant(value=since),
         },
     )
+    # These count checks run every 5 minutes across all count-triggered reports, so keep them
+    # off the online cluster that serves user-facing queries — route to the offline replica.
     with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.ENRICHMENT, team_id=report.team_id):
-        result = execute_hogql_query(query=query, team=report.team)
+        result = execute_hogql_query(query=query, team=report.team, workload=Workload.OFFLINE)
     rows = result.results or []
     if not rows:
         return 0
@@ -227,7 +230,7 @@ def _find_nth_eval_timestamp(
         },
     )
     with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.ENRICHMENT, team_id=team.pk):
-        result = execute_hogql_query(query=query, team=team)
+        result = execute_hogql_query(query=query, team=team, workload=Workload.OFFLINE)
     rows = result.results or []
     if rows and rows[0][0] is not None:
         ts = rows[0][0]


### PR DESCRIPTION
## Problem

The count-triggered eval report coordinator (`llma-eval-reports-count-triggered-coordinator`) runs every 5 minutes. Each tick pulls every count-triggered eval report across all teams and fires one `count()` scan over the events table per report. Those queries were running on the **online** ClickHouse cluster that serves user-facing queries, so as the number of count-triggered reports grows they add steadily to `ClickHouseAtCapacity` pressure.

## Changes

Route both eval-report count queries (`_count_eval_results_for_report` and `_find_nth_eval_timestamp`) to the offline cluster via `workload=Workload.OFFLINE`.

Celery tasks get offline routing automatically (via the `task_prerun` signal), but Temporal activities do not — the default workload is `ONLINE`. Sibling background Temporal activities already set this explicitly (`posthog/temporal/experiments/activities.py`, `posthog/temporal/weekly_digest/activities.py`); this brings the eval-report coordinator in line with that pattern.

A follow-up PR ([#71015](https://github.com/PostHog/posthog/pull/71015)) cuts the query volume itself; this PR is the minimal, low-risk routing fix.

## How did you test this code?

No manual/stack testing was done by the agent. The change is a one-argument routing change with direct prior art in two other Temporal activities. `ruff check` and `ruff format` pass on the touched file. Worth confirming in staging that the offline cluster is provisioned for the LLM analytics workload before relying on it in prod.

## Docs update

No user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread where the suggested "throttle/silence" fix was questioned as both too broad (`ClickHouseAtCapacity` is a shared error type raised fleet-wide) and not addressing the real capacity issue. Explored the coordinator and PostHog's established ClickHouse capacity-handling patterns before choosing offline routing as the cheapest high-impact first step.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1784102271694409?thread_ts=1784102271.694409&cid=C0B8ZE81ZT7)*

