### PR TITLE
fix(aio): clarify eval runs summary covers all runs, not the latest 250

### DIFF
--- a/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
+++ b/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
@@ -365,37 +365,40 @@ export function AIObservabilityEvaluation(): JSX.Element {
                                     <p className="text-muted text-sm m-0">
                                         History of when this evaluation has been executed.
                                         {runsSummary && runsSummary.total > EVALUATION_SUMMARY_MAX_RUNS && (
-                                            <> Showing the latest {EVALUATION_SUMMARY_MAX_RUNS} runs.</>
+                                            <> The table below shows the latest {EVALUATION_SUMMARY_MAX_RUNS} runs.</>
                                         )}
                                     </p>
                                     {runsSummary && (
-                                        <div className="flex gap-4 text-sm">
-                                            <div className="text-center">
-                                                <div className="font-semibold text-lg">{runsSummary.total}</div>
-                                                <div className="text-muted">Total runs</div>
-                                            </div>
-                                            {supportsRunSummary && (
+                                        <div className="flex flex-col items-end gap-1">
+                                            <div className="flex gap-4 text-sm">
                                                 <div className="text-center">
-                                                    <div className="font-semibold text-lg text-success">
-                                                        {runsSummary.successRate}%
-                                                    </div>
-                                                    <div className="text-muted">Success rate</div>
+                                                    <div className="font-semibold text-lg">{runsSummary.total}</div>
+                                                    <div className="text-muted">Total runs</div>
                                                 </div>
-                                            )}
-                                            {supportsRunSummary && evaluation.output_config.allows_na && (
+                                                {supportsRunSummary && (
+                                                    <div className="text-center">
+                                                        <div className="font-semibold text-lg text-success">
+                                                            {runsSummary.successRate}%
+                                                        </div>
+                                                        <div className="text-muted">Success rate</div>
+                                                    </div>
+                                                )}
+                                                {supportsRunSummary && evaluation.output_config.allows_na && (
+                                                    <div className="text-center">
+                                                        <div className="font-semibold text-lg">
+                                                            {runsSummary.applicabilityRate}%
+                                                        </div>
+                                                        <div className="text-muted">Applicable</div>
+                                                    </div>
+                                                )}
                                                 <div className="text-center">
-                                                    <div className="font-semibold text-lg">
-                                                        {runsSummary.applicabilityRate}%
+                                                    <div className="font-semibold text-lg text-danger">
+                                                        {runsSummary.errors}
                                                     </div>
-                                                    <div className="text-muted">Applicable</div>
+                                                    <div className="text-muted">Errors</div>
                                                 </div>
-                                            )}
-                                            <div className="text-center">
-                                                <div className="font-semibold text-lg text-danger">
-                                                    {runsSummary.errors}
-                                                </div>
-                                                <div className="text-muted">Errors</div>
                                             </div>
+                                            <div className="text-muted text-xs">Across all runs, all time</div>
                                         </div>
                                     )}
                                 </div>


### PR DESCRIPTION
## Problem

On the evaluation detail page's "Runs" tab, the summary header (Total runs / Success rate / Applicable / Errors) is computed from a server-side aggregate over *all* runs. But it sits right next to a "Showing the latest 250 runs" note, so it was unclear whether the success rate applied only to those 250 runs. Flagged from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784072443129019?thread_ts=1784072443.129019&cid=C087XQ7K9K7).

## Changes

- Reworded the note to scope it to the table: "The table below shows the latest 250 runs."
- Added an "Across all runs, all time" caption under the summary stats so it's clear the header numbers span the full history, not the truncated table.

Copy/layout only — no logic change; the stats already come from the all-runs aggregate.

## How did you test this code?

Copy and layout change only. I (the agent) could not run `typescript:check` in this environment (node_modules not installed), but the change adds no new types, imports, or props — only JSX text and wrapper markup.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this header. No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed from a Slack bug report asking to clarify in the UI whether the success rate covers only the latest 250 runs. Confirmed via the code that \`runsSummary\` already derives total / success rate / applicability from the server-side \`runsStats\` aggregate (no LIMIT), so the numbers are all-time — the issue was purely ambiguous copy. Chose a minimal copy + caption fix over any logic change. No skills invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784072443129019?thread_ts=1784072443.129019&cid=C087XQ7K9K7)*