### PR TITLE
feat(signals): capture refund note on the refund analytics event

### DIFF
--- a/products/signals/backend/test/test_refunds.py
+++ b/products/signals/backend/test/test_refunds.py
@@ -264,14 +264,22 @@ class TestSignalReportRefundAPI(APIBaseTest):
     def test_refund_fires_analytics_event(self, _flag):
         report = self._report_with_pr(pr_created_at=datetime(2026, 6, 10, tzinfo=UTC))
         with patch("products.signals.backend.views.report_user_action") as mock_report:
-            self._refund(report)
+            self._refund(report, {"reason": "other", "note": "agent refactored the wrong module"})
         mock_report.assert_called_once()
         assert mock_report.call_args.args[1] == "signals_pr_refund_created"
         properties = mock_report.call_args.kwargs["properties"]
         assert properties["billing_path"] == "credited"
         assert properties["credits"] == 1500
+        assert properties["note"] == "agent refactored the wrong module"
         assert properties["pr_merged"] is False
         assert properties["days_since_pr"] == 5
+
+    @freeze_time(_NOW)
+    def test_refund_analytics_event_without_note_sends_null(self, _flag):
+        report = self._report_with_pr(pr_created_at=datetime(2026, 6, 10, tzinfo=UTC))
+        with patch("products.signals.backend.views.report_user_action") as mock_report:
+            self._refund(report)
+        assert mock_report.call_args.kwargs["properties"]["note"] is None
 
     @freeze_time(_NOW)
     def test_restore_of_refunded_report_is_blocked(self, _flag):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -551,6 +551,10 @@ class SignalReportBulkStateResponseSerializer(serializers.Serializer):
 SIGNALS_PR_REFUNDS_FEATURE_FLAG = "signals-pr-refunds"
 
 
+# The refund note travels on the analytics event for the weekly refund review, clipped well below
+# the 4000-char storage cap (same bound the scout harness uses for free text in telemetry).
+_REFUND_NOTE_ANALYTICS_MAX_LENGTH = 1000
+
 # User-facing message for each shared `refund_ineligibility_reason` the refund action rejects on
 # (`already_refunded` never reaches a 400 — it takes the idempotent 200 path instead).
 _REFUND_INELIGIBLE_MESSAGES = {
@@ -1832,6 +1836,7 @@ class SignalReportViewSet(
                 "billing_path": billing_path,
                 "credits": refund.credits,
                 "reason": refund.reason,
+                "note": refund.note[:_REFUND_NOTE_ANALYTICS_MAX_LENGTH] or None,
                 "pr_merged": pr_merged,
                 "days_since_pr": (now - billable_run.created_at).days,
             },


### PR DESCRIPTION
## Problem

The PR refund flow captures a structured `reason` plus an optional free-form `note`.
The note lands on the refund row and the report's dismissal artefact, but not on the `signals_pr_refund_created` analytics event, so the weekly refund review can chart reason codes yet can't read what users actually wrote — the most useful signal when the reason is `other`.

## Changes

- `signals_pr_refund_created` now carries a `note` property: the refund note clipped to 1000 chars (the same free-text bound used elsewhere for telemetry), `null` when no note was given so `is_set` filters stay meaningful.

## How did you test this code?

- Extended `test_refund_fires_analytics_event` to assert the note passes through — catches the property being dropped from the event.
- Added `test_refund_analytics_event_without_note_sends_null` — catches the empty-string-instead-of-null regression that would pollute the property's `is_set` semantics.
- `ruff check` passes on both changed files. I couldn't run the pytest suite in the agent sandbox (no usable Python venv); relying on CI for the run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) while building a refund-tracking dashboard: a "last N custom refund notes" table insight needs the note on the event, which surfaced this gap.
Skills invoked: /improving-drf-endpoints, /writing-tests.
Considered filtering the insight to `reason='other'` instead, but the note can accompany any reason, so the event property is unconditional.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
