### PR TITLE
fix(inbox): hide scout signals section when nothing emitted

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -154,8 +154,10 @@ function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element 
     const { selectedScoutFindingId } = useValues(inboxSceneLogic)
 
     // No run in the window emitted anything — keep the section out entirely rather than show an
-    // empty box (mirrors the Reports section above).
-    if (emittedRuns.length === 0) {
+    // empty box (mirrors the Reports section above). Only once the runs window has settled, though:
+    // before that, `emittedRuns` is empty by default and hiding would skip the loading skeleton
+    // for scouts that do have signals.
+    if (runsWindowLoadedOnce && emittedRuns.length === 0) {
         return null
     }
 

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -139,13 +139,25 @@ function ScoutReportsSection({ skillName }: { skillName: string }): JSX.Element 
 /**
  * The Signals section: every finding this scout emitted in the recent window, newest first.
  * Emissions are fetched per emitted run by `scoutDetailLogic` (keyed by skill) off the fleet's
- * already-polled runs window. Most runs are quiet, so an empty list is the healthy default.
+ * already-polled runs window. Most runs are quiet — and scouts are moving to the report channel —
+ * so the section is hidden entirely when nothing emitted, rather than showing an empty box.
  */
-function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element {
-    const { emissionRows, emissionsLoading, emissionsLoadFailed, runsWindowLoadedOnce, runsWindowComplete } = useValues(
-        scoutDetailLogic({ skillName })
-    )
+function ScoutSignalsSection({ skillName }: { skillName: string }): JSX.Element | null {
+    const {
+        emissionRows,
+        emissionsLoading,
+        emissionsLoadFailed,
+        emittedRuns,
+        runsWindowLoadedOnce,
+        runsWindowComplete,
+    } = useValues(scoutDetailLogic({ skillName }))
     const { selectedScoutFindingId } = useValues(inboxSceneLogic)
+
+    // No run in the window emitted anything — keep the section out entirely rather than show an
+    // empty box (mirrors the Reports section above).
+    if (emittedRuns.length === 0) {
+        return null
+    }
 
     // "Loading" until the fleet's runs window has settled once AND this scout's emissions have
     // resolved — otherwise a fresh deep-link would flash the empty state before we know the


### PR DESCRIPTION
## Problem

The scout detail page (`/inbox/scouts/:skillName`) always renders a Signals section, even when no run in the recent window emitted anything. With scouts moving toward authoring and editing reports rather than emitting signals, most scouts now show a permanently empty dashed box saying "No signals emitted", which adds noise without telling the user anything useful.

## Changes

- `ScoutSignalsSection` now returns `null` when no run in the loaded window has `emitted_count > 0`, mirroring how the Reports section above it already hides itself when the scout never touched a report.
- The skeleton, load-failure, and truncated-window states are unchanged for scouts that did emit signals.

## How did you test this code?

No automated tests cover this view. I verified the gate reuses the existing `emittedRuns` selector in `scoutDetailLogic` (the same rollup data the section's emission fetches are keyed on), so a scout with signals in the window renders exactly as before. I (Claude) could not run the frontend typecheck or a browser in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) from a screenshot of the empty Signals box on a scout detail page. The gate uses the logic's existing `emittedRuns` selector rather than `emissionRows`, so the section stays visible (with its skeleton or retry state) while emissions for runs that did emit are still loading or failing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*