### PR TITLE
fix(error-tracking): handle missing initial event

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.test.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.test.ts
@@ -1,3 +1,5 @@
+import { expectLogic } from 'kea-test-utils'
+
 import { ErrorTrackingFingerprint } from 'lib/components/Errors/types'
 
 import { useMocks } from '~/mocks/jest'
@@ -54,5 +56,13 @@ describe('errorTrackingIssueSceneLogic', () => {
         mutate(logic)
 
         expect(logic.values.eventsQueryKey).not.toBe(initialKey)
+    })
+
+    it('handles an empty initial event query result', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadInitialEvent('2026-01-01T00:00:00Z')
+        })
+            .toDispatchActions(['loadInitialEventSuccess'])
+            .toMatchValues({ initialEvent: null })
     })
 })

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
@@ -221,11 +221,8 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                     }),
                     { refresh: 'blocking' }
                 )
-                const issue = response.results[0]
-                let positionEvent = null
-                if (issue.last_event) {
-                    positionEvent = issue.last_event
-                } else {
+                const positionEvent = response.results[0]?.last_event
+                if (!positionEvent) {
                     return null
                 }
                 const initialEvent: ErrorEventType = {


### PR DESCRIPTION
## Problem

Opening an error tracking issue can trigger an initial-event query that returns no rows. The scene assumes the first row always exists and crashes instead of rendering the issue without a selected event.

**Why:** The query result is legitimately empty when no event matches the narrow timestamp window, so the frontend needs to handle that response as an empty state.

## Changes

- Read the initial event with optional access and return `null` when the query has no matching row or event.
- Add a logic test covering an empty initial-event query result.

## How did you test this code?

- Added a focused logic regression test that catches the empty query result crash.
- Ran `git diff --check` successfully.
- I could not run Jest or the TypeScript check because this environment does not have the repository Node dependencies, `hogli`, or `flox` installed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed. This is a defensive fix that does not change the documented workflow or API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI investigated and implemented this change using the `/investigating-error-issue` and `/writing-tests` skills. The fix keeps the existing loader behavior and only handles the API's valid empty-result case instead of introducing a fallback query or changing timestamp selection.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
