### PR TITLE
fix(signals): load inbox usage refund summary when flag resolves late

### DIFF
--- a/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.tsx
@@ -194,7 +194,8 @@ export function InboxUsageWidget(): JSX.Element | null {
                 </div>
                 <div className="flex items-center justify-between gap-2 text-xs">
                     <Tooltip title="PRs opened by agents across your whole organization this billing period">
-                        <span className="text-secondary tabular-nums">
+                        {/* tabIndex so keyboard users can focus the count and get the org-wide scope */}
+                        <span className="text-secondary tabular-nums" tabIndex={0}>
                             <span className="font-medium text-default">{usedPrsDisplay}</span>
                             {limitPrs != null ? ` / ${limitPrs}` : ''} PRs created
                         </span>

--- a/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxUsageWidget.tsx
@@ -193,10 +193,12 @@ export function InboxUsageWidget(): JSX.Element | null {
                     )}
                 </div>
                 <div className="flex items-center justify-between gap-2 text-xs">
-                    <span className="text-secondary tabular-nums">
-                        <span className="font-medium text-default">{usedPrsDisplay}</span>
-                        {limitPrs != null ? ` / ${limitPrs}` : ''} PRs created
-                    </span>
+                    <Tooltip title="PRs opened by agents across your whole organization this billing period">
+                        <span className="text-secondary tabular-nums">
+                            <span className="font-medium text-default">{usedPrsDisplay}</span>
+                            {limitPrs != null ? ` / ${limitPrs}` : ''} PRs created
+                        </span>
+                    </Tooltip>
                     {resetDate && (
                         <span className="text-tertiary tabular-nums">Resets {resetDate.format('MMM D')}</span>
                     )}

--- a/frontend/src/scenes/inbox/logics/inboxUsageLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/inboxUsageLogic.test.ts
@@ -13,10 +13,10 @@ import { inboxUsageLogic } from './inboxUsageLogic'
 
 const CREDITS_PER_PR = 1500
 
-const mountWithUsage = async (
+const mockUsageEndpoints = (
     currentUsage: number,
     summary: Omit<SignalReportRefundSummaryResponseApi, 'credited_refund_count'>
-): Promise<ReturnType<typeof inboxUsageLogic.build>> => {
+): void => {
     useMocks({
         get: {
             '/api/billing': () => [
@@ -29,10 +29,21 @@ const mountWithUsage = async (
             ],
         },
     })
-    featureFlagLogic.mount()
+}
+
+const setRefundsFlag = (): void => {
     featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.SIGNALS_PR_REFUNDS], {
         [FEATURE_FLAGS.SIGNALS_PR_REFUNDS]: true,
     })
+}
+
+const mountWithUsage = async (
+    currentUsage: number,
+    summary: Omit<SignalReportRefundSummaryResponseApi, 'credited_refund_count'>
+): Promise<ReturnType<typeof inboxUsageLogic.build>> => {
+    mockUsageEndpoints(currentUsage, summary)
+    featureFlagLogic.mount()
+    setRefundsFlag()
     const logic = inboxUsageLogic()
     logic.mount()
     await expectLogic(logic).toFinishAllListeners()
@@ -43,6 +54,9 @@ describe('inboxUsageLogic', () => {
     let logic: ReturnType<typeof inboxUsageLogic.build> | undefined
 
     beforeEach(() => {
+        // featureFlagLogic persists to localStorage, which jsdom keeps across tests — without
+        // clearing, a flag set in one test leaks into the next test's mount-time state.
+        localStorage.clear()
         initKeaTests()
     })
 
@@ -67,5 +81,24 @@ describe('inboxUsageLogic', () => {
         })
 
         expect(logic.values.usedPrs).toBe(expectedPrs)
+    })
+
+    // The refunds flag is keyed on the organization group, so on a fresh pageload it resolves
+    // only after mount (once posthog-js registers the group and re-fetches flags). A mount-time
+    // load alone would skip the summary forever, pinning the widget to billing's lagging
+    // recorded usage until an unrelated archive re-triggered the loader.
+    it('loads the refund summary when the flag arrives after mount', async () => {
+        mockUsageEndpoints(1500, { period_billable_credits: 6000, credited_credits: 0 })
+        featureFlagLogic.mount()
+        logic = inboxUsageLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.refundSummary).toBeNull()
+        expect(logic.values.usedPrs).toBe(1)
+
+        setRefundsFlag()
+        await expectLogic(logic).toDispatchActions(['loadRefundSummarySuccess'])
+
+        expect(logic.values.usedPrs).toBe(4)
     })
 })

--- a/frontend/src/scenes/inbox/logics/inboxUsageLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/inboxUsageLogic.test.ts
@@ -97,6 +97,10 @@ describe('inboxUsageLogic', () => {
         expect(logic.values.usedPrs).toBe(1)
 
         setRefundsFlag()
+        await expectLogic(logic).toDispatchActions(['loadRefundSummary'])
+        // The already-rendered card must not collapse into a skeleton while the late-triggered
+        // summary load is in flight — the count updates in place once it lands.
+        expect(logic.values.isLoading).toBe(false)
         await expectLogic(logic).toDispatchActions(['loadRefundSummarySuccess'])
 
         expect(logic.values.usedPrs).toBe(4)

--- a/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
@@ -131,16 +131,24 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
                 billing?.products?.find((p) => p.type === INBOX_PRODUCT_TYPE) ?? null,
         ],
         isLoading: [
-            (s) => [s.billing, s.billingLoading, s.refundSummary, s.refundSummaryLoading, s.featureFlags],
-            (billing, billingLoading, refundSummary, refundSummaryLoading, featureFlags): boolean => {
+            (s) => [
+                s.billing,
+                s.billingLoading,
+                s.product,
+                s.refundSummary,
+                s.refundSummaryLoading,
+                s.refundsFlagEnabled,
+            ],
+            (billing, billingLoading, product, refundSummary, refundSummaryLoading, refundsFlagEnabled): boolean => {
                 if (billing === null && billingLoading) {
                     return true
                 }
                 // With refunds on, the PR count needs the refund summary too (live top-up +
-                // credited netting) — rendering on billing alone briefly shows the gross number.
-                return (
-                    !!featureFlags[FEATURE_FLAGS.SIGNALS_PR_REFUNDS] && refundSummary === null && refundSummaryLoading
-                )
+                // credited netting) — but only hold the skeleton while the card has nothing to
+                // show yet. Once billing has rendered a count, a summary load kicked off by the
+                // late-resolving org-keyed flag updates the number in place instead of tearing
+                // the card down into a skeleton and back.
+                return !product && refundsFlagEnabled && refundSummary === null && refundSummaryLoading
             },
         ],
         // Free plan can't raise the limit past the free allocation — the widget points to

--- a/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
+++ b/frontend/src/scenes/inbox/logics/inboxUsageLogic.ts
@@ -1,6 +1,7 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Dayjs } from 'lib/dayjs'
@@ -65,9 +66,8 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
         // contains credited-refunded PRs (the money comes back as an invoice credit, not lower
         // usage), so the widget subtracts these to show the net PR count. Excluded-path refunds
         // never reach billing usage and need no adjustment.
-        // TODO(signals): usage + refund summary are org-wide (billing allocates the free PR tier
-        // per org), but this widget renders on a project-routed page where the number can read as
-        // project usage — label it org-wide, or revisit if billing ever splits usage per project.
+        // Usage + refund summary are org-wide (billing allocates the free PR tier per org); the
+        // widget labels the count accordingly. Revisit if billing ever splits usage per project.
         refundSummary: [
             null as SignalReportRefundSummaryResponseApi | null,
             {
@@ -118,6 +118,13 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
         },
     })),
     selectors({
+        // The refunds flag is keyed on the organization group, so posthog-js only resolves it
+        // after the org group is registered and flags are re-fetched — typically after this logic
+        // has mounted. Derived here so a subscription can react to it flipping on.
+        refundsFlagEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.SIGNALS_PR_REFUNDS],
+        ],
         product: [
             (s) => [s.billing],
             (billing): BillingProductV2Type | null =>
@@ -265,10 +272,19 @@ export const inboxUsageLogic = kea<inboxUsageLogicType>([
         // listener — a plain archive just makes this a cheap no-op reload).
         [inboxBulkActionsLogic.actionTypes.reportArchived]: () => actions.loadRefundSummary(),
     })),
+    // Fires on mount and again when the org-group-keyed flag arrives after mount — a mount-time
+    // load alone silently skips the summary on pageloads where flags resolve late, leaving the
+    // widget on billing's lagging recorded usage until something else re-triggers the loader.
+    subscriptions(({ actions }) => ({
+        refundsFlagEnabled: (enabled: boolean) => {
+            if (enabled) {
+                actions.loadRefundSummary()
+            }
+        },
+    })),
     afterMount(({ actions, values }) => {
         if (!values.billing) {
             actions.loadBilling()
         }
-        actions.loadRefundSummary()
     }),
 ])


### PR DESCRIPTION
## Problem

The inbox PR usage counter shows inconsistent numbers. On a fresh pageload it shows a small number that reads as a personal or per-project count, but after refunding a PR it jumps to the live org-wide count, then reverts on the next refresh.

**Why:** raised while dogfooding the inbox refund flow ([#69066](https://github.com/PostHog/posthog/pull/69066)) - the counter appeared to switch between "personal" and organization data depending on whether a refund had just happened.

Two things stack up here:

1. **The flag race (fixed in this PR).** `signals-pr-refunds` is keyed on the organization group, so on a fresh pageload posthog-js resolves it only after the org group is registered and flags are re-fetched - after `inboxUsageLogic` has mounted. The mount-time `loadRefundSummary()` sees the flag as off and skips, and nothing re-triggers it when flags arrive. The org-wide live count (`period_billable_credits`) therefore only appears once an archive/refund action reloads the summary. Production `$feature_flag_called` events confirm the first read per pageload flips between true and false for users the flag is enabled for.
2. **Why the fallback number looks "personal".** Without the summary, the widget falls back to the billing product's `current_usage`, which is billing-recorded usage plus the posthog-side `todays_usage` top-up. For the affected org the billing service currently returns no recorded signals usage for the period (despite nightly usage reports being sent since the product launched), so the fallback collapses to just today's org-wide PR count - a small number that can coincide with a user's personal PR count. That billing-side gap is out of scope here and worth a separate look; with this fix the widget always fetches the live period count, so the max() masks it for this surface.

## Changes

- `inboxUsageLogic` now loads the refund summary via a kea subscription on a derived flag-enabled selector - fires on mount and again when the org-group-keyed flag flips on, so the widget shows the live org-wide count regardless of flag timing.
- The counter gets a tooltip labelling it as organization-wide for the current billing period (resolves the existing TODO about the number reading as project usage). The trigger is focusable (`tabIndex`) so keyboard users can open it.

## How did you test this code?

- Added one Jest case to `inboxUsageLogic.test.ts`: mounts with the flag absent, then delivers it, and asserts the summary loads and the PR count switches from recorded-only to the live max. Catches the exact regression fixed here (removing the flag-arrival reload path silently pins the widget to stale usage); no existing test covered late flag delivery - they all set flags before mount.
- Ran the full `inboxUsageLogic` Jest suite (5 passed) and kea typegen for the touched logic. `hogli ci:preflight --fix` clean.
- Could not run the whole-repo `typescript:check` meaningfully in this sandbox (generated kea `*Type.ts` files are absent repo-wide); CI covers it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs page covers the inbox usage widget yet; behavior change is a bug fix behind the existing flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude). Skills invoked: `/writing-tests`. Investigation traced the widget's data sources (billing `current_usage`, refund-summary endpoint) to confirm both are already org-scoped, then used production `$feature_flag_called` analytics to prove the flag's first read per pageload is nondeterministic for org-group-keyed flags, which pinpointed the mount-time race. Later verified via `organization usage report` events that nightly signals usage HAS been reported daily since launch, while the billing API returns no recorded signals usage - pinning the "personal-looking" fallback number to the todays-usage-only term. Considered dropping the client-side flag gate and tolerating the endpoint's 404 instead, but kept the gate plus a subscription to avoid firing the request for every org without the feature.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
