### PR TITLE
fix(aio): guard against null summarization response in summary view

### DIFF
--- a/products/ai_observability/frontend/summary-view/summaryViewLogic.ts
+++ b/products/ai_observability/frontend/summary-view/summaryViewLogic.ts
@@ -147,6 +147,12 @@ export const summaryViewLogic = kea<summaryViewLogicType>([
                 // nosemgrep: prefer-codegen-api
                 const data = await api.create(`api/environments/${teamId}/llm_analytics/summarization/`, payload)
 
+                // The endpoint can resolve to an empty body (e.g. no summary available yet),
+                // so guard before reading fields to avoid a null dereference.
+                if (!data || !data.summary) {
+                    throw new Error('No summary available for this trace yet')
+                }
+
                 return {
                     summary: data.summary,
                     text_repr: data.text_repr,


### PR DESCRIPTION
## Problem

The AI observability trace summary view threw an uncaught `TypeError: Cannot read properties of null (reading 'summary')` from `summaryViewLogic.ts`. The `generateSummary` loader called the summarization endpoint and read `data.summary` directly. When the endpoint resolves to an empty/null body (for example when no summary is available yet), that dereference blew up. Surfaced by an [error tracking alert](https://us.posthog.com/project/2/error_tracking/019f5f61-0cc6-7b32-aa9d-befd25be6ac6).

## Changes

Guard the response before reading its fields. If the body is missing or has no `summary`, the loader now throws a clear "No summary available for this trace yet" error, which the kea loader captures as a normal failure state instead of a null dereference.

## How did you test this code?

No automated test added — this is a one-line defensive guard in a kea loader. I (the agent) did not run the frontend manually. The change is type-safe against the existing `{ summary, text_repr } | null` loader default.

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated the error tracking issue from a Slack thread using the PostHog MCP tools (`query-error-tracking-issues-list`, `query-error-tracking-issue-events`) and the `investigating-error-issue` skill. The single sample event pointed at `summaryViewLogic.ts:150` where `data.summary` was read without a null check. Chose a minimal guard over a broader refactor since the loader already models a nullable result.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1784011627269589?thread_ts=1784011627.269589&cid=C0A006STKHR)*
