### PR TITLE
fix(workflows): bound worker config staleness with a background cache refresh

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
@@ -4,6 +4,7 @@ import { FixtureHogFlowBuilder } from '~/cdp/_tests/builders/hogflow.builder'
 import { HogFlow } from '~/cdp/schema/hogflow'
 import { closeHub, createHub } from '~/common/utils/db/hub'
 import { PostgresUse } from '~/common/utils/db/postgres'
+import { waitForExpect } from '~/tests/helpers/expectations'
 import { forSnapshot } from '~/tests/helpers/snapshots'
 import { createTeam, getTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { Hub } from '~/types'
@@ -100,6 +101,46 @@ describe('HogFlowManager', () => {
         expect(items.find((item) => item.id === hogFlows[0].id)).toMatchObject({
             id: hogFlows[0].id,
             name: 'Test Hog Flow team 1 updated',
+        })
+    })
+
+    describe('cache staleness bounds', () => {
+        it('picks up an edit without a reload notification once the background refresh age passes', async () => {
+            const baseNow = Date.now()
+            try {
+                let items = await manager.getHogFlowsForTeam(teamId1)
+                expect(items.find((item) => item.id === hogFlows[0].id)?.name).toBe('Test Hog Flow team 1')
+
+                // Edit WITHOUT dispatching the reload notification - the missed-publish case
+                await hub.postgres.query(
+                    PostgresUse.COMMON_WRITE,
+                    `UPDATE posthog_hogflow SET name='Renamed without notification', updated_at = NOW() WHERE id = $1`,
+                    [hogFlows[0].id],
+                    'testKey'
+                )
+
+                // Still within the background refresh age: served from cache
+                items = await manager.getHogFlowsForTeam(teamId1)
+                expect(items.find((item) => item.id === hogFlows[0].id)?.name).toBe('Test Hog Flow team 1')
+
+                // Past the background age (30s + up to 24s jitter) but under the 2 min hard cap:
+                // this get serves stale and kicks off a non-blocking refresh
+                jest.spyOn(Date, 'now').mockReturnValue(baseNow + 60_000)
+                items = await manager.getHogFlowsForTeam(teamId1)
+                expect(items.find((item) => item.id === hogFlows[0].id)?.name).toBe('Test Hog Flow team 1')
+
+                // The background refresh lands and the edit becomes visible - self-healed with no
+                // markForRefresh. Guards against reverting to the LazyLoader defaults (5 min
+                // blocking-only refresh), which would leave this stale until well past 60s.
+                await waitForExpect(async () => {
+                    const refreshed = await manager.getHogFlowsForTeam(teamId1)
+                    expect(refreshed.find((item) => item.id === hogFlows[0].id)?.name).toBe(
+                        'Renamed without notification'
+                    )
+                }, 1500)
+            } finally {
+                jest.spyOn(Date, 'now').mockReturnValue(baseNow)
+            }
         })
     })
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
@@ -105,6 +105,7 @@ describe('HogFlowManager', () => {
     })
 
     describe('cache staleness bounds', () => {
+        // Own timeout: the polling window below plus DB round-trips can exceed the suite's 2s default
         it('picks up an edit without a reload notification once the background refresh age passes', async () => {
             const baseNow = Date.now()
             try {
@@ -141,7 +142,7 @@ describe('HogFlowManager', () => {
             } finally {
                 jest.spyOn(Date, 'now').mockReturnValue(baseNow)
             }
-        })
+        }, 10000)
     })
 
     describe('getHogFlowIdsForTeam', () => {

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
@@ -45,6 +45,9 @@ export class HogFlowManagerService {
         const cacheOptions = {
             refreshAgeMs: 2 * 60 * 1000,
             refreshBackgroundAgeMs: 30 * 1000,
+            // Absorb transient Postgres blips inside a single load attempt so failed background
+            // refreshes don't re-fire at caller QPS and hard-cap refreshes don't fail the batch.
+            loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
         }
 
         this.lazyLoaderByTeam = new LazyLoader({

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
@@ -36,13 +36,26 @@ export class HogFlowManagerService {
         private postgres: PostgresRouter,
         private pubSub: PubSub
     ) {
+        // The reload-hog-flows pub/sub below is the primary invalidation; these ages bound how
+        // stale a worker can run when it misses the publish (pod restart, Redis blip). Live edits
+        // are expected to reach in-flight runs, so a hot flow self-heals within ~30s via a
+        // non-blocking background refresh, with a 2 minute hard cap - without these, a missed
+        // publish serves stale config for the 5 minute default and the expiry refetch blocks the
+        // worker's hot path.
+        const cacheOptions = {
+            refreshAgeMs: 2 * 60 * 1000,
+            refreshBackgroundAgeMs: 30 * 1000,
+        }
+
         this.lazyLoaderByTeam = new LazyLoader({
             name: 'hog_flow_manager_by_team',
+            ...cacheOptions,
             loader: async (teamIds) => await this.fetchTeamHogFlows(teamIds),
         })
 
         this.lazyLoader = new LazyLoader({
             name: 'hog_flow_manager',
+            ...cacheOptions,
             loader: async (ids) => await this.fetchHogFlows(ids),
         })
 


### PR DESCRIPTION
## Problem

The workflows worker's follow-live behavior depends on reading fresh config, but the hogflow manager's two LazyLoaders run on defaults: a 5 minute TTL (plus up to 1 minute jitter) whose expiry refetch is a blocking Postgres round-trip on the worker's hot path, and no background refresh. The `reload-hog-flows` Redis publish is the primary invalidation, but when a pod misses it (restart, Redis blip), edits silently don't reach in-flight runs for up to ~6 minutes. One of the "edits can silently never arrive" items on #66380.

Refs #66380

## Changes

Explicit cache options on both hogflow loaders (`hog_flow_manager`, `hog_flow_manager_by_team`):

```diff
+ refreshAgeMs: 2 * 60 * 1000,        // hard cap, was the 5 min default with a blocking refetch
+ refreshBackgroundAgeMs: 30 * 1000,  // serve stale + non-blocking refresh, was unset
+ loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },  // absorb transient Postgres blips, was unset
```

Pub/sub stays the fast path. The 30s background age means a hot flow picks up a missed edit within roughly 30-55s (jitter included) with zero added hot-path latency, since the loader serves the cached value and reloads in the background. The 2 minute hard cap matches the sibling `team-workflows-config` cache (hog-watcher runs 30s, persons-manager 1 min). Both loaders get the same values because the by-team loader governs whether new and archived flows are picked up at all.

Postgres impact: worst case one primary-key `fetchHogFlows` per actively-executing flow per pod per 30s, coalesced by the loader's buffer - below what persons-manager (1 min TTL, per-person keys) already does on the same COMMON_READ pool. Worth watching `lazy_loader_cache_hits{name="hog_flow_manager", hit="hit_background"}` and COMMON_READ qps after deploy. The `loaderRetry` policy (same values as `TeamManager` in `ingestion-general-server.ts`) retries transient errors inside a single load attempt, so a Postgres blip doesn't re-fire failed background refreshes at caller QPS or fail a whole batch once the hard cap forces a blocking refresh.

## How did you test this code?

Ran the manager suite locally (5/5). The new test edits a flow WITHOUT dispatching the reload notification, advances the clock past the background age, and asserts the edit becomes visible with no `markForRefresh` - it fails against the unpatched manager (verified by stashing the service change and re-running) and passes with it. That's the regression it guards: reverting these loaders to the LazyLoader defaults, which no existing test caught because every existing case invalidates explicitly.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None in this repo - the propagation bound will be stated on the upcoming live-edit semantics page (posthog.com repo, tracked in #66380).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code task). Skills invoked: /writing-tests. Note for reviewers: #66380 phrased this gap as "a worker that misses the reload notification runs the old version forever" - exploration showed the 5 minute default TTL already bounds it, so the fix became tighten + make the refresh non-blocking rather than add a missing max-age.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
