### PR TITLE
feat(signals): link scout labels in inbox to the scout

### DIFF
--- a/frontend/src/lib/signals/ScoutLink.tsx
+++ b/frontend/src/lib/signals/ScoutLink.tsx
@@ -1,0 +1,23 @@
+import { Link } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
+
+import { scoutDisplayName } from './signalCardSourceLine'
+
+/**
+ * The authoring scout's prettified name, linked to its detail page in the inbox so a reader can jump
+ * straight from a report or finding to the scout that wrote it. Renders nothing when the slug can't be
+ * prettified (a bare/empty `signals-scout` slug). `stopPropagation` keeps a click from also triggering
+ * an enclosing card/row link.
+ */
+export function ScoutLink({ skillName, className }: { skillName: string; className?: string }): JSX.Element | null {
+    const name = scoutDisplayName(skillName)
+    if (!name) {
+        return null
+    }
+    return (
+        <Link to={urls.inboxScout(skillName)} className={className} onClick={(e) => e.stopPropagation()}>
+            {name}
+        </Link>
+    )
+}

--- a/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
+++ b/frontend/src/scenes/inbox/components/cards/ReportCard.tsx
@@ -5,6 +5,7 @@ import { IconArchive, IconPullRequest, IconUndo } from '@posthog/icons'
 import { LemonButton, LemonTag, LemonTagType, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import { ScoutLink } from 'lib/signals/ScoutLink'
 import { scoutDisplayName } from 'lib/signals/signalCardSourceLine'
 import { urls } from 'scenes/urls'
 
@@ -46,28 +47,33 @@ export function ConventionalCommitScopeTag({ type, scope }: { type: string; scop
 /** Icon stack + primary source-product label, with a `+ n` tail when more sources contributed. */
 export function InboxCardSourceMeta({
     sourceProducts,
-    scoutName,
+    scoutSkillName,
 }: {
     sourceProducts?: string[] | null
-    /** Authoring scout's display name, when scout-authored — appended to the "Scout" label. */
-    scoutName?: string | null
+    /** Authoring scout's raw skill slug, when scout-authored — its name links to the scout off the "Scout" label. */
+    scoutSkillName?: string | null
 }): JSX.Element | null {
     const entries = knownSourceProductEntries(sourceProducts)
     const [primary, ...overflow] = entries
     if (!primary) {
         return null
     }
-    // Name the authoring scout on a scout-authored report so it's clear at a glance who wrote it.
-    const primaryLabel =
-        primary.key === SignalSourceProduct.SignalsScout && scoutName
-            ? `${primary.meta.label} · ${scoutName}`
-            : primary.meta.label
+    // Name the authoring scout on a scout-authored report so it's clear at a glance who wrote it,
+    // and link the name straight to the scout's detail page.
+    const scoutName = scoutDisplayName(scoutSkillName)
+    const showScout = primary.key === SignalSourceProduct.SignalsScout && !!scoutName
     return (
         <Tooltip title={sourceProductsTooltipTitle(entries)}>
             <div className="flex items-center gap-2 min-w-0 text-xs text-tertiary leading-none select-none cursor-help">
                 <SourceProductIconRow entries={entries} className="flex items-center gap-1.5 shrink-0" />
                 <span>
-                    {primaryLabel}
+                    {primary.meta.label}
+                    {showScout && scoutSkillName ? (
+                        <>
+                            {' · '}
+                            <ScoutLink skillName={scoutSkillName} className="text-tertiary" />
+                        </>
+                    ) : null}
                     {overflow.length > 0 ? ` + ${overflow.length}` : null}
                 </span>
             </div>
@@ -266,7 +272,7 @@ export function ReportCard({
                             {hasPr && repoSlug ? <span className="truncate font-mono">{repoSlug}</span> : null}
                             <InboxCardSourceMeta
                                 sourceProducts={report.source_products}
-                                scoutName={scoutDisplayName(report.scout_name)}
+                                scoutSkillName={report.scout_name}
                             />
                             {!hasPr && (!isReady || !report.actionability) && (
                                 <SignalReportStatusBadge status={report.status} />

--- a/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
@@ -8,6 +8,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { IconLink } from 'lib/lemon-ui/icons'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { LemonMenu, LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
+import { ScoutLink } from 'lib/signals/ScoutLink'
 import { scoutDisplayName } from 'lib/signals/signalCardSourceLine'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { addProjectIdIfMissing } from 'lib/utils/kea-router'
@@ -83,13 +84,13 @@ function ReportDetailMeta({
     report,
     evidenceCount,
     actionabilityExplanation,
-    scoutName,
+    scoutSkillName,
 }: {
     report: SignalReport
     evidenceCount: number
     actionabilityExplanation?: string | null
-    /** Authoring scout's display name, when the report was scout-authored — appended to the "Scout" chip. */
-    scoutName?: string | null
+    /** Authoring scout's raw skill slug, when scout-authored — its name links to the scout off the "Scout" chip. */
+    scoutSkillName?: string | null
 }): JSX.Element {
     const hasSource = hasKnownSourceProduct(report.source_products)
     // "Ready" is the default terminal state; surface the status chip only until actionability is known.
@@ -119,7 +120,7 @@ function ReportDetailMeta({
         </span>
     )
     if (hasSource) {
-        stats.push(<MetaSourceStack sourceProducts={report.source_products} scoutName={scoutName} />)
+        stats.push(<MetaSourceStack sourceProducts={report.source_products} scoutSkillName={scoutSkillName} />)
     }
 
     return (
@@ -145,27 +146,32 @@ function ReportDetailMeta({
 /** Source-product icon stack reused inside the detail meta row. */
 function MetaSourceStack({
     sourceProducts,
-    scoutName,
+    scoutSkillName,
 }: {
     sourceProducts?: string[] | null
-    scoutName?: string | null
+    scoutSkillName?: string | null
 }): JSX.Element | null {
     const entries = knownSourceProductEntries(sourceProducts)
     const [primary, ...overflow] = entries
     if (!primary) {
         return null
     }
-    // Name the authoring scout on a scout-authored report so it's clear at a glance who wrote it.
-    const primaryLabel =
-        primary.key === SignalSourceProduct.SignalsScout && scoutName
-            ? `${primary.meta.label} · ${scoutName}`
-            : primary.meta.label
+    // Name the authoring scout on a scout-authored report so it's clear at a glance who wrote it,
+    // and link the name straight to the scout's detail page.
+    const scoutName = scoutDisplayName(scoutSkillName)
+    const showScout = primary.key === SignalSourceProduct.SignalsScout && !!scoutName
     return (
         <Tooltip title={sourceProductsTooltipTitle(entries)}>
             <span className="inline-flex items-center gap-1.5 min-w-0 cursor-help">
                 <SourceProductIconRow entries={entries} className="inline-flex items-center gap-1 shrink-0" />
                 <span>
-                    {primaryLabel}
+                    {primary.meta.label}
+                    {showScout && scoutSkillName ? (
+                        <>
+                            {' · '}
+                            <ScoutLink skillName={scoutSkillName} className="text-tertiary" />
+                        </>
+                    ) : null}
                     {overflow.length > 0 ? ` + ${overflow.length}` : null}
                 </span>
             </span>
@@ -277,9 +283,6 @@ export function InboxDetailFrame({
     const signals = reportSignals ?? []
     const evidenceCount = reportSignals !== null ? signals.length : report.signal_count
     const hasEvidence = evidenceCount > 0
-
-    // Which scout authored this report — the serializer resolves the skill_name off the backing signals.
-    const scoutName = scoutDisplayName(report.scout_name)
 
     const summaryPending =
         report.status === SignalReportStatus.IN_PROGRESS || report.status === SignalReportStatus.CANDIDATE
@@ -399,7 +402,7 @@ export function InboxDetailFrame({
                                 report={report}
                                 evidenceCount={evidenceCount}
                                 actionabilityExplanation={actionabilityExplanation}
-                                scoutName={scoutName}
+                                scoutSkillName={report.scout_name}
                             />
                         </div>
                     </div>

--- a/frontend/src/scenes/inbox/components/signalCards/SignalCardShell.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SignalCardShell.tsx
@@ -1,4 +1,5 @@
-import { signalCardSourceLine } from 'lib/signals/signalCardSourceLine'
+import { ScoutLink } from 'lib/signals/ScoutLink'
+import { scoutDisplayName, signalCardSourceLine } from 'lib/signals/signalCardSourceLine'
 import type { SignalNode } from 'scenes/debug/signals/types'
 
 import { getSourceProductMeta } from '../badges/sourceProductIcons'
@@ -21,6 +22,13 @@ export function SignalCardHeader({
     const meta = getSourceProductMeta(signal.source_product)
     const Icon = meta?.Icon
 
+    // Scout-authored findings link the scout's name to its detail page; everything else stays plain text.
+    const scoutSkillName =
+        signal.source_product === 'signals_scout'
+            ? (signal.extra as { skill_name?: unknown } | undefined)?.skill_name
+            : undefined
+    const scoutName = typeof scoutSkillName === 'string' ? scoutDisplayName(scoutSkillName) : null
+
     return (
         <div className="flex items-center gap-2 mb-2">
             {Icon ? (
@@ -35,7 +43,15 @@ export function SignalCardHeader({
             ) : (
                 <span className="size-2.5 rounded-full shrink-0 bg-border" />
             )}
-            <span className="text-xs font-medium text-tertiary">{signalCardSourceLine(signal)}</span>
+            <span className="text-xs font-medium text-tertiary">
+                {scoutName && typeof scoutSkillName === 'string' ? (
+                    <>
+                        Scout · <ScoutLink skillName={scoutSkillName} className="text-tertiary" />
+                    </>
+                ) : (
+                    signalCardSourceLine(signal)
+                )}
+            </span>
             {label && <span className="text-xs font-medium text-primary flex-1 truncate">{label}</span>}
             <span className="flex-1" />
             {rightSlot}


### PR DESCRIPTION
## Problem

Inbox reports and their evidence findings show a "Scout · <name>" label naming the scout that authored them, but the label is plain text. There's no easy way to get from a report back to the scout it came from — you'd have to navigate to the scout list and find it by name.

## Changes

The scout name in the "Scout · <name>" label is now a link to the scout's detail page (`/inbox/scouts/<skill-name>`) in three places:

- the report detail header meta row
- the report list card
- each evidence finding card header

A small shared `ScoutLink` component builds the link from the raw scout skill slug (prettifying it for display via the existing `scoutDisplayName`) and stops click propagation so it works even inside the clickable report row.

## How did you test this code?

I (Claude) couldn't run the frontend typecheck/lint/format here — `node_modules` isn't installed in this environment. Changes are pure `.tsx` edits that reuse existing helpers (`urls.inboxScout`, `scoutDisplayName`) and the existing linked-`v{version}` pattern already used in the scout finding card, so the wiring mirrors code that already works. Please rely on CI for typecheck/lint.

No behavior changes beyond the label becoming a link; the fallback "Scout · Cross-source finding" text (when there's no resolvable scout slug) stays plain text.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Andy: make the scout SLO-monitoring (and every scout) label in inbox reports link to the corresponding scout so users can navigate there easily. I traced the label rendering to three components sharing the same `Scout · <name>` pattern, found that the raw slug (`report.scout_name` / `signal.extra.skill_name`) was being discarded in favor of the display name at each call site, and threaded the raw slug through instead so `urls.inboxScout()` can build the link. Factored the name-to-link rendering into a shared `ScoutLink` to keep the three sites consistent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
