### PR TITLE
fix(engineering-analytics): stop broken-tests query 500 on repo filter

### DIFF
--- a/products/engineering_analytics/backend/logic/queries/broken_tests.py
+++ b/products/engineering_analytics/backend/logic/queries/broken_tests.py
@@ -81,7 +81,10 @@ _FINGERPRINTS_SELECT = """
         count() AS occurrences,
         uniqExactIf(branch, branch != '') AS branches,
         countIf(branch IN {default_branches}) AS master_hits,
-        any(repo) AS repo,
+        -- Aliased away from `repo`: HogQL binds a WHERE identifier to a matching SELECT alias, so
+        -- `any(repo) AS repo` would make the `lower(repo)` filter below resolve to this aggregate and
+        -- 500 with "aggregate function found in WHERE". Keep the alias distinct from the filtered column.
+        any(repo) AS repo_name,
         argMax(run_id, timestamp) AS latest_run_id,
         argMax(branch, timestamp) AS latest_branch,
         argMax(workflow_name, timestamp) AS workflow_name,

--- a/products/engineering_analytics/backend/tests/test_broken_tests.py
+++ b/products/engineering_analytics/backend/tests/test_broken_tests.py
@@ -1,16 +1,24 @@
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
+from posthog.test.base import BaseTest, ClickhouseTestMixin
 from unittest import mock
 
+from posthog.clickhouse.client import sync_execute
+
 from products.engineering_analytics.backend.facade.contracts import BROKEN_TEST_SPARKLINE_HOURS, BrokenTestState
+from products.engineering_analytics.backend.logic.job_logs.constants import CI_LOGS_SERVICE_NAME
 from products.engineering_analytics.backend.logic.queries import broken_tests as module
+from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource
 from products.engineering_analytics.backend.logic.queries.broken_tests import (
     _classify,
     _sparklines_by_fingerprint,
     query_broken_tests,
 )
+from products.engineering_analytics.backend.logic.sources import GitHubTables
 
 
 # Ages are seconds-ago-from-now (smaller = more recent). last_master_hit_age is the fingerprint's most
@@ -238,3 +246,60 @@ def test_build_query_embeds_the_failures_view():
     # not the registered warehouse view by name (keeps the product off the global catalog).
     assert "engineering_analytics_ci_failures" not in module._FINGERPRINTS_SELECT
     assert "FAILED" in module.ci_failures.build_query()
+
+
+class TestBrokenTestsQueryOverClickHouse(ClickhouseTestMixin, BaseTest):
+    """The unit tests above mock curated.run, so the fingerprints/hourly SQL never actually runs.
+    This drives query_broken_tests through real HogQL over seeded logs — the only place a SQL fault
+    like an aggregate alias shadowing the WHERE-filtered `repo` column surfaces (it 500'd the endpoint
+    in prod: "Aggregate function ... is found in WHERE")."""
+
+    def _insert_logs(self, rows: list[dict[str, Any]]) -> None:
+        payload = "".join(json.dumps({"team_id": self.team.id, **row}) + "\n" for row in rows)
+        sync_execute(f"INSERT INTO logs FORMAT JSONEachRow\n{payload}")
+
+    def _failure_log(self, *, repo: str, test_id: str) -> dict[str, Any]:
+        # attributes_map_str keys carry the "__str" suffix the logs table strips for the queryable map.
+        return {
+            "timestamp": "2026-07-10 12:00:00.000000",
+            "body": f"FAILED {test_id} - AssertionError: boom",
+            "service_name": CI_LOGS_SERVICE_NAME,
+            "attributes_map_str": {
+                "repo__str": repo,
+                "branch__str": "master",
+                "head_sha__str": "abc123",
+                "workflow_name__str": "Backend CI",
+                "job_name__str": "test (1)",
+                "run_id__str": "100",
+                "conclusion__str": "failure",
+            },
+        }
+
+    def _source(self) -> CuratedGitHubSource:
+        # workflow_jobs=None → jobs_source() is None → the master-status query is skipped, so this
+        # exercises only the logs-backed fingerprints + hourly reads without warehouse setup.
+        return CuratedGitHubSource(
+            team=self.team,
+            tables=GitHubTables(
+                pull_requests="unused", workflow_runs="unused", workflow_jobs=None, repository="PostHog/posthog"
+            ),
+        )
+
+    def test_fingerprints_query_runs_and_filters_by_repo(self) -> None:
+        self._insert_logs(
+            [
+                self._failure_log(repo="PostHog/posthog", test_id="posthog/api/test_foo.py::test_bar"),
+                self._failure_log(repo="other/repo", test_id="other/test_x.py::test_y"),
+            ]
+        )
+        result = query_broken_tests(
+            curated=self._source(),
+            date_from=datetime(2026, 7, 9, tzinfo=UTC),
+            hourly_from=datetime(2026, 7, 9, tzinfo=UTC),
+            window_days=2,
+            limit=200,
+        )
+        # No aggregate-in-WHERE 500, and lower(repo) binds to the column (not the any(repo) alias):
+        # only the selected repo's failure comes back.
+        assert [row.test_id for row in result.rows] == ["posthog/api/test_foo.py::test_bar"]
+        assert result.rows[0].repo == "PostHog/posthog"


### PR DESCRIPTION
## Problem

The "currently broken tests" panel in engineering analytics 500s on every real call in prod. Users just see "Couldn't load broken tests: A server error occurred." It shipped broken with the panel earlier today.

Reproduced against prod via the PostHog MCP `execute-sql`, the actual ClickHouse error is:

```
Aggregate function any(repo) AS repo is found in WHERE in query.
```

The `broken_tests` fingerprints query aliased its aggregate as `any(repo) AS repo`, shadowing the `repo` column the `WHERE` clause filters on. HogQL binds a `WHERE` identifier to a matching SELECT alias, so `lower(repo)` resolved to the aggregate instead of the column and ClickHouse rejected the query. The endpoint only catches `ValueError`, so this bubbles up as a 500.

## Changes

Rename the aggregate alias to `repo_name` so it no longer collides with the filtered column. One-line SQL fix at the source, plus a comment so the next person doesn't reintroduce it.

> [!NOTE]
> Why the tests were green: every existing test in `test_broken_tests.py` mocks `curated.run`, so the SQL string never actually runs through HogQL. This is exactly the "idealized-fixture tests stayed green" trap the product SPEC calls out.

## How did you test this code?

Added a ClickHouse-backed regression test (`TestBrokenTestsQueryOverClickHouse`) that seeds `logs` and drives `query_broken_tests` over real HogQL (in TEST, `Workload.LOGS` routes to the test DB). It catches a regression no existing test does: any fingerprints/hourly SQL fault that only surfaces in HogQL execution — the alias shadowing being the concrete one. It also asserts `lower(repo)` actually filters (only the selected repo's failure comes back).

Verified both directions locally:
- With the fix: full file `18 passed`.
- Reverting the alias reproduces the exact prod error: `CHQueryErrorIllegalAggregation: Aggregate function any(repo) AS repo is found in WHERE`.

I (Claude) did not do manual UI testing; the automated test above exercises the failing read path end to end.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Julian pointed me at the prod error and asked me to check error tracking. I (Claude) triaged via the PostHog MCP (error tracking + `execute-sql`), traced the 500 to the alias/WHERE collision by reproducing the query against prod, then applied the fix and added the ClickHouse-backed guard. Invoked the `/writing-tests` and `/simplify` skills while shaping the change.

Follow-up worth a separate PR: the other `logic/queries/*` modules share the same mock-`curated.run` pattern, so any similar SQL fault there is also invisible to tests. A small sweep of ClickHouse-backed smoke tests for the non-trivial WHERE/alias queries would close the class of bug.
