### PR TITLE
feat(devbox): support --name/-n on devbox:cleanup:disk

### DIFF
--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -1939,7 +1939,12 @@ def devbox_cleanup_disk(workspace: str | None, prune_docker: bool, prune_cargo: 
     """
     if workspace:
         ensure_runtime_ready()
-        name, _ = resolve_workspace_name(workspace)
+        # Cleanup is destructive (removes caches and build artifacts), so refuse
+        # to run it against someone else's shared `@user[/label]` devbox.
+        if workspace.startswith("@"):
+            _fail("devbox:cleanup:disk only runs against your own devboxes, not a shared '@user' workspace.")
+        name, workspaces = resolve_workspace_name(workspace)
+        _get_workspace_or_fail(name, workspaces)
         if not coder_ssh_alias_configured(name):
             _fail(
                 "SSH access for devboxes isn't configured. Run `hogli devbox:setup` (it runs `coder config-ssh`), then retry."

--- a/tools/hogli-commands/hogli_commands/devbox/cli.py
+++ b/tools/hogli-commands/hogli_commands/devbox/cli.py
@@ -1918,6 +1918,7 @@ def _rm_dir(label: str, path: Path) -> None:
 
 
 @click.command(name="devbox:cleanup:disk", help="Free disk space by cleaning caches and build artifacts")
+@workspace_argument
 @click.option("--docker", "prune_docker", is_flag=True, help="Also prune stopped Docker containers")
 @click.option(
     "--cargo",
@@ -1925,14 +1926,32 @@ def _rm_dir(label: str, path: Path) -> None:
     is_flag=True,
     help="Also remove Cargo build artifacts (forces full Rust recompile on next build)",
 )
-def devbox_cleanup_disk(prune_docker: bool, prune_cargo: bool) -> None:
+def devbox_cleanup_disk(workspace: str | None, prune_docker: bool, prune_cargo: bool) -> None:
     """Free disk space by removing caches and build artifacts that are safe to delete.
 
     The default run is safe: it only removes orphaned packages, download caches,
     and old Nix generations — none of which force a full rebuild on next use.
     Use --cargo to also remove Cargo build artifacts (forces full Rust recompile).
     Use --docker to also prune stopped containers.
+
+    Runs locally by default. Pass a WORKSPACE (or --name/-n) to run it remotely
+    on that devbox over ssh instead.
     """
+    if workspace:
+        ensure_runtime_ready()
+        name, _ = resolve_workspace_name(workspace)
+        if not coder_ssh_alias_configured(name):
+            _fail(
+                "SSH access for devboxes isn't configured. Run `hogli devbox:setup` (it runs `coder config-ssh`), then retry."
+            )
+        remote_cmd = ["hogli", "devbox:cleanup:disk"]
+        if prune_docker:
+            remote_cmd.append("--docker")
+        if prune_cargo:
+            remote_cmd.append("--cargo")
+        exec_replace(name, remote_cmd)
+        return  # unreachable; exec_replace replaces the process
+
     home = Path.home()
     # Watch distinct filesystems: home covers uv/sccache/cargo; /nix covers Nix store
     # (may be a separate volume); / covers Docker storage and anything else.


### PR DESCRIPTION
## Problem

`hogli devbox:cleanup:disk` only ran locally — it had no `--name`/`-n` option to target a specific devbox, unlike `devbox:exec` and the other devbox commands. Raised in [this Slack thread](https://posthog.slack.com/archives/C0AMVFGJY7Q/p1784123965011689?thread_ts=1784123965.011689&cid=C0AMVFGJY7Q).

## Changes

Added the shared `workspace_argument` decorator (positional `WORKSPACE` plus `--name`/`-n`) to `devbox:cleanup:disk`. When a target is given, the cleanup re-invokes itself remotely on that devbox over ssh via `exec_replace`, gated on `coder_ssh_alias_configured` like `devbox:exec`. Without a target it runs locally as before. The `--docker`/`--cargo` flags are forwarded to the remote run.

## How did you test this code?

Rendered the command's `--help` to confirm `-n, --name` now appears alongside the existing flags, and ran `ruff check` on the file. Did not exercise the remote ssh path against a live devbox.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The `-n` convention was mirrored from `devbox:exec`, reusing the existing `workspace_argument` decorator and `exec_replace`/`coder_ssh_alias_configured` helpers rather than adding a bespoke option, so cleanup:disk behaves consistently with the other devbox commands. No skills were required.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AMVFGJY7Q/p1784123965011689?thread_ts=1784123965.011689&cid=C0AMVFGJY7Q)*
