### PR TITLE
feat(ingestion): show stash dwell and retry timing in batch flow graph

### DIFF
--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -599,6 +599,13 @@ impl Dispatcher {
         gauge!("ingestion_consumer_dispatcher_pins_total").set(table.pins.len() as f64);
         record_stash_gauges(&table.stash);
 
+        if !assignments.by_worker.is_empty() {
+            record_if(&self.debug_recorder, || DebugEventKind::DeferredFlushed {
+                batch_id: batch_id.to_string(),
+                sub_batches: assignments.sub_batch_infos(),
+            });
+        }
+
         assignments.into_sub_batches()
     }
 
@@ -1471,6 +1478,47 @@ mod tests {
             !dispatcher.has_deferred("batch-2"),
             "nothing left after flush"
         );
+    }
+
+    #[test]
+    fn test_flush_deferred_records_debug_event() {
+        let registry = healthy_registry(2);
+        let mut dispatcher = Dispatcher::new(Arc::clone(&registry));
+        let recorder = DebugRecorder::new(100, Duration::from_secs(60));
+        dispatcher.set_debug_recorder(Arc::clone(&recorder));
+
+        let b1 = dispatcher.assign("batch-1", make_msgs(&[("t", "user-1")]));
+        let pinned = b1[0].worker.clone();
+        registry.start_draining(&pinned);
+        assert!(dispatcher
+            .assign("batch-2", make_msgs(&[("t", "user-1")]))
+            .is_empty());
+        dispatcher.on_sub_batch_resolved(&pinned, b1[0].messages.len(), &b1[0].routing_keys, false);
+
+        let flushed = dispatcher.flush_deferred("batch-2");
+        assert_eq!(flushed.len(), 1);
+
+        let flush_events: Vec<_> = recorder
+            .backlog()
+            .into_iter()
+            .filter_map(|e| match e.kind {
+                DebugEventKind::DeferredFlushed {
+                    batch_id,
+                    sub_batches,
+                } => Some((batch_id, sub_batches)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            flush_events.len(),
+            1,
+            "flush_deferred must record a DeferredFlushed debug event"
+        );
+        let (batch_id, sub_batches) = &flush_events[0];
+        assert_eq!(batch_id, "batch-2");
+        assert_eq!(sub_batches.len(), 1);
+        assert_eq!(sub_batches[0].worker, flushed[0].worker.to_string());
+        assert_eq!(sub_batches[0].messages, 1);
     }
 
     #[test]

--- a/rust/ingestion-control-plane/src/ui/consumer_debug.html
+++ b/rust/ingestion-control-plane/src/ui/consumer_debug.html
@@ -252,8 +252,14 @@
       const fmtDur = (ms) => {
         if (ms == null || !isFinite(ms) || ms < 0) return "—";
         if (ms < 1000) return `${Math.round(ms)}ms`;
-        if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-        return `${Math.floor(ms / 60000)}m ${String(Math.round((ms % 60000) / 1000)).padStart(2, "0")}s`;
+        // Round before picking the unit so 59,999ms doesn't render as "60.0s"
+        // or 119,999ms as "1m 60s".
+        if (ms < 60000) {
+          const seconds = Math.round(ms / 100) / 10;
+          if (seconds < 60) return `${seconds.toFixed(1)}s`;
+        }
+        const totalSeconds = Math.round(ms / 1000);
+        return `${Math.floor(totalSeconds / 60)}m ${String(totalSeconds % 60).padStart(2, "0")}s`;
       };
 
       // ---------- point-in-time load (polled fast, no event backlog) ----------
@@ -499,13 +505,18 @@
         const flow = buildFlow(b, workers);
 
         // Annotate flushes with the stash dwell time so defer → retry gaps are
-        // readable without diffing timestamps by hand.
-        let lastDeferTs = null;
+        // readable without diffing timestamps by hand. Measured from the first
+        // deferral of the current stash cycle: several Deferred events can pile
+        // up before one flush, and the earliest is what waited longest.
+        let cycleDeferTs = null;
         const timeline = b.events.map((ev) => {
           const [cls, html] = describe(ev);
           let extra = "";
-          if (ev.type === "Deferred") lastDeferTs = ev.ts_ms;
-          if (ev.type === "DeferredFlushed" && lastDeferTs !== null) extra = `<span class="tag"> · waited ${fmtDur(ev.ts_ms - lastDeferTs)}</span>`;
+          if (ev.type === "Deferred" && cycleDeferTs === null) cycleDeferTs = ev.ts_ms;
+          if (ev.type === "DeferredFlushed" && cycleDeferTs !== null) {
+            extra = `<span class="tag"> · waited ${fmtDur(ev.ts_ms - cycleDeferTs)}</span>`;
+            cycleDeferTs = null;
+          }
           return `<div class="item ${cls}"><span class="t">${fmtTime(ev.ts_ms)}</span>${html}${extra}</div>`;
         }).join("");
 

--- a/rust/ingestion-control-plane/src/ui/consumer_debug.html
+++ b/rust/ingestion-control-plane/src/ui/consumer_debug.html
@@ -249,6 +249,12 @@
         const d = new Date(ms);
         return d.toLocaleTimeString("en-US", { hour12: false }) + "." + String(d.getMilliseconds()).padStart(3, "0");
       };
+      const fmtDur = (ms) => {
+        if (ms == null || !isFinite(ms) || ms < 0) return "—";
+        if (ms < 1000) return `${Math.round(ms)}ms`;
+        if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+        return `${Math.floor(ms / 60000)}m ${String(Math.round((ms % 60000) / 1000)).padStart(2, "0")}s`;
+      };
 
       // ---------- point-in-time load (polled fast, no event backlog) ----------
       let loadSamples = []; // rolling {t, v} of total in-flight, for a peak-hold
@@ -329,10 +335,10 @@
             case "BatchAssigned":
               b.assigned = ev.sub_batches; b.distinct_ids = ev.distinct_ids;
               b.deferredGroups = (b.deferredGroups || 0) + ev.deferred_groups + ev.unroutable_groups; break;
-            case "Deferred": b.deferred.push({ reason: ev.reason, groups: ev.groups }); break;
-            case "DeferredFlushed": ev.sub_batches.forEach((s) => b.flushed.push(s)); break;
-            case "SendRetry": b.retries.push({ worker: ev.worker, attempt: ev.attempt, reason: ev.reason }); break;
-            case "SendExhausted": b.exhausted.push({ worker: ev.worker, error: ev.error }); break;
+            case "Deferred": b.deferred.push({ reason: ev.reason, groups: ev.groups, ts: ev.ts_ms }); break;
+            case "DeferredFlushed": ev.sub_batches.forEach((s) => b.flushed.push({ ...s, ts: ev.ts_ms })); break;
+            case "SendRetry": b.retries.push({ worker: ev.worker, attempt: ev.attempt, reason: ev.reason, ts: ev.ts_ms }); break;
+            case "SendExhausted": b.exhausted.push({ worker: ev.worker, error: ev.error, ts: ev.ts_ms }); break;
             case "BatchCommitted":
               b.committed = { accepted: ev.accepted, duration_ms: ev.duration_ms, partitions: ev.partitions, ts: ev.ts_ms };
               recordCommit(ev); break;
@@ -492,9 +498,15 @@
 
         const flow = buildFlow(b, workers);
 
+        // Annotate flushes with the stash dwell time so defer → retry gaps are
+        // readable without diffing timestamps by hand.
+        let lastDeferTs = null;
         const timeline = b.events.map((ev) => {
           const [cls, html] = describe(ev);
-          return `<div class="item ${cls}"><span class="t">${fmtTime(ev.ts_ms)}</span>${html}</div>`;
+          let extra = "";
+          if (ev.type === "Deferred") lastDeferTs = ev.ts_ms;
+          if (ev.type === "DeferredFlushed" && lastDeferTs !== null) extra = `<span class="tag"> · waited ${fmtDur(ev.ts_ms - lastDeferTs)}</span>`;
+          return `<div class="item ${cls}"><span class="t">${fmtTime(ev.ts_ms)}</span>${html}${extra}</div>`;
         }).join("");
 
         const fresh = openDetailId !== b.id;
@@ -528,8 +540,14 @@
         b.deferred.forEach((d) => (deferBy[d.reason] = (deferBy[d.reason] || 0) + d.groups));
         const hasStash = b.deferred.length > 0;
         const totalDeferred = b.deferred.reduce((a, d) => a + d.groups, 0);
+        const firstDefer = hasStash ? b.deferred[0].ts : null;
+        const firstFlush = b.flushed.length ? Math.min(...b.flushed.map((s) => s.ts)) : null;
         const flushedBy = {};
-        b.flushed.forEach((s) => (flushedBy[s.worker] = (flushedBy[s.worker] || 0) + s.messages));
+        b.flushed.forEach((s) => {
+          const f = (flushedBy[s.worker] = flushedBy[s.worker] || { messages: 0, ts: s.ts });
+          f.messages += s.messages;
+          f.ts = Math.max(f.ts, s.ts);
+        });
 
         const partsShort = b.partitions.map((p) => `${p.partition}@${p.offset}`).join(" ") || "—";
         const sourceNode = `<div class="node src" id="n-source"><div class="title">Kafka batch</div><div class="big">${b.messages}</div><div class="sub">msgs · p ${partsShort}</div></div>`;
@@ -551,8 +569,11 @@
         }).join("") || '<div class="node" id="n-w-none"><div class="sub">not yet assigned</div></div>';
 
         const reasons = Object.entries(deferBy).filter(([, n]) => n > 0).map(([r, n]) => `${r}: ${n}`).join(" · ");
+        const stashTiming = b.flushed.length
+          ? `↻ flushed after ${fmtDur(firstFlush - firstDefer)}`
+          : "awaiting flush";
         const stashNode = hasStash
-          ? `<div class="node stash" id="n-stash"><div class="title">Stash / defer</div><div class="big">${totalDeferred}</div><div class="sub">${reasons}</div><div class="sub">${b.flushed.length ? "↻ flushed &amp; re-routed" : "awaiting flush"}</div></div>`
+          ? `<div class="node stash" id="n-stash"><div class="title">Stash / defer</div><div class="big">${totalDeferred}</div><div class="sub">${reasons}</div><div class="sub">⏸ ${fmtTime(firstDefer)}</div><div class="sub">${stashTiming}</div></div>`
           : "";
 
         const sinkNode = b.committed
@@ -573,7 +594,7 @@
         const C = { muted: "#8b93a1", warn: "#d29922", good: "#3fb950", error: "#f85149", accent: "#4f7cff" };
         const edges = [];
         edges.push({ from: "n-source", to: "n-assign", label: `${b.messages} msgs`, color: C.accent });
-        workers.forEach((w, i) => { if (w.assignedMsgs > 0) edges.push({ from: "n-assign", to: `n-w-${i}`, label: `sent ${w.assignedMsgs}`, color: C.muted }); });
+        workers.forEach((w, i) => { if (w.assignedMsgs > 0) edges.push({ from: "n-assign", to: `n-w-${i}`, label: `sent ${w.assignedMsgs}${w.retries ? ` · ↻${w.retries}` : ""}`, color: w.retries ? C.warn : C.muted }); });
 
         if (hasStash) {
           let incoming = 0;
@@ -585,7 +606,7 @@
           }
           workers.forEach((w, i) => { if (w.exhausted) { edges.push({ from: `n-w-${i}`, to: "n-stash", label: "send failed", color: C.error }); incoming++; } });
           if (deferBy.send_failed > 0 && incoming === 0) edges.push({ from: "n-assign", to: "n-stash", label: "send failed", color: C.error });
-          Object.entries(flushedBy).forEach(([worker, msgs]) => { const i = idx[worker]; if (i != null) edges.push({ from: "n-stash", to: `n-w-${i}`, label: `flushed ${msgs}`, color: C.warn }); });
+          Object.entries(flushedBy).forEach(([worker, f]) => { const i = idx[worker]; if (i != null) edges.push({ from: "n-stash", to: `n-w-${i}`, label: `flushed ${f.messages} · +${fmtDur(f.ts - firstDefer)}`, color: C.warn }); });
         }
 
         if (b.committed) {


### PR DESCRIPTION
## Problem

Follow-up to #71033. In the consumer debug batch detail view, a deferred batch only shows that work was stashed ("flushed & re-routed" or "awaiting flush"). The events carry timestamps, but the flow graph drops them when aggregating, so you can't see when the work was deferred, how long it sat stashed, or when and where it was retried without diffing lifecycle timestamps by hand.

## Changes

- The consumer never emitted the DeferredFlushed debug event: flush_deferred built the re-routed sub-batches but never recorded the event, so the UI showed every stashed batch as "awaiting flush" forever. The flush path now records it (with a dispatcher regression test).
- The batch model now keeps `ts_ms` on deferred, flushed, retry, and exhausted entries instead of discarding it.
- The stash node in the flow graph shows when the work was deferred and, once flushed, the dwell time ("flushed after 340ms"); until then it still shows "awaiting flush".
- Stash-to-worker flush edges are labeled with the flushed message count plus dwell relative to the first deferral ("flushed 120 · +340ms").
- Assign-to-worker edges show send retry counts ("sent 120 · ↻2") and turn amber when retries happened.
- The lifecycle timeline annotates each flush event with how long the stashed work waited.
- Adds a small `fmtDur` helper (ms / s / m formatting).

## How did you test this code?

Browser-only vanilla JS with no test harness. I extracted the inline script and ran `node --check` for syntax, plus a node unit test of `buildFlow` with a synthetic batch (deferred at t, flushed at t+340ms to one worker, one retry on another) asserting the stash node dwell text, the flush edge label, the retry edge label and color, the `fmtDur` formats, and the "awaiting flush" state for a still-stashed batch. I was not able to exercise it against a live consumer in this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal debug tooling, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by José: the deferred/stash graphics didn't show how and when stashed work was retried. I (Claude) threaded the existing event timestamps through the client-side batch model rather than adding new backend events, since the SSE stream already carries `ts_ms` on every event. Dwell on flush edges is measured against the first deferral of the batch, which is an approximation when a batch defers multiple times — the lifecycle timeline has the exact per-event gaps.

