### PR TITLE
perf(insights): skip full response model_dump when serving insight results

### DIFF
--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import structlog
 from pydantic import BaseModel
@@ -10,7 +10,7 @@ from posthog.hogql.constants import LimitContext
 from posthog.api.services.query import ExecutionMode, process_query_dict
 from posthog.clickhouse.query_tagging import get_team_query_tags, tag_queries
 from posthog.event_usage import AnalyticsProps
-from posthog.hogql_queries.query_runner import get_query_runner_or_none
+from posthog.hogql_queries.query_runner import get_query_runner_or_none, response_results_contain_models
 from posthog.models import Team, User
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 
@@ -24,6 +24,33 @@ if TYPE_CHECKING:
 
 
 logger = structlog.get_logger(__name__)
+
+
+def _model_field_as_dict(model: BaseModel, field: str) -> Optional[dict]:
+    value = getattr(model, field, None)
+    if value is None:
+        return None
+    if isinstance(value, BaseModel):
+        return value.model_dump(by_alias=True)
+    return value
+
+
+def _dump_nested_models(value: Any) -> Any:
+    """Container-preserving conversion of pydantic models to dicts (lists, dicts, scalars pass through)."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(by_alias=True)
+    if isinstance(value, list):
+        return [_dump_nested_models(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _dump_nested_models(item) for key, item in value.items()}
+    return value
+
+
+def _model_list_field_as_dicts(model: BaseModel, field: str) -> Optional[list]:
+    value = getattr(model, field, None)
+    if value is None:
+        return None
+    return [item.model_dump(by_alias=True) if isinstance(item, BaseModel) else item for item in value]
 
 
 def calculate_cache_key(target: Union[DashboardTile, Insight]) -> Optional[str]:
@@ -83,7 +110,7 @@ def calculate_for_query_based_insight(
     if query_json is None:
         raise ValueError("Insight has no query and no query_override was provided")
 
-    response = process_response = process_query_dict(
+    process_response = process_query_dict(
         team,
         query_json,
         dashboard_filters_json=dashboard_filters_json,
@@ -99,16 +126,43 @@ def calculate_for_query_based_insight(
         analytics_props=analytics_props,
     )
 
-    if isinstance(process_response, BaseModel):
-        response = process_response.model_dump(by_alias=True)
-
-    assert isinstance(response, dict)
-
     if isinstance(process_response, CacheMissResponse):
-        return NothingInCacheResult(cache_key=process_response.cache_key, query_status=response.get("query_status"))
+        return NothingInCacheResult(
+            cache_key=process_response.cache_key, query_status=_model_field_as_dict(process_response, "query_status")
+        )
 
-    cache_key = response.get("cache_key")
-    last_refresh = response.get("last_refresh")
+    if isinstance(process_response, BaseModel):
+        # Don't model_dump() the whole response: `results` alone can be tens of MB of plain
+        # dicts, and dumping deep-copies all of it only for a handful of fields to be re-read.
+        # Pull fields off the model instead, converting just the small nested models to dicts
+        # (which is what model_dump produced before). The response class may not carry every
+        # field (legacy insights shape), hence the getattr defaults.
+        result = getattr(process_response, "results", None)
+        if result is not None and response_results_contain_models(type(process_response)):
+            # Model-typed results (e.g. RetentionResult, PathsLink) must be dumped to dicts
+            # like model_dump did — DRF's JSON encoder would otherwise mangle them into
+            # (field, value) tuple arrays. Results whose annotation is plain data (the huge
+            # trends/funnels payloads, or scalar/dict-shaped results) pass through untouched.
+            result = _dump_nested_models(result)
+        return InsightResult(
+            result=result,
+            has_more=getattr(process_response, "hasMore", None),
+            columns=getattr(process_response, "columns", None),
+            last_refresh=getattr(process_response, "last_refresh", None),
+            cache_key=getattr(process_response, "cache_key", None),
+            is_cached=getattr(process_response, "is_cached", False),
+            timezone=getattr(process_response, "timezone", None),
+            next_allowed_client_refresh=getattr(process_response, "next_allowed_client_refresh", None),
+            cache_target_age=getattr(process_response, "cache_target_age", None),
+            timings=_model_list_field_as_dicts(process_response, "timings"),
+            query_status=_model_field_as_dict(process_response, "query_status"),
+            hogql=getattr(process_response, "hogql", None),
+            types=getattr(process_response, "types", None),
+            resolved_date_range=_model_field_as_dict(process_response, "resolved_date_range"),
+        )
+
+    response = process_response
+    assert isinstance(response, dict)
 
     return InsightResult(
         # Translating `QueryResponse` to legacy insights shape
@@ -116,8 +170,8 @@ def calculate_for_query_based_insight(
         result=response.get("results"),
         has_more=response.get("hasMore"),
         columns=response.get("columns"),
-        last_refresh=last_refresh,
-        cache_key=cache_key,
+        last_refresh=response.get("last_refresh"),
+        cache_key=response.get("cache_key"),
         is_cached=response.get("is_cached", False),
         timezone=response.get("timezone"),
         next_allowed_client_refresh=response.get("next_allowed_client_refresh"),

--- a/posthog/caching/fetch_from_cache.py
+++ b/posthog/caching/fetch_from_cache.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import structlog
 from prometheus_client import Counter
 
-from posthog.schema import QueryTiming, ResolvedDateRangeResponse
+from posthog.schema import QueryTiming
 
 from posthog.cache_utils import OrjsonJsonSerializer
 from posthog.caching.query_cache_routing import get_query_cache
@@ -61,7 +61,8 @@ class InsightResult:
     query_status: Optional[Any] = None
     hogql: Optional[str] = None
     types: Optional[list] = None
-    resolved_date_range: Optional[ResolvedDateRangeResponse] = None
+    # A ResolvedDateRangeResponse-shaped dict — the field carries model_dump output
+    resolved_date_range: Optional[dict] = None
 
 
 @dataclass(frozen=True)

--- a/posthog/caching/test/test_calculate_results.py
+++ b/posthog/caching/test/test_calculate_results.py
@@ -1,0 +1,106 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.schema import (
+    CachedMarketingAnalyticsAggregatedQueryResponse,
+    CachedMarketingAnalyticsTableQueryResponse,
+    CachedRetentionQueryResponse,
+    CachedTrendsQueryResponse,
+    HogQueryResponse,
+    MarketingAnalyticsItem,
+    RetentionResult,
+)
+
+from posthog.api.services.query import ExecutionMode
+from posthog.caching.calculate_results import calculate_for_query_based_insight
+
+from products.product_analytics.backend.models.insight import Insight
+
+
+class TestCalculateForQueryBasedInsight(BaseTest):
+    def _calculate(self, response):
+        insight = Insight.objects.create(
+            team=self.team,
+            query={"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": []}},
+        )
+        with patch("posthog.caching.calculate_results.process_query_dict", return_value=response):
+            return calculate_for_query_based_insight(
+                insight,
+                team=self.team,
+                execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
+                user=None,
+            )
+
+    # Model-typed results (e.g. retention, paths, marketing analytics) must be dumped to
+    # dicts: DRF's JSON encoder falls back to iterating pydantic models, mangling them into
+    # (field, value) tuple arrays in the rendered response.
+    def test_model_typed_results_are_returned_as_dicts(self):
+        response = CachedRetentionQueryResponse(
+            results=[RetentionResult(date=datetime(2026, 1, 1, tzinfo=UTC), label="Day 0", values=[])],
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert isinstance(insight_result.result[0], dict)
+        assert insight_result.result[0]["label"] == "Day 0"
+
+    def test_models_nested_in_result_lists_are_returned_as_dicts(self):
+        # e.g. CachedMarketingAnalyticsTableQueryResponse.results: list[list[MarketingAnalyticsItem]]
+        response = CachedMarketingAnalyticsTableQueryResponse(
+            results=[[MarketingAnalyticsItem(key="spend", kind="unit", value=1.0)]],
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert isinstance(insight_result.result[0][0], dict)
+        assert insight_result.result[0][0]["key"] == "spend"
+
+    def test_dict_shaped_results_keep_their_shape_with_models_dumped(self):
+        response = CachedMarketingAnalyticsAggregatedQueryResponse(
+            results={"spend": MarketingAnalyticsItem(key="spend", kind="unit", value=1.0)},
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert isinstance(insight_result.result, dict)
+        assert isinstance(insight_result.result["spend"], dict)
+        assert insight_result.result["spend"]["key"] == "spend"
+
+    def test_scalar_results_pass_through(self):
+        insight_result = self._calculate(HogQueryResponse(results="ERROR: nope"))
+
+        assert insight_result.result == "ERROR: nope"
+
+    def test_plain_dict_results_pass_through_without_copying(self):
+        series = {"data": [1.0, 2.0], "label": "series", "action": {"order": 0}}
+        response = CachedTrendsQueryResponse(
+            results=[series],
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            cache_key="key",
+            timezone="UTC",
+        )
+
+        insight_result = self._calculate(response)
+
+        assert insight_result.result[0] is response.results[0]
+        assert insight_result.is_cached is True
+        assert insight_result.cache_key == "key"

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
+from functools import cache
 from time import perf_counter
 from types import UnionType
 from typing import Any, Generic, NamedTuple, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args, get_origin
@@ -210,6 +211,28 @@ def get_survey_query_metric_labels(query: Any) -> dict[str, str] | None:
         "query_type": getattr(query, "kind", "Other"),
         "query_name": getattr(tags, "name", None) or UNKNOWN_QUERY_METRIC_LABEL,
     }
+
+
+def _annotation_mentions_base_model(annotation: Any) -> bool:
+    if annotation is None:
+        return False
+    if isinstance(annotation, type):
+        return issubclass(annotation, BaseModel)
+    return any(_annotation_mentions_base_model(arg) for arg in get_args(annotation))
+
+
+@cache
+def response_results_contain_models(response_class: type[BaseModel]) -> bool:
+    """Whether the class's `results` annotation can hold pydantic models (e.g. list[RetentionResult]).
+
+    Responses are only ever built by validating plain data (a cached JSON blob, or the dict a fresh
+    calculation was dumped to), so model instances can appear in `results` exactly where the
+    annotation declares a model type — `Any`/`dict[str, Any]` positions stay plain data.
+    """
+    field = response_class.model_fields.get("results")
+    if field is None:
+        return False
+    return _annotation_mentions_base_model(field.annotation)
 
 
 def execution_mode_from_refresh(refresh_requested: bool | str | None) -> ExecutionMode:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -228,6 +228,11 @@ def response_results_contain_models(response_class: type[BaseModel]) -> bool:
     Responses are only ever built by validating plain data (a cached JSON blob, or the dict a fresh
     calculation was dumped to), so model instances can appear in `results` exactly where the
     annotation declares a model type — `Any`/`dict[str, Any]` positions stay plain data.
+
+    Response classes are split on this roughly down the middle: many type `results` items as models,
+    while others — including the largest payloads (trends, funnels) — type them as plain data.
+    That split is historical, not a pattern to extend; this helper only exists to serve both
+    correctly, and should disappear if the response classes ever converge on one style.
     """
     field = response_class.model_fields.get("results")
     if field is None:


### PR DESCRIPTION
## TL;DR (eli5)

When a dashboard or insight is served, the server was unpacking the whole chart result into a big Python dict copy just to read about 14 small fields off it, then throwing the copy away. Now it reads those fields straight off the response object and leaves the (potentially tens of MB) results untouched. Same bytes out, one full copy of the result tree less per request.

## Problem

`calculate_for_query_based_insight` called `model_dump(by_alias=True)` on the entire query response model, only to `.get()` a handful of scalar fields from the resulting dict. For large cached insights the `results` payload dominates the dump, so every dashboard tile GET paid a deep copy of data that was passed through unchanged. On a large local dashboard repro this accounted for roughly 13% of median GET wall time.

This is the second extraction from [#70967](https://github.com/PostHog/posthog/pull/70967) (optimization 1 of 3 there), following the already-merged serializer reuse in [#71022](https://github.com/PostHog/posthog/pull/71022).

## Changes

- Pull fields directly off the response model in `calculate_for_query_based_insight`, dumping only the small nested models (`timings`, `query_status`, `resolved_date_range`) — matching what `model_dump` produced before. The dict path for legacy responses is unchanged.
- Response classes whose `results` annotation carries pydantic models (retention, paths, marketing analytics) get a container-preserving conversion to dicts via the new `response_results_contain_models` check, since DRF's JSON encoder would otherwise iterate model instances into `(field, value)` tuple arrays and corrupt the response. Plain-data results (the big trends/funnels payloads) pass through by reference.
- Type `InsightResult.resolved_date_range` as the dict it has always carried at runtime.

## How did you test this code?

- New `posthog/caching/test/test_calculate_results.py` (5 tests): catches the model-typed-results corruption (flat, nested-list, and dict-shaped model results), plus scalar and plain-dict identity pass-through — a regression no existing test covered, found by an adversarial review pass on #70967. Asserts through the public `calculate_for_query_based_insight` interface with only `process_query_dict` mocked.
- `posthog/caching/` — 82 passed.
- `posthog/api/test/dashboards/test_dashboard.py` — 176 passed, 1 failed (`test_shared_dashboard`) which fails identically on master in this environment (no object storage) and is unrelated.
- `posthog/hogql_queries/test/test_query_runner.py` — 88 passed, 1 failed (`test_modifier_passthrough`) which also fails identically on master here (local ClickHouse version) and is unrelated.
- `products/product_analytics/backend/api/test/test_insight.py -k "cach or refresh or shared"` — 12 passed.
- On the original branch this change was additionally verified byte-identical: sha256 of a 29.9 MB dashboard response unchanged before/after.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — internal performance change, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

**Why:** we're splitting the large dashboard-GET optimization PR #70967 into individually reviewable pieces; this is the next simplest one after the merged serializer reuse.

Extracted by Claude Code (PostHog Code session) from #70967: took optimization 1 (skip full-response `model_dump`) plus its follow-up fixes from later commits on that branch (model-typed results conversion, `resolved_date_range` typing), while leaving out the raw-cached-results machinery that belongs to optimization 3. Skills invoked: /writing-tests. Verified with the test runs listed above against a locally provisioned Postgres/Redis/ClickHouse stack.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
