### PR TITLE
feat(dashboards): add interval filter override

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5431,9 +5431,9 @@ snapshots:
     scenes-app-customer-analytics-journeys-nodes-profileflownode--optional-not-completed--light:
         hash: v1.k794b7964.165b884e9e737c00707811f9efa7d348927a432402c544b41495eac9722a1fca.wqLWQTzb1O7RBTeeyTR5l_hUeX0IpJXkgexpAQbuNWs
     scenes-app-dashboards--access-control-dashboard--dark:
-        hash: v1.k794b7964.6bbc5cd2acac63e7f9fba6f2aa33d7e2d52a8352127fed8d428219540a49b890.omqO-GOryjeLGk99ofm9J4gqx_CQWdMPupmPU6WW278
+        hash: v1.k794b7964.11fd596aad9a5ed51c4486b64828e1416573b34c63a10b2ed37b08d25da48d91.jj69suHKiPBYs2VMR83Q_FMRnb4Pg7C4lU0Pra6VdYE
     scenes-app-dashboards--access-control-dashboard--light:
-        hash: v1.k794b7964.d101d57a6d623f754e7c62f7f79c78968822118050421f72c802718fa493a933.6pV1ojpc6ehy_SZd9xEHNQ0b8ZPGi1c-nuFHYebBLI8
+        hash: v1.k794b7964.a29a85daeff98faa6ea496a8485323ea965ee6fce98e2f1f67a032cd7bd38f31.VIhetTOlL6LTRVS-ALs4f7DOMCWcDomR7fgQAlRZUvo
     scenes-app-dashboards--edit--dark:
         hash: v1.k794b7964.b85e622d121e2edfb031fec73921ba7d775a50124f5d68c8c82ad28a51985434.eFMlXYTQdWLdvwn7YobjvgCNrFbx2IMXMt2Lzs0yyo4
     scenes-app-dashboards--edit--light:
@@ -5459,9 +5459,9 @@ snapshots:
     scenes-app-dashboards--not-found--light:
         hash: v1.k794b7964.ed4b8e9397bf960ff4b19b54e722c74962b25a2ec0270ecc090eda9b6d5d7f7b.XiealyyQzU_NqFX_PQmkZiIkJcX0h_joVE0Wbl-1twc
     scenes-app-dashboards--view-only-dashboard--dark:
-        hash: v1.k794b7964.1ee0dc03f9575313eba452798bd1a1ad195840099ab6c8beb535cdec8e2a62bf.X8vY6iak_BgscSHRrhbaAYQClcpTT5TcQerf5ZA1CME
+        hash: v1.k794b7964.a65acee97de57aeef30368365580e0e2c962193d6215acf55dac639823cb0ca8.zkO7nnEw6JoWOSq1KJ1DQrXzCI1FSmD0yzRsrMwcfA0
     scenes-app-dashboards--view-only-dashboard--light:
-        hash: v1.k794b7964.47528e5f78b66dbf0a83e44d5d106dbc868b39ee6e9e00e3b2ba72094803d5af.9qvvPG9BfTZFU1dJw7jR1QvEQz7atIMP_EppulGxk9w
+        hash: v1.k794b7964.7ebc4aa50c00cbfa580fd96d32ef6565a6bd399e1ae6289278d36309c89e87f1.9xwqldb2HI9IewJABGeU3kmuyGXS-hwbloJgjznVypQ
     scenes-app-dashboards-add-insight-to-dashboard-modal--default--dark:
         hash: v1.k794b7964.65a26ab25825086d5463677deec55324c7ada5ad92d46976038a9334748fdafd.-icTyqvvUjLQRZfthpF9m2gJ513_nxn6zhe-ChRyTrI
     scenes-app-dashboards-add-insight-to-dashboard-modal--default--light:

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -98,7 +98,7 @@ export enum DashboardEventSource {
     DashboardVariableOverride = 'dashboard_variable_override',
 }
 
-export type DashboardFilterChangeType = 'date' | 'properties' | 'breakdown' | 'variable'
+export type DashboardFilterChangeType = 'date' | 'properties' | 'breakdown' | 'variable' | 'interval'
 
 export enum InsightEventSource {
     LongPress = 'long_press',

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconCalendar } from '@posthog/icons'
+import { LemonSelect } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -18,11 +19,40 @@ import { Scene } from 'scenes/sceneTypes'
 import { groupsModel } from '~/models/groupsModel'
 import { VariablesForDashboard } from '~/queries/nodes/DataVisualization/Components/Variables/Variables'
 import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
-import { DashboardMode, InsightLogicProps } from '~/types'
+import { DashboardMode, InsightLogicProps, IntervalType } from '~/types'
 
 interface DashboardEditBarProps {
     showDateFilter?: boolean
     className?: string
+}
+
+export function DashboardIntervalFilter(): JSX.Element {
+    const { dashboardMode, effectiveEditBarFilters } = useValues(dashboardLogic)
+    const { setInterval, setDashboardMode } = useActions(dashboardLogic)
+
+    return (
+        <span className="flex items-center gap-2">
+            <span className="hidden md:inline">grouped by</span>
+            <LemonSelect<IntervalType | null>
+                size="small"
+                value={effectiveEditBarFilters.interval ?? null}
+                dropdownMatchSelectWidth={false}
+                onChange={(interval) => {
+                    if (dashboardMode !== DashboardMode.Edit) {
+                        setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
+                    }
+                    setInterval(interval)
+                }}
+                options={[
+                    { value: null, label: "each insight's interval" },
+                    { value: 'hour', label: 'hour' },
+                    { value: 'day', label: 'day' },
+                    { value: 'week', label: 'week' },
+                    { value: 'month', label: 'month' },
+                ]}
+            />
+        </span>
+    )
 }
 
 export function DashboardEditBar({ showDateFilter = true, className }: DashboardEditBarProps): JSX.Element {
@@ -88,6 +118,11 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
                             )}
                         />
                     </Shortcut>
+                </div>
+            )}
+            {showDateFilter && (
+                <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
+                    <DashboardIntervalFilter />
                 </div>
             )}
             <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -99,6 +99,7 @@ import {
     InsightColor,
     InsightModel,
     InsightShortId,
+    IntervalType,
     ProjectTreeRef,
     QueryBasedInsightModel,
     TextModel,
@@ -333,6 +334,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         }),
         setProperties: (properties: AnyPropertyFilter[] | null) => ({ properties }),
         setBreakdownFilter: (breakdown_filter: BreakdownFilter | null) => ({ breakdown_filter }),
+        setInterval: (interval: IntervalType | null) => ({ interval }),
         setExternalFilters: (filters: DashboardFilter) => ({ filters }),
         saveEditModeChanges: () => true,
         resetUrlFilters: () => true,
@@ -799,6 +801,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 setDates: () => false,
                 setProperties: () => false,
                 setBreakdownFilter: () => false,
+                setInterval: () => false,
                 loadDashboardSuccess: () => false,
                 loadDashboardFailure: () => false,
                 applyFilters: () => true,
@@ -1270,6 +1273,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 properties: undefined,
                 breakdown_filter: undefined,
                 explicitDate: undefined,
+                interval: undefined,
             } as DashboardFilter,
             {
                 setDates: (state, { date_from, date_to, explicitDate }) => ({
@@ -1286,12 +1290,17 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     ...state,
                     breakdown_filter,
                 }),
+                setInterval: (state, { interval }) => ({
+                    ...state,
+                    interval,
+                }),
                 resetIntermittentFilters: () => ({
                     date_from: undefined,
                     date_to: undefined,
                     properties: undefined,
                     breakdown_filter: undefined,
                     explicitDate: undefined,
+                    interval: undefined,
                 }),
             },
         ],
@@ -3008,6 +3017,18 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 })
             }
         },
+        setInterval: ({ interval }) => {
+            eventUsageLogic.actions.reportDashboardFiltersChanged(values.dashboard, 'interval', {
+                interval,
+            })
+
+            if (values.canAutoPreview) {
+                actions.refreshDashboardItems({
+                    action: RefreshDashboardItemsAction.Preview,
+                    forceRefresh: false,
+                })
+            }
+        },
         setExternalFilters: () => {
             if (values.tiles.length > 0) {
                 actions.refreshDashboardItems({
@@ -3197,6 +3218,25 @@ export const dashboardLogic = kea<dashboardLogicType>([
             return [
                 currentLocation.pathname,
                 { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                currentLocation.hashParams,
+            ]
+        },
+        setInterval: ({ interval }) => {
+            if (!values.canAutoPreview) {
+                return
+            }
+
+            const { currentLocation } = router.values
+
+            const urlFilters = parseURLFilters(currentLocation.searchParams)
+            const newUrlFilters: DashboardFilter = {
+                ...urlFilters,
+                interval,
+            }
+
+            return [
+                currentLocation.pathname,
+                { ...currentLocation.searchParams, ...encodeURLFilters(newUrlFilters) },
                 currentLocation.hashParams,
             ]
         },


### PR DESCRIPTION
## TL;DR

Dashboards get a "grouped by" dropdown next to the date filter. Pick hour/day/week/month and every time-series insight on the dashboard uses that granularity. Leave it on "each insight's interval" and nothing changes.

## Problem

Dashboard-level filters let a viewer override date range, properties, and breakdown across all insights on a dashboard, but there was no way to change time granularity. To see every time-series tile at, say, weekly, you had to open each insight individually.

Extracted from [#68612](https://github.com/PostHog/posthog/pull/68612), which now carries only the test-account override. The schema fields, query-runner application, and backend tests shipped in [#68754](https://github.com/PostHog/posthog/pull/68754) (merged).

## Changes

- A compact "grouped by" interval select in the dashboard edit bar and primary filters, next to the date filter, with an "each insight's interval" inherit option (the default, so existing dashboards are unchanged).
- A new `setInterval` action wired into the existing intermittent → effective filter pipeline. The key flows through the filter-combination utility, the refresh `filters_override` param, the URL filter params, and the edit-mode save diff with no per-key plumbing, since those helpers are key-generic. Filter change reporting gains an `interval` change type.

## How did you test this code?

The diff is extracted verbatim from #68612, which passed full CI. No new tests here: the wiring mirrors the existing `setBreakdownFilter` path exactly, and the backend behavior (override application per query type, API round-trip) is covered by the automated tests merged in #68754. I ran oxlint and oxfmt on the changed files; I was not able to run the app or exercise the UI in this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) split this out of #68612 at @thmsobrmlr's request so the interval override and the test-account override can land independently. The extraction is a pure partition of that PR's diff: interval pieces here, test-account pieces stay in #68612. Verified no cross-references remain in either half and cross-checked the local typecheck error set against a master baseline.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*