### PR TITLE
fix(aio): render message tool_calls as tool-call blocks

### DIFF
--- a/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
@@ -198,6 +198,35 @@ describe('LLMMessageDisplay', () => {
         })
     })
 
+    it('renders message-level tool_calls as tool-call blocks instead of a JSON kwargs dump', async () => {
+        const message: CompatMessage = {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+                {
+                    type: 'function',
+                    id: 'call_qeXd2gLSx1ws',
+                    function: { name: 'exec', arguments: { command: 'search ^skill-get$' } },
+                },
+            ],
+        }
+        const { container } = render(
+            <Provider>
+                <LLMMessageDisplay message={message} show />
+            </Provider>
+        )
+        expect(container.textContent).toContain('exec')
+        expect(container.textContent).toContain('call_qeXd2gLSx1ws')
+        await waitFor(
+            () => {
+                expect(container.textContent).toContain('command')
+                expect(container.textContent).toContain('search ^skill-get$')
+            },
+            { timeout: JSON_VIEWER_TIMEOUT_MS }
+        )
+        expect(container.textContent).not.toContain('tool_calls')
+    })
+
     it('renders content[].type=function with stringified JSON arguments', async () => {
         const message: CompatMessage = {
             role: 'assistant',

--- a/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -628,6 +628,8 @@ export const LLMMessageDisplay = React.memo(
         messageSentiment?: { label: string; score: number }
     }): JSX.Element => {
         const { role, content, ...additionalKwargs } = message
+        // Tool calls get the dedicated tool-call rendering below instead of the kwargs JSON dump.
+        const toolCalls = Array.isArray(message.tool_calls) && message.tool_calls.length > 0 ? message.tool_calls : null
         let resolvedIsRenderingMarkdown = isRenderingMarkdown
         let resolvedIsRenderingXml = isRenderingXml
 
@@ -658,7 +660,11 @@ export const LLMMessageDisplay = React.memo(
                   }
                   return tool
               })
-            : Object.fromEntries(Object.entries(additionalKwargs).filter(([, value]) => value !== undefined))
+            : Object.fromEntries(
+                  Object.entries(additionalKwargs).filter(
+                      ([key, value]) => value !== undefined && !(key === 'tool_calls' && toolCalls)
+                  )
+              )
 
         const renderMessageContent = (
             content: string | { type: string; content: string } | VercelSDKImageMessage | MultiModalContentItem[],
@@ -812,7 +818,7 @@ export const LLMMessageDisplay = React.memo(
                             {role}
                             {messageSentiment && <MessageSentimentBar sentiment={messageSentiment} />}
                         </span>
-                        {(content || Object.keys(additionalKwargsEntries).length > 0) && (
+                        {(content || toolCalls || Object.keys(additionalKwargsEntries).length > 0) && (
                             <>
                                 <LemonButton
                                     size="small"
@@ -864,6 +870,20 @@ export const LLMMessageDisplay = React.memo(
                         ) : (
                             renderMessageContent(content, searchQuery)
                         )}
+                    </div>
+                )}
+                {show && toolCalls && (
+                    <div className={clsx('space-y-2', !minimal ? 'p-2 border-t' : 'p-1 text-xs')}>
+                        {toolCalls.map((toolCall, index) => (
+                            <React.Fragment key={index}>
+                                {renderContentItem(
+                                    (toolCall.function && !toolCall.type
+                                        ? { ...toolCall, type: 'function' }
+                                        : toolCall) as MultiModalContentItem,
+                                    searchQuery
+                                )}
+                            </React.Fragment>
+                        ))}
                     </div>
                 )}
                 {show && (!minimal || !content) && Object.keys(additionalKwargsEntries).length > 0 && (


### PR DESCRIPTION
## Problem

Assistant messages that carry tool calls in the message-level `tool_calls` field render as a raw JSON tree in the trace conversation view. `LLMMessageDisplay` destructures `role` and `content` and dumps every remaining field through the "additional kwargs" JSON viewer, so a tool-call message shows up as `{"tool_calls": [{"type": "function", "id": ..., "function": {...}}]}` with all the structural noise, while the dedicated tool-call block (wrench icon, tool name, call id, parsed args) only kicks in for function items nested inside `content` arrays.

Any agent trace whose transcript normalizes tool calls onto `message.tool_calls` (OpenAI Responses API / chat completions items, MCP-driven agents) hits this on every single tool call, which for agentic runs is most of the conversation.

## Changes

In `LLMMessageDisplay`, pull `tool_calls` out of the kwargs dump and render each entry through the existing `renderContentItem` function-call block. Entries that carry `function` but no `type` are coerced to `type: function` so they hit the pretty path; anything unrecognized falls back to a per-item JSON viewer as before. The remaining kwargs still render as JSON below.

Before: tool-call messages show a collapsed JSON tree of the whole `tool_calls` array.
After: each tool call renders as the same block used for content-array function items - wrench icon, bold tool name, call id, and the arguments in a JSON viewer.

## How did you test this code?

- New jest case `renders message-level tool_calls as tool-call blocks instead of a JSON kwargs dump`: catches the regression where `tool_calls` falls back into the kwargs JSON dump. No existing test covered message-level `tool_calls` (only `content[].type=function` items).
- Full `ConversationMessagesDisplay.test.tsx` suite passes (27 tests).
- I (the agent) couldn't capture UI screenshots in this session - the rendering path reuses the existing, already-tested function-call block, and the new test asserts the raw `tool_calls` key no longer appears in the rendered output.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - trace view rendering detail, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Fable), driven by Andy Maguire. Skills invoked: `/writing-tests`.
- Origin: eyeballing signals scout run traces. After #71070 made Responses API envelopes parse, tool-call messages were the remaining eyesore - Andy pointed at the raw `tool_calls` JSON dump in the conversation view.
- First instinct was a team-level custom parser recipe, but recipes only shape normalized messages; the JSON dump happens downstream in the display component, so the fix belongs here. Kept the change minimal by reusing `renderContentItem` rather than introducing a new tool-call component.