### PR TITLE
fix(data-warehouse): survive pyarrow string_view in v3 cdc delete enrichment

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -68,6 +68,29 @@ def _get_write_type(sync_type: SyncTypeLiteral) -> Literal["incremental", "full_
     return "full_refresh"
 
 
+def _read_existing_rows_by_first_pk(
+    existing_delta_table: deltalake.DeltaTable,
+    first_pk: str,
+    first_components: list[Any],
+) -> pa.Table:
+    """Read the existing rows whose `first_pk` value is in `first_components`.
+
+    Prefers Delta filter pushdown (prunes files, cheap). pyarrow >= 21 materializes
+    string columns as `string_view`, whose `equal`/`greater_equal` compute kernels are
+    unimplemented, so pushing an `in` predicate down onto a string primary key raises
+    `ArrowNotImplementedError`. When that happens, read the table and filter in PyArrow
+    after casting the key to `string`, which has working kernels.
+    """
+    try:
+        return existing_delta_table.to_pyarrow_table(filters=[(first_pk, "in", first_components)])
+    except pa.lib.ArrowNotImplementedError:
+        logger.warning("cdc_delete_enrichment_pushdown_fallback", primary_key=first_pk)
+        existing = existing_delta_table.to_pyarrow_table()
+        key = existing.column(first_pk).cast(pa.string())
+        wanted = pa.array(first_components, pa.string())
+        return existing.filter(pc.is_in(key, value_set=wanted))
+
+
 def _apply_partitioning(
     export_signal: ExportSignalMessage,
     pa_table: pa.Table,
@@ -512,8 +535,8 @@ def process_message(
                         # For composite PKs that IN is a superset — narrow in PyArrow below.
                         first_pk = present_pks[0]
                         first_components = list({t[0] for t in delete_key_set})
-                        existing_rows = existing_delta_table.to_pyarrow_table(
-                            filters=[(first_pk, "in", first_components)]
+                        existing_rows = _read_existing_rows_by_first_pk(
+                            existing_delta_table, first_pk, first_components
                         )
 
                         # For composite PKs the IN filter is a superset — narrow to exact matches.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -1,9 +1,11 @@
+import tempfile
 from typing import Any
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pyarrow as pa
+from deltalake import DeltaTable, write_deltalake
 from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
@@ -12,6 +14,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _get_write_type,
     _mark_job_completed,
     _promote_staged_cursor,
+    _read_existing_rows_by_first_pk,
     process_message,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.test_mocks import mock_delta_table
@@ -338,3 +341,40 @@ class TestMarkJobCompleted:
             mock_finish_row_tracking.assert_not_awaited()
         # The pipeline lock must be released either way, or the next sync is blocked.
         mock_release.assert_called_once_with(team_id=1, schema_id="schema-1", token="wf-run-1")
+
+
+# Regression guard for #70476: pyarrow 21+ string_view broke delta pushdown on string PKs.
+class TestReadExistingRowsByFirstPk:
+    @staticmethod
+    def _string_view_table(path: str) -> DeltaTable:
+        sv = pa.string_view()
+        write_deltalake(
+            path,
+            pa.table({"id": pa.array(["a", "b", "c"], sv), "val": pa.array([1, 2, 3], pa.int64())}),
+            mode="overwrite",
+        )
+        # Second file so file pruning is exercised.
+        write_deltalake(
+            path,
+            pa.table({"id": pa.array(["d", "e", "f"], sv), "val": pa.array([4, 5, 6], pa.int64())}),
+            mode="append",
+        )
+        return DeltaTable(path)
+
+    @parameterized.expand(
+        [
+            ("subset_across_files", ["a", "e"], ["a", "e"]),
+            ("single", ["c"], ["c"]),
+            ("superset_with_miss", ["b", "zzz"], ["b"]),
+            ("no_match", ["nope"], []),
+        ]
+    )
+    def test_returns_matching_rows_on_string_view_pk(
+        self, _name: str, components: list[str], expected_ids: list[str]
+    ) -> None:
+        with tempfile.TemporaryDirectory() as path:
+            delta_table = self._string_view_table(path)
+
+            result = _read_existing_rows_by_first_pk(delta_table, "id", components)
+
+            assert set(result.column("id").to_pylist()) == set(expected_ids)


### PR DESCRIPTION
## Problem

#70476 bumped `deltalake` to 1.6.1 and `pyarrow` to 23.0.1. pyarrow 21+ materializes string columns as Arrow `string_view`, and the `equal` / `greater_equal` compute kernels have no `(string_view, string_view)` implementation.

The v3 CDC delete-enrichment step reads the existing delta table filtered by a primary key to backfill columns on standalone DELETE rows. It does that with a pushed-down `in` predicate:

https://github.com/PostHog/posthog/blob/7a4d1d1e93adf85e31874e28abe6554ef1d8fdc4/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py#L503-L505

When the primary key is a string, that pushdown now runs the missing kernel and raises `ArrowNotImplementedError`. It is deterministic, so all three attempts fail and the whole run fails. Since the deploy this has been firing continuously on the v3 CDC path (`workflow_type=cdc-extraction`), while v2 is unaffected because its load path does no equivalent filtered pyarrow read.

Stack trace on every failure:

```
processor.py process_message
 -> deltalake/table.py to_pyarrow_table
   -> pyarrow._dataset.Scanner.to_table
     -> pyarrow.lib.pyarrow_internal_check_status
ArrowNotImplementedError: Function 'greater_equal' has no kernel matching input types (string_view, string_view)
```

## Changes

`_read_existing_rows_by_first_pk` wraps the read. It keeps the delta filter pushdown as the fast path (file pruning, cheap, still correct for numeric and timestamp keys). On `ArrowNotImplementedError` it falls back to reading the table and filtering in pyarrow after casting the key column to `string`, which has working kernels. The composite-PK narrowing and SCD2 filtering downstream are unchanged.

> [!NOTE]
> The fallback reads the existing table without file pruning, so it is heavier than the pushdown. It only runs for CDC batches that carry deletes on a string key, and only while pyarrow lacks the string_view kernels. Numeric and timestamp keys keep the fast path. If a later pyarrow adds the kernel, the fast path just starts serving string keys again and the fallback stops triggering.

This is a forward-fix that keeps the engine upgrade rather than reverting #70476.

## How did you test this code?

Reproduced the exact failure locally against the now-pinned `pyarrow==23.0.1` / `deltalake==1.6.1`: a delta table written with `string_view` columns makes `to_pyarrow_table(filters=[(pk, "in", vals)])` raise the same `greater_equal (string_view, string_view)` error seen in production. Confirmed the fallback returns the correct rows.

Added `TestReadExistingRowsByFirstPk` in `test_processor.py`. It writes a real local-filesystem delta table with `string_view` columns across two files (so file pruning is exercised like production) and asserts the helper returns exactly the rows whose PK is in the requested set, across subset / single / superset-with-miss / no-match cases. This is the regression no existing test caught: the existing `test_processor.py` covers partitioning and write-type mapping, and `test_delta_table_helper.py` covers merge behavior, neither the string_view filtered read. On the current pinned pyarrow the subset/single/superset cases exercise the fallback path (the fix); the test stays correct if a future pyarrow makes the fast path serve string keys.

I (Claude, agent-assisted) could not run the S3/Postgres-backed e2e suite locally (no Docker in this environment). Automated tests I actually ran:

- `test_processor.py::TestReadExistingRowsByFirstPk` — 4 passed
- full `test_processor.py` — 17 passed, no regressions
- `ruff check` + `ruff format` — clean
- `hogli ci:preflight` — 0 failures

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Produced with PostHog Code (Claude). Follow-up to a production investigation that traced a v3 CDC failure surge to #70476: the error appeared the moment the new loader image rolled, was zero for the ~41h before, and is exclusively on the CDC delete-enrichment `to_pyarrow_table` read. I verified no other PR deployed that day touched the failing path and that #70476's own code diff was cosmetic, so the library bump is the cause.

Skills invoked: `investigating-warehouse-sources-load` (production RCA across Grafana logs/metrics and the federated queue Postgres) and `/writing-tests` (test value gate).

Decisions: I tried three narrower fixes first and rejected them empirically against a reproduced string_view table — casting inside the filter expression, forcing the dataset schema to `string`, and `as_large_types=True` all still hit the same kernel error because statistics-based file pruning compares string_view before the cast applies. Only reading without a value predicate and filtering in pyarrow avoids the missing kernel. Chose a try-fast-then-fallback shape so numeric/timestamp keys keep pruning and the workaround self-disables if pyarrow later fills the gap. A full revert of #70476 was the alternative; this keeps the engine upgrade.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
