### PR TITLE
feat(capture): pass $snapshot_host through to the replay snapshot message

### DIFF
--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -90,9 +90,6 @@ pub struct RecordingProperties {
     #[serde(rename = "$snapshot_source", skip_serializing_if = "Option::is_none")]
     pub snapshot_source: Option<Value>,
 
-    /// The recorded page's hostname, stamped by the browser SDK; the ml-mirror anonymizer keys
-    /// its host classification on it. `Value` (not `String`) so a malformed stamp cannot fail
-    /// the whole properties parse; a non-string is dropped at serialization.
     #[serde(rename = "$snapshot_host", skip_serializing_if = "Option::is_none")]
     pub snapshot_host: Option<Value>,
 

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -90,6 +90,12 @@ pub struct RecordingProperties {
     #[serde(rename = "$snapshot_source", skip_serializing_if = "Option::is_none")]
     pub snapshot_source: Option<Value>,
 
+    /// The recorded page's hostname, stamped by the browser SDK; the ml-mirror anonymizer keys
+    /// its host classification on it. `Value` (not `String`) so a malformed stamp cannot fail
+    /// the whole properties parse; a non-string is dropped at serialization.
+    #[serde(rename = "$snapshot_host", skip_serializing_if = "Option::is_none")]
+    pub snapshot_host: Option<Value>,
+
     #[serde(rename = "$lib", skip_serializing_if = "Option::is_none")]
     pub lib: Option<String>,
 
@@ -275,6 +281,12 @@ pub async fn process_replay_events(
         .take()
         .unwrap_or(default_snapshot_source);
 
+    let snapshot_host = first_event
+        .properties
+        .snapshot_host
+        .take()
+        .filter(Value::is_string);
+
     let snapshot_library = first_event
         .properties
         .lib
@@ -374,6 +386,7 @@ pub async fn process_replay_events(
         &session_id,
         &window_id,
         &snapshot_source,
+        snapshot_host.as_ref(),
         &snapshot_items,
         &snapshot_library,
     );
@@ -411,6 +424,7 @@ pub async fn serialize_snapshot_data_async(
     session_id: Value,
     window_id: Value,
     snapshot_source: Value,
+    snapshot_host: Option<Value>,
     snapshot_items: Vec<Value>,
     snapshot_library: String,
 ) -> Result<String, CaptureError> {
@@ -420,6 +434,7 @@ pub async fn serialize_snapshot_data_async(
             &session_id,
             &window_id,
             &snapshot_source,
+            snapshot_host.as_ref(),
             &snapshot_items,
             &snapshot_library,
         )
@@ -438,10 +453,11 @@ pub fn serialize_snapshot_data_sync(
     session_id: &Value,
     window_id: &Value,
     snapshot_source: &Value,
+    snapshot_host: Option<&Value>,
     snapshot_items: &Vec<Value>,
     snapshot_library: &String,
 ) -> String {
-    json!({
+    let mut data = json!({
         "event": "$snapshot_items",
         "properties": {
             "distinct_id": distinct_id,
@@ -451,8 +467,11 @@ pub fn serialize_snapshot_data_sync(
             "$snapshot_items": snapshot_items,
             "$lib": snapshot_library,
         }
-    })
-    .to_string()
+    });
+    if let Some(host) = snapshot_host {
+        data["properties"]["$snapshot_host"] = host.clone();
+    }
+    data.to_string()
 }
 
 fn snapshot_library_fallback_from(user_agent: Option<&String>) -> Option<String> {
@@ -733,6 +752,39 @@ mod tests {
         assert!(!captured[0].metadata.force_overflow);
         assert!(!captured[0].metadata.skip_person_processing);
         assert!(!captured[0].metadata.redirect_to_dlq);
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_host_passes_through_to_the_serialized_message() {
+        // The ml-mirror anonymizer keys host classification on `properties.$snapshot_host`
+        // surviving this rebuild; capture silently dropping it would permanently disable
+        // classification downstream (the fallback there is also collapse-everything).
+        let cases: &[(Option<Value>, Option<&str>)] = &[
+            (Some(json!("app.example.com")), Some("app.example.com")),
+            (Some(json!(42)), None), // non-string stamps must not pass through
+            (None, None),
+        ];
+        for (stamp, expected) in cases {
+            let events_captured = Arc::new(Mutex::new(Vec::new()));
+            let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+                events: events_captured.clone(),
+            });
+            let mut recording = create_test_recording();
+            recording.properties.snapshot_host = stamp.clone();
+            let context = create_test_context();
+
+            process_replay_events(sink, None, None, vec![recording], &context)
+                .await
+                .unwrap();
+
+            let captured = events_captured.lock().unwrap();
+            let data: Value = serde_json::from_str(&captured[0].event.data).unwrap();
+            assert_eq!(
+                data["properties"].get("$snapshot_host"),
+                expected.map(|h| json!(h)).as_ref(),
+                "stamp={stamp:?}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

I added a new property, `$snapshot_host` to session replay events in posthog-js in https://github.com/PostHog/posthog-js/pull/4143. Let's wire that up through the capture service.

Posthog Code continues:

Capture rebuilds incoming `$snapshot` events into the `$snapshot_items` Kafka message through a fixed property set: `RecordingProperties` deserializes only the fields it needs (serde drops the rest), and `serialize_snapshot_data_sync` emits a hard-coded property list. That silently drops `$snapshot_host` - the recorded page's masked hostname the browser SDK is starting to stamp on replay flushes ([posthog-js#4143](https://github.com/PostHog/posthog-js/pull/4143)).

The ml-mirror anonymizer ([#70528](https://github.com/PostHog/posthog/pull/70528)) keys its hostname classification on that property surviving this rebuild. Without the pass-through, classification can never activate - silently, because the anonymizer's fallback for a missing stamp is also its intended pre-stamp behavior (collapse every hostname). This gap was found by a multi-agent review of #70528: every test there injects the stamp downstream of capture, so nothing caught the middle hop dropping it.

## Changes

- `RecordingProperties` gains `snapshot_host: Option<Value>` - `Value` rather than `String` so a malformed stamp cannot fail the whole properties parse and drop the event
- The value is taken from the batch's first event (matching `$snapshot_source`/`$lib` handling), forwarded only when it is a string, and emitted into the serialized message's properties; absent or non-string stamps leave the output unchanged
- `serialize_snapshot_data_sync`/`_async` signatures gain the optional host parameter

Deploy ordering: this should ship before (or with) the posthog-js stamp reaching production traffic. Shipping it earlier is a no-op - no SDK stamps the property yet, and absent stamps produce byte-identical output to today.

## How did you test this code?

- New test `test_snapshot_host_passes_through_to_the_serialized_message`: runs the full `process_replay_events` path and asserts a string stamp lands in the serialized message's properties, and that non-string or absent stamps leave the property out. This is the regression the review found - capture dropping the property while both neighbors' test suites pass - which no existing test covered because none asserted the serialized output against an unknown input property.
- `cargo test -p capture --lib events::recordings`: 21 tests pass.
- Not done manually: no end-to-end run through a live capture deployment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal message-shape change, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), spun out of the review of [#70528](https://github.com/PostHog/posthog/pull/70528) where a compatibility-focused review agent identified that the `$snapshot_host` contract spans three services (posthog-js → capture → ml-mirror anonymizer), not two, and the middle hop dropped the property. Robbie (AI research, which owns the ml-mirror pipeline) directed the work.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*