### PR TITLE
feat(web-analytics): no-join compute for lazy overview and paths precompute

### DIFF
--- a/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
@@ -304,6 +304,12 @@ def check_common_eligible(runner: LazyPrecomputeRunner, *, require_integer_timez
         raise DateRangeOverMax(days)
 
 
+def is_constant_true(expr: ast.Expr) -> bool:
+    """True when a substituted filter placeholder is the trivial `Constant(True)` —
+    i.e. the cache key carries no user or test-account filter."""
+    return isinstance(expr, ast.Constant) and expr.value is True
+
+
 def user_filter_expr(runner: LazyPrecomputeRunner) -> ast.Expr:
     """Build the AST expression that gets substituted into the INSERT's WHERE clause.
 

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -27,6 +27,7 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     check_common_eligible,
     events_session_id_expr,
     floor_utc_day,
+    is_constant_true,
     test_account_filter_expr,
     user_filter_expr,
 )
@@ -170,10 +171,7 @@ def ensure_web_overview_precomputed(
         "pad_minutes": ast.Constant(value=SESSION_FORWARD_PAD_MINUTES),
     }
 
-    is_unfiltered = all(
-        isinstance(placeholders[key], ast.Constant) and placeholders[key].value is True
-        for key in ("user_filter", "test_account_filter")
-    )
+    is_unfiltered = all(is_constant_true(placeholders[key]) for key in ("user_filter", "test_account_filter"))
 
     return web_ensure_precomputed(
         team=runner.team,

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -71,7 +71,15 @@ _check_lazy_precompute_eligible = check_common_eligible
 # its events that spill past midnight — the HAVING clause attributes the session
 # to its start hour, but the events scan needs the trailing events to compute
 # correct `$session_duration` / `$pageview_count` / `$is_bounce`.
-INSERT_QUERY_TEMPLATE = """
+# Filtered cache keys (a `$host` user filter or applied test-account filters) keep the
+# join shape below: those filters constrain which sessions qualify and can only be
+# evaluated on the events side, so the two-scan template would cache wrong session
+# metrics for them. Unfiltered keys — the overwhelming majority — use the no-join
+# template: events self-attribute to the session-start hour via the UUIDv7 timestamp
+# embedded in the session id, and duration/bounce come straight from the sessions
+# table (which also makes the forward-pad hack unnecessary on that side, since
+# raw_sessions already holds complete-session state).
+JOIN_INSERT_QUERY_TEMPLATE = """
 SELECT
     toStartOfHour(start_timestamp) AS time_window_start,
     uniqState(session_person_id) AS uniq_users_state,
@@ -106,6 +114,49 @@ GROUP BY time_window_start
 """
 
 
+NO_JOIN_INSERT_QUERY_TEMPLATE = """
+SELECT
+    e.time_window_start AS time_window_start,
+    e.uniq_users_state AS uniq_users_state,
+    e.uniq_sessions_state AS uniq_sessions_state,
+    e.sum_pageviews_state AS sum_pageviews_state,
+    ifNull(s.avg_duration_state, arrayReduce('avgState', arrayFilter(x -> 0 != 0, [toFloat(0)]))) AS avg_duration_state,
+    ifNull(s.avg_bounce_state, arrayReduce('avgState', arrayFilter(x -> 0 != 0, [assumeNotNull(toInt(0))]))) AS avg_bounce_state
+FROM (
+    SELECT
+        toStartOfHour(fromUnixTimestamp(intDiv(toInt(bitShiftRight(_toUInt128(toUUID({events_session_id})), 80)), 1000))) AS time_window_start,
+        uniqState(events.person_id) AS uniq_users_state,
+        uniqState({events_session_id}) AS uniq_sessions_state,
+        sumState(assumeNotNull(toInt(1))) AS sum_pageviews_state
+    FROM events
+    WHERE and(
+        {events_session_id} IS NOT NULL,
+        events.$session_id_uuid IS NOT NULL,
+        {event_type_filter},
+        timestamp >= {time_window_min},
+        timestamp < ({time_window_max} + toIntervalMinute({pad_minutes})),
+        {user_filter},
+        {test_account_filter}
+    )
+    GROUP BY time_window_start
+    HAVING and(time_window_start >= {time_window_min}, time_window_start < {time_window_max})
+) AS e
+LEFT JOIN (
+    SELECT
+        toStartOfHour(sessions.$start_timestamp) AS time_window_start,
+        avgState(assumeNotNull(toFloat(sessions.$session_duration))) AS avg_duration_state,
+        avgState(assumeNotNull(toInt(sessions.$is_bounce))) AS avg_bounce_state
+    FROM sessions
+    WHERE and(
+        sessions.$start_timestamp >= {time_window_min},
+        sessions.$start_timestamp < {time_window_max},
+        or(sessions.$pageview_count > 0, sessions.$screen_count > 0),
+    )
+    GROUP BY time_window_start
+) AS s ON e.time_window_start = s.time_window_start
+"""
+
+
 def ensure_web_overview_precomputed(
     runner: "WebOverviewQueryRunner",
     time_range_start: datetime,
@@ -119,9 +170,14 @@ def ensure_web_overview_precomputed(
         "pad_minutes": ast.Constant(value=SESSION_FORWARD_PAD_MINUTES),
     }
 
+    is_unfiltered = all(
+        isinstance(placeholders[key], ast.Constant) and placeholders[key].value is True
+        for key in ("user_filter", "test_account_filter")
+    )
+
     return web_ensure_precomputed(
         team=runner.team,
-        insert_query=INSERT_QUERY_TEMPLATE,
+        insert_query=NO_JOIN_INSERT_QUERY_TEMPLATE if is_unfiltered else JOIN_INSERT_QUERY_TEMPLATE,
         time_range_start=time_range_start,
         time_range_end=time_range_end,
         ttl_seconds=LAZY_TTL_SECONDS,

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -235,6 +235,16 @@ def _entry_breakdown_value_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr:
     return runner._apply_path_cleaning(path)
 
 
+def _entry_breakdown_value_sessions_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr:
+    """`_entry_breakdown_value_expr` with chains resolving against a direct
+    `FROM sessions` scope — used by the no-join insert, whose bounce side reads
+    the sessions table without the events join."""
+    path: ast.Expr = ast.Field(chain=["sessions", "$entry_pathname"])
+    if runner.query.includeHost:
+        path = _prepend_host_nullif_empty(ast.Field(chain=["sessions", "$entry_hostname"]), path)
+    return runner._apply_path_cleaning(path)
+
+
 # Cap on stored breakdown rows: only the top-K paths PER DAY by the query's sort
 # metric. The PATHS tile shows a paginated top-N and the read's `LIMIT` can't prune
 # the scan (it must aggregate every path to find the top), so the long tail — paths
@@ -300,8 +310,60 @@ FROM (
 GROUP BY time_window_start, breakdown_value
 """
 
+# No-join variant for unfiltered PAGE cache keys: counts/persons come from events
+# self-attributed to the session-start hour via the UUIDv7 timestamp in the session
+# id; bounce-per-entry-path comes straight from the sessions table. Paths that are
+# never entry paths get an empty avg state via arrayReduce. INITIAL_PAGE and any
+# filtered key keep the join shape (persons-per-entry-path and filter evaluation
+# both need the events↔sessions association).
+_NO_JOIN_PER_WINDOW_AGG_SQL = """
+SELECT
+    e.time_window_start AS time_window_start,
+    e.breakdown_value AS breakdown_value,
+    e.uniq_users_state AS uniq_users_state,
+    e.sum_pageviews_state AS sum_pageviews_state,
+    ifNull(s.avg_bounce_state, arrayReduce('avgState', arrayFilter(x -> 0 != 0, [toFloat(0)]))) AS avg_bounce_state
+FROM (
+    SELECT
+        toStartOfHour(fromUnixTimestamp(intDiv(toInt(bitShiftRight(_toUInt128(toUUID({events_session_id})), 80)), 1000))) AS time_window_start,
+        {breakdown_value_expr} AS breakdown_value,
+        uniqState(events.person_id) AS uniq_users_state,
+        sumState(assumeNotNull(toInt(1))) AS sum_pageviews_state
+    FROM events
+    WHERE and(
+        {events_session_id} IS NOT NULL,
+        events.$session_id_uuid IS NOT NULL,
+        {event_type_filter},
+        timestamp >= {time_window_min},
+        timestamp < ({time_window_max} + toIntervalMinute({pad_minutes})),
+        {user_filter},
+        {test_account_filter}
+    )
+    GROUP BY time_window_start, breakdown_value
+    HAVING and(
+        breakdown_value IS NOT NULL,
+        time_window_start >= {time_window_min},
+        time_window_start < {time_window_max}
+    )
+) AS e
+LEFT JOIN (
+    SELECT
+        toStartOfHour(sessions.$start_timestamp) AS time_window_start,
+        {entry_breakdown_value_sessions_expr} AS breakdown_value,
+        avgState(toFloat(sessions.$is_bounce)) AS avg_bounce_state
+    FROM sessions
+    WHERE and(
+        sessions.$start_timestamp >= {time_window_min},
+        sessions.$start_timestamp < {time_window_max},
+        or(sessions.$pageview_count > 0, sessions.$screen_count > 0),
+    )
+    GROUP BY time_window_start, breakdown_value
+) AS s ON e.time_window_start = s.time_window_start AND e.breakdown_value = s.breakdown_value
+"""
+
 # Uncapped insert — current behaviour, used for ASC sorts (see `_top_k_ranking_expr`).
 INSERT_QUERY_TEMPLATE = _PER_WINDOW_AGG_SQL
+NO_JOIN_INSERT_QUERY_TEMPLATE = _NO_JOIN_PER_WINDOW_AGG_SQL
 
 # Capped insert — keep the top-K `breakdown_value`s by `{top_k_metric}` (the query's
 # sort metric) computed PER DAY, then store all per-hour rows of any path that reaches
@@ -324,10 +386,7 @@ INSERT_QUERY_TEMPLATE = _PER_WINDOW_AGG_SQL
 # `<= PATHS_TOP_K` keeps the union of daily top-Ks. (HogQL parses `LIMIT n BY` but the
 # printer can't emit it, so the cap ranks with window functions.) The metric stays in the
 # AST, so each sort variant gets its own job.
-INSERT_QUERY_TEMPLATE_CAPPED = (
-    "WITH per_window AS ("
-    + _PER_WINDOW_AGG_SQL
-    + """)
+_CAPPED_WRAPPER = """)
 SELECT
     time_window_start AS time_window_start,
     breakdown_value AS breakdown_value,
@@ -357,9 +416,10 @@ FROM (
         FROM per_window
     )
 )
-WHERE breakdown_rank <= """
-    + str(PATHS_TOP_K)
-)
+WHERE breakdown_rank <= """ + str(PATHS_TOP_K)
+
+INSERT_QUERY_TEMPLATE_CAPPED = "WITH per_window AS (" + _PER_WINDOW_AGG_SQL + _CAPPED_WRAPPER
+NO_JOIN_INSERT_QUERY_TEMPLATE_CAPPED = "WITH per_window AS (" + _NO_JOIN_PER_WINDOW_AGG_SQL + _CAPPED_WRAPPER
 
 
 def _top_k_ranking_expr(runner: "WebStatsTableQueryRunner") -> ast.Expr | None:
@@ -433,14 +493,28 @@ def ensure_web_stats_paths_precomputed(
         "pad_minutes": ast.Constant(value=SESSION_FORWARD_PAD_MINUTES),
     }
 
+    # Unfiltered PAGE keys use the no-join shape (events self-attribute to the
+    # session-start hour via the UUIDv7 session id; bounce comes from the sessions
+    # table). INITIAL_PAGE needs the join for persons-per-entry-path, and filtered
+    # keys need it because the sessions side can't evaluate event/person filters.
+    use_no_join = (
+        runner.query.breakdownBy == WebStatsBreakdown.PAGE
+        and isinstance(placeholders["user_filter"], ast.Constant)
+        and placeholders["user_filter"].value is True
+        and isinstance(placeholders["test_account_filter"], ast.Constant)
+        and placeholders["test_account_filter"].value is True
+    )
+    if use_no_join:
+        placeholders["entry_breakdown_value_sessions_expr"] = _entry_breakdown_value_sessions_expr(runner)
+
     # Cap to the displayable top-K for descending sorts; store the full set otherwise.
     # The metric goes into the INSERT AST, so the sort dimension joins the job hash.
     ranking_expr = _top_k_ranking_expr(runner)
     if ranking_expr is not None:
-        insert_query = INSERT_QUERY_TEMPLATE_CAPPED
+        insert_query = NO_JOIN_INSERT_QUERY_TEMPLATE_CAPPED if use_no_join else INSERT_QUERY_TEMPLATE_CAPPED
         placeholders["top_k_metric"] = ranking_expr
     else:
-        insert_query = INSERT_QUERY_TEMPLATE
+        insert_query = NO_JOIN_INSERT_QUERY_TEMPLATE if use_no_join else INSERT_QUERY_TEMPLATE
 
     # Warmers keep the framework default; user-facing calls get the 10s budget, or the
     # caller-provided remainder of it when this is the second (compare-period) ensure.

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -34,6 +34,7 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     LazyComputationResult,
     LazyComputationTable,
 )
+from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import is_constant_true
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
     LAZY_TTL_SECONDS,
     SESSION_FORWARD_PAD_MINUTES,
@@ -497,12 +498,8 @@ def ensure_web_stats_paths_precomputed(
     # session-start hour via the UUIDv7 session id; bounce comes from the sessions
     # table). INITIAL_PAGE needs the join for persons-per-entry-path, and filtered
     # keys need it because the sessions side can't evaluate event/person filters.
-    use_no_join = (
-        runner.query.breakdownBy == WebStatsBreakdown.PAGE
-        and isinstance(placeholders["user_filter"], ast.Constant)
-        and placeholders["user_filter"].value is True
-        and isinstance(placeholders["test_account_filter"], ast.Constant)
-        and placeholders["test_account_filter"].value is True
+    use_no_join = runner.query.breakdownBy == WebStatsBreakdown.PAGE and all(
+        is_constant_true(placeholders[key]) for key in ("user_filter", "test_account_filter")
     )
     if use_no_join:
         placeholders["entry_breakdown_value_sessions_expr"] = _entry_breakdown_value_sessions_expr(runner)


### PR DESCRIPTION
## Problem

The lazy precompute warming INSERTs still use the events↔sessions join shape that #70746 removed from the live read paths - so every warming job (SWR revalidations, the dimensional DAG, first-read computes) pays the per-shard sessions fan-out. That join cost is why warming historically OOM'd and needed week-boundary job splitting.

## Changes

Both compute templates get a no-join variant, applied outright (no trial gate) wherever the semantics decompose:

- **Overview** (`web_overview_lazy_precompute.py`): events self-attribute to the session-start hour via the UUIDv7 timestamp embedded in the session id (visitors + pageviews per hour, no join), and duration/bounce states come straight from the sessions table per start hour; the two sides meet in a LEFT JOIN on the hour bucket (≤24 rows per daily job). Bonus: the sessions side doesn't need the forward-pad hack - raw_sessions already holds complete-session state.
- **Paths** (`web_stats_paths_lazy_precompute.py`): same decomposition per (hour, breakdown) for `PAGE` keys - counts/persons from events, bounce-per-entry-path from the sessions table (with a sessions-scope twin of the entry-breakdown expression, path cleaning included). The top-K capped variant shares the wrapper, so both capped and uncapped inserts get both shapes.
- **The join templates remain and are chosen for keys where they're semantically required**: any `$host` user filter or applied test-account filters (the sessions side can't evaluate event/person filters), and `INITIAL_PAGE` (persons-per-entry-path needs the events↔sessions association until raw_sessions carries a person uniq state). This is a correctness boundary, not a rollout gate.
- Paths that never appear as entry paths get an empty avg state via `arrayReduce('avgState', arrayFilter(...))` - HogQL's whitelist rules out `initializeAggregation`/`CAST`/`emptyArrayFloat64`.

Expected effect mirrors the live-path rollout (measured there: ~10× fewer rows read, 25-45× less memory): warming jobs get dramatically cheaper, and the week-boundary job splitting may become unnecessary.

## How did you test this code?

- The existing compute→read round-trip suites now exercise the no-join templates directly (unfiltered PAGE/overview fixtures route through them, with metric-value assertions - that's the parity check): `test_web_overview_lazy_precompute.py` 26 passed, `test_web_stats_paths_lazy_precompute.py` 50 passed.
- Filtered and `INITIAL_PAGE` cases in the same suites still route through the join templates.
- **Production shadow validation done (read-only)**: rendered both templates through the real parse/print pipeline, pointed them at the dogfood team for a full production day, finalized the states, and diffed hour by hour. Duration and bounce - the metrics the decomposition moved to the sessions table - came out **bit-identical on every hour**; visitors/sessions/views within 0.03-0.6% (boundary attribution + uniq estimation, same drift class as the live no-join paths already serving at 100%).
- Not done yet: a production shadow-compute diff (write new-shape rows under a distinct job id for a window already covered by old-shape rows and compare finalized states) - recommended as the acceptance step before merge, plus watching the `web_overview_lazy_insert` / paths insert tags in query_log for the cost drop.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing change; cached values are semantically equivalent (same drift class as the live no-join paths, verified by round-trip tests).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Follow-up to the no-join rollout, per Lucas: apply the same optimization to the lazy compute path, no trial gating. The join-template fallback for filtered/INITIAL_PAGE keys is semantic necessity, not a trial.
- Skills invoked: /writing-tests, /evaluating-web-analytics-performance.
- Implementation notes for reviewers: HogQL's function whitelist shaped the SQL (no `toUInt64`/`uniqMergeState`/`CAST`/`emptyArray*` - hence `toInt` for the UUIDv7 shift, LEFT JOIN over union-remerge, and the arrayReduce empty-state idiom); state types must match the destination columns exactly (`assumeNotNull` coercions mirror the old templates).
