### PR TITLE
fix(tracing): truncate long facet values instead of widening the rail

### DIFF
--- a/products/tracing/frontend/components/FacetRail/Facet.tsx
+++ b/products/tracing/frontend/components/FacetRail/Facet.tsx
@@ -203,7 +203,10 @@ function FacetValueButton({
             data-attr={`tracing-facet-${slug}-${slugify(option.value)}`}
         >
             <span className="flex items-center gap-2 min-w-0 w-full">
-                <span className="truncate flex-1">{option.label}</span>
+                {/* Native title so a truncated value is still readable without popover cost per virtualized row. */}
+                <span className="truncate flex-1" title={option.label}>
+                    {option.label}
+                </span>
                 {option.count != null && (
                     <span className="shrink-0 text-muted tabular-nums">{humanFriendlyLargeNumber(option.count)}</span>
                 )}

--- a/products/tracing/frontend/components/FacetRail/FacetRail.tsx
+++ b/products/tracing/frontend/components/FacetRail/FacetRail.tsx
@@ -126,7 +126,9 @@ export function FacetRail(): JSX.Element {
             ref={railRef}
             className="relative flex flex-col shrink-0 border rounded bg-surface-primary overflow-hidden"
             // eslint-disable-next-line react/forbid-dom-props
-            style={{ width: desiredSize ?? DEFAULT_WIDTH_PX, minWidth: 'min-content', maxWidth: '40%' }}
+            // The width is the user's alone: a fixed min (not min-content) so a long facet value
+            // can never force the rail wider — values truncate to fit instead.
+            style={{ width: desiredSize ?? DEFAULT_WIDTH_PX, minWidth: COLLAPSE_THRESHOLD_PX, maxWidth: '40%' }}
             data-attr="tracing-facet-rail"
         >
             <div className="px-2 py-1 border-b">


### PR DESCRIPTION
## Problem

A long facet value (a k8s namespace like `cdp-precalculated-filters-consumer-ws`) forces the facet rail wider than the width the user chose with the resizer. The rail's inline style has `minWidth: 'min-content'`, so the widest untruncated row sets the rail's floor and the existing `truncate` class on value labels never engages — the content wins over the user.

## Changes

- `FacetRail.tsx`: pin `minWidth` to the collapse threshold (120px) instead of `min-content`. The rail's width is now always the user's resizer choice (or the 240px default); long values ellipsize to fit. The truncation chain already works once the width is constrained — `LemonButton__content` has `min-width: 0` and the label span has `truncate flex-1`.
- `Facet.tsx`: add a native `title` to the value label so a truncated value is still readable on hover. Native rather than a Lemon `Tooltip` to keep per-row cost at zero in the virtualized list.

Stacked on #70376 (both touch the same files).

## How did you test this code?

Existing FacetRail jest suite passes (24 tests). Layout behavior (min-width vs min-content) isn't measurable in jsdom, so no new test — verified the truncation chain by reading the LemonButton styles (`LemonButton__content` has `min-width: 0`) and the label already carrying `truncate`. Not manually tested in a browser by the agent.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, flag-gated UI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) at Jon's direction from a screenshot of the rail being forced wide. Root cause was the `min-content` floor, not missing truncation styles — the label already had `truncate`, it just never engaged. The logs facet rail has the identical `min-content` floor (`products/logs/.../FacetRail.tsx`) and would benefit from the same fix as a follow-up.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*