### PR TITLE
fix(notebooks): regenerate stale kea typegen for SQL V2 logic

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
@@ -88,6 +88,7 @@ export interface NotebookNodeSQLV2LogicProps {
 export interface notebookNodeSQLV2LogicValues {
     activeOperation: NotebookOperation | null // notebookOperationsLogic
     isBusy: boolean // notebookOperationsLogic
+    isInterrupting: boolean
     isRunning: boolean
     operationBlockReason: string | null
     page: number
@@ -108,6 +109,9 @@ export interface notebookNodeSQLV2LogicActions {
     startOperation: (operation: NotebookOperation) => {
         operation: NotebookOperation
     } // notebookOperationsLogic
+    interruptRun: () => {
+        value: true
+    }
     pollResult: (runId: string) => {
         runId: string
     }
@@ -122,6 +126,9 @@ export interface notebookNodeSQLV2LogicActions {
         code: string
         opts: RunQueryOptions
         refs: Record<string, SqlV2RunRef>
+    }
+    setIsInterrupting: (isInterrupting: boolean) => {
+        isInterrupting: boolean
     }
     setIsRunning: (isRunning: boolean) => {
         isRunning: boolean


### PR DESCRIPTION
## Problem

Master's Frontend CI is red: the "Check if schema.json and validators.js are up to date" step fails because the inline kea-typegen block in `notebookNodeSQLV2Logic.ts` is stale. A change added `isInterrupting` state plus `interruptRun` / `setIsInterrupting` actions to the logic, but the committed generated types weren't refreshed, so `typegen` produces a diff in CI.

## Changes

Regenerate the inline typegen block for `notebookNodeSQLV2Logic`: add `isInterrupting` to the values interface and `interruptRun` / `setIsInterrupting` to the actions interface. Matches exactly the output the CI check computes.

## How did you test this code?

node_modules isn't available in this environment, so I couldn't run `typegen` locally. Instead I applied the precise diff that the failing CI step printed as its expected output, so the `git diff --exit-code` check will now pass. No behavior change — this only updates generated type declarations.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triggered by a master-is-red alert. Diagnosed the failing Frontend CI run (Frontend typechecking → schema/validators check), traced it to a stale inline typegen block under `frontend/src/scenes/notebooks` (an `inlinePaths` directory in `.kearc`), and applied the exact regeneration the CI step expects.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1784117922812389?thread_ts=1784117922.812389&cid=C0AS64N6DJL)*
