### PR TITLE
fix(data-warehouse): make duplicate-prefix source error actionable

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -1995,7 +1995,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                         },
                     )
             elif self.prefix_exists(source_type, prefix):
-                return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={
+                        "message": f"Another source of this type already uses the prefix '{prefix}'. Choose a different prefix so this connection's tables don't clash."
+                    },
+                )
 
         if access_method == ExternalDataSource.AccessMethod.WAREHOUSE and is_any_external_data_schema_paused(
             self.team_id
@@ -4096,7 +4101,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                     },
                 )
         elif self.prefix_exists(source_type, prefix):
-            return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": f"Another source of this type already uses the prefix '{prefix}'. Choose a different prefix so this connection's tables don't clash."
+                },
+            )
 
         return Response(status=status.HTTP_200_OK)
 

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -1195,7 +1195,12 @@ class TestExternalDataSource(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), {"message": "Prefix already exists"})
+        self.assertEqual(
+            response.json(),
+            {
+                "message": "Another source of this type already uses the prefix 'test_'. Choose a different prefix so this connection's tables don't clash."
+            },
+        )
 
     def _make_external_data_source(
         self, source_type: str = "Postgres", prefix: t.Optional[str] = None, deleted: bool = False
@@ -1236,7 +1241,7 @@ class TestExternalDataSource(APIBaseTest):
                 [("foo_", False)],
                 "foo_",
                 400,
-                "Prefix already exists",
+                "Another source of this type already uses the prefix 'foo_'. Choose a different prefix so this connection's tables don't clash.",
             ),
             (
                 "no-prefix source (null) blocks another no-prefix",


### PR DESCRIPTION
## Problem

When onboarding a new data warehouse source, if the chosen table prefix collides with an existing source of the same type, the wizard rejects it with the bare message **"Prefix already exists"**, surfaced inline on the prefix field. It doesn't name the conflicting prefix or say what to do next. Real onboarding sessions show users getting stuck here — including rage-clicking the affected step — even though the fix (pick a different prefix) is simple.

The adjacent no-prefix case already has an actionable message ("You already have a source of this type. Add a table prefix so this connection's tables don't clash..."); the collision case was left terse.

## Changes

Reword both call sites in `external_data_source.py` (source create and the `source_prefix` availability check) so the error names the prefix and states the next action:

> Another source of this type already uses the prefix '<prefix>'. Choose a different prefix so this connection's tables don't clash.

Updated the two exact-match assertions in the existing prefix-validation tests.

## How did you test this code?

Copy-only change to two existing 400 responses; the frontend already renders `data.message` as the inline prefix-field error, so no client change is needed. Updated the existing backend assertions to the new strings. The full DWH API suite requires a DB/ClickHouse/Temporal stack that wasn't available in this environment, so I couldn't run it locally — CI covers it.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code while synthesizing friction themes from data-warehouse new-source onboarding session summaries. Invoked the `/improving-drf-endpoints` skill to confirm the change is a pure copy edit within existing responses (no serializer/schema impact). Chose this because it's a self-contained, obviously-correct copy improvement backed by observed user friction; larger themes (OAuth redirect handling, sync-frequency limits) were left as recommendations rather than PRs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*