### PR TITLE
feat(replay): add metrics to the ml block-metadata parquet sink

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-batcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-batcher.ts
@@ -6,6 +6,7 @@ import { findOffsetsToCommit } from '~/common/kafka/consumer/consumer-v1'
 import { parseBlockMetadataMessages } from './block-metadata-message'
 import { BlockMetadataParquetStore } from './block-metadata-parquet-store'
 import { MlBlockMetadataRow } from './block-metadata-row'
+import { MlParquetSinkMetrics } from './metrics'
 
 /** The subset of the Kafka consumer the batcher needs: storing offsets it has durably written. */
 export interface OffsetStore {
@@ -61,7 +62,8 @@ export class BlockMetadataBatcher {
      */
     public async flush(nowMs: number): Promise<void> {
         this.lastFlushMs = nowMs
-        if (this.buffer.length > 0) {
+        const wroteObject = this.buffer.length > 0
+        if (wroteObject) {
             await this.store.write(this.buffer)
             this.buffer = []
         }
@@ -69,6 +71,9 @@ export class BlockMetadataBatcher {
             // Commit after the write lands so a failed write replays; skipped-only batches still advance here.
             this.offsetStore.offsetsStore([...this.pendingOffsets.values()])
             this.pendingOffsets.clear()
+            // 'empty' means we advanced past messages that produced no rows (all skipped/malformed): healthy
+            // offset progress with zero Parquet output, the one state Kafka lag can't distinguish.
+            MlParquetSinkMetrics.incFlush(wroteObject ? 'written' : 'empty')
         }
     }
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-message.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-message.ts
@@ -4,6 +4,7 @@ import { logger } from '~/common/utils/logger'
 
 import { isWellFormedRow } from './block-metadata-columns'
 import { MlBlockMetadataRow } from './block-metadata-row'
+import { MlParquetSinkMetrics } from './metrics'
 
 export function parseBlockMetadataMessages(messages: readonly { value: Buffer | null }[]): MlBlockMetadataRow[] {
     const rows: MlBlockMetadataRow[] = []
@@ -17,13 +18,16 @@ export function parseBlockMetadataMessages(messages: readonly { value: Buffer | 
         } catch (error) {
             // Skip malformed rows rather than wedge the partition; they're rare and non-fatal for training data.
             logger.warn('🪶', 'ml_parquet_metadata_parse_failed', { error: String(error) })
+            MlParquetSinkMetrics.incRowsRejected('parse_failed')
             continue
         }
         if (!isWellFormedRow(row)) {
             logger.warn('🪶', 'ml_parquet_metadata_row_invalid')
+            MlParquetSinkMetrics.incRowsRejected('invalid')
             continue
         }
         rows.push(row)
     }
+    MlParquetSinkMetrics.incRowsParsed(rows.length)
     return rows
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-parquet-store.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-parquet-store.ts
@@ -31,9 +31,13 @@ export class BlockMetadataParquetStore {
         }
         // Sorting clusters a recording's blocks together for better compression and reads.
         rows.sort((a, b) => cmp(a.team_id, b.team_id) || cmp(a.session_id, b.session_id))
-        const body = await rowsToParquetBuffer(rows)
-        const key = this.objectKey(minEventDate(rows))
+        let body: Buffer
+        let key: string
         try {
+            // Encoding, key derivation, and upload all count as write failures: each leaves the batch to
+            // replay from Kafka, so the counter must see them, not just the S3 send.
+            body = await rowsToParquetBuffer(rows)
+            key = this.objectKey(minEventDate(rows))
             await this.s3Client.send(
                 new PutObjectCommand({
                     Bucket: this.bucket,

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-parquet-store.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/block-metadata-parquet-store.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto'
 import { logger } from '~/common/utils/logger'
 
 import { MlBlockMetadataRow } from './block-metadata-row'
+import { MlParquetSinkMetrics } from './metrics'
 import { rowsToParquetBuffer } from './parquet-writer'
 
 const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0)
@@ -32,14 +33,20 @@ export class BlockMetadataParquetStore {
         rows.sort((a, b) => cmp(a.team_id, b.team_id) || cmp(a.session_id, b.session_id))
         const body = await rowsToParquetBuffer(rows)
         const key = this.objectKey(minEventDate(rows))
-        await this.s3Client.send(
-            new PutObjectCommand({
-                Bucket: this.bucket,
-                Key: key,
-                Body: body,
-                ContentType: 'application/vnd.apache.parquet',
-            })
-        )
+        try {
+            await this.s3Client.send(
+                new PutObjectCommand({
+                    Bucket: this.bucket,
+                    Key: key,
+                    Body: body,
+                    ContentType: 'application/vnd.apache.parquet',
+                })
+            )
+        } catch (error) {
+            MlParquetSinkMetrics.incWriteError()
+            throw error
+        }
+        MlParquetSinkMetrics.observeWrite(rows.length, body.length)
         logger.info('🪶', 'ml_parquet_metadata_written', { rows: rows.length, bytes: body.length, key })
     }
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/metrics.ts
@@ -1,0 +1,57 @@
+import { Counter } from 'prom-client'
+
+/**
+ * Metrics for the ML block-metadata Parquet sink (drains the mirror's block-metadata topic to the ML
+ * bucket). The sink can consume and commit offsets while writing nothing: if every row is rejected the
+ * buffer stays empty, so flush advances offsets without a write. Kafka lag alone can't see that state.
+ */
+export class MlParquetSinkMetrics {
+    private static readonly rowsParsed = new Counter({
+        name: 'ml_mirror_parquet_sink_rows_parsed_total',
+        help: 'Block-metadata rows parsed from Kafka and accepted into the Parquet buffer',
+    })
+    private static readonly rowsRejected = new Counter({
+        name: 'ml_mirror_parquet_sink_rows_rejected_total',
+        help: 'Block-metadata Kafka messages skipped before buffering, by reason',
+        labelNames: ['reason'],
+    })
+    private static readonly objectsWritten = new Counter({
+        name: 'ml_mirror_parquet_sink_objects_written_total',
+        help: 'Parquet objects written to the ML bucket',
+    })
+    private static readonly rowsWritten = new Counter({
+        name: 'ml_mirror_parquet_sink_rows_written_total',
+        help: 'Block-metadata rows written to the ML bucket as Parquet',
+    })
+    private static readonly bytesWritten = new Counter({
+        name: 'ml_mirror_parquet_sink_bytes_written_total',
+        help: 'Parquet bytes written to the ML bucket',
+    })
+    private static readonly writeErrors = new Counter({
+        name: 'ml_mirror_parquet_sink_write_errors_total',
+        help: 'Parquet object writes that threw (the batch replays from Kafka)',
+    })
+    private static readonly flushes = new Counter({
+        name: 'ml_mirror_parquet_sink_flushes_total',
+        help: 'Batcher flushes by outcome: wrote a Parquet object, or committed offsets with an empty buffer',
+        labelNames: ['outcome'],
+    })
+
+    public static incRowsParsed(count: number): void {
+        this.rowsParsed.inc(count)
+    }
+    public static incRowsRejected(reason: 'parse_failed' | 'invalid'): void {
+        this.rowsRejected.labels(reason).inc()
+    }
+    public static observeWrite(rows: number, bytes: number): void {
+        this.objectsWritten.inc()
+        this.rowsWritten.inc(rows)
+        this.bytesWritten.inc(bytes)
+    }
+    public static incWriteError(): void {
+        this.writeErrors.inc()
+    }
+    public static incFlush(outcome: 'written' | 'empty'): void {
+        this.flushes.labels(outcome).inc()
+    }
+}


### PR DESCRIPTION
## Problem

The ML block-metadata parquet path (mirror produces block metadata to Kafka, the parquet sink drains it to the ML bucket) has no metrics on the write side, only log lines. That leaves a blind spot: the sink can consume the topic and commit offsets while writing zero parquet. If every row fails `isWellFormedRow`, `parseBlockMetadataMessages` skips them all, the batcher's buffer stays empty, and `flush()` advances offsets without ever calling `store.write`. Kafka consume rate and lag look perfectly healthy in that state, so from Grafana you can't tell "writing parquet" from "silently dropping everything".

This came out of debugging a report that parquet metadata stopped flushing. The Kafka-level metrics (produce rate, sink consume rate, consumer-group lag) all looked healthy, which is exactly the situation these counters are meant to disambiguate. We won't get history, but from now on we can prove whether parquet is actually being written.

## Changes

New prom counters, all `ml_mirror_parquet_sink_*`, in a co-located `ml-mirror/metrics.ts`:

| Metric | Where | Answers |
| --- | --- | --- |
| `rows_parsed_total` | parser | are accepted rows reaching the buffer? |
| `rows_rejected_total{reason}` | parser | `reason=parse_failed` / `invalid` — are rows dropped before buffering? |
| `objects_written_total` | store | are parquet objects actually landing in S3? |
| `rows_written_total` | store | how many rows per write |
| `bytes_written_total` | store | write volume |
| `write_errors_total` | store | did a PutObject throw (batch replays)? |
| `flushes_total{outcome}` | batcher | `outcome=written` vs `empty` — the direct "consumed but wrote nothing" signal |

The `flushes_total{outcome="empty"}` counter is the key one: it increments when a flush commits offsets with an empty buffer, i.e. healthy offset progress with zero parquet output. That's the one state Kafka lag can't surface.

No behavior change beyond wrapping the existing `PutObjectCommand` in a try/catch to count errors before rethrowing (the throw semantics are unchanged, so a failed write still replays from Kafka).

## How did you test this code?

Automated only, run by me (Claude):

- `pnpm exec jest src/ingestion/pipelines/sessionreplay/ml-mirror` — 53 passed, 35 skipped (the skips are the native anonymizer addon, not built locally).
- `pnpm exec eslint` + `prettier` on the changed files — clean.
- `tsc --noEmit` — no errors in any of the four changed files. The local run reports pre-existing failures in unrelated modules that aren't built in this environment (`@posthog/hogvm`, `@posthog/cyclotron`, `@posthog/replay-anonymizer`) plus some `cdp` `any` errors; none are mine.

I did not add tests for the counters themselves — asserting a counter increments would test the metrics library, not a regression in our logic, and the existing parse/store/batcher tests already cover the behavior these counters observe.

I have not deployed this or watched the metrics in a live environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Robbie) directed this; Claude Code wrote it while we were debugging why parquet block-metadata appeared to stop flushing. We started from a Grafana dashboard built off existing metrics and traced the pipeline end to end. The Kafka-level metrics showed the mirror producing and the sink consuming with bounded lag, which pointed at the write step, and the write step has no metrics. Rather than keep inferring from logs, we added counters at each stage.

On placement and naming: there was no existing metrics file these belonged in without mixing deployments — `sessionreplay/metrics.ts` and `sessions/metrics.ts` are the mirror/main record path, a different process than the sink. The repo convention is a co-located `metrics.ts` per module, so this follows the sibling `ml-mirror-image-scrub/metrics.ts` (also a Kafka→S3 ML sink): a `class …Metrics` with static `inc*`/`observe*` methods, and a lane-scoped `ml_mirror_parquet_sink_*` prefix rather than the record-path `recording_blob_ingestion_v2_*` prefix, so both ML sinks group under `ml_mirror_` in Grafana. First draft used bare module-level counters under the `recording_blob` prefix; I switched to the sibling's shape after comparing. No skills were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
