### PR TITLE
feat(ingestion): improve control plane UI for large deployments

### DIFF
--- a/rust/ingestion-control-plane/src/ui/consumer_debug.html
+++ b/rust/ingestion-control-plane/src/ui/consumer_debug.html
@@ -65,8 +65,9 @@
       .tab.active { color: var(--text); background: var(--panel-2); border-color: var(--border); }
       .tab .badge { color: var(--muted); font-family: var(--mono); font-size: 11px; margin-left: 4px; }
 
-      /* live feed */
-      #feed { max-height: calc(100vh - 190px); overflow-y: auto; font-family: var(--mono); font-size: 12px; }
+      /* live feed: a bounded tail — fixed height, not vh-based, so it stays
+         stable when the page is embedded in an auto-sizing iframe. */
+      #feed { max-height: 600px; overflow-y: auto; font-family: var(--mono); font-size: 12px; }
       .ev { padding: 5px 14px; border-bottom: 1px solid var(--border); display: flex; gap: 10px; align-items: baseline; }
       .ev .t { color: var(--muted); flex: 0 0 62px; font-size: 11px; }
       .ev .body { flex: 1 1 auto; word-break: break-word; }
@@ -80,8 +81,9 @@
       .controls { display: flex; gap: 8px; align-items: center; }
       .controls label { color: var(--muted); font-size: 11px; }
 
-      /* batches list */
-      #batches-view { max-height: calc(100vh - 190px); overflow-y: auto; }
+      /* batches list: grows with content — the page (or embedding iframe)
+         expands instead of squeezing the list into an inner scroll box. */
+      #batches-view { overflow-y: visible; }
       .brow { display: grid; grid-template-columns: 96px 90px 1fr auto; gap: 10px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--border); cursor: pointer; }
       .brow:hover { background: var(--panel-2); }
       .brow .id { font-family: var(--mono); color: #d2a8ff; }
@@ -132,7 +134,7 @@
       .banner { margin: 12px 14px 0; padding: 8px 12px; border-radius: 6px; font-size: 12px; }
       .banner.ok { background: rgba(63,185,80,0.12); color: var(--good); }
       .banner.bad { background: rgba(248,81,73,0.14); color: var(--error); font-weight: 600; }
-      #commits { max-height: calc(100vh - 240px); overflow-y: auto; }
+      #commits { overflow-y: visible; }
       tr.ooo td { background: rgba(248,81,73,0.12); }
       .offchips { display: flex; flex-wrap: wrap; gap: 6px; }
       .offchip { display: inline-flex; align-items: baseline; gap: 6px; padding: 2px 8px; border-radius: 6px;

--- a/rust/ingestion-control-plane/src/ui/index.html
+++ b/rust/ingestion-control-plane/src/ui/index.html
@@ -76,6 +76,20 @@
       }
       button:hover { border-color: var(--accent); }
       button:disabled { opacity: 0.5; cursor: default; }
+      button:disabled:hover { border-color: var(--border); }
+      input.search {
+        background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+        border-radius: 6px; padding: 5px 10px; font-size: 12px; font-family: inherit; width: 240px;
+      }
+      input.search:focus { outline: none; border-color: var(--accent); }
+      .toolbar { border-bottom: 1px solid var(--border); }
+      .toolbar .count { margin-left: auto; }
+      .pager { border-top: 1px solid var(--border); justify-content: flex-end; }
+      .ns-head {
+        font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted);
+        margin: 0; padding: 12px 14px 6px; display: flex; align-items: baseline; gap: 8px;
+      }
+      .ns-head .ns { color: var(--text); font-family: var(--mono); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
       button.small { padding: 2px 8px; font-size: 11px; }
       .muted { color: var(--muted); }
       .mono { font-family: var(--mono); }
@@ -107,7 +121,9 @@
       .hist-row .hbar { height: 10px; border-radius: 2px; background: var(--accent); }
       .hist-row .hcnt { color: var(--muted); font-family: var(--mono); }
 
-      iframe.debug { width: 100%; height: calc(100vh - 300px); border: 0; background: var(--bg); display: block; }
+      /* Height is driven by the embedded document (same-origin), so the panel
+         expands to fit the debug UI instead of squeezing it into a viewport box. */
+      iframe.debug { width: 100%; min-height: 480px; border: 0; background: var(--bg); display: block; }
     </style>
   </head>
   <body>
@@ -128,6 +144,8 @@
         for (const [k, v] of Object.entries(attrs)) {
           if (k === "class") node.className = v;
           else if (k.startsWith("on")) node.addEventListener(k.slice(2), v);
+          else if (v === false || v === null || v === undefined) continue;
+          else if (v === true) node.setAttribute(k, "");
           else node.setAttribute(k, v);
         }
         for (const child of children.flat()) {
@@ -153,6 +171,48 @@
       const copy = (text) => navigator.clipboard && navigator.clipboard.writeText(text);
       const copyable = (text, cls) =>
         el("span", { class: cls, title: `${text} (click to copy)`, onclick: () => copy(text) }, text);
+
+      // Client-side search + pagination over an in-memory row list. The search
+      // input is kept stable across re-renders so typing survives refreshes.
+      function listView({ placeholder, pageSize, matches, renderTable, emptyText }) {
+        let rows = [];
+        const state = { query: "", page: 0 };
+        const body = el("div", {});
+        const count = el("span", { class: "muted mono count" });
+        const search = el("input", {
+          type: "search", class: "search", placeholder,
+          oninput: () => { state.query = search.value.trim().toLowerCase(); state.page = 0; render(); },
+        });
+        const toolbar = el("div", { class: "row toolbar" }, search, count);
+
+        function render() {
+          const filtered = state.query ? rows.filter((row) => matches(row, state.query)) : rows;
+          const pages = Math.max(1, Math.ceil(filtered.length / pageSize));
+          state.page = Math.min(state.page, pages - 1);
+          const pageRows = filtered.slice(state.page * pageSize, (state.page + 1) * pageSize);
+          count.textContent = state.query ? `${fmtInt(filtered.length)} of ${fmtInt(rows.length)}` : fmtInt(rows.length);
+          const children = [toolbar];
+          if (!pageRows.length) {
+            children.push(el("div", { class: "empty" }, state.query ? "No matches." : emptyText));
+          } else {
+            children.push(renderTable(pageRows));
+          }
+          if (pages > 1) {
+            children.push(el("div", { class: "row pager" },
+              el("button", { class: "small", disabled: state.page === 0, onclick: () => { state.page--; render(); } }, "‹ prev"),
+              el("span", { class: "muted mono" }, `page ${state.page + 1} / ${pages}`),
+              el("button", { class: "small", disabled: state.page >= pages - 1, onclick: () => { state.page++; render(); } }, "next ›")));
+          }
+          body.replaceChildren(...children);
+        }
+
+        return {
+          body,
+          setRows(next) { rows = next; render(); },
+          rerender: render,
+          reset() { search.value = ""; state.query = ""; state.page = 0; },
+        };
+      }
 
       // Section registry: extending the tool = appending an entry here.
       const SECTIONS = [];
@@ -195,6 +255,21 @@
           const analysisTitle = el("span", {}, "Analysis");
           const analysisBody = el("div", {}, el("div", { class: "empty" }, "Start an analysis from a partition row: head reads from the group's committed offset, tail samples the newest messages."));
 
+          this.overviewView = listView({
+            placeholder: "Filter by group or topic…",
+            pageSize: 25,
+            matches: (row, q) => row.group.toLowerCase().includes(q) || row.topic.toLowerCase().includes(q),
+            renderTable: (rows) => this.renderOverviewTable(rows),
+            emptyText: "No consumer targets configured.",
+          });
+          this.partitionsView = listView({
+            placeholder: "Filter by partition…",
+            pageSize: 100,
+            matches: (p, q) => String(p.partition).includes(q),
+            renderTable: (rows) => this.renderPartitionsTable(rows),
+            emptyText: "No partitions.",
+          });
+
           this.ui = { overviewBody, overviewFetchedAt, partitionsTitle, partitionsBody, analysisTitle, analysisBody };
 
           root.append(
@@ -215,46 +290,48 @@
           const { overviewBody, overviewFetchedAt } = this.ui;
           try {
             const data = await fetchJSON("api/lag/overview");
-            const rows = data.groups;
             overviewFetchedAt.textContent = `as of ${new Date(data.fetched_at).toLocaleTimeString()}`;
-            if (!rows.length) {
-              overviewBody.replaceChildren(el("div", { class: "empty" }, "No consumer targets configured."));
-              return;
-            }
-            const maxLag = Math.max(1, ...rows.map((r) => r.total_lag));
-            overviewBody.replaceChildren(
-              el("table", {},
-                el("thead", {}, el("tr", {},
-                  el("th", {}, "group"), el("th", {}, "topic"), el("th", {}, "partitions"),
-                  el("th", {}, "lagging"), el("th", {}, "total lag"), el("th", {}, ""))),
-                el("tbody", {}, rows.map((row) =>
-                  row.error
-                    ? el("tr", {},
-                        el("td", { class: "mono" }, row.group),
-                        el("td", { class: "mono" }, row.topic),
-                        el("td", { colspan: "4" }, el("span", { class: "pill bad", title: row.error }, "scan failed")))
-                    : el("tr", { class: `clickable ${this.selectedTarget && row.group === this.selectedTarget.group && row.topic === this.selectedTarget.topic ? "selected" : ""}`, onclick: () => this.selectTarget(row) },
-                        el("td", { class: "mono" }, row.group),
-                        el("td", { class: "mono" }, row.topic),
-                        el("td", { class: "mono" }, fmtInt(row.partitions)),
-                        el("td", {}, row.lagging_partitions > 0
-                          ? el("span", { class: "pill warn" }, fmtInt(row.lagging_partitions))
-                          : el("span", { class: "pill good" }, "0")),
-                        el("td", { class: "mono" }, fmtInt(row.total_lag)),
-                        el("td", {}, row.total_lag > 0
-                          ? el("span", { class: `bar ${row.total_lag > maxLag * 0.66 ? "hot" : row.total_lag > maxLag * 0.33 ? "warm" : ""}`, style: `width:${Math.max(2, (row.total_lag / maxLag) * 140)}px` })
-                          : null))
-                ))
-              )
-            );
+            this.overviewMaxLag = Math.max(1, ...data.groups.map((r) => r.total_lag ?? 0));
+            this.overviewView.setRows(data.groups);
+            overviewBody.replaceChildren(this.overviewView.body);
           } catch (e) {
             overviewBody.replaceChildren(el("div", { class: "error-box" }, String(e)));
           }
         },
 
+        // Heat bars are scaled against the full result set, not the visible page,
+        // so paging/filtering does not recalibrate the colors.
+        renderOverviewTable(rows) {
+          const maxLag = this.overviewMaxLag;
+          return el("table", {},
+            el("thead", {}, el("tr", {},
+              el("th", {}, "group"), el("th", {}, "topic"), el("th", {}, "partitions"),
+              el("th", {}, "lagging"), el("th", {}, "total lag"), el("th", {}, ""))),
+            el("tbody", {}, rows.map((row) =>
+              row.error
+                ? el("tr", {},
+                    el("td", { class: "mono" }, row.group),
+                    el("td", { class: "mono" }, row.topic),
+                    el("td", { colspan: "4" }, el("span", { class: "pill bad", title: row.error }, "scan failed")))
+                : el("tr", { class: `clickable ${this.selectedTarget && row.group === this.selectedTarget.group && row.topic === this.selectedTarget.topic ? "selected" : ""}`, onclick: () => this.selectTarget(row) },
+                    el("td", { class: "mono" }, row.group),
+                    el("td", { class: "mono" }, row.topic),
+                    el("td", { class: "mono" }, fmtInt(row.partitions)),
+                    el("td", {}, row.lagging_partitions > 0
+                      ? el("span", { class: "pill warn" }, fmtInt(row.lagging_partitions))
+                      : el("span", { class: "pill good" }, "0")),
+                    el("td", { class: "mono" }, fmtInt(row.total_lag)),
+                    el("td", {}, row.total_lag > 0
+                      ? el("span", { class: `bar ${row.total_lag > maxLag * 0.66 ? "hot" : row.total_lag > maxLag * 0.33 ? "warm" : ""}`, style: `width:${Math.max(2, (row.total_lag / maxLag) * 140)}px` })
+                      : null))
+            ))
+          );
+        },
+
         selectTarget(target) {
           this.selectedTarget = { group: target.group, topic: target.topic };
-          this.refreshOverview();
+          this.overviewView.rerender();
+          this.partitionsView.reset();
           this.refreshPartitions();
         },
 
@@ -265,33 +342,37 @@
           partitionsBody.replaceChildren(el("div", { class: "empty" }, "Scanning…"));
           try {
             const data = await fetchJSON(`api/lag?group=${encodeURIComponent(this.selectedTarget.group)}&topic=${encodeURIComponent(this.selectedTarget.topic)}`);
-            const maxLag = Math.max(1, ...data.partitions.map((p) => p.lag));
-            partitionsBody.replaceChildren(
-              el("table", {},
-                el("thead", {}, el("tr", {},
-                  el("th", {}, "partition"), el("th", {}, "low"), el("th", {}, "high"),
-                  el("th", {}, "committed"), el("th", {}, "lag"), el("th", {}, ""), el("th", {}, "analyze"))),
-                el("tbody", {}, data.partitions.map((p) => {
-                  const width = Math.max(2, Math.round((p.lag / maxLag) * 140));
-                  const heat = p.lag === 0 ? "" : p.lag > maxLag * 0.66 ? "hot" : p.lag > maxLag * 0.33 ? "warm" : "";
-                  return el("tr", {},
-                    el("td", { class: "mono" }, String(p.partition)),
-                    el("td", { class: "mono" }, fmtInt(p.low_watermark)),
-                    el("td", { class: "mono" }, fmtInt(p.high_watermark)),
-                    el("td", { class: "mono" }, p.committed_offset === null ? "–" : fmtInt(p.committed_offset)),
-                    el("td", { class: "mono" }, fmtInt(p.lag)),
-                    el("td", {}, p.lag > 0 ? el("span", { class: `bar ${heat}`, style: `width:${width}px` }) : null),
-                    el("td", {},
-                      el("button", { class: "small", onclick: () => this.startAnalysis(p.partition, "committed") }, "head"),
-                      " ",
-                      el("button", { class: "small", onclick: () => this.startAnalysis(p.partition, "tail") }, "tail"))
-                  );
-                }))
-              )
-            );
+            this.partitionsMaxLag = Math.max(1, ...data.partitions.map((p) => p.lag));
+            this.partitionsView.setRows(data.partitions);
+            partitionsBody.replaceChildren(this.partitionsView.body);
           } catch (e) {
             partitionsBody.replaceChildren(el("div", { class: "error-box" }, String(e)));
           }
+        },
+
+        renderPartitionsTable(partitions) {
+          const maxLag = this.partitionsMaxLag;
+          return el("table", {},
+            el("thead", {}, el("tr", {},
+              el("th", {}, "partition"), el("th", {}, "low"), el("th", {}, "high"),
+              el("th", {}, "committed"), el("th", {}, "lag"), el("th", {}, ""), el("th", {}, "analyze"))),
+            el("tbody", {}, partitions.map((p) => {
+              const width = Math.max(2, Math.round((p.lag / maxLag) * 140));
+              const heat = p.lag === 0 ? "" : p.lag > maxLag * 0.66 ? "hot" : p.lag > maxLag * 0.33 ? "warm" : "";
+              return el("tr", {},
+                el("td", { class: "mono" }, String(p.partition)),
+                el("td", { class: "mono" }, fmtInt(p.low_watermark)),
+                el("td", { class: "mono" }, fmtInt(p.high_watermark)),
+                el("td", { class: "mono" }, p.committed_offset === null ? "–" : fmtInt(p.committed_offset)),
+                el("td", { class: "mono" }, fmtInt(p.lag)),
+                el("td", {}, p.lag > 0 ? el("span", { class: `bar ${heat}`, style: `width:${width}px` }) : null),
+                el("td", {},
+                  el("button", { class: "small", onclick: () => this.startAnalysis(p.partition, "committed") }, "head"),
+                  " ",
+                  el("button", { class: "small", onclick: () => this.startAnalysis(p.partition, "tail") }, "tail"))
+              );
+            }))
+          );
         },
 
         // One analysis at a time: starting a new one cancels and replaces the current.
@@ -444,18 +525,31 @@
               podsBody.replaceChildren(el("div", { class: "empty" }, "No matching pods found."));
               return;
             }
+            // One group per namespace: each ingestion lane deploys into its own.
+            const byNamespace = new Map();
+            for (const pod of data.pods) {
+              const ns = pod.namespace || "–";
+              if (!byNamespace.has(ns)) byNamespace.set(ns, []);
+              byNamespace.get(ns).push(pod);
+            }
             podsBody.replaceChildren(
-              el("table", {},
-                el("thead", {}, el("tr", {}, el("th", {}, "pod"), el("th", {}, "namespace"), el("th", {}, "ip"), el("th", {}, "phase"), el("th", {}, "restarts"), el("th", {}, "started"))),
-                el("tbody", {}, data.pods.map((pod) =>
-                  el("tr", { class: `clickable ${pod.name === this.selectedPod ? "selected" : ""}`, onclick: () => this.selectPod(pod) },
-                    el("td", { class: "mono" }, pod.name),
-                    el("td", {}, pod.namespace || "–"),
-                    el("td", { class: "mono" }, pod.ip || "–"),
-                    el("td", {}, el("span", { class: `pill ${pod.ready ? "good" : "warn"}` }, pod.phase || "?")),
-                    el("td", { class: "mono" }, String(pod.restarts)),
-                    el("td", { class: "muted mono" }, pod.started_at ? new Date(pod.started_at).toLocaleString() : "–"))
-                ))
+              ...[...byNamespace.entries()].map(([ns, pods]) =>
+                el("div", {},
+                  el("h3", { class: "ns-head" },
+                    el("span", { class: "ns" }, ns),
+                    el("span", {}, `${pods.length} pod${pods.length === 1 ? "" : "s"}`)),
+                  el("table", {},
+                    el("thead", {}, el("tr", {}, el("th", {}, "pod"), el("th", {}, "ip"), el("th", {}, "phase"), el("th", {}, "restarts"), el("th", {}, "started"))),
+                    el("tbody", {}, pods.map((pod) =>
+                      el("tr", { class: `clickable ${pod.name === this.selectedPod ? "selected" : ""}`, onclick: () => this.selectPod(pod) },
+                        el("td", { class: "mono" }, pod.name),
+                        el("td", { class: "mono" }, pod.ip || "–"),
+                        el("td", {}, el("span", { class: `pill ${pod.ready ? "good" : "warn"}` }, pod.phase || "?")),
+                        el("td", { class: "mono" }, String(pod.restarts)),
+                        el("td", { class: "muted mono" }, pod.started_at ? new Date(pod.started_at).toLocaleString() : "–"))
+                    ))
+                  )
+                )
               )
             );
           } catch (e) {
@@ -471,8 +565,23 @@
             el("div", { class: "panel" },
               el("h2", {}, `Debug — ${pod.name}`,
                 el("a", { href: url, target: "_blank", style: "color: var(--accent); font-size: 11px; text-transform: none; letter-spacing: 0" }, "open in new tab ↗")),
-              el("iframe", { class: "debug", src: url }))
+              el("iframe", { class: "debug", src: url, onload: (e) => this.autosize(e.target) }))
           );
+        },
+
+        // Grow the iframe to fit the embedded debug page (same-origin via our
+        // proxy) so the outer page scrolls instead of nesting a scrollbar.
+        autosize(frame) {
+          const doc = frame.contentDocument;
+          if (!doc || !doc.body) return;
+          // Measure the body, not documentElement: the latter is floored at the
+          // iframe's own height, which would let the frame grow but never shrink.
+          const resize = () => {
+            if (!frame.isConnected) return;
+            frame.style.height = `${Math.max(480, doc.body.scrollHeight)}px`;
+          };
+          resize();
+          new ResizeObserver(resize).observe(doc.body);
         },
       };
 

--- a/rust/ingestion-control-plane/src/ui/index.html
+++ b/rust/ingestion-control-plane/src/ui/index.html
@@ -577,11 +577,19 @@
           // Measure the body, not documentElement: the latter is floored at the
           // iframe's own height, which would let the frame grow but never shrink.
           const resize = () => {
-            if (!frame.isConnected) return;
             frame.style.height = `${Math.max(480, doc.body.scrollHeight)}px`;
           };
+          // Disconnect once the frame is replaced so switching pods doesn't
+          // accumulate observers retaining detached iframe documents.
+          const observer = new ResizeObserver(() => {
+            if (!frame.isConnected) {
+              observer.disconnect();
+              return;
+            }
+            resize();
+          });
           resize();
-          new ResizeObserver(resize).observe(doc.body);
+          observer.observe(doc.body);
         },
       };
 


### PR DESCRIPTION
## Problem

The control plane UI doesn't scale to our larger deployments. Some topics have 1000 partitions, so the lagging partitions table becomes one giant unnavigable list, and the consumer groups table is heading the same way. The consumer debug pod list mixes pods from every ingestion lane into one flat table. And the per-pod debug view (batches, commits) is squeezed into a fixed-height iframe with nested scrollbars instead of the page expanding to fit the data.

## Changes

- Add a reusable client-side search + pagination widget (`listView`) to the lag section. The consumer groups table filters by group or topic (25 per page), the partitions table filters by partition number (100 per page). The search input survives refreshes, and lag heat bars stay scaled against the full result set so paging doesn't recalibrate the colors.
- Group consumer debug pods by namespace, one section per ingestion lane, instead of a flat table with a namespace column.
- Auto-size the pod debug iframe to its content via a `ResizeObserver` (same origin through the control plane's proxy), so the outer page scrolls naturally instead of nesting scrollbars.
- In the embedded debug page, let the batches and commits views grow with their content instead of clamping to `100vh` (which inside an iframe is the iframe's height, hence the squeeze). The live feed keeps a bounded 600px tail, decoupled from `vh` so it can't feed back into the iframe auto-sizing.

## How did you test this code?

This is browser-only vanilla JS with no test harness, so I verified it by extracting the inline script and running `node --check` for syntax, plus a DOM-stub unit test exercising `listView` end to end (paging through 1000 partitions, substring search, empty states, page clamping when the row set shrinks, filter reset). I was not able to run the UI against a live control plane in this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal debug tooling, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. José described the three pain points (huge partition lists, lanes mixed together, the batches view fitting its container instead of the container expanding) and I (Claude) implemented them. Notable decisions: heat bars scale against the full dataset rather than the visible page; the iframe auto-size measures `body.scrollHeight` rather than `documentElement.scrollHeight` because the latter is floored at the iframe's own height and would let the frame grow but never shrink; the live feed got a fixed pixel height instead of growing unbounded, since a `vh`-based clamp inside an auto-sizing iframe is a feedback loop.
