### PR TITLE
fix(linear): retry connection broken mid-body instead of failing import

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linear/linear.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linear/linear.py
@@ -97,10 +97,11 @@ def _make_paginated_request(
     def execute(variables: dict[str, Any]) -> dict:
         try:
             response = sess.post(LINEAR_API_URL, json={"query": query, "variables": variables}, timeout=60)
-        except (requests.ConnectionError, requests.Timeout) as e:
+        except (requests.ConnectionError, requests.Timeout, requests.exceptions.ChunkedEncodingError) as e:
             # The session's urllib3 Retry only covers idempotent methods, so Linear's POSTs get no
-            # transport-level retry. Route transient network failures (read timeout, connection reset)
-            # through the same backoff path as 5xx/429 instead of failing the whole activity on one blip.
+            # transport-level retry. Route transient network failures (read timeout, connection reset,
+            # a connection broken mid-body which surfaces as ChunkedEncodingError) through the same
+            # backoff path as 5xx/429 instead of failing the whole activity on one blip.
             raise LinearRetryableError(f"Linear: transient network error - {e}")
 
         if response.status_code >= 500:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linear/test_linear.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linear/test_linear.py
@@ -243,6 +243,12 @@ class TestMakePaginatedRequest:
         [
             ("read_timeout", requests.exceptions.ReadTimeout("Read timed out. (read timeout=60)")),
             ("connection_reset", requests.exceptions.ConnectionError("Connection aborted")),
+            # ChunkedEncodingError is not a ConnectionError subclass, so it must be listed explicitly
+            # to ride the retry path instead of failing the activity on a connection broken mid-body.
+            (
+                "chunked_encoding_broken",
+                requests.exceptions.ChunkedEncodingError("Connection broken: InvalidChunkLength"),
+            ),
         ]
     )
     @patch("time.sleep", return_value=None)


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `ChunkedEncodingError` raised from the Linear data-warehouse import source (`products/warehouse_sources/backend/temporal/data_imports/sources/linear/linear.py`, in `execute`). The message is the generic urllib3 protocol error: `Connection broken: InvalidChunkLength(...)`.

This happens when Linear's edge drops the connection partway through streaming a response body. `requests` raises it out of `sess.post(...)`, before we ever reach the JSON parse.

The `execute` function already folds transient network failures into the retry backoff by catching `requests.ConnectionError` and `requests.Timeout` and re-raising them as `LinearRetryableError`. But `ChunkedEncodingError` is a direct subclass of `RequestException`, not `ConnectionError`, so it slipped past that clause and failed the whole import activity on a single blip.

This is the same class of transient failure the code already means to ride out (read timeout, connection reset), so it belongs on the retry path, not in `NonRetryableErrors`.

## Changes

Add `requests.exceptions.ChunkedEncodingError` to the transient-network except clause in `execute`, so a connection broken mid-body is re-raised as `LinearRetryableError` and retried with backoff like other transient failures. This matches how the other REST sources (cohere, airops, anthropic, etc.) already treat `ChunkedEncodingError`.

## How did you test this code?

Extended the existing parameterized `test_transient_network_error_is_retried_then_succeeds` with a `chunked_encoding_broken` case that raises `ChunkedEncodingError` on the first attempt and asserts the request is retried and succeeds. The existing `read_timeout` / `connection_reset` cases would still pass with the fix reverted (they are `ConnectionError`/`Timeout` subclasses), so this new case is what actually guards the regression.

Ran the source's test suite locally (`uv run pytest .../linear/test_linear.py` — 36 passed), plus `ruff check` and `ruff format --check` clean. I (Claude) did not do any manual end-to-end testing against the live Linear API.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by Claude (Claude Code) while triaging a live error-tracking issue for the Linear import source. I confirmed the failure originates in this source's `execute` frame, read the implementation and the retry wiring, and decided it was a fixable bug rather than a user/upstream error: the connection breaking mid-transfer is transient and should be retried, so it does not belong in `NonRetryableErrors`. I checked the exception hierarchy to confirm `ChunkedEncodingError` is not a `ConnectionError` subclass (which is why it escaped), and cross-checked that sibling REST sources already list it as retryable. Invoked `/writing-tests` before extending the test to confirm the new case catches a regression the existing cases do not.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
