### PR TITLE
fix(personhog): move harness ports out of the ephemeral range

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -557,23 +557,17 @@ jobs:
               run: cargo test -p personhog-test-harness
 
             - name: Run the e2e gate
-              env:
-                  RUST_BACKTRACE: 1
               run: |
                   ./target/debug/personhog-test-harness gate \
                     --leaders 2 --partitions 4 --persons 100 --concurrency 10 --duration 10s
 
             - name: Run the e2e gate under chaos (kill + scale-up)
-              env:
-                  RUST_BACKTRACE: 1
               run: |
                   ./target/debug/personhog-test-harness gate \
                     --leaders 3 --partitions 8 --persons 100 --concurrency 10 --duration 15s \
                     --kill-after 5s --scale-up-after 8s
 
             - name: Run the e2e gate under chaos (drain + zombie + writer lag)
-              env:
-                  RUST_BACKTRACE: 1
               run: |
                   ./target/debug/personhog-test-harness gate \
                     --leaders 3 --partitions 8 --persons 100 --concurrency 10 --duration 18s \
@@ -581,8 +575,6 @@ jobs:
                     --writer-pause-after 4s --writer-pause-duration 6s
 
             - name: Run the e2e gate under chaos (TTL-expiry kill + restarts)
-              env:
-                  RUST_BACKTRACE: 1
               run: |
                   ./target/debug/personhog-test-harness gate \
                     --leaders 3 --partitions 8 --persons 100 --concurrency 10 --duration 18s \
@@ -590,8 +582,6 @@ jobs:
                     --writer-crash-after 9s --restart-after 12s
 
             - name: Run the e2e gate under chaos (coordinator failover + mid-handoff kill)
-              env:
-                  RUST_BACKTRACE: 1
               run: |
                   ./target/debug/personhog-test-harness gate \
                     --routers 2 --leaders 3 --partitions 8 --persons 100 --concurrency 10 \

--- a/rust/personhog-test-harness/README.md
+++ b/rust/personhog-test-harness/README.md
@@ -34,7 +34,7 @@ target/debug/personhog-test-harness gate --external-router-url http://127.0.0.1:
   --pg-target-table personhog_person_tmp
 ```
 
-The spawned stack is isolated from the dev stack: its own port range (51xxx), its own etcd prefix (`/personhog-test-harness/`), and a per-run changelog topic (`personhog_test_harness_<run_id>`, deleted on teardown).
+The spawned stack is isolated from the dev stack: its own port range (24xxx, kept below the ephemeral range so outbound connections cannot steal a listen port), its own etcd prefix (`/personhog-test-harness/`), and a per-run changelog topic (`personhog_test_harness_<run_id>`, deleted on teardown).
 Persons are seeded directly in Postgres for a reserved harness team id (SQL is the interim seeding mechanism until the create RPC's future is settled; `src/seed.rs` is the swap seam).
 Service logs land in `<bin-dir>/harness-logs/<run_id>/`.
 

--- a/rust/personhog-test-harness/src/stack/mod.rs
+++ b/rust/personhog-test-harness/src/stack/mod.rs
@@ -17,13 +17,20 @@ use process::ServiceProcess;
 /// dev stack (gRPC 50051-50054, metrics 9100-9105) without collisions.
 /// Routers occupy base..base+3 and leaders start at base+6, which caps the
 /// router count at 4.
-const REPLICA_GRPC_PORT: u16 = 51051;
-const ROUTER_GRPC_BASE_PORT: u16 = 51054;
-const LEADER_GRPC_BASE_PORT: u16 = 51060;
-const REPLICA_METRICS_PORT: u16 = 51151;
-const WRITER_METRICS_PORT: u16 = 51153;
-const ROUTER_METRICS_BASE_PORT: u16 = 51154;
-const LEADER_METRICS_BASE_PORT: u16 = 51160;
+///
+/// The range must stay below 32768: Linux allocates the local port of
+/// every outbound connection from the ephemeral range (default
+/// 32768-60999), so a fixed listen port inside it loses a lottery against
+/// whichever process's Kafka/PG/etcd connection grabbed the port first —
+/// during bring-up, every service opens outbound sockets in the same
+/// instant the listeners bind.
+const REPLICA_GRPC_PORT: u16 = 24051;
+const ROUTER_GRPC_BASE_PORT: u16 = 24054;
+const LEADER_GRPC_BASE_PORT: u16 = 24060;
+const REPLICA_METRICS_PORT: u16 = 24151;
+const WRITER_METRICS_PORT: u16 = 24153;
+const ROUTER_METRICS_BASE_PORT: u16 = 24154;
+const LEADER_METRICS_BASE_PORT: u16 = 24160;
 const MAX_ROUTERS: u32 = 4;
 
 const ETCD_PREFIX: &str = "/personhog-test-harness/";

--- a/rust/personhog-test-harness/src/stack/process.rs
+++ b/rust/personhog-test-harness/src/stack/process.rs
@@ -31,7 +31,10 @@ impl ServiceSpec {
             // PATH and HOME survive so the binaries can resolve tools and
             // dotfiles (librdkafka, DNS, etc.) the way they do in dev.
             .envs(env::vars().filter(|(k, _)| k == "PATH" || k == "HOME"))
-            .env("RUST_BACKTRACE", "1")
+            // No RUST_BACKTRACE and no colors: a service panic's message is
+            // the signal, and fifty frames of runtime internals push it out
+            // of the log tail that failure reports embed.
+            .env("NO_COLOR", "1")
             .env("RUST_LOG", "info")
             .stdout(Stdio::from(log_file))
             .stderr(Stdio::from(stderr_file))
@@ -174,6 +177,44 @@ impl ServiceProcess {
         };
         let all: Vec<&str> = content.lines().collect();
         let start = all.len().saturating_sub(lines);
-        all[start..].join("\n")
+        strip_ansi(&all[start..].join("\n"))
+    }
+}
+
+/// Strip ANSI escape sequences. Failure reports embed log tails inside the
+/// harness's own log output, where raw escapes render as `\x1b[2m` soup;
+/// spawned services get NO_COLOR but this guards logs written by anything
+/// that ignores it.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        // CSI sequences (ESC '[' ... final byte in @..~) are all tracing
+        // emits; a bare ESC before anything else just gets dropped.
+        if chars.peek() == Some(&'[') {
+            chars.next();
+            for c in chars.by_ref() {
+                if ('\x40'..='\x7e').contains(&c) {
+                    break;
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_ansi;
+
+    #[test]
+    fn strip_ansi_removes_csi_sequences_and_keeps_text() {
+        let colored = "\x1b[2m2026-07-15\x1b[0m \x1b[32m INFO\x1b[0m plain \x1b[3mkey\x1b[0m\x1b[2m=\x1b[0mvalue";
+        assert_eq!(strip_ansi(colored), "2026-07-15  INFO plain key=value");
+        assert_eq!(strip_ansi("no escapes"), "no escapes");
     }
 }


### PR DESCRIPTION
## Problem

The e2e harness's fixed listen ports (51051-51160) sit inside Linux's ephemeral port range (default 32768-60999), where the kernel allocates the local port of every outbound connection. During stack bring-up, eight services open Kafka, Postgres, and etcd connections in the same instant the listeners bind, so a listener occasionally loses its port to someone's outbound socket and dies with EADDRINUSE. This is a pure lottery that has now failed the gate on unrelated PRs (observed twice in CI: a leader gRPC port and a leader metrics port), always passing on retry.
  
The failure reports for those crashes were also nearly useless. The harness forced `RUST_BACKTRACE=1` into every spawned service, so the panic printed ~50 frames of runtime internals that pushed the panic message itself out of the 30-line log tail the report embeds. The one line naming the cause was the one line missing, and what did survive was wrapped in raw ANSI escape codes rendered as literal `\x1b[2m` soup.
  
## Changes

- All harness ports move from 51xxx to 24xxx, below the ephemeral floor, where the kernel never allocates local ports. The collision becomes structurally impossible instead of merely unlikely, and the port-range comment now documents the below-32768 constraint so the range does not drift back up.
- Spawned services run without `RUST_BACKTRACE` (a panic prints just its message, which fits the log tail) and with `NO_COLOR=1`. `log_tail` additionally strips ANSI escape sequences as a guarantee for anything that ignores `NO_COLOR`.
- The gate CI steps drop their `RUST_BACKTRACE: 1` env. The harness's own errors are context-rich anyhow chains, and the 35-frame tokio backtrace appended to each one carried no signal. The workspace `cargo test` step keeps its backtrace setting, where it is actually useful.
  
## How did you test this code?

All automated, no manual testing beyond running the harness locally:
  
  - `cargo test -p personhog-test-harness` passes (10 tests). One new unit test covers the ANSI stripper, since a broken stripper would silently degrade every future failure report rather than fail any run.
  - A full gate run passes on the new ports (100 persons, 10s, zero violations), and the service log files from that run were verified byte-for-byte free of ANSI escapes, confirming the services honor `NO_COLOR` at the source.
  - clippy with `-D warnings` and fmt are clean; the workflow YAML parses.
  
## 🤖 Agent context
  
**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The port collision was diagnosed from two CI failures with the same shape (EADDRINUSE at bring-up on the very first gate step, so no leftover-process explanation was possible, and green on retry). The readability problem was found while diagnosing the second failure: the embedded log tail showed backtrace frames 44 through 53 but not the panic message, which turned out to be the harness's own doing via the forced `RUST_BACKTRACE=1`. An alternative considered for the ports was reserving them via `ip_local_reserved_ports` in CI, rejected as runner-specific plumbing when moving the range fixes it everywhere, including local runs.