### PR TITLE
feat(data-warehouse): implement instana import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -242,6 +242,7 @@ the row lists both.
 | inflowinventory                  | HTTP                        | requests                                                        | ✅                          |
 | inngest                          | HTTP                        | requests                                                        | ✅                          |
 | insightly                        | HTTP                        | requests                                                        | ✅                          |
+| instana                          | HTTP                        | requests                                                        | ✅                          |
 | instatus                         | HTTP                        | requests                                                        | ✅                          |
 | intercom                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | intruder                         | HTTP                        | requests                                                        | ✅                          |
@@ -708,7 +709,6 @@ doesn't conflict with concurrent PRs.
 - infor_nexus
 - insightful
 - instagram
-- instana
 - instantly
 - interzoid
 - jamf_pro

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -2086,7 +2086,8 @@ class InstagramSourceConfig(config.Config):
 
 @config.config
 class InstanaSourceConfig(config.Config):
-    pass
+    base_url: str
+    api_token: str
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/canonical_descriptions.py
@@ -1,0 +1,116 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+# Descriptions sourced from the official Instana OpenAPI specification
+# (https://instana.github.io/openapi/). Keyed by endpoint name as returned by `get_schemas`.
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "events": {
+        "description": "Incidents, issues, and changes detected by Instana across your monitored environment.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getEvents",
+        "columns": {
+            "eventId": "Unique identifier of the event.",
+            "start": "Timestamp when the event started, in epoch milliseconds.",
+            "end": "Timestamp when the event ended, in epoch milliseconds; unset while the event is still open.",
+            "type": "Event type: INCIDENT, ISSUE, or CHANGE.",
+            "state": "Current state of the event (e.g. OPEN or CLOSED).",
+            "severity": "Numeric severity of the event (5 = warning, 10 = critical).",
+            "problem": "Short description of the detected problem.",
+            "detail": "Detailed description of the event.",
+            "entityName": "Type of the entity the event was detected on (e.g. host, jvm).",
+            "entityLabel": "Display label of the entity the event was detected on.",
+            "entityType": "Category of the affected entity.",
+            "snapshotId": "Identifier of the infrastructure snapshot the event relates to.",
+            "eventSpecificationId": "Identifier of the event specification (rule) that triggered the event.",
+            "fixSuggestion": "Suggested remediation for the detected problem.",
+        },
+    },
+    "applications": {
+        "description": "Application perspectives defined in Instana's application monitoring.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getApplications",
+        "columns": {
+            "id": "Unique identifier of the application perspective.",
+            "label": "Display name of the application perspective.",
+            "boundaryScope": "Which calls are part of the application: INBOUND or ALL.",
+            "entityType": "Entity type of the record (application).",
+        },
+    },
+    "services": {
+        "description": "Services discovered by Instana's application monitoring.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getServices",
+        "columns": {
+            "id": "Unique identifier of the service.",
+            "label": "Display name of the service.",
+            "types": "Service types (e.g. HTTP, DATABASE, MESSAGING).",
+            "technologies": "Technologies detected for the service.",
+            "snapshotIds": "Infrastructure snapshot identifiers backing the service.",
+            "entityType": "Entity type of the record (service).",
+        },
+    },
+    "endpoints": {
+        "description": "Service endpoints (HTTP paths, RPC methods, queues) discovered by Instana.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getApplicationEndpoints",
+        "columns": {
+            "id": "Unique identifier of the endpoint.",
+            "label": "Display name of the endpoint.",
+            "serviceId": "Identifier of the service the endpoint belongs to.",
+            "type": "Endpoint type (e.g. HTTP, DATABASE, MESSAGING).",
+            "technologies": "Technologies detected for the endpoint.",
+            "synthetic": "Whether the endpoint only receives synthetic traffic.",
+        },
+    },
+    "websites": {
+        "description": "Websites configured for Instana end-user (website) monitoring.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getWebsites",
+        "columns": {
+            "id": "Unique identifier of the website configuration.",
+            "name": "Name of the monitored website.",
+            "appName": "Application name associated with the website.",
+        },
+    },
+    "synthetic_tests": {
+        "description": "Synthetic monitoring tests configured in Instana.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getSyntheticTests",
+        "columns": {
+            "id": "Unique identifier of the synthetic test.",
+            "label": "Display name of the synthetic test.",
+            "active": "Whether the test is currently active.",
+            "testFrequency": "How often the test runs, in minutes.",
+            "locations": "Identifiers of the locations the test runs from.",
+            "createdAt": "Timestamp when the test was created, in epoch milliseconds.",
+            "modifiedAt": "Timestamp when the test was last modified, in epoch milliseconds.",
+        },
+    },
+    "alerting_channels": {
+        "description": "Alert channels (integrations) configured in Instana's alerting settings.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getAlertingChannels",
+        "columns": {
+            "id": "Unique identifier of the alert channel.",
+            "name": "Display name of the alert channel.",
+            "kind": "Channel type (e.g. EMAIL, SLACK, WEB_HOOK, OPS_GENIE).",
+        },
+    },
+    "alert_configs": {
+        "description": "Alerting configurations that route triggered events to alert channels.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getAlerts",
+        "columns": {
+            "id": "Unique identifier of the alerting configuration.",
+            "alertName": "Display name of the alerting configuration.",
+            "integrationIds": "Identifiers of the alert channels this configuration notifies.",
+            "eventFilteringConfiguration": "Rules selecting which events trigger this alert.",
+            "muteUntil": "Timestamp the alert is muted until, in epoch milliseconds.",
+            "lastUpdated": "Timestamp of the last modification, in epoch milliseconds.",
+        },
+    },
+    "infrastructure_snapshots": {
+        "description": "Snapshot summaries of infrastructure entities currently monitored by Instana agents.",
+        "docs_url": "https://instana.github.io/openapi/#operation/getSnapshots",
+        "columns": {
+            "snapshotId": "Unique identifier of the infrastructure snapshot.",
+            "plugin": "Entity type (plugin) that produced the snapshot (e.g. host, jvmRuntimePlatform).",
+            "label": "Display label of the monitored entity.",
+            "host": "Identifier of the host the entity runs on.",
+            "tags": "Tags attached to the monitored entity.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
@@ -1,0 +1,340 @@
+import dataclasses
+from collections.abc import Iterator
+from datetime import UTC, date, datetime
+from typing import Any, Optional
+from urllib.parse import urlencode, urlparse
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _is_host_safe
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.settings import (
+    EVENTS_DEFAULT_LOOKBACK_DAYS,
+    EVENTS_WINDOW_CHUNK_MS,
+    INSTANA_ENDPOINTS,
+    PAGE_SIZE,
+    SNAPSHOTS_MAX_SIZE,
+    InstanaEndpointConfig,
+)
+
+REQUEST_TIMEOUT_SECONDS = 60
+MAX_RETRY_ATTEMPTS = 5
+
+HOST_NOT_ALLOWED_ERROR = "Instana base URL is not allowed"
+
+
+class InstanaRetryableError(Exception):
+    pass
+
+
+class InstanaHostNotAllowedError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class InstanaResumeConfig:
+    # Next page to fetch for the page-paginated application-monitoring catalogs.
+    next_page: int | None = None
+    # Epoch-ms start of the next `/api/events` window chunk.
+    events_window_from: int | None = None
+
+
+def normalize_base_url(url: str) -> str:
+    """Reduce user input to a validated ``https://<host>`` Instana base URL.
+
+    Accepts a SaaS tenant URL (``https://unit-tenant.instana.io``) or a self-hosted domain, with
+    or without a scheme. Forcing https prevents a plaintext downgrade, and dropping any
+    path/query/credentials means the API token is only ever sent to endpoint paths we build.
+    """
+    cleaned = url.strip()
+    if not cleaned:
+        raise ValueError("Instana base URL is required")
+    if "://" not in cleaned:
+        cleaned = f"https://{cleaned}"
+    parsed = urlparse(cleaned)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname or parsed.username or parsed.password:
+        raise ValueError(f"Invalid Instana base URL: {url!r}. Enter it like 'https://unit-tenant.instana.io'.")
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"https://{parsed.hostname}{port}"
+
+
+def _host_from_url(base_url: str) -> str:
+    return (urlparse(normalize_base_url(base_url)).hostname or "").lower()
+
+
+def _headers(api_token: str) -> dict[str, str]:
+    return {"Authorization": f"apiToken {api_token}", "Accept": "application/json"}
+
+
+def _to_epoch_ms(value: Any) -> int | None:
+    """Coerce an incremental cursor to epoch milliseconds (Instana's native timestamp unit)."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return int(value)
+    if isinstance(value, datetime):
+        aware = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+        return int(aware.timestamp() * 1000)
+    if isinstance(value, date):
+        return int(datetime.combine(value, datetime.min.time(), tzinfo=UTC).timestamp() * 1000)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _build_url(root: str, path: str, params: dict[str, Any]) -> str:
+    if not params:
+        return f"{root}{path}"
+    return f"{root}{path}?{urlencode(params)}"
+
+
+def _check_host(base_url: str, team_id: int) -> None:
+    # The base URL is fully customer-controlled (self-hosted Instana is a supported target), so
+    # block hosts that resolve to private/internal addresses (SSRF). Re-checked at run time, not
+    # just source-create, to cover URL edits and DNS rebinding. Only enforced on cloud.
+    host_ok, host_err = _is_host_safe(_host_from_url(base_url), team_id)
+    if not host_ok:
+        raise InstanaHostNotAllowedError(host_err or HOST_NOT_ALLOWED_ERROR)
+
+
+def validate_credentials(base_url: str, api_token: str, team_id: int | None = None) -> tuple[bool, int | None]:
+    """Probe ``/api/instana/version`` — the cheapest authenticated endpoint — to confirm the token.
+
+    Returns ``(ok, status_code)``; ``status_code`` is ``None`` on a transport error. Raises
+    ``ValueError`` on a malformed base URL and ``InstanaHostNotAllowedError`` on a blocked host so
+    the caller can surface precise messages.
+    """
+    root = normalize_base_url(base_url)
+    if team_id is not None:
+        _check_host(base_url, team_id)
+    url = _build_url(root, "/api/instana/version", {})
+    try:
+        response = make_tracked_session(allow_redirects=False, redact_values=(api_token,)).get(
+            url, headers=_headers(api_token), timeout=10
+        )
+    except requests.exceptions.RequestException:
+        return False, None
+    return response.status_code == 200, response.status_code
+
+
+def _fetch(
+    session: requests.Session,
+    url: str,
+    logger: FilteringBoundLogger,
+) -> Any:
+    @retry(
+        retry=retry_if_exception_type((InstanaRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=1, max=30),
+        reraise=True,
+    )
+    def fetch_once() -> Any:
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        # Instana rate-limits to 5000 calls/hour and answers excess with 429; transient 5xx are
+        # retryable too. Back off and retry rather than failing the sync.
+        if response.status_code == 429 or response.status_code >= 500:
+            raise InstanaRetryableError(f"Instana API error (retryable): status={response.status_code}, url={url}")
+
+        if not response.ok:
+            logger.error(f"Instana API error: status={response.status_code}, body={response.text}, url={url}")
+            response.raise_for_status()
+
+        return response.json()
+
+    return fetch_once()
+
+
+def _extract_items(response_json: Any, config: InstanaEndpointConfig) -> list[dict[str, Any]]:
+    if config.data_path is None:
+        return response_json if isinstance(response_json, list) else []
+    if isinstance(response_json, dict):
+        items = response_json.get(config.data_path, [])
+        return items if isinstance(items, list) else []
+    return []
+
+
+def _get_event_rows(
+    session: requests.Session,
+    root: str,
+    config: InstanaEndpointConfig,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[InstanaResumeConfig],
+    should_use_incremental_field: bool,
+    db_incremental_field_last_value: Any,
+) -> Iterator[list[dict[str, Any]]]:
+    """Chunk `/api/events` into ascending from/to windows and yield each chunk's events.
+
+    The endpoint has no pagination — the window bounds the response — so wide ranges are walked in
+    fixed chunks. Chunk boundaries are inclusive on both requests, and an incremental run restarts
+    exactly at the watermark, so boundary events are re-fetched and merge dedupes them on
+    `eventId`. Ongoing events that started before the window are returned in every chunk they are
+    active in; the merge refreshes their mutable `state`/`end` fields.
+    """
+    now_ms = int(datetime.now(UTC).timestamp() * 1000)
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    watermark = _to_epoch_ms(db_incremental_field_last_value) if should_use_incremental_field else None
+    if resume is not None and resume.events_window_from is not None:
+        window_from = resume.events_window_from
+        logger.debug(f"Instana: resuming events from window_from={window_from}")
+    elif watermark is not None:
+        # A future-dated watermark (bad clock upstream) would build an empty forward window every
+        # run; clamping to now keeps the sync self-healing.
+        window_from = min(watermark, now_ms)
+    else:
+        window_from = now_ms - EVENTS_DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000
+
+    while window_from < now_ms:
+        window_to = min(window_from + EVENTS_WINDOW_CHUNK_MS, now_ms)
+        url = _build_url(root, config.path, {"from": window_from, "to": window_to})
+        items = _extract_items(_fetch(session, url, logger), config)
+
+        if items:
+            yield items
+
+        if window_to >= now_ms:
+            break
+        # Save AFTER yielding, and only while more windows remain, so a crash re-fetches the last
+        # chunk rather than skipping it — merge dedupes on the primary key.
+        resumable_source_manager.save_state(InstanaResumeConfig(events_window_from=window_to))
+        window_from = window_to
+
+
+def _get_paged_rows(
+    session: requests.Session,
+    root: str,
+    config: InstanaEndpointConfig,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[InstanaResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    """Walk a page/pageSize-paginated application-monitoring catalog.
+
+    The OpenAPI spec doesn't document the first page index, so the first request omits `page` and
+    the server's default page is read back from the response body (ApplicationResult et al. echo
+    `page`), making the walk correct for either indexing base.
+    """
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    page = resume.next_page if resume is not None else None
+    if page is not None:
+        logger.debug(f"Instana: resuming {config.name} from page={page}")
+
+    fetched = 0
+    while True:
+        params: dict[str, Any] = {"pageSize": PAGE_SIZE}
+        if page is not None:
+            params["page"] = page
+        url = _build_url(root, config.path, params)
+        data = _fetch(session, url, logger)
+
+        items = _extract_items(data, config)
+        if not items:
+            break
+
+        yield items
+        fetched += len(items)
+
+        current_page = data.get("page") if isinstance(data, dict) else None
+        total_hits = data.get("totalHits") if isinstance(data, dict) else None
+        if len(items) < PAGE_SIZE:
+            break
+        if isinstance(total_hits, int) and fetched >= total_hits:
+            break
+
+        next_page = (current_page if isinstance(current_page, int) else page or 1) + 1
+        resumable_source_manager.save_state(InstanaResumeConfig(next_page=next_page))
+        page = next_page
+
+
+def _get_list_rows(
+    session: requests.Session,
+    root: str,
+    config: InstanaEndpointConfig,
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    """Fetch a single-shot list endpoint (websites, alerting settings, snapshots)."""
+    url = _build_url(root, config.path, dict(config.extra_params))
+    items = _extract_items(_fetch(session, url, logger), config)
+    if config.name == "infrastructure_snapshots" and len(items) >= SNAPSHOTS_MAX_SIZE:
+        logger.warning(
+            f"Instana: infrastructure_snapshots returned {len(items)} items, hitting the size cap "
+            f"({SNAPSHOTS_MAX_SIZE}) — the inventory may be truncated"
+        )
+    if items:
+        yield items
+
+
+def get_rows(
+    base_url: str,
+    api_token: str,
+    endpoint: str,
+    team_id: int,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[InstanaResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> Iterator[list[dict[str, Any]]]:
+    config = INSTANA_ENDPOINTS[endpoint]
+    root = normalize_base_url(base_url)
+    _check_host(base_url, team_id)
+
+    # One tracked session reused across every request; the token is redacted from logged URLs and
+    # captured samples, and redirects are never followed (SSRF boundary for user-supplied hosts).
+    session = make_tracked_session(headers=_headers(api_token), redact_values=(api_token,), allow_redirects=False)
+
+    if config.is_events:
+        yield from _get_event_rows(
+            session,
+            root,
+            config,
+            logger,
+            resumable_source_manager,
+            should_use_incremental_field,
+            db_incremental_field_last_value,
+        )
+    elif config.pagination == "page":
+        yield from _get_paged_rows(session, root, config, logger, resumable_source_manager)
+    else:
+        yield from _get_list_rows(session, root, config, logger)
+
+
+def instana_source(
+    base_url: str,
+    api_token: str,
+    endpoint: str,
+    team_id: int,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[InstanaResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = INSTANA_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            base_url=base_url,
+            api_token=api_token,
+            endpoint=endpoint,
+            team_id=team_id,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        ),
+        primary_keys=[config.primary_key],
+        # Event windows ascend, so batches arrive in (chunk-level) ascending `start` order; the
+        # catalog endpoints are full refresh where the watermark is unused.
+        sort_mode="asc",
+        partition_count=1,
+        partition_size=1,
+        # Instana timestamps are epoch-ms integers rather than ISO datetimes, so there is no safe
+        # datetime partition key — tables are left unpartitioned.
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
@@ -18,6 +18,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.instana.se
     EVENTS_DEFAULT_LOOKBACK_DAYS,
     EVENTS_WINDOW_CHUNK_MS,
     INSTANA_ENDPOINTS,
+    MAX_CATALOG_PAGES,
     PAGE_SIZE,
     SNAPSHOTS_MAX_SIZE,
     InstanaEndpointConfig,
@@ -43,6 +44,7 @@ MAX_DOWNLOAD_SECONDS = 300
 HOST_NOT_ALLOWED_ERROR = "Instana base URL is not allowed"
 RESPONSE_TOO_LARGE_ERROR = "Instana response body was too large"
 RESPONSE_TOO_SLOW_ERROR = "Instana response download was too slow"
+PAGINATION_LIMIT_ERROR = "Instana catalog pagination exceeded the page limit"
 
 
 class InstanaRetryableError(Exception):
@@ -58,6 +60,10 @@ class InstanaResponseTooLargeError(Exception):
 
 
 class InstanaResponseTooSlowError(Exception):
+    pass
+
+
+class InstanaPaginationLimitError(Exception):
     pass
 
 
@@ -293,12 +299,21 @@ def _get_paged_rows(
         logger.debug(f"Instana: resuming {config.name} from page={page}")
 
     fetched = 0
+    pages_walked = 0
     while True:
+        # A self-hosted host can return a full page forever while omitting `totalHits`, so the
+        # termination conditions below never trip; bound the walk so the loop (and its ingestion)
+        # can't run for the whole activity. Non-retryable — the same host replays the same loop.
+        if pages_walked >= MAX_CATALOG_PAGES:
+            raise InstanaPaginationLimitError(
+                f"{PAGINATION_LIMIT_ERROR}: stopped after {MAX_CATALOG_PAGES} pages for {config.name}"
+            )
         params: dict[str, Any] = {"pageSize": PAGE_SIZE}
         if page is not None:
             params["page"] = page
         url = _build_url(root, config.path, params)
         data = _fetch(session, url, logger)
+        pages_walked += 1
 
         items = _extract_items(data, config)
         if not items:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
@@ -1,3 +1,5 @@
+import json
+import time
 import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime
@@ -24,7 +26,20 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.instana.se
 REQUEST_TIMEOUT_SECONDS = 60
 MAX_RETRY_ATTEMPTS = 5
 
+# The base URL is customer-controlled, so a body must never be buffered unbounded: requests reads
+# the whole response into memory by default, and the read timeout only guards idle gaps between
+# reads, not a steady large (or gzip-expanded) transfer. Cap what we read into memory — generous
+# for any real Instana page, anything past it is refused.
+MAX_RESPONSE_BYTES = 256 * 1024 * 1024
+RESPONSE_CHUNK_BYTES = 256 * 1024
+# Wall-clock budget for downloading one response body. The per-read timeout can't stop a host that
+# dribbles the body slowly enough to stay under it while holding a shared worker open. 256 MiB in
+# 300s is a ~0.85 MiB/s floor — far below any real API response, far above a slow-drip stall.
+MAX_DOWNLOAD_SECONDS = 300
+
 HOST_NOT_ALLOWED_ERROR = "Instana base URL is not allowed"
+RESPONSE_TOO_LARGE_ERROR = "Instana response body was too large"
+RESPONSE_TOO_SLOW_ERROR = "Instana response download was too slow"
 
 
 class InstanaRetryableError(Exception):
@@ -33,6 +48,41 @@ class InstanaRetryableError(Exception):
 
 class InstanaHostNotAllowedError(Exception):
     pass
+
+
+class InstanaResponseTooLargeError(Exception):
+    pass
+
+
+class InstanaResponseTooSlowError(Exception):
+    pass
+
+
+def _read_capped_body(response: requests.Response) -> bytes:
+    """Stream the body into memory, aborting past MAX_RESPONSE_BYTES or MAX_DOWNLOAD_SECONDS.
+
+    The host is customer-controlled, so a body must never be buffered unbounded (size cap) nor be
+    allowed to hold the connection open indefinitely by dribbling under the per-read timeout (time
+    cap). Both are non-retryable: re-fetching the same request yields the same oversized/slow body.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    deadline = time.monotonic() + MAX_DOWNLOAD_SECONDS
+    try:
+        for chunk in response.iter_content(chunk_size=RESPONSE_CHUNK_BYTES):
+            if time.monotonic() > deadline:
+                raise InstanaResponseTooSlowError(
+                    f"{RESPONSE_TOO_SLOW_ERROR}: exceeded {MAX_DOWNLOAD_SECONDS}s download budget"
+                )
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > MAX_RESPONSE_BYTES:
+                raise InstanaResponseTooLargeError(f"{RESPONSE_TOO_LARGE_ERROR}: exceeded {MAX_RESPONSE_BYTES} bytes")
+            chunks.append(chunk)
+    finally:
+        response.close()
+    return b"".join(chunks)
 
 
 @dataclasses.dataclass
@@ -116,12 +166,17 @@ def validate_credentials(base_url: str, api_token: str, team_id: int | None = No
         _check_host(base_url, team_id)
     url = _build_url(root, "/api/instana/version", {})
     try:
+        # stream=True so a customer-controlled host can't force us to buffer an unbounded probe
+        # body; we only need the status, so read nothing and close immediately.
         response = make_tracked_session(allow_redirects=False, redact_values=(api_token,)).get(
-            url, headers=_headers(api_token), timeout=10
+            url, headers=_headers(api_token), timeout=10, stream=True
         )
     except requests.exceptions.RequestException:
         return False, None
-    return response.status_code == 200, response.status_code
+    try:
+        return response.status_code == 200, response.status_code
+    finally:
+        response.close()
 
 
 def _fetch(
@@ -136,18 +191,24 @@ def _fetch(
         reraise=True,
     )
     def fetch_once() -> Any:
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        # stream=True so the body isn't buffered until we cap it — see _read_capped_body.
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS, stream=True)
 
         # Instana rate-limits to 5000 calls/hour and answers excess with 429; transient 5xx are
         # retryable too. Back off and retry rather than failing the sync.
         if response.status_code == 429 or response.status_code >= 500:
+            response.close()
             raise InstanaRetryableError(f"Instana API error (retryable): status={response.status_code}, url={url}")
 
+        body = _read_capped_body(response)
+
         if not response.ok:
-            logger.error(f"Instana API error: status={response.status_code}, body={response.text}, url={url}")
+            logger.error(
+                f"Instana API error: status={response.status_code}, body={body.decode(errors='replace')}, url={url}"
+            )
             response.raise_for_status()
 
-        return response.json()
+        return json.loads(body or b"null")
 
     return fetch_once()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
@@ -32,6 +32,9 @@ MAX_RETRY_ATTEMPTS = 5
 # for any real Instana page, anything past it is refused.
 MAX_RESPONSE_BYTES = 256 * 1024 * 1024
 RESPONSE_CHUNK_BYTES = 256 * 1024
+# Error bodies are customer-controlled and can be as large as the response cap, so never
+# interpolate the whole thing into a log event — log a small decoded preview plus the byte length.
+ERROR_BODY_LOG_PREVIEW_BYTES = 8 * 1024
 # Wall-clock budget for downloading one response body. The per-read timeout can't stop a host that
 # dribbles the body slowly enough to stay under it while holding a shared worker open. 256 MiB in
 # 300s is a ~0.85 MiB/s floor — far below any real API response, far above a slow-drip stall.
@@ -203,8 +206,10 @@ def _fetch(
         body = _read_capped_body(response)
 
         if not response.ok:
+            preview = body[:ERROR_BODY_LOG_PREVIEW_BYTES].decode(errors="replace")
             logger.error(
-                f"Instana API error: status={response.status_code}, body={body.decode(errors='replace')}, url={url}"
+                f"Instana API error: status={response.status_code}, body_bytes={len(body)}, "
+                f"body_preview={preview}, url={url}"
             )
             response.raise_for_status()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/instana.py
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.instana.se
     EVENTS_WINDOW_CHUNK_MS,
     INSTANA_ENDPOINTS,
     MAX_CATALOG_PAGES,
+    MAX_CATALOG_WALK_SECONDS,
     PAGE_SIZE,
     SNAPSHOTS_MAX_SIZE,
     InstanaEndpointConfig,
@@ -300,10 +301,18 @@ def _get_paged_rows(
 
     fetched = 0
     pages_walked = 0
+    walk_deadline = time.monotonic() + MAX_CATALOG_WALK_SECONDS
     while True:
         # A self-hosted host can return a full page forever while omitting `totalHits`, so the
         # termination conditions below never trip; bound the walk so the loop (and its ingestion)
-        # can't run for the whole activity. Non-retryable — the same host replays the same loop.
+        # can't run for the whole activity. Both bounds are non-retryable — the same host replays
+        # the same loop. The wall-clock budget is the effective bound: a slow host can stay under
+        # the page cap while streaming each page for MAX_DOWNLOAD_SECONDS, so pages alone wouldn't
+        # cap worker time.
+        if time.monotonic() > walk_deadline:
+            raise InstanaPaginationLimitError(
+                f"{PAGINATION_LIMIT_ERROR}: exceeded {MAX_CATALOG_WALK_SECONDS}s walk budget for {config.name}"
+            )
         if pages_walked >= MAX_CATALOG_PAGES:
             raise InstanaPaginationLimitError(
                 f"{PAGINATION_LIMIT_ERROR}: stopped after {MAX_CATALOG_PAGES} pages for {config.name}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/settings.py
@@ -1,0 +1,119 @@
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
+
+# Instana's paginated application-monitoring catalogs accept a `pageSize` param; their analyze
+# endpoints cap page sizes at 200, so stay at that known-safe value here too.
+PAGE_SIZE = 200
+
+# `/api/events` has no pagination — the window itself bounds the response — so wide ranges must be
+# chunked. One-day chunks keep responses small while the first sync stays at ~30 requests.
+EVENTS_WINDOW_CHUNK_MS = 24 * 60 * 60 * 1000
+
+# First sync / full refresh reaches back this far. Instana retains events for a limited window
+# (typically ~31 days), so asking for more returns nothing extra.
+EVENTS_DEFAULT_LOOKBACK_DAYS = 30
+
+# `/api/infrastructure-monitoring/snapshots` has a `size` cap instead of pagination. The window
+# only needs to cover entities currently reporting, so keep it short.
+SNAPSHOTS_WINDOW_MS = 60 * 60 * 1000
+SNAPSHOTS_MAX_SIZE = 1000
+
+PaginationStyle = Literal["page", "none"]
+
+
+@dataclass
+class InstanaEndpointConfig:
+    name: str
+    path: str
+    # Key in the response body holding the list of records. ``None`` means the body itself is the list.
+    data_path: Optional[str] = None
+    primary_key: str = "id"
+    pagination: PaginationStyle = "none"
+    # Only `events` filters server-side (from/to epoch-ms window on the event `start`); everything
+    # else is a config/topology catalog with no updated-since cursor, so it ships full refresh.
+    is_events: bool = False
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    # Extra query params sent on every request.
+    extra_params: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def supports_incremental(self) -> bool:
+        return self.is_events
+
+
+def _start_incremental_fields() -> list[IncrementalField]:
+    # Instana timestamps are epoch milliseconds (int64), not ISO datetimes.
+    return [
+        {
+            "label": "start",
+            "type": IncrementalFieldType.Integer,
+            "field": "start",
+            "field_type": IncrementalFieldType.Integer,
+        }
+    ]
+
+
+# Endpoint catalog, verified against the official OpenAPI spec
+# (https://instana.github.io/openapi/openapi.yaml). Instana has no Airbyte/Fivetran connector to
+# mirror, so coverage follows what the UI surfaces: events, the application-monitoring catalogs
+# (applications/services/endpoints), website + synthetic monitoring configs, alerting settings,
+# and the infrastructure snapshot inventory. Metric time-series and trace analytics endpoints are
+# POST-with-body cursor APIs and are intentionally out of scope for the first release.
+INSTANA_ENDPOINTS: dict[str, InstanaEndpointConfig] = {
+    "events": InstanaEndpointConfig(
+        name="events",
+        path="/api/events",
+        primary_key="eventId",
+        is_events=True,
+        incremental_fields=_start_incremental_fields(),
+    ),
+    "applications": InstanaEndpointConfig(
+        name="applications",
+        path="/api/application-monitoring/applications",
+        data_path="items",
+        pagination="page",
+    ),
+    "services": InstanaEndpointConfig(
+        name="services",
+        path="/api/application-monitoring/services",
+        data_path="items",
+        pagination="page",
+    ),
+    "endpoints": InstanaEndpointConfig(
+        name="endpoints",
+        path="/api/application-monitoring/applications/services/endpoints",
+        data_path="items",
+        pagination="page",
+    ),
+    "websites": InstanaEndpointConfig(
+        name="websites",
+        path="/api/website-monitoring/config",
+    ),
+    "synthetic_tests": InstanaEndpointConfig(
+        name="synthetic_tests",
+        path="/api/synthetics/settings/tests",
+    ),
+    "alerting_channels": InstanaEndpointConfig(
+        name="alerting_channels",
+        path="/api/events/settings/alertingChannels",
+    ),
+    "alert_configs": InstanaEndpointConfig(
+        name="alert_configs",
+        path="/api/events/settings/alerts",
+    ),
+    "infrastructure_snapshots": InstanaEndpointConfig(
+        name="infrastructure_snapshots",
+        path="/api/infrastructure-monitoring/snapshots",
+        data_path="items",
+        primary_key="snapshotId",
+        extra_params={"windowSize": str(SNAPSHOTS_WINDOW_MS), "size": str(SNAPSHOTS_MAX_SIZE)},
+    ),
+}
+
+ENDPOINTS = tuple(INSTANA_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in INSTANA_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/settings.py
@@ -7,6 +7,12 @@ from products.warehouse_sources.backend.types import IncrementalField, Increment
 # endpoints cap page sizes at 200, so stay at that known-safe value here too.
 PAGE_SIZE = 200
 
+# A self-hosted server the user controls can return a full page on every request while never
+# signalling the end of pagination, keeping the catalog walk (and its ingestion) running for the
+# whole activity. Cap the pages walked and fail non-retryably past it — far above any real catalog
+# (10k pages x 200 = 2M records), so a legitimate inventory is never truncated.
+MAX_CATALOG_PAGES = 10_000
+
 # `/api/events` has no pagination — the window itself bounds the response — so wide ranges must be
 # chunked. One-day chunks keep responses small while the first sync stays at ~30 requests.
 EVENTS_WINDOW_CHUNK_MS = 24 * 60 * 60 * 1000

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/settings.py
@@ -9,8 +9,15 @@ PAGE_SIZE = 200
 
 # A self-hosted server the user controls can return a full page on every request while never
 # signalling the end of pagination, keeping the catalog walk (and its ingestion) running for the
-# whole activity. Cap the pages walked and fail non-retryably past it — far above any real catalog
-# (10k pages x 200 = 2M records), so a legitimate inventory is never truncated.
+# whole activity. Two independent bounds stop the walk and fail non-retryably:
+#
+#  - A cumulative wall-clock budget is the effective bound. A page count alone doesn't cap worker
+#    time — each page may stream for MAX_DOWNLOAD_SECONDS, so a slow host could stay under a page
+#    cap yet hold the worker for days. 30 minutes is far longer than any real catalog walk (which
+#    is minutes) but far below the import activity timeout, so a slow-drip host is evicted quickly.
+#  - A page ceiling is a secondary record/memory bound (10k pages x 200 = 2M records), far above
+#    any real catalog, so a legitimate inventory is never truncated.
+MAX_CATALOG_WALK_SECONDS = 30 * 60
 MAX_CATALOG_PAGES = 10_000
 
 # `/api/events` has no pagination — the window itself bounds the response — so wide ranges must be

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/source.py
@@ -1,22 +1,54 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import InstanaSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.instana import (
+    InstanaHostNotAllowedError,
+    InstanaResumeConfig,
+    instana_source,
+    validate_credentials as validate_instana_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.settings import (
+    ENDPOINTS,
+    EVENTS_DEFAULT_LOOKBACK_DAYS,
+    INCREMENTAL_FIELDS,
+    INSTANA_ENDPOINTS,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class InstanaSource(SimpleSource[InstanaSourceConfig]):
+class InstanaSource(ResumableSource[InstanaSourceConfig, InstanaResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.INSTANA
+
+    @property
+    def connection_host_fields(self) -> list[str]:
+        # The API token is sent to whatever host `base_url` points at, so retargeting it must
+        # re-require the token (prevents credential exfiltration to another host).
+        return ["base_url"]
 
     @property
     def get_source_config(self) -> SourceConfig:
@@ -24,7 +56,119 @@ class InstanaSource(SimpleSource[InstanaSourceConfig]):
             name=SchemaExternalDataSourceType.INSTANA,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="IBM Instana Observability",
+            releaseStatus=ReleaseStatus.ALPHA,
+            keywords=["ibm", "apm", "observability", "monitoring"],
+            caption="""Enter your Instana tenant URL and API token to pull your Instana data into the PostHog Data warehouse.
+
+Your base URL is the address you use to open the Instana UI, e.g. `https://unit-tenant.instana.io` (or your self-hosted domain). Create an API token under **Settings → Team Settings → API Tokens**; the token's permission scopes control which tables can be synced.""",
             iconPath="/static/services/instana.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/instana",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="base_url",
+                        label="Base URL",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="https://unit-tenant.instana.io",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="api_token",
+                        label="API token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.instana.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # 401/403 surface as a requests HTTPError when `_fetch` calls `raise_for_status()`.
+            # Retrying can never fix a credential/permission problem, so fail the sync. The host is
+            # per-tenant, so match only the stable status text.
+            "401 Client Error: Unauthorized": "Your Instana API token is invalid or has been revoked. Create a new API token under Settings → Team Settings → API Tokens, then reconnect.",
+            "403 Client Error: Forbidden": "Your Instana API token is missing the permission scopes needed to sync this data. Grant the required scopes on the token, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: InstanaSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        def _build_schema(endpoint: str) -> SourceSchema:
+            endpoint_config = INSTANA_ENDPOINTS[endpoint]
+            return SourceSchema(
+                name=endpoint,
+                supports_incremental=endpoint_config.supports_incremental,
+                # Events mutate after creation (`state` and `end` change while an issue is open),
+                # so append mode would materialize each update as a duplicate row — merge only.
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                description=(
+                    f"Only syncs the last {EVENTS_DEFAULT_LOOKBACK_DAYS} days on initial sync"
+                    if endpoint == "events"
+                    else None
+                ),
+            )
+
+        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: InstanaSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        try:
+            ok, status_code = validate_instana_credentials(config.base_url, config.api_token, team_id)
+        except (ValueError, InstanaHostNotAllowedError) as e:
+            return False, str(e)
+
+        if ok:
+            return True, None
+        if status_code == 401:
+            return False, "Invalid Instana API token"
+        # A 403 means the token is genuine but lacks the probed endpoint's scope — users may
+        # legitimately only grant scopes for the tables they want to sync, so accept it at
+        # source-create. Sync-time 403s are handled by `get_non_retryable_errors`.
+        if status_code == 403:
+            return True, None
+        return False, "Could not connect to Instana with the provided base URL and API token"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[InstanaResumeConfig]:
+        return ResumableSourceManager[InstanaResumeConfig](inputs, InstanaResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: InstanaSourceConfig,
+        resumable_source_manager: ResumableSourceManager[InstanaResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return instana_source(
+            base_url=config.base_url,
+            api_token=config.api_token,
+            endpoint=inputs.schema_name,
+            team_id=inputs.team_id,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/source.py
@@ -22,6 +22,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import InstanaSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.instana.instana import (
+    PAGINATION_LIMIT_ERROR,
     RESPONSE_TOO_LARGE_ERROR,
     RESPONSE_TOO_SLOW_ERROR,
     InstanaHostNotAllowedError,
@@ -104,6 +105,7 @@ Your base URL is the address you use to open the Instana UI, e.g. `https://unit-
             "403 Client Error: Forbidden": "Your Instana API token is missing the permission scopes needed to sync this data. Grant the required scopes on the token, then reconnect.",
             RESPONSE_TOO_LARGE_ERROR: "Instana returned a response that was too large to process. Please contact support if this persists.",
             RESPONSE_TOO_SLOW_ERROR: "Instana took too long to send a response. Check that the base URL points at a healthy Instana instance, then reconnect.",
+            PAGINATION_LIMIT_ERROR: "Instana returned an unexpectedly large catalog that exceeded the pagination limit. Please contact support if this persists.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/source.py
@@ -22,6 +22,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import InstanaSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.instana.instana import (
+    RESPONSE_TOO_LARGE_ERROR,
+    RESPONSE_TOO_SLOW_ERROR,
     InstanaHostNotAllowedError,
     InstanaResumeConfig,
     instana_source,
@@ -100,6 +102,8 @@ Your base URL is the address you use to open the Instana UI, e.g. `https://unit-
             # per-tenant, so match only the stable status text.
             "401 Client Error: Unauthorized": "Your Instana API token is invalid or has been revoked. Create a new API token under Settings → Team Settings → API Tokens, then reconnect.",
             "403 Client Error: Forbidden": "Your Instana API token is missing the permission scopes needed to sync this data. Grant the required scopes on the token, then reconnect.",
+            RESPONSE_TOO_LARGE_ERROR: "Instana returned a response that was too large to process. Please contact support if this persists.",
+            RESPONSE_TOO_SLOW_ERROR: "Instana took too long to send a response. Check that the base URL points at a healthy Instana instance, then reconnect.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
@@ -254,6 +254,31 @@ class TestPagedRows:
             with pytest.raises(inst.InstanaPaginationLimitError):
                 _run_get_rows("applications", [full_page])
 
+    def test_pagination_walk_stops_at_time_budget(self) -> None:
+        # A slow host can stay under the per-page limits (and the page cap) while holding the worker,
+        # so the walk must also stop on a cumulative wall-clock budget. Fetch is stubbed to isolate
+        # the loop from the body-reader's own clock; monotonic advances 1s per call.
+        full_page = self._page(PAGE_SIZE, page=1, total_hits=10**9)
+        ticker = iter(range(0, 10_000))
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+        manager.load_state.return_value = None
+        with (
+            mock.patch.object(inst, "MAX_CATALOG_WALK_SECONDS", 5),
+            mock.patch.object(inst.time, "monotonic", lambda: next(ticker)),
+            mock.patch.object(inst, "_fetch", return_value=full_page),
+        ):
+            with pytest.raises(inst.InstanaPaginationLimitError):
+                list(
+                    inst._get_paged_rows(
+                        mock.MagicMock(),
+                        BASE_URL,
+                        inst.INSTANA_ENDPOINTS["applications"],
+                        mock.MagicMock(),
+                        manager,
+                    )
+                )
+
 
 class TestListRows:
     def test_bare_list_body_is_yielded(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
@@ -266,6 +266,30 @@ class TestListRows:
         assert rows == [[{"snapshotId": "s1", "plugin": "host"}]]
 
 
+class TestErrorBodyLogging:
+    def test_large_error_body_is_bounded_in_log(self) -> None:
+        # A customer-controlled host can return a huge 4xx body; the log must carry only a bounded
+        # preview plus the byte length, never interpolate the whole body (log-flooding guard).
+        oversized = b"x" * (inst.ERROR_BODY_LOG_PREVIEW_BYTES + 5000)
+        resp = mock.MagicMock()
+        resp.status_code = 400
+        resp.ok = False
+        resp.iter_content.return_value = iter([oversized])
+        resp.raise_for_status.side_effect = requests.HTTPError("400")
+
+        session = mock.MagicMock()
+        session.get.return_value = resp
+        logger = mock.MagicMock()
+
+        with pytest.raises(requests.HTTPError):
+            inst._fetch(session, f"{BASE_URL}/api/events", logger)
+
+        logged = logger.error.call_args[0][0]
+        assert f"body_bytes={len(oversized)}" in logged
+        # Only the preview is interpolated, not the full body.
+        assert logged.count("x") == inst.ERROR_BODY_LOG_PREVIEW_BYTES
+
+
 class TestValidateCredentials:
     @pytest.mark.parametrize(
         ("status_code", "expected"),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
@@ -275,7 +275,7 @@ class TestErrorBodyLogging:
         resp.status_code = 400
         resp.ok = False
         resp.iter_content.return_value = iter([oversized])
-        resp.raise_for_status.side_effect = requests.HTTPError("400")
+        resp.raise_for_status.side_effect = requests.HTTPError("400", response=resp)
 
         session = mock.MagicMock()
         session.get.return_value = resp

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, date, datetime
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -27,6 +28,17 @@ BASE_URL = "https://unit-tenant.instana.io"
 
 def _patch_host_safe():
     return mock.patch.object(inst, "_is_host_safe", return_value=(True, None))
+
+
+def _make_response(status_code: int, payload: Any = None, ok: bool | None = None) -> Any:
+    """Build a streaming-response mock: `_read_capped_body` reads it via `iter_content`."""
+    resp = mock.MagicMock()
+    resp.status_code = status_code
+    resp.ok = ok if ok is not None else status_code < 400
+    body = b"" if payload is None else json.dumps(payload).encode()
+    resp.iter_content.return_value = iter([body]) if body else iter([])
+    resp.text = body.decode()
+    return resp
 
 
 class TestNormalizeBaseUrl:
@@ -97,13 +109,10 @@ def _run_get_rows(
 
     fetched_urls: list[str] = []
 
-    def fake_get(url: str, timeout: Any = None) -> Any:
+    def fake_get(url: str, timeout: Any = None, stream: bool = False) -> Any:
         fetched_urls.append(url)
-        resp = mock.MagicMock()
-        resp.status_code = 200
-        resp.ok = True
-        resp.json.return_value = pages[min(len(fetched_urls), len(pages)) - 1]
-        return resp
+        payload = pages[min(len(fetched_urls), len(pages)) - 1]
+        return _make_response(200, payload)
 
     with _patch_host_safe(), mock.patch.object(inst, "make_tracked_session") as mock_session:
         mock_session.return_value.get.side_effect = fake_get

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
@@ -1,0 +1,328 @@
+from datetime import UTC, date, datetime
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from freezegun import freeze_time
+from unittest import mock
+
+import requests
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana import instana as inst
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.instana import (
+    InstanaResumeConfig,
+    _to_epoch_ms,
+    instana_source,
+    normalize_base_url,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.settings import (
+    EVENTS_DEFAULT_LOOKBACK_DAYS,
+    EVENTS_WINDOW_CHUNK_MS,
+    PAGE_SIZE,
+)
+
+BASE_URL = "https://unit-tenant.instana.io"
+
+
+def _patch_host_safe():
+    return mock.patch.object(inst, "_is_host_safe", return_value=(True, None))
+
+
+class TestNormalizeBaseUrl:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("https://unit-tenant.instana.io", "https://unit-tenant.instana.io"),
+            ("unit-tenant.instana.io", "https://unit-tenant.instana.io"),
+            ("  https://unit-tenant.instana.io/  ", "https://unit-tenant.instana.io"),
+            # http is upgraded so the token never travels in plaintext.
+            ("http://selfhosted.example.com", "https://selfhosted.example.com"),
+            # Paths/queries are dropped so endpoint paths always join against the bare host.
+            ("https://unit-tenant.instana.io/some/path?q=1", "https://unit-tenant.instana.io"),
+            ("https://selfhosted.example.com:8443", "https://selfhosted.example.com:8443"),
+        ],
+    )
+    def test_normalizes(self, raw: str, expected: str) -> None:
+        assert normalize_base_url(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "   ",
+            "https://",
+            "ftp://unit-tenant.instana.io",
+            # Embedded credentials could smuggle the request elsewhere.
+            "https://user:pass@evil.example.com",
+        ],
+    )
+    def test_rejects_invalid(self, raw: str) -> None:
+        with pytest.raises(ValueError):
+            normalize_base_url(raw)
+
+
+class TestToEpochMs:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (1767225600000, 1767225600000),
+            (1767225600000.0, 1767225600000),
+            ("1767225600000", 1767225600000),
+            (datetime(2026, 1, 1, tzinfo=UTC), 1767225600000),
+            (datetime(2026, 1, 1), 1767225600000),  # naive treated as UTC
+            (date(2026, 1, 1), 1767225600000),
+            ("not-a-number", None),
+            (None, None),
+            (True, None),
+        ],
+    )
+    def test_coercion(self, value: Any, expected: int | None) -> None:
+        assert _to_epoch_ms(value) == expected
+
+
+def _run_get_rows(
+    endpoint: str,
+    pages: list[Any],
+    can_resume: bool = False,
+    resume_state: InstanaResumeConfig | None = None,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> tuple[list[Any], list[InstanaResumeConfig], list[str]]:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = can_resume
+    manager.load_state.return_value = resume_state
+    saved: list[InstanaResumeConfig] = []
+    manager.save_state.side_effect = saved.append
+
+    fetched_urls: list[str] = []
+
+    def fake_get(url: str, timeout: Any = None) -> Any:
+        fetched_urls.append(url)
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.ok = True
+        resp.json.return_value = pages[min(len(fetched_urls), len(pages)) - 1]
+        return resp
+
+    with _patch_host_safe(), mock.patch.object(inst, "make_tracked_session") as mock_session:
+        mock_session.return_value.get.side_effect = fake_get
+        rows = list(
+            inst.get_rows(
+                base_url=BASE_URL,
+                api_token="token",
+                endpoint=endpoint,
+                team_id=1,
+                logger=mock.MagicMock(),
+                resumable_source_manager=manager,
+                should_use_incremental_field=should_use_incremental_field,
+                db_incremental_field_last_value=db_incremental_field_last_value,
+            )
+        )
+    return rows, saved, fetched_urls
+
+
+def _query(url: str) -> dict[str, list[str]]:
+    return parse_qs(urlparse(url).query)
+
+
+@freeze_time("2026-01-10T00:00:00Z")
+class TestEventRows:
+    NOW_MS = 1768003200000
+
+    def test_incremental_run_chunks_from_watermark(self) -> None:
+        watermark = self.NOW_MS - int(1.5 * EVENTS_WINDOW_CHUNK_MS)
+        pages = [[{"eventId": "a", "start": watermark + 1}]]
+        rows, saved, fetched = _run_get_rows(
+            "events",
+            pages,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=watermark,
+        )
+
+        assert len(fetched) == 2
+        first, second = _query(fetched[0]), _query(fetched[1])
+        assert first["from"] == [str(watermark)]
+        assert first["to"] == [str(watermark + EVENTS_WINDOW_CHUNK_MS)]
+        assert second["from"] == [str(watermark + EVENTS_WINDOW_CHUNK_MS)]
+        assert second["to"] == [str(self.NOW_MS)]
+        # Both chunks yielded rows.
+        assert len(rows) == 2
+        # State saved only between chunks (after the yield), never after the final chunk.
+        assert [s.events_window_from for s in saved] == [watermark + EVENTS_WINDOW_CHUNK_MS]
+
+    def test_first_sync_reaches_back_the_default_lookback(self) -> None:
+        rows, _saved, fetched = _run_get_rows("events", [[]])
+
+        expected_from = self.NOW_MS - EVENTS_DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000
+        assert _query(fetched[0])["from"] == [str(expected_from)]
+        assert _query(fetched[-1])["to"] == [str(self.NOW_MS)]
+        assert len(fetched) == EVENTS_DEFAULT_LOOKBACK_DAYS
+        # Empty windows keep advancing without yielding.
+        assert rows == []
+
+    def test_resume_starts_at_saved_window(self) -> None:
+        resume_from = self.NOW_MS - EVENTS_WINDOW_CHUNK_MS // 2
+        _rows, _saved, fetched = _run_get_rows(
+            "events",
+            [[]],
+            can_resume=True,
+            resume_state=InstanaResumeConfig(events_window_from=resume_from),
+        )
+
+        assert len(fetched) == 1
+        assert _query(fetched[0])["from"] == [str(resume_from)]
+
+    def test_future_watermark_is_clamped_and_makes_no_requests(self) -> None:
+        rows, saved, fetched = _run_get_rows(
+            "events",
+            [[]],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=self.NOW_MS + 10_000,
+        )
+
+        assert fetched == []
+        assert rows == []
+        assert saved == []
+
+
+class TestPagedRows:
+    def _page(self, count: int, page: int, total_hits: int) -> dict[str, Any]:
+        return {"items": [{"id": f"p{page}-{i}"} for i in range(count)], "page": page, "totalHits": total_hits}
+
+    def test_first_request_omits_page_and_follows_server_page_number(self) -> None:
+        pages = [
+            self._page(PAGE_SIZE, page=1, total_hits=PAGE_SIZE + 1),
+            self._page(1, page=2, total_hits=PAGE_SIZE + 1),
+        ]
+        rows, saved, fetched = _run_get_rows("applications", pages)
+
+        assert "page" not in _query(fetched[0])
+        assert _query(fetched[0])["pageSize"] == [str(PAGE_SIZE)]
+        assert _query(fetched[1])["page"] == ["2"]
+        assert [s.next_page for s in saved] == [2]
+        assert len(rows) == 2
+
+    def test_zero_indexed_server_does_not_skip_a_page(self) -> None:
+        # The spec doesn't document the first page index; the walk must follow the index base the
+        # server reports back rather than assuming 1-based.
+        pages = [
+            self._page(PAGE_SIZE, page=0, total_hits=PAGE_SIZE + 1),
+            self._page(1, page=1, total_hits=PAGE_SIZE + 1),
+        ]
+        _rows, _saved, fetched = _run_get_rows("applications", pages)
+
+        assert _query(fetched[1])["page"] == ["1"]
+
+    def test_short_page_terminates(self) -> None:
+        pages = [self._page(3, page=1, total_hits=3)]
+        rows, saved, fetched = _run_get_rows("services", pages)
+
+        assert len(fetched) == 1
+        assert saved == []
+        assert len(rows[0]) == 3
+
+    def test_total_hits_terminates_a_full_final_page(self) -> None:
+        pages = [self._page(PAGE_SIZE, page=1, total_hits=PAGE_SIZE)]
+        _rows, saved, fetched = _run_get_rows("endpoints", pages)
+
+        assert len(fetched) == 1
+        assert saved == []
+
+    def test_resume_starts_at_saved_page(self) -> None:
+        pages = [self._page(2, page=5, total_hits=1000)]
+        _rows, _saved, fetched = _run_get_rows(
+            "applications", pages, can_resume=True, resume_state=InstanaResumeConfig(next_page=5)
+        )
+
+        assert _query(fetched[0])["page"] == ["5"]
+
+
+class TestListRows:
+    def test_bare_list_body_is_yielded(self) -> None:
+        pages: list[Any] = [[{"id": "w1", "name": "site"}]]
+        rows, saved, fetched = _run_get_rows("websites", pages)
+
+        assert len(fetched) == 1
+        assert rows == [[{"id": "w1", "name": "site"}]]
+        assert saved == []
+
+    def test_snapshots_items_are_extracted_with_window_params(self) -> None:
+        pages: list[Any] = [{"items": [{"snapshotId": "s1", "plugin": "host"}]}]
+        rows, _saved, fetched = _run_get_rows("infrastructure_snapshots", pages)
+
+        query = _query(fetched[0])
+        assert "windowSize" in query
+        assert "size" in query
+        assert rows == [[{"snapshotId": "s1", "plugin": "host"}]]
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize(
+        ("status_code", "expected"),
+        [
+            (200, (True, 200)),
+            (401, (False, 401)),
+            (403, (False, 403)),
+            (500, (False, 500)),
+        ],
+    )
+    def test_status_mapping(self, status_code: int, expected: tuple[bool, int]) -> None:
+        response = mock.MagicMock()
+        response.status_code = status_code
+
+        with _patch_host_safe(), mock.patch.object(inst, "make_tracked_session") as mock_session:
+            mock_session.return_value.get.return_value = response
+            assert validate_credentials(BASE_URL, "token", team_id=1) == expected
+
+    def test_transport_error_returns_none_status(self) -> None:
+        with _patch_host_safe(), mock.patch.object(inst, "make_tracked_session") as mock_session:
+            mock_session.return_value.get.side_effect = requests.exceptions.ConnectionError("boom")
+            assert validate_credentials(BASE_URL, "token", team_id=1) == (False, None)
+
+    def test_blocked_host_raises(self) -> None:
+        with mock.patch.object(inst, "_is_host_safe", return_value=(False, "blocked")):
+            with pytest.raises(inst.InstanaHostNotAllowedError):
+                validate_credentials(BASE_URL, "token", team_id=1)
+
+
+class TestGetRowsHostCheck:
+    def test_blocked_host_fails_the_sync(self) -> None:
+        with mock.patch.object(inst, "_is_host_safe", return_value=(False, "blocked")):
+            with pytest.raises(inst.InstanaHostNotAllowedError):
+                list(
+                    inst.get_rows(
+                        base_url=BASE_URL,
+                        api_token="token",
+                        endpoint="websites",
+                        team_id=1,
+                        logger=mock.MagicMock(),
+                        resumable_source_manager=mock.MagicMock(),
+                    )
+                )
+
+
+class TestInstanaSourceResponse:
+    @pytest.mark.parametrize(
+        ("endpoint", "expected_pk"),
+        [
+            ("events", "eventId"),
+            ("applications", "id"),
+            ("infrastructure_snapshots", "snapshotId"),
+        ],
+    )
+    def test_source_response_shape(self, endpoint: str, expected_pk: str) -> None:
+        response = instana_source(
+            base_url=BASE_URL,
+            api_token="token",
+            endpoint=endpoint,
+            team_id=1,
+            logger=mock.MagicMock(),
+            resumable_source_manager=mock.MagicMock(),
+        )
+
+        assert response.name == endpoint
+        assert response.primary_keys == [expected_pk]
+        assert response.sort_mode == "asc"
+        # Instana timestamps are epoch-ms integers, so tables are unpartitioned.
+        assert response.partition_mode is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana.py
@@ -246,6 +246,14 @@ class TestPagedRows:
 
         assert _query(fetched[0])["page"] == ["5"]
 
+    def test_pagination_limit_aborts_runaway_walk(self) -> None:
+        # A self-hosted host can return a full page forever while omitting a reliable totalHits, so
+        # the normal termination conditions never trip; the walk must abort past MAX_CATALOG_PAGES.
+        full_page = self._page(PAGE_SIZE, page=1, total_hits=10**9)
+        with mock.patch.object(inst, "MAX_CATALOG_PAGES", 3):
+            with pytest.raises(inst.InstanaPaginationLimitError):
+                _run_get_rows("applications", [full_page])
+
 
 class TestListRows:
     def test_bare_list_body_is_yielded(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/instana/tests/test_instana_source.py
@@ -1,0 +1,189 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import InstanaSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.instana import (
+    InstanaHostNotAllowedError,
+    InstanaResumeConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.instana.source import InstanaSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+def _make_inputs(**overrides: Any) -> SourceInputs:
+    defaults: dict[str, Any] = {
+        "schema_name": "events",
+        "schema_id": "schema-1",
+        "source_id": "source-1",
+        "team_id": 123,
+        "should_use_incremental_field": False,
+        "db_incremental_field_last_value": None,
+        "db_incremental_field_earliest_value": None,
+        "incremental_field": None,
+        "incremental_field_type": None,
+        "job_id": "job-1",
+        "logger": mock.MagicMock(),
+        "reset_pipeline": False,
+    }
+    defaults.update(overrides)
+    return SourceInputs(**defaults)
+
+
+class TestInstanaSource:
+    def setup_method(self) -> None:
+        self.source = InstanaSource()
+        self.team_id = 123
+        self.config = InstanaSourceConfig(base_url="https://unit-tenant.instana.io", api_token="secret-token")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.INSTANA
+
+    def test_base_url_is_a_connection_host_field(self) -> None:
+        # Changing the base URL must force the token to be re-entered so it's never
+        # sent to a freshly-specified host.
+        assert self.source.connection_host_fields == ["base_url"]
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+
+        assert config.name.value == "Instana"
+        assert config.label == "IBM Instana Observability"
+        assert not config.unreleasedSource
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+
+        base_url_field, api_token_field = config.fields
+
+        assert isinstance(base_url_field, SourceFieldInputConfig)
+        assert base_url_field.name == "base_url"
+        assert base_url_field.type == SourceFieldInputConfigType.TEXT
+        assert base_url_field.required is True
+        assert base_url_field.secret is False
+
+        assert isinstance(api_token_field, SourceFieldInputConfig)
+        assert api_token_field.name == "api_token"
+        assert api_token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert api_token_field.required is True
+        assert api_token_field.secret is True
+
+    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error"])
+    def test_non_retryable_errors(self, expected_key: str) -> None:
+        assert any(expected_key in key for key in self.source.get_non_retryable_errors())
+
+    def test_get_schemas_incremental_flags(self) -> None:
+        schemas = {s.name: s for s in self.source.get_schemas(self.config, self.team_id)}
+
+        assert set(schemas) == set(ENDPOINTS)
+
+        assert schemas["events"].supports_incremental is True
+        # Events mutate while open (state/end change), so append mode is never offered.
+        assert schemas["events"].supports_append is False
+        assert schemas["events"].incremental_fields == [
+            {
+                "label": "start",
+                "type": "integer",
+                "field": "start",
+                "field_type": "integer",
+            }
+        ]
+        assert schemas["events"].description is not None
+
+        for name in set(ENDPOINTS) - {"events"}:
+            assert schemas[name].supports_incremental is False
+            assert schemas[name].supports_append is False
+            assert schemas[name].incremental_fields == []
+
+    def test_get_schemas_filtered_by_names(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["applications"])
+        assert [s.name for s in schemas] == ["applications"]
+
+    @pytest.mark.parametrize(
+        ("probe_result", "expected_valid"),
+        [
+            ((True, 200), True),
+            # 403 = genuine token missing the probe's scope; must not block source-create.
+            ((False, 403), True),
+            ((False, 401), False),
+            ((False, 500), False),
+            ((False, None), False),
+        ],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.instana.source.validate_instana_credentials"
+    )
+    def test_validate_credentials(
+        self,
+        mock_validate: mock.MagicMock,
+        probe_result: tuple[bool, int | None],
+        expected_valid: bool,
+    ) -> None:
+        mock_validate.return_value = probe_result
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert (error_message is None) is expected_valid
+        mock_validate.assert_called_once_with("https://unit-tenant.instana.io", "secret-token", self.team_id)
+
+    @pytest.mark.parametrize("exception", [ValueError("bad url"), InstanaHostNotAllowedError("blocked")])
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.instana.source.validate_instana_credentials"
+    )
+    def test_validate_credentials_surfaces_url_errors(
+        self, mock_validate: mock.MagicMock, exception: Exception
+    ) -> None:
+        mock_validate.side_effect = exception
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is False
+        assert error_message == str(exception)
+
+    def test_get_resumable_source_manager_bound_to_resume_config(self) -> None:
+        manager = self.source.get_resumable_source_manager(_make_inputs())
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is InstanaResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.instana.source.instana_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_source: mock.MagicMock) -> None:
+        inputs = _make_inputs(schema_name="applications", team_id=99)
+        manager = mock.MagicMock(spec=ResumableSourceManager)
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_source.assert_called_once_with(
+            base_url="https://unit-tenant.instana.io",
+            api_token="secret-token",
+            endpoint="applications",
+            team_id=99,
+            logger=inputs.logger,
+            resumable_source_manager=manager,
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+        )
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.instana.source.instana_source")
+    def test_source_for_pipeline_drops_watermark_when_incremental_disabled(self, mock_source: mock.MagicMock) -> None:
+        inputs = _make_inputs(should_use_incremental_field=False, db_incremental_field_last_value=1767225600000)
+        manager = mock.MagicMock(spec=ResumableSourceManager)
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        assert mock_source.call_args.kwargs["db_incremental_field_last_value"] is None
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.instana.source.instana_source")
+    def test_source_for_pipeline_passes_watermark_when_incremental_enabled(self, mock_source: mock.MagicMock) -> None:
+        inputs = _make_inputs(should_use_incremental_field=True, db_incremental_field_last_value=1767225600000)
+        manager = mock.MagicMock(spec=ResumableSourceManager)
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["db_incremental_field_last_value"] == 1767225600000


### PR DESCRIPTION
## Problem

The IBM Instana Observability source was scaffolded in #71137 with an empty stub hidden behind `unreleasedSource=True`. Teams using Instana want its events, application/service catalogs, and infrastructure inventory in the warehouse to track reliability trends alongside product data.

## Changes

Implements the Instana source end to end and ships it visible with `releaseStatus=ReleaseStatus.ALPHA` (the `unreleasedSource` flag is removed).

- `settings.py` declares nine endpoints, verified against the [official Instana OpenAPI spec](https://instana.github.io/openapi/openapi.yaml): `events` (incremental), plus `applications`, `services`, `endpoints`, `websites`, `synthetic_tests`, `alerting_channels`, `alert_configs`, and `infrastructure_snapshots` (full refresh — these are config/topology catalogs with no updated-since filter).
- `instana.py` is a bespoke transport on `make_tracked_session()` (no redirects, token redacted). `/api/events` has no pagination, so incremental sync walks ascending 24-hour `from`/`to` windows from the watermark on the epoch-ms `start` field, saving resumable state after each yielded chunk; first sync reaches back 30 days to match Instana's event retention. The application-monitoring catalogs use `page`/`pageSize` pagination.
- The user supplies a per-tenant base URL (SaaS or self-hosted) plus an API token (`Authorization: apiToken ...`). The URL is normalized to a bare https host, checked with `_is_host_safe` at create and sync time (SSRF), and declared in `connection_host_fields` so retargeting it re-requires the token.
- `validate_credentials` probes `/api/instana/version` and accepts a 403 at source-create, since Instana tokens are scope-limited per endpoint. 401/403 during sync are non-retryable with actionable messages.
- Adds `canonical_descriptions.py` from the spec, sets `lists_tables_without_credentials = True`, moves instana into the Implemented table in `SOURCES.md`, and regenerates `InstanaSourceConfig`.

> [!NOTE]
> Two behaviors could not be verified against a live tenant (no Instana account available): whether catalog pagination is 0- or 1-based (the spec doesn't say — the walk reads the page index back from the response body, so either base works), and the effective `size` cap on the snapshots endpoint (a hit on our cap logs a truncation warning). Both are noted in code comments. Metric time-series and trace analytics endpoints (POST-with-body cursor APIs) are intentionally out of scope for this first release.

The user-facing doc was written per the docs template, but posthog.com isn't part of this repo — it needs to land there as `contents/docs/cdp/sources/instana.md` (companion PR referenced below if opened).

## How did you test this code?

- `pytest products/warehouse_sources/.../instana/tests/` (59 tests) plus the registry-wide `test_source_categories.py` — all pass.
- `test_instana.py` (transport): base-URL normalization rejects credential-bearing/invalid URLs (token retargeting), watermark coercion to epoch ms, events windowing (chunk boundaries, resume-from-saved-window, state saved only after yield, future-watermark clamp that would otherwise wedge the sync), catalog pagination (server page-index self-heal so a 0-based server can't skip the first page, short-page and totalHits termination, resume), credential status mapping, and blocked-host failure. No existing test covered any of these paths.
- `test_instana_source.py` (source class): schema incremental flags (`events` merge-only), create-time 403 acceptance, resumable manager binding, and pipeline argument plumbing.
- Could not run a live sync against a real Instana tenant; endpoint shapes were verified against the official OpenAPI spec instead.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Doc written for posthog.com (`contents/docs/cdp/sources/instana.md`) following the canonical source-doc template; `docsUrl` points at `https://posthog.com/docs/cdp/sources/instana`. `audit_source_docs` reports no instana issues (pre-existing failures for other batch sources remain).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Implemented with Claude Code following the `implementing-warehouse-sources`, `writing-tests`, and `documenting-warehouse-sources` skills. Key decisions: downloaded and parsed the official Instana OpenAPI spec to verify endpoint paths, params, and response schemas instead of relying on documentation from memory; chose a bespoke transport over the generic REST client because `/api/events` needs window chunking rather than pagination; left all tables unpartitioned because every Instana timestamp is an epoch-ms integer, not a datetime (same reasoning as Datadog's `slos` table); marked `events` merge-only because open events mutate (`state`/`end`). Rejected shipping trace/metric analytics endpoints in v1 — they are POST-with-body cursor APIs with much higher volume, better done as a follow-up.
