### PR TITLE
fix(data-warehouse): fail fast when CDC source has no replication slot

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -54,6 +54,7 @@ from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import 
     CDCErrorCategory,
     CDCErrorInfo,
     CDCSchemaMergeError,
+    CDCSlotNotConfiguredError,
     classify_cdc_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.cdc.naming import cdc_qualified_table_name
@@ -710,6 +711,7 @@ class CDCExtractActivity:
             self.log.warning("cdc_orphan_reconcile_unexpected_failed", exc_info=True)
 
         try:
+            self._require_configured_slot()
             self.reader.connect()
 
             self._load_pk_columns()
@@ -1284,6 +1286,19 @@ class CDCExtractActivity:
                 continue
             self._update_schema_sync_type_config(schema, updates={"cdc_last_log_position": self.last_end_lsn})
 
+    def _require_configured_slot(self) -> None:
+        """Fail fast when a CDC-enabled source has no replication slot name stored.
+
+        Streaming an empty slot name surfaces as ``replication slot "" does not exist``, which
+        the invalidation check reads as a recoverable slot drop — so recovery (and Repair CDC)
+        run, only to dead-end because there is no slot name to recreate. Raise the non-retryable
+        misconfiguration up front instead, with guidance that actually resolves it.
+        """
+        assert self.adapter is not None
+        assert self.source is not None
+        if not self.adapter.parse_cdc_config(self.source).slot_name:
+            raise CDCSlotNotConfiguredError()
+
     # ------------------------------------------------------------------
     # Failure / success finalization
     # ------------------------------------------------------------------
@@ -1358,7 +1373,11 @@ class CDCExtractActivity:
         # the per-schema FAILED state + the cdc_broken marker the UI/health check read and pauses the
         # schedule, so it stops firing hourly against a resource that is gone (the same zombie the lag
         # safety net produces). Any other failure just fails this run's schemas.
-        marked_broken = info.category in (CDCErrorCategory.SLOT_MISSING, CDCErrorCategory.PUBLICATION_MISSING)
+        marked_broken = info.category in (
+            CDCErrorCategory.SLOT_MISSING,
+            CDCErrorCategory.SLOT_NOT_CONFIGURED,
+            CDCErrorCategory.PUBLICATION_MISSING,
+        )
         if marked_broken:
             assert self.source is not None
             mark_cdc_broken(self.source, info.category.value, friendly)

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/errors.py
@@ -28,6 +28,7 @@ class CDCErrorCategory(enum.StrEnum):
     CONNECTION_FAILED = "connection_failed"
     HOST_UNREACHABLE = "host_unreachable"
     SLOT_MISSING = "slot_missing"
+    SLOT_NOT_CONFIGURED = "slot_not_configured"
     PUBLICATION_MISSING = "publication_missing"
     SLOT_IN_USE = "slot_in_use"
     WAL_DECODE_ERROR = "wal_decode_error"
@@ -49,6 +50,17 @@ class CDCTransactionTooLargeError(Exception):
     Non-retryable: re-decoding replays the same oversized transaction. The decoder guard
     that raises this lives in the source-specific decoder; the type is defined here so the
     shared classifier owns the mapping to ``TRANSACTION_TOO_LARGE``.
+    """
+
+
+class CDCSlotNotConfiguredError(Exception):
+    """Change data capture is enabled but the source has no replication slot name stored.
+
+    Non-retryable: without a slot name there is nothing to stream from and nothing to recreate,
+    so retrying — or the slot-invalidation recovery / Repair CDC paths — replays the same dead
+    end. The extraction activity raises this before streaming (streaming an empty slot name would
+    surface as a misleading "replication slot does not exist"). Defined here so the shared
+    classifier owns the mapping to ``SLOT_NOT_CONFIGURED``.
     """
 
 
@@ -90,6 +102,11 @@ _CATEGORY_DEFAULTS: dict[CDCErrorCategory, tuple[str, bool]] = {
     CDCErrorCategory.SLOT_MISSING: (
         "The replication slot no longer exists on the source database, so changes can no longer be "
         "read. Use Repair CDC to recreate it and re-sync.",
+        False,
+    ),
+    CDCErrorCategory.SLOT_NOT_CONFIGURED: (
+        "Change data capture is enabled for this source but no replication slot is configured, so "
+        "changes can't be read. Disable and re-enable change data capture to set it up again.",
         False,
     ),
     CDCErrorCategory.PUBLICATION_MISSING: (
@@ -149,6 +166,8 @@ def classify_cdc_error(exc: BaseException, adapter: CDCSourceAdapter | None) -> 
     Falls back to a retryable ``unknown`` so a misclassification never strands a recoverable run.
     """
     for err in _iter_cause_chain(exc):
+        if isinstance(err, CDCSlotNotConfiguredError):
+            return cdc_error_info(CDCErrorCategory.SLOT_NOT_CONFIGURED)
         if isinstance(err, CDCTransactionTooLargeError):
             return cdc_error_info(CDCErrorCategory.TRANSACTION_TOO_LARGE)
         if isinstance(err, CDCSchemaMergeError):

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_errors.py
@@ -6,6 +6,7 @@ from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import 
     CDCErrorCategory,
     CDCErrorInfo,
     CDCSchemaMergeError,
+    CDCSlotNotConfiguredError,
     CDCTransactionTooLargeError,
     cdc_error_info,
     classify_cdc_error,
@@ -34,6 +35,7 @@ class TestCDCErrorInfo:
             (CDCErrorCategory.CONNECTION_FAILED, True),
             (CDCErrorCategory.HOST_UNREACHABLE, False),
             (CDCErrorCategory.SLOT_MISSING, False),
+            (CDCErrorCategory.SLOT_NOT_CONFIGURED, False),
             (CDCErrorCategory.PUBLICATION_MISSING, False),
             (CDCErrorCategory.SLOT_IN_USE, True),
             (CDCErrorCategory.WAL_DECODE_ERROR, False),
@@ -82,6 +84,13 @@ class TestClassifyCDCError:
     def test_transaction_too_large_is_classified_without_adapter(self):
         info = classify_cdc_error(CDCTransactionTooLargeError("500001 events"), None)
         assert info.category is CDCErrorCategory.TRANSACTION_TOO_LARGE
+        assert info.retryable is False
+
+    def test_slot_not_configured_is_classified_without_adapter(self):
+        # A CDC-enabled source with no slot name is a config dead end, not a psycopg failure, so it
+        # must classify to a non-retryable category regardless of engine adapter.
+        info = classify_cdc_error(CDCSlotNotConfiguredError(), None)
+        assert info.category is CDCErrorCategory.SLOT_NOT_CONFIGURED
         assert info.retryable is False
 
     def test_schema_merge_error_is_non_retryable_via_cause_chain(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -1924,6 +1924,69 @@ class TestErrorClassification:
             assert mock_mark_broken.call_args.args[0] is source
             assert mock_mark_broken.call_args.args[1] == expected_reason
 
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.mark_cdc_broken")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_machine_id",
+        return_value="machine-1",
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.posthoganalytics")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_missing_slot_name_fails_before_streaming_without_recovery(
+        self,
+        mock_close_conns,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        mock_activity,
+        mock_posthoganalytics,
+        mock_get_machine_id,
+        mock_mark_broken,
+    ):
+        # A CDC-enabled source whose stored slot name is empty must fail fast and non-retryably:
+        # streaming an empty slot name reads as a recoverable slot drop, so recovery / Repair CDC
+        # run only to dead-end with no slot name to recreate. Guard before streaming instead.
+        source = _make_source(
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "testdb",
+                "user": "test",
+                "password": "test",
+                "cdc_publication_name": "posthog_pub",
+            }
+        )
+        MockSourceModel.objects.get.return_value = source
+        schema = _make_schema("users", cdc_mode="streaming", source=source)
+        mock_get_schemas.return_value = [schema]
+
+        mock_reader = MagicMock()
+        mock_adapter = MagicMock()
+        mock_adapter.create_reader.return_value = mock_reader
+        mock_adapter.is_slot_invalidation_error.return_value = False
+        mock_adapter.parse_cdc_config = PostgresCDCAdapter().parse_cdc_config  # reads the empty slot name
+        mock_get_adapter.return_value = mock_adapter
+
+        mock_activity.heartbeat = MagicMock()
+        mock_activity.info.return_value = MagicMock(workflow_id="wf-1", workflow_run_id="run-1", attempt=1)
+
+        inputs = CDCExtractInput(team_id=1, source_id=source.id)
+        with pytest.raises(NonRetryableException) as exc_info:
+            cdc_extract_activity(inputs)
+
+        assert str(exc_info.value) == cdc_error_info(CDCErrorCategory.SLOT_NOT_CONFIGURED).friendly_message
+        # Never streamed and never tried to recover — the guard fired first.
+        mock_reader.connect.assert_not_called()
+        mock_reader.read_changes.assert_not_called()
+        mock_adapter.recreate_slot.assert_not_called()
+        # Broken state persisted so the schedule stops firing against an unconfigured slot.
+        mock_mark_broken.assert_called_once()
+        assert mock_mark_broken.call_args.args[0] is source
+        assert mock_mark_broken.call_args.args[1] == "slot_not_configured"
+
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_machine_id",
         return_value="machine-1",


### PR DESCRIPTION
## Problem

Error tracking surfaced a Postgres CDC source failing with a misleading, dead-end error. The exception chain was:

1. `psycopg UndefinedObject: replication slot "" does not exist` — note the empty slot name
2. `RuntimeError: Cannot recreate CDC replication slot: no slot name configured for this source`
3. `NonRetryableException: The replication slot no longer exists on the source database ... Use Repair CDC to recreate it and re-sync.`

The source had change data capture enabled but no replication slot name stored in its config. The extraction activity streamed with an empty slot name, which Postgres reports as `replication slot "" does not exist`. The slot-invalidation check reads that as a recoverable slot drop, so it runs the destructive recovery path (resets every CDC schema to snapshot, marks them failed) and then dead-ends in `recreate_slot`, which raises because there is no slot name to recreate.

The failure ends up classified as `SLOT_MISSING`, so the user is told to "Use Repair CDC". But Repair CDC also calls `recreate_slot` and fails the same way — there is no slot name. The guidance is a dead end.

## Changes

Detect the missing-slot configuration up front and treat it as its own non-retryable category:

- New `CDCSlotNotConfiguredError` and `CDCErrorCategory.SLOT_NOT_CONFIGURED` in the shared CDC error taxonomy, with actionable copy: disable and re-enable change data capture to set it up again.
- The extraction activity guards for an empty slot name before streaming (`_require_configured_slot`). This skips the doomed empty-slot peek and the destructive slot-invalidation recovery entirely, and routes through the normal failure path so the source is still marked broken and the schedule stops firing.
- `SLOT_NOT_CONFIGURED` is wired into the set of categories that mark the source broken, matching `SLOT_MISSING` / `PUBLICATION_MISSING`.

Behavior for a healthy source, and for a genuine slot-dropped source (which still correctly points at Repair CDC), is unchanged.

> [!NOTE]
> This lives in the shared `cdc/` layer, so it applies to both CDC engines (Postgres and Supabase). The guard is universally correct: a CDC source with no slot name can never stream.

## How did you test this code?

Automated tests only (I, Claude, did not run this against a live source):

- `test_extract_activity.py::TestErrorClassification::test_missing_slot_name_fails_before_streaming_without_recovery` — an empty-slot CDC source raises `NonRetryableException` with the new actionable message, never connects or streams, never calls `recreate_slot`, and marks the source broken with reason `slot_not_configured`. Catches a regression where the guard is removed and the empty-slot case again dead-ends at Repair CDC. Distinct from the existing missing-slot/publication test, which exercises a real slot name dropped on the source database (a different path).
- `test_errors.py::TestClassifyCDCError::test_slot_not_configured_is_classified_without_adapter` and a new row in `test_retryable_flag` — lock in that the new exception classifies to `SLOT_NOT_CONFIGURED` and is non-retryable.

Ran locally: the two CDC test files plus `TestSlotInvalidationRecovery` and the Postgres CDC error tests all pass. `ruff check` and `ruff format --check` clean on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) triaging a Postgres data-warehouse CDC error from PostHog error tracking. Invoked the `/writing-tests` skill before adding the regression tests.

Decision: this is a fixable bug, not a user/upstream error to add to `NonRetryableErrors`. The error was already non-retryable (it flows through the CDC `classify_cdc_error` path, not the batch `get_non_retryable_errors` path), so the remaining defect was the misleading dead-end guidance and the destructive recovery running on an unrecoverable config. Considered instead making `recreate_slot` regenerate a default slot name so Repair CDC could recover it, but rejected that as riskier: it would change recovery semantics and could orphan a real slot on a source that legitimately had a custom name that was lost.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
