### PR TITLE
feat(wizard): accept local audit ledgers for the signals setup review

### DIFF
--- a/products/wizard/backend/presentation/serializers.py
+++ b/products/wizard/backend/presentation/serializers.py
@@ -1,8 +1,18 @@
 """DRF serializers for wizard. Bound to facade DTOs, not Django models."""
 
+from rest_framework import serializers
 from rest_framework_dataclasses.serializers import DataclassSerializer
 
 from products.wizard.backend.facade.contracts import UpsertWizardSessionRequest, WizardSessionDTO
+
+# Caps mirror the cloud audit capture (products/tasks run_wizard_audit): the review
+# is a nudge built from a handful of findings, so an oversized ledger is truncated,
+# not rejected — old or over-eager clients still get their review.
+SETUP_REVIEW_MAX_CHECKS = 50
+SETUP_REVIEW_MAX_DETAILS_CHARS = 2000
+
+# Ledger bookkeeping rows that aren't setup findings (same set the cloud capture prunes).
+SETUP_REVIEW_NON_FINDING_CHECK_IDS = frozenset({"write-report", "upload-notebook"})
 
 
 class WizardSessionSerializer(DataclassSerializer):
@@ -10,6 +20,51 @@ class WizardSessionSerializer(DataclassSerializer):
 
     class Meta:
         dataclass = WizardSessionDTO
+
+
+class SetupReviewCheckSerializer(serializers.Serializer):
+    """One row of the wizard audit's check ledger (.posthog-audit-checks.json)."""
+
+    id = serializers.CharField(max_length=200)
+    label = serializers.CharField(max_length=500)  # type: ignore[assignment]
+    status = serializers.CharField(max_length=50)
+    area = serializers.CharField(max_length=200, required=False, allow_null=True, allow_blank=True)
+    file = serializers.CharField(max_length=1000, required=False, allow_null=True, allow_blank=True)
+    details = serializers.CharField(required=False, allow_null=True, allow_blank=True, trim_whitespace=False)
+
+    def validate_details(self, value: str | None) -> str | None:
+        if not value:
+            return None
+        return value[:SETUP_REVIEW_MAX_DETAILS_CHARS]
+
+
+class SetupReviewRequestSerializer(serializers.Serializer):
+    """Input: a local wizard audit's check ledger, posted for the signals setup review.
+
+    The cloud counterpart captures the same ledger inside the sandbox
+    (products/tasks run_wizard_audit activity); this shape lets an interactive
+    local `wizard audit` feed the identical review pipeline.
+    """
+
+    repository = serializers.CharField(
+        max_length=300,
+        help_text=(
+            "GitHub repository the audited project lives in, as 'owner/repo'. The signals "
+            "pipeline uses it to pick the implementation repo for the review's PRs."
+        ),
+    )
+    checks = SetupReviewCheckSerializer(many=True, allow_empty=False)
+
+    def validate_repository(self, value: str) -> str:
+        repository = value.strip()
+        parts = repository.split("/")
+        if len(parts) != 2 or not all(parts):
+            raise serializers.ValidationError("Repository must be in 'owner/repo' format.")
+        return repository
+
+    def validate_checks(self, value: list[dict]) -> list[dict]:
+        findings = [check for check in value if check["id"] not in SETUP_REVIEW_NON_FINDING_CHECK_IDS]
+        return findings[:SETUP_REVIEW_MAX_CHECKS]
 
 
 class UpsertWizardSessionRequestSerializer(DataclassSerializer):

--- a/products/wizard/backend/presentation/serializers.py
+++ b/products/wizard/backend/presentation/serializers.py
@@ -5,13 +5,10 @@ from rest_framework_dataclasses.serializers import DataclassSerializer
 
 from products.wizard.backend.facade.contracts import UpsertWizardSessionRequest, WizardSessionDTO
 
-# Caps mirror the cloud audit capture (products/tasks run_wizard_audit): the review
-# is a nudge built from a handful of findings, so an oversized ledger is truncated,
-# not rejected — old or over-eager clients still get their review.
+# Mirror the cloud audit capture (products/tasks run_wizard_audit): oversized
+# ledgers are truncated, not rejected, and bookkeeping rows aren't findings.
 SETUP_REVIEW_MAX_CHECKS = 50
 SETUP_REVIEW_MAX_DETAILS_CHARS = 2000
-
-# Ledger bookkeeping rows that aren't setup findings (same set the cloud capture prunes).
 SETUP_REVIEW_NON_FINDING_CHECK_IDS = frozenset({"write-report", "upload-notebook"})
 
 
@@ -39,12 +36,7 @@ class SetupReviewCheckSerializer(serializers.Serializer):
 
 
 class SetupReviewRequestSerializer(serializers.Serializer):
-    """Input: a local wizard audit's check ledger, posted for the signals setup review.
-
-    The cloud counterpart captures the same ledger inside the sandbox
-    (products/tasks run_wizard_audit activity); this shape lets an interactive
-    local `wizard audit` feed the identical review pipeline.
-    """
+    """Input: a local wizard audit's check ledger, posted for the signals setup review."""
 
     repository = serializers.CharField(
         max_length=300,

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -28,6 +28,7 @@ from posthog.api.streaming import sse_streaming_response
 from posthog.models.scoping import team_scope
 from posthog.sync import database_sync_to_async
 
+from products.signals.backend.facade import api as signals_facade
 from products.wizard.backend.facade import api as wizard_facade
 from products.wizard.backend.facade.contracts import (
     UpsertWizardSessionInput,
@@ -35,6 +36,7 @@ from products.wizard.backend.facade.contracts import (
     WizardSessionDTO,
 )
 from products.wizard.backend.presentation.serializers import (
+    SetupReviewRequestSerializer,
     UpsertWizardSessionRequestSerializer,
     WizardSessionSerializer,
 )
@@ -121,12 +123,12 @@ def _wizard_sync_killswitch_enabled(distinct_id: str) -> bool:
 class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "wizard_session"
     scope_object_read_actions = ["list", "retrieve", "stream", "latest"]
-    scope_object_write_actions = ["create"]
+    scope_object_write_actions = ["create", "setup_review"]
     http_method_names = ["get", "post", "head", "options"]
     lookup_field = "session_id"
-    # Negative lookahead so a session_id of `stream` or `latest` can't collide
-    # with the `@action(url_path=...)` detail-vs-action routes.
-    lookup_value_regex = r"(?!(?:stream|latest)$)[^/]+"
+    # Negative lookahead so a session_id of `stream`, `latest` or `setup_review`
+    # can't collide with the `@action(url_path=...)` detail-vs-action routes.
+    lookup_value_regex = r"(?!(?:stream|latest|setup_review)$)[^/]+"
 
     def check_permissions(self, request: Request) -> None:
         try:
@@ -283,6 +285,39 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
         response_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response(WizardSessionSerializer(dto).data, status=response_status)
+
+    @extend_schema(
+        description=(
+            "Submit a local wizard audit's check ledger for the post-onboarding setup "
+            "review. The signals pipeline turns the strongest failing checks into a "
+            "handful of complimentary implementation PRs in the inbox. This should only "
+            "be called by the PostHog Wizard. Fire-and-forget: always 202 once the "
+            "payload validates — the review itself is idempotent (one per team, ever) "
+            "and gated server-side on org AI consent."
+        ),
+        request=SetupReviewRequestSerializer,
+        responses={202: OpenApiResponse(description="Ledger accepted for review.")},
+    )
+    @action(detail=False, methods=["post"], url_path="setup_review")
+    def setup_review(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        serializer = SetupReviewRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        checks = serializer.validated_data["checks"]
+        if checks:
+            # Same best-effort contract as the PR-merge webhook dispatch (products/tasks
+            # webhooks.py): a Temporal hiccup must not bubble to the wizard, which treats
+            # this upload as fail-silent anyway. Deduping and consent live in the workflow.
+            try:
+                signals_facade.start_wizard_setup_review(
+                    team_id=self.team_id,
+                    repository=serializer.validated_data["repository"],
+                    checks=checks,
+                )
+            except Exception:
+                logger.warning("wizard_setup_review_dispatch_failed", team_id=self.team_id, exc_info=True)
+
+        return Response(status=status.HTTP_202_ACCEPTED)
 
     @extend_schema(
         description=(

--- a/products/wizard/backend/presentation/views.py
+++ b/products/wizard/backend/presentation/views.py
@@ -305,9 +305,7 @@ class WizardSessionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         checks = serializer.validated_data["checks"]
         if checks:
-            # Same best-effort contract as the PR-merge webhook dispatch (products/tasks
-            # webhooks.py): a Temporal hiccup must not bubble to the wizard, which treats
-            # this upload as fail-silent anyway. Deduping and consent live in the workflow.
+            # Best-effort like the merge-webhook dispatch: a Temporal hiccup must not bubble up.
             try:
                 signals_facade.start_wizard_setup_review(
                     team_id=self.team_id,

--- a/products/wizard/backend/tests/test_presentation.py
+++ b/products/wizard/backend/tests/test_presentation.py
@@ -333,3 +333,100 @@ class TestWizardSessionViewSet(APIBaseTest):
             return_value=flag_value,
         ):
             self.assertEqual(_wizard_sync_killswitch_enabled("distinct-id"), expected)
+
+
+class TestSetupReviewEndpoint(APIBaseTest):
+    def _url(self) -> str:
+        return f"/api/projects/{self.team.id}/wizard/sessions/setup_review/"
+
+    def _check(self, check_id: str = "identify-stable-distinct-id", **overrides) -> dict:
+        check = {
+            "id": check_id,
+            "area": "identify",
+            "label": f"Label for {check_id}",
+            "status": "error",
+            "file": "src/auth.ts",
+            "details": "distinct_id changes per session",
+        }
+        check.update(overrides)
+        return check
+
+    def _post(self, payload: dict):
+        with patch("products.wizard.backend.presentation.views.signals_facade.start_wizard_setup_review") as mock_start:
+            response = self.client.post(self._url(), payload, format="json")
+        return response, mock_start
+
+    def test_valid_ledger_dispatches_the_review(self):
+        checks = [self._check(), self._check("capture-growth-events", status="warning")]
+
+        response, mock_start = self._post({"repository": "acme/webapp", "checks": checks})
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_start.assert_called_once_with(team_id=self.team.id, repository="acme/webapp", checks=checks)
+
+    def test_prunes_bookkeeping_rows_and_caps_the_ledger(self):
+        checks = [
+            self._check("write-report", status="pass"),
+            self._check("upload-notebook", status="pass"),
+            *(self._check(f"check-{i}") for i in range(60)),
+        ]
+
+        response, mock_start = self._post({"repository": "acme/webapp", "checks": checks})
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        dispatched = mock_start.call_args.kwargs["checks"]
+        self.assertEqual(len(dispatched), 50)
+        self.assertTrue(all(check["id"].startswith("check-") for check in dispatched))
+
+    def test_truncates_oversized_details(self):
+        checks = [self._check(details="x" * 5000)]
+
+        _, mock_start = self._post({"repository": "acme/webapp", "checks": checks})
+
+        self.assertEqual(len(mock_start.call_args.kwargs["checks"][0]["details"]), 2000)
+
+    def test_only_bookkeeping_rows_skips_dispatch_but_still_202s(self):
+        checks = [self._check("write-report", status="pass")]
+
+        response, mock_start = self._post({"repository": "acme/webapp", "checks": checks})
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_start.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("missing_repository", {"checks": [{"id": "a", "label": "b", "status": "error"}]}),
+            (
+                "malformed_repository",
+                {"repository": "not-owner-repo", "checks": [{"id": "a", "label": "b", "status": "error"}]},
+            ),
+            ("empty_checks", {"repository": "acme/webapp", "checks": []}),
+            ("check_missing_required_fields", {"repository": "acme/webapp", "checks": [{"id": "a"}]}),
+        ]
+    )
+    def test_rejects_invalid_payloads(self, _name, payload):
+        response, mock_start = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_start.assert_not_called()
+
+    def test_temporal_failure_stays_202(self):
+        with patch(
+            "products.wizard.backend.presentation.views.signals_facade.start_wizard_setup_review",
+            side_effect=RuntimeError("temporal down"),
+        ):
+            response = self.client.post(
+                self._url(),
+                {"repository": "acme/webapp", "checks": [self._check()]},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+    def test_requires_authentication(self):
+        self.client.logout()
+
+        response, mock_start = self._post({"repository": "acme/webapp", "checks": [self._check()]})
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        mock_start.assert_not_called()

--- a/products/wizard/frontend/generated/api.schemas.ts
+++ b/products/wizard/frontend/generated/api.schemas.ts
@@ -137,6 +137,42 @@ export interface UpsertWizardSessionRequestApi {
     error?: UpsertWizardSessionRequestApiError
 }
 
+/**
+ * One row of the wizard audit's check ledger (.posthog-audit-checks.json).
+ */
+export interface SetupReviewCheckApi {
+    /** @maxLength 200 */
+    id: string
+    /** @maxLength 500 */
+    label: string
+    /** @maxLength 50 */
+    status: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    area?: string | null
+    /**
+     * @maxLength 1000
+     * @nullable
+     */
+    file?: string | null
+    /** @nullable */
+    details?: string | null
+}
+
+/**
+ * Input: a local wizard audit's check ledger, posted for the signals setup review.
+ */
+export interface SetupReviewRequestApi {
+    /**
+     * GitHub repository the audited project lives in, as 'owner/repo'. The signals pipeline uses it to pick the implementation repo for the review's PRs.
+     * @maxLength 300
+     */
+    repository: string
+    checks: SetupReviewCheckApi[]
+}
+
 export type WizardSessionsListParams = {
     /**
      * Number of results to return per page.

--- a/products/wizard/frontend/generated/api.ts
+++ b/products/wizard/frontend/generated/api.ts
@@ -10,6 +10,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  */
 import type {
     PaginatedWizardSessionDTOListApi,
+    SetupReviewRequestApi,
     UpsertWizardSessionRequestApi,
     WizardSessionDTOApi,
     WizardSessionsLatestRetrieveParams,
@@ -112,6 +113,26 @@ export const wizardSessionsLatestRetrieve = async (
     return apiMutator<WizardSessionDTOApi | void>(getWizardSessionsLatestRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getWizardSessionsSetupReviewCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/wizard/sessions/setup_review/`
+}
+
+/**
+ * Submit a local wizard audit's check ledger for the post-onboarding setup review. The signals pipeline turns the strongest failing checks into a handful of complimentary implementation PRs in the inbox. This should only be called by the PostHog Wizard. Fire-and-forget: always 202 once the payload validates — the review itself is idempotent (one per team, ever) and gated server-side on org AI consent.
+ */
+export const wizardSessionsSetupReviewCreate = async (
+    projectId: string,
+    setupReviewRequestApi: SetupReviewRequestApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getWizardSessionsSetupReviewCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(setupReviewRequestApi),
     })
 }
 

--- a/products/wizard/frontend/generated/api.zod.ts
+++ b/products/wizard/frontend/generated/api.zod.ts
@@ -66,3 +66,41 @@ export const WizardSessionsCreateBody = /* @__PURE__ */ zod
             .describe("Populated when run_phase='error'. Shape: { type: string, message: string }."),
     })
     .describe('Input: validates the JSON the wizard CLI posts. team_id is derived from URL.')
+
+/**
+ * Submit a local wizard audit's check ledger for the post-onboarding setup review. The signals pipeline turns the strongest failing checks into a handful of complimentary implementation PRs in the inbox. This should only be called by the PostHog Wizard. Fire-and-forget: always 202 once the payload validates — the review itself is idempotent (one per team, ever) and gated server-side on org AI consent.
+ */
+export const wizardSessionsSetupReviewCreateBodyRepositoryMax = 300
+
+export const wizardSessionsSetupReviewCreateBodyChecksItemIdMax = 200
+
+export const wizardSessionsSetupReviewCreateBodyChecksItemLabelMax = 500
+
+export const wizardSessionsSetupReviewCreateBodyChecksItemStatusMax = 50
+
+export const wizardSessionsSetupReviewCreateBodyChecksItemAreaMax = 200
+
+export const wizardSessionsSetupReviewCreateBodyChecksItemFileMax = 1000
+
+export const WizardSessionsSetupReviewCreateBody = /* @__PURE__ */ zod
+    .object({
+        repository: zod
+            .string()
+            .max(wizardSessionsSetupReviewCreateBodyRepositoryMax)
+            .describe(
+                "GitHub repository the audited project lives in, as 'owner\/repo'. The signals pipeline uses it to pick the implementation repo for the review's PRs."
+            ),
+        checks: zod.array(
+            zod
+                .object({
+                    id: zod.string().max(wizardSessionsSetupReviewCreateBodyChecksItemIdMax),
+                    label: zod.string().max(wizardSessionsSetupReviewCreateBodyChecksItemLabelMax),
+                    status: zod.string().max(wizardSessionsSetupReviewCreateBodyChecksItemStatusMax),
+                    area: zod.string().max(wizardSessionsSetupReviewCreateBodyChecksItemAreaMax).nullish(),
+                    file: zod.string().max(wizardSessionsSetupReviewCreateBodyChecksItemFileMax).nullish(),
+                    details: zod.string().nullish(),
+                })
+                .describe("One row of the wizard audit's check ledger (.posthog-audit-checks.json).")
+        ),
+    })
+    .describe("Input: a local wizard audit's check ledger, posted for the signals setup review.")

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -53288,6 +53288,42 @@ export namespace Schemas {
     }
 
     /**
+     * One row of the wizard audit's check ledger (.posthog-audit-checks.json).
+     */
+    export interface SetupReviewCheck {
+      /** @maxLength 200 */
+      id: string;
+      /** @maxLength 500 */
+      label: string;
+      /** @maxLength 50 */
+      status: string;
+      /**
+         * @maxLength 200
+         * @nullable
+         */
+      area?: string | null;
+      /**
+         * @maxLength 1000
+         * @nullable
+         */
+      file?: string | null;
+      /** @nullable */
+      details?: string | null;
+    }
+
+    /**
+     * Input: a local wizard audit's check ledger, posted for the signals setup review.
+     */
+    export interface SetupReviewRequest {
+      /**
+         * GitHub repository the audited project lives in, as 'owner/repo'. The signals pipeline uses it to pick the implementation repo for the review's PRs.
+         * @maxLength 300
+         */
+      repository: string;
+      checks: SetupReviewCheck[];
+    }
+
+    /**
      * * `trace` - trace
      * * `debug` - debug
      * * `info` - info

--- a/tach.toml
+++ b/tach.toml
@@ -1005,7 +1005,7 @@ from = [
 
 [[modules]]
 path = "products.wizard"
-depends_on = ["posthog"]
+depends_on = ["posthog", "products.signals"]
 layer = "modules"
 
 [[interfaces]]


### PR DESCRIPTION
## Problem

#70681 gives cloud wizard runs a post-onboarding setup review, but locally onboarded teams (npx @posthog/wizard) produce the same audit check ledger and throw it away — their inbox stays cold.

## Changes

stacked on #70681. new `POST /api/projects/{id}/wizard/sessions/setup_review/` on `WizardSessionViewSet` (`wizard_session:write`, a scope the wizard's oauth token already carries):

- validates `{repository, checks}`, mirroring the cloud capture: 50-check cap, 2000-char details truncation, bookkeeping rows (`write-report`, `upload-notebook`) pruned
- dispatches `signals_facade.start_wizard_setup_review` best-effort (always 202 once the payload validates), same contract as the merge webhook — the workflow owns idempotency (one review per team ever) and the consent gates
- repository is client-supplied (derived from the project's `origin` remote); if the team's github integration doesn't cover it, the report still lands in the inbox and the review waits there — a decent nudge to connect github

companion wizard change (the upload): PostHog/wizard#903

> [!NOTE]
> `hogli build:openapi` regen for `products/wizard/frontend/generated` not included — local stack wasn't running. will fix up if CI flags it.

## How did you test this code?

new `TestSetupReviewEndpoint` in test_presentation.py: dispatch payload shape, pruning + cap, details truncation, all-bookkeeping no-op, invalid payload 400s, temporal failure stays 202, auth required. ran ruff + mypy locally; django tests verify in CI (no local sqlx).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

internal code paths only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

claude code session directed by the assignee: port of the cloud setup review trigger to local wizard runs.