### PR TITLE
feat(review_hog): add for-you/entire-project scope to recent reviews

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,7 +507,7 @@ importers:
         version: 5.3.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1943,7 +1943,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4185,6 +4185,10 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      kea-test-utils:
+        specifier: 'catalog:'
+        version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
 
   products/session_replay:
     dependencies:

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -655,7 +655,7 @@ Mirrors the Inbox scope switch: the block can now list every review on the proje
 - **UI/logic:** `LemonSegmentedButton` "For you / Entire project" on the section header;
   `reviewsScope` + `hasUserChosenReviewsScope` persisted reducers in `reviewHogSettingsLogic`;
   **auto-default** — an empty first mine-scope load flips to Entire project via `applyDefaultReviewsScope`, which is _not_ marked as a user choice so a later explicit pick wins (both directions jest-tested);
-  scope mirrored to `?reviews_scope=` (hydrating from a shared link counts as an explicit choice);
+  an explicit pick is mirrored to `?reviews_scope=` — the auto-default never writes the URL, since hydrating from a link counts as an explicit choice and would make the fallback permanent;
   the loader takes a `breakpoint()` after the fetch so a scope flip mid-flight drops the stale response;
   rows show `by <pr_author>` in everyone scope only;
   an empty mine-scope shows an empty state instead of hiding the section (the toggle must stay reachable) — loaded-and-empty hides the section only in everyone scope.

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -639,6 +639,30 @@ payload into Python) from the turn's working-state artefacts, preferring the sna
   must not masquerade as another skill card. Hidden until data exists. In-progress row label format:
   "Step k/4 · <stage> · NN%" (stages fetching/chunking/reviewing/validating numbered 1-4).
 
+#### ✅ BUILT 2026-07-15 — "For you / Entire project" scope on the recent-reviews block
+
+Mirrors the Inbox scope switch: the block can now list every review on the project, not just the requesting user's.
+
+- **`GET review_hog/reviews/?scope=mine|everyone`** (`ReviewsListParamsSerializer`, default `mine`):
+  `everyone` drops the `acting_user` filter; everything else (running-first ordering, 5-row cap, DB-side enrichment) is unchanged.
+  Bad values 400 via `is_valid(raise_exception=True)`.
+  The `scope` ChoiceField's enum stays inline in the OpenAPI query parameter, so no `ScopeEnum` component collision (verified with `--fail-on-warn`).
+- **`retrieve` is now project-wide** (queries with `SCOPE_EVERYONE` internally) so any listed review opens;
+  another team's report id still 404s (`for_team`), garbage ids still 404.
+  `perspective_stats` stays personal — it describes *your* reviewers' effectiveness.
+- **Index:** `(team, -last_run_at)` `reviewhog_rpt_team_recent_idx` (migration 0016, `SafeAddIndexConcurrently`) serves the everyone-scope completed slice;
+  the mine slice keeps the 0011 `(team, acting_user, -last_run_at)` index.
+- **UI/logic:** `LemonSegmentedButton` "For you / Entire project" on the section header;
+  `reviewsScope` + `hasUserChosenReviewsScope` persisted reducers in `reviewHogSettingsLogic`;
+  **auto-default** — an empty first mine-scope load flips to Entire project via `applyDefaultReviewsScope`, which is *not* marked as a user choice so a later explicit pick wins (both directions jest-tested);
+  scope mirrored to `?reviews_scope=` (hydrating from a shared link counts as an explicit choice);
+  the loader takes a `breakpoint()` after the fetch so a scope flip mid-flight drops the stale response;
+  rows show `by <pr_author>` in everyone scope only;
+  an empty mine-scope shows an empty state instead of hiding the section (the toggle must stay reachable) — loaded-and-empty hides the section only in everyone scope.
+- Tests: everyone-scope list (teammate rows in, cross-team rows out, bad scope 400s as the params-serializer wiring guard);
+  retrieve contract flip (teammate's review 200, other team's 404);
+  2 jest tests for the auto-default rule.
+
 #### ✅ BUILT 2026-07-02 — authoring guide moved to a canonical skill (`review-hog-authoring`)
 
 The "Create your own …" frontend prompts were fat, self-describing instruction sets — an

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -649,12 +649,12 @@ Mirrors the Inbox scope switch: the block can now list every review on the proje
   The `scope` ChoiceField's enum stays inline in the OpenAPI query parameter, so no `ScopeEnum` component collision (verified with `--fail-on-warn`).
 - **`retrieve` is now project-wide** (queries with `SCOPE_EVERYONE` internally) so any listed review opens;
   another team's report id still 404s (`for_team`), garbage ids still 404.
-  `perspective_stats` stays personal — it describes *your* reviewers' effectiveness.
+  `perspective_stats` stays personal — it describes _your_ reviewers' effectiveness.
 - **Index:** `(team, -last_run_at)` `reviewhog_rpt_team_recent_idx` (migration 0016, `SafeAddIndexConcurrently`) serves the everyone-scope completed slice;
   the mine slice keeps the 0011 `(team, acting_user, -last_run_at)` index.
 - **UI/logic:** `LemonSegmentedButton` "For you / Entire project" on the section header;
   `reviewsScope` + `hasUserChosenReviewsScope` persisted reducers in `reviewHogSettingsLogic`;
-  **auto-default** — an empty first mine-scope load flips to Entire project via `applyDefaultReviewsScope`, which is *not* marked as a user choice so a later explicit pick wins (both directions jest-tested);
+  **auto-default** — an empty first mine-scope load flips to Entire project via `applyDefaultReviewsScope`, which is _not_ marked as a user choice so a later explicit pick wins (both directions jest-tested);
   scope mirrored to `?reviews_scope=` (hydrating from a shared link counts as an explicit choice);
   the loader takes a `breakpoint()` after the fetch so a scope flip mid-flight drops the stale response;
   rows show `by <pr_author>` in everyone scope only;

--- a/products/review_hog/backend/api/reviews.py
+++ b/products/review_hog/backend/api/reviews.py
@@ -50,6 +50,18 @@ _PRIORITY_CHOICES = [priority.value for priority in IssuePriority]
 # Display order for the detail view: most urgent first.
 _PRIORITY_DISPLAY_RANK = {IssuePriority.MUST_FIX: 0, IssuePriority.SHOULD_FIX: 1, IssuePriority.CONSIDER: 2}
 
+SCOPE_MINE = "mine"
+SCOPE_EVERYONE = "everyone"
+
+
+class ReviewsListParamsSerializer(serializers.Serializer):
+    scope = serializers.ChoiceField(
+        choices=[SCOPE_MINE, SCOPE_EVERYONE],
+        default=SCOPE_MINE,
+        help_text="Whose reviews to list: `mine` for reviews of the requesting user's pull requests "
+        "(the default), `everyone` for every review on this project.",
+    )
+
 
 class ReviewProgressSerializer(serializers.Serializer):
     review_stage = serializers.ChoiceField(
@@ -341,12 +353,14 @@ def _review_payload(
 
 
 class ReviewRecentReviewsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
-    """The requesting user's most recent ReviewHog reviews (reports where they are the acting user).
+    """Recent ReviewHog reviews on this project.
 
     Read-only meta for the Code review tab's "recent reviews" block: what was reviewed, how many
     valid findings at each effective priority, the reviewed PR's facts, and the pipeline shape of
-    the latest turn. `retrieve` adds the findings themselves (valid + dismissed) and the published
-    review body.
+    the latest turn. `list` covers the requesting user's reviews (reports where they are the acting
+    user) by default, or the whole project's via `scope=everyone` — mirroring the inbox's
+    "For you / Entire project" switch. `retrieve` adds the findings themselves (valid + dismissed)
+    and the published review body; it is project-wide so any listed review can be opened.
     """
 
     scope_object = "INTERNAL"
@@ -355,23 +369,30 @@ class ReviewRecentReviewsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet
     serializer_class = ReviewRecentReviewSerializer
     pagination_class = None
 
-    def _reports(self, request: Request) -> tuple[int, QuerySet[ReviewReport]]:
+    def _reports(self, request: Request, scope: str = SCOPE_MINE) -> tuple[int, QuerySet[ReviewReport]]:
         team_id = resolve_effective_team_id(self.team_id)
-        return team_id, ReviewReport.objects.for_team(team_id, canonical=True).filter(acting_user_id=request.user.id)
+        queryset = ReviewReport.objects.for_team(team_id, canonical=True)
+        if scope == SCOPE_MINE:
+            queryset = queryset.filter(acting_user_id=request.user.id)
+        return team_id, queryset
 
     @extend_schema(
+        parameters=[ReviewsListParamsSerializer],
         responses={
             200: OpenApiResponse(
                 response=ReviewRecentReviewSerializer(many=True),
-                description="The user's reviews: in-progress runs first, then completed newest first.",
+                description="The scoped reviews: in-progress runs first, then completed newest first.",
             ),
         },
-        summary="List the user's recent reviews",
-        description="The requesting user's ReviewHog reviews on this project: actively running reviews "
-        "first (with the in-flight turn's stage), then the most recent completed ones (at most 5 rows).",
+        summary="List recent reviews",
+        description="Recent ReviewHog reviews on this project: actively running reviews first (with the "
+        "in-flight turn's stage), then the most recent completed ones (at most 5 rows). By default only "
+        "the requesting user's reviews; `scope=everyone` lists every review on the project.",
     )
     def list(self, request: Request, **kwargs) -> Response:
-        team_id, queryset = self._reports(request)
+        params = ReviewsListParamsSerializer(data=request.query_params)
+        params.is_valid(raise_exception=True)
+        team_id, queryset = self._reports(request, scope=params.validated_data["scope"])
         completed = list(queryset.filter(last_run_at__isnull=False).order_by("-last_run_at")[:RECENT_REVIEWS_LIMIT])
         # First-turn runs have no completed turn yet; they only surface while visibly running.
         running_first_turn = list(
@@ -471,19 +492,20 @@ class ReviewRecentReviewsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet
                 response=ReviewDetailSerializer,
                 description="The review's detail: findings (valid and dismissed) and the published body.",
             ),
-            404: OpenApiResponse(description="No such review of the requesting user's pull requests."),
+            404: OpenApiResponse(description="No such review on this project."),
         },
         summary="Retrieve one review's detail",
-        description="One completed ReviewHog review of the requesting user's pull requests, with the latest "
-        "turn's validated findings, the findings the validator dismissed (and why), and the review body "
-        "published to GitHub.",
+        description="One completed ReviewHog review on this project, with the latest turn's validated "
+        "findings, the findings the validator dismissed (and why), and the review body published to "
+        "GitHub. Project-wide, so reviews listed under `scope=everyone` can be opened too.",
     )
     def retrieve(self, request: Request, pk: str | None = None, **kwargs) -> Response:
         try:
             report_uuid = uuid.UUID(str(pk))
         except ValueError:
             raise NotFound("Review not found.")
-        team_id, queryset = self._reports(request)
+        # Project-wide on purpose: the detail must open for any review the everyone-scope list shows.
+        team_id, queryset = self._reports(request, scope=SCOPE_EVERYONE)
         # Detail describes a completed turn — a first run still in flight has nothing to show yet.
         report = queryset.filter(id=report_uuid, last_run_at__isnull=False).first()
         if report is None:

--- a/products/review_hog/backend/migrations/0016_reviewreport_reviewhog_rpt_team_recent_idx.py
+++ b/products/review_hog/backend/migrations/0016_reviewreport_reviewhog_rpt_team_recent_idx.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for concurrent index creation
+
+    dependencies = [
+        ("review_hog", "0015_reviewreport_status_comment_edited_at_and_more"),
+    ]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="reviewreport",
+            index=models.Index(
+                fields=["team", "-last_run_at"],
+                name="reviewhog_rpt_team_recent_idx",
+            ),
+        ),
+    ]

--- a/products/review_hog/backend/migrations/max_migration.txt
+++ b/products/review_hog/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0015_reviewreport_status_comment_edited_at_and_more
+0016_reviewreport_reviewhog_rpt_team_recent_idx

--- a/products/review_hog/backend/models.py
+++ b/products/review_hog/backend/models.py
@@ -92,6 +92,8 @@ class ReviewReport(UUIDModel, TeamScopedRootMixin):
             models.Index(fields=["signal_report_id"], name="reviewhog_rpt_signal_rpt_idx"),
             # Serves the "recent reviews" API: one user's reports, newest completed turn first.
             models.Index(fields=["team", "acting_user", "-last_run_at"], name="reviewhog_rpt_recent_idx"),
+            # Same API's everyone scope: the whole project's reports, newest completed turn first.
+            models.Index(fields=["team", "-last_run_at"], name="reviewhog_rpt_team_recent_idx"),
         ]
 
 

--- a/products/review_hog/backend/tests/test_reviews_api.py
+++ b/products/review_hog/backend/tests/test_reviews_api.py
@@ -5,7 +5,7 @@ from posthog.test.base import APIBaseTest
 
 from django.utils import timezone
 
-from posthog.models import User
+from posthog.models import Team, User
 
 from products.review_hog.backend.models import ReviewReport, ReviewReportArtefact
 from products.review_hog.backend.reviewer.artefact_content import ReviewIssueFinding, ValidationVerdict
@@ -66,9 +66,18 @@ class TestRecentReviewsAPI(APIBaseTest):
         super().setUp()
         self.url = f"/api/projects/{self.team.id}/review_hog/reviews/"
 
-    def _report(self, *, pr_number: int, acting_user: User | None, completed: bool = True, **kwargs) -> ReviewReport:
-        return ReviewReport.objects.for_team(self.team.id).create(
-            team_id=self.team.id,
+    def _report(
+        self,
+        *,
+        pr_number: int,
+        acting_user: User | None,
+        completed: bool = True,
+        team_id: int | None = None,
+        **kwargs,
+    ) -> ReviewReport:
+        team_id = team_id if team_id is not None else self.team.id
+        return ReviewReport.objects.for_team(team_id).create(
+            team_id=team_id,
             repository="PostHog/posthog",
             pr_number=pr_number,
             pr_url=kwargs.pop("pr_url", f"https://github.com/PostHog/posthog/pull/{pr_number}"),
@@ -120,9 +129,9 @@ class TestRecentReviewsAPI(APIBaseTest):
         )
 
     def test_lists_only_my_completed_reviews(self) -> None:
-        # The block is "your recent reviews": a teammate's report and an abandoned (stale, never
-        # completed) run must not appear — a filter regression would leak other users' review
-        # activity or show a dead run as forever in progress.
+        # The default (mine) scope is "your recent reviews": a teammate's report and an abandoned
+        # (stale, never completed) run must not appear — a filter regression would leak other users'
+        # review activity or show a dead run as forever in progress.
         mine = self._report(pr_number=1, acting_user=self.user)
         with freeze_time(timezone.now() - timedelta(hours=2)):
             self._report(pr_number=2, acting_user=self.user, completed=False)
@@ -137,6 +146,22 @@ class TestRecentReviewsAPI(APIBaseTest):
         assert rows[0]["github_url"] == mine.pr_url
         assert rows[0]["published"] is False
         assert "perspective_selection" not in rows[0]  # detail-only payload — the list stays lean
+
+    def test_list_scope_everyone_covers_the_whole_project(self) -> None:
+        # The "Entire project" switch: everyone-scope must include teammates' reviews but never
+        # another team's (tenant isolation), and a bad scope value must 400 — proving the params
+        # serializer is actually wired into the view.
+        self._report(pr_number=1, acting_user=self.user)
+        other = User.objects.create_and_join(self.organization, "other-everyone@posthog.com", None)
+        self._report(pr_number=2, acting_user=other)
+        cold_team = Team.objects.create(organization=self.organization, name="cold")
+        self._report(pr_number=3, acting_user=other, team_id=cold_team.id)
+
+        res = self.client.get(self.url, {"scope": "everyone"})
+
+        assert res.status_code == 200
+        assert {r["pr_number"] for r in res.json()} == {1, 2}
+        assert self.client.get(self.url, {"scope": "nonsense"}).status_code == 400
 
     def test_counts_scope_to_the_latest_run_and_fall_back_to_the_branch_url(self) -> None:
         # Counts must reflect only the latest turn's VALID findings at their EFFECTIVE priority —
@@ -481,10 +506,14 @@ class TestRecentReviewsAPI(APIBaseTest):
             {"skill_name": blind, "raised": 1, "kept": 1, "dismissed": 0},
         ]
 
-    def test_retrieve_scopes_to_the_acting_user(self) -> None:
-        # A teammate's report id must 404, not leak their PR's findings; garbage ids must not 500.
+    def test_retrieve_is_project_wide_but_never_cross_team(self) -> None:
+        # Opening a teammate's review from the everyone-scope list must work, but another team's
+        # report id must still 404 (tenant isolation), and garbage ids must not 500.
         other = User.objects.create_and_join(self.organization, "other-reviews-detail@posthog.com", None)
         theirs = self._report(pr_number=9, acting_user=other)
+        cold_team = Team.objects.create(organization=self.organization, name="cold")
+        foreign = self._report(pr_number=10, acting_user=other, team_id=cold_team.id)
 
-        assert self.client.get(f"{self.url}{theirs.id}/").status_code == 404
+        assert self.client.get(f"{self.url}{theirs.id}/").status_code == 200
+        assert self.client.get(f"{self.url}{foreign.id}/").status_code == 404
         assert self.client.get(f"{self.url}not-a-uuid/").status_code == 404

--- a/products/review_hog/frontend/CodeReviewScene.tsx
+++ b/products/review_hog/frontend/CodeReviewScene.tsx
@@ -475,18 +475,23 @@ function RecentReviewRow({ review }: { review: ReviewRecentReviewApi }): JSX.Ele
 
 /** Compact proof-of-life block under the hero — hidden entirely until the project has reviews. */
 function RecentReviewsSection(): JSX.Element | null {
-    const { recentReviews, reviewsScope, hasUserChosenReviewsScope } = useValues(reviewHogSettingsLogic)
+    const { recentReviews, recentReviewsLoading, reviewsScope, hasUserChosenReviewsScope } =
+        useValues(reviewHogSettingsLogic)
     const { setReviewsScope } = useActions(reviewHogSettingsLogic)
     const everyone = reviewsScope === ReviewHogReviewsListScope.Everyone
+    const loadedEmpty = recentReviews !== null && recentReviews.length === 0
 
-    // Loaded-and-empty on the Entire project scope means the project has no reviews at all — hide
-    // the section entirely. An empty For-you scope keeps the section (with an empty state) so the
-    // scope switch stays reachable; while the auto-default to Entire project is still pending, the
-    // skeleton keeps holding the space instead of the section flashing out and back in.
-    if (recentReviews !== null && !recentReviews.length && everyone) {
+    // Settled-and-empty on the Entire project scope means the project has no reviews at all — hide
+    // the section entirely. The scope flips before the reload lands, so an in-flight load keeps the
+    // section mounted (skeleton below) instead of yanking the toggle away mid-click. An empty
+    // For-you scope keeps the section (with an empty state) so the scope switch stays reachable.
+    if (loadedEmpty && everyone && !recentReviewsLoading) {
         return null
     }
-    const pendingAutoDefault = recentReviews !== null && !recentReviews.length && !hasUserChosenReviewsScope
+    // A stale EMPTY list must not render an empty state while a reload (scope switch, auto-default)
+    // is in flight — but previous ROWS are kept during refreshes, so the in-progress poll never
+    // flashes skeletons.
+    const emptyAwaitingReload = loadedEmpty && (recentReviewsLoading || !hasUserChosenReviewsScope)
 
     return (
         // The one section without a top hairline — it reads as a continuation of the hero.
@@ -516,7 +521,7 @@ function RecentReviewsSection(): JSX.Element | null {
                 />
             </div>
             <LemonCard hoverEffect={false} className="divide-y divide-primary p-0">
-                {recentReviews === null || pendingAutoDefault ? (
+                {recentReviews === null || emptyAwaitingReload ? (
                     [0, 1, 2].map((i) => (
                         <div key={i} className="flex items-center gap-3 px-4 py-3">
                             <span className="flex w-6 shrink-0 justify-center">

--- a/products/review_hog/frontend/CodeReviewScene.tsx
+++ b/products/review_hog/frontend/CodeReviewScene.tsx
@@ -318,6 +318,9 @@ function progressLabel(review: ReviewRecentReviewApi): string {
 
 /** A first review still running: no findings to expand into yet, just the live stage. */
 function RunningReviewRow({ review }: { review: ReviewRecentReviewApi }): JSX.Element {
+    const { reviewsScope } = useValues(reviewHogSettingsLogic)
+    // On the Entire project scope, whose PR it is matters at a glance; on For you it's always yours.
+    const showAuthor = reviewsScope === ReviewHogReviewsListScope.Everyone && !!review.pr_author
     return (
         <div className="flex items-center gap-3 px-4 py-3">
             <span className="flex w-6 shrink-0 justify-center">
@@ -329,6 +332,12 @@ function RunningReviewRow({ review }: { review: ReviewRecentReviewApi }): JSX.El
                     <span className="whitespace-nowrap font-mono text-tertiary">
                         {review.repository}#{review.pr_number ?? review.head_branch}
                     </span>
+                    {showAuthor && (
+                        <>
+                            <span className="text-tertiary">·</span>
+                            <span className="whitespace-nowrap">by {review.pr_author}</span>
+                        </>
+                    )}
                     <span className="text-tertiary">·</span>
                     <span className="whitespace-nowrap font-medium text-warning">{progressLabel(review)}</span>
                 </div>

--- a/products/review_hog/frontend/CodeReviewScene.tsx
+++ b/products/review_hog/frontend/CodeReviewScene.tsx
@@ -16,6 +16,7 @@ import {
 import {
     LemonBanner,
     LemonButton,
+    LemonSegmentedButton,
     LemonSkeleton,
     LemonSlider,
     LemonSwitch,
@@ -48,6 +49,7 @@ import type {
     ReviewRecentReviewApi,
     UrgencyThresholdEnumApi,
 } from 'products/review_hog/frontend/generated/api.schemas'
+import { ReviewHogReviewsListScope } from 'products/review_hog/frontend/generated/api.schemas'
 
 import { ReviewDrawerTab, ReviewSkillKind, reviewHogSettingsLogic } from './reviewHogSettingsLogic'
 
@@ -340,10 +342,12 @@ function RunningReviewRow({ review }: { review: ReviewRecentReviewApi }): JSX.El
 
 /** One expandable review row: essentials collapsed; PR facts + funnel + findings entry when open. */
 function RecentReviewRow({ review }: { review: ReviewRecentReviewApi }): JSX.Element {
-    const { expandedReviewIds } = useValues(reviewHogSettingsLogic)
+    const { expandedReviewIds, reviewsScope } = useValues(reviewHogSettingsLogic)
     const { toggleReviewRowExpanded, openReviewDetail } = useActions(reviewHogSettingsLogic)
     const expanded = expandedReviewIds.includes(review.id)
     const validated = review.must_fix_count + review.should_fix_count + review.consider_count
+    // On the Entire project scope, whose PR it is matters at a glance; on For you it's always yours.
+    const showAuthor = reviewsScope === ReviewHogReviewsListScope.Everyone && !!review.pr_author
 
     // A first review has no completed turn to expand into — it renders as a live progress row.
     if (review.in_progress && review.run_count === 0) {
@@ -379,6 +383,12 @@ function RecentReviewRow({ review }: { review: ReviewRecentReviewApi }): JSX.Ele
                         <span className="whitespace-nowrap font-mono text-tertiary">
                             {review.repository}#{review.pr_number ?? review.head_branch}
                         </span>
+                        {showAuthor && (
+                            <>
+                                <span className="text-tertiary">·</span>
+                                <span className="whitespace-nowrap">by {review.pr_author}</span>
+                            </>
+                        )}
                         <span className="text-tertiary">·</span>
                         <FindingCounts review={review} />
                         {review.last_run_at && (
@@ -463,38 +473,69 @@ function RecentReviewRow({ review }: { review: ReviewRecentReviewApi }): JSX.Ele
     )
 }
 
-/** Compact proof-of-life block under the hero — hidden entirely until the user has reviews. */
+/** Compact proof-of-life block under the hero — hidden entirely until the project has reviews. */
 function RecentReviewsSection(): JSX.Element | null {
-    const { recentReviews } = useValues(reviewHogSettingsLogic)
+    const { recentReviews, reviewsScope, hasUserChosenReviewsScope } = useValues(reviewHogSettingsLogic)
+    const { setReviewsScope } = useActions(reviewHogSettingsLogic)
+    const everyone = reviewsScope === ReviewHogReviewsListScope.Everyone
 
-    // Loaded-and-empty hides the section entirely; `null` means the first load is still in flight,
-    // so a skeleton holds the space instead of the page jumping when the rows land. Poll refreshes
-    // keep the previous rows, so the skeleton only ever shows once.
-    if (recentReviews !== null && !recentReviews.length) {
+    // Loaded-and-empty on the Entire project scope means the project has no reviews at all — hide
+    // the section entirely. An empty For-you scope keeps the section (with an empty state) so the
+    // scope switch stays reachable; while the auto-default to Entire project is still pending, the
+    // skeleton keeps holding the space instead of the section flashing out and back in.
+    if (recentReviews !== null && !recentReviews.length && everyone) {
         return null
     }
+    const pendingAutoDefault = recentReviews !== null && !recentReviews.length && !hasUserChosenReviewsScope
 
     return (
         // The one section without a top hairline — it reads as a continuation of the hero.
         <section className="flex flex-col gap-4">
-            <SectionHeader icon={<IconPullRequest />} title="Your recent reviews">
-                The latest ReviewHog runs on pull requests you authored. Expand a review for its details and findings.
-            </SectionHeader>
+            <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+                <SectionHeader icon={<IconPullRequest />} title={everyone ? 'Recent reviews' : 'Your recent reviews'}>
+                    {everyone
+                        ? 'The latest ReviewHog runs on pull requests across this project. Expand a review for its details and findings.'
+                        : 'The latest ReviewHog runs on pull requests you authored. Expand a review for its details and findings.'}
+                </SectionHeader>
+                <LemonSegmentedButton
+                    size="small"
+                    value={reviewsScope}
+                    onChange={(value) => setReviewsScope(value)}
+                    options={[
+                        {
+                            value: ReviewHogReviewsListScope.Mine,
+                            label: 'For you',
+                            tooltip: 'Only reviews of pull requests you authored',
+                        },
+                        {
+                            value: ReviewHogReviewsListScope.Everyone,
+                            label: 'Entire project',
+                            tooltip: 'Every ReviewHog review on this project',
+                        },
+                    ]}
+                />
+            </div>
             <LemonCard hoverEffect={false} className="divide-y divide-primary p-0">
-                {recentReviews === null
-                    ? [0, 1, 2].map((i) => (
-                          <div key={i} className="flex items-center gap-3 px-4 py-3">
-                              <span className="flex w-6 shrink-0 justify-center">
-                                  <LemonSkeleton.Circle className="size-2" />
-                              </span>
-                              <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                                  <LemonSkeleton className="h-4 w-80 max-w-full" />
-                                  <LemonSkeleton className="h-3 w-56 max-w-full" />
-                              </div>
-                              <LemonSkeleton className="h-8 w-24 shrink-0" />
-                          </div>
-                      ))
-                    : recentReviews.map((review) => <RecentReviewRow key={review.id} review={review} />)}
+                {recentReviews === null || pendingAutoDefault ? (
+                    [0, 1, 2].map((i) => (
+                        <div key={i} className="flex items-center gap-3 px-4 py-3">
+                            <span className="flex w-6 shrink-0 justify-center">
+                                <LemonSkeleton.Circle className="size-2" />
+                            </span>
+                            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                                <LemonSkeleton className="h-4 w-80 max-w-full" />
+                                <LemonSkeleton className="h-3 w-56 max-w-full" />
+                            </div>
+                            <LemonSkeleton className="h-8 w-24 shrink-0" />
+                        </div>
+                    ))
+                ) : recentReviews.length ? (
+                    recentReviews.map((review) => <RecentReviewRow key={review.id} review={review} />)
+                ) : (
+                    <div className="px-4 py-6 text-center text-sm text-secondary">
+                        No reviews of your pull requests yet. Switch to "Entire project" to see the whole team's.
+                    </div>
+                )}
             </LemonCard>
         </section>
     )

--- a/products/review_hog/frontend/generated/api.schemas.ts
+++ b/products/review_hog/frontend/generated/api.schemas.ts
@@ -463,3 +463,21 @@ export interface PatchedReviewValidatorConfigSelectApi {
     /** Set true to make this the single validator that runs on the user's PR reviews. Only true is accepted — validators are single-active, so you switch by selecting a different one, not by deactivating the current one. */
     active?: boolean
 }
+
+export type ReviewHogReviewsListParams = {
+    /**
+     * Whose reviews to list: `mine` for reviews of the requesting user's pull requests (the default), `everyone` for every review on this project.
+     *
+     * * `mine` - mine
+     * * `everyone` - everyone
+     * @minLength 1
+     */
+    scope?: ReviewHogReviewsListScope
+}
+
+export type ReviewHogReviewsListScope = (typeof ReviewHogReviewsListScope)[keyof typeof ReviewHogReviewsListScope]
+
+export const ReviewHogReviewsListScope = {
+    Mine: 'mine',
+    Everyone: 'everyone',
+} as const

--- a/products/review_hog/frontend/generated/api.ts
+++ b/products/review_hog/frontend/generated/api.ts
@@ -15,6 +15,7 @@ import type {
     PatchedReviewValidatorConfigSelectApi,
     ReviewBlindSpotsConfigApi,
     ReviewDetailApi,
+    ReviewHogReviewsListParams,
     ReviewPerspectiveConfigApi,
     ReviewPerspectiveStatsApi,
     ReviewRecentReviewApi,
@@ -102,19 +103,32 @@ export const reviewHogPerspectivesPartialUpdate = async (
     })
 }
 
-export const getReviewHogReviewsListUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/review_hog/reviews/`
+export const getReviewHogReviewsListUrl = (projectId: string, params?: ReviewHogReviewsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/review_hog/reviews/?${stringifiedParams}`
+        : `/api/projects/${projectId}/review_hog/reviews/`
 }
 
 /**
- * The requesting user's ReviewHog reviews on this project: actively running reviews first (with the in-flight turn's stage), then the most recent completed ones (at most 5 rows).
- * @summary List the user's recent reviews
+ * Recent ReviewHog reviews on this project: actively running reviews first (with the in-flight turn's stage), then the most recent completed ones (at most 5 rows). By default only the requesting user's reviews; `scope=everyone` lists every review on the project.
+ * @summary List recent reviews
  */
 export const reviewHogReviewsList = async (
     projectId: string,
+    params?: ReviewHogReviewsListParams,
     options?: RequestInit
 ): Promise<ReviewRecentReviewApi[]> => {
-    return apiMutator<ReviewRecentReviewApi[]>(getReviewHogReviewsListUrl(projectId), {
+    return apiMutator<ReviewRecentReviewApi[]>(getReviewHogReviewsListUrl(projectId, params), {
         ...options,
         method: 'GET',
     })
@@ -125,7 +139,7 @@ export const getReviewHogReviewsRetrieveUrl = (projectId: string, id: string) =>
 }
 
 /**
- * One completed ReviewHog review of the requesting user's pull requests, with the latest turn's validated findings, the findings the validator dismissed (and why), and the review body published to GitHub.
+ * One completed ReviewHog review on this project, with the latest turn's validated findings, the findings the validator dismissed (and why), and the review body published to GitHub. Project-wide, so reviews listed under `scope=everyone` can be opened too.
  * @summary Retrieve one review's detail
  */
 export const reviewHogReviewsRetrieve = async (

--- a/products/review_hog/frontend/reviewHogSettingsLogic.test.ts
+++ b/products/review_hog/frontend/reviewHogSettingsLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { useMocks } from '~/mocks/jest'
@@ -54,6 +55,9 @@ describe('reviewHogSettingsLogic', () => {
                 hasUserChosenReviewsScope: false,
             })
         expect(logic.values.recentReviews).toHaveLength(1)
+        // The auto-default must not write the URL: hydrating `?reviews_scope=` from a link marks
+        // the scope as explicitly chosen, so mirroring the fallback would make it permanent.
+        expect(router.values.searchParams.reviews_scope).toBeUndefined()
     })
 
     it('respects an explicit scope choice even when that scope is empty', async () => {

--- a/products/review_hog/frontend/reviewHogSettingsLogic.test.ts
+++ b/products/review_hog/frontend/reviewHogSettingsLogic.test.ts
@@ -1,0 +1,77 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { ReviewHogReviewsListScope } from 'products/review_hog/frontend/generated/api.schemas'
+
+import { reviewHogSettingsLogic } from './reviewHogSettingsLogic'
+
+describe('reviewHogSettingsLogic', () => {
+    let logic: ReturnType<typeof reviewHogSettingsLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                // The user has no reviews of their own; the project has one.
+                '/api/projects/:team_id/review_hog/reviews/': ({ request }) => [
+                    200,
+                    new URL(request.url).searchParams.get('scope') === ReviewHogReviewsListScope.Everyone
+                        ? [{ id: 'r1', in_progress: false }]
+                        : [],
+                ],
+                '/api/projects/:team_id/review_hog/reviews/perspective_stats/': () => [
+                    200,
+                    { report_count: 0, perspectives: [] },
+                ],
+                '/api/projects/:team_id/review_hog/settings/': () => [
+                    200,
+                    { review_inbox_prs: false, review_labeled_prs: true, urgency_threshold: 'should_fix' },
+                ],
+                '/api/projects/:team_id/review_hog/perspectives/': () => [200, []],
+                '/api/projects/:team_id/review_hog/blind_spots/': () => [200, []],
+                '/api/projects/:team_id/review_hog/validators/': () => [200, []],
+            },
+        })
+        // The scope reducers persist; without this a prior test's explicit choice leaks over.
+        localStorage.clear()
+        initKeaTests()
+        logic = reviewHogSettingsLogic()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('auto-defaults to the entire project when the user has no reviews of their own', async () => {
+        logic.mount()
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadRecentReviewsSuccess', 'applyDefaultReviewsScope', 'loadRecentReviewsSuccess'])
+            .toMatchValues({
+                reviewsScope: ReviewHogReviewsListScope.Everyone,
+                // The auto-default is not an explicit choice — a later real one must still win.
+                hasUserChosenReviewsScope: false,
+            })
+        expect(logic.values.recentReviews).toHaveLength(1)
+    })
+
+    it('respects an explicit scope choice even when that scope is empty', async () => {
+        logic.mount()
+        // Consume the mount-time auto-default, so the not-dispatched window below starts after it.
+        await expectLogic(logic).toDispatchActions([
+            'loadRecentReviewsSuccess',
+            'applyDefaultReviewsScope',
+            'loadRecentReviewsSuccess',
+        ])
+
+        await expectLogic(logic, () => logic.actions.setReviewsScope(ReviewHogReviewsListScope.Mine))
+            .toDispatchActions(['loadRecentReviewsSuccess'])
+            .toNotHaveDispatchedActions(['applyDefaultReviewsScope'])
+            .toMatchValues({
+                reviewsScope: ReviewHogReviewsListScope.Mine,
+                hasUserChosenReviewsScope: true,
+                recentReviews: [],
+            })
+    })
+})

--- a/products/review_hog/frontend/reviewHogSettingsLogic.ts
+++ b/products/review_hog/frontend/reviewHogSettingsLogic.ts
@@ -181,7 +181,8 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
         recentReviews: [
             null as ReviewRecentReviewApi[] | null,
             {
-                loadRecentReviews: async (_, breakpoint) => {
+                // The default param keeps the action zero-arg in the generated logic type.
+                loadRecentReviews: async (_ = null, breakpoint) => {
                     const scope = values.reviewsScope
                     const response = await reviewHogReviewsList(currentProjectId(), { scope })
                     // A scope switch mid-flight dispatched a newer load — drop this stale response.

--- a/products/review_hog/frontend/reviewHogSettingsLogic.ts
+++ b/products/review_hog/frontend/reviewHogSettingsLogic.ts
@@ -479,10 +479,12 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
         },
     })),
 
-    // The scope is mirrored to the URL (`?reviews_scope=everyone`) so a specific view can be
-    // shared via a link; the default scope keeps the URL clean.
-    actionToUrl(({ values }) => {
-        const toUrl = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => [
+    // An explicit scope pick is mirrored to the URL (`?reviews_scope=everyone`) so a specific view
+    // can be shared via a link; the default scope keeps the URL clean. The auto-default deliberately
+    // does NOT write the URL: hydrating from a link marks the scope as chosen (below), so mirroring
+    // the fallback would silently upgrade it into a permanent explicit choice on reload.
+    actionToUrl(({ values }) => ({
+        setReviewsScope: (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => [
             router.values.location.pathname,
             {
                 ...router.values.searchParams,
@@ -490,12 +492,8 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
             },
             router.values.hashParams,
             { replace: true },
-        ]
-        return {
-            setReviewsScope: toUrl,
-            applyDefaultReviewsScope: toUrl,
-        }
-    }),
+        ],
+    })),
 
     urlToAction(({ actions, values }) => ({
         [urls.codeReview()]: (_, searchParams) => {

--- a/products/review_hog/frontend/reviewHogSettingsLogic.ts
+++ b/products/review_hog/frontend/reviewHogSettingsLogic.ts
@@ -1,6 +1,6 @@
 import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -34,6 +34,7 @@ import type {
     ReviewUserSettingsApi,
     ReviewValidatorConfigApi,
 } from 'products/review_hog/frontend/generated/api.schemas'
+import { ReviewHogReviewsListScope } from 'products/review_hog/frontend/generated/api.schemas'
 
 import type { reviewHogSettingsLogicType } from './reviewHogSettingsLogicType'
 
@@ -138,11 +139,15 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
         closeReviewDrawer: true,
         setReviewDrawerTab: (tab: ReviewDrawerTab) => ({ tab }),
         toggleReviewRowExpanded: (reviewId: string) => ({ reviewId }),
+        setReviewsScope: (scope: ReviewHogReviewsListScope) => ({ scope }),
+        // Auto-select a default scope (Entire project when the user has no reviews of their own)
+        // without marking it as an explicit user choice, so a later real choice still wins.
+        applyDefaultReviewsScope: (scope: ReviewHogReviewsListScope) => ({ scope }),
         startSkillAuthorTask: (kind: ReviewSkillKind) => ({ kind }),
         startSkillAuthorTaskFinished: true,
     }),
 
-    loaders(() => ({
+    loaders(({ values }) => ({
         settings: [
             null as ReviewUserSettingsApi | null,
             {
@@ -176,7 +181,13 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
         recentReviews: [
             null as ReviewRecentReviewApi[] | null,
             {
-                loadRecentReviews: async () => await reviewHogReviewsList(currentProjectId()),
+                loadRecentReviews: async (_, breakpoint) => {
+                    const scope = values.reviewsScope
+                    const response = await reviewHogReviewsList(currentProjectId(), { scope })
+                    // A scope switch mid-flight dispatched a newer load — drop this stale response.
+                    breakpoint()
+                    return response
+                },
             },
         ],
         reviewDetail: [
@@ -266,6 +277,26 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
                     state.includes(reviewId) ? state.filter((id) => id !== reviewId) : [...state, reviewId],
             },
         ],
+        // Whose reviews the "recent reviews" block lists — mirrors the inbox's
+        // "For you / Entire project" switch.
+        reviewsScope: [
+            ReviewHogReviewsListScope.Mine as ReviewHogReviewsListScope,
+            { persist: true },
+            {
+                setReviewsScope: (_, { scope }) => scope,
+                applyDefaultReviewsScope: (_, { scope }) => scope,
+            },
+        ],
+        // Whether the user has explicitly picked a scope. Once true, the empty-list auto-default
+        // no longer fires, so a deliberate choice of "For you" is respected even with zero reviews.
+        // A shared link is an explicit choice too, so URL hydration goes through setReviewsScope.
+        hasUserChosenReviewsScope: [
+            false,
+            { persist: true },
+            {
+                setReviewsScope: () => true,
+            },
+        ],
         initialLoadFailed: [
             false,
             {
@@ -343,7 +374,18 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
             } else {
                 cache.disposables.dispose('inProgressPoll')
             }
+            // No reviews of the user's own PRs: default to the whole project so the block isn't
+            // empty — only until the user picks a scope themselves.
+            if (
+                !values.recentReviews?.length &&
+                values.reviewsScope === ReviewHogReviewsListScope.Mine &&
+                !values.hasUserChosenReviewsScope
+            ) {
+                actions.applyDefaultReviewsScope(ReviewHogReviewsListScope.Everyone)
+            }
         },
+        setReviewsScope: () => actions.loadRecentReviews(),
+        applyDefaultReviewsScope: () => actions.loadRecentReviews(),
         loadAll: () => {
             actions.loadSettings()
             actions.loadPerspectives()
@@ -432,6 +474,36 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
                 lemonToast.error(error?.detail || error?.message || `Failed to start "${title}"`)
             } finally {
                 actions.startSkillAuthorTaskFinished()
+            }
+        },
+    })),
+
+    // The scope is mirrored to the URL (`?reviews_scope=everyone`) so a specific view can be
+    // shared via a link; the default scope keeps the URL clean.
+    actionToUrl(({ values }) => {
+        const toUrl = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => [
+            router.values.location.pathname,
+            {
+                ...router.values.searchParams,
+                reviews_scope: values.reviewsScope === ReviewHogReviewsListScope.Mine ? undefined : values.reviewsScope,
+            },
+            router.values.hashParams,
+            { replace: true },
+        ]
+        return {
+            setReviewsScope: toUrl,
+            applyDefaultReviewsScope: toUrl,
+        }
+    }),
+
+    urlToAction(({ actions, values }) => ({
+        [urls.codeReview()]: (_, searchParams) => {
+            const parsed = searchParams.reviews_scope
+            if (
+                (parsed === ReviewHogReviewsListScope.Mine || parsed === ReviewHogReviewsListScope.Everyone) &&
+                parsed !== values.reviewsScope
+            ) {
+                actions.setReviewsScope(parsed)
             }
         },
     })),

--- a/products/review_hog/package.json
+++ b/products/review_hog/package.json
@@ -8,6 +8,9 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:"
     },
+    "devDependencies": {
+        "kea-test-utils": "catalog:"
+    },
     "peerDependencies": {
         "@posthog/icons": "catalog:",
         "@types/react": "*",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -74381,6 +74381,25 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type ReviewHogReviewsListParams = {
+    /**
+     * Whose reviews to list: `mine` for reviews of the requesting user's pull requests (the default), `everyone` for every review on this project.
+     *
+     * * `mine` - mine
+     * * `everyone` - everyone
+     * @minLength 1
+     */
+    scope?: ReviewHogReviewsListScope;
+    };
+
+    export type ReviewHogReviewsListScope = typeof ReviewHogReviewsListScope[keyof typeof ReviewHogReviewsListScope];
+
+
+    export const ReviewHogReviewsListScope = {
+      Mine: 'mine',
+      Everyone: 'everyone',
+    } as const;
+
     export type SandboxCustomImagesListParams = {
     /**
      * Number of results to return per page.


### PR DESCRIPTION
## Problem

ReviewHog's "Your recent reviews" block on the Code review tab only lists reviews of pull requests the requesting user authored. There was no way to see the rest of the project's reviews, unlike the inbox, which has a "For you / Entire project" scope switch for exactly this.

## Changes

**Backend**

- `GET review_hog/reviews/` accepts `scope=mine|everyone` (default `mine`, validated by a query-params serializer, documented via `extend_schema`). `everyone` drops the acting-user filter; ordering, the row cap, and enrichment are unchanged.
- `retrieve` is now project-wide so any review listed under the everyone scope can be opened. Another team's report id still 404s; `perspective_stats` stays personal.
- New `(team, -last_run_at)` index for the project-wide slice, added with `SafeAddIndexConcurrently` (migration 0016).

**Frontend**

- "For you / Entire project" segmented toggle on the recent-reviews section, mirroring the inbox pattern.
- Scope is persisted and URL-synced (`?reviews_scope=everyone`); a shared link counts as an explicit choice.
- Auto-default: if the first load in "For you" comes back empty and the user never picked a scope, the block switches itself to "Entire project" (an explicit pick later always wins).
- Rows show the PR author in project scope; an empty "For you" list shows an empty state instead of hiding the section, so the toggle stays reachable.

**Demo** (recorded with Puppeteer against this branch running locally, with seeded demo reviews):

![reviewhog-scope-toggle-demo](https://raw.githubusercontent.com/PostHog/pr-assets/49bf59fa920c171ee0b4fdd6bf5a14fac9c80b6c/2026/07/0e599924-5844-4ea2-9378-5641db59c0d9.gif)

## How did you test this code?

- `products/review_hog/backend/tests/test_reviews_api.py` — 10 passed. New `test_list_scope_everyone_covers_the_whole_project` catches the scope filter being dropped or inverted, cross-team leakage, and the params serializer being unwired (bad scope → 400). `test_retrieve_is_project_wide_but_never_cross_team` (reworked from the old acting-user-scoping test) locks in the new retrieve contract including tenant isolation, which is the new risk this PR introduces by widening retrieve.
- `products/review_hog/frontend/reviewHogSettingsLogic.test.ts` — 2 passed, covering the auto-default rule in both directions (fires when the user never chose a scope; never fires after an explicit choice). No existing test covered this logic.
- Adjacent smoke: `test_models.py`, `test_settings_api.py`, `test_acting_user.py` — 24 passed.
- `makemigrations --check` clean; `sqlmigrate` confirms `CREATE INDEX CONCURRENTLY`; OpenAPI schema regenerated with `--fail-on-warn` (no enum collisions); TypeScript check clean for the touched files; ruff and oxfmt clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`products/review_hog/ARCHITECTURE.md` gets a dated build-log entry describing the API scope, the index, and the frontend scope/auto-default behavior, following the file's convention.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked: `/improving-drf-endpoints`, `/django-migrations`, `/writing-tests`, `/adopting-generated-api-types`.

Decisions along the way: the user asked for an "entire organization" switch; implemented as project scope (`everyone`) because ReviewHog data is team-scoped (`for_team`) and the inbox switch this mirrors is also project-level. `retrieve` was deliberately widened to project scope rather than gating it on the list's scope param, so deep links open regardless of toggle state; cross-team access stays fail-closed. The `scope` ChoiceField was checked against the OpenAPI enum-collision gate (`scope` is a collision-prone field name) — the enum stays inline in the query parameter, so no `ENUM_NAME_OVERRIDES` entry was needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

