### PR TITLE
chore(self-driving): Simplify buttons in Slack notifications

### DIFF
--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -26,7 +26,6 @@ from posthog.models import User
 from posthog.models.integration import Integration, SlackIntegration
 
 from products.signals.backend.enums import SIGNAL_SOURCE_PRODUCT_LABELS
-from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
 from products.signals.backend.models import (
     AutonomyPriority,
     SignalReport,
@@ -58,9 +57,6 @@ _MAX_REVIEWER_MENTIONS = 5
 
 # Deep link opened by the PostHog Code desktop app. Override via env for dev (`posthog-code-dev`).
 POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME = getattr(settings, "POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME", "posthog-code")
-
-# Wire contract with products/slack_app/backend/api.py — keep this action_id in sync.
-SIGNALS_DISMISS_REPORT_ACTION_ID = "signals_dismiss_report"
 
 # Priority ranking — lower index is higher priority. Index used for threshold comparison.
 _PRIORITY_ORDER: tuple[str, ...] = (
@@ -357,8 +353,6 @@ def _build_message_blocks(
     source_products: list[str],
     reviewer_mentions: list[str],
     repository: str | None = None,
-    implementation_pr_url: str | None = None,
-    dismiss_button_value: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New signals inbox item"
     header_text = (
@@ -405,40 +399,13 @@ def _build_message_blocks(
             }
         )
 
-    action_elements: list[dict] = []
-    if implementation_pr_url:
-        action_elements.append(
-            {
-                "type": "button",
-                "text": {"type": "plain_text", "text": "Review PR", "emoji": True},
-                "url": implementation_pr_url,
-            }
-        )
-    action_elements.append(
+    action_elements: list[dict] = [
         {
             "type": "button",
-            "text": {"type": "plain_text", "text": "Open in PostHog", "emoji": True},
+            "text": {"type": "plain_text", "text": "Review in PostHog", "emoji": True},
             "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/reports/{report.id}",
         }
-    )
-    if dismiss_button_value:
-        action_elements.append(
-            {
-                "type": "button",
-                "action_id": SIGNALS_DISMISS_REPORT_ACTION_ID,
-                "text": {"type": "plain_text", "text": "Dismiss", "emoji": True},
-                "value": dismiss_button_value,
-                "confirm": {
-                    "title": {"type": "plain_text", "text": "Dismiss this report?"},
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "This will dismiss the report for everyone. You can still find it in PostHog.",
-                    },
-                    "confirm": {"type": "plain_text", "text": "Dismiss"},
-                    "deny": {"type": "plain_text", "text": "Cancel"},
-                },
-            }
-        )
+    ]
     blocks.append({"type": "actions", "elements": action_elements})
 
     priority_suffix = f" ({priority})" if priority else ""
@@ -731,7 +698,6 @@ def dispatch_inbox_item_notifications(
 
     sources = source_products or []
     repository = _report_repository(report)
-    implementation_pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
 
     sent = 0
     for route in routes:
@@ -745,21 +711,12 @@ def dispatch_inbox_item_notifications(
         try:
             slack = SlackIntegration(route.integration)
             mentions = _resolve_reviewer_mentions(slack, route.users)
-            dismiss_button_value = json.dumps(
-                {
-                    "integration_id": route.integration.id,
-                    "report_id": str(report.id),
-                    "team_id": team_id,
-                }
-            )
             blocks, text = _build_message_blocks(
                 report,
                 priority=priority,
                 source_products=sources,
                 reviewer_mentions=mentions,
                 repository=repository,
-                implementation_pr_url=implementation_pr_url,
-                dismiss_button_value=dismiss_button_value,
             )
             response = slack.client.chat_postMessage(channel=channel_id, blocks=blocks, text=text)
             sent += 1

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -3,7 +3,6 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 
-from django.apps import apps
 from django.conf import settings
 
 from social_django.models import UserSocialAuth
@@ -30,7 +29,6 @@ from products.signals.backend.slack_inbox_notifications import (
     _summary_excerpt,
     dispatch_inbox_item_notifications,
 )
-from products.signals.backend.task_run_artefacts import record_implementation_task
 
 
 @pytest.mark.parametrize(
@@ -108,9 +106,10 @@ def test_build_message_blocks_includes_recipient_and_open_in_posthog_button() ->
     assert "12 signals" in context_text
     assert "👤 Suggested reviewers: <@U123>" in context_text
     assert "Inbox" not in context_text
-    button = blocks[3]["elements"][0]
-    assert button["text"]["text"] == "Open in PostHog"
-    assert button["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
+    buttons = blocks[3]["elements"]
+    assert len(buttons) == 1
+    assert buttons[0]["text"]["text"] == "Review in PostHog"
+    assert buttons[0]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
     assert text == "Inbox item (P1): Checkout errors spiked"
 
 
@@ -162,68 +161,6 @@ def test_build_message_blocks_escapes_mrkdwn_in_llm_derived_fields() -> None:
     assert "<!channel>" not in section_text
     assert "&lt;!here&gt;" in section_text
     assert "&amp;" in section_text
-
-
-def test_build_message_blocks_includes_github_pr_button_when_pr_url_provided() -> None:
-    report = SignalReport(
-        id="report-uuid",
-        team_id=42,
-        title="Checkout errors spiked",
-        summary="Error rate rose after deploy.",
-        signal_count=12,
-    )
-    pr_url = "https://github.com/org/repo/pull/42"
-    blocks, _ = _build_message_blocks(
-        report,
-        priority="P1",
-        source_products=["error_tracking"],
-        reviewer_mentions=["<@U123>"],
-        implementation_pr_url=pr_url,
-    )
-
-    buttons = blocks[3]["elements"]
-    assert len(buttons) == 2
-    assert buttons[0]["text"]["text"] == "Review PR"
-    assert buttons[0]["url"] == pr_url
-    assert buttons[1]["text"]["text"] == "Open in PostHog"
-    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
-
-
-def test_build_message_blocks_omits_github_pr_button_without_pr_url() -> None:
-    report = SignalReport(id="report-uuid", title="No PR yet")
-    blocks, _ = _build_message_blocks(
-        report,
-        priority=None,
-        source_products=[],
-        reviewer_mentions=["Marcus Twix"],
-        implementation_pr_url=None,
-    )
-
-    assert blocks[1]["text"]["text"] == "*No PR yet*"
-    assert blocks[2]["elements"][0]["text"] == "👤 Suggested reviewers: Marcus Twix"
-    assert len(blocks[3]["elements"]) == 1
-
-
-def test_build_message_blocks_appends_dismiss_button_last_with_action_id() -> None:
-    report = SignalReport(id="report-uuid", title="Dismissable")
-    dismiss_value = '{"integration_id": 2, "report_id": "report-uuid", "team_id": 1}'
-    blocks, _ = _build_message_blocks(
-        report,
-        priority="P2",
-        source_products=[],
-        reviewer_mentions=["<@U123>"],
-        implementation_pr_url="https://github.com/org/repo/pull/42",
-        dismiss_button_value=dismiss_value,
-    )
-
-    buttons = blocks[3]["elements"]
-    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog", "Dismiss"]
-    dismiss = buttons[-1]
-    assert dismiss["action_id"] == "signals_dismiss_report"
-    assert dismiss["value"] == dismiss_value
-    assert "url" not in dismiss
-    assert dismiss["confirm"]["confirm"]["text"] == "Dismiss"
-    assert dismiss["confirm"]["deny"]["text"] == "Cancel"
 
 
 @pytest.mark.parametrize(
@@ -345,33 +282,6 @@ def _make_ready_report(
             content=json.dumps([{"github_login": login} for login in suggested_logins]),
         )
     return report
-
-
-def _create_implementation_task_with_run(
-    team: Team,
-    report: SignalReport,
-    *,
-    pr_url: str | None = None,
-) -> None:
-    Task = apps.get_model("tasks", "Task")
-    TaskRun = apps.get_model("tasks", "TaskRun")
-    task = Task.objects.create(
-        team=team,
-        title="Implementation task",
-        description="Fix the bug",
-        origin_product=Task.OriginProduct.SIGNAL_REPORT,
-    )
-    record_implementation_task(
-        team_id=team.id,
-        report_id=str(report.id),
-        task_id=str(task.id),
-    )
-    TaskRun.objects.create(
-        team=team,
-        task=task,
-        status=TaskRun.Status.COMPLETED,
-        output={"pr_url": pr_url},
-    )
 
 
 @pytest.mark.django_db
@@ -658,48 +568,16 @@ def test_dispatch_team_channel_tags_only_fallback_reviewers(org_and_team):
 
 
 @pytest.mark.django_db
-def test_dispatch_includes_github_pr_button_when_implementation_task_has_pr(org_and_team):
+def test_dispatch_includes_repository_from_repo_selection_artefact(org_and_team):
     org, team = org_and_team
-    user = _make_reviewer_user(org, "reviewer-pr@example.com", "pr-bot")
+    user = _make_reviewer_user(org, "reviewer-repo@example.com", "repo-bot")
     integration = _make_slack_integration(team, user)
     SignalUserAutonomyConfig.objects.create(
         user=user,
         slack_notification_integration=integration,
         slack_notification_channel="C123|#inbox",
     )
-    report = _make_ready_report(team, priority=AutonomyPriority.P1, suggested_logins=["pr-bot"])
-    _create_implementation_task_with_run(team, report, pr_url="https://github.com/org/repo/pull/99")
-
-    fake_client = MagicMock()
-    with (
-        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
-        patch(
-            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
-            return_value=None,
-        ),
-    ):
-        slack_cls.return_value.client = fake_client
-        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
-
-    assert sent == 1
-    buttons = fake_client.chat_postMessage.call_args.kwargs["blocks"][3]["elements"]
-    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Open in PostHog", "Dismiss"]
-    assert buttons[0]["url"] == "https://github.com/org/repo/pull/99"
-    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/{team.id}/inbox/reports/{report.id}"
-    assert buttons[-1]["action_id"] == "signals_dismiss_report"
-
-
-@pytest.mark.django_db
-def test_dispatch_dismiss_button_carries_routing_ids_and_repository(org_and_team):
-    org, team = org_and_team
-    user = _make_reviewer_user(org, "reviewer-dismiss@example.com", "dismiss-bot")
-    integration = _make_slack_integration(team, user)
-    SignalUserAutonomyConfig.objects.create(
-        user=user,
-        slack_notification_integration=integration,
-        slack_notification_channel="C123|#inbox",
-    )
-    report = _make_ready_report(team, priority=AutonomyPriority.P2, suggested_logins=["dismiss-bot"])
+    report = _make_ready_report(team, priority=AutonomyPriority.P2, suggested_logins=["repo-bot"])
     SignalReportArtefact.objects.create(
         team=team,
         report=report,
@@ -721,12 +599,6 @@ def test_dispatch_dismiss_button_carries_routing_ids_and_repository(org_and_team
     assert sent == 1
     blocks = fake_client.chat_postMessage.call_args.kwargs["blocks"]
     assert "PostHog/posthog" in blocks[1]["text"]["text"]
-    dismiss = blocks[3]["elements"][-1]
-    assert json.loads(dismiss["value"]) == {
-        "integration_id": integration.id,
-        "report_id": str(report.id),
-        "team_id": team.id,
-    }
 
 
 @pytest.mark.django_db

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -3551,7 +3551,7 @@ def _handle_permission_submit(payload: dict) -> HttpResponse:
     return HttpResponse(status=200)
 
 
-# Wire contract with products/signals/backend/slack_inbox_notifications.py (SIGNALS_DISMISS_REPORT_ACTION_ID).
+# Handles the Dismiss button on inbox notifications delivered before that button was removed.
 SIGNALS_DISMISS_REPORT_ACTION_ID = "signals_dismiss_report"
 
 


### PR DESCRIPTION
## Problem

Signals inbox notifications posted to Slack had three buttons: "Review PR", "Open in PostHog", and "Dismiss".
Way too many. I really only want to do one thing from Slack alone: _review_.

## Changes

Removed the "Review PR" and "Dismiss" buttons from inbox item Slack notifications.
Renamed the remaining "Open in PostHog" button to "Review in PostHog".

Left the dismiss interaction handler in `slack_app` untouched so any messages already delivered with a Dismiss button keep working.

## How did you test this code?

By Claude:

Updated the unit and dispatch tests in `test_slack_inbox_notifications.py` to assert a single "Review in PostHog" button and dropped the tests that covered the removed buttons. These guard against a regression that re-adds the extra buttons or reverts the label.

I (the PostHog Slack app agent) could not run the test suite in this environment — the sandbox's Django install is broken (`No module named 'django.utils'`), unrelated to this change. `ruff check`, `ruff format --check`, and `py_compile` all pass on the touched files, and `hogli ci:preflight --strict` is clean.
