### PR TITLE
feat(hogli): support 200 GiB devboxes

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -1310,7 +1310,7 @@ def _maybe_hint_region_mismatch(name: str) -> None:
 @workspace_argument
 @click.option(
     "--disk",
-    type=click.Choice(["60", "80", "100"]),
+    type=click.Choice(["100", "200"]),
     default="100",
     help="Disk size in GiB (default: 100)",
 )

--- a/tools/hogli-commands/hogli_commands/tests/test_devbox.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devbox.py
@@ -1551,6 +1551,23 @@ class TestDevboxCommands:
             "start_app": "None",
         }
 
+    def test_devbox_start_forwards_larger_disk_size(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Guards that --disk 200 is an accepted choice and reaches create_workspace;
+        # regresses if the choice list drifts from the Coder template's disk_size options.
+        captured: dict[str, str | None] = {}
+
+        monkeypatch.setattr(devbox_cli, "ensure_runtime_ready", lambda: None)
+        monkeypatch.setattr(devbox_cli, "resolve_workspace_name", lambda ws, **kw: ("devbox-test-user", []))
+        monkeypatch.setattr(devbox_cli, "get_workspace", lambda name, workspaces=None: None)
+        monkeypatch.setattr(devbox_cli, "extract_workspace_label", lambda name: None)
+        monkeypatch.setattr(devbox_cli, "load_config", lambda: {})
+        monkeypatch.setattr(devbox_cli, "create_workspace", _stub_create_workspace(captured))
+
+        result = runner.invoke(cli, ["devbox:start", "--disk", "200"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["disk_size"] == "200"
+
     def test_devbox_start_with_name_creates_labeled_workspace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: dict[str, str | None] = {}
 


### PR DESCRIPTION
## Problem

- `hogli devbox:start --disk` only offered `60` / `80` / `100` GiB. The posthog-linux Coder template has since moved on: `100` GiB is the golden-AMI floor (smaller volumes fail at launch with `InvalidBlockDeviceMapping`), and it now exposes a `200` GiB option. So the CLI advertised two sizes that fail at launch and couldn't create the larger boxes the template supports.

## Changes

- `--disk` choices are now `100` / `200`, matching the template's `disk_size` options.
- Added a comment tying the choice list back to the template so the two stay in sync.

## How did you test this code?

- Added `test_devbox_start_forwards_larger_disk_size`: asserts `--disk 200` is accepted and reaches `create_workspace` as `disk_size="200"`. No existing test covered a non-default disk, so this guards the choice list drifting from the template's valid options.
- `ruff check` / `ruff format` clean, `hogli ci:preflight --strict` passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- None. The infra-side disk options live in posthog-cloud-infra, not this repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (Opus 4.8) at Raúl's direction. Skill invoked: `/writing-tests`.
- Source of truth for valid sizes is the posthog-linux template's `disk_size` parameter (100/200 GiB). I dropped the below-floor 60/80 options rather than only adding 200, since those now fail at launch.
