### PR TITLE
feat(ingestion): add control plane to rust deploy matrix

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -168,6 +168,9 @@ jobs:
                     - release: ingestion-consumer
                       digest_key: ingestion-consumer
                       values_key: image
+                    - release: ingestion-control-plane
+                      digest_key: ingestion-control-plane
+                      values_key: image
                     - release: kafka-deduplicator
                       digest_key: kafka-deduplicator
                       values_key: image


### PR DESCRIPTION
## Problem

`ingestion-control-plane` builds on master via `rust-images.yml` (e.g. the run for 6df5920e5 built and pushed it), but the `deploy` job in `rust-docker-build.yml` has no matrix entry for it, so no `commit_state_update` dispatch reaches PostHog/charts and `state/ingestion-control-plane.yaml` stays pinned to a stale digest.

## Changes

- Add the `ingestion-control-plane` release to the deploy matrix (`digest_key`/`values_key` following the ingestion-consumer entry). The entry inherits the existing job-level gate (`CD_DEPLOY_ENABLED` + PostHog org + master), per the deploy-gating conventions.

## How did you test this code?

- `hogli lint:workflows` passes (all 6 checks across 101 workflows). Matrix-only change to an already-gated job; the deploy step itself is unchanged and skips gracefully when a build didn't produce this image's digest.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @jose-sequeira, after tracing why the charts state digest wasn't updated by the PostHog/posthog#70828 merge: the build job ran but there was no `deploy ingestion-control-plane` job in the run. Skills invoked: /gating-production-deploys (confirmed the matrix entry inherits the existing job-level gate rather than needing its own).
