### PR TITLE
fix(llm-gateway): fail fast instead of broken bedrock fallback for fable-5

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -24,6 +24,7 @@ from llm_gateway.bedrock import (
     count_tokens_with_bedrock,
     count_tokens_with_bedrock_mantle,
     ensure_bedrock_configured,
+    is_bedrock_fallback_ineligible,
     map_to_bedrock_model,
 )
 from llm_gateway.circuit_breaker import AnthropicCircuitBreaker
@@ -280,7 +281,7 @@ async def _maybe_bypass_anthropic(
     """Bypass requires the caller to have opted in via `use_bedrock_fallback`; without that
     we never silently change the upstream provider, even if Anthropic looks unhealthy.
     """
-    if breaker is None or not use_bedrock_fallback:
+    if breaker is None or not use_bedrock_fallback or is_bedrock_fallback_ineligible(model):
         return False
 
     decision = await breaker.evaluate()
@@ -439,7 +440,11 @@ async def _handle_anthropic_messages(
         billing_block = _is_anthropic_billing_block(exc)
         fallback_eligible = billing_block or not _is_breaker_success(exc.status_code)
         await _record_anthropic_outcome(breaker, success=not fallback_eligible)
-        if not use_bedrock_fallback or not fallback_eligible:
+        # Ineligible models (unmet Bedrock account prerequisites — see
+        # BEDROCK_FALLBACK_INELIGIBLE_MODELS) surface the genuine Anthropic error
+        # instead of a guaranteed second failure on Bedrock. Checked after the
+        # breaker outcome is recorded so breaker accounting is unchanged.
+        if not use_bedrock_fallback or not fallback_eligible or is_bedrock_fallback_ineligible(body.model):
             raise
 
         error_type = "billing_block" if billing_block else _anthropic_error_type(exc)

--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -101,6 +101,25 @@ BEDROCK_MODEL_IDS: Final[frozenset[str]] = frozenset(
 )
 
 
+# Models whose Bedrock fallback is known-broken until an AWS account-level
+# prerequisite is met. Fable 5 requires the Bedrock data-retention mode
+# `provider_data_share` (set via the Bedrock Data Retention API; accounts
+# default to `default`), otherwise every invocation is rejected with
+# HTTP 400 "data retention mode 'default' is not available for this model" —
+# during an Anthropic 429 burst, every fallback that reached Bedrock failed on
+# exactly that. Until the account setting is flipped, failing fast with the
+# original Anthropic error beats a guaranteed second failure and a false
+# "fallback broken" page. Remove a model from this set once its retention
+# prerequisite is verified in the account the gateway runs in.
+BEDROCK_FALLBACK_INELIGIBLE_MODELS: Final[frozenset[str]] = frozenset({"claude-fable-5"})
+
+
+def is_bedrock_fallback_ineligible(model: str) -> bool:
+    # Match dated variants too (e.g. "claude-fable-5-20260101"): eligibility is a
+    # property of the model family's Bedrock prerequisites, not the snapshot date.
+    return any(model == entry or model.startswith(f"{entry}-") for entry in BEDROCK_FALLBACK_INELIGIBLE_MODELS)
+
+
 def is_bedrock_model_id(model: str) -> bool:
     return model.startswith(BEDROCK_ANTHROPIC_MODEL_PREFIXES)
 

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -1511,6 +1511,66 @@ class TestAnthropicCircuitBreakerIntegration:
         assert mock_anthropic.call_args_list[1].kwargs["model"] == "bedrock/us.anthropic.claude-opus-4-8"
 
     @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_fallback_ineligible_model_raises_original_anthropic_error(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        install_breaker,
+    ) -> None:
+        """Fable 5 requires the Bedrock `provider_data_share` retention mode, which the
+        account doesn't have yet — a fallback attempt is a guaranteed second failure, so
+        the caller must get the genuine Anthropic error and Bedrock must not be called.
+        """
+        request_body = {"model": "claude-fable-5", "messages": [{"role": "user", "content": "Hi"}]}
+        breaker = install_breaker(bypass=False)
+        error = Exception("rate limited")
+        error.status_code = 429  # type: ignore[attr-defined]
+        error.message = "rate limited"  # type: ignore[attr-defined]
+        error.type = "rate_limit_error"  # type: ignore[attr-defined]
+        mock_anthropic.side_effect = [error]
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json=request_body,
+            headers={
+                "Authorization": "Bearer phx_test_key",
+                "X-PostHog-Use-Bedrock-Fallback": "true",
+            },
+        )
+
+        assert response.status_code == 429
+        assert mock_anthropic.call_count == 1
+        assert mock_anthropic.call_args.kwargs["model"] == "anthropic/claude-fable-5"
+        breaker.record_outcome.assert_awaited_with(success=False)
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_open_breaker_does_not_bypass_for_fallback_ineligible_model(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        install_breaker,
+        mock_response_dict: dict,
+    ) -> None:
+        request_body = {"model": "claude-fable-5", "messages": [{"role": "user", "content": "Hi"}]}
+        breaker = install_breaker(bypass=True)
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=mock_response_dict)
+        mock_anthropic.return_value = mock_response
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json=request_body,
+            headers={
+                "Authorization": "Bearer phx_test_key",
+                "X-PostHog-Use-Bedrock-Fallback": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        assert mock_anthropic.call_args.kwargs["model"] == "anthropic/claude-fable-5"
+        breaker.evaluate.assert_not_called()
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
     def test_anthropic_only_param_stripped_before_bedrock_fallback(
         self,
         mock_anthropic: MagicMock,


### PR DESCRIPTION
## Problem

The `LLMGatewayBedrockFallbackFailingCritical` alert paged today: during an Anthropic 429 burst on `claude-fable-5` (`posthog_code` traffic), every request that fell back to Bedrock **also failed**, all with the same Bedrock 400:

> `data retention mode 'default' is not available for this model`

The Bedrock fallback for Fable 5 has never worked. Per the [AWS announcement](https://aws.amazon.com/blogs/aws/anthropic-claude-fable-5-on-aws-mythos-class-capabilities-with-built-in-safeguards-now-available/) and [Bedrock data-retention docs](https://docs.aws.amazon.com/bedrock/latest/userguide/data-retention.html), Fable 5 (Mythos-class) can only be invoked when the account's Bedrock data-retention mode is set to `provider_data_share` (prompts/completions shared with Anthropic, retained up to 30 days for trust & safety). Accounts default to `default`, which Bedrock rejects for this model — it's an account-level setting via the Bedrock Data Retention API, not a request field, so no request shape from the gateway can succeed until the account is opted in. There's a matching upstream report: [anthropics/claude-code#66594](https://github.com/anthropics/claude-code/issues/66594).

So during Anthropic incidents, Fable 5 callers get a doubled failure (Anthropic error, then a guaranteed Bedrock 400) and the "fallback broadly broken" alert pages — for a fallback that cannot succeed.

## Changes

Stopgap until the account-level fix lands:

- `BEDROCK_FALLBACK_INELIGIBLE_MODELS` in `bedrock.py` (currently `{"claude-fable-5"}`, dated variants matched) with `is_bedrock_fallback_ineligible()`.
- The 429/5xx/billing fallback path in `_handle_anthropic_messages` re-raises the original Anthropic error for ineligible models instead of attempting Bedrock. Circuit-breaker accounting is unchanged (outcome recorded before the check).
- The open-breaker bypass (`_maybe_bypass_anthropic`) also refuses to route ineligible models straight to Bedrock.

**The real fix is on the AWS side** and needs a deliberate decision from this team: opt the gateway's AWS account into `provider_data_share` retention for Fable 5 via the Bedrock Data Retention API. Note what that means: Bedrock-fallback prompts/completions get shared with Anthropic for up to 30 days. Given the gateway's primary path already sends this exact traffic to Anthropic first-party, that seems acceptable — but it's a data-handling decision the team (and possibly security) should make explicitly, not something I want to smuggle in via a code PR. Once the account setting is verified, remove `claude-fable-5` from the set and the fallback works as designed.

Reviewer note: I don't work on the gateway or Bedrock day-to-day — please review the eligibility-check placement (especially breaker interaction and the streaming path) skeptically.

## How did you test this code?

- `test_fallback_ineligible_model_raises_original_anthropic_error`: Anthropic 429 on fable-5 with the fallback header returns the genuine 429, Bedrock is never called, breaker records the failure — the exact incident scenario, which previously double-failed.
- `test_open_breaker_does_not_bypass_for_fallback_ineligible_model`: an open breaker doesn't route fable-5 straight to Bedrock.
- Full suite: `tests/test_anthropic.py` — 133 passed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Investigated from the live alert: Prometheus showed 100% fallback failure isolated to `model=claude-fable-5`, Loki showed the uniform Bedrock 400, and AWS docs confirmed the account-level retention requirement.
- Skills invoked: /writing-tests.
