### PR TITLE
fix(data-warehouse): report auto-detect repartition targets as 'auto' instead of null

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
@@ -275,7 +275,11 @@ async def maybe_flag_for_repartition(
                 "max_partition_bytes_before": max_bytes,
                 "trigger_reason": trigger_reason,
                 "recent_oom_count": oom_count,
-                "partition_mode_after": target.partition_mode,
+                # An unpartitioned table's target has mode None ("enable partitioning, auto-detect
+                # the scheme on the first rewrite batch"). Emit an explicit "auto" so dashboards can
+                # render the target scheme instead of a null — half of all flagged events are this
+                # case, and a null here NULL-poisons any string built from the scheme properties.
+                "partition_mode_after": target.partition_mode or "auto",
                 "partition_format_after": target.partition_format,
                 "partition_count_after": target.partition_count,
                 "partition_size_after": target.partition_size,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
@@ -95,6 +95,27 @@ class TestRepartitionDetection:
         assert pending["trigger_reason"] == "proactive_threshold"
         assert capture.call_args.args[0] == "warehouse_repartition_flagged"
 
+    def test_unpartitioned_table_flags_auto_target_scheme(self, team):
+        # An unpartitioned table's target legitimately has mode None (auto-detect at rewrite time),
+        # but the flagged event must report "auto" — a null here NULL-poisons dashboard strings —
+        # while the pending target must keep mode None so the rewrite still auto-detects.
+        schema = _make_schema(team, {"primary_key_columns": ["id"]})
+        with tempfile.TemporaryDirectory() as d:
+            delta = _write_unpartitioned_delta(f"{d}/t")
+            with (
+                patch.object(ctrl, "target_partition_bytes", return_value=1),
+                patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
+                patch.object(ctrl, "capture_repartition_event") as capture,
+            ):
+                self._detect(team, schema, delta)
+
+        schema.refresh_from_db()
+        pending = schema.repartition_pending
+        assert pending is not None
+        assert pending["partition_mode"] is None
+        assert capture.call_args.args[0] == "warehouse_repartition_flagged"
+        assert capture.call_args.args[1]["partition_mode_after"] == "auto"
+
     def test_within_budget_records_size_but_does_not_flag(self, team):
         schema = _make_schema(team, {"partitioning_enabled": True, "partition_mode": "md5", "partition_count": 2})
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## Problem

The "Recent repartitions — from → to" dashboard tile renders a null `to_scheme` for half of all `warehouse_repartition_flagged` events (2,617 of ~5,200 in the last 14 days). Every null row is an **unpartitioned table being flagged**: `select_repartition_target`'s enable-partitioning branch returns a target with `partition_mode=None` — meaning "auto-detect the scheme on the first rewrite batch" — and the event captured that `None` verbatim. Any string a dashboard builds from the scheme properties (`concat(toString(partition_mode_after), …)`) is then NULL-poisoned.

## Changes

The flagged event now reports `partition_mode_after: "auto"` when the target's mode is None. Only the event property changes — the pending target persisted on the schema keeps `partition_mode=None`, so the rewrite's auto-detection is untouched.

## How did you test this code?

Added `test_unpartitioned_table_flags_auto_target_scheme`: an unpartitioned over-budget table's flagged event carries `partition_mode_after == "auto"` while the pending target keeps `partition_mode is None`. The second assertion is the load-bearing one — accidentally writing "auto" into the pending target would break the rewrite (it's not a valid `PartitionMode`), and no existing test pins the event-vs-pending distinction. Full `TestRepartitionDetection` suite: 7 passed locally.

The dashboard insight is being updated separately (saved-insight change, not in this repo) to render historical events null-safely.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal telemetry only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by Tom. Diagnosed from the dashboard tile: queried the flagged events, found all null `partition_mode_after` rows are unpartitioned tables (mode-before also null), and traced it to the auto-detect target's None mode being captured verbatim. Skill invoked: /writing-tests. Deliberately did not change `base_event_props`' `partition_mode` (the "from" side) — null there truthfully reflects an unpartitioned schema and is shared by all repartition events; the dashboard handles it with a display-side coalesce.
