### PR TITLE
chore(data-warehouse): add agent rule for temporal workflow versioning

### DIFF
--- a/.claude/rules/temporal-workflow-versioning.md
+++ b/.claude/rules/temporal-workflow-versioning.md
@@ -1,0 +1,26 @@
+---
+paths:
+  - 'posthog/temporal/**'
+  - 'products/*/backend/temporal/**'
+---
+
+**Editing a `@workflow.defn` body (adding/removing/reordering `execute_activity`, child-workflow
+starts, or timers) breaks in-flight executions with "Non Deterministic Error"** — on deploy every
+running execution replays its recorded history against the new code, and any new unconditional
+command at a point an execution already passed fails the replay. Activity implementations and
+activity *input* dataclasses are safe to edit; workflow command sequences are not.
+
+When adding a new activity or child-workflow start to an existing workflow, gate it one of two ways:
+
+1. `if workflow.patched("my-change-2026-07"): ...` — the default. Old histories skip the block,
+   new executions record a marker and run it. Precedent: `posthog/temporal/ai_observability/run_evaluation.py`.
+   Once no pre-patch executions remain (days, for short-lived workflows), optionally swap to
+   `workflow.deprecate_patch(...)` + unconditional code.
+2. Gate on a **new field of an existing activity's output dataclass that defaults to the skip
+   value** (e.g. `enrichment_needed: bool = False` in `create_job_model.py`) — old histories decode
+   the missing field to the default, so the new command never fires during replay. Only valid when
+   the decision comes from recorded history and skipping is acceptable for in-flight runs.
+
+Never gate workflow commands on values computed inside the workflow body (feature flags, settings,
+clock, DB reads) — that is itself non-deterministic. Removing/reordering existing commands needs
+`workflow.patched()` with the old path kept in the `else` branch.

--- a/.claude/rules/temporal-workflow-versioning.md
+++ b/.claude/rules/temporal-workflow-versioning.md
@@ -8,7 +8,7 @@ paths:
 starts, or timers) breaks in-flight executions with "Non Deterministic Error"** — on deploy every
 running execution replays its recorded history against the new code, and any new unconditional
 command at a point an execution already passed fails the replay. Activity implementations and
-activity *input* dataclasses are safe to edit; workflow command sequences are not.
+activity _input_ dataclasses are safe to edit; workflow command sequences are not.
 
 When adding a new activity or child-workflow start to an existing workflow, gate it one of two ways:
 

--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -320,6 +320,11 @@ def trigger_schedule_buffer_one_activity(schedule_id: str) -> None:
 
 
 # TODO: update retry policies
+#
+# DETERMINISM: adding, removing, or reordering activities / child-workflow starts in `run` breaks
+# every in-flight execution with a non-deterministic replay error on deploy. Gate new commands with
+# `workflow.patched("...")`, or on a new `create_job_model` output field that defaults to the skip
+# value — see .claude/rules/temporal-workflow-versioning.md.
 @workflow.defn(name="external-data-job")
 class ExternalDataJobWorkflow(PostHogWorkflow):
     @staticmethod


### PR DESCRIPTION
## Problem

Adding new activities to `ExternalDataJobWorkflow` (and Temporal workflows generally) without a versioning gate breaks every in-flight execution with "Non Deterministic Error" on deploy — replay of the recorded history hits the new unconditional command and fails the workflow task. This has bitten the warehouse import workflow repeatedly, and nothing told agents (or humans skimming the file) about the hazard at the point of edit.

## Changes

- New `.claude/rules/temporal-workflow-versioning.md`, path-scoped to `posthog/temporal/**` and `products/*/backend/temporal/**`, so agents get it injected whenever they touch Temporal code. It explains the replay hazard, the two safe patterns — `workflow.patched("...")` (with the `deprecate_patch` lifecycle, citing the existing `run_evaluation.py` precedent) and gating on a defaulted output field of an existing activity (the `create_job_model.py` pattern) — and the anti-pattern of gating workflow commands on flags/settings/clock computed in the workflow body.
- A short DETERMINISM comment above `ExternalDataJobWorkflow` pointing at the rule, since the workflow file itself is where the edit happens.

## How did you test this code?

Instructions-only change plus a comment; ruff clean on the touched Python file. The rule follows the existing `.claude/rules/*.md` format (`paths:` frontmatter globs, e.g. `drf-endpoints.md`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The rule file is the doc.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by Tom, after repeated non-deterministic replay failures from unconditional activity additions to the external-data-job workflow. Chose a path-scoped `.claude/rules/` file over a nested AGENTS.md because the rules mechanism injects guidance exactly when matching files are edited; a linter for "new unguarded workflow command" isn't practical to express.
