### PR TITLE
feat(tracing): add operation detail scene with latency histogram and trace samples

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3016,6 +3016,9 @@ const api = {
                 serviceNames?: string[]
                 statusCodes?: number[]
                 filterGroup?: PropertyGroupFilter
+                // true (default) buckets root spans only (a distribution of traces); false buckets
+                // every matching span — pair with a span name filter for operation-scoped pages.
+                rootSpans?: boolean
             },
             signal?: AbortSignal
         ): Promise<{

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2955,6 +2955,8 @@ const api = {
                 // false (default) groups by trace_id and returns root spans; true returns every
                 // matching span (root and child) flat. See products/tracing/backend logic.py.
                 flatSpans?: boolean
+                // true omits the per-span attribute maps — use when only scalar span fields are read.
+                excludeAttributes?: boolean
             },
             signal?: AbortSignal
         ): Promise<{
@@ -2972,12 +2974,14 @@ const api = {
                 statusCodes?: number[]
                 filterGroup?: PropertyGroupFilter
                 offset?: number
-            }
+            },
+            signal?: AbortSignal
         ): Promise<{ results: Record<string, any>[]; hasMore: boolean; nextOffset?: number | null }> {
             return new ApiRequest()
                 .tracingSpans()
                 .withAction(`trace/${traceId}`)
                 .create({
+                    signal,
                     data: {
                         ...query,
                         dateRange: query?.dateRange ?? { date_from: '-24h' },

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -156,6 +156,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
     Skill: () => import('../../products/skills/frontend/LLMSkillScene'),
     SlackTaskContext: () => import('../../products/tasks/frontend/SlackTaskContextScene'),
     Tracing: () => import('../../products/tracing/frontend/TracingScene'),
+    TracingOperation: () => import('../../products/tracing/frontend/TracingOperationScene'),
     UserInterviews: () => import('../../products/user_interviews/frontend/UserInterviews'),
     UserInterview: () => import('../../products/user_interviews/frontend/UserInterview'),
     UserInterviewResponse: () => import('../../products/user_interviews/frontend/UserInterviewResponse'),
@@ -305,6 +306,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/skills/:name': ['Skill', 'skill'],
     '/slack-task-context': ['SlackTaskContext', 'slackTaskContext'],
     '/tracing': ['Tracing', 'tracing'],
+    '/tracing/operation': ['TracingOperation', 'tracingOperation'],
     '/user_research': ['UserInterviews', 'userInterviews'],
     '/user_research/:topicId/response/:responseId': ['UserInterviewResponse', 'userInterviewResponse'],
     '/user_research/:id': ['UserInterview', 'userInterview'],
@@ -872,6 +874,14 @@ export const productConfiguration: Record<string, any> = {
         description: 'Monitor and analyze distributed traces to understand service performance and debug issues.',
         iconType: 'tracing',
     },
+    TracingOperation: {
+        name: 'Operation',
+        projectBased: true,
+        layout: 'app-container',
+        activityScope: 'Tracing',
+        description: 'Latency distribution and sample traces for a single operation.',
+        iconType: 'tracing',
+    },
     UserInterviews: {
         name: 'User research',
         projectBased: true,
@@ -1313,6 +1323,8 @@ export const productUrls = {
     slackTaskContext: (): string => '/slack-task-context',
     toolbarLaunch: (): string => '/toolbar',
     tracing: (): string => '/tracing',
+    tracingOperation: (serviceName: string, spanName: string): string =>
+        combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
     userInterviews: (): string => '/user_research',
     userInterview: (id: string): string => `/user_research/${id}`,
     userInterviewResponse: (topicId: string, responseId: string): string =>
@@ -2237,7 +2249,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         flag: FEATURE_FLAGS.TRACING,
         tags: ['alpha'],
         sceneKey: 'Tracing',
-        sceneKeys: ['Tracing'],
+        sceneKeys: ['Tracing', 'TracingOperation'],
     },
     {
         path: 'User research',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1323,8 +1323,19 @@ export const productUrls = {
     slackTaskContext: (): string => '/slack-task-context',
     toolbarLaunch: (): string => '/toolbar',
     tracing: (): string => '/tracing',
-    tracingOperation: (serviceName: string, spanName: string): string =>
-        combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
+    tracingOperation: (
+        serviceName: string,
+        spanName: string,
+        dateRange?: {
+            date_from?: string | null
+            date_to?: string | null
+        }
+    ): string =>
+        combineUrl('/tracing/operation', {
+            service: serviceName,
+            name: spanName,
+            ...(dateRange ? { dateRange: JSON.stringify(dateRange) } : {}),
+        }).url,
     userInterviews: (): string => '/user_research',
     userInterview: (id: string): string => `/user_research/${id}`,
     userInterviewResponse: (topicId: string, responseId: string): string =>

--- a/products/tracing/backend/duration_histogram_query_runner.py
+++ b/products/tracing/backend/duration_histogram_query_runner.py
@@ -9,7 +9,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client.connection import Workload
@@ -29,8 +29,10 @@ class TraceSpansDurationHistogramQueryRunner(TraceSpansQueryRunner):
     bucket (the root is the row the list displays), grouped by service. Only non-empty buckets
     are returned; the frontend fills gaps along the series so the axis is continuous.
 
-    Root scoping is unconditional — `query.rootSpans` is deliberately ignored. The histogram is a
-    distribution of *traces*; counting child spans would mix units. The 1-2-5 bucketing below is
+    Root scoping is the default — a distribution of *traces* for the trace list, where counting
+    child spans would mix units. When `query.rootSpans` is explicitly False (the operation detail
+    page, which scopes by span name), every matching span is counted instead: same-named spans
+    are the same unit, so a span-level distribution is sound there. The 1-2-5 bucketing below is
     mirrored in `frontend/durationBuckets.ts` (snapDurationToBucket), which re-snaps client-side
     only to place the scroll highlight — change the series in BOTH places.
     """
@@ -80,7 +82,7 @@ class TraceSpansDurationHistogramQueryRunner(TraceSpansQueryRunner):
                 count() AS count
             FROM posthog.trace_spans
             WHERE {where}
-                AND is_root_span = 1
+                AND {root_scope}
                 AND timestamp >= {date_from} AND timestamp < {date_to}
             GROUP BY bucket_ns, service
             ORDER BY bucket_ns ASC, count DESC
@@ -90,6 +92,9 @@ class TraceSpansDurationHistogramQueryRunner(TraceSpansQueryRunner):
             placeholders={
                 **self.query_date_range.to_placeholders(),
                 "where": self.where(),
+                "root_scope": parse_expr("is_root_span = 1")
+                if self.query.rootSpans is not False
+                else ast.Constant(value=True),
             },
         )
         assert isinstance(query, ast.SelectQuery)
@@ -103,6 +108,7 @@ def run_duration_histogram_query(
     service_names: list[str] | None = None,
     status_codes: list[int] | None = None,
     filter_group: PropertyGroupFilter | None = None,
+    root_spans: bool = True,
 ) -> TraceSpansQueryResponse | CachedTraceSpansQueryResponse:
     """Facade-friendly entry point for running a duration histogram query."""
     query = TraceSpansQuery(
@@ -110,6 +116,7 @@ def run_duration_histogram_query(
         serviceNames=service_names,
         statusCodes=status_codes,
         filterGroup=filter_group,
+        rootSpans=root_spans,
     )
     runner = TraceSpansDurationHistogramQueryRunner(query, team)
     response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)

--- a/products/tracing/backend/facade/api.py
+++ b/products/tracing/backend/facade/api.py
@@ -119,14 +119,20 @@ def run_duration_histogram_query(
     service_names: list[str] | None = None,
     status_codes: list[int] | None = None,
     filter_group: PropertyGroupFilter | None = None,
+    root_spans: bool = True,
 ) -> TraceSpansQueryResponse | CachedTraceSpansQueryResponse:
-    """Run the per-bucket trace-duration histogram (root spans, stacked by service)."""
+    """Run the per-bucket duration histogram, stacked by service.
+
+    Root spans by default (a distribution of traces); `root_spans=False` buckets every
+    matching span — pair with a span name filter for operation-scoped distributions.
+    """
     return _run_duration_histogram_query(
         team=team,
         date_range=date_range,
         service_names=service_names,
         status_codes=status_codes,
         filter_group=filter_group,
+        root_spans=root_spans,
     )
 
 

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -214,6 +214,22 @@ class _TracingTimeseriesRequestSerializer(serializers.Serializer):
     query = _TracingTimeseriesQueryBodySerializer(help_text="The sparkline / duration-histogram query to execute.")
 
 
+class _TracingDurationHistogramQueryBodySerializer(_TracingTimeseriesQueryBodySerializer):
+    rootSpans = serializers.BooleanField(
+        required=False,
+        default=True,
+        help_text=(
+            "When true (default), bucket root-span durations only — a distribution of traces. "
+            "When false, bucket every matching span — used with a span name filter for "
+            "operation-scoped distributions."
+        ),
+    )
+
+
+class _TracingDurationHistogramRequestSerializer(serializers.Serializer):
+    query = _TracingDurationHistogramQueryBodySerializer(help_text="The duration-histogram query to execute.")
+
+
 class _TracingSparklineQueryBodySerializer(_TracingTimeseriesQueryBodySerializer):
     rootSpans = serializers.BooleanField(
         required=False,
@@ -878,7 +894,7 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
 
         return Response({"results": response.results}, status=status.HTTP_200_OK)
 
-    @extend_schema(request=_TracingTimeseriesRequestSerializer)
+    @extend_schema(request=_TracingDurationHistogramRequestSerializer)
     @action(detail=False, methods=["POST"], url_path="duration-histogram", required_scopes=["tracing:read"])
     def duration_histogram(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=ProductKey.TRACING, feature=Feature.QUERY)
@@ -900,6 +916,7 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             service_names=query_data.get("serviceNames", None),
             status_codes=query_data.get("statusCodes", None),
             filter_group=filter_group,
+            root_spans=query_data.get("rootSpans", True),
         )
 
         return Response({"results": response.results}, status=status.HTTP_200_OK)

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -210,10 +210,6 @@ class _TracingTimeseriesQueryBodySerializer(serializers.Serializer):
     )
 
 
-class _TracingTimeseriesRequestSerializer(serializers.Serializer):
-    query = _TracingTimeseriesQueryBodySerializer(help_text="The sparkline / duration-histogram query to execute.")
-
-
 class _TracingDurationHistogramQueryBodySerializer(_TracingTimeseriesQueryBodySerializer):
     rootSpans = serializers.BooleanField(
         required=False,
@@ -910,13 +906,28 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         except (ValidationError, ValueError, ParseError):
             filter_group = None
 
+        root_spans = query_data.get("rootSpans", True)
         response = run_duration_histogram_query(
             team=self.team,
             date_range=date_range,
             service_names=query_data.get("serviceNames", None),
             status_codes=query_data.get("statusCodes", None),
             filter_group=filter_group,
-            root_spans=query_data.get("rootSpans", True),
+            root_spans=root_spans,
+        )
+
+        report_user_action(
+            request.user,
+            "tracing duration histogram queried",
+            {
+                "buckets_count": len(response.results),
+                "root_spans": root_spans,
+                "has_filter_group": bool(query_data.get("filterGroup")),
+                "service_names_count": len(query_data.get("serviceNames") or []),
+                "status_codes_count": len(query_data.get("statusCodes") or []),
+            },
+            team=self.team,
+            request=request,
         )
 
         return Response({"results": response.results}, status=status.HTTP_200_OK)
@@ -951,6 +962,19 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             compare_filter=compare_filter,
             filter_group=filter_group,
             service_names=query_data.get("serviceNames", None),
+        )
+
+        report_user_action(
+            request.user,
+            "tracing aggregation queried",
+            {
+                "results_count": len(response.results),
+                "has_compare": bool(query_data.get("compareFilter")),
+                "has_filter_group": bool(query_data.get("filterGroup")),
+                "service_names_count": len(query_data.get("serviceNames") or []),
+            },
+            team=self.team,
+            request=request,
         )
 
         return Response(
@@ -1142,6 +1166,19 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         # Self-time needs a span's children present. On a paged (truncated) trace it overstates for
         # spans whose children fall on a later page — an accepted bound, same as the prior 2000 cap.
         annotate_self_time(results)
+
+        report_user_action(
+            request.user,
+            "tracing trace fetched",
+            {
+                "spans_count": len(results),
+                "has_more": has_more,
+                "is_paginated": offset > 0,
+                "has_filter_group": bool(query_data.get("filterGroup")),
+            },
+            team=self.team,
+            request=request,
+        )
 
         return Response(
             {

--- a/products/tracing/backend/tests/test_duration_histogram.py
+++ b/products/tracing/backend/tests/test_duration_histogram.py
@@ -47,8 +47,8 @@ class TestTraceSpansDurationHistogram(_TraceSpansTestBase):
             "timestamp, end_time, observed_timestamp, status_code, service_name) VALUES " + ",".join(rows)
         )
 
-    def _histogram(self, *, service_names: list[str] | None = None) -> list[dict]:
-        query: dict = {"dateRange": {"date_from": DATE_FROM, "date_to": DATE_TO}}
+    def _histogram(self, *, service_names: list[str] | None = None, **extra_query: object) -> list[dict]:
+        query: dict = {"dateRange": {"date_from": DATE_FROM, "date_to": DATE_TO}, **extra_query}
         if service_names is not None:
             query["serviceNames"] = service_names
         response = self.client.post(
@@ -75,3 +75,23 @@ class TestTraceSpansDurationHistogram(_TraceSpansTestBase):
     def test_service_filter_flows_through(self):
         rows = {(row["bucket_ns"], row["service"]): row["count"] for row in self._histogram(service_names=["web"])}
         self.assertEqual(rows, {(1 * MS, "web"): 1, (2 * MS, "web"): 2})
+
+    def test_root_spans_false_counts_child_spans_for_operation_scope(self):
+        # The operation detail page scopes by span name and needs child spans counted: the 5s
+        # 'db query' child (invisible to the root-only histogram above) must appear.
+        rows = {
+            (row["bucket_ns"], row["service"]): row["count"]
+            for row in self._histogram(
+                rootSpans=False,
+                filterGroup={
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [{"type": "span", "key": "name", "operator": "exact", "value": ["db query"]}],
+                        }
+                    ],
+                },
+            )
+        }
+        self.assertEqual(rows, {(5_000 * MS, "web"): 1})

--- a/products/tracing/frontend/OperationHistogram.tsx
+++ b/products/tracing/frontend/OperationHistogram.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useMemo } from 'react'
+
+import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
+
+import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
+
+import {
+    formatBucketLabel,
+    selectionToDurationRange,
+    snapDurationToBucket,
+    type TracingDurationHistogramData,
+} from './durationBuckets'
+import type { DurationRange } from './operationFilters'
+
+interface OperationHistogramProps {
+    data: TracingDurationHistogramData
+    loading: boolean
+    selection: DurationRange | null
+    onSelect: (selection: DurationRange) => void
+    onClear: () => void
+}
+
+// Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is already
+// log-spaced, so a plain category axis renders it evenly (mirrors TracingSparkline).
+function withCategoryXScale(scale: AnyScaleOptions): AnyScaleOptions {
+    return {
+        ...scale,
+        type: 'category',
+        ticks: {
+            display: true,
+            maxRotation: 0,
+            maxTicksLimit: 8,
+            font: {
+                size: 10,
+                lineHeight: 1,
+            },
+        },
+    } as AnyScaleOptions
+}
+
+export function OperationHistogram({
+    data,
+    loading,
+    selection,
+    onSelect,
+    onClear,
+}: OperationHistogramProps): JSX.Element {
+    const onSelectionChange = useCallback(
+        ({ startIndex, endIndex }: { startIndex: number; endIndex: number }): void => {
+            const range = selectionToDurationRange(data.bucketsNs, startIndex, endIndex)
+            if (range) {
+                onSelect(range)
+            }
+        },
+        [data.bucketsNs, onSelect]
+    )
+
+    // Map the persisted selection back onto bucket indices: snap each edge onto the same
+    // 1-2-5 series the backend bucketed with, then find those buckets on the axis.
+    const highlightedRange = useMemo(() => {
+        if (!selection || data.bucketsNs.length === 0) {
+            return null
+        }
+        const { bucketsNs, labels } = data
+        const startIndexRaw = bucketsNs.indexOf(snapDurationToBucket(selection.minNs))
+        // maxNs is the exclusive upper edge — the highlight ends at the bar before it.
+        const endIndexRaw = bucketsNs.indexOf(snapDurationToBucket(selection.maxNs))
+        const startIndex = startIndexRaw === -1 ? 0 : startIndexRaw
+        const endIndex = endIndexRaw === -1 ? bucketsNs.length : endIndexRaw
+        if (startIndex >= endIndex) {
+            return null
+        }
+        return { xMin: labels[startIndex], xMax: labels[endIndex] ?? labels[labels.length - 1] }
+    }, [selection, data])
+
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2 min-h-6">
+                <span className="text-xs text-muted">Latency distribution</span>
+                {selection ? (
+                    <>
+                        <span className="text-xs font-mono">
+                            {formatBucketLabel(selection.minNs)} – {formatBucketLabel(selection.maxNs)}
+                        </span>
+                        <LemonButton size="xsmall" type="tertiary" onClick={onClear}>
+                            Clear
+                        </LemonButton>
+                    </>
+                ) : (
+                    <span className="text-xs text-muted italic">Drag to select a duration range</span>
+                )}
+            </div>
+            <div className="relative h-32">
+                {data.data.length > 0 ? (
+                    <Sparkline
+                        labels={data.labels}
+                        data={data.data}
+                        className="w-full h-full"
+                        onSelectionChange={onSelectionChange}
+                        withXScale={withCategoryXScale}
+                        renderLabel={(label) => label}
+                        tooltipRowCutoff={100}
+                        hideZerosInTooltip
+                        sortTooltipByCount
+                        highlightedRange={highlightedRange}
+                    />
+                ) : !loading ? (
+                    <div className="h-full text-muted flex items-center justify-center">No spans in this range</div>
+                ) : null}
+                {loading && <SpinnerOverlay />}
+            </div>
+        </div>
+    )
+}

--- a/products/tracing/frontend/OperationHistogram.tsx
+++ b/products/tracing/frontend/OperationHistogram.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 
-import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
+import { Sparkline } from 'lib/components/Sparkline'
 
 import {
     formatBucketLabel,
@@ -11,6 +11,7 @@ import {
     type TracingDurationHistogramData,
 } from './durationBuckets'
 import type { DurationRange } from './operationFilters'
+import { categoryDurationXScale } from './TracingSparkline'
 
 interface OperationHistogramProps {
     data: TracingDurationHistogramData
@@ -18,24 +19,8 @@ interface OperationHistogramProps {
     selection: DurationRange | null
     onSelect: (selection: DurationRange) => void
     onClear: () => void
-}
-
-// Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is already
-// log-spaced, so a plain category axis renders it evenly (mirrors TracingSparkline).
-function withCategoryXScale(scale: AnyScaleOptions): AnyScaleOptions {
-    return {
-        ...scale,
-        type: 'category',
-        ticks: {
-            display: true,
-            maxRotation: 0,
-            maxTicksLimit: 8,
-            font: {
-                size: 10,
-                lineHeight: 1,
-            },
-        },
-    } as AnyScaleOptions
+    /** Clearing the selection refetches samples — disable the button while that's in flight. */
+    samplesLoading?: boolean
 }
 
 export function OperationHistogram({
@@ -44,6 +29,7 @@ export function OperationHistogram({
     selection,
     onSelect,
     onClear,
+    samplesLoading = false,
 }: OperationHistogramProps): JSX.Element {
     const onSelectionChange = useCallback(
         ({ startIndex, endIndex }: { startIndex: number; endIndex: number }): void => {
@@ -65,8 +51,12 @@ export function OperationHistogram({
         const startIndexRaw = bucketsNs.indexOf(snapDurationToBucket(selection.minNs))
         // maxNs is the exclusive upper edge — the highlight ends at the bar before it.
         const endIndexRaw = bucketsNs.indexOf(snapDurationToBucket(selection.maxNs))
-        const startIndex = startIndexRaw === -1 ? 0 : startIndexRaw
-        const endIndex = endIndexRaw === -1 ? bucketsNs.length : endIndexRaw
+        // An off-axis edge clamps toward its near end; a selection entirely off the axis
+        // (e.g. persisted before a date change reshaped the distribution) collapses to
+        // start >= end and renders no highlight.
+        const startIndex = startIndexRaw !== -1 ? startIndexRaw : selection.minNs <= bucketsNs[0] ? 0 : bucketsNs.length
+        const endIndex =
+            endIndexRaw !== -1 ? endIndexRaw : selection.maxNs > bucketsNs[bucketsNs.length - 1] ? bucketsNs.length : 0
         if (startIndex >= endIndex) {
             return null
         }
@@ -82,7 +72,12 @@ export function OperationHistogram({
                         <span className="text-xs font-mono">
                             {formatBucketLabel(selection.minNs)} – {formatBucketLabel(selection.maxNs)}
                         </span>
-                        <LemonButton size="xsmall" type="tertiary" onClick={onClear}>
+                        <LemonButton
+                            size="xsmall"
+                            type="tertiary"
+                            onClick={onClear}
+                            disabledReason={samplesLoading ? 'Loading samples…' : undefined}
+                        >
                             Clear
                         </LemonButton>
                     </>
@@ -97,7 +92,7 @@ export function OperationHistogram({
                         data={data.data}
                         className="w-full h-full"
                         onSelectionChange={onSelectionChange}
-                        withXScale={withCategoryXScale}
+                        withXScale={categoryDurationXScale}
                         renderLabel={(label) => label}
                         tooltipRowCutoff={100}
                         hideZerosInTooltip

--- a/products/tracing/frontend/OperationsTable.tsx
+++ b/products/tracing/frontend/OperationsTable.tsx
@@ -24,8 +24,13 @@ function formatRate(count: number, windowMs: number): string {
     return `${humanFriendlyNumber(perSec * 3600, 1)}/hr`
 }
 
-function errorRate(row: AggregatedSpanRow): number {
+export function errorRate(row: AggregatedSpanRow): number {
     return row.count > 0 ? row.error_count / row.count : 0
+}
+
+// Sub-1% rates get an extra decimal so small-but-nonzero rates don't render as 0.0%.
+export function formatErrorRate(rate: number): string {
+    return `${(rate * 100).toFixed(rate > 0 && rate < 0.01 ? 2 : 1)}%`
 }
 
 const durationCell =
@@ -68,11 +73,7 @@ function buildColumns(windowMs: number): VirtualizedTableColumn<AggregatedSpanRo
             sorter: (a, b) => errorRate(a) - errorRate(b),
             render: (row) => {
                 const rate = errorRate(row)
-                return (
-                    <span className={rate > 0 ? 'text-danger' : 'text-muted'}>
-                        {`${(rate * 100).toFixed(rate > 0 && rate < 0.01 ? 2 : 1)}%`}
-                    </span>
-                )
+                return <span className={rate > 0 ? 'text-danger' : 'text-muted'}>{formatErrorRate(rate)}</span>
             },
         },
         {

--- a/products/tracing/frontend/TracingOperationScene.tsx
+++ b/products/tracing/frontend/TracingOperationScene.tsx
@@ -15,6 +15,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { OperationHistogram } from './OperationHistogram'
+import { errorRate, formatErrorRate } from './OperationsTable'
 import { formatDuration, TraceWaterfallView } from './TraceWaterfallView'
 import { tracingOperationSceneLogic, type TracingOperationSceneLogicProps } from './tracingOperationSceneLogic'
 
@@ -57,18 +58,16 @@ export function TracingOperationScene(): JSX.Element {
     } = useValues(tracingOperationSceneLogic)
     const { setDateRange, setDurationSelection, setSampleIndex, selectSpan } = useActions(tracingOperationSceneLogic)
 
-    if (!spanName) {
+    if (!spanName || !serviceName) {
         return (
             <SceneContent>
                 <div className="flex flex-col items-center gap-1 py-16">
-                    <span>This link is missing an operation name.</span>
+                    <span>This link is missing an operation or service name.</span>
                     <Link to={urls.tracing()}>Back to tracing</Link>
                 </div>
             </SceneContent>
         )
     }
-
-    const errorRate = operationStats && operationStats.count > 0 ? operationStats.error_count / operationStats.count : 0
 
     return (
         <SceneContent>
@@ -94,10 +93,7 @@ export function TracingOperationScene(): JSX.Element {
             {operationStats && (
                 <div className="flex gap-8">
                     <StatBlock label="Requests" value={humanFriendlyNumber(operationStats.count)} />
-                    <StatBlock
-                        label="Error rate"
-                        value={`${(errorRate * 100).toFixed(errorRate > 0 && errorRate < 0.01 ? 2 : 1)}%`}
-                    />
+                    <StatBlock label="Error rate" value={formatErrorRate(errorRate(operationStats))} />
                     <StatBlock label="p50" value={formatDuration(operationStats.p50_duration_nano)} />
                     <StatBlock label="p95" value={formatDuration(operationStats.p95_duration_nano)} />
                     <StatBlock label="p99" value={formatDuration(operationStats.p99_duration_nano)} />
@@ -109,6 +105,7 @@ export function TracingOperationScene(): JSX.Element {
                 selection={durationSelection}
                 onSelect={setDurationSelection}
                 onClear={() => setDurationSelection(null)}
+                samplesLoading={samplesLoading}
             />
             <SceneDivider />
             {samples.length === 0 && samplesLoading ? (
@@ -128,7 +125,7 @@ export function TracingOperationScene(): JSX.Element {
                             }
                         />
                         <span className="text-sm whitespace-nowrap">
-                            {samples.length > 0 ? sampleIndex + 1 : 0} of {samples.length}
+                            {sampleIndex + 1} of {samples.length}
                             {samplesHaveMore ? '+' : ''}
                         </span>
                         <LemonButton

--- a/products/tracing/frontend/TracingOperationScene.tsx
+++ b/products/tracing/frontend/TracingOperationScene.tsx
@@ -1,0 +1,178 @@
+import { useActions, useValues } from 'kea'
+
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { LemonButton, LemonTag, Link, SpinnerOverlay } from '@posthog/lemon-ui'
+
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { OperationHistogram } from './OperationHistogram'
+import { formatDuration, TraceWaterfallView } from './TraceWaterfallView'
+import { tracingOperationSceneLogic, type TracingOperationSceneLogicProps } from './tracingOperationSceneLogic'
+
+export const scene: SceneExport<TracingOperationSceneLogicProps> = {
+    component: TracingOperationScene,
+    logic: tracingOperationSceneLogic,
+    paramsToProps: ({ searchParams: { service, name } }) => ({
+        serviceName: String(service ?? ''),
+        spanName: String(name ?? ''),
+    }),
+    productKey: ProductKey.TRACING,
+}
+
+function StatBlock({ label, value }: { label: string; value: string }): JSX.Element {
+    return (
+        <div className="flex flex-col">
+            <span className="text-xs text-muted">{label}</span>
+            <span className="font-mono text-sm">{value}</span>
+        </div>
+    )
+}
+
+export function TracingOperationScene(): JSX.Element {
+    const {
+        serviceName,
+        spanName,
+        dateRange,
+        histogramData,
+        rawHistogramLoading,
+        durationSelection,
+        samples,
+        samplesLoading,
+        samplesHaveMore,
+        sampleIndex,
+        currentSample,
+        sampleTraceSpans,
+        sampleTraceSpansLoading,
+        selectedSpanId,
+        operationStats,
+    } = useValues(tracingOperationSceneLogic)
+    const { setDateRange, setDurationSelection, setSampleIndex, selectSpan } = useActions(tracingOperationSceneLogic)
+
+    if (!spanName) {
+        return (
+            <SceneContent>
+                <div className="flex flex-col items-center gap-1 py-16">
+                    <span>This link is missing an operation name.</span>
+                    <Link to={urls.tracing()}>Back to tracing</Link>
+                </div>
+            </SceneContent>
+        )
+    }
+
+    const errorRate = operationStats && operationStats.count > 0 ? operationStats.error_count / operationStats.count : 0
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name={spanName}
+                description={serviceName}
+                resourceType={{
+                    type: 'tracing',
+                }}
+                forceBackTo={{
+                    key: 'tracing',
+                    name: 'Tracing',
+                    path: urls.tracing(),
+                }}
+                actions={
+                    <DateFilter
+                        dateFrom={dateRange.date_from}
+                        dateTo={dateRange.date_to}
+                        onChange={(date_from, date_to) => setDateRange({ date_from, date_to })}
+                    />
+                }
+            />
+            {operationStats && (
+                <div className="flex gap-8">
+                    <StatBlock label="Requests" value={humanFriendlyNumber(operationStats.count)} />
+                    <StatBlock
+                        label="Error rate"
+                        value={`${(errorRate * 100).toFixed(errorRate > 0 && errorRate < 0.01 ? 2 : 1)}%`}
+                    />
+                    <StatBlock label="p50" value={formatDuration(operationStats.p50_duration_nano)} />
+                    <StatBlock label="p95" value={formatDuration(operationStats.p95_duration_nano)} />
+                    <StatBlock label="p99" value={formatDuration(operationStats.p99_duration_nano)} />
+                </div>
+            )}
+            <OperationHistogram
+                data={histogramData}
+                loading={rawHistogramLoading}
+                selection={durationSelection}
+                onSelect={setDurationSelection}
+                onClear={() => setDurationSelection(null)}
+            />
+            <SceneDivider />
+            {samples.length === 0 && samplesLoading ? (
+                <div className="relative min-h-32">
+                    <SpinnerOverlay />
+                </div>
+            ) : samples.length > 0 ? (
+                <>
+                    <div className="flex items-center gap-2">
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            icon={<IconChevronLeft />}
+                            onClick={() => setSampleIndex(sampleIndex - 1)}
+                            disabledReason={
+                                samplesLoading ? 'Loading samples…' : sampleIndex === 0 ? 'First sample' : undefined
+                            }
+                        />
+                        <span className="text-sm whitespace-nowrap">
+                            {samples.length > 0 ? sampleIndex + 1 : 0} of {samples.length}
+                            {samplesHaveMore ? '+' : ''}
+                        </span>
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            icon={<IconChevronRight />}
+                            onClick={() => setSampleIndex(sampleIndex + 1)}
+                            disabledReason={
+                                samplesLoading
+                                    ? 'Loading samples…'
+                                    : sampleIndex >= samples.length - 1
+                                      ? 'Last sample'
+                                      : undefined
+                            }
+                        />
+                        {currentSample && (
+                            <div className="flex items-center gap-2 ml-2 text-sm text-muted">
+                                <span>{humanFriendlyDetailedTime(currentSample.timestamp)}</span>
+                                <span className="font-mono">{formatDuration(currentSample.duration_nano)}</span>
+                                {currentSample.status_code === 2 && <LemonTag type="danger">Error</LemonTag>}
+                            </div>
+                        )}
+                    </div>
+                    <div className="relative min-h-96 flex-1">
+                        <TraceWaterfallView
+                            spans={sampleTraceSpans}
+                            selectedSpanId={selectedSpanId}
+                            onSpanSelect={selectSpan}
+                        />
+                        {sampleTraceSpansLoading && <SpinnerOverlay />}
+                    </div>
+                </>
+            ) : (
+                <div className="flex flex-col items-center gap-1 py-8 text-muted">
+                    <span>No sampled traces in this range</span>
+                    {durationSelection && (
+                        <LemonButton size="small" type="secondary" onClick={() => setDurationSelection(null)}>
+                            Clear selection
+                        </LemonButton>
+                    )}
+                </div>
+            )}
+        </SceneContent>
+    )
+}
+
+export default TracingOperationScene

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { LemonBanner, LemonButton, LemonModal, LemonTabs, Link } from '@posthog/lemon-ui'
@@ -10,6 +11,7 @@ import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
@@ -194,6 +196,7 @@ function TracingSceneContents(): JSX.Element {
                         rows={aggregation.current}
                         loading={aggregationLoading}
                         windowMs={operationsWindowMs}
+                        onRowClick={(row) => router.actions.push(urls.tracingOperation(row.service_name, row.name))}
                     />
                 ) : (
                     <>

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -196,7 +196,9 @@ function TracingSceneContents(): JSX.Element {
                         rows={aggregation.current}
                         loading={aggregationLoading}
                         windowMs={operationsWindowMs}
-                        onRowClick={(row) => router.actions.push(urls.tracingOperation(row.service_name, row.name))}
+                        onRowClick={(row) =>
+                            router.actions.push(urls.tracingOperation(row.service_name, row.name, filters.dateRange))
+                        }
                     />
                 ) : (
                     <>

--- a/products/tracing/frontend/TracingSparkline.tsx
+++ b/products/tracing/frontend/TracingSparkline.tsx
@@ -14,6 +14,25 @@ import { type TracingDurationHistogramData, type VisibleDurationRange, snapDurat
 import { SparklineCompareOverlay } from './SparklineCompareOverlay'
 import type { TracingSparklineData, VisibleSpanTimeRange } from './tracingDataLogic'
 
+// Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is already
+// log-spaced, so a plain category axis renders it evenly. Shared with OperationHistogram
+// so the two duration histograms render identically.
+export function categoryDurationXScale(scale: AnyScaleOptions): AnyScaleOptions {
+    return {
+        ...scale,
+        type: 'category',
+        ticks: {
+            display: true,
+            maxRotation: 0,
+            maxTicksLimit: 8,
+            font: {
+                size: 10,
+                lineHeight: 1,
+            },
+        },
+    } as AnyScaleOptions
+}
+
 interface CompareConfig {
     fullStartMs: number
     fullEndMs: number
@@ -68,21 +87,7 @@ export function TracingSparkline({
     const withXScale = useCallback(
         (scale: AnyScaleOptions): AnyScaleOptions => {
             if (durationMode) {
-                // Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is
-                // already log-spaced, so a plain category axis renders it evenly.
-                return {
-                    ...scale,
-                    type: 'category',
-                    ticks: {
-                        display: true,
-                        maxRotation: 0,
-                        maxTicksLimit: 8,
-                        font: {
-                            size: 10,
-                            lineHeight: 1,
-                        },
-                    },
-                } as AnyScaleOptions
+                return categoryDurationXScale(scale)
             }
             return {
                 ...scale,

--- a/products/tracing/frontend/durationBuckets.test.ts
+++ b/products/tracing/frontend/durationBuckets.test.ts
@@ -1,7 +1,9 @@
 import {
+    bucketUpperBound,
     fillBucketSeries,
     formatBucketLabel,
     pivotDurationHistogram,
+    selectionToDurationRange,
     snapDurationToBucket,
     visibleDurationRange,
 } from './durationBuckets'
@@ -58,6 +60,32 @@ describe('durationBuckets', () => {
 
     it('pivotDurationHistogram returns empties for no rows', () => {
         expect(pivotDurationHistogram([], ['c1'])).toEqual({ data: [], bucketsNs: [], labels: [] })
+    })
+
+    it.each([
+        [1, 2],
+        [2, 5],
+        [5, 10],
+        [500 * MS, 1_000 * MS], // 500ms → 1s
+        [1_000 * MS, 2_000 * MS],
+    ])('bucketUpperBound(%i) → %i', (bucket, expected) => {
+        expect(bucketUpperBound(bucket)).toBe(expected)
+    })
+
+    // Bucket b covers [b, nextBucket(b)) — an off-by-one here silently shifts which spans a
+    // histogram drag-selection matches (the 5ms bar must mean [5ms, 10ms)).
+    it.each<[number, number, { minNs: number; maxNs: number } | null]>([
+        [0, 1, { minNs: 1 * MS, maxNs: 5 * MS }], // interior selection: max is the bucket after the last bar
+        [2, 2, { minNs: 5 * MS, maxNs: 10 * MS }], // single bar
+        [2, 3, { minNs: 5 * MS, maxNs: 20 * MS }], // ends on the last bar: upper edge extrapolated on the series
+        [3, 99, { minNs: 10 * MS, maxNs: 20 * MS }], // out-of-range end clamps to the last bar
+    ])('selectionToDurationRange over [1,2,5,10]ms maps [%i, %i] → %o', (startIndex, endIndex, expected) => {
+        const bucketsNs = [1, 2, 5, 10].map((bucketMs) => bucketMs * MS)
+        expect(selectionToDurationRange(bucketsNs, startIndex, endIndex)).toEqual(expected)
+    })
+
+    it('selectionToDurationRange returns null for an empty axis', () => {
+        expect(selectionToDurationRange([], 0, 0)).toBeNull()
     })
 
     it('visibleDurationRange orders min/max regardless of sort direction and clamps indices', () => {

--- a/products/tracing/frontend/durationBuckets.ts
+++ b/products/tracing/frontend/durationBuckets.ts
@@ -112,6 +112,33 @@ export function pivotDurationHistogram(
     return { data, bucketsNs, labels: bucketsNs.map(formatBucketLabel) }
 }
 
+/** Exclusive upper edge of a 1-2-5 bucket — the next bucket on the series (1→2, 2→5, 5→10). */
+export function bucketUpperBound(bucketNs: number): number {
+    const decade = Math.pow(10, Math.floor(Math.log10(Math.max(bucketNs, 1))))
+    const mantissa = bucketNs / decade
+    return Math.round(mantissa < 2 ? 2 * decade : mantissa < 5 ? 5 * decade : 10 * decade)
+}
+
+/**
+ * Duration range covered by an inclusive bar-index selection on the histogram axis.
+ * Bucket b covers [b, nextBucket(b)), so the range's max is the bucket after the last selected
+ * bar (extrapolated on the 1-2-5 series when the selection ends on the last bar).
+ */
+export function selectionToDurationRange(
+    bucketsNs: number[],
+    startIndex: number,
+    endIndex: number
+): { minNs: number; maxNs: number } | null {
+    if (bucketsNs.length === 0) {
+        return null
+    }
+    const start = Math.max(0, Math.min(startIndex, bucketsNs.length - 1))
+    const end = Math.max(start, Math.min(endIndex, bucketsNs.length - 1))
+    const minNs = bucketsNs[start]
+    const maxNs = bucketsNs[end + 1] ?? bucketUpperBound(bucketsNs[end])
+    return { minNs, maxNs }
+}
+
 /**
  * Duration range spanned by the visible slice of a duration-sorted list, given the durations of
  * its rows in display order. Returns min/max regardless of ASC/DESC sort direction.

--- a/products/tracing/frontend/durationBuckets.ts
+++ b/products/tracing/frontend/durationBuckets.ts
@@ -1,4 +1,4 @@
-// Pure helpers for the duration-histogram sparkline (JON-36). The list sorted by duration pairs
+// Pure helpers for the duration-histogram sparkline. The list sorted by duration pairs
 // with a histogram of trace counts per logarithmic duration bucket; everything here is pure so it
 // can be unit-tested without the kea logic's import graph.
 
@@ -15,10 +15,13 @@ export interface TracingDurationHistogramData {
     labels: string[]
 }
 
-export interface VisibleDurationRange {
+/** A `[minNs, maxNs)` duration range in nanoseconds — the shared currency of selection and filtering. */
+export interface DurationRange {
     minNs: number
     maxNs: number
 }
+
+export type VisibleDurationRange = DurationRange
 
 const BUCKET_MANTISSAS = [1, 2, 5]
 
@@ -114,9 +117,7 @@ export function pivotDurationHistogram(
 
 /** Exclusive upper edge of a 1-2-5 bucket — the next bucket on the series (1→2, 2→5, 5→10). */
 export function bucketUpperBound(bucketNs: number): number {
-    const decade = Math.pow(10, Math.floor(Math.log10(Math.max(bucketNs, 1))))
-    const mantissa = bucketNs / decade
-    return Math.round(mantissa < 2 ? 2 * decade : mantissa < 5 ? 5 * decade : 10 * decade)
+    return fillBucketSeries(bucketNs, bucketNs * 10)[1]
 }
 
 /**
@@ -128,7 +129,7 @@ export function selectionToDurationRange(
     bucketsNs: number[],
     startIndex: number,
     endIndex: number
-): { minNs: number; maxNs: number } | null {
+): DurationRange | null {
     if (bucketsNs.length === 0) {
         return null
     }

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -223,7 +223,7 @@ export interface _TracingCountResponseApi {
     traceCount: number
 }
 
-export interface _TracingTimeseriesQueryBodyApi {
+export interface _TracingDurationHistogramQueryBodyApi {
     /** Date range for the query. Defaults to last hour. */
     dateRange?: _TracingDateRangeApi
     /** Filter by service names. */
@@ -232,11 +232,13 @@ export interface _TracingTimeseriesQueryBodyApi {
     statusCodes?: number[]
     /** Property filters for the query. */
     filterGroup?: _SpanPropertyFilterApi[]
+    /** When true (default), bucket root-span durations only — a distribution of traces. When false, bucket every matching span — used with a span name filter for operation-scoped distributions. */
+    rootSpans?: boolean
 }
 
-export interface _TracingTimeseriesRequestApi {
-    /** The sparkline / duration-histogram query to execute. */
-    query: _TracingTimeseriesQueryBodyApi
+export interface _TracingDurationHistogramRequestApi {
+    /** The duration-histogram query to execute. */
+    query: _TracingDurationHistogramQueryBodyApi
 }
 
 export interface _HasSpansResponseApi {

--- a/products/tracing/frontend/generated/api.ts
+++ b/products/tracing/frontend/generated/api.ts
@@ -24,9 +24,9 @@ import type {
     _TracingAttributesResponseApi,
     _TracingCountRequestApi,
     _TracingCountResponseApi,
+    _TracingDurationHistogramRequestApi,
     _TracingQueryRequestApi,
     _TracingSparklineRequestApi,
-    _TracingTimeseriesRequestApi,
     _TracingTraceRequestApi,
     _TracingTreeRequestApi,
 } from './api.schemas'
@@ -135,14 +135,14 @@ export const getTracingSpansDurationHistogramCreateUrl = (projectId: string) => 
 
 export const tracingSpansDurationHistogramCreate = async (
     projectId: string,
-    _tracingTimeseriesRequestApi: _TracingTimeseriesRequestApi,
+    _tracingDurationHistogramRequestApi: _TracingDurationHistogramRequestApi,
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getTracingSpansDurationHistogramCreateUrl(projectId), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(_tracingTimeseriesRequestApi),
+        body: JSON.stringify(_tracingDurationHistogramRequestApi),
     })
 }
 

--- a/products/tracing/frontend/generated/api.zod.ts
+++ b/products/tracing/frontend/generated/api.zod.ts
@@ -286,6 +286,7 @@ export const TracingSpansCountCreateBody = /* @__PURE__ */ zod.object({
 })
 
 export const tracingSpansDurationHistogramCreateBodyQueryOneFilterGroupDefault = []
+export const tracingSpansDurationHistogramCreateBodyQueryOneRootSpansDefault = true
 
 export const TracingSpansDurationHistogramCreateBody = /* @__PURE__ */ zod.object({
     query: zod
@@ -357,8 +358,14 @@ export const TracingSpansDurationHistogramCreateBody = /* @__PURE__ */ zod.objec
                 )
                 .default(tracingSpansDurationHistogramCreateBodyQueryOneFilterGroupDefault)
                 .describe('Property filters for the query.'),
+            rootSpans: zod
+                .boolean()
+                .default(tracingSpansDurationHistogramCreateBodyQueryOneRootSpansDefault)
+                .describe(
+                    'When true (default), bucket root-span durations only — a distribution of traces. When false, bucket every matching span — used with a span name filter for operation-scoped distributions.'
+                ),
         })
-        .describe('The sparkline \/ duration-histogram query to execute.'),
+        .describe('The duration-histogram query to execute.'),
 })
 
 export const tracingSpansQueryCreateBodyQueryOneFilterGroupDefault = []

--- a/products/tracing/frontend/operationFilters.ts
+++ b/products/tracing/frontend/operationFilters.ts
@@ -1,0 +1,43 @@
+import {
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyGroupFilter,
+    PropertyOperator,
+    SpanPropertyFilter,
+} from '~/types'
+
+export interface DurationRange {
+    minNs: number
+    maxNs: number
+}
+
+const NS_PER_MS = 1_000_000
+
+/**
+ * Filter group scoping a spans query to one operation, optionally to a duration range.
+ * The span `duration` property filter's value unit is milliseconds — the backend translates
+ * it to `duration_nano` (see translate_span_filter in backend/logic.py).
+ */
+export function operationFilterGroup(spanName: string, durationRange: DurationRange | null): PropertyGroupFilter {
+    const values: SpanPropertyFilter[] = [
+        { type: PropertyFilterType.Span, key: 'name', operator: PropertyOperator.Exact, value: [spanName] },
+    ]
+    if (durationRange) {
+        values.push({
+            type: PropertyFilterType.Span,
+            key: 'duration',
+            operator: PropertyOperator.GreaterThanOrEqual,
+            value: durationRange.minNs / NS_PER_MS,
+        })
+        values.push({
+            type: PropertyFilterType.Span,
+            key: 'duration',
+            operator: PropertyOperator.LessThan,
+            value: durationRange.maxNs / NS_PER_MS,
+        })
+    }
+    return {
+        type: FilterLogicalOperator.And,
+        values: [{ type: FilterLogicalOperator.And, values }],
+    }
+}

--- a/products/tracing/frontend/operationFilters.ts
+++ b/products/tracing/frontend/operationFilters.ts
@@ -6,10 +6,9 @@ import {
     SpanPropertyFilter,
 } from '~/types'
 
-export interface DurationRange {
-    minNs: number
-    maxNs: number
-}
+import type { DurationRange } from './durationBuckets'
+
+export type { DurationRange } from './durationBuckets'
 
 const NS_PER_MS = 1_000_000
 

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -48,9 +48,9 @@ export interface VisibleSpanTimeRange {
 
 const DEFAULT_PAGE_SIZE = 100
 export const PREFETCH_SPANS = 20
-const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
+export const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 
-function isUserInitiatedError(error: unknown): boolean {
+export function isUserInitiatedError(error: unknown): boolean {
     const errorStr = String(error).toLowerCase()
     return error === NEW_QUERY_STARTED_ERROR_MESSAGE || errorStr.includes('abort')
 }
@@ -567,6 +567,9 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
                             serviceNames:
                                 values.filters.serviceNames.length > 0 ? values.filters.serviceNames : undefined,
                             filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            // Match the population the list shows (and the sparkline counts):
+                            // root spans in Traces view, every matching span in Spans view.
+                            rootSpans: values.filters.viewMode === 'traces',
                         },
                         controller.signal
                     )

--- a/products/tracing/frontend/tracingOperationSceneLogic.test.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.test.ts
@@ -1,0 +1,95 @@
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { tracingOperationSceneLogic } from './tracingOperationSceneLogic'
+import type { Span } from './types'
+
+const createMockSample = (n: number): Span => ({
+    uuid: `uuid-${n}`,
+    trace_id: `trace-${n}`,
+    span_id: `span-${n}`,
+    parent_span_id: 'parent',
+    name: 'db query',
+    kind: 3,
+    service_name: 'web',
+    status_code: 1,
+    timestamp: `2024-01-01T0${n}:00:00Z`,
+    end_time: `2024-01-01T0${n}:00:01Z`,
+    duration_nano: 1_000_000_000,
+    is_root_span: false,
+    matched_filter: true,
+    attributes: {},
+    resource_attributes: {},
+})
+
+describe('tracingOperationSceneLogic', () => {
+    let logic: ReturnType<typeof tracingOperationSceneLogic.build>
+    let listSpansSpy: jest.SpyInstance
+    let getTraceSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+        initKeaTests()
+        jest.spyOn(api.tracing, 'durationHistogram').mockResolvedValue({ results: [] })
+        jest.spyOn(api.tracing, 'aggregate').mockResolvedValue({ results: [] })
+        listSpansSpy = jest.spyOn(api.tracing, 'listSpans').mockResolvedValue({ results: [], hasMore: false })
+        getTraceSpy = jest.spyOn(api.tracing, 'getTrace').mockResolvedValue({ results: [], hasMore: false })
+        logic = tracingOperationSceneLogic({ serviceName: 'web', spanName: 'db query' })
+        logic.mount()
+        // Settle the mount-time fetches (these calls supersede them via the loader breakpoint),
+        // so their empty results can't land mid-test and clobber seeded samples.
+        await Promise.all([
+            logic.asyncActions.fetchHistogram(),
+            logic.asyncActions.fetchStats(),
+            logic.asyncActions.fetchSamples(),
+        ])
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        jest.restoreAllMocks()
+    })
+
+    it('drag-selecting a duration range refetches samples scoped to the range and resets the pager', async () => {
+        logic.actions.fetchSamplesSuccess([1, 2, 3, 4].map(createMockSample))
+        logic.actions.setSampleIndex(3)
+
+        logic.actions.setDurationSelection({ minNs: 5_000_000, maxNs: 10_000_000 })
+        // The listener wiring dispatches the refetch synchronously, and the pager resets with it.
+        expect(logic.values.samplesLoading).toBe(true)
+        expect(logic.values.sampleIndex).toBe(0)
+
+        await logic.asyncActions.fetchSamples()
+        expect(listSpansSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                flatSpans: true,
+                serviceNames: ['web'],
+                filterGroup: {
+                    type: 'AND',
+                    values: [
+                        {
+                            type: 'AND',
+                            values: [
+                                { type: 'span', key: 'name', operator: 'exact', value: ['db query'] },
+                                // The span duration filter's unit is ms; the range above is 5–10ms in ns.
+                                { type: 'span', key: 'duration', operator: 'gte', value: 5 },
+                                { type: 'span', key: 'duration', operator: 'lt', value: 10 },
+                            ],
+                        },
+                    ],
+                },
+            })
+        )
+    })
+
+    it('paging to another sample fetches its containing trace and anchors the waterfall on the sample span', async () => {
+        logic.actions.fetchSamplesSuccess([1, 2].map(createMockSample))
+
+        logic.actions.setSampleIndex(1)
+        expect(logic.values.sampleTraceSpansLoading).toBe(true)
+
+        await logic.asyncActions.fetchSampleTrace({ sample: logic.values.currentSample! })
+        expect(getTraceSpy).toHaveBeenLastCalledWith('trace-2', expect.anything())
+        expect(logic.values.selectedSpanId).toBe('span-2')
+    })
+})

--- a/products/tracing/frontend/tracingOperationSceneLogic.test.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.test.ts
@@ -78,7 +78,8 @@ describe('tracingOperationSceneLogic', () => {
                         },
                     ],
                 },
-            })
+            }),
+            expect.anything()
         )
     })
 
@@ -89,7 +90,7 @@ describe('tracingOperationSceneLogic', () => {
         expect(logic.values.sampleTraceSpansLoading).toBe(true)
 
         await logic.asyncActions.fetchSampleTrace({ sample: logic.values.currentSample! })
-        expect(getTraceSpy).toHaveBeenLastCalledWith('trace-2', expect.anything())
+        expect(getTraceSpy).toHaveBeenLastCalledWith('trace-2', expect.anything(), expect.anything())
         expect(logic.values.selectedSpanId).toBe('span-2')
     })
 })

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -6,12 +6,14 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { dataColorVars } from 'lib/colors'
+import { objectsEqual } from 'lib/utils/objects'
 
 import { AggregatedSpanRow, DateRange } from '~/queries/schema/schema-general'
 
 import { type DurationHistogramRow, pivotDurationHistogram, type TracingDurationHistogramData } from './durationBuckets'
 import { type DurationRange, operationFilterGroup } from './operationFilters'
 import { traceLookupDateRange } from './traceLinks'
+import { isUserInitiatedError, NEW_QUERY_STARTED_ERROR_MESSAGE } from './tracingDataLogic'
 import { DEFAULT_DATE_RANGE } from './tracingFiltersLogic'
 import type { tracingOperationSceneLogicType } from './tracingOperationSceneLogicType'
 import type { Span } from './types'
@@ -22,6 +24,22 @@ export interface TracingOperationSceneLogicProps {
 }
 
 const SAMPLE_LIMIT = 100
+
+// One tracked AbortController per loader: re-issuing a fetch aborts the superseded request
+// (not just discards its result), and unmount aborts whatever is still in flight.
+function trackedSignal(cache: Record<string, any>, key: string): AbortSignal {
+    let controller!: AbortController
+    cache.disposables.add(
+        () => {
+            controller = new AbortController()
+            return () => controller.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+        },
+        key,
+        // In-flight requests must survive tab switches — only supersession or unmount aborts.
+        { pauseOnPageHidden: false }
+    )
+    return controller.signal
+}
 
 export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
     props({} as TracingOperationSceneLogicProps),
@@ -34,22 +52,26 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
         setSampleIndex: (index: number) => ({ index }),
         selectSpan: (spanId: string | null) => ({ spanId }),
         setSamplesHaveMore: (hasMore: boolean) => ({ hasMore }),
+        loadCurrentSampleTrace: true,
     }),
 
-    loaders(({ props, values, actions }) => ({
+    loaders(({ props, values, actions, cache }) => ({
         rawHistogram: [
             [] as DurationHistogramRow[],
             {
                 fetchHistogram: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.durationHistogram({
-                        dateRange: values.dateRange,
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, null),
-                        // Span-level: operations are often child spans, and the samples query
-                        // below is span-level too — both must count the same population.
-                        rootSpans: false,
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.durationHistogram(
+                        {
+                            dateRange: values.dateRange,
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, null),
+                            // Span-level: operations are often child spans, and the samples query
+                            // below is span-level too — both must count the same population.
+                            rootSpans: false,
+                        },
+                        trackedSignal(cache, 'fetchHistogram')
+                    )
                     breakpoint()
                     return response.results
                 },
@@ -59,16 +81,22 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             [] as Span[],
             {
                 fetchSamples: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.listSpans({
-                        dateRange: values.dateRange,
-                        orderBy: 'timestamp',
-                        orderDirection: 'DESC',
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, values.durationSelection),
-                        flatSpans: true,
-                        limit: SAMPLE_LIMIT,
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.listSpans(
+                        {
+                            dateRange: values.dateRange,
+                            orderBy: 'timestamp',
+                            orderDirection: 'DESC',
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, values.durationSelection),
+                            flatSpans: true,
+                            limit: SAMPLE_LIMIT,
+                            // Samples only feed the pager header (5 scalar fields); the waterfall
+                            // loads the full trace separately, so skip the heavy attribute maps.
+                            excludeAttributes: true,
+                        },
+                        trackedSignal(cache, 'fetchSamples')
+                    )
                     breakpoint()
                     actions.setSamplesHaveMore(!!response.hasMore)
                     return response.results as Span[]
@@ -79,12 +107,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             null as AggregatedSpanRow | null,
             {
                 fetchStats: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.aggregate({
-                        dateRange: values.dateRange,
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, null),
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.aggregate(
+                        {
+                            dateRange: values.dateRange,
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, null),
+                        },
+                        trackedSignal(cache, 'fetchStats')
+                    )
                     breakpoint()
                     return response.results.find((row) => row.name === props.spanName) ?? null
                 },
@@ -94,10 +125,14 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             [] as Span[],
             {
                 fetchSampleTrace: async ({ sample }: { sample: Span }, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.getTrace(sample.trace_id, {
-                        dateRange: traceLookupDateRange(sample.timestamp),
-                    })
+                    await breakpoint(100) // debounce rapid pager clicks
+                    const response = await api.tracing.getTrace(
+                        sample.trace_id,
+                        {
+                            dateRange: traceLookupDateRange(sample.timestamp),
+                        },
+                        trackedSignal(cache, 'fetchSampleTrace')
+                    )
                     breakpoint()
                     return response.results as Span[]
                 },
@@ -144,6 +179,19 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             actions.fetchSamples()
             actions.fetchStats()
         },
+        loadCurrentSampleTrace: () => {
+            const sample = values.currentSample
+            if (!sample) {
+                return
+            }
+            // Adjacent samples often share a trace (a child operation hit N times per request) —
+            // re-anchor on the already-loaded trace instead of refetching it.
+            if (values.sampleTraceSpans[0]?.trace_id === sample.trace_id) {
+                actions.selectSpan(sample.span_id)
+                return
+            }
+            actions.fetchSampleTrace({ sample })
+        },
         fetchSamplesSuccess: ({ samples }) => {
             if (samples.length === 0) {
                 actions.selectSpan(null)
@@ -154,14 +202,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
                 actions.setSampleIndex(0)
                 return
             }
-            if (values.currentSample) {
-                actions.fetchSampleTrace({ sample: values.currentSample })
-            }
+            actions.loadCurrentSampleTrace()
         },
         setSampleIndex: () => {
-            if (values.currentSample) {
-                actions.fetchSampleTrace({ sample: values.currentSample })
+            // While samples are (re)loading, the index points into the outgoing result set;
+            // fetchSamplesSuccess (or fetchSamplesFailure) loads the trace for the resolved index.
+            if (values.samplesLoading) {
+                return
             }
+            actions.loadCurrentSampleTrace()
         },
         fetchSampleTraceSuccess: () => {
             // Anchor the waterfall on the operation's own span — for child operations the
@@ -169,23 +218,38 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             actions.selectSpan(values.currentSample?.span_id ?? null)
         },
         fetchHistogramFailure: ({ error }) => {
-            lemonToast.error(`Failed to load latency distribution: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load latency distribution: ${error}`)
+            }
         },
         fetchSamplesFailure: ({ error }) => {
+            if (isUserInitiatedError(error)) {
+                return
+            }
             lemonToast.error(`Failed to load sample traces: ${error}`)
+            // The failed refetch already blanked the waterfall (see the sampleTraceSpans reducer);
+            // reload the trace for the retained samples so the scene stays usable.
+            actions.loadCurrentSampleTrace()
         },
         fetchStatsFailure: ({ error }) => {
-            lemonToast.error(`Failed to load operation stats: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load operation stats: ${error}`)
+            }
         },
         fetchSampleTraceFailure: ({ error }) => {
-            lemonToast.error(`Failed to load trace: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load trace: ${error}`)
+            }
         },
     })),
 
     actionToUrl(({ values }) => {
         const withSelectionParams = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => {
-            const { min, max, sample, ...rest } = router.values.searchParams
+            const { min, max, sample, dateRange, ...rest } = router.values.searchParams
             const params: Record<string, any> = { ...rest }
+            if (!objectsEqual(values.dateRange, DEFAULT_DATE_RANGE)) {
+                params.dateRange = JSON.stringify(values.dateRange)
+            }
             if (values.durationSelection) {
                 params.min = values.durationSelection.minNs
                 params.max = values.durationSelection.maxNs
@@ -196,6 +260,7 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             return [router.values.location.pathname, params, router.values.hashParams, { replace: true }]
         }
         return {
+            setDateRange: withSelectionParams,
             setDurationSelection: withSelectionParams,
             setSampleIndex: withSelectionParams,
         }
@@ -206,26 +271,42 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             if (method === 'REPLACE') {
                 return // our own actionToUrl writes
             }
+            // Restore the date range first: setDateRange resets sampleIndex.
+            if (searchParams.dateRange) {
+                try {
+                    const dateRange =
+                        typeof searchParams.dateRange === 'string'
+                            ? JSON.parse(searchParams.dateRange)
+                            : searchParams.dateRange
+                    if (!objectsEqual(dateRange, values.dateRange)) {
+                        actions.setDateRange(dateRange)
+                    }
+                } catch {
+                    // Malformed param — keep the current range.
+                }
+            }
             const minNs = parseInt(String(searchParams.min), 10)
             const maxNs = parseInt(String(searchParams.max), 10)
             const selection = !isNaN(minNs) && !isNaN(maxNs) ? { minNs, maxNs } : null
-            if (JSON.stringify(selection) !== JSON.stringify(values.durationSelection)) {
+            if (!objectsEqual(selection, values.durationSelection)) {
                 actions.setDurationSelection(selection)
             }
             const sample = parseInt(String(searchParams.sample), 10)
-            if (!isNaN(sample) && sample !== values.sampleIndex) {
+            if (!isNaN(sample) && sample >= 0 && sample !== values.sampleIndex) {
                 actions.setSampleIndex(sample)
             }
         },
     })),
 
-    afterMount(({ actions, values }) => {
+    afterMount(({ actions, props }) => {
+        // A malformed link renders the scene's missing-params fallback; don't query for it.
+        if (!props.spanName || !props.serviceName) {
+            return
+        }
+        // URL restore may have dispatched these already in this same tick — the loaders'
+        // leading breakpoint coalesces the duplicates into one request each.
         actions.fetchHistogram()
         actions.fetchStats()
-        // A deep link restores the selection via urlToAction, whose listener already fetches
-        // samples — only fetch directly when mounting without one.
-        if (!values.durationSelection) {
-            actions.fetchSamples()
-        }
+        actions.fetchSamples()
     }),
 ])

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -1,0 +1,231 @@
+import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { actionToUrl, router, urlToAction } from 'kea-router'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { dataColorVars } from 'lib/colors'
+
+import { AggregatedSpanRow, DateRange } from '~/queries/schema/schema-general'
+
+import { type DurationHistogramRow, pivotDurationHistogram, type TracingDurationHistogramData } from './durationBuckets'
+import { type DurationRange, operationFilterGroup } from './operationFilters'
+import { traceLookupDateRange } from './traceLinks'
+import { DEFAULT_DATE_RANGE } from './tracingFiltersLogic'
+import type { tracingOperationSceneLogicType } from './tracingOperationSceneLogicType'
+import type { Span } from './types'
+
+export interface TracingOperationSceneLogicProps {
+    serviceName: string
+    spanName: string
+}
+
+const SAMPLE_LIMIT = 100
+
+export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
+    props({} as TracingOperationSceneLogicProps),
+    key(({ serviceName, spanName }) => `${serviceName}//${spanName}`),
+    path((key) => ['products', 'tracing', 'frontend', 'tracingOperationSceneLogic', key]),
+
+    actions({
+        setDateRange: (dateRange: DateRange) => ({ dateRange }),
+        setDurationSelection: (selection: DurationRange | null) => ({ selection }),
+        setSampleIndex: (index: number) => ({ index }),
+        selectSpan: (spanId: string | null) => ({ spanId }),
+        setSamplesHaveMore: (hasMore: boolean) => ({ hasMore }),
+    }),
+
+    loaders(({ props, values, actions }) => ({
+        rawHistogram: [
+            [] as DurationHistogramRow[],
+            {
+                fetchHistogram: async (_: void, breakpoint) => {
+                    await breakpoint(100)
+                    const response = await api.tracing.durationHistogram({
+                        dateRange: values.dateRange,
+                        serviceNames: [props.serviceName],
+                        filterGroup: operationFilterGroup(props.spanName, null),
+                        // Span-level: operations are often child spans, and the samples query
+                        // below is span-level too — both must count the same population.
+                        rootSpans: false,
+                    })
+                    breakpoint()
+                    return response.results
+                },
+            },
+        ],
+        samples: [
+            [] as Span[],
+            {
+                fetchSamples: async (_: void, breakpoint) => {
+                    await breakpoint(100)
+                    const response = await api.tracing.listSpans({
+                        dateRange: values.dateRange,
+                        orderBy: 'timestamp',
+                        orderDirection: 'DESC',
+                        serviceNames: [props.serviceName],
+                        filterGroup: operationFilterGroup(props.spanName, values.durationSelection),
+                        flatSpans: true,
+                        limit: SAMPLE_LIMIT,
+                    })
+                    breakpoint()
+                    actions.setSamplesHaveMore(!!response.hasMore)
+                    return response.results as Span[]
+                },
+            },
+        ],
+        operationStats: [
+            null as AggregatedSpanRow | null,
+            {
+                fetchStats: async (_: void, breakpoint) => {
+                    await breakpoint(100)
+                    const response = await api.tracing.aggregate({
+                        dateRange: values.dateRange,
+                        serviceNames: [props.serviceName],
+                        filterGroup: operationFilterGroup(props.spanName, null),
+                    })
+                    breakpoint()
+                    return response.results.find((row) => row.name === props.spanName) ?? null
+                },
+            },
+        ],
+        sampleTraceSpans: [
+            [] as Span[],
+            {
+                fetchSampleTrace: async ({ sample }: { sample: Span }, breakpoint) => {
+                    await breakpoint(100)
+                    const response = await api.tracing.getTrace(sample.trace_id, {
+                        dateRange: traceLookupDateRange(sample.timestamp),
+                    })
+                    breakpoint()
+                    return response.results as Span[]
+                },
+            },
+        ],
+    })),
+
+    reducers({
+        dateRange: [DEFAULT_DATE_RANGE as DateRange, { setDateRange: (_, { dateRange }) => dateRange }],
+        durationSelection: [null as DurationRange | null, { setDurationSelection: (_, { selection }) => selection }],
+        sampleIndex: [
+            0,
+            {
+                setSampleIndex: (_, { index }) => index,
+                setDurationSelection: () => 0,
+                setDateRange: () => 0,
+            },
+        ],
+        selectedSpanId: [null as string | null, { selectSpan: (_, { spanId }) => spanId }],
+        samplesHaveMore: [false, { setSamplesHaveMore: (_, { hasMore }) => hasMore }],
+        // A stale waterfall must not linger under a new (or empty) sample set.
+        sampleTraceSpans: { fetchSamples: () => [] },
+    }),
+
+    selectors({
+        serviceName: [() => [(_, props) => props.serviceName], (serviceName: string): string => serviceName],
+        spanName: [() => [(_, props) => props.spanName], (spanName: string): string => spanName],
+        histogramData: [
+            (s) => [s.rawHistogram],
+            (rows: DurationHistogramRow[]): TracingDurationHistogramData => pivotDurationHistogram(rows, dataColorVars),
+        ],
+        currentSample: [
+            (s) => [s.samples, s.sampleIndex],
+            (samples: Span[], sampleIndex: number): Span | null => samples[sampleIndex] ?? null,
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        setDurationSelection: () => {
+            actions.fetchSamples()
+        },
+        setDateRange: () => {
+            actions.fetchHistogram()
+            actions.fetchSamples()
+            actions.fetchStats()
+        },
+        fetchSamplesSuccess: ({ samples }) => {
+            if (samples.length === 0) {
+                actions.selectSpan(null)
+                return
+            }
+            if (values.sampleIndex >= samples.length) {
+                // A deep-linked or stale index past the new result set would render a blank sample.
+                actions.setSampleIndex(0)
+                return
+            }
+            if (values.currentSample) {
+                actions.fetchSampleTrace({ sample: values.currentSample })
+            }
+        },
+        setSampleIndex: () => {
+            if (values.currentSample) {
+                actions.fetchSampleTrace({ sample: values.currentSample })
+            }
+        },
+        fetchSampleTraceSuccess: () => {
+            // Anchor the waterfall on the operation's own span — for child operations the
+            // sample sits deep in a larger trace and would otherwise open unfocused at the root.
+            actions.selectSpan(values.currentSample?.span_id ?? null)
+        },
+        fetchHistogramFailure: ({ error }) => {
+            lemonToast.error(`Failed to load latency distribution: ${error}`)
+        },
+        fetchSamplesFailure: ({ error }) => {
+            lemonToast.error(`Failed to load sample traces: ${error}`)
+        },
+        fetchStatsFailure: ({ error }) => {
+            lemonToast.error(`Failed to load operation stats: ${error}`)
+        },
+        fetchSampleTraceFailure: ({ error }) => {
+            lemonToast.error(`Failed to load trace: ${error}`)
+        },
+    })),
+
+    actionToUrl(({ values }) => {
+        const withSelectionParams = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => {
+            const { min, max, sample, ...rest } = router.values.searchParams
+            const params: Record<string, any> = { ...rest }
+            if (values.durationSelection) {
+                params.min = values.durationSelection.minNs
+                params.max = values.durationSelection.maxNs
+            }
+            if (values.sampleIndex > 0) {
+                params.sample = values.sampleIndex
+            }
+            return [router.values.location.pathname, params, router.values.hashParams, { replace: true }]
+        }
+        return {
+            setDurationSelection: withSelectionParams,
+            setSampleIndex: withSelectionParams,
+        }
+    }),
+
+    urlToAction(({ actions, values }) => ({
+        '/tracing/operation': (_, searchParams, __, { method }) => {
+            if (method === 'REPLACE') {
+                return // our own actionToUrl writes
+            }
+            const minNs = parseInt(String(searchParams.min), 10)
+            const maxNs = parseInt(String(searchParams.max), 10)
+            const selection = !isNaN(minNs) && !isNaN(maxNs) ? { minNs, maxNs } : null
+            if (JSON.stringify(selection) !== JSON.stringify(values.durationSelection)) {
+                actions.setDurationSelection(selection)
+            }
+            const sample = parseInt(String(searchParams.sample), 10)
+            if (!isNaN(sample) && sample !== values.sampleIndex) {
+                actions.setSampleIndex(sample)
+            }
+        },
+    })),
+
+    afterMount(({ actions, values }) => {
+        actions.fetchHistogram()
+        actions.fetchStats()
+        // A deep link restores the selection via urlToAction, whose listener already fetches
+        // samples — only fetch directly when mounting without one.
+        if (!values.durationSelection) {
+            actions.fetchSamples()
+        }
+    }),
+])

--- a/products/tracing/manifest.tsx
+++ b/products/tracing/manifest.tsx
@@ -1,3 +1,5 @@
+import { combineUrl } from 'kea-router'
+
 import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
@@ -16,13 +18,27 @@ export const manifest: ProductManifest = {
             description: 'Monitor and analyze distributed traces to understand service performance and debug issues.',
             iconType: 'tracing',
         },
+        TracingOperation: {
+            name: 'Operation',
+            import: () => import('./frontend/TracingOperationScene'),
+            projectBased: true,
+            layout: 'app-container',
+            activityScope: 'Tracing',
+            description: 'Latency distribution and sample traces for a single operation.',
+            iconType: 'tracing',
+        },
     },
     routes: {
         '/tracing': ['Tracing', 'tracing'],
+        '/tracing/operation': ['TracingOperation', 'tracingOperation'],
     },
     redirects: {},
     urls: {
         tracing: (): string => '/tracing',
+        // Query params rather than path segments: span names ("GET /api/stats") contain slashes
+        // and arbitrary characters that break path routing.
+        tracingOperation: (serviceName: string, spanName: string): string =>
+            combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
     },
     fileSystemTypes: {},
     treeItemsNew: [],

--- a/products/tracing/manifest.tsx
+++ b/products/tracing/manifest.tsx
@@ -37,8 +37,16 @@ export const manifest: ProductManifest = {
         tracing: (): string => '/tracing',
         // Query params rather than path segments: span names ("GET /api/stats") contain slashes
         // and arbitrary characters that break path routing.
-        tracingOperation: (serviceName: string, spanName: string): string =>
-            combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
+        tracingOperation: (
+            serviceName: string,
+            spanName: string,
+            dateRange?: { date_from?: string | null; date_to?: string | null }
+        ): string =>
+            combineUrl('/tracing/operation', {
+                service: serviceName,
+                name: spanName,
+                ...(dateRange ? { dateRange: JSON.stringify(dateRange) } : {}),
+            }).url,
     },
     fileSystemTypes: {},
     treeItemsNew: [],

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -54929,6 +54929,24 @@ export namespace Schemas {
       traceCount: number;
     }
 
+    export interface _TracingDurationHistogramQueryBody {
+      /** Date range for the query. Defaults to last hour. */
+      dateRange?: _TracingDateRange;
+      /** Filter by service names. */
+      serviceNames?: string[];
+      /** Filter by OTel span status codes (0 Unset, 1 OK, 2 Error) — not HTTP status codes. Use [2] to select error spans. */
+      statusCodes?: number[];
+      /** Property filters for the query. */
+      filterGroup?: _SpanPropertyFilter[];
+      /** When true (default), bucket root-span durations only — a distribution of traces. When false, bucket every matching span — used with a span name filter for operation-scoped distributions. */
+      rootSpans?: boolean;
+    }
+
+    export interface _TracingDurationHistogramRequest {
+      /** The duration-histogram query to execute. */
+      query: _TracingDurationHistogramQueryBody;
+    }
+
     /**
      * * `timestamp` - timestamp
      * * `duration` - duration
@@ -55002,22 +55020,6 @@ export namespace Schemas {
     export interface _TracingSparklineRequest {
       /** The sparkline query to execute. */
       query: _TracingSparklineQueryBody;
-    }
-
-    export interface _TracingTimeseriesQueryBody {
-      /** Date range for the query. Defaults to last hour. */
-      dateRange?: _TracingDateRange;
-      /** Filter by service names. */
-      serviceNames?: string[];
-      /** Filter by OTel span status codes (0 Unset, 1 OK, 2 Error) — not HTTP status codes. Use [2] to select error spans. */
-      statusCodes?: number[];
-      /** Property filters for the query. */
-      filterGroup?: _SpanPropertyFilter[];
-    }
-
-    export interface _TracingTimeseriesRequest {
-      /** The sparkline / duration-histogram query to execute. */
-      query: _TracingTimeseriesQueryBody;
     }
 
     export interface _TracingTraceRequest {

--- a/services/mcp/src/generated/tracing/api.ts
+++ b/services/mcp/src/generated/tracing/api.ts
@@ -356,6 +356,7 @@ export const TracingSpansDurationHistogramCreateParams = /* @__PURE__ */ zod.obj
 })
 
 export const tracingSpansDurationHistogramCreateBodyQueryOneFilterGroupDefault = []
+export const tracingSpansDurationHistogramCreateBodyQueryOneRootSpansDefault = true
 
 export const TracingSpansDurationHistogramCreateBody = /* @__PURE__ */ zod.object({
     query: zod
@@ -427,8 +428,14 @@ export const TracingSpansDurationHistogramCreateBody = /* @__PURE__ */ zod.objec
                 )
                 .default(tracingSpansDurationHistogramCreateBodyQueryOneFilterGroupDefault)
                 .describe('Property filters for the query.'),
+            rootSpans: zod
+                .boolean()
+                .default(tracingSpansDurationHistogramCreateBodyQueryOneRootSpansDefault)
+                .describe(
+                    'When true (default), bucket root-span durations only — a distribution of traces. When false, bucket every matching span — used with a span name filter for operation-scoped distributions.'
+                ),
         })
-        .describe('The sparkline / duration-histogram query to execute.'),
+        .describe('The duration-histogram query to execute.'),
 })
 
 export const TracingSpansQueryCreateParams = /* @__PURE__ */ zod.object({


### PR DESCRIPTION
## Problem

The Operations tab shows aggregate latency and error stats per operation, but there's no way to drill into one operation: no view of how its latency distributes, and no path from "p95 looks bad" to an actual slow trace. Separately, tracing's read endpoints were only partially instrumented, so we couldn't measure whether anyone uses these surfaces across web, API, and MCP callers.

## Changes

Clicking a row in the Operations tab now opens a per-operation scene:

- A span-level latency distribution histogram on 1-2-5 log buckets. Operations are usually child spans, so the histogram endpoint honors `rootSpans=false` and buckets the operation's own span durations, the same population the samples query counts.
- Drag-select a duration range on the histogram to filter a pager of sampled traces from that range, each rendered as an inline waterfall anchored on the operation's own span.
- Date range, duration selection, and sample index all sync to the URL for deep linking. The date range carries over from the Operations tab, so the detail stats match the row that was clicked.

Backend instrumentation: the duration-histogram, aggregate, and per-trace endpoints now fire `report_user_action` events (`tracing duration histogram queried`, `tracing aggregation queried`, `tracing trace fetched`) matching the existing `tracing query executed` pattern, so usage is segmentable by `access_method` (web, personal API key, MCP).

Review hardening rolled into this PR:

- Superseded requests are aborted server-side (per-loader `AbortController`s via the disposables plugin), instead of just having their results discarded client-side.
- The samples query passes `excludeAttributes` since the scene only reads scalar span fields, and adjacent samples that share a trace reuse the already-loaded waterfall instead of refetching it.
- Deep links with a negative `sample` index are rejected, links missing the service param get the missing-params fallback instead of a silent empty query, and a persisted duration selection that falls entirely off a reshaped histogram axis renders no highlight instead of highlighting everything.
- The trace-list duration histogram now counts the population the active view shows (root spans in Traces view, every matching span in Spans view), matching the sparkline.
- Deduplicated helpers: category duration axis config, error-rate formatting, and the duration-range type each live in one place now.

Screenshots are from a locally seeded run; I can attach them in a comment.

## How did you test this code?

Automated, run locally:

- `products/tracing/backend/tests/test_duration_histogram.py` covers root-level vs span-level bucketing through the endpoint, including the `rootSpans=false` path the scene depends on.
- `products/tracing/frontend/durationBuckets.test.ts` covers the 1-2-5 bucket math (snap, fill, upper bound, selection-to-range).
- `products/tracing/frontend/tracingOperationSceneLogic.test.ts` covers the two regressions most likely to recur: a drag selection must refetch samples scoped to the selected range and reset the pager, and paging to a sample must fetch its containing trace and anchor the waterfall on the sample's own span.
- Full affected suite green: 52 frontend tests across the three tracing test files, 6 backend tests, plus `ruff` and `oxlint`/`oxfmt` on changed files. TypeScript check is clean for every touched file.

Manually verified earlier in the session against a locally seeded dev stack: scene loads from the Operations tab, drag selection filters samples, pager and waterfall behave, deep links restore selection and sample.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked while producing this PR: `/improving-drf-endpoints`, `/writing-tests`, `/using-kea-disposables`, plus a simplify and multi-angle code review pass whose confirmed findings were applied here.

Decisions worth knowing about as a reviewer: the histogram endpoint defaults `rootSpans=true` so existing callers keep the trace-level distribution, and the scene opts into span-level explicitly. Instrumentation went into the backend viewset (not `posthog.capture` in the frontend) specifically so usage is visible across web, API, and MCP via `access_method`. The review pass deliberately skipped a few flagged items as out of scope: single-bucket drag selection needs a shared `Sparkline` change, the hand-rolled `api.tracing` client block predates this PR and migrating it to generated types is a separate effort, and the repeated `report_user_action`/filter-group parsing boilerplate in the tracing viewset (7 and 5 copies now) is worth a follow-up helper.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*