### PR TITLE
fix(aio): resample llm judge on structured-output parse failures

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_llm_judge.py
+++ b/posthog/temporal/ai_observability/evaluation_llm_judge.py
@@ -1,5 +1,5 @@
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Any
 
@@ -29,7 +29,12 @@ from posthog.temporal.ai_observability.metrics import (
 from posthog.temporal.ai_observability.model_resolution import model_spec
 from posthog.temporal.common.utils import close_db_connections
 
-from products.ai_observability.backend.llm import DEFAULT_MODEL_BY_PROVIDER, Client, CompletionRequest
+from products.ai_observability.backend.llm import (
+    DEFAULT_MODEL_BY_PROVIDER,
+    Client,
+    CompletionRequest,
+    CompletionResponse,
+)
 from products.ai_observability.backend.llm.config import get_eval_config
 from products.ai_observability.backend.llm.errors import (
     AuthenticationError,
@@ -55,6 +60,13 @@ LLM_JUDGE_RETRY_POLICY = RetryPolicy(
     maximum_interval=timedelta(seconds=60),
     backoff_coefficient=2.0,
 )
+
+# A malformed judge response (a null verdict when applicable, or truncated JSON) is almost
+# always a one-off bad generation rather than a permanent failure, so resample the judge a
+# few times before giving up. Without this a single stochastic miss silently skips the eval
+# and floods error tracking. Kept in-activity (rather than via Temporal retries) so a genuinely
+# unparseable case is captured once, not once per Temporal attempt.
+MAX_JUDGE_PARSE_ATTEMPTS = 3
 
 
 class BooleanEvalResult(BaseModel):
@@ -104,7 +116,11 @@ Note: If the criteria above instructs you to return "N/A", "not applicable", or 
 Return:
 - applicable: true if the criteria applies to this input/output, false if it doesn't apply
 - verdict: true if it passes, false if it fails, or null if not applicable
-- reasoning: a brief explanation (1 sentence)""",
+- reasoning: a brief explanation (1 sentence)
+
+Consistency rules (both are required):
+- When applicable is true, verdict MUST be true or false — never null. If you set applicable to true you have to commit to a verdict.
+- When applicable is false, verdict MUST be null.""",
         )
     return OutputTypeConfig(
         response_format=BooleanEvalResult,
@@ -272,6 +288,52 @@ def _execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> EvaluationActi
     )
 
 
+def _parse_retry_reminder(allows_na: bool) -> str:
+    """Corrective instruction appended on retry after a structured-output parse failure."""
+    reminder = (
+        "Your previous response could not be parsed. Respond with ONLY valid JSON matching the "
+        "required schema exactly, with no extra text before or after it."
+    )
+    if allows_na:
+        reminder += (
+            " When applicable is true, verdict must be true or false and never null; "
+            "when applicable is false, verdict must be null."
+        )
+    return reminder
+
+
+def _complete_judge_with_parse_retries(
+    client: Client, request: CompletionRequest, *, allows_na: bool
+) -> CompletionResponse:
+    """Run the judge completion, resampling on structured-output parse failures.
+
+    Only `StructuredOutputParseError` is retried here; every other provider error propagates
+    to the caller's handlers unchanged. On each retry a corrective reminder is appended to the
+    system prompt to nudge the model back onto the schema. Raises the last parse error if all
+    attempts fail.
+    """
+    reminder = _parse_retry_reminder(allows_na)
+    last_error: StructuredOutputParseError | None = None
+    for attempt in range(MAX_JUDGE_PARSE_ATTEMPTS):
+        attempt_request = request
+        if attempt > 0:
+            reinforced_system = f"{request.system}\n\n{reminder}" if request.system else reminder
+            attempt_request = replace(request, system=reinforced_system)
+        try:
+            return client.complete(attempt_request)
+        except StructuredOutputParseError as e:
+            last_error = e
+            logger.warning(
+                "LLM judge returned unparseable structured output",
+                provider=request.provider,
+                model=request.model,
+                attempt=attempt + 1,
+                max_attempts=MAX_JUDGE_PARSE_ATTEMPTS,
+            )
+    assert last_error is not None  # loop runs at least once, so this is set on every failure path
+    raise last_error
+
+
 def call_llm_judge(
     *,
     evaluation: dict[str, Any],
@@ -312,16 +374,15 @@ def call_llm_judge(
         capture_analytics=False,
     )
 
+    request = CompletionRequest(
+        model=model,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_prompt}],
+        provider=provider,
+        response_format=response_format,
+    )
     try:
-        response = client.complete(
-            CompletionRequest(
-                model=model,
-                system=system_prompt,
-                messages=[{"role": "user", "content": user_prompt}],
-                provider=provider,
-                response_format=response_format,
-            )
-        )
+        response = _complete_judge_with_parse_retries(client, request, allows_na=allows_na)
     except AuthenticationError:
         if is_byok:
             increment_user_errors("auth_error", provider=provider)

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -37,7 +37,7 @@ from .evaluation_errors import (
     status_reason_detail_for_terminal_user_error,
     terminal_user_error_result_from_application_error,
 )
-from .evaluation_llm_judge import JUDGE_EVENT_MAX_CHARS
+from .evaluation_llm_judge import JUDGE_EVENT_MAX_CHARS, MAX_JUDGE_PARSE_ATTEMPTS
 from .run_evaluation import (
     BooleanEvalResult,
     BooleanWithNAEvalResult,
@@ -308,6 +308,83 @@ class TestRunEvaluationWorkflow:
         assert result.get("terminal_user_error") is not True
         assert "model" not in result
         mock_client.complete.assert_called_once()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_execute_llm_judge_activity_retries_and_recovers_on_parse_failure(self, setup_data, grandfathered):
+        """A stochastic bad generation should be resampled, not silently skipped."""
+        team = setup_data["team"]
+        evaluation_obj = setup_data["evaluation"]
+
+        evaluation = {
+            "id": str(evaluation_obj.id),
+            "name": "Test Evaluation",
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": "Is this response factually accurate?"},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+        event_data = create_mock_event_data(
+            team.id,
+            properties={
+                "$ai_input": [{"role": "user", "content": "What is 2+2?"}],
+                "$ai_output_choices": [{"role": "assistant", "content": "4"}],
+            },
+        )
+
+        good_response = MagicMock()
+        good_response.parsed = BooleanEvalResult(verdict=True, reasoning="The answer is correct")
+        good_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
+
+        with patch("posthog.temporal.ai_observability.evaluation_llm_judge.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.complete.side_effect = [
+                StructuredOutputParseError("Failed to parse structured output: verdict is required"),
+                good_response,
+            ]
+
+            result = execute_llm_judge_activity(ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=event_data))
+
+        assert result["verdict"] is True
+        assert result.get("skipped") is not True
+        assert mock_client.complete.call_count == 2
+
+    @pytest.mark.django_db(transaction=True)
+    def test_execute_llm_judge_activity_raises_parse_error_after_exhausting_retries(self, setup_data, grandfathered):
+        """Persistent parse failures still surface as a non-retryable parse_error after all attempts."""
+        team = setup_data["team"]
+        evaluation_obj = setup_data["evaluation"]
+
+        evaluation = {
+            "id": str(evaluation_obj.id),
+            "name": "Test Evaluation",
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": "Is this response factually accurate?"},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+        event_data = create_mock_event_data(
+            team.id,
+            properties={
+                "$ai_input": [{"role": "user", "content": "What is 2+2?"}],
+                "$ai_output_choices": [{"role": "assistant", "content": "4"}],
+            },
+        )
+
+        with patch("posthog.temporal.ai_observability.evaluation_llm_judge.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.complete.side_effect = StructuredOutputParseError(
+                "Failed to parse structured output: verdict is required"
+            )
+
+            with pytest.raises(ApplicationError) as exc_info:
+                execute_llm_judge_activity(ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=event_data))
+
+        assert exc_info.value.details[0]["error_type"] == "parse_error"
+        assert mock_client.complete.call_count == MAX_JUDGE_PARSE_ATTEMPTS
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

The LLM eval judge sometimes returns structured output that fails schema validation — most commonly a `null` verdict when `applicable` is true (the `BooleanWithNAEvalResult` consistency rule), and occasionally truncated/invalid JSON. Today that failure is raised as a non-retryable `parse_error`, which the workflow catches and converts into a **silent skip**: the evaluation produces no verdict and each occurrence lands in error tracking.

Because it's a stochastic generation problem rather than a permanent one, a single bad sample shouldn't throw the whole evaluation away. This shape shows up across all three judge providers (OpenAI, Anthropic, Gemini), so the failure is in the shared judge/schema/prompt path, not any one provider.

Context (Slack): https://posthog.slack.com/archives/C0BCHQJBJR5/p1784121084023949?thread_ts=1784121084.023949&cid=C0BCHQJBJR5

## Changes

- Resample the judge up to `MAX_JUDGE_PARSE_ATTEMPTS` on `StructuredOutputParseError`, appending a short corrective reminder to the system prompt on each retry. Centralized in `call_llm_judge` so it covers every provider. Kept in-activity (not via Temporal retries) so a genuinely unparseable case is captured once rather than once per Temporal attempt.
- Harden the N/A judge prompt with an explicit applicable/verdict consistency rule that mirrors the validator, lowering the base rate of malformed responses.
- Only parse errors are retried; all other provider errors (auth, rate limit, context window, …) propagate to their existing handlers unchanged.

## How did you test this code?

Added two unit tests in `test_run_evaluation.py` driving `execute_llm_judge_activity`:
- **retry recovers a stochastic parse failure** — first completion raises `StructuredOutputParseError`, second succeeds; asserts the verdict is returned (not skipped) and the judge was called twice. Catches regressions that remove the retry or leak the parse error on a recoverable miss.
- **exhaustion still raises `parse_error`** — every completion raises; asserts an `ApplicationError` with `error_type == "parse_error"` after exactly `MAX_JUDGE_PARSE_ATTEMPTS` calls. Catches an off-by-one in the attempt count or a swallowed terminal failure.

`ruff check` and `ruff format --check` pass on the changed files. The dev stack (pytest + deps) isn't available in the environment this was authored in, so **I did not run the test suite locally** — CI needs to validate it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The request was to pick the highest-priority item from an AI-observability digest and fix it; error-tracking data showed the eval-judge schema failure was the largest by volume and spanned all three providers (the digest had it as OpenAI-only), so it was chosen over the lower-volume Slack-delivery item. Considered making the existing Temporal retry policy handle parse errors, but that would capture the exception once per attempt; an in-activity resample keeps error-tracking noise to one capture per genuinely-unparseable evaluation. No repo migration/DRF/frontend skills applied (backend Temporal-only change).


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCHQJBJR5/p1784121084023949?thread_ts=1784121084.023949&cid=C0BCHQJBJR5)*
