### PR TITLE
fix(warehouse): widen webhook-only delta columns on type conflict

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -1,6 +1,6 @@
 import json
 import asyncio
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from typing import Any, Literal
 
 from django.conf import settings
@@ -129,6 +129,32 @@ def _realign_decimal_buffers(table: pa.Table) -> pa.Table:
         return table
 
     return pa.table(new_columns, schema=table.schema)
+
+
+class _UnsafeToWidenError(Exception):
+    """Raised by the pre-write verification pass when a stored value would not survive the
+    widening cast. Str value is the offending column name. Internal control flow for
+    `DeltaTableHelper.widen_stored_column_types` only — never propagated."""
+
+
+def _widened_column_type(stored: pa.DataType, incoming: pa.DataType) -> pa.DataType | None:
+    """The type a stored integer column must widen to for `incoming` values to fit, or None.
+
+    Mirrors the conflicts `evolve_pyarrow_schema` raises `SchemaColumnTypeChangedException`
+    for: an integer column now receiving floats, decimals, or wider integers. Floats always
+    widen to float64 and integers to int64 — Delta's `double`/`long` — so one rewrite settles
+    the column no matter which width arrives next. decimal256 is excluded because Delta caps
+    decimal precision at 38 (decimal128).
+    """
+    if not pa.types.is_integer(stored):
+        return None
+    if pa.types.is_floating(incoming):
+        return pa.float64()
+    if pa.types.is_decimal128(incoming):
+        return incoming
+    if pa.types.is_integer(incoming) and incoming.bit_width > stored.bit_width:
+        return pa.int64()
+    return None
 
 
 def _first_per_pk_table(
@@ -331,6 +357,91 @@ class DeltaTableHelper:
             return []
 
         return await asyncio.to_thread(delta_table.file_uris)
+
+    async def widen_stored_column_types(self, incoming_schema: pa.Schema) -> deltalake.DeltaTable | None:
+        """Rewrite the table so stored integer columns adopt the wider type now arriving.
+
+        delta-rs cannot widen a column's type in place (no `typeWidening` support), so the only
+        way for a table to accept e.g. fractional prices in a column created as int64 is to
+        rewrite every row. That cost is deliberate: this is reserved for tables whose data cannot
+        be re-pulled from the source (webhook-only resources), where the usual remedy — reset and
+        fully re-sync — is a no-op by design (see `handle_reset_or_full_refresh`), leaving the
+        table wedged forever on the first fractional value.
+
+        Before anything is written, every widened column is streamed through a pyarrow safe cast
+        to prove the rewrite is lossless (safe int→double casts reject values beyond 2**53, where
+        doubles lose integer precision). Returns the refreshed table after a single atomic
+        overwrite commit, or None when there is nothing safe to widen — callers should let their
+        original error propagate. A crash mid-rewrite leaves the table on its previous version;
+        parquet files from the aborted write are untracked and cleaned up by vacuum.
+        """
+        delta_table = await self.get_delta_table()
+        if delta_table is None:
+            return None
+
+        stored_schema = pyarrow_schema_from_arrow_exportable(delta_table.schema())
+        widened: dict[str, pa.DataType] = {}
+        for stored_field in stored_schema:
+            incoming_index = incoming_schema.get_field_index(stored_field.name)
+            if incoming_index == -1:
+                continue
+            target_type = _widened_column_type(stored_field.type, incoming_schema.field(incoming_index).type)
+            if target_type is not None and target_type != stored_field.type:
+                widened[stored_field.name] = target_type
+
+        if not widened:
+            await self._logger.adebug("widen_stored_column_types: no stored column is widenable")
+            return None
+
+        existing_partition_columns = getattr(delta_table.metadata(), "partition_columns", None) or []
+        partition_by = PARTITION_KEY if PARTITION_KEY in existing_partition_columns else None
+
+        def _rewrite() -> None:
+            dataset = delta_table.to_pyarrow_dataset()
+            target_schema = pa.schema(
+                [field.with_type(widened.get(field.name, field.type)) for field in dataset.schema],
+                metadata=dataset.schema.metadata,
+            )
+
+            # Verification pass, column-pruned so only the widened columns are read. It must
+            # complete before the write starts: an exception raised from a batch generator
+            # mid-write surfaces as an opaque DeltaError from the Rust writer boundary, and
+            # would leave orphaned parquet files behind.
+            for name, target_type in widened.items():
+                for verify_batch in dataset.scanner(columns=[name]).to_batches():
+                    try:
+                        verify_batch.column(0).cast(target_type)
+                    except pa.ArrowInvalid as e:
+                        raise _UnsafeToWidenError(name) from e
+
+            def _casted_batches() -> Iterator[pa.RecordBatch]:
+                for batch in dataset.to_batches():
+                    yield from pa.Table.from_batches([batch]).cast(target_schema).to_batches()
+
+            reader = pa.RecordBatchReader.from_batches(target_schema, _casted_batches())
+            deltalake.write_deltalake(
+                table_or_uri=delta_table,
+                data=reader,
+                partition_by=partition_by,
+                mode="overwrite",
+                schema_mode="overwrite",
+            )
+
+        try:
+            await asyncio.to_thread(_rewrite)
+        except _UnsafeToWidenError as e:
+            await self._logger.awarning(
+                f"widen_stored_column_types: aborted, stored values in column '{e}' would not survive the widening cast"
+            )
+            return None
+
+        self.get_delta_table.cache_clear()
+        refreshed = await self.get_delta_table()
+        assert refreshed is not None
+
+        widened_description = ", ".join(f"{name} -> {dtype}" for name, dtype in sorted(widened.items()))
+        await self._logger.ainfo(f"widen_stored_column_types: rewrote table widening columns: {widened_description}")
+        return refreshed
 
     async def _dedupe_incremental_batch(
         self, data: pa.Table, primary_keys: Sequence[Any], use_partitioning: bool

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -66,6 +66,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     SourceResponse,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import (
+    SchemaColumnTypeChangedException,
     _append_debug_column_to_pyarrows_table,
     _handle_null_columns_with_definitions,
     evolve_pyarrow_schema,
@@ -89,6 +90,33 @@ T = TypeVar("T")
 # (e.g. Stripe API pagination) can't starve the default executor which is
 # shared by logging, DB operations, and S3 writes.
 _SOURCE_ITERATOR_EXECUTOR = ThreadPoolExecutor(max_workers=32, thread_name_prefix="source-iter")
+
+
+async def _evolve_schema_or_widen(
+    pa_table: pa.Table,
+    delta_table: deltalake.DeltaTable | None,
+    resource: SourceResponse,
+    delta_table_helper: DeltaTableHelper,
+) -> pa.Table:
+    """Evolve the incoming batch toward the stored Delta schema, widening the table when it can't.
+
+    A stored-type conflict normally surfaces `SchemaColumnTypeChangedException`, whose remedy is
+    a reset and full re-sync. For webhook-only resources that remedy is a dead end:
+    `handle_reset_or_full_refresh` deliberately no-ops the reset for them (webhook rows cannot be
+    re-pulled from any API), so the table would wedge forever on the first conflicting value —
+    e.g. an `events` table whose price column was created int64 from whole-valued deliveries,
+    then receives 19.99. Widening the stored column in place is the only escape, so it happens
+    here, transparently, and the batch is evolved against the widened schema.
+    """
+    try:
+        return evolve_pyarrow_schema(pa_table, delta_table.schema() if delta_table is not None else None)
+    except SchemaColumnTypeChangedException:
+        if delta_table is None or not resource.webhook_only:
+            raise
+        widened_table = await delta_table_helper.widen_stored_column_types(pa_table.schema)
+        if widened_table is None:
+            raise
+        return evolve_pyarrow_schema(pa_table, widened_table.schema())
 
 
 async def async_iterate(iterable: Iterable[T] | AsyncIterable[T]) -> AsyncIterator[T]:
@@ -394,7 +422,7 @@ class PipelineNonDLT(Generic[ResumableData]):
 
         pa_table = await setup_partitioning(pa_table, delta_table, self._schema, self._resource, self._logger)
 
-        pa_table = evolve_pyarrow_schema(pa_table, delta_table.schema() if delta_table is not None else None)
+        pa_table = await _evolve_schema_or_widen(pa_table, delta_table, self._resource, self._delta_table_helper)
         pa_table = _handle_null_columns_with_definitions(pa_table, self._resource)
 
         write_type: Literal["incremental", "full_refresh", "append"] = "full_refresh"

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -20,7 +20,10 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _first_per_pk_table,
     _realign_decimal_buffers,
 )
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import evolve_pyarrow_schema
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import (
+    SchemaColumnTypeChangedException,
+    evolve_pyarrow_schema,
+)
 
 
 def _decimal_array(values: list, *, precision: int = 10, scale: int = 2, misaligned: bool) -> pa.Array:
@@ -901,6 +904,88 @@ class TestRunMaintenance:
 
         assert result == 150
         vacuum_if_stale.assert_awaited_once_with(40, 100)
+
+
+def _create_int_price_table(path: str, *, partitioned: bool = False, prices: list[int | None] | None = None) -> None:
+    """Seed a Delta table whose price column got locked to int64 by whole-valued first
+    deliveries — the wedge `widen_stored_column_types` exists to escape."""
+    prices = prices if prices is not None else [0, 10, None]
+    fields = [pa.field("id", pa.int64()), pa.field("price", pa.int64())]
+    data: dict[str, Any] = {
+        "id": pa.array(range(1, len(prices) + 1), type=pa.int64()),
+        "price": pa.array(prices, type=pa.int64()),
+    }
+    if partitioned:
+        fields.append(pa.field(PARTITION_KEY, pa.string()))
+        data[PARTITION_KEY] = pa.array(["p0"] * len(prices))
+    deltalake.write_deltalake(
+        path, pa.table(data, schema=pa.schema(fields)), partition_by=PARTITION_KEY if partitioned else None
+    )
+
+
+def _fractional_price_batch(*, partitioned: bool = False) -> pa.Table:
+    data: dict[str, Any] = {"id": pa.array([4], type=pa.int64()), "price": pa.array([19.99], type=pa.float64())}
+    if partitioned:
+        data[PARTITION_KEY] = pa.array(["p0"])
+    return pa.table(data)
+
+
+class TestWidenStoredColumnTypes:
+    @pytest.mark.parametrize("partitioned", [False, True], ids=["flat", "partitioned"])
+    @pytest.mark.asyncio
+    async def test_widens_int_column_to_double_preserving_rows_and_partitioning(
+        self, partitioned: bool, tmp_path: Path
+    ) -> None:
+        delta_path = str(tmp_path / "table")
+        _create_int_price_table(delta_path, partitioned=partitioned)
+        helper = _make_local_helper(delta_path)
+        incoming = _fractional_price_batch(partitioned=partitioned)
+
+        # Baseline: the incoming batch genuinely conflicts with the stored schema.
+        with pytest.raises(SchemaColumnTypeChangedException):
+            evolve_pyarrow_schema(incoming, deltalake.DeltaTable(delta_path).schema())
+
+        result = await helper.widen_stored_column_types(incoming.schema)
+
+        assert result is not None
+        final = result.to_pyarrow_table()
+        assert final.schema.field("price").type == pa.float64()
+        by_id = dict(zip(final.column("id").to_pylist(), final.column("price").to_pylist()))
+        assert by_id == {1: 0.0, 2: 10.0, 3: None}
+        expected_partition_columns = [PARTITION_KEY] if partitioned else []
+        assert result.metadata().partition_columns == expected_partition_columns
+
+        # The wedge is gone: the conflicting batch now evolves cleanly against the new schema.
+        evolved = evolve_pyarrow_schema(incoming, result.schema())
+        assert evolved.column("price").to_pylist() == [19.99]
+
+    @pytest.mark.parametrize(
+        "stored_prices, incoming_price_type",
+        [
+            # int64 beyond 2**53 loses precision as a double: the round-trip check must abort.
+            ([2**53 + 1], pa.float64()),
+            # Incoming type matches the stored type: nothing to widen.
+            ([1, 2], pa.int64()),
+        ],
+        ids=["unsafe_beyond_double_precision", "nothing_widenable"],
+    )
+    @pytest.mark.asyncio
+    async def test_returns_none_and_leaves_table_untouched(
+        self, stored_prices: list[int], incoming_price_type: pa.DataType, tmp_path: Path
+    ) -> None:
+        delta_path = str(tmp_path / "table")
+        _create_int_price_table(delta_path, prices=cast(list[Any], stored_prices))
+        helper = _make_local_helper(delta_path)
+        incoming_schema = pa.schema([pa.field("id", pa.int64()), pa.field("price", incoming_price_type)])
+
+        result = await helper.widen_stored_column_types(incoming_schema)
+
+        assert result is None
+        untouched = deltalake.DeltaTable(delta_path)
+        assert untouched.version() == 0
+        final = untouched.to_pyarrow_table()
+        assert final.schema.field("price").type == pa.int64()
+        assert sorted(final.column("price").to_pylist()) == sorted(stored_prices)
 
 
 class TestIsTableCorrupted:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -910,7 +910,7 @@ def _create_int_price_table(path: str, *, partitioned: bool = False, prices: lis
     """Seed a Delta table whose price column got locked to int64 by whole-valued first
     deliveries — the wedge `widen_stored_column_types` exists to escape."""
     prices = prices if prices is not None else [0, 10, None]
-    fields = [pa.field("id", pa.int64()), pa.field("price", pa.int64())]
+    fields: list[pa.Field] = [pa.field("id", pa.int64()), pa.field("price", pa.int64())]
     data: dict[str, Any] = {
         "id": pa.array(range(1, len(prices) + 1), type=pa.int64()),
         "price": pa.array(prices, type=pa.int64()),
@@ -985,7 +985,7 @@ class TestWidenStoredColumnTypes:
         assert untouched.version() == 0
         final = untouched.to_pyarrow_table()
         assert final.schema.field("price").type == pa.int64()
-        assert sorted(final.column("price").to_pylist()) == sorted(stored_prices)
+        assert final.column("price").to_pylist() == stored_prices
 
 
 class TestIsTableCorrupted:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline.py
@@ -2,17 +2,28 @@ import time
 import asyncio
 import threading
 import contextvars
+from pathlib import Path
 from typing import cast
 
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pyarrow as pa
+import deltalake
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.cdp_producer import CDPProducer
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.delta_table_helper import (
+    DeltaTableHelper,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.pipeline import (
     PipelineNonDLT,
+    _evolve_schema_or_widen,
     async_iterate,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import (
+    SchemaColumnTypeChangedException,
+)
 
 _probe: contextvars.ContextVar[str | None] = contextvars.ContextVar("probe", default=None)
 
@@ -131,3 +142,58 @@ async def test_run_cleanup_failure_does_not_mask_import_error(monkeypatch):
         await pipeline.run()
 
     pipeline._logger.aexception.assert_awaited_once_with("Failed to clean up delta table helper")
+
+
+def _wedged_local_helper(tmp_path: Path) -> tuple[str, DeltaTableHelper]:
+    """A DeltaTableHelper over a local table whose price column is locked to int64."""
+    delta_path = str(tmp_path / "table")
+    deltalake.write_deltalake(
+        delta_path, pa.table({"id": pa.array([1, 2], type=pa.int64()), "price": pa.array([0, 10], type=pa.int64())})
+    )
+    logger = MagicMock(adebug=AsyncMock(), ainfo=AsyncMock(), awarning=AsyncMock())
+    helper = DeltaTableHelper(resource_name="events", job=MagicMock(), logger=logger)
+    patch.object(helper, "_get_delta_table_uri", new=AsyncMock(return_value=delta_path)).start()
+    patch.object(helper, "_get_credentials", new=MagicMock(return_value={})).start()
+    helper.get_delta_table.cache_clear()
+    return delta_path, helper
+
+
+def _webhook_resource(*, webhook_only: bool) -> SourceResponse:
+    return SourceResponse(name="events", items=lambda: [], primary_keys=["id"], webhook_only=webhook_only)
+
+
+@pytest.mark.asyncio
+async def test_evolve_schema_or_widen_unwedges_webhook_only_table(tmp_path: Path):
+    # The production incident: a webhook-only table locked to int64 can't take the
+    # "reset and fully re-sync" advice (handle_reset_or_full_refresh no-ops the reset
+    # for it), so the type conflict must be resolved by widening the table in place.
+    _, helper = _wedged_local_helper(tmp_path)
+    delta_table = await helper.get_delta_table()
+    incoming = pa.table({"id": pa.array([3], type=pa.int64()), "price": pa.array([19.99], type=pa.float64())})
+
+    evolved = await _evolve_schema_or_widen(incoming, delta_table, _webhook_resource(webhook_only=True), helper)
+
+    assert evolved.schema.field("price").type == pa.float64()
+    assert evolved.column("price").to_pylist() == [19.99]
+    refreshed = await helper.get_delta_table()
+    assert refreshed is not None
+    stored = refreshed.to_pyarrow_table()
+    assert stored.schema.field("price").type == pa.float64()
+    by_id = dict(zip(stored.column("id").to_pylist(), stored.column("price").to_pylist()))
+    assert by_id == {1: 0.0, 2: 10.0}
+
+
+@pytest.mark.asyncio
+async def test_evolve_schema_or_widen_still_raises_for_poll_sources(tmp_path: Path):
+    # Poll-based sources keep the fail-fast behavior: reset and re-sync genuinely works
+    # for them, and a surprise full-table rewrite mid-sync is not acceptable there.
+    delta_path, helper = _wedged_local_helper(tmp_path)
+    delta_table = await helper.get_delta_table()
+    incoming = pa.table({"id": pa.array([3], type=pa.int64()), "price": pa.array([19.99], type=pa.float64())})
+
+    with pytest.raises(SchemaColumnTypeChangedException):
+        await _evolve_schema_or_widen(incoming, delta_table, _webhook_resource(webhook_only=False), helper)
+
+    untouched = deltalake.DeltaTable(delta_path)
+    assert untouched.version() == 0
+    assert untouched.to_pyarrow_table().schema.field("price").type == pa.int64()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/source.py
@@ -255,8 +255,9 @@ class RevenueCatSource(
             "Source column type changed": (
                 "A column in this table started receiving values that don't fit the type stored from "
                 "earlier syncs (for example a price column created from whole-number values now "
-                "receiving a decimal price). We can't widen an existing column in place — reset and "
-                "fully re-sync this table to adopt the new type."
+                "receiving a decimal price). PostHog normally converts the stored column to the wider "
+                "type automatically, but that conversion wasn't possible here. Contact support to "
+                "migrate this table."
             ),
         }
 


### PR DESCRIPTION
## Problem

#71002 made a stored-type conflict fail fast with actionable guidance: when a Delta column created as int64 (e.g. a price column whose first-synced deliveries were all whole-valued) starts receiving fractional values, the sync surfaces `SchemaColumnTypeChangedException` telling the user to reset and fully re-sync the table.

For webhook-only resources that advice is a dead end. `handle_reset_or_full_refresh` deliberately no-ops the reset for them, because webhook rows exist only as delivered events and a wiped table could never be rebuilt. So an operator-triggered reset resync consumes the reset flag, keeps the int64 table, replays the buffered webhook files into it, and hits the exact same conflict. The table is wedged forever, and there is no self-service escape. Every webhook-fed table created before the type coercion in #71002 (whose stored column type disagrees with what now arrives) is in this state.

**Before**

```mermaid
flowchart LR
  A([fractional value arrives]) --> B[evolve toward stored schema]
  B --> C[error: reset and fully re-sync]
  C --> D[operator resets]
  D --> E[reset is a no-op for webhook-only]
  E --> B
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class A phYellow;
  class C,E phRed;
  class B,D phGray;
```

**After**

```mermaid
flowchart LR
  A([fractional value arrives]) --> B[evolve toward stored schema]
  B --> C{webhook-only resource?}
  C -- no --> D[fail fast: reset and re-sync]
  C -- yes --> E[widen stored column in place]
  E --> F([sync continues])
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class A,F phYellow;
  class E phBlue;
  class B,C,D phGray;
```

## Changes

- `DeltaTableHelper.widen_stored_column_types(incoming_schema)`: rewrites the table so stored integer columns adopt the wider type now arriving (int to float64, int to decimal128, narrower int to int64). delta-rs has no `typeWidening` support, so this is a streamed full rewrite into a single atomic overwrite commit. Before anything is written, a column-pruned verification pass streams each widened column through a pyarrow safe cast, proving the rewrite is lossless (safe int-to-double casts reject values beyond 2^53) and leaving zero orphaned files when it aborts. Partition layout is preserved and the cached table handle is refreshed.
- The v1/v2 pipeline catches `SchemaColumnTypeChangedException` at the evolve site and, only for `webhook_only` resources with an existing table, widens and retries. Poll-based sources keep the fail-fast behavior, since reset genuinely works for them and a surprise full-table rewrite mid-sync is not acceptable there.
- RevenueCat's friendly message for this error no longer advises the impossible reset. If it ever surfaces now, automatic widening wasn't possible, so it points at support.

> [!NOTE]
> The pipeline_v3 load processor evolves against the stored schema at its own call site and is not wired to widen yet, because it doesn't know whether the resource is webhook-only. The helper is shared, so plumbing that knowledge through the v3 queue is a small follow-up.

Wedged tables heal automatically on their next sync after deploy, with all rows preserved. No operator action is needed beyond unpausing schemas that already failed into a paused state.

## How did you test this code?

Automated tests (all run locally, 273 passed across the touched suites):

- `TestWidenStoredColumnTypes::test_widens_int_column_to_double_preserving_rows_and_partitioning` (flat + partitioned): catches a broken rewrite that drops rows, mangles values, loses the partition layout, or fails to actually clear the conflict. No existing test exercises widening.
- `TestWidenStoredColumnTypes::test_returns_none_and_leaves_table_untouched`: catches removal of the pre-write lossless verification, which would silently corrupt int64 values beyond 2^53, and pins that an aborted widen leaves the table at its original version.
- `test_evolve_schema_or_widen_unwedges_webhook_only_table`: the production wiring, a wedged int64 table plus an incoming fractional batch on a webhook-only resource syncs instead of raising.
- `test_evolve_schema_or_widen_still_raises_for_poll_sources`: catches an inverted or removed gate that would start rewriting poll-source tables where reset is the designed remedy.

3 pre-existing failures in `TestGetDeltaTableUnrecoverableErrors` are environmental (they need object-storage DNS unavailable in the sandbox) and fail identically on a clean checkout.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference the old remedy text; the user-facing error copy lives in the source mapping updated here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (PostHog Code session), directed by the assignee, as a follow-up to #71002 after a reset resync on a webhook-fed table failed to clear the type conflict in production. Skills invoked: `/writing-tests`. I (Claude) traced the failed reset to the webhook-only no-op in `handle_reset_or_full_refresh`, then chose in-place widening over the two rejected alternatives: honoring the wipe (drops rows that can only exist as delivered webhooks) and a temp-table-plus-swap rewrite (unnecessary, a single overwrite commit is already atomic). An earlier draft verified losslessness during the write via round-trip comparison inside the batch generator; that was replaced with the pre-write verification pass after tests showed generator exceptions surface as opaque `DeltaError`s from the Rust writer boundary and can't be caught reliably.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
