### PR TITLE
fix(postgres): treat pgcat AllServersDown pooler failure as transient

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -219,6 +219,16 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     # ("password authentication failed", "SASL authentication failed"), and exclude the volatile
     # millisecond value.
     "authentication did not complete within",
+    # pgcat (a Rust Postgres pooler) refuses to hand out a backend when every server in the pool is
+    # currently banned/down — a failed health check bans a server and pgcat auto-unbans it after
+    # `ban_time` — reporting it as SQLSTATE 58000 ("could not get connection from the pool -
+    # AllServersDown"), which psycopg maps to OperationalError. It's transient by construction (a
+    # banned server rejoins once it passes a health check, or the ban expires), the pgcat analog of
+    # Supavisor's ECHECKOUT* pool-checkout failures above, so a fresh reconnect recovers. It can land
+    # on the first discovery query (`SELECT version()` in `_is_duckdb_connection`), so the discovery
+    # retry must catch it. Match the stable prefix + reason and leave pgcat's non-transient reasons
+    # (e.g. BadConfig) to surface.
+    "could not get connection from the pool - allserversdown",
 )
 
 # Supavisor (Supabase's connection pooler) doesn't surface a dropped upstream connection with a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1355,6 +1355,11 @@ class TestIsConnectionDroppedError:
             psycopg.errors.ConnectionFailure(
                 "Failed to connect to database: authentication did not complete within 15000ms"
             ),
+            # pgcat refuses to hand out a backend when every pooled server is banned/down, reporting
+            # it as SQLSTATE 58000 (psycopg's SystemError, an OperationalError) rather than the
+            # Supavisor XX000 InternalError_ codes above. Transient — a banned server rejoins on a
+            # passing health check or once its ban expires — so the reconnect must catch it.
+            psycopg.errors.SystemError("could not get connection from the pool - AllServersDown"),
         ],
     )
     def test_connection_dropped_errors_are_detected(self, error):


### PR DESCRIPTION
## Problem

Error tracking surfaced a `SystemError: could not get connection from the pool - AllServersDown` firing from the Postgres data-warehouse import source during schema discovery ([issue](https://us.posthog.com/project/2/error_tracking/019f6631-4203-77a1-bdc4-325d7b45c312)). The top in-app frame is `_is_duckdb_connection` running the first discovery query (`SELECT version()`).

`AllServersDown` is a [pgcat](https://github.com/postgresml/pgcat) pooler state: pgcat refuses to hand out a backend connection when every server in its pool is currently banned or down. A failed health check bans a server, and pgcat auto-unbans it after `ban_time`, so the condition is transient by construction. It arrives as SQLSTATE 58000, which psycopg maps to `SystemError` (an `OperationalError` subclass).

The problem: this message didn't match any substring in `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, so `_is_connection_dropped_error` returned `False`. Schema discovery's in-process retry (`_is_dropped_or_connection_limit`) therefore treated it as permanent, failed the discovery activity, and captured it as error-tracking noise even though a fresh reconnect a moment later would succeed.

This is the direct pgcat analog of the Supavisor `ECHECKOUTRETRIES` / `ECHECKOUTTIMEOUT` pool-checkout failures we already recognise as transient. The only difference is the transport: Supavisor surfaces its drops as XX000 `InternalError_`, pgcat surfaces this one as 58000 `SystemError`.

## Changes

Added the stable pgcat signal `could not get connection from the pool - allserversdown` to `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`. Because `SystemError` is already an `OperationalError`, the existing type check matches and the message substring is all that was missing. This flows through both the discovery retry (`_is_dropped_or_connection_limit`) and the read/sync connect retry (`_is_dropped_or_connect_timeout`), so the in-process reconnect now recovers wherever the failure lands.

The match is deliberately scoped to the `AllServersDown` reason rather than the bare `could not get connection from the pool` prefix, so pgcat's non-transient reasons (e.g. `BadConfig`) still surface instead of being retried indefinitely.

> [!NOTE]
> This keeps the error retryable — it is **not** added to `get_non_retryable_errors`. A transient pooler-capacity condition should recover, not permanently disable the sync.

## How did you test this code?

Added one parameterized case to `TestIsConnectionDroppedError::test_connection_dropped_errors_are_detected` asserting the pgcat `SystemError` message is recognised as a dropped connection. It's the only case exercising a 58000 `SystemError` pooler failure — every existing pooler case is a Supavisor XX000 `InternalError_`, so a revert of the substring would slip past all of them but fail this one.

```
.venv/bin/python -m pytest ".../postgres/test_postgres.py::TestIsConnectionDroppedError" -q
33 passed
```

I (Claude) did not run the full suite or any manual sync against a live pgcat pooler.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres import source. I confirmed the issue in error tracking (pulled the stack trace, exception type `SystemError`/SQLSTATE 58000, and representative events), traced the failure to `_is_duckdb_connection`'s `SELECT version()` inside the schema-discovery retry, and verified via the psycopg source that `SystemError` subclasses `OperationalError` — so only a message-substring match was missing.

Decision: transient upstream/infra condition, not a user-config error and not a bug in our request logic, so it stays retryable and is recognised in-process rather than added to `get_non_retryable_errors`. Rejected matching the broad `could not get connection from the pool` prefix to avoid swallowing pgcat's permanent reasons.

Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
