### PR TITLE
fix(data-warehouse): match the id primary-key fallback case-insensitively

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -251,8 +251,13 @@ def resolve_primary_keys(
         return schema.primary_key_columns
     if resource.primary_keys:
         return list(resource.primary_keys)
-    if "id" in extract_available_column_names(schema.schema_metadata):
-        return ["id"]
+    # Case-insensitive: engines like Snowflake uppercase unquoted identifiers, so the column
+    # arrives as `ID`. Return the actual stored casing — the merge indexes batches by real name.
+    id_column = next(
+        (name for name in extract_available_column_names(schema.schema_metadata) if name.lower() == "id"), None
+    )
+    if id_column is not None:
+        return [id_column]
     return None
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -35,6 +35,10 @@ class TestResolvePrimaryKeys:
             ("id_fallback_when_neither", None, None, {"columns": [{"name": "id"}, {"name": "name"}]}, ["id"]),
             # Nothing to fall back on -> None, so the keyless-table guardrail still fires.
             ("none_when_no_id_and_nothing_else", None, None, {"columns": [{"name": "name"}]}, None),
+            # Snowflake uppercases unquoted identifiers: the fallback must match `ID`
+            # case-insensitively AND return the actual stored casing — the merge indexes batches
+            # by the real column name, so a hardcoded lowercase `id` would fail it just the same.
+            ("uppercase_id_matched_with_actual_casing", None, None, {"columns": [{"name": "ID"}]}, ["ID"]),
         ]
     )
     def test_precedence(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/base.py
@@ -100,11 +100,13 @@ class SQLSource(SimpleSource[ConfigType], Generic[ConfigType]):
     def _default_primary_key_from_columns(self, columns: list[tuple[str, str, bool]]) -> list[str] | None:
         """Fallback: use `id` when the driver didn't detect a PK but one is present.
 
-        Mirrors what every SQL source has always done just before building
-        a `SourceSchema`.
+        Mirrors what every SQL source has always done just before building a `SourceSchema`.
+        Matched case-insensitively (Snowflake uppercases unquoted identifiers) but the column's
+        actual stored casing is returned, because the merge indexes batches by the real name.
         """
-        if any(col[0] == "id" for col in columns):
-            return ["id"]
+        id_column = next((col[0] for col in columns if col[0].lower() == "id"), None)
+        if id_column is not None:
+            return [id_column]
         return None
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/tests/test_types.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/tests/test_types.py
@@ -1,0 +1,21 @@
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.types import (
+    resolve_detected_primary_keys,
+)
+
+
+class TestResolveDetectedPrimaryKeys:
+    @parameterized.expand(
+        [
+            # Driver-discovered keys always win over the name fallback.
+            ("discovered_wins", ["pk"], [("id", "integer", False)], ["pk"]),
+            ("id_fallback", None, [("name", "text", True), ("id", "integer", False)], ["id"]),
+            # Snowflake uppercases unquoted identifiers: match `ID` case-insensitively and return
+            # the actual stored casing — the merge indexes batches by the real column name.
+            ("uppercase_id_matched_with_actual_casing", None, [("ID", "text", False)], ["ID"]),
+            ("no_id_column", None, [("name", "text", True)], None),
+        ]
+    )
+    def test_fallback(self, _name, discovered, columns, expected):
+        assert resolve_detected_primary_keys(discovered, columns) == expected

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/types.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/types.py
@@ -14,14 +14,16 @@ def resolve_detected_primary_keys(
 ) -> list[str] | None:
     """Pick the per-table primary key columns to advertise on a `SourceSchema`.
 
-    Returns the discovered list when present, otherwise falls back to `["id"]` if any column is
-    literally named `id` (the convention every SQL source we ingest from happens to follow), else
-    None. Used by Postgres / MySQL / MSSQL / Redshift discovery.
+    Returns the discovered list when present, otherwise falls back to a column named `id` —
+    matched case-insensitively, since engines like Snowflake uppercase unquoted identifiers —
+    else None. The column's actual stored casing is returned, because the merge later indexes
+    batches by the real column name. Used by Postgres / MySQL / MSSQL / Redshift discovery.
     """
     if discovered_pk_columns:
         return discovered_pk_columns
-    if any(column[0] == "id" for column in columns):
-        return ["id"]
+    id_column = next((column[0] for column in columns if column[0].lower() == "id"), None)
+    if id_column is not None:
+        return [id_column]
     return None
 
 


### PR DESCRIPTION
## Problem

A Snowflake import with a table that has an `ID` column failed incremental syncs with "Primary key required for incremental syncs", and the UI didn't preselect the primary key at setup.

Snowflake uppercases unquoted identifiers, so the column surfaces as `ID` everywhere. `SHOW PRIMARY KEYS` only returns *declared* PK constraints — which Snowflake doesn't enforce and most tables don't have — so detection falls through to the `id`-column name fallback. That fallback compared against the literal lowercase string `"id"` in all three places it exists (SQL-source discovery ×2 and the sync-time `resolve_primary_keys` last resort), so `ID` missed every one, no key was resolved, and the keyless-table guardrail fired. This affects any Snowflake table without a declared PK constraint, and any other source reporting uppercase column names.

## Changes

All three fallbacks now match the `id` column case-insensitively and return the column's **actual stored casing** (`["ID"]`, not a hardcoded `["id"]`):

- `sources/common/sql/types.py` — `resolve_detected_primary_keys` (Postgres / MySQL / MSSQL / Redshift discovery)
- `sources/common/sql/base.py` — `SQLSource._default_primary_key_from_columns` (generic SQL discovery)
- `pipelines/common/extract.py` — `resolve_primary_keys` (sync-time last resort)

Returning the actual casing matters: the merge indexes extracted batches by the real column name, so returning a lowercase `"id"` for an `ID` column would just move the same failure into the merge.

## How did you test this code?

Automated tests I (Claude) ran locally, all green:

- New `test_types.py` for `resolve_detected_primary_keys` (parameterized: discovered-wins, lowercase fallback, uppercase `ID` returning actual casing, no-id → None) — no test covered this helper at all; the uppercase case is the production regression.
- One new case in the existing `TestResolvePrimaryKeys` precedence table: `{"name": "ID"}` resolves to `["ID"]` — catches both a revert to case-sensitive matching and a change to returning hardcoded lowercase.
- Full `test_extract.py` + `sources/common/sql/tests/` suites: 365 passed.

`_default_primary_key_from_columns` carries the identical three-line change and is exercised transitively through the SQL-source discovery suites; a third copy of the same parameterized matrix wouldn't catch anything new.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No behavior documented externally changes — PK detection just works for uppercase `ID` columns now. Affected users can also self-serve today by setting the primary key manually in the table's sync settings (user overrides take precedence).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by Tom, from a user report of a Snowflake `ID` (type `text`) column not being detected. Investigation confirmed the column type is irrelevant (the fallback only looks at names) and the uppercase identifier is the whole story. Skill invoked: /writing-tests.
