### PR TITLE
fix(data-warehouse): don't re-trigger OOM repartition a rewrite already fixed

### DIFF
--- a/products/warehouse_sources/backend/models/oom_event.py
+++ b/products/warehouse_sources/backend/models/oom_event.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 from django.db import models
 from django.utils import timezone
 
+from dateutil import parser
+
 from posthog.models.scoping.root_mixin import TeamScopedRootMixin
 from posthog.models.utils import UUIDModel, sane_repr
 
@@ -51,6 +53,16 @@ class ExternalDataSchemaOOMEvent(TeamScopedRootMixin, UUIDModel):
 
         `days` is required (no default) so it stays sourced from `DATA_WAREHOUSE_REPARTITION_OOM_WINDOW_DAYS`
         at the call site rather than duplicating that window here where the two could silently diverge.
+
+        The window is also floored at the schema's `last_repartition_at`: a completed repartition addresses
+        the OOMs that preceded it, so counting them again would re-trigger a repartition on the same (now
+        healthy) table every cooldown until they age out. Only OOMs a repartition did not fix count.
         """
         since = timezone.now() - timedelta(days=days)
+        last_repartition_at = schema.last_repartition_at
+        if last_repartition_at:
+            try:
+                since = max(since, parser.parse(last_repartition_at))
+            except (ValueError, TypeError):
+                pass
         return cls.objects.for_team(schema.team_id).filter(schema_id=schema.pk, created_at__gte=since).count()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
@@ -208,9 +208,11 @@ async def maybe_flag_for_repartition(
 
         if schema.repartition_pending is not None:
             await logger.adebug(
-                f"repartition: over budget but already queued for the next run schema_id={schema.id} "
-                f"max_partition_bytes={max_bytes} budget_bytes={budget} repartition_pending={schema.repartition_pending}",
+                f"repartition: needs repartition (trigger_reason={trigger_reason}) but already queued for the next "
+                f"run schema_id={schema.id} max_partition_bytes={max_bytes} budget_bytes={budget} "
+                f"repartition_pending={schema.repartition_pending}",
                 schema_id=str(schema.id),
+                trigger_reason=trigger_reason,
                 max_partition_bytes=max_bytes,
                 budget_bytes=budget,
                 repartition_pending=schema.repartition_pending,
@@ -220,10 +222,11 @@ async def maybe_flag_for_repartition(
         cooldown_remaining = _cooldown_seconds_remaining(schema)
         if cooldown_remaining > 0:
             await logger.adebug(
-                f"repartition: over budget but skipped, in post-repartition cooldown schema_id={schema.id} "
-                f"max_partition_bytes={max_bytes} budget_bytes={budget} last_repartition_at={schema.last_repartition_at} "
-                f"cooldown_seconds_remaining={int(cooldown_remaining)}",
+                f"repartition: needs repartition (trigger_reason={trigger_reason}) but skipped, in post-repartition "
+                f"cooldown schema_id={schema.id} max_partition_bytes={max_bytes} budget_bytes={budget} "
+                f"last_repartition_at={schema.last_repartition_at} cooldown_seconds_remaining={int(cooldown_remaining)}",
                 schema_id=str(schema.id),
+                trigger_reason=trigger_reason,
                 max_partition_bytes=max_bytes,
                 budget_bytes=budget,
                 last_repartition_at=schema.last_repartition_at,

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -234,6 +234,27 @@ class TestExternalDataSchemaOOMEvent(BaseTest):
         assert ExternalDataSchemaOOMEvent.recent_count(schema_a, days=30) == 3
         assert ExternalDataSchemaOOMEvent.recent_count(schema_b, days=7) == 1
 
+    def test_recent_count_ignores_ooms_before_last_repartition(self) -> None:
+        # A repartition fixes the OOMs that preceded it. Without this floor, those OOMs keep counting
+        # and re-trigger a repartition on the same healthy table every cooldown until they age out.
+        schema = self._schema("orders")
+        self._oom(schema, age_days=2)
+        self._oom(schema, age_days=2)
+        self._oom(schema, age_days=2)
+        schema.sync_type_config = {
+            **(schema.sync_type_config or {}),
+            "last_repartition_at": (timezone.now() - timedelta(days=1)).isoformat(),
+        }
+        schema.save()
+
+        # All three OOMs predate the repartition, so none count toward re-triggering it.
+        assert ExternalDataSchemaOOMEvent.recent_count(schema, days=7) == 0
+
+        # An OOM recorded after the repartition still counts: the rewrite did not fix it, so this is a
+        # real escalation the controller should act on.
+        self._oom(schema)
+        assert ExternalDataSchemaOOMEvent.recent_count(schema, days=7) == 1
+
 
 class TestUpdateSyncTypeConfigKeys(BaseTest):
     """The locked-merge helper that keeps the CDC extract activity and concurrent API PATCHes from


### PR DESCRIPTION
## Problem

The repartition controller has a hybrid trigger: a table whose largest partition is within the size budget still gets repartitioned if it has OOM'd repeatedly (compressed at-rest size under-counts the merge's real working set). That trigger reads `ExternalDataSchemaOOMEvent.recent_count(schema, days=7)` — a plain count of OOMs in the trailing window, with **no awareness of `last_repartition_at`**.

So once a table OOMs ≥3× and gets repartitioned, those same OOM rows keep counting. After each 24h cooldown the trigger fires again — even with zero new OOMs since the rewrite — and repartitions the (now healthy) table again, roughly daily, until the old OOMs age out of the 7-day window. The size trigger is self-correcting (a rewrite shrinks partitions back under budget); the OOM trigger was not.

This surfaced in prod as logs like `over budget but skipped, in post-repartition cooldown max_partition_bytes=808068 budget_bytes=500000000` — a table ~808 KB under a 500 MB budget, "over budget," queued to repartition again the moment its cooldown expired.

## Changes

- **`recent_count` floors its window at `last_repartition_at`** (`oom_event.py`). A completed repartition addresses the OOMs that preceded it, so only OOMs it did *not* fix count toward re-triggering. A table with no post-rewrite OOMs goes quiet; a table that keeps OOMing after a rewrite still escalates (correctly). `last_repartition_at` is an ISO string in `sync_type_config`, parsed the same way `_cooldown_seconds_remaining` does, with a graceful fallback.
- **Fix the misleading skip-branch logs** (`repartition_controller.py`). Both the "already queued" and "in cooldown" logs hardcoded `over budget`, even on the `oom_history` path (which is within budget). They now report the actual `trigger_reason` in both the message and the structured fields, so the Syncs UI shows why a table was flagged.

## How did you test this code?

Added `test_recent_count_ignores_ooms_before_last_repartition` to `TestExternalDataSchemaOOMEvent` (reuses the existing `_oom(age_days=…)` helper): three OOMs predating a repartition count as 0; a fresh OOM after it counts as 1. No existing test covered the `last_repartition_at` floor — the existing window/scope test has no repartition set, so it's unaffected (and still passes).

I (actually Claude) couldn't run the Django suite locally — this checkout's venv is Python 3.12 and master needs 3.13 — so the DB test runs in CI. Locally I ran `ruff check`/`ruff format` (clean), `py_compile` on the changed modules, and a standalone check of the `parser.parse` + `max()` window math (floors correctly, and falls back to `now - days` when `last_repartition_at` is absent or malformed, both across timezone-aware datetimes).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal pipeline behavior, no user-facing docs under `docs/` affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom spotted the confusing `over budget` log on a within-budget table and asked why. Tracing it showed the table wasn't over budget at all — it was flagged by the OOM-history trigger and skipped for cooldown, and the log wording was wrong. Following up on how that trigger behaves on recently-repartitioned tables surfaced the real bug: the OOM count never resets after a repartition, so a fixed table re-repartitions every cooldown for up to a week.

Considered pruning OOM rows on repartition instead, but that loses the append-only audit log; flooring the count window at `last_repartition_at` keeps the log and is a one-line semantic change. Skill invoked: `/writing-tests` for the added case.
