### PR TITLE
fix(aio): count all evaluation runs in detail summary

### DIFF
--- a/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
+++ b/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
@@ -38,6 +38,7 @@ import { EvaluationReportConfig } from './components/EvaluationReportConfig'
 import { EvaluationReportsTab } from './components/EvaluationReportsTab'
 import { EvaluationRunsTable } from './components/EvaluationRunsTable'
 import { EvaluationTriggers } from './components/EvaluationTriggers'
+import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
 import {
     evaluationSupportsReports,
     evaluationTypeHasEditableCriteria,
@@ -353,6 +354,9 @@ export function AIObservabilityEvaluation(): JSX.Element {
                                 <div className="flex justify-between items-center mb-4">
                                     <p className="text-muted text-sm m-0">
                                         History of when this evaluation has been executed.
+                                        {runsSummary && runsSummary.total > EVALUATION_SUMMARY_MAX_RUNS && (
+                                            <> Showing the latest {EVALUATION_SUMMARY_MAX_RUNS} runs.</>
+                                        )}
                                     </p>
                                     {runsSummary && (
                                         <div className="flex gap-4 text-sm">

--- a/products/ai_observability/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/ai_observability/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -575,8 +575,8 @@ describe('llmEvaluationLogic', () => {
                 expect(logic.values.runsSummary).toBeNull()
             })
 
-            it('calculates summary correctly', async () => {
-                logic.actions.loadEvaluationRunsSuccess(mockRuns)
+            it('calculates summary from server-side aggregate counts', async () => {
+                logic.actions.loadRunsStatsSuccess({ total: 3, applicable: 2, passed: 1 })
 
                 await expectLogic(logic).toMatchValues({
                     runsSummary: {

--- a/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
@@ -20,7 +20,7 @@ import {
 import { parseTrialProviderKeyId } from '../ModelPicker'
 import { LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
 import { getUnhealthyProviderKey } from '../settings/providerKeyStateUtils'
-import { queryEvaluationRuns } from '../utils'
+import { EvaluationRunsStats, queryEvaluationRuns, queryEvaluationRunsStats } from '../utils'
 import { evaluationErrorMessage } from './apiErrors'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
 import {
@@ -246,6 +246,21 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     }
 
                     return await queryEvaluationRuns({
+                        evaluationId: props.evaluationId,
+                        forceRefresh: values.isForceRefresh,
+                    })
+                },
+            },
+        ],
+        runsStats: [
+            null as EvaluationRunsStats | null,
+            {
+                loadRunsStats: async () => {
+                    if (!props.evaluationId || props.evaluationId === 'new') {
+                        return null
+                    }
+
+                    return await queryEvaluationRunsStats({
                         evaluationId: props.evaluationId,
                         forceRefresh: values.isForceRefresh,
                     })
@@ -573,6 +588,10 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             actions.loadEvaluationRuns()
         },
 
+        loadEvaluationRuns: () => {
+            actions.loadRunsStats()
+        },
+
         regenerateEvaluationSummary: () => {
             posthog.capture('llma evaluation regenerate clicked', {
                 filter: values.evaluationSummaryFilter,
@@ -851,26 +870,23 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         ],
 
         runsSummary: [
-            (s) => [s.evaluationRuns],
-            (runs) => {
-                if (runs.length === 0) {
+            (s) => [s.runsStats],
+            (stats: EvaluationRunsStats | null) => {
+                if (!stats || stats.total === 0) {
                     return null
                 }
 
-                const successfulRuns = runs.filter((r) => r.result === true).length
-                const failedRuns = runs.filter((r) => r.result === false).length
-                const errorRuns = runs.filter((r) => r.status === 'failed').length
-                // Applicable runs excludes N/A (result === null)
-                const applicableRuns = successfulRuns + failedRuns
-                const completedRuns = runs.filter((r) => r.status === 'completed').length
+                const { total, applicable, passed } = stats
+                // Applicable runs excludes N/A results
+                const failed = applicable - passed
 
                 return {
-                    total: runs.length,
-                    successful: successfulRuns,
-                    failed: failedRuns,
-                    errors: errorRuns,
-                    successRate: applicableRuns > 0 ? Math.round((successfulRuns / applicableRuns) * 100) : 0,
-                    applicabilityRate: completedRuns > 0 ? Math.round((applicableRuns / completedRuns) * 100) : 0,
+                    total,
+                    successful: passed,
+                    failed,
+                    errors: 0,
+                    successRate: applicable > 0 ? Math.round((passed / applicable) * 100) : 0,
+                    applicabilityRate: total > 0 ? Math.round((applicable / total) * 100) : 0,
                 }
             },
         ],

--- a/products/ai_observability/frontend/utils.ts
+++ b/products/ai_observability/frontend/utils.ts
@@ -1201,3 +1201,58 @@ export async function queryEvaluationRuns(params: {
 
     return (response.results || []).map(mapEvaluationRunRow)
 }
+
+export interface EvaluationRunsStats {
+    total: number
+    applicable: number
+    passed: number
+}
+
+// Counts every matching run server-side. queryEvaluationRuns caps its fetch at
+// EVALUATION_SUMMARY_MAX_RUNS, so summary stats can't be derived from that list without
+// undercounting. Counting semantics mirror the evaluations list view (evaluationMetricsLogic)
+// so both surfaces report the same totals.
+export async function queryEvaluationRunsStats(params: {
+    evaluationId?: string
+    traceId?: string
+    forceRefresh?: boolean
+}): Promise<EvaluationRunsStats> {
+    const { evaluationId, traceId, forceRefresh } = params
+
+    const propertyValue = evaluationId || traceId
+
+    if (!propertyValue) {
+        throw new Error('Either evaluationId or traceId must be provided')
+    }
+
+    const propertyName = evaluationId ? '$ai_evaluation_id' : '$ai_trace_id'
+
+    const query = hogql`
+        SELECT
+            count() as total,
+            countIf(properties.$ai_evaluation_result IS NOT NULL) as applicable,
+            countIf(properties.$ai_evaluation_result = 1) as passed
+        FROM events
+        WHERE
+            event = '$ai_evaluation'
+            AND ${hogql.raw(`properties.${propertyName}`)} = ${propertyValue}
+    `
+
+    const response = await api.queryHogQL(
+        query,
+        { scene: 'AIObservability', productKey: 'llm_analytics' },
+        { ...(forceRefresh && { refresh: 'force_blocking' }) }
+    )
+
+    const row = response.results?.[0]
+
+    if (!row) {
+        return { total: 0, applicable: 0, passed: 0 }
+    }
+
+    return {
+        total: Number(row[0]) || 0,
+        applicable: Number(row[1]) || 0,
+        passed: Number(row[2]) || 0,
+    }
+}


### PR DESCRIPTION
## Problem

The evaluation detail page's "Runs" tab shows a summary header with "Total runs", "Success rate", "Applicable" and "Errors". For an evaluation with a large history, that header reported "250 Total runs" and an 86% success rate, while the evaluations list view (same evaluation) showed the real numbers: 137,005 runs at 84.1%.

Andy flagged the mismatch in Slack. The root cause: the two views count from different sources.

- The **list view** reads a real server-side `count()` aggregate (in `evaluationMetricsLogic`).
- The **detail "Runs" tab** computed its header entirely client-side from the `evaluationRuns` array, which `queryEvaluationRuns` hard-caps at `LIMIT EVALUATION_SUMMARY_MAX_RUNS` (250). That 250 cap is legitimate for bounding the runs table and the "Summarize" payload, but `runsSummary` was reusing the truncated array as if it were the full history. So "Total runs" was really "runs we happened to fetch", and the rate was just the rate over that 250-row window.

## Changes

- **`utils.ts`**: new `queryEvaluationRunsStats()` that runs an aggregate (`count()`, `countIf(result IS NOT NULL)`, `countIf(result = 1)`) with no `LIMIT`, using the same counting semantics as the list view so both surfaces agree.
- **`llmEvaluationLogic.ts`**: added a `runsStats` loader (fired alongside `loadEvaluationRuns` via one listener, so mount, navigation, and refresh all cover it), and rewired the `runsSummary` selector to derive `total` / `successRate` / `applicabilityRate` from that aggregate instead of the capped array.
- **`AIObservabilityEvaluation.tsx`**: the header now shows the true total, but the table below still lists the latest 250 rows, so I added a small "Showing the latest 250 runs." note when the total exceeds the cap, to avoid a new source of confusion.

> [!NOTE]
> The list view's number is scoped to that page's date filter, while the detail page has no date filter and now counts all-time (consistent with the all-time runs table on the same page). Both count real totals now, but they can still differ if the list's date range is not "all time". That is expected, not the bug.

One behavior nuance: the detail header previously derived `errors` from per-run `status === 'failed'`, but `queryEvaluationRuns` maps every row to `status: 'completed'`, so that count was always 0 in practice. The aggregate does not carry an error status, so `errors` stays 0 with no observable change.

## How did you test this code?

- `hogli test products/ai_observability/frontend/evaluations/llmEvaluationLogic.test.ts` — 82 passing. Updated the `runsSummary` case to feed the new server-side aggregate (`loadRunsStatsSuccess({ total: 3, applicable: 2, passed: 1 })`) and assert the same summary output. This locks in that the header stats come from the real count, not the capped fetch — the exact regression this PR fixes.
- `pnpm --filter=@posthog/frontend typescript:check` — clean.
- I (Claude) did not run the app against live data, so the UI copy and the number reconciliation against production were not manually verified in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this header. No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Carlos directed this from a Slack bug report. I (Claude, via PostHog Code) investigated with an Explore subagent to map the two counting paths, confirmed the 250 cap in `queryEvaluationRuns`, and matched the fix's counting semantics to the existing list-view aggregate so the two surfaces reconcile.

Considered and rejected: computing the total from `evaluationRuns.length` with a separate count field bolted on — that keeps two sources of truth. Chose a dedicated aggregate query mirroring `evaluationMetricsLogic` instead. No skills shaped the code beyond `/writing-tests` (invoked to keep the test a single behavior-focused case rather than new bloat). Kea types were regenerated with `typegen:file`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
