### PR TITLE
feat(self-driving): Fix scout linking on report

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
@@ -158,9 +158,10 @@ function MetaSourceStack({
         return null
     }
     // Name the authoring scout on a scout-authored report so it's clear at a glance who wrote it,
-    // and link the name straight to the scout's detail page.
+    // and link the name straight to the scout's detail page. The scout may not sort first among mixed
+    // sources, so key off whether any source is a scout rather than just the primary.
     const scoutName = scoutDisplayName(scoutSkillName)
-    const showScout = primary.key === SignalSourceProduct.SignalsScout && !!scoutName
+    const showScout = entries.some(({ key }) => key === SignalSourceProduct.SignalsScout) && !!scoutName
     return (
         <Tooltip title={sourceProductsTooltipTitle(entries)}>
             <span className="inline-flex items-center gap-1.5 min-w-0 cursor-help">


### PR DESCRIPTION
## ~~Problem~~

~~The inbox report detail scene names which scout authored a report, but only as plain text. There was no way to jump from a report to the scout that created it, even though we have a scout detail page, as experienced by @pauldambra.~~

## ~~Changes~~

~~In the report detail meta line, the scout name on a scout-authored report now links through to the scout's detail page.~~

Actually, someone already _just_ did this in another PR, so just fixing the way we detect the scout here.
