### PR TITLE
feat(agent-platform): add native Slack agent messaging experience

### DIFF
--- a/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/slack.ts
@@ -39,6 +39,10 @@ import type { RouteCtx, TriggerDeps, TriggerModule } from './types'
 // enforcement point, but the helper stays available on the package surface.
 export { verifySlackSignature }
 
+/** Fallback greeting for a new agent conversation when the spec sets no
+ *  `welcome_message`. */
+const DEFAULT_AGENT_WELCOME = "Hi! I'm your PostHog agent — ask me anything and I'll get to work."
+
 async function slackEventsHandler(ctx: RouteCtx): Promise<void> {
     const { req, res, deps, resolved } = ctx
     // Signature already verified by the slack_signing guard.
@@ -56,6 +60,31 @@ async function slackEventsHandler(ctx: RouteCtx): Promise<void> {
         return
     }
     const event = body.event
+    // The agent's slack trigger config drives every gate below; extract it once
+    // up front so the agent-surface lifecycle handler and the message gate share
+    // one view.
+    const slackConfig =
+        slackSpecTrigger && 'config' in slackSpecTrigger
+            ? (slackSpecTrigger.config as SlackTriggerConfig)
+            : ({} as SlackTriggerConfig)
+
+    // Agent-surface lifecycle events (Slack's "Agent messaging experience").
+    // They only arrive when `agent_surface` is enabled in the manifest, so
+    // handle them before the message/app_mention gate. Everything the handler
+    // does is fire-and-forget — a Slack hiccup must never break the 200 ack.
+    if (
+        event &&
+        !event.bot_id &&
+        (slackConfig.agent_surface ?? false) &&
+        (event.type === 'assistant_thread_started' ||
+            event.type === 'app_home_opened' ||
+            event.type === 'assistant_thread_context_changed')
+    ) {
+        await handleAgentSurfaceEvent(ctx, event, slackConfig)
+        res.json({ ok: true, agent_surface_event: event.type })
+        return
+    }
+
     // Accept both `message` (channel messages the bot is a member of) and
     // `app_mention` (someone @-mentioned the bot). Slack delivers the latter
     // even when a workspace only subscribed to mentions, and the spec's
@@ -68,24 +97,6 @@ async function slackEventsHandler(ctx: RouteCtx): Promise<void> {
 
     // Workspace trust check. trusted_workspaces is required in the spec: an
     // array gates on membership; `"*"` opens to any workspace.
-    const slackConfig =
-        slackSpecTrigger && 'config' in slackSpecTrigger
-            ? (slackSpecTrigger.config as {
-                  trusted_workspaces?: string[] | '*'
-                  mention_only?: boolean
-                  auto_resume_threads?: boolean
-                  allow_workspace_participants?: boolean
-                  allow_direct_messages?: boolean
-                  ack_reaction?: string
-              })
-            : ({} as {
-                  trusted_workspaces?: string[] | '*'
-                  mention_only?: boolean
-                  auto_resume_threads?: boolean
-                  allow_workspace_participants?: boolean
-                  allow_direct_messages?: boolean
-                  ack_reaction?: string
-              })
     const trusted = slackConfig.trusted_workspaces
     // message events lack event.team; fall back to the envelope team_id.
     const workspaceId = event.team ?? body.team_id ?? 'unknown'
@@ -122,7 +133,10 @@ async function slackEventsHandler(ctx: RouteCtx): Promise<void> {
     const ackReaction = slackConfig.ack_reaction
     // DM surface. `im` = 1:1, `mpim` = group DM. A DM is inherently directed at
     // the bot (there's no @-mention in a 1:1), so it bypasses `mention_only`.
-    const allowDirectMessages = slackConfig.allow_direct_messages ?? false
+    // The agent surface is DM-first (the manifest subscribes `message.im` for
+    // it), so `agent_surface` enables DMs on its own — same rule the manifest
+    // builder uses.
+    const allowDirectMessages = (slackConfig.allow_direct_messages ?? false) || (slackConfig.agent_surface ?? false)
     const isDm = event.channel_type === 'im' || event.channel_type === 'mpim'
     // A DM arriving while the surface isn't opted in must not be silently
     // processed — drop it with a structured reason.
@@ -785,6 +799,106 @@ async function postThreadMessage(
 }
 
 /**
+ * Handle Slack "Agent messaging experience" lifecycle events. On a new
+ * conversation (`assistant_thread_started`) post the welcome message and set the
+ * suggested prompts; on the new-experience DM open (`app_home_opened` on the
+ * Messages tab) refresh the suggested prompts. `assistant_thread_context_changed`
+ * is accepted and ignored for now (channel-context grounding is a follow-up).
+ * Every Slack call is best-effort and swallowed — this never throws, so the
+ * caller can ack Slack unconditionally.
+ */
+async function handleAgentSurfaceEvent(ctx: RouteCtx, event: SlackEvent, config: SlackTriggerConfig): Promise<void> {
+    const { deps, resolved } = ctx
+    const prompts = config.suggested_prompts ?? []
+    if (event.type === 'assistant_thread_started') {
+        const channel = event.assistant_thread?.channel_id
+        const threadTs = event.assistant_thread?.thread_ts
+        if (!channel || !threadTs) {
+            return
+        }
+        await postThreadMessage(deps, resolved.application, resolved.revision, {
+            channel,
+            thread_ts: threadTs,
+            text: config.welcome_message ?? DEFAULT_AGENT_WELCOME,
+        }).catch(() => false)
+        if (prompts.length > 0) {
+            await postSuggestedPrompts(deps, resolved.application, resolved.revision, {
+                channel,
+                thread_ts: threadTs,
+                prompts,
+            }).catch(() => false)
+        }
+        return
+    }
+    if (event.type === 'app_home_opened') {
+        // Only the Messages tab is the agent DM surface; ignore Home-tab opens.
+        if ((event.tab && event.tab !== 'messages') || !event.channel || prompts.length === 0) {
+            return
+        }
+        await postSuggestedPrompts(deps, resolved.application, resolved.revision, {
+            channel: event.channel,
+            prompts,
+        }).catch(() => false)
+    }
+}
+
+/**
+ * Set the agent's suggested prompts via `assistant.threads.setSuggestedPrompts`.
+ * In the Agent messaging experience `thread_ts` is optional (prompts pin to the
+ * top of the Messages tab). Best-effort — swallows every error, returns true
+ * only on a clean Slack `ok`.
+ */
+async function postSuggestedPrompts(
+    deps: TriggerDeps,
+    application: AgentApplication,
+    revision: AgentRevision,
+    opts: { channel: string; thread_ts?: string; prompts: Array<{ title: string; message: string }> }
+): Promise<boolean> {
+    const token = await deps.signingSecretResolver.resolve(SLACK_BOT_TOKEN_KEY, revision)
+    if (!token || !deps.http) {
+        log.warn(
+            { slug: application.slug, has_token: Boolean(token), has_http: Boolean(deps.http) },
+            'suggested_prompts_skipped'
+        )
+        return false
+    }
+    try {
+        const res = await deps.http.fetch('https://slack.com/api/assistant.threads.setSuggestedPrompts', {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json; charset=utf-8',
+            },
+            body: JSON.stringify({
+                channel_id: opts.channel,
+                ...(opts.thread_ts ? { thread_ts: opts.thread_ts } : {}),
+                prompts: opts.prompts,
+            }),
+        })
+        let body: { ok?: boolean; error?: string } = {}
+        try {
+            body = (await res.json()) as { ok?: boolean; error?: string }
+        } catch {
+            // Non-JSON response — treat as failure but don't throw.
+        }
+        if (!res.ok || body.ok === false) {
+            log.warn(
+                { slug: application.slug, channel: opts.channel, status: res.status, slack_error: body.error ?? null },
+                'suggested_prompts_failed'
+            )
+            return false
+        }
+        return true
+    } catch (err) {
+        log.warn(
+            { slug: application.slug, channel: opts.channel, err: err instanceof Error ? err.message : String(err) },
+            'suggested_prompts_threw'
+        )
+        return false
+    }
+}
+
+/**
  * Resolve a clicking Slack user to the same AgentUser id the events trigger
  * would produce. When the identity store is wired this is a stable lookup;
  * without it we fall back to the raw `workspace:user` tuple which matches what
@@ -823,6 +937,27 @@ interface SlackEvent {
     ts: string
     thread_ts?: string
     bot_id?: string
+    /** Present on `assistant_thread_started` / `assistant_thread_context_changed`
+     *  — the channel/thread/user live here rather than at the top level. */
+    assistant_thread?: { user_id?: string; channel_id?: string; thread_ts?: string; context?: unknown }
+    /** Present on `app_home_opened` — which tab the user opened (`"messages"`
+     *  is the agent DM surface, `"home"` is the App Home tab). */
+    tab?: string
+}
+
+/** The slack trigger's `config` (see `AgentSpecSchema`), narrowed to the fields
+ *  the ingress reads. Optional throughout — a missing block reads as defaults. */
+interface SlackTriggerConfig {
+    trusted_workspaces?: string[] | '*'
+    mention_only?: boolean
+    auto_resume_threads?: boolean
+    allow_workspace_participants?: boolean
+    allow_direct_messages?: boolean
+    ack_reaction?: string
+    agent_surface?: boolean
+    agent_description?: string
+    suggested_prompts?: Array<{ title: string; message: string }>
+    welcome_message?: string
 }
 
 /** Published `bodySchema` covers only the two envelope shapes we route on

--- a/products/agent_platform/services/agent-runner/src/loop/driver.ts
+++ b/products/agent_platform/services/agent-runner/src/loop/driver.ts
@@ -296,6 +296,15 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
     // thread (the system prompt below tells the model to answer in natural
     // language instead of calling a slack tool).
     const slackReply = session.trigger_metadata?.kind === 'slack' ? session.trigger_metadata : null
+    // When the agent opts into Slack's "Agent messaging experience"
+    // (`agent_surface`), report progress with the native
+    // `assistant.threads.setStatus` indicator; otherwise fall back to the
+    // simulated status message. Read from the spec — no need to thread it
+    // through trigger_metadata.
+    const slackAgentSurface =
+        ((rev.spec.triggers ?? []).find((t) => t.type === 'slack')?.config as
+            | { agent_surface?: boolean }
+            | undefined)?.agent_surface === true
     const system = await buildSystemPrompt(rev, deps.bundle, {
         unavailableMcps: (deps.mcpFailures ?? []).map((f) => ({
             id: f.ref.id,
@@ -328,6 +337,7 @@ export async function runSession(rev: AgentRevision, session: AgentSession, deps
               channel: slackReply.channel,
               thread_ts: slackReply.thread_ts,
               sessionId: session.id,
+              mode: slackAgentSurface ? 'native' : 'simulated',
               logger: { warn: (meta, m) => log('warn', m, meta), info: (meta, m) => log('info', m, meta) },
           })
         : null

--- a/products/agent_platform/services/agent-shared/src/runtime/slack-reply.test.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/slack-reply.test.ts
@@ -7,6 +7,7 @@ import {
     postSlackReply,
     SlackStatusReporter,
     slackTextFromContent,
+    toPlainStatus,
 } from './slack-reply'
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -250,5 +251,38 @@ describe('SlackStatusReporter', () => {
 
         await r.start('working again')
         expect(calls.filter((c) => c.url.endsWith('chat.postMessage'))).toHaveLength(2)
+    })
+
+    it('native mode uses assistant.threads.setStatus and never posts/deletes a message', async () => {
+        const { http, calls } = recorder()
+        let nowMs = 1000
+        const r = new SlackStatusReporter({
+            http,
+            token: 'xoxb',
+            channel: 'C1',
+            thread_ts: 't',
+            mode: 'native',
+            minUpdateIntervalMs: 1000,
+            now: () => nowMs,
+        })
+        await r.start(':hourglass_flowing_sand: _Working on it…_')
+        nowMs += 1000
+        await r.update('running a query')
+        await r.clear() // native status auto-clears on reply → no-op
+
+        const statusCalls = calls.filter((c) => c.url.endsWith('assistant.threads.setStatus'))
+        expect(statusCalls).toHaveLength(2)
+        // Status is plain text: emoji shortcodes + markdown emphasis stripped.
+        expect(statusCalls[0].body).toEqual({ channel_id: 'C1', thread_ts: 't', status: 'Working on it…' })
+        expect(statusCalls[1].body).toMatchObject({ status: 'running a query' })
+        expect(calls.some((c) => c.url.endsWith('chat.postMessage'))).toBe(false)
+        expect(calls.some((c) => c.url.endsWith('chat.delete'))).toBe(false)
+    })
+})
+
+describe('toPlainStatus', () => {
+    it('strips emoji shortcodes and markdown emphasis', () => {
+        expect(toPlainStatus(':hourglass_flowing_sand: _Working on it…_')).toBe('Working on it…')
+        expect(toPlainStatus('**bold** and `code`')).toBe('bold and code')
     })
 })

--- a/products/agent_platform/services/agent-shared/src/runtime/slack-reply.ts
+++ b/products/agent_platform/services/agent-shared/src/runtime/slack-reply.ts
@@ -24,6 +24,16 @@ export function slackTextFromContent(content: ReadonlyArray<{ type: string; text
         .join('\n\n')
 }
 
+/** Native status is plain text ("<App> <status>") — strip emoji shortcodes and
+ *  markdown emphasis that only render in a normal message. */
+export function toPlainStatus(text: string): string {
+    return text
+        .replace(/:[a-z0-9_+-]+:/gi, '')
+        .replace(/[*_`]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+}
+
 export interface SlackReplyLogger {
     warn: (meta: Record<string, unknown>, msg: string) => void
     info?: (meta: Record<string, unknown>, msg: string) => void
@@ -45,21 +55,34 @@ export interface SlackStatusReporterDeps {
     thread_ts: string
     sessionId?: string
     logger?: SlackReplyLogger
-    /** Min gap between chat.update calls — Slack rate-limits updates. Default 1000ms. */
+    /** Min gap between status updates — Slack rate-limits both chat.update and
+     *  assistant.threads.setStatus. Default 1000ms. */
     minUpdateIntervalMs?: number
     /** Injectable clock for tests. Default Date.now. */
     now?: () => number
+    /**
+     * How to render the "working on it" indicator:
+     *   - `'native'` (agent surface / `agent_surface: true`) — Slack's native
+     *     `assistant.threads.setStatus`, which shows "<App> <status>" and
+     *     auto-clears when the app posts its reply. `clear()` is a no-op.
+     *   - `'simulated'` (default, back-compat for BYO apps without the agent
+     *     surface) — a normal message we post / chat.update / chat.delete.
+     */
+    mode?: 'native' | 'simulated'
 }
 
 /**
- * A single ephemeral-feeling "working on it" status message in the thread. The
- * runner posts it while a turn is in flight, updates it as tools run, and
- * removes it the moment a real reply lands (re-posting on the next turn) so the
- * latest visible message is always the agent's actual answer. Never throws.
+ * The "working on it" status shown while a turn is in flight, cleared when the
+ * agent's real reply lands. Two renderings selected by `deps.mode`:
  *
- * Not a true Slack ephemeral (those need a response_url and can't be edited) —
- * a normal message we post / chat.update / chat.delete, which works from an
- * event-triggered session.
+ *   - `native`: Slack's `assistant.threads.setStatus` — the real agent thinking
+ *     indicator. It auto-clears when the app posts a message, so `clear()` does
+ *     nothing; the reply relay in the driver clears it implicitly.
+ *   - `simulated`: a normal thread message we post / `chat.update` / `chat.delete`
+ *     (not a true Slack ephemeral — those need a response_url and can't be
+ *     edited). The fallback for apps that haven't enabled the agent surface.
+ *
+ * Never throws — a Slack hiccup must not break the agent loop.
  */
 export class SlackStatusReporter {
     private ts: string | null = null
@@ -68,9 +91,22 @@ export class SlackStatusReporter {
 
     constructor(private readonly deps: SlackStatusReporterDeps) {}
 
-    /** Post the status message if it isn't already shown. */
+    private get mode(): 'native' | 'simulated' {
+        return this.deps.mode ?? 'simulated'
+    }
+
+    /** Post/show the status if it isn't already shown. */
     async start(text: string): Promise<void> {
-        if (this.ts || !this.deps.token) {
+        if (!this.deps.token) {
+            return
+        }
+        if (this.mode === 'native') {
+            this.lastText = text
+            this.lastUpdateMs = this.clock()
+            await this.setNativeStatus(text)
+            return
+        }
+        if (this.ts) {
             return
         }
         const res = await this.call('chat.postMessage', {
@@ -85,13 +121,22 @@ export class SlackStatusReporter {
         }
     }
 
-    /** Edit the status text. Throttled + best-effort; no-op if not shown. */
+    /** Update the status text. Throttled + best-effort. */
     async update(text: string): Promise<void> {
-        if (!this.ts || !this.deps.token || text === this.lastText) {
+        if (!this.deps.token || text === this.lastText) {
             return
         }
         const now = this.clock()
         if (now - this.lastUpdateMs < (this.deps.minUpdateIntervalMs ?? 1000)) {
+            return
+        }
+        if (this.mode === 'native') {
+            this.lastText = text
+            this.lastUpdateMs = now
+            await this.setNativeStatus(text)
+            return
+        }
+        if (!this.ts) {
             return
         }
         this.lastText = text
@@ -99,14 +144,27 @@ export class SlackStatusReporter {
         await this.call('chat.update', { channel: this.deps.channel, ts: this.ts, text })
     }
 
-    /** Remove the status message. Idempotent. */
+    /** Remove the status. Native status auto-clears on reply, so it's a no-op
+     *  there; simulated deletes the message. Idempotent. */
     async clear(): Promise<void> {
-        if (!this.ts || !this.deps.token) {
+        if (!this.deps.token || this.mode === 'native') {
+            return
+        }
+        if (!this.ts) {
             return
         }
         const ts = this.ts
         this.ts = null
         await this.call('chat.delete', { channel: this.deps.channel, ts })
+    }
+
+    /** Native indicator via assistant.threads.setStatus (plain text only). */
+    private async setNativeStatus(text: string): Promise<void> {
+        await this.call('assistant.threads.setStatus', {
+            channel_id: this.deps.channel,
+            thread_ts: this.deps.thread_ts,
+            status: toPlainStatus(text),
+        })
     }
 
     private clock(): number {

--- a/products/agent_platform/services/agent-shared/src/spec/slack-manifest.test.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/slack-manifest.test.ts
@@ -143,4 +143,45 @@ describe('buildSlackManifest', () => {
         expect(longDesc.startsWith(kept)).toBe(true) // a clean prefix, not mangled
         expect(longDesc[kept.length]).toBe(' ') // cut fell on a word boundary
     })
+
+    it('agent_surface=true → agent_view, assistant:write, App Home, and assistant events', () => {
+        const { manifest, notes } = build({
+            triggers: [
+                slackTrigger({
+                    mention_only: true,
+                    agent_surface: true,
+                    agent_description: 'Ask me about on-call',
+                    suggested_prompts: [{ title: "Who's on call?", message: 'Who is on call right now?' }],
+                }),
+            ],
+        })
+        expect(manifest.oauth_config.scopes.bot).toContain('assistant:write')
+        expect(manifest.features.agent_view).toEqual({
+            agent_description: 'Ask me about on-call',
+            suggested_prompts: [{ title: "Who's on call?", message: 'Who is on call right now?' }],
+        })
+        // Agent surface is DM-first: Messages tab + DM events/scopes ride along.
+        expect(manifest.features.app_home).toEqual({
+            messages_tab_enabled: true,
+            messages_tab_read_only_enabled: false,
+        })
+        expect(manifest.settings.event_subscriptions.bot_events).toContain('assistant_thread_started')
+        expect(manifest.settings.event_subscriptions.bot_events).toContain('app_home_opened')
+        expect(manifest.settings.event_subscriptions.bot_events).toContain('message.im')
+        expect(manifest.oauth_config.scopes.bot).toContain('im:history')
+        expect(notes.some((n) => n.toLowerCase().includes('agent surface enabled'))).toBe(true)
+    })
+
+    it('agent_surface=true with no description/prompts → agent_view present but empty', () => {
+        const { manifest } = build({ triggers: [slackTrigger({ mention_only: true, agent_surface: true })] })
+        expect(manifest.features.agent_view).toEqual({})
+    })
+
+    it('agent_surface default false → no agent_view or assistant:write (back-compat)', () => {
+        const { manifest } = build({ triggers: [slackTrigger({ mention_only: true })] })
+        expect(manifest.features.agent_view).toBeUndefined()
+        expect(manifest.oauth_config.scopes.bot).not.toContain('assistant:write')
+        expect(manifest.settings.event_subscriptions.bot_events).not.toContain('assistant_thread_started')
+        expect(manifest.settings.event_subscriptions.bot_events).not.toContain('app_home_opened')
+    })
 })

--- a/products/agent_platform/services/agent-shared/src/spec/slack-manifest.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/slack-manifest.ts
@@ -25,6 +25,14 @@ export interface SlackAppManifest {
         /** Only emitted when DMs are enabled — Slack hides the Messages tab
          *  (and so the ability to DM the bot) unless this opts in. */
         app_home?: { messages_tab_enabled: boolean; messages_tab_read_only_enabled: boolean }
+        /** Slack's "Agent messaging experience" config. Emitted only when the
+         *  agent surface is enabled (`agent_surface`). Slack caps
+         *  `agent_description` at 300 chars and shows at most 4
+         *  `suggested_prompts`. */
+        agent_view?: {
+            agent_description?: string
+            suggested_prompts?: Array<{ title: string; message: string }>
+        }
     }
     oauth_config: { scopes: { bot: string[] } }
     settings: {
@@ -97,14 +105,24 @@ export function buildSlackManifest(input: BuildSlackManifestInput): BuildSlackMa
     // mirrors the ingress gate exactly.
     const mentionOnly = config.mention_only ?? false
     const autoResumeThreads = config.auto_resume_threads ?? false
-    const allowDms = config.allow_direct_messages ?? false
+    const agentSurface = config.agent_surface ?? false
+    // The agent surface is inherently DM-first (turns arrive as `message.im`),
+    // so it enables the DM plumbing on its own without a separate flag.
+    const dmEnabled = (config.allow_direct_messages ?? false) || agentSurface
     const needsMessageEvents = mentionOnly === false || autoResumeThreads === true
     const botEvents = ['app_mention']
     if (needsMessageEvents) {
         botEvents.push('message.channels', 'message.groups')
     }
-    if (allowDms) {
+    if (dmEnabled) {
         botEvents.push('message.im', 'message.mpim')
+    }
+    if (agentSurface) {
+        // `assistant_thread_started` fires when a conversation opens in the
+        // split-view surface; `app_home_opened` is the new experience's
+        // DM-open signal (Slack no longer fires `assistant_thread_started`
+        // for that). Both let the ingress push the welcome + suggested prompts.
+        botEvents.push('assistant_thread_started', 'app_home_opened')
     }
 
     // Bot OAuth scopes. Union the Slack scopes declared by the agent's Slack
@@ -128,10 +146,17 @@ export function buildSlackManifest(input: BuildSlackManifestInput): BuildSlackMa
         scopes.add('channels:history')
         scopes.add('groups:history')
     }
-    if (allowDms) {
+    if (dmEnabled) {
         // Required to receive message.im / message.mpim events.
         scopes.add('im:history')
         scopes.add('mpim:history')
+    }
+    if (agentSurface) {
+        // Grants access to the native agent methods (setStatus /
+        // setSuggestedPrompts / setTitle). Slack auto-adds this when the AI-app
+        // feature is enabled in the app settings; requesting it in the manifest
+        // keeps the two in sync.
+        scopes.add('assistant:write')
     }
 
     // Interactivity is only used by approval-gated tools (the elevation buttons).
@@ -149,9 +174,30 @@ export function buildSlackManifest(input: BuildSlackManifestInput): BuildSlackMa
         'Invite the bot to each channel it should listen in — Slack only delivers channel ' +
             'message events to channels the bot has joined.'
     )
-    if (allowDms) {
+    if (dmEnabled) {
         notes.push("Direct messages enabled — users can DM the bot from the app's Messages tab.")
     }
+    if (agentSurface) {
+        notes.push(
+            'Agent surface enabled — the bot appears as a native, DM-able agent with a thinking ' +
+                'indicator and suggested prompts. Enable the AI-app feature in your Slack app ' +
+                "settings (Agents & AI Apps) so the `assistant:write` scope is granted, then reinstall."
+        )
+    }
+
+    // Present only when the agent surface is on; the presence of the
+    // `agent_view` key is what selects Slack's Agent messaging experience, so
+    // it's emitted even when no description/prompts are set.
+    const agentView = agentSurface
+        ? {
+              ...(config.agent_description
+                  ? { agent_description: truncate(config.agent_description, 300, true) }
+                  : {}),
+              ...(config.suggested_prompts && config.suggested_prompts.length > 0
+                  ? { suggested_prompts: config.suggested_prompts }
+                  : {}),
+          }
+        : null
 
     const manifest: SlackAppManifest = {
         display_information: {
@@ -161,8 +207,9 @@ export function buildSlackManifest(input: BuildSlackManifestInput): BuildSlackMa
         features: {
             bot_user: { display_name: truncate(input.displayName, 35), always_online: true },
             // Without the Messages tab enabled, users literally can't open a DM
-            // with the bot — so this rides along with allow_direct_messages.
-            ...(allowDms ? { app_home: { messages_tab_enabled: true, messages_tab_read_only_enabled: false } } : {}),
+            // with the bot — so this rides along with DMs / the agent surface.
+            ...(dmEnabled ? { app_home: { messages_tab_enabled: true, messages_tab_read_only_enabled: false } } : {}),
+            ...(agentView !== null ? { agent_view: agentView } : {}),
         },
         oauth_config: { scopes: { bot: [...scopes].sort() } },
         settings: {

--- a/products/agent_platform/services/agent-shared/src/spec/spec.ts
+++ b/products/agent_platform/services/agent-shared/src/spec/spec.ts
@@ -138,6 +138,15 @@ export const TriggerSchema = z.discriminatedUnion('type', [
      *     `message.im` / `message.mpim`, add the `im:history` / `mpim:history`
      *     scopes, and enable the App Home Messages tab (otherwise users can't
      *     open a DM with the bot). The manifest builder emits all three.
+     *   - Agent surface (`agent_surface: true`): opts the app into Slack's
+     *     "Agent messaging experience" so the bot shows up as a native,
+     *     DM-able agent (thinking indicator, suggested prompts, welcome). The
+     *     manifest builder then emits `features.agent_view`, the `assistant:write`
+     *     scope, the App Home Messages tab, and the `assistant_thread_started` /
+     *     `app_home_opened` bot events; the runner switches the "working on it"
+     *     status to the native `assistant.threads.setStatus` indicator. Implies
+     *     DMs (arriving as `message.im`), so it is treated as DM-enabling on its
+     *     own.
      *
      * The session key for a channel/thread is `slack:<channel>:<thread_ts>`
      * (the opening @-mention's `ts` becomes the thread root); every later event
@@ -226,6 +235,51 @@ export const TriggerSchema = z.discriminatedUnion('type', [
              * "any-workspace" default.
              */
             trusted_workspaces: z.union([z.array(z.string()).min(1), z.literal('*')]),
+            /**
+             * Opt into Slack's "Agent messaging experience" (the June-2026
+             * successor to the Assistant experience). When true the bot appears
+             * as a native agent you can DM: conversations live in the app's
+             * Messages tab, the runner reports progress with the native
+             * `assistant.threads.setStatus` "thinking" indicator (instead of the
+             * simulated status message), and the ingress greets new
+             * conversations with `welcome_message` + `suggested_prompts` via
+             * `assistant.threads.setSuggestedPrompts`.
+             *
+             * Drives the manifest builder to emit `features.agent_view`, the
+             * `assistant:write` scope, the App Home Messages tab, and the
+             * `assistant_thread_started` / `app_home_opened` bot events. Because
+             * agent turns arrive as `message.im`, this is DM-enabling on its own
+             * (no need to also set `allow_direct_messages`). Default false so
+             * already-deployed BYO apps are unaffected. The workspace admin must
+             * re-apply the regenerated manifest and enable the AI-app feature
+             * before the surface takes effect.
+             */
+            agent_surface: z.boolean().default(false),
+            /**
+             * Short description of the agent shown in Slack's agent/split-view
+             * surface (manifest `features.agent_view.agent_description`). Only
+             * meaningful when `agent_surface` is true. Slack caps this at 300
+             * characters.
+             */
+            agent_description: z.string().max(300).optional(),
+            /**
+             * Starter prompts shown at the top of the agent's Messages tab. Each
+             * is a `{ title, message }` pair — `title` is the clickable label,
+             * `message` is the text sent as the user's turn when clicked. Set on
+             * the manifest (fixed prompts) and pushed at runtime via
+             * `assistant.threads.setSuggestedPrompts` when a conversation opens.
+             * Slack shows at most 4. Only meaningful when `agent_surface` is true.
+             */
+            suggested_prompts: z
+                .array(z.object({ title: z.string().min(1).max(64), message: z.string().min(1) }))
+                .max(4)
+                .optional(),
+            /**
+             * Greeting the ingress posts into a new agent conversation (on
+             * `assistant_thread_started`). Only meaningful when `agent_surface`
+             * is true; when unset a generic default is used.
+             */
+            welcome_message: z.string().optional(),
         }),
     }),
     z.object({

--- a/products/agent_platform/services/agent-tests/src/cases/slack-trigger.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/slack-trigger.test.ts
@@ -1542,4 +1542,220 @@ describe('slack trigger: real e2e', () => {
             }
         })
     })
+
+    describe('agent surface (native agent experience)', () => {
+        /** Records slack.com calls so we can assert on setSuggestedPrompts /
+         *  setStatus / the welcome + reply posts. `resolveSecrets` feeds the
+         *  runner's bot token (native setStatus is a runner-side call). */
+        async function recorderCluster(secrets: Record<string, string> = {}): Promise<{
+            cc: Cluster
+            slackCalls: Array<{ url: string; body: Record<string, unknown> }>
+        }> {
+            const slackCalls: Array<{ url: string; body: Record<string, unknown> }> = []
+            const recorder = {
+                fetch: (input: string | URL, init?: RequestInit): Promise<Response> => {
+                    const url = typeof input === 'string' ? input : input.toString()
+                    if (url.includes('slack.com/api/')) {
+                        slackCalls.push({
+                            url,
+                            body: typeof init?.body === 'string' ? JSON.parse(init.body) : {},
+                        })
+                        return Promise.resolve({
+                            ok: true,
+                            status: 200,
+                            json: async () => ({ ok: true, ts: 'TS_STATUS' }),
+                            text: async () => '{"ok":true,"ts":"TS_STATUS"}',
+                        } as unknown as Response)
+                    }
+                    return Promise.reject(new Error(`unexpected fetch in test: ${url}`))
+                },
+            }
+            const cc = await buildCluster({ http: recorder, resolveSecrets: async () => secrets })
+            return { cc, slackCalls }
+        }
+
+        const PROMPTS = [{ title: 'Top errors', message: 'What are my top errors today?' }]
+
+        function agentSurfaceSpec(): Record<string, unknown> {
+            return {
+                triggers: [
+                    {
+                        type: 'slack',
+                        config: {
+                            mention_only: false,
+                            auto_resume_threads: false,
+                            agent_surface: true,
+                            welcome_message: 'Hey! What can I dig into?',
+                            suggested_prompts: PROMPTS,
+                            trusted_workspaces: '*',
+                        },
+                    },
+                ],
+                auth: { modes: [{ type: 'public', acknowledge_public_exposure: true }] },
+            }
+        }
+
+        it('assistant_thread_started → posts the welcome and sets suggested prompts', async () => {
+            const { cc, slackCalls } = await recorderCluster({ SLACK_BOT_TOKEN: 'xoxb-agent' })
+            try {
+                await cc.deployAgent({
+                    slug: 'agentic',
+                    spec: agentSurfaceSpec(),
+                    encrypted_env: { ...SLACK_ENV, SLACK_BOT_TOKEN: 'xoxb-agent' },
+                })
+                const res = await cc.slackPost(
+                    'agentic',
+                    'events',
+                    {
+                        type: 'event_callback',
+                        event_id: 'Ev_ats',
+                        event: {
+                            type: 'assistant_thread_started',
+                            assistant_thread: { user_id: 'U01', channel_id: 'D01', thread_ts: '900.0' },
+                        },
+                    },
+                    SLACK_SECRET
+                )
+                expect(res.status).toBe(200)
+                expect(res.body.agent_surface_event).toBe('assistant_thread_started')
+                expect(res.body.session_id).toBeUndefined() // lifecycle event, not a turn
+
+                const prompts = slackCalls.filter((c) => c.url.endsWith('assistant.threads.setSuggestedPrompts'))
+                expect(prompts).toHaveLength(1)
+                expect(prompts[0].body).toMatchObject({ channel_id: 'D01', thread_ts: '900.0', prompts: PROMPTS })
+                const welcome = slackCalls.filter(
+                    (c) => c.url.endsWith('chat.postMessage') && String(c.body.text).includes('What can I dig into')
+                )
+                expect(welcome).toHaveLength(1)
+                expect(welcome[0].body).toMatchObject({ channel: 'D01', thread_ts: '900.0' })
+            } finally {
+                await cc.teardown()
+            }
+        })
+
+        it('app_home_opened on the Messages tab → refreshes suggested prompts (no thread_ts)', async () => {
+            const { cc, slackCalls } = await recorderCluster({ SLACK_BOT_TOKEN: 'xoxb-agent' })
+            try {
+                await cc.deployAgent({
+                    slug: 'homeopen',
+                    spec: agentSurfaceSpec(),
+                    encrypted_env: { ...SLACK_ENV, SLACK_BOT_TOKEN: 'xoxb-agent' },
+                })
+                const res = await cc.slackPost(
+                    'homeopen',
+                    'events',
+                    {
+                        type: 'event_callback',
+                        event_id: 'Ev_aho',
+                        event: { type: 'app_home_opened', user: 'U01', channel: 'D01', tab: 'messages' },
+                    },
+                    SLACK_SECRET
+                )
+                expect(res.status).toBe(200)
+                expect(res.body.agent_surface_event).toBe('app_home_opened')
+                const prompts = slackCalls.filter((c) => c.url.endsWith('assistant.threads.setSuggestedPrompts'))
+                expect(prompts).toHaveLength(1)
+                expect(prompts[0].body).toMatchObject({ channel_id: 'D01', prompts: PROMPTS })
+                expect(prompts[0].body.thread_ts).toBeUndefined()
+            } finally {
+                await cc.teardown()
+            }
+        })
+
+        it('app_home_opened on the Home tab is ignored (not the agent DM surface)', async () => {
+            const { cc, slackCalls } = await recorderCluster({ SLACK_BOT_TOKEN: 'xoxb-agent' })
+            try {
+                await cc.deployAgent({
+                    slug: 'hometab',
+                    spec: agentSurfaceSpec(),
+                    encrypted_env: { ...SLACK_ENV, SLACK_BOT_TOKEN: 'xoxb-agent' },
+                })
+                const res = await cc.slackPost(
+                    'hometab',
+                    'events',
+                    {
+                        type: 'event_callback',
+                        event_id: 'Ev_home',
+                        event: { type: 'app_home_opened', user: 'U01', channel: 'D01', tab: 'home' },
+                    },
+                    SLACK_SECRET
+                )
+                expect(res.status).toBe(200)
+                expect(slackCalls.filter((c) => c.url.endsWith('assistant.threads.setSuggestedPrompts'))).toHaveLength(
+                    0
+                )
+            } finally {
+                await cc.teardown()
+            }
+        })
+
+        it('DMs enqueue under agent_surface even without allow_direct_messages (agent surface is DM-first)', async () => {
+            const { cc } = await recorderCluster({ SLACK_BOT_TOKEN: 'xoxb-agent' })
+            try {
+                cc.setScript([fauxText('dm handled')])
+                await cc.deployAgent({
+                    slug: 'agent-dm',
+                    spec: agentSurfaceSpec(), // no allow_direct_messages set
+                    encrypted_env: { ...SLACK_ENV, SLACK_BOT_TOKEN: 'xoxb-agent' },
+                })
+                const res = await cc.slackPost(
+                    'agent-dm',
+                    'events',
+                    slackEvent({ eventType: 'message', channel_type: 'im', channel: 'D01', text: 'hey agent' }),
+                    SLACK_SECRET
+                )
+                expect(res.status).toBe(200)
+                expect(res.body.session_id).toBeTruthy()
+                expect(res.body.dropped).toBeUndefined()
+            } finally {
+                await cc.teardown()
+            }
+        })
+
+        it('a turn under agent_surface reports progress with native setStatus (not a simulated message)', async () => {
+            const { cc, slackCalls } = await recorderCluster({ SLACK_BOT_TOKEN: 'xoxb-agent' })
+            try {
+                cc.setScript([fauxText('here is the answer')])
+                await cc.deployAgent({
+                    slug: 'native-status',
+                    spec: agentSurfaceSpec(),
+                    encrypted_env: { ...SLACK_ENV, SLACK_BOT_TOKEN: 'xoxb-agent' },
+                })
+                const res = await cc.slackPost(
+                    'native-status',
+                    'events',
+                    slackEvent({
+                        eventType: 'app_mention',
+                        channel: 'C01',
+                        text: '<@U0BOT> help',
+                        ts: '950.0',
+                        thread_ts: '950.0',
+                    }),
+                    SLACK_SECRET
+                )
+                expect(res.status).toBe(200)
+                await cc.drain()
+
+                // Native indicator via assistant.threads.setStatus…
+                const statusCalls = slackCalls.filter((c) => c.url.endsWith('assistant.threads.setStatus'))
+                expect(statusCalls.length).toBeGreaterThanOrEqual(1)
+                expect(statusCalls[0].body).toMatchObject({ channel_id: 'C01', thread_ts: '950.0' })
+                // …and NOT the simulated status message (no "Working on it" post, no delete).
+                expect(
+                    slackCalls.filter(
+                        (c) => c.url.endsWith('chat.postMessage') && String(c.body.text).includes('Working on it')
+                    )
+                ).toHaveLength(0)
+                expect(slackCalls.filter((c) => c.url.endsWith('chat.delete'))).toHaveLength(0)
+                // The real reply still lands in the thread.
+                const replyPosts = slackCalls.filter(
+                    (c) => c.url.endsWith('chat.postMessage') && c.body.text === 'here is the answer'
+                )
+                expect(replyPosts).toHaveLength(1)
+                expect(replyPosts[0].body).toMatchObject({ channel: 'C01', thread_ts: '950.0' })
+            } finally {
+                await cc.teardown()
+            }
+        })
+    })
 })


### PR DESCRIPTION
## Problem

Connecting an agent-platform agent to Slack is a bring-your-own-app flow, and once connected the bot shows up as a plain Slack bot. Slack's June-2026 "Agent messaging experience" lets an app appear as a native, DM-able agent — with suggested starter prompts and a real "thinking" indicator that auto-clears on reply — and we weren't taking advantage of any of it. Progress was faked with a normal message that gets posted, edited, and deleted.

**Why:** we want agents to use Slack's native agent tooling and show up as an agent you can talk to, not just a bot. This is milestone 1 of that effort; a follow-up will auto-create and manage the Slack app itself so users don't have to hand-build it.

## Changes

Adds an opt-in `agent_surface` flag to the `slack` trigger config. When enabled:

- **Manifest** (`slack-manifest.ts`): emits `features.agent_view` (+ `agent_description` and fixed `suggested_prompts`), the `assistant:write` scope, the App Home Messages tab, and the `assistant_thread_started` / `app_home_opened` bot events.
- **Ingress** (`slack.ts`): handles the new lifecycle events — greets a new conversation with a welcome message and pushes suggested prompts via `assistant.threads.setSuggestedPrompts`. The agent surface is DM-first, so the flag enables DMs on its own.
- **Runner** (`slack-reply.ts` + `driver.ts`): reports progress with the native `assistant.threads.setStatus` indicator (auto-clears when the reply lands) instead of the simulated post/edit/delete status message.

Everything is gated behind `agent_surface` (default `false`), so existing bring-your-own Slack apps are byte-for-byte unaffected (verified by a back-compat manifest test). Suggested prompts / `agent_description` / `welcome_message` are new optional fields on the same trigger config.

## How did you test this code?

The agent **did not run these tests locally** — this was done in a sparse, dependency-free checkout where the JS workspace can't be installed. The tests below were added following existing patterns and are expected to run in CI:

- `slack-manifest.test.ts` — `agent_surface=true` emits `agent_view` / `assistant:write` / the new events / App Home; `agent_surface=false` stays byte-identical to today (back-compat guard); empty `agent_view` when no description/prompts.
- `slack-reply.test.ts` — native mode calls `assistant.threads.setStatus` and `clear()` is a no-op; simulated mode keeps post/update/delete; `toPlainStatus` strips emoji + markdown. Catches a regression where native status would fall back to posting/deleting a message.
- `slack-trigger.test.ts` (e2e) — `assistant_thread_started` posts welcome + prompts; `app_home_opened` (Messages tab) refreshes prompts and is ignored on the Home tab; a turn under `agent_surface` uses native `setStatus` (no simulated status message, no delete) while the reply still lands; a DM enqueues under `agent_surface` without `allow_direct_messages`. This is also the wire test for the spec → native-status plumbing.

## Docs update

No user-facing docs under `products/agent_platform/docs/` describe Slack setup today; the trigger's own JSDoc (the authored contract) was extended in `spec.ts`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by Ben White.

- Tool: PostHog Code (Claude Opus 4.8). Work started as an investigation into improving the Slack configuration and using Slack's native agent tooling, then implemented the first milestone.
- No mandatory repo skills were triggered — the change is node-side (zod spec, manifest generator, ingress/runner TypeScript); it touches no Django serializer/viewset, migration, or generated API types, so `hogli build:openapi` should be a no-op (worth confirming in CI).
- Key decision: the manifest uses `features.agent_view` (not the deprecated `assistant_view`), and suggested prompts are both set on the manifest (fixed) and pushed at runtime — matching Slack's current Agent-experience docs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
