### PR TITLE
feat(conversations): attribute nudge classifier generations in traces

### DIFF
--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -732,6 +732,16 @@ class TestSlackNudge(BaseTest):
         assert event_props["classifier_verdict"] == expected_verdict
         assert event_props["llm_classifier_used"] is (expected_verdict in ("yes", "no"))
 
+        # The generation itself must carry attribution: a span name for the traces view and
+        # the same Slack keys as the funnel events, so a generation joins to its outcome.
+        create_kwargs = mock_get_llm_client.return_value.chat.completions.create.call_args.kwargs
+        assert create_kwargs["extra_headers"] == {
+            "x-posthog-property-feature": "slack_nudge_classifier",
+            "x-posthog-property-$ai_span_name": "slack_nudge_classifier",
+            "x-posthog-property-slack_channel_id": "C_OTHER",
+            "x-posthog-property-slack_thread_ts": "1700000000.000100",
+        }
+
     @override_settings(TEST=False, LLM_GATEWAY_URL="http://gateway.local", LLM_GATEWAY_API_KEY="test-key")
     @patch(f"{MODULE}.posthoganalytics.feature_enabled", return_value=True)
     @patch("posthog.llm.gateway_client.get_llm_client")

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -732,8 +732,7 @@ class TestSlackNudge(BaseTest):
         assert event_props["classifier_verdict"] == expected_verdict
         assert event_props["llm_classifier_used"] is (expected_verdict in ("yes", "no"))
 
-        # The generation itself must carry attribution: a span name for the traces view and
-        # the same Slack keys as the funnel events, so a generation joins to its outcome.
+        # The generation must carry the funnel events' Slack keys so it joins to its outcome.
         create_kwargs = mock_get_llm_client.return_value.chat.completions.create.call_args.kwargs
         assert create_kwargs["extra_headers"] == {
             "x-posthog-property-feature": "slack_nudge_classifier",

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -702,7 +702,7 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
         # click "Open ticket" (handled by the interactivity endpoint). Heuristics
         # keep us from pestering the whole channel.
         if settings_dict.get("slack_nudge_enabled", True):
-            decision = _should_send_nudge(team, channel, slack_user_id, text, blocks, files)
+            decision = _should_send_nudge(team, channel, slack_user_id, text, blocks, files, message_ts or "")
             if decision.send:
                 post_ticket_confirmation_prompt(
                     team=team,
@@ -836,7 +836,9 @@ def _is_nudge_classifier_flag_enabled(team: Team) -> bool:
         return False
 
 
-def _nudge_classifier_verdict(team: Team, text: str, files: list[dict] | None) -> NudgeClassifierVerdict:
+def _nudge_classifier_verdict(
+    team: Team, text: str, files: list[dict] | None, channel: str, message_ts: str
+) -> NudgeClassifierVerdict:
     """Final nudge gate: ask a cheap LLM whether the message reads like a genuine support
     request rather than channel chatter.
 
@@ -867,6 +869,16 @@ def _nudge_classifier_verdict(team: Team, text: str, files: list[dict] | None) -
     content = (text or "")[:NUDGE_CLASSIFIER_MAX_TEXT_CHARS]
     if files:
         content += f"\n\n[the message has {len(files)} file attachment(s)]"
+    # $ai_span_name names the generation in the AI observability traces view; the slack_*
+    # keys mirror the nudge funnel events (nudge_event_properties) so a generation joins to
+    # its outcome (sent / clicked / dismissed) on slack_thread_ts.
+    attribution_headers = {
+        "x-posthog-property-feature": "slack_nudge_classifier",
+        "x-posthog-property-$ai_span_name": "slack_nudge_classifier",
+        "x-posthog-property-slack_channel_id": channel,
+    }
+    if message_ts:
+        attribution_headers["x-posthog-property-slack_thread_ts"] = message_ts
     try:
         client = get_llm_client(product="conversations", team_id=team_id)
         response = client.chat.completions.create(
@@ -875,7 +887,7 @@ def _nudge_classifier_verdict(team: Team, text: str, files: list[dict] | None) -
             temperature=0,
             timeout=NUDGE_CLASSIFIER_TIMEOUT_SECONDS,
             user=f"team-{team_id}",
-            extra_headers={"x-posthog-property-feature": "slack_nudge_classifier"},
+            extra_headers=attribution_headers,
             messages=[
                 {"role": "system", "content": NUDGE_CLASSIFIER_SYSTEM_PROMPT},
                 {"role": "user", "content": content},
@@ -902,6 +914,7 @@ def _should_send_nudge(
     text: str,
     blocks: list[dict] | None,
     files: list[dict] | None,
+    message_ts: str,
 ) -> NudgeDecision:
     """Heuristics to avoid pestering the channel: nudge only external users on substantive
     messages, skipping anyone recently nudged/dismissed or who @mentioned the bot (which
@@ -935,7 +948,7 @@ def _should_send_nudge(
     # message from a chatty author re-runs the classifier, unbounded; with it, the cadence
     # is what the pre-classifier nudge already established: one evaluation per
     # user/channel per window.
-    verdict = _nudge_classifier_verdict(team, text, files)
+    verdict = _nudge_classifier_verdict(team, text, files, channel, message_ts)
     if verdict == "no":
         suppress_nudge(team_id, channel, slack_user_id, NUDGE_COOLDOWN_TTL)
         return NudgeDecision(send=False, classifier_verdict=verdict)

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -756,6 +756,8 @@ def _is_trivial_message(text: str, files: list[dict] | None) -> bool:
 # package's __init__ pulls in the whole Temporal workflow surface). Must stay in the gateway's
 # `conversations` product allowlist (services/llm-gateway/src/llm_gateway/products/config.py).
 NUDGE_CLASSIFIER_MODEL = "claude-haiku-4-5"
+# Both the feature tag and the $ai_span_name on captured generations — they must stay equal.
+NUDGE_CLASSIFIER_FEATURE = "slack_nudge_classifier"
 # Bound the call so a slow gateway can't stall Slack event processing on the Celery worker.
 NUDGE_CLASSIFIER_TIMEOUT_SECONDS = 10
 # A yes/no read doesn't get better past this much text; cap what we send.
@@ -869,16 +871,6 @@ def _nudge_classifier_verdict(
     content = (text or "")[:NUDGE_CLASSIFIER_MAX_TEXT_CHARS]
     if files:
         content += f"\n\n[the message has {len(files)} file attachment(s)]"
-    # $ai_span_name names the generation in the AI observability traces view; the slack_*
-    # keys mirror the nudge funnel events (nudge_event_properties) so a generation joins to
-    # its outcome (sent / clicked / dismissed) on slack_thread_ts.
-    attribution_headers = {
-        "x-posthog-property-feature": "slack_nudge_classifier",
-        "x-posthog-property-$ai_span_name": "slack_nudge_classifier",
-        "x-posthog-property-slack_channel_id": channel,
-    }
-    if message_ts:
-        attribution_headers["x-posthog-property-slack_thread_ts"] = message_ts
     try:
         client = get_llm_client(product="conversations", team_id=team_id)
         response = client.chat.completions.create(
@@ -887,7 +879,13 @@ def _nudge_classifier_verdict(
             temperature=0,
             timeout=NUDGE_CLASSIFIER_TIMEOUT_SECONDS,
             user=f"team-{team_id}",
-            extra_headers=attribution_headers,
+            # slack_* keys mirror nudge_event_properties so a generation joins its funnel outcome.
+            extra_headers={
+                "x-posthog-property-feature": NUDGE_CLASSIFIER_FEATURE,
+                "x-posthog-property-$ai_span_name": NUDGE_CLASSIFIER_FEATURE,
+                "x-posthog-property-slack_channel_id": channel,
+                "x-posthog-property-slack_thread_ts": message_ts,
+            },
             messages=[
                 {"role": "system", "content": NUDGE_CLASSIFIER_SYSTEM_PROMPT},
                 {"role": "user", "content": content},


### PR DESCRIPTION
## Problem

The Slack nudge LLM classifier went live today and its `$ai_generation` events show up as "Unnamed" in the [AI observability traces view](https://us.posthog.com/project/2/ai-observability/traces), with no property tying a generation to the nudge it gated. Reviewing classifier decisions (the whole point of the trial) means manually cross-referencing timestamps.

## Changes

All via the gateway's `x-posthog-property-*` header mechanism the call already uses for its `feature` tag:

- `$ai_span_name: slack_nudge_classifier`, so traces are named and filterable. The gateway merges caller property headers into the captured event and only re-asserts `ai_product`, `$ai_billable`, `$ai_effort`, and `team_id` as spoof-proof, so a `$`-prefixed name passes through:

https://github.com/PostHog/posthog/blob/79cffa79ea1667556e5e37e07d6cca8e21903fa8/services/llm-gateway/src/llm_gateway/callbacks/posthog.py#L75-L83

- `slack_channel_id` and `slack_thread_ts`, the same keys the nudge funnel events carry, so a generation joins directly to its outcome (`support nudge sent` / `open ticket clicked` / `dismissed`) in SQL. This adopts the ai_reply pipeline's convention of stamping the domain join key on the generation:

https://github.com/PostHog/posthog/blob/79cffa79ea1667556e5e37e07d6cca8e21903fa8/products/conversations/backend/temporal/ai_reply/llms.py#L16-L29

- Threads `message_ts` through `_should_send_nudge` into `_nudge_classifier_verdict` so the keys are available at the call site.

No behavior change to the nudge itself, only event attribution.

## How did you test this code?

I (or, actually Claude) extended the existing parameterized gate test to assert the exact outbound `extra_headers`. The regression it catches that nothing previously did: a refactor dropping or renaming the attribution headers would silently un-name traces and break the generation-to-outcome join, with every other test still green.

Ran: `ruff check` + `format`, byte-compile of both files, and `pytest --collect-only` (67 tests collect, so the full import chain resolves the new signatures). The agent sandbox had no container runtime today, so Claude could not execute the Django suite locally. CI has since run it: the full backend suite is green (Django Tests Pass), including the extended gate test, plus mypy and ruff via Python code quality checks. Both call sites of the re-signed functions were grep-verified (there are exactly two, both updated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, internal instrumentation only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude (PostHog Code) to add the span name and survey other gateway callers for properties we might be missing. The survey found three classes in use: the `team_id` default header (already set), a product tag (`feature` here, `ai_stage`/`source_product` in signals, already set), and a domain join key (`ticket_id` in ai_reply, adopted here as the Slack keys). One idea was considered and rejected: deterministic per-message trace grouping via `metadata.user_id`, which ai_reply uses natively on the Anthropic client. Support for a caller-supplied `metadata` body param on the OpenAI-compat path is unverified in the gateway, and a rejected request body would degrade a live prod feature for a nice-to-have, so trace-per-call stays. Skills invoked: /writing-tests. Tools: gh CLI, ruff, signed-commit tooling.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

