### PR TITLE
fix(signup): prevent Chrome translate DOM crash on paper-desk signup

### DIFF
--- a/frontend/src/scenes/authentication/shared/paperDesk/Typewriter.tsx
+++ b/frontend/src/scenes/authentication/shared/paperDesk/Typewriter.tsx
@@ -39,6 +39,10 @@ export function Typewriter({ lines }: { lines: string[] }): JSX.Element {
         <div
             className="absolute top-[clamp(20px,4vh,40px)] left-[clamp(20px,4vw,44px)] z-[2] min-h-[2.6em] font-mono text-xs leading-relaxed whitespace-pre"
             aria-hidden
+            // Chrome's in-page translation replaces text nodes with <font> elements; on this
+            // 40ms-tick animation React then crashes removing text it no longer owns
+            // (removeChild NotFoundError, react#11538). Decorative code-style notes — never translate.
+            translate="no"
         >
             {parts.map((part, idx) => (
                 <div key={idx} className="text-primary/50 first:font-semibold">

--- a/frontend/src/scenes/authentication/signup/signupForm/TurnstileChallenge.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/TurnstileChallenge.tsx
@@ -55,7 +55,9 @@ export function TurnstileChallenge({ siteKey, onSuccess, tokenReceived, email }:
                     </LemonButton>
                     {failureCount >= 2 && (
                         <p className="text-sm text-secondary">
-                            Having trouble signing up?{' '}
+                            {/* Text is span-wrapped so Chrome's in-page translation (which replaces bare text
+                                nodes with <font> elements) can't break React sibling ops — react#11538 */}
+                            <span>Having trouble signing up?</span>{' '}
                             <Link
                                 data-attr="turnstile-error-contact-support"
                                 onClick={(e) => {

--- a/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
+++ b/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
@@ -23,6 +23,9 @@ import { LoginMethod } from '~/types'
 
 import { signupLogic } from '../../signupForm/signupLogic'
 
+// Bare text nodes below are wrapped in <span>s: Chrome's in-page translation replaces text
+// nodes with <font> elements, which crashes React's sibling insert/remove operations
+// (removeChild/insertBefore NotFoundError, see react#11538). Text inside its own element is safe.
 const NOTES: Record<number, string[]> = {
     0: ['// create an account', '// 1M events free, every month'],
     1: ['// step 2 of 2', '// make it a good one'],
@@ -44,7 +47,7 @@ function SignupEmailPanel(): JSX.Element {
 
     const footer = preflight?.demo ? undefined : (
         <p className="mt-5 mb-0 text-sm text-secondary text-center">
-            Already have an account?{' '}
+            <span>Already have an account?</span>{' '}
             <Link
                 to={loginUrl}
                 data-attr="signup-login-link"
@@ -144,9 +147,9 @@ function PendingInvitePanel(): JSX.Element {
                 title="You've already been invited"
                 sub={
                     <span>
-                        <b className="text-primary">{org}</b> invited{' '}
-                        <span className="PaperDesk__mono">{signupPanelEmail.email}</span> to join them on PostHog. The
-                        invite link is in your inbox.
+                        <b className="text-primary">{org}</b> <span>invited</span>{' '}
+                        <span className="PaperDesk__mono">{signupPanelEmail.email}</span>{' '}
+                        <span>to join them on PostHog. The invite link is in your inbox.</span>
                     </span>
                 }
                 className="mb-5"
@@ -200,15 +203,15 @@ function SignupAuthPanel(): JSX.Element {
     const footer = (
         <>
             <p className="PaperDesk__terms mt-5 mb-0 text-xs leading-relaxed text-tertiary text-center">
-                By creating an account, you agree to our{' '}
+                <span>By creating an account, you agree to our</span>{' '}
                 <Link to="https://posthog.com/terms" target="_blank">
                     Terms of Service ↗
                 </Link>{' '}
-                and{' '}
+                <span>and</span>{' '}
                 <Link to="https://posthog.com/privacy" target="_blank">
                     Privacy Policy ↗
                 </Link>
-                .
+                <span>.</span>
             </p>
             <p className="mt-3 mb-0 text-sm text-secondary text-center">
                 <Link
@@ -227,13 +230,13 @@ function SignupAuthPanel(): JSX.Element {
                 title="Secure your account"
                 sub={
                     <span>
-                        Signing up as <span className="PaperDesk__mono">{signupPanelEmail.email}</span>
+                        <span>Signing up as</span> <span className="PaperDesk__mono">{signupPanelEmail.email}</span>
                     </span>
                 }
             />
             {passkeyError && (
                 <div className="mb-4 py-2.5 px-3 text-sm leading-normal text-primary text-left bg-danger-highlight border border-danger rounded">
-                    {passkeyError}
+                    <span>{passkeyError}</span>
                 </div>
             )}
             {passkeySignupEnabled &&
@@ -332,15 +335,17 @@ function SignupProfilePanel(): JSX.Element {
     const footer = (
         <>
             <p className="PaperDesk__terms mt-5 mb-0 text-xs leading-relaxed text-tertiary text-center">
-                By {preflight?.demo ? 'entering the demo environment' : 'creating an account'}, you agree to our{' '}
+                <span>
+                    By {preflight?.demo ? 'entering the demo environment' : 'creating an account'}, you agree to our
+                </span>{' '}
                 <Link to="https://posthog.com/terms" target="_blank">
                     Terms of Service ↗
                 </Link>{' '}
-                and{' '}
+                <span>and</span>{' '}
                 <Link to="https://posthog.com/privacy" target="_blank">
                     Privacy Policy ↗
                 </Link>
-                .
+                <span>.</span>
             </p>
             {!preflight?.demo && (
                 <p className="mt-5 mb-0 text-sm text-secondary text-center">
@@ -361,13 +366,14 @@ function SignupProfilePanel(): JSX.Element {
                 title="Tell us about yourself"
                 sub={
                     <span>
-                        Setting up the account for <span className="PaperDesk__mono">{signupPanelEmail.email}</span>
+                        <span>Setting up the account for</span>{' '}
+                        <span className="PaperDesk__mono">{signupPanelEmail.email}</span>
                     </span>
                 }
             />
             {signupPanelOnboardingManualErrors?.generic && (
                 <div className="mb-4 py-2.5 px-3 text-sm leading-normal text-primary text-left bg-danger-highlight border border-danger rounded">
-                    {signupPanelOnboardingManualErrors.generic.detail || 'Could not complete your signup.'}
+                    <span>{signupPanelOnboardingManualErrors.generic.detail || 'Could not complete your signup.'}</span>
                 </div>
             )}
             <Form


### PR DESCRIPTION
## Problem

Reported via ZD ticket [62356](https://posthoghelp.zendesk.com/agent/tickets/62356) and tracked as error tracking issue [`019c29c3`](https://us.posthog.com/project/2/error_tracking/019c29c3-9af5-7f20-b993-82bfc23a628e).

Signing up with Chrome's built-in page translation enabled crashes React with `NotFoundError: Failed to execute 'removeChild' on 'Node'` ([react#11538](https://github.com/facebook/react/issues/11538)). Translate replaces bare text nodes with `<font>` elements, so React's sibling insert/remove operations fail during reconciliation. On signup the crash interrupts the post-signup redirect and users see an "Authentication credentials were not provided" error.

Reproduce: open the signup page, use Chrome's translation tool to translate it to another language, add an email, and click continue.

## Changes

- Wrapped bare text nodes that share a parent with element siblings in `<span>`s across the paper-desk signup panels and the Turnstile challenge, so Translate mutates inside the span and React's sibling operations stay valid.
- Added `translate="no"` to the animated Typewriter corner notes. Its text mutates every 40ms and resets on each panel transition, which is exactly where React removed text nodes Translate had already replaced.

## How did you test this code?

Reproduced the crash locally with Chrome page translation on the signup flow, then verified after the change that the full flow (all three panels, error paths, and links) completes without the DOMException or the post-signup auth error. Pages are visually unchanged with translation off. No new automated tests, since jsdom can't simulate Chrome Translate's DOM mutations, a unit test would only assert markup structure.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
