### PR TITLE
fix(aio): prevent trace search stack overflow from URL sync loop

### DIFF
--- a/products/ai_observability/frontend/aiObservabilityTraceLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityTraceLogic.test.ts
@@ -92,6 +92,26 @@ describe('aiObservabilityTraceLogic', () => {
         })
     })
 
+    it('does not write the search query back to the URL when it originates from the URL', async () => {
+        // Regression: setSearchQuery's listener wrote the query back to the URL, which
+        // re-fired urlToAction, which called setSearchQuery again. For a query that the URL
+        // builder and the browser encode/read differently (e.g. one containing a space, like
+        // "[cite] "), the value-only guard never converged and the two recursed until the
+        // stack overflowed. A URL-sourced query must not trigger a write-back.
+        const replaceSpy = jest.spyOn(router.actions, 'replace')
+        const traceId = 'trace-with-search'
+        const traceUrl = combineUrl(urls.aiObservabilityTrace(traceId, { search: '[cite] ' }))
+
+        router.actions.push(addProjectIdIfMissing(traceUrl.url, MOCK_TEAM_ID))
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.traceId).toBe(traceId)
+        expect(logic.values.searchQuery).toContain('cite')
+        expect(replaceSpy).not.toHaveBeenCalled()
+
+        replaceSpy.mockRestore()
+    })
+
     describe('messageShowStates reducer', () => {
         it('has correct initial state', () => {
             expect(logic.values.messageShowStates).toEqual({

--- a/products/ai_observability/frontend/aiObservabilityTraceLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilityTraceLogic.ts
@@ -487,7 +487,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
         initializeMessageStates: ({ inputCount, outputCount }) => {
             // Apply display option when initializing
             const displayOption = values.displayOption
@@ -504,8 +504,17 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
             actions.applySearchResults(inputStates, outputStates)
         },
         setSearchQuery: ({ searchQuery }) => {
+            // When the query came from the URL (via urlToAction), don't write it back.
+            // The URL builder and the router's decoder don't round-trip every string
+            // identically (e.g. queries containing a space), so the value-only comparison
+            // below can stay unequal forever and recurse until the stack overflows. This
+            // re-entrancy flag breaks the loop regardless of encoding.
+            if (cache.settingSearchFromUrl) {
+                cache.settingSearchFromUrl = false
+                return
+            }
+
             // Only update URL if the search query actually changed
-            // This prevents infinite loop when setSearchQuery is called from urlToAction
             const currentUrl = window.location.search
             const urlParams = new URLSearchParams(currentUrl)
             const currentSearchInUrl = urlParams.get('search') || ''
@@ -564,7 +573,7 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
         },
     })),
 
-    urlToAction(({ actions }) => ({
+    urlToAction(({ actions, cache }) => ({
         [urls.aiObservabilityTrace(':id')]: ({ id }, { event, timestamp, exception_ts, search, line, tab, msg }) => {
             actions.setTraceId(id ?? '')
             void addProductIntent({
@@ -587,7 +596,9 @@ export const aiObservabilityTraceLogic = kea<aiObservabilityTraceLogicType>([
                     parsedDate.add(EXCEPTION_LOOKUP_WINDOW_MINUTES, 'minutes').toISOString()
                 )
             }
-            // Set search from URL param if provided, otherwise clear it
+            // Set search from URL param if provided, otherwise clear it.
+            // Mark it as URL-driven so the listener doesn't write it straight back to the URL.
+            cache.settingSearchFromUrl = true
             actions.setSearchQuery(search || '')
         },
     })),


### PR DESCRIPTION
## Problem

The AI observability **trace view** throws `RangeError: Maximum call stack size exceeded` (a stack overflow) when certain search queries are entered. The search box and the URL were wired in a two-way loop: `setSearchQuery`'s listener wrote the query into the URL (`router.actions.replace`), which re-fired `urlToAction`, which called `setSearchQuery` again. A value-only guard (`searchQuery !== currentSearchInUrl`) was meant to break the loop, but for queries the URL builder and the browser encode/read differently (e.g. one containing a space), the comparison never converged — the two actions recursed synchronously until the stack overflowed and the tab crashed. Surfaced via an error tracking alert; low volume so far but the search feature is broken for the affected inputs.

Origin: [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1784021635953209?thread_ts=1784021635.953209&cid=C0A006STKHR)

## Changes

Added a re-entrancy flag (`cache.settingSearchFromUrl`) in `aiObservabilityTraceLogic`: `urlToAction` sets it before dispatching `setSearchQuery`, and the listener skips the URL write-back when it's set. This breaks the loop structurally, regardless of how the query string encodes. The existing value-guard is kept as an optimization to avoid unnecessary history churn.

## How did you test this code?

Added one regression test in `aiObservabilityTraceLogic.test.ts`: pushes a trace URL whose `search` param contains a space (`[cite] `, the production trigger) and asserts the query is applied without being written back to the URL (`router.actions.replace` not called) — i.e. no re-entrant write-back that would recurse. Removing the guard reintroduces the write-back this test forbids.

Note: this environment has no `node_modules`, so I (the agent) could not run jest or the typecheck locally. The change is a small, self-contained kea logic edit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated an error tracking issue from a Slack thread using the PostHog MCP error-tracking tools (`query-error-tracking-issues-list`, `query-error-tracking-issue-events`), which pointed at `setSearchQuery` in `aiObservabilityTraceLogic.ts` with a sample URL containing a spaced search query. Skills invoked: `/investigating-error-issue` and `/writing-tests`.

Considered an encoding-agnostic fix by comparing the fully-built target URL against the current URL, but the exact round-trip through kea-router's decoder couldn't be verified in this environment; the re-entrancy flag is the standard kea pattern for URL⟷state sync loops and is robust to encoding quirks, so it was chosen instead.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1784021635953209?thread_ts=1784021635.953209&cid=C0A006STKHR)*
