### PR TITLE
perf(dashboards): reuse tile serializer across dashboard tiles

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2025,8 +2025,24 @@ class DashboardSerializer(DashboardMetadataSerializer):
             if not sorted_tiles:
                 return []
 
+            # One serializer reused across tiles: constructing DashboardTileSerializer per tile
+            # deep-copies every declared field of the tile + nested insight serializers, which
+            # dominates CPU on large dashboards. Per-tile state is passed via the shared context.
+            # (dashboard, insight) is unique per dashboard, so the per-instance insight_result
+            # lru_cache never leaks a result from one tile to another.
+            tile_context = self.context.copy()
+            reused_serializer = DashboardTileSerializer(context=tile_context)
             for order, tile in enumerate(sorted_tiles):
-                order, tile_data = serialize_tile_with_context(tile, order, self.context)
+                tile_context.update({"dashboard_tile": tile, "order": order})
+
+                if isinstance(tile.layouts, str):
+                    tile.layouts = json.loads(tile.layouts)
+
+                try:
+                    tile_data = reused_serializer.to_representation(tile)
+                except pydantic_core.ValidationError:
+                    # Fall back to the fresh-serializer path, which handles the error shape
+                    order, tile_data = serialize_tile_with_context(tile, order, self.context)
                 serialized_tiles.append(cast(ReturnDict, tile_data))
 
         return serialized_tiles


### PR DESCRIPTION
## TL;DR (eli5)

Rendering a dashboard builds a brand-new tile serializer for every single tile, and building one is expensive: DRF deep-copies all ~60 declared fields, including the big nested insight serializer, each time. Now we build it once and reuse it for every tile. Same output, less CPU.

## Why

Extracted from #70967, which bundles three independent optimizations and is too large to review and merge safely. This is the smallest and most self-contained of the three; the others will follow as separate PRs.

## Problem

Large dashboard GETs (70+ insight tiles) spend most of their wall time outside Postgres even when every tile is served from the query cache. Profiling showed per-tile `DashboardTileSerializer` construction (DRF's `get_fields` deepcopy of every declared field plus the nested insight serializer) as one of the dominant CPU costs, ~90 ms median on a 70-tile local repro.

## Changes

In `DashboardSerializer.get_tiles`, construct one `DashboardTileSerializer` and reuse it for all tiles. Per-tile state (`dashboard_tile`, `order`) flows through the shared context dict, which nested serializers read via the root serializer.

Safety of reuse:

- `(dashboard, insight)` is unique per dashboard, so the insight serializer's per-instance `@lru_cache(maxsize=1)` methods (`insight_result`, `dashboard_tile_from_context`) can't leak one tile's result into another.
- On `pydantic_core.ValidationError` the tile falls back to the original fresh-serializer path (`serialize_tile_with_context`), which handles the error shape.

On the 70-tile repro from #70967 this cut median GET wall time from 873 ms to 787 ms (measured there on top of another optimization; the serializer-construction saving is independent of it).

## How did you test this code?

- The diff is byte-identical to commit `7f12e959` on #70967, where the full backend CI suite passed with this change included.
- `ruff check` / `ruff format` and `hogli ci:preflight --fix` pass locally (0 failures).
- I (the agent) could not run the dashboard API test suite in this environment (no database stack available); `posthog/api/test/dashboards/test_dashboard.py` exercises `get_tiles` output shape, tile order, and the error-tile fallback, and will run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — no user-facing, API, or config change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code). The human driver asked to split #70967 into separate PRs starting with the simplest optimization. The agent identified this serializer-reuse commit as the smallest fully independent change (single file, no config gating, no follow-up fixes on the parent PR), extracted it verbatim onto a fresh branch off master, and verified the diff matches the original commit exactly. Skills invoked: `/improving-drf-endpoints` (no schema-affecting changes found — the change is implementation-only inside a `SerializerMethodField` getter).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
