### PR TITLE
chore(clickhouse): pin legacy hcl reference + local snapshot tooling

### DIFF
--- a/posthog/clickhouse/hcl/.gitignore
+++ b/posthog/clickhouse/hcl/.gitignore
@@ -1,2 +1,5 @@
 # transient empty-schema baseline written by gen-sql.sh
 .empty-schema.*
+
+# local-only legacy snapshot materialized by bin/snapshot-legacy.sh (never committed)
+.legacy/

--- a/posthog/clickhouse/hcl/bin/snapshot-legacy.sh
+++ b/posthog/clickhouse/hcl/bin/snapshot-legacy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Materialize the legacy composition (roles/, manifest.hcl, golden/, sql/) at the
+# pinned reference into a gitignored .legacy/ for local introspection and the
+# compare-old.sh parity diff. Never committed — the legacy state lives only as the
+# sha in legacy-ref.txt; this reconstitutes it on demand.
+#
+# Usage: bin/snapshot-legacy.sh [ref]   (ref defaults to legacy-ref.txt)
+set -euo pipefail
+
+HCL=posthog/clickhouse/hcl
+REF="${1:-$(cat "$HCL/legacy-ref.txt")}"
+
+rm -rf "$HCL/.legacy" && mkdir -p "$HCL/.legacy"
+git archive "$REF" -- "$HCL/roles" "$HCL/manifest.hcl" "$HCL/golden" "$HCL/sql" \
+  | tar -x --strip-components=3 -C "$HCL/.legacy"
+echo "$REF" > "$HCL/.legacy/ref.txt"
+echo "snapshot of $REF -> $HCL/.legacy"

--- a/posthog/clickhouse/hcl/compare-old.sh
+++ b/posthog/clickhouse/hcl/compare-old.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Local parity helper: diff the current per-env goldens against the pinned legacy
+# snapshot (.legacy/, created by bin/snapshot-legacy.sh). NOT run in CI — a
+# restructure PR proves parity by showing zero content diffs in committed golden/.
+# This is the convenience check while iterating locally.
+#
+# Env mapping: legacy "local" == new "local-multi".
+set -euo pipefail
+
+HCL=posthog/clickhouse/hcl
+[ -d "$HCL/.legacy/golden" ] || { echo "run $HCL/bin/snapshot-legacy.sh first"; exit 2; }
+
+map_env() { case "$1" in local-multi) echo local ;; *) echo "$1" ;; esac; }
+
+rc=0
+for g in "$HCL"/golden/*/*.hcl; do                       # per-env-dir goldens
+  [ -e "$g" ] || continue                                # no per-env goldens yet (pre-conversion)
+  env=$(basename "$(dirname "$g")"); role=$(basename "$g" .hcl)
+  old="$HCL/.legacy/golden/$(map_env "$env")-$role.hcl"  # legacy flat golden
+  [ -f "$old" ] || continue                              # new coverage, no parity target
+  out=$("$HCL/bin/hclexp" diff -left "$old" -right "$g")
+  [ "$out" = "no differences" ] || { echo "PARITY FAIL: $env/$role"; echo "$out"; rc=1; }
+done
+[ "$rc" -eq 0 ] && echo "compare-old: all per-env goldens match the legacy snapshot"
+exit $rc

--- a/posthog/clickhouse/hcl/legacy-ref.txt
+++ b/posthog/clickhouse/hcl/legacy-ref.txt
@@ -1,0 +1,1 @@
+acc7fd0effbf59bfe3f8d63f271c306508fa003a

--- a/posthog/clickhouse/hcl/migration.md
+++ b/posthog/clickhouse/hcl/migration.md
@@ -130,9 +130,9 @@ Full implementation plan: `docs/plans/2026-07-14-hcl-recreate.md`.
 ## Repos
 
 - this repo, PostHog/posthog - base repository
-- /Users/orian/workspace/posthog/clickhouse-schema - schema dumps, github: PostHog/clickhouse-schema
-- /Users/orian/workspace/posthog/python-clickhouse-schema - hclexp, github repo is PostHog/chschema
+- PostHog/clickhouse-schema - schema dumps, github: PostHog/clickhouse-schema
+- PostHog/chschema - hclexp, github repo is PostHog/chschema
   - all needed tooling is on main (per-object comparison #139, locate + -duplicates #145); pin >= sha-5756e98
-- /Users/orian/workspace/posthog/posthog-cloud-infra - a repository with ansible and machine configurations
+- PostHog/posthog-cloud-infra - a repository with ansible and machine configurations
   - notable branch: pawel/chore/clickhouse-hcl-data-goldens — the compose harness (vendored base + overrides + data goldens with mat\_ columns), to be merged first
-- /Users/orian/workspace/posthog/charts - kubernetes config and apps deployment scripts, an old / current clickhouse migration mechanism is run here as job in django web app deployemnt
+- PostHog/charts - kubernetes config and apps deployment scripts, an old / current clickhouse migration mechanism is run here as job in django web app deployemnt

--- a/posthog/clickhouse/hcl/migration.md
+++ b/posthog/clickhouse/hcl/migration.md
@@ -1,0 +1,138 @@
+# PostHog ClickHouse setup quirks
+
+## ClickHouse cluster architecture
+
+Production environment setup.
+
+| cluster   | node role                                        | sharded?                            | comment/purpose                                                                                                                                                                                              |
+| --------- | ------------------------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| posthog   | DATA (both `offline` and `online` replica types) | yes,<br>dev: 2,<br>eu: 8,<br>us: 10 | the biggest, main data repository,<br>handles most queries, has distributed tables pointing to satellite nodes' tables,<br>has offline / online replica designation,                                         |
+| aux       | AUX (auxiliary)                                  | no                                  | satellite node,<br>all tables that do not have lot data and do not need to be fully replicated on DATA nodes                                                                                                 |
+| ai_events | AI_EVENTS                                        | no                                  | satellite node,<br>AI related events and stuff                                                                                                                                                               |
+| sessions  | SESSIONS                                         | no                                  | satellite node,<br>sessions related tables, as sessions are all the time updated, this generates huge number of parts that ClickHouse have to merge all the time                                             |
+| ops       | OPS                                              | no                                  | satellite node,<br>operation cluster, we keep query_log_archive, metrics, and other operational stuff<br>other nodes exports some metrics here<br>it's suppose to stay up even if the main cluster struggles |
+| logs      | LOGS                                             | yes                                 | cluster supporting logs and metrics product (APM)<br>technically a satellite cluster                                                                                                                         |
+| events    | INGESTION_EVENTS                                 | no                                  | ingestion layer;<br>used only to consume main events kafka/warpstream topic and ingest events into writable_events                                                                                           |
+| medium    | INGESTION_MEDIUM                                 | no                                  | ingestion layer;<br>consumes medium load topics and inserts into clickhouse tables                                                                                                                           |
+| small     | INGESTION_SMALL                                  | no                                  | ingestion layer;<br>same as other ingestion, used for the smallest ingestion topics                                                                                                                          |
+| endpoints | ENDPOINTS                                        | no                                  | a stateless cluster, mostly runs queries against S3 files                                                                                                                                                    |
+
+All nodes shall have metrics and query_log_archive_mv dumping query_log into ops.query_log_archive.
+Ingestion layer should have mostly distributed tables and materialized views.
+,
+
+## 4.5 distinct environments
+
+There are local and cloud environments.
+
+### Local
+
+The local one is started directly from the `PostHog/posthog` repository.
+Development happens on a 1 node ClickHouse that has all (logical) clusters.
+There is a test setup that spins multiple clickhouse nodes, each being a separate cluster (DATA + sattelites clusters). It serves only to validate the migrations.
+
+Local deployment uses Kafka.
+
+### Cloud
+
+There are 3 separate cloud deployments:
+
+- dev - think about it as a staging, it's similar to prod, we aim to make it same arch / setup as our main environments
+- prod-us - our main and biggest production environment,
+- prod-eu - our second environment, for customers who prefer their data to stay in EU,
+
+We use WarpStream in production environment, therefore the MV are different in local and cloud. This leads to the Kafka tables having slightly different schema.
+
+Our cloud environment has some customizations per env, this is mostly the `events` distributed table and `sharded_events` replicated table, that has different materialized columns (`mat_` prefix).
+
+Because of the historical reasons, the nodes may have little differences between tables. This is not on purpose, but a schema drift that needs to be handled long term.
+
+Schema sources of truth:
+PostHog/clickhouse-schema repo contains per environment node schema dumps as HCL.
+
+## Migration desired state
+
+We want to achieve a state of full schema of each env and cluster to be represented as HCL.
+
+End state: we have 5 environments schemas as HCL, a golden per cluster, something like:
+
+- local-single (in PostHog/posthog)
+  - schema.hcl
+- local-multi (in PostHog/posthog):
+  - ops.hcl
+  - posthog.hcl
+  - aux.hcl
+  - ...
+- dev (in posthog-cloud-infra):
+  - posthog.hcl
+  - aux.hcl
+  - sessions.hcl
+  - ...
+- prod-us (in posthog-cloud-infra):
+  - posthog.hcl
+  - aux.hcl
+  - sessions.hcl
+  - ai_events.hcl
+  - ops.hcl
+  - ...
+- prod-eu (in posthog-cloud-infra)
+  - ...
+
+The above files should be a result of cluster config composed of multiple smaller files.
+
+Repo split (hard rule): cloud env customizations are NEVER committed to PostHog/posthog (it's public; e.g. `mat_` columns encode customer property names).
+PostHog/posthog holds only the env-uniform base layers (shared / cloud-uniform / local) and the local goldens; everything env-specific for dev, prod-us, prod-eu (per-env override layers, cloud goldens, the drift catalog) lives in posthog-cloud-infra, composed as pinned vendored base + overrides.
+
+Schema drift. We may ignore minor drifts, we shall collect all of them for the purpose of fixing it.
+
+Envs:
+
+- local single (single node)
+- local multi (multi node)
+- dev
+- prod-us
+- prod-eu
+
+Each table shall be defined once, if there's a difference between envs, it shall be extended (prefered) or overriden, whatever is simple.
+
+The purpose of the extension is to making the schema changes uniform across all envs: think adding a column or table shall be possible in one place and affect all envs.
+
+If a given role is missing in the environment, we probably shall use the main cluster.
+
+The process of migrating to the HCL:
+
+1. collect all dumps from the nodes:
+1. dump a single local node from the basic dev setup in posthog/posthog
+1. dump each node for multinode setup
+1. prepare posthog-clickhouse repo with per-env/per-node dump hcl files
+1. for each object in production environment:
+1. compare it with all other envs, corresponding clusters (e.g. take ops from all envs)
+1. if it's the same every whery -> dump it into shared (PostHog/posthog)
+1. if there's a difference, take the shared part (e.g. column list) and put it in shared, then extend it per env — the per-env extension goes straight into posthog-cloud-infra overrides, never into PostHog/posthog
+1. it may be that a table HCL is defined as a part of other cluster (e.g. query_log_archive, the base may be defined in other cluster)
+
+The posthog-cloud-infra compose harness (vendored base pinned by sha + overrides) is stood up BEFORE the decomposition starts, so env customizations land there from day one — there is no "move it later" step.
+
+The restructure in PostHog/posthog is in place and there is only ever ONE composition in the repo — no `roles_old/`, no second manifest (a parked parallel copy creates unnecessary chaos).
+The legacy state is pinned by a committed `legacy-ref.txt` sha; `bin/snapshot-legacy.sh` copies it into a gitignored `.legacy/` dir locally, so it's easy to introspect just in case, without committing it.
+Restructure PRs prove they change nothing by leaving the committed goldens byte-identical.
+
+Full implementation plan: `docs/plans/2026-07-14-hcl-recreate.md`.
+
+## Deployment
+
+1. local and schema changes to base are done in PostHog/posthog, this is also what all tests run against
+2. PR in PostHog/posthog shall trigger a run of a check in posthog-cloud-infra that validates that changes could be merged with the prod layer
+3. the cloud schema is composed as base + customizations in posthog-cloud-infra
+4. when a PR is merged in PostHog/posthog it shall trigger a job and create PR in posthog-cloud-infra to bump pinned version of base; it shall generate a full ordered list of SQL queries that will be executed as part of migration
+5. after approval, the PR is merged and a migrator executes a migration
+
+## Repos
+
+- this repo, PostHog/posthog - base repository
+- /Users/orian/workspace/posthog/clickhouse-schema - schema dumps, github: PostHog/clickhouse-schema
+- /Users/orian/workspace/posthog/python-clickhouse-schema - hclexp, github repo is PostHog/chschema
+  - all needed tooling is on main (per-object comparison #139, locate + -duplicates #145); pin >= sha-5756e98
+- /Users/orian/workspace/posthog/posthog-cloud-infra - a repository with ansible and machine configurations
+  - notable branch: pawel/chore/clickhouse-hcl-data-goldens — the compose harness (vendored base + overrides + data goldens with mat\_ columns), to be merged first
+- /Users/orian/workspace/posthog/charts - kubernetes config and apps deployment scripts, an old / current clickhouse migration mechanism is run here as job in django web app deployemnt


### PR DESCRIPTION
## Problem

The HCL composition (`posthog/clickhouse/hcl/`) is being rebuilt in place per `migration.md`. To prove a restructure PR changes no schema, we need the pre-restructure "legacy" composition available locally for parity diffs. Committing a second copy of the tree (a parked `roles_old/` + second manifest) creates its own mess: two manifests, dual-gated scripts, and constant confusion about where to edit. So the legacy state lives as a pinned git sha, reconstituted on demand into a gitignored directory.

## Changes

First of Phase 1's two setup PRs. No behavior change, no CI change (paths already covered by the existing triggers).

- `legacy-ref.txt` — the pinned master sha (`acc7fd0`, the commit that regenerated the local-data golden against CH 26.6 via #70173). This is the legacy baseline.
- `bin/snapshot-legacy.sh` — `git archive`s the composition (`roles/`, `manifest.hcl`, `golden/`, `sql/`) at that ref into a gitignored `.legacy/`.
- `compare-old.sh` — local-only helper that diffs the current per-env goldens against `.legacy/` (env map: legacy `local` == new `local-multi`). Not wired into CI; restructure PRs prove parity by showing zero committed-golden diffs.
- `.gitignore` — ignore `.legacy/`.
- Track `migration.md` (the spec for this work; was untracked).

## How did you test this code?

All via the pinned `hclexp` container:

- `bin/snapshot-legacy.sh` materializes `.legacy/` (22 legacy goldens) and `.legacy/` stays untracked (gitignored).
- End-to-end parity path works: `hclexp diff` of a `.legacy/` golden against its current committed counterpart returns "no differences".
- `compare-old.sh` runs cleanly (vacuous pass pre-conversion — the per-env golden layout arrives in the next PR).
- `check.sh` green (this PR only adds files; it touches no layer, golden, or sql).
- `hogli ci:preflight` clean after formatting `migration.md` with oxfmt.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`migration.md` is the design doc for this effort and is added here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) implemented Task 1.1 of `docs/plans/2026-07-14-hcl-recreate.md` under Pawel's direction. Mid-session the plan pivoted from an earlier "park the tree as `roles_old/`" approach to this single-composition + pinned-legacy-ref design; the park work was discarded before it was pushed. Sequencing: the pin waits on #70173 (CH 26.6 local-data golden regen) so the legacy baseline already carries that golden — #70173 merged first, then `legacy-ref.txt` was set to that sha.

`compare-old.sh` got a small guard over the plan's draft so it no-ops cleanly before the per-env golden layout exists. `migration.md` needed an `oxfmt --write` pass to satisfy the markdown-format gate (the `--fix` chain's markdownlint step short-circuits before oxfmt runs); the reformat is cosmetic, word count unchanged.
