### PR TITLE
feat(data-warehouse): implement doppler import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -166,6 +166,7 @@ the row lists both.
 | dockerhub                        | HTTP                        | requests                                                        | ✅                          |
 | docuseal                         | HTTP                        | requests                                                        | ✅                          |
 | doit                             | HTTP                        | requests                                                        | ✅                          |
+| doppler                          | HTTP                        | requests                                                        | ✅                          |
 | drata                            | HTTP                        | requests                                                        | ✅                          |
 | dropbox_sign                     | HTTP                        | requests                                                        | ✅                          |
 | drip                             | HTTP                        | requests                                                        | ✅                          |
@@ -637,6 +638,7 @@ doesn't conflict with concurrent PRs.
 - dodopayments
 - dolibarr
 - doppler
+- drata
 - dremio
 - dropbox
 - dub

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/canonical_descriptions.py
@@ -1,0 +1,96 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "projects": {
+        "description": "A Doppler project, the top-level grouping of environments and configs for an application or service.",
+        "docs_url": "https://docs.doppler.com/reference/projects-list",
+        "columns": {
+            "id": "Unique identifier for the project.",
+            "slug": "URL-safe identifier for the project, used as the `project` parameter in API calls.",
+            "name": "Human-readable name of the project.",
+            "description": "Description of the project.",
+            "created_at": "When the project was created.",
+        },
+    },
+    "environments": {
+        "description": "An environment within a Doppler project (e.g. development, staging, production).",
+        "docs_url": "https://docs.doppler.com/reference/environments-list",
+        "columns": {
+            "id": "Identifier for the environment, unique within its project (e.g. `dev`, `stg`, `prd`).",
+            "name": "Human-readable name of the environment.",
+            "project": "Identifier of the project the environment belongs to.",
+            "initial_fetch_at": "When secrets were first fetched from an environment config.",
+            "created_at": "When the environment was created.",
+        },
+    },
+    "configs": {
+        "description": "A config within a Doppler project environment, holding a set of secrets. Secret values are not synced.",
+        "docs_url": "https://docs.doppler.com/reference/configs-list",
+        "columns": {
+            "name": "Name of the config, unique within its project.",
+            "project": "Identifier of the project the config belongs to.",
+            "environment": "Identifier of the environment the config belongs to.",
+            "root": "Whether this is the environment's root config (branch configs are non-root).",
+            "locked": "Whether the config is locked against deletion.",
+            "initial_fetch_at": "When secrets were first fetched from this config.",
+            "last_fetch_at": "When secrets were last fetched from this config.",
+            "created_at": "When the config was created.",
+        },
+    },
+    "activity_logs": {
+        "description": "Workplace activity log entries recording project, config, secret, and access changes.",
+        "docs_url": "https://docs.doppler.com/reference/activity_logs-list",
+        "columns": {
+            "id": "Unique identifier for the activity log entry.",
+            "text": "Plain-text description of the activity.",
+            "html": "HTML description of the activity.",
+            "project": "Identifier of the project the activity relates to, if any.",
+            "environment": "Identifier of the environment the activity relates to, if any.",
+            "config": "Name of the config the activity relates to, if any.",
+            "user": "The user who performed the activity (email, name, profile image).",
+            "created_at": "When the activity occurred.",
+        },
+    },
+    "workplace_users": {
+        "description": "Users belonging to the Doppler workplace, with their workplace-level access role.",
+        "docs_url": "https://docs.doppler.com/reference/users-list",
+        "columns": {
+            "id": "Unique identifier for the workplace user.",
+            "access": "The user's workplace access role (e.g. `owner`, `admin`, `collaborator`).",
+            "user": "The user's account details (email, name, username, profile image).",
+            "created_at": "When the user joined the workplace.",
+        },
+    },
+    "groups": {
+        "description": "User groups in the Doppler workplace, used to manage project access in bulk.",
+        "docs_url": "https://docs.doppler.com/reference/groups-list",
+        "columns": {
+            "slug": "Unique identifier for the group.",
+            "name": "Name of the group.",
+            "default_project_role": "The project role members of this group receive by default.",
+            "created_at": "When the group was created.",
+        },
+    },
+    "service_accounts": {
+        "description": "Machine identities in the Doppler workplace used for programmatic access.",
+        "docs_url": "https://docs.doppler.com/reference/service_accounts-list",
+        "columns": {
+            "slug": "Unique identifier for the service account.",
+            "name": "Name of the service account.",
+            "workplace_role": "The service account's workplace role and permissions.",
+            "created_at": "When the service account was created.",
+        },
+    },
+    "invites": {
+        "description": "Pending invitations to join the Doppler workplace.",
+        "docs_url": "https://docs.doppler.com/reference/invites-list",
+        "columns": {
+            "slug": "Unique identifier for the invite.",
+            "email": "Email address the invite was sent to.",
+            "workplace_role": "The workplace role the invitee will receive on acceptance.",
+            "created_at": "When the invite was sent.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/doppler.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/doppler.py
@@ -1,0 +1,273 @@
+import dataclasses
+from collections.abc import Iterator
+from datetime import UTC, date, datetime
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.settings import (
+    DEFAULT_PER_PAGE,
+    DOPPLER_ENDPOINTS,
+    DopplerEndpointConfig,
+)
+
+DOPPLER_BASE_URL = "https://api.doppler.com/v3"
+
+
+class DopplerRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class DopplerResumeConfig:
+    # Next 1-indexed page to fetch.
+    next_page: int = 1
+    # Fan-out bookmark: slug of the project currently being processed. A stable slug (not a
+    # positional index) so projects created or deleted between a crash and the retry can't resume
+    # into the wrong project. None for workplace-level endpoints.
+    project: str | None = None
+
+
+def _headers(api_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_token}", "Accept": "application/json"}
+
+
+def _build_url(path: str, params: dict[str, Any]) -> str:
+    if not params:
+        return f"{DOPPLER_BASE_URL}{path}"
+    return f"{DOPPLER_BASE_URL}{path}?{urlencode(params)}"
+
+
+def _parse_doppler_datetime(value: Any) -> datetime | None:
+    """Parse Doppler's ISO 8601 `Z`-suffixed timestamps into an aware datetime."""
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _coerce_watermark(value: Any) -> datetime | None:
+    """Normalize the stored incremental watermark into an aware datetime for row comparisons."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    if isinstance(value, date):
+        return datetime.combine(value, datetime.min.time(), tzinfo=UTC)
+    if isinstance(value, str):
+        return _parse_doppler_datetime(value)
+    return None
+
+
+@retry(
+    # Doppler enforces plan-tiered per-minute read limits and returns 429 with a retry-after
+    # header when exceeded; transient 5xx are retryable too.
+    retry=retry_if_exception_type((DopplerRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=2, max=60),
+    reraise=True,
+)
+def _fetch_page(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
+    response = session.get(url, headers=headers, timeout=60)
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise DopplerRetryableError(f"Doppler API error (retryable): status={response.status_code}, url={url}")
+
+    if not response.ok:
+        logger.error(f"Doppler API error: status={response.status_code}, body={response.text}, url={url}")
+        response.raise_for_status()
+
+    return response.json()
+
+
+def _iter_project_slugs(
+    session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger
+) -> Iterator[str]:
+    page = 1
+    while True:
+        url = _build_url("/projects", {"page": page, "per_page": DEFAULT_PER_PAGE})
+        projects = _fetch_page(session, url, headers, logger).get("projects") or []
+        for project in projects:
+            slug = project.get("slug") or project.get("id")
+            if slug:
+                yield slug
+
+        if len(projects) < DEFAULT_PER_PAGE:
+            break
+        page += 1
+
+
+def _get_fan_out_rows(
+    session: requests.Session,
+    headers: dict[str, str],
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[DopplerResumeConfig],
+    config: DopplerEndpointConfig,
+    resume: DopplerResumeConfig | None,
+) -> Iterator[Any]:
+    """Fan out over every project for endpoints that require a `project` query param.
+
+    Rows already carry a `project` field in Doppler's responses, so no parent injection is needed
+    for the composite primary keys.
+    """
+    project_slugs = list(_iter_project_slugs(session, headers, logger))
+
+    # Resolve the saved project bookmark to the slice of projects still to process. If the
+    # bookmarked project no longer exists (deleted between runs), start over from the first
+    # project — merge dedupes the re-pulled rows on the primary key.
+    remaining = project_slugs
+    resume_page = 1
+    if resume is not None and resume.project is not None and resume.project in project_slugs:
+        remaining = project_slugs[project_slugs.index(resume.project) :]
+        resume_page = resume.next_page or 1
+        logger.debug(f"Doppler: resuming {config.name} from project={resume.project}, page={resume_page}")
+
+    for index, project_slug in enumerate(remaining):
+        page = resume_page
+        resume_page = 1  # only the resumed-into project starts mid-way; the rest start at page 1
+
+        while True:
+            params: dict[str, Any] = {"project": project_slug}
+            if config.paginated:
+                params["page"] = page
+                if config.per_page is not None:
+                    params["per_page"] = config.per_page
+
+            data = _fetch_page(session, _build_url(config.path, params), headers, logger)
+            items = data.get(config.data_key) or []
+            if items:
+                yield items
+
+            has_more = config.paginated and config.per_page is not None and len(items) >= config.per_page
+            if not has_more:
+                break
+            # Save AFTER yielding so a crash re-yields the last page rather than skipping it —
+            # merge dedupes on the primary key.
+            resumable_source_manager.save_state(DopplerResumeConfig(next_page=page + 1, project=project_slug))
+            page += 1
+
+        # Advance the bookmark to the next project so a crash between projects resumes correctly.
+        if index + 1 < len(remaining):
+            resumable_source_manager.save_state(DopplerResumeConfig(next_page=1, project=remaining[index + 1]))
+
+
+def get_rows(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[DopplerResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> Iterator[Any]:
+    config = DOPPLER_ENDPOINTS[endpoint]
+    headers = _headers(api_token)
+    # One session reused across every page (and, for fan-out, every project) so urllib3 keeps the
+    # connection alive instead of re-handshaking per request.
+    session = make_tracked_session()
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    if config.fan_out_over_projects:
+        yield from _get_fan_out_rows(session, headers, logger, resumable_source_manager, config, resume)
+        return
+
+    watermark = (
+        _coerce_watermark(db_incremental_field_last_value)
+        if should_use_incremental_field and config.incremental_fields
+        else None
+    )
+
+    page = resume.next_page if resume is not None and resume.next_page else 1
+    if page > 1:
+        logger.debug(f"Doppler: resuming {endpoint} from page {page}")
+
+    while True:
+        params: dict[str, Any] = {"page": page}
+        if config.per_page is not None:
+            params["per_page"] = config.per_page
+
+        data = _fetch_page(session, _build_url(config.path, params), headers, logger)
+        items = data.get(config.data_key) or []
+        if not items:
+            break
+
+        if watermark is not None:
+            # The activity log has no server-side time filter, but it's append-only and returned
+            # newest-first, so incremental syncs page from the top and stop at the watermark.
+            # Rows with a missing/unparseable created_at are kept — merge dedupes on the primary key.
+            fresh = [item for item in items if _is_after_watermark(item, config, watermark)]
+            if fresh:
+                yield fresh
+            if len(fresh) < len(items):
+                # Once a row at or before the watermark appears, every remaining page is older.
+                break
+        else:
+            yield items
+
+        has_more = len(items) >= config.per_page if config.per_page is not None else True
+        if not has_more:
+            break
+        # Save AFTER yielding so a crash re-yields the last page rather than skipping it — merge
+        # dedupes on the primary key. New rows arriving mid-sync only push older rows to later
+        # pages (newest-first), so resuming at a saved page can re-read rows but never skip them.
+        resumable_source_manager.save_state(DopplerResumeConfig(next_page=page + 1))
+        page += 1
+
+
+def _is_after_watermark(item: dict[str, Any], config: DopplerEndpointConfig, watermark: datetime) -> bool:
+    incremental_field = config.incremental_fields[0]["field"]
+    created_at = _parse_doppler_datetime(item.get(incremental_field))
+    if created_at is None:
+        return True
+    return created_at > watermark
+
+
+def doppler_source(
+    api_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[DopplerResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = DOPPLER_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_token=api_token,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        ),
+        primary_keys=config.primary_keys,
+        # Activity logs arrive newest-first; desc mode makes the pipeline persist the incremental
+        # watermark at successful job end rather than per batch.
+        sort_mode=config.sort_mode,
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+    )
+
+
+def validate_credentials(api_token: str) -> tuple[bool, int | None]:
+    """Probe Doppler's `/v3/me` token-info endpoint, which accepts every Doppler token type.
+
+    Returns ``(ok, status_code)``. ``status_code`` is ``None`` on a transport error.
+    """
+    try:
+        response = make_tracked_session().get(f"{DOPPLER_BASE_URL}/me", headers=_headers(api_token), timeout=10)
+    except Exception:
+        return False, None
+    return response.status_code == 200, response.status_code

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/settings.py
@@ -1,0 +1,111 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SortMode
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
+
+# Doppler's documented default page size. The API docs don't state a maximum for `per_page`, so we
+# stay at the documented default rather than risk a 400 on an unverified larger value.
+DEFAULT_PER_PAGE = 20
+
+
+def _created_at_incremental_fields() -> list[IncrementalField]:
+    return [
+        {
+            "label": "created_at",
+            "type": IncrementalFieldType.DateTime,
+            "field": "created_at",
+            "field_type": IncrementalFieldType.DateTime,
+        },
+    ]
+
+
+@dataclass
+class DopplerEndpointConfig:
+    name: str
+    path: str  # Path under /v3, e.g. "/projects"
+    # Root key of the list in the JSON response (e.g. `logs` for /v3/logs).
+    data_key: str
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+    # Endpoint accepts a `page` query param. Doppler's environments list takes no pagination
+    # params at all and returns everything in one response.
+    paginated: bool = True
+    # `per_page` value to request. None for paginated endpoints that document no `per_page`
+    # param (workplace users) — those terminate on the first empty page instead of a short one.
+    per_page: Optional[int] = DEFAULT_PER_PAGE
+    # Fan out one request-set per project: the endpoint requires a `project` query param.
+    fan_out_over_projects: bool = False
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    # Stable creation-time field to partition by. Only worthwhile for the (large, append-only)
+    # activity log; the remaining endpoints are small dimension tables.
+    partition_key: Optional[str] = None
+    sort_mode: SortMode = "asc"
+    should_sync_default: bool = True
+
+
+DOPPLER_ENDPOINTS: dict[str, DopplerEndpointConfig] = {
+    "projects": DopplerEndpointConfig(
+        name="projects",
+        path="/projects",
+        data_key="projects",
+    ),
+    "environments": DopplerEndpointConfig(
+        name="environments",
+        path="/environments",
+        data_key="environments",
+        # Environment ids ("dev", "stg", …) are only unique within their project.
+        primary_keys=["project", "id"],
+        paginated=False,
+        per_page=None,
+        fan_out_over_projects=True,
+    ),
+    "configs": DopplerEndpointConfig(
+        name="configs",
+        path="/configs",
+        data_key="configs",
+        # Configs have no id field; the name is unique within its project.
+        primary_keys=["project", "name"],
+        fan_out_over_projects=True,
+    ),
+    "activity_logs": DopplerEndpointConfig(
+        name="activity_logs",
+        path="/logs",
+        data_key="logs",
+        incremental_fields=_created_at_incremental_fields(),
+        partition_key="created_at",
+        # /v3/logs has no sort param and returns newest-first; incremental syncs stop paging once
+        # a page reaches already-synced entries (see doppler.py).
+        sort_mode="desc",
+    ),
+    "workplace_users": DopplerEndpointConfig(
+        name="workplace_users",
+        path="/workplace/users",
+        data_key="workplace_users",
+        # The users list documents only a `page` param, no `per_page`.
+        per_page=None,
+    ),
+    "groups": DopplerEndpointConfig(
+        name="groups",
+        path="/workplace/groups",
+        data_key="groups",
+        primary_keys=["slug"],
+    ),
+    "service_accounts": DopplerEndpointConfig(
+        name="service_accounts",
+        path="/workplace/service_accounts",
+        data_key="service_accounts",
+        primary_keys=["slug"],
+    ),
+    "invites": DopplerEndpointConfig(
+        name="invites",
+        path="/workplace/invites",
+        data_key="invites",
+        primary_keys=["slug"],
+    ),
+}
+
+ENDPOINTS = tuple(DOPPLER_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in DOPPLER_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/source.py
@@ -1,19 +1,43 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.doppler import (
+    DopplerResumeConfig,
+    doppler_source,
+    validate_credentials as validate_doppler_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.settings import (
+    DOPPLER_ENDPOINTS,
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import DopplerSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class DopplerSource(SimpleSource[DopplerSourceConfig]):
+class DopplerSource(ResumableSource[DopplerSourceConfig, DopplerResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.DOPPLER
@@ -24,7 +48,104 @@ class DopplerSource(SimpleSource[DopplerSourceConfig]):
             name=SchemaExternalDataSourceType.DOPPLER,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="Doppler",
+            releaseStatus=ReleaseStatus.ALPHA,
+            caption="""Enter a Doppler API token to pull your Doppler projects, configs, and activity logs into the PostHog Data warehouse for audit and change tracking. Secret values are never synced.
+
+Use a [personal token](https://docs.doppler.com/docs/personal-tokens) or a [service account token](https://docs.doppler.com/docs/service-accounts) with read access to the workplace and the projects you want to sync.""",
             iconPath="/static/services/doppler.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/doppler",
+            keywords=["secrets"],
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_token",
+                        label="API token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="dp.pt....",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # 401/403 surface as a requests HTTPError when `_fetch_page` calls `raise_for_status()`.
+            # Retrying can never fix a credential/permission problem, so fail the sync. Match the
+            # stable status text and base host, not the per-request path/query.
+            "401 Client Error: Unauthorized for url: https://api.doppler.com": "Your Doppler API token is invalid or has been revoked. Create a new token in your Doppler dashboard, then reconnect.",
+            "403 Client Error: Forbidden for url: https://api.doppler.com": "Your Doppler API token is missing the read access needed to sync this data. Check the token's workplace and project access, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: DopplerSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        def _build_schema(endpoint: str) -> SourceSchema:
+            endpoint_config = DOPPLER_ENDPOINTS[endpoint]
+            has_incremental = bool(endpoint_config.incremental_fields)
+            return SourceSchema(
+                name=endpoint,
+                supports_incremental=has_incremental,
+                # Crash-resume can re-yield the last batch (resume state saves after yield), so
+                # only merge — which dedupes on the primary key — is safe; append would duplicate.
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                should_sync_default=endpoint_config.should_sync_default,
+                description=(
+                    "Workplace activity log of project, config, and access changes. Incremental syncs "
+                    "stop paging once they reach already-synced entries."
+                    if endpoint == "activity_logs"
+                    else None
+                ),
+            )
+
+        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: DopplerSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        ok, status_code = validate_doppler_credentials(config.api_token)
+
+        if ok:
+            return True, None
+        if status_code == 401:
+            return False, "Invalid Doppler API token"
+        return False, "Could not connect to Doppler with the provided API token"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[DopplerResumeConfig]:
+        return ResumableSourceManager[DopplerResumeConfig](inputs, DopplerResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: DopplerSourceConfig,
+        resumable_source_manager: ResumableSourceManager[DopplerResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return doppler_source(
+            api_token=config.api_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/tests/test_doppler.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/tests/test_doppler.py
@@ -1,0 +1,283 @@
+from datetime import UTC, date, datetime
+from typing import Any
+
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler import doppler
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.doppler import (
+    DopplerResumeConfig,
+    _coerce_watermark,
+    doppler_source,
+    get_rows,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.settings import DEFAULT_PER_PAGE
+
+_BASE = "https://api.doppler.com/v3"
+
+
+class _FakeResumableManager:
+    def __init__(self, state: DopplerResumeConfig | None = None) -> None:
+        self._state = state
+        self.saved: list[DopplerResumeConfig] = []
+
+    def can_resume(self) -> bool:
+        return self._state is not None
+
+    def load_state(self) -> DopplerResumeConfig | None:
+        return self._state
+
+    def save_state(self, data: DopplerResumeConfig) -> None:
+        self.saved.append(data)
+
+
+def _patch_fetch(monkeypatch: Any, pages: dict[str, Any]) -> list[str]:
+    fetched: list[str] = []
+
+    def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
+        fetched.append(url)
+        return pages[url]
+
+    monkeypatch.setattr(doppler, "_fetch_page", fake_fetch)
+    return fetched
+
+
+def _collect(manager: _FakeResumableManager, **kwargs: Any) -> list[dict]:
+    rows: list[dict] = []
+    for batch in get_rows(
+        api_token="token",
+        logger=MagicMock(),
+        resumable_source_manager=manager,  # type: ignore[arg-type]
+        **kwargs,
+    ):
+        rows.extend(batch)
+    return rows
+
+
+def _items(key: str, ids: list[str]) -> dict[str, Any]:
+    return {key: [{"id": item_id, "created_at": "2024-01-05T00:00:00.000Z"} for item_id in ids], "page": 1}
+
+
+def _full_page(key: str, prefix: str) -> dict[str, Any]:
+    return _items(key, [f"{prefix}{i}" for i in range(DEFAULT_PER_PAGE)])
+
+
+class TestCoerceWatermark:
+    @parameterized.expand(
+        [
+            ("aware_datetime", datetime(2024, 1, 2, tzinfo=UTC), datetime(2024, 1, 2, tzinfo=UTC)),
+            ("naive_datetime", datetime(2024, 1, 2), datetime(2024, 1, 2, tzinfo=UTC)),
+            ("date_value", date(2024, 1, 2), datetime(2024, 1, 2, tzinfo=UTC)),
+            ("z_string", "2024-01-02T00:00:00.000Z", datetime(2024, 1, 2, tzinfo=UTC)),
+            ("offset_string", "2024-01-02T00:00:00+00:00", datetime(2024, 1, 2, tzinfo=UTC)),
+            ("bad_string", "not-a-date", None),
+            ("none", None, None),
+        ]
+    )
+    def test_coerce(self, _name: str, value: Any, expected: datetime | None) -> None:
+        result = _coerce_watermark(value)
+        assert result == expected
+        # Doppler rows carry aware timestamps; a naive watermark would raise on comparison.
+        if result is not None:
+            assert result.tzinfo is not None
+
+
+class TestGetRows:
+    def test_paginates_until_short_page(self, monkeypatch: Any) -> None:
+        pages = {
+            f"{_BASE}/projects?page=1&per_page=20": _full_page("projects", "a"),
+            f"{_BASE}/projects?page=2&per_page=20": _items("projects", ["last"]),
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+        manager = _FakeResumableManager()
+
+        rows = _collect(manager, endpoint="projects")
+
+        assert len(rows) == DEFAULT_PER_PAGE + 1
+        assert fetched == list(pages)
+        # State is saved only while more pages remain, never on the last page.
+        assert manager.saved == [DopplerResumeConfig(next_page=2)]
+
+    def test_stops_on_empty_page(self, monkeypatch: Any) -> None:
+        pages = {f"{_BASE}/projects?page=1&per_page=20": _items("projects", [])}
+        fetched = _patch_fetch(monkeypatch, pages)
+
+        rows = _collect(_FakeResumableManager(), endpoint="projects")
+
+        assert rows == []
+        assert fetched == [f"{_BASE}/projects?page=1&per_page=20"]
+
+    def test_resumes_from_saved_page(self, monkeypatch: Any) -> None:
+        pages = {f"{_BASE}/projects?page=3&per_page=20": _items("projects", ["p1"])}
+        fetched = _patch_fetch(monkeypatch, pages)
+
+        rows = _collect(_FakeResumableManager(DopplerResumeConfig(next_page=3)), endpoint="projects")
+
+        assert [r["id"] for r in rows] == ["p1"]
+        assert fetched == [f"{_BASE}/projects?page=3&per_page=20"]
+
+    def test_endpoint_without_per_page_terminates_on_empty_page(self, monkeypatch: Any) -> None:
+        # workplace users documents no `per_page`, so a short page must NOT stop pagination —
+        # only an empty page does.
+        pages = {
+            f"{_BASE}/workplace/users?page=1": _items("workplace_users", ["u1", "u2"]),
+            f"{_BASE}/workplace/users?page=2": _items("workplace_users", []),
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+
+        rows = _collect(_FakeResumableManager(), endpoint="workplace_users")
+
+        assert [r["id"] for r in rows] == ["u1", "u2"]
+        assert fetched == list(pages)
+
+
+class TestGetRowsIncremental:
+    def _log(self, log_id: str, created_at: str | None) -> dict[str, Any]:
+        return {"id": log_id, "created_at": created_at}
+
+    def test_stops_paging_at_watermark_and_drops_synced_rows(self, monkeypatch: Any) -> None:
+        watermark = datetime(2024, 1, 2, tzinfo=UTC)
+        fresh_page = {
+            "logs": [self._log(f"l{i}", "2024-01-05T00:00:00.000Z") for i in range(DEFAULT_PER_PAGE)],
+        }
+        boundary_page = {
+            "logs": [
+                self._log("new", "2024-01-03T00:00:00.000Z"),
+                self._log("unparseable", None),  # kept — merge dedupes on the primary key
+                self._log("at_watermark", "2024-01-02T00:00:00.000Z"),  # already synced
+                self._log("old", "2024-01-01T00:00:00.000Z"),
+            ],
+        }
+        pages = {
+            f"{_BASE}/logs?page=1&per_page=20": fresh_page,
+            f"{_BASE}/logs?page=2&per_page=20": boundary_page,
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+
+        rows = _collect(
+            _FakeResumableManager(),
+            endpoint="activity_logs",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=watermark,
+        )
+
+        # Rows at/before the watermark are dropped, and paging stops at the boundary page even
+        # though it isn't the last one — no page 3 request.
+        assert [r["id"] for r in rows] == [f"l{i}" for i in range(DEFAULT_PER_PAGE)] + ["new", "unparseable"]
+        assert fetched == list(pages)
+
+    def test_first_sync_without_watermark_walks_all_pages(self, monkeypatch: Any) -> None:
+        pages = {
+            f"{_BASE}/logs?page=1&per_page=20": _full_page("logs", "l"),
+            f"{_BASE}/logs?page=2&per_page=20": _items("logs", ["last"]),
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+
+        rows = _collect(
+            _FakeResumableManager(),
+            endpoint="activity_logs",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=None,
+        )
+
+        assert len(rows) == DEFAULT_PER_PAGE + 1
+        assert fetched == list(pages)
+
+
+class TestGetRowsFanOut:
+    _PROJECTS_URL = f"{_BASE}/projects?page=1&per_page=20"
+
+    def _projects_page(self, slugs: list[str]) -> dict[str, Any]:
+        return {"projects": [{"id": f"id-{slug}", "slug": slug} for slug in slugs]}
+
+    def test_fans_out_over_every_project_and_bookmarks_progress(self, monkeypatch: Any) -> None:
+        pages = {
+            self._PROJECTS_URL: self._projects_page(["proj-a", "proj-b"]),
+            f"{_BASE}/configs?project=proj-a&page=1&per_page=20": _full_page("configs", "a"),
+            f"{_BASE}/configs?project=proj-a&page=2&per_page=20": _items("configs", ["a-last"]),
+            f"{_BASE}/configs?project=proj-b&page=1&per_page=20": _items("configs", ["b0"]),
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+        manager = _FakeResumableManager()
+
+        rows = _collect(manager, endpoint="configs")
+
+        assert len(rows) == DEFAULT_PER_PAGE + 2
+        assert fetched == list(pages)
+        assert manager.saved == [
+            DopplerResumeConfig(next_page=2, project="proj-a"),
+            DopplerResumeConfig(next_page=1, project="proj-b"),
+        ]
+
+    def test_resumes_from_bookmarked_project_and_page(self, monkeypatch: Any) -> None:
+        pages = {
+            self._PROJECTS_URL: self._projects_page(["proj-a", "proj-b"]),
+            f"{_BASE}/configs?project=proj-b&page=2&per_page=20": _items("configs", ["b-page2"]),
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+
+        rows = _collect(_FakeResumableManager(DopplerResumeConfig(next_page=2, project="proj-b")), endpoint="configs")
+
+        # proj-a is skipped entirely; proj-b picks up at its saved page.
+        assert [r["id"] for r in rows] == ["b-page2"]
+        assert fetched == list(pages)
+
+    def test_restarts_when_bookmarked_project_no_longer_exists(self, monkeypatch: Any) -> None:
+        pages = {
+            self._PROJECTS_URL: self._projects_page(["proj-a"]),
+            f"{_BASE}/configs?project=proj-a&page=1&per_page=20": _items("configs", ["a0"]),
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+
+        rows = _collect(
+            _FakeResumableManager(DopplerResumeConfig(next_page=4, project="deleted-project")), endpoint="configs"
+        )
+
+        assert [r["id"] for r in rows] == ["a0"]
+        assert fetched == list(pages)
+
+    def test_unpaginated_fan_out_makes_one_request_per_project(self, monkeypatch: Any) -> None:
+        # /v3/environments takes no pagination params; one request per project, no page loop.
+        pages = {
+            self._PROJECTS_URL: self._projects_page(["proj-a", "proj-b"]),
+            f"{_BASE}/environments?project=proj-a": _items("environments", ["dev", "prd"]),
+            f"{_BASE}/environments?project=proj-b": _items("environments", ["dev"]),
+        }
+        fetched = _patch_fetch(monkeypatch, pages)
+        manager = _FakeResumableManager()
+
+        rows = _collect(manager, endpoint="environments")
+
+        assert [r["id"] for r in rows] == ["dev", "prd", "dev"]
+        assert fetched == list(pages)
+        assert manager.saved == [DopplerResumeConfig(next_page=1, project="proj-b")]
+
+
+class TestDopplerSourceResponse:
+    @parameterized.expand(
+        [
+            ("projects", ["id"], "asc", None),
+            ("environments", ["project", "id"], "asc", None),
+            ("configs", ["project", "name"], "asc", None),
+            ("activity_logs", ["id"], "desc", ["created_at"]),
+            ("workplace_users", ["id"], "asc", None),
+            ("groups", ["slug"], "asc", None),
+            ("service_accounts", ["slug"], "asc", None),
+            ("invites", ["slug"], "asc", None),
+        ]
+    )
+    def test_source_response_shape(
+        self, endpoint: str, primary_keys: list[str], sort_mode: str, partition_keys: list[str] | None
+    ) -> None:
+        response = doppler_source(
+            api_token="token",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=MagicMock(),
+        )
+
+        assert response.name == endpoint
+        assert response.primary_keys == primary_keys
+        assert response.sort_mode == sort_mode
+        assert response.partition_keys == partition_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/tests/test_doppler_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doppler/tests/test_doppler_source.py
@@ -1,0 +1,152 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.doppler import DopplerResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.settings import (
+    DOPPLER_ENDPOINTS,
+    ENDPOINTS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.doppler.source import DopplerSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import DopplerSourceConfig
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+# The activity log is the only endpoint with a usable incremental cursor (append-only,
+# newest-first); everything else is full refresh.
+_INCREMENTAL_ENDPOINTS = {"activity_logs"}
+
+
+class TestDopplerSource:
+    def setup_method(self):
+        self.source = DopplerSource()
+        self.team_id = 123
+        self.config = DopplerSourceConfig(api_token="dp.pt.token")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.DOPPLER
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "Doppler"
+        assert config.label == "Doppler"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/doppler.png"
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/doppler"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["api_token"]
+
+    def test_api_token_field_is_secret_password(self):
+        config = self.source.get_source_config
+        token_field = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig))
+        assert token_field.type == SourceFieldInputConfigType.PASSWORD
+        assert token_field.secret is True
+        assert token_field.required is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.doppler.com/v3/logs?page=1&per_page=20",
+            "403 Client Error: Forbidden for url: https://api.doppler.com/v3/projects?page=1&per_page=20",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "429 Client Error: Too Many Requests for url: https://api.doppler.com/v3/logs",
+            "500 Server Error: Internal Server Error for url: https://api.doppler.com/v3/logs",
+            "HTTPSConnectionPool(host='api.doppler.com', port=443): Read timed out.",
+        ],
+    )
+    def test_non_retryable_errors_do_not_match_transient(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)
+
+    def test_get_schemas_match_endpoints_with_correct_sync_modes(self):
+        schemas = {schema.name: schema for schema in self.source.get_schemas(self.config, self.team_id)}
+
+        assert set(schemas) == set(ENDPOINTS)
+        for name, schema in schemas.items():
+            expected_incremental = name in _INCREMENTAL_ENDPOINTS
+            assert schema.supports_incremental is expected_incremental
+            # Crash-resume can re-yield the last batch, so append (no dedupe) is never offered.
+            assert schema.supports_append is False
+            if expected_incremental:
+                assert [f["field"] for f in schema.incremental_fields] == ["created_at"]
+            else:
+                assert schema.incremental_fields == []
+
+    def test_get_schemas_filtered_by_names(self):
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["activity_logs"])
+        assert [schema.name for schema in schemas] == ["activity_logs"]
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    def test_lists_tables_without_credentials_publishes_catalog(self):
+        # Static endpoint catalog (no I/O) — the public docs table list should render.
+        assert self.source.lists_tables_without_credentials is True
+        documented = self.source.get_documented_tables()
+        assert {table["name"] for table in documented} == set(ENDPOINTS)
+
+    def test_canonical_descriptions_cover_every_endpoint(self):
+        canonical = self.source.get_canonical_descriptions()
+        assert set(canonical) == set(DOPPLER_ENDPOINTS)
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            ((True, 200), True, None),
+            ((False, 401), False, "Invalid Doppler API token"),
+            ((False, 403), False, "Could not connect to Doppler with the provided API token"),
+            ((False, None), False, "Could not connect to Doppler with the provided API token"),
+        ],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.doppler.source.validate_doppler_credentials"
+    )
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with("dp.pt.token")
+
+    def test_get_resumable_source_manager_bound_to_resume_config(self):
+        manager = self.source.get_resumable_source_manager(mock.MagicMock())
+        assert manager._data_class is DopplerResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.doppler.source.doppler_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_doppler_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "activity_logs"
+        inputs.should_use_incremental_field = True
+        inputs.db_incremental_field_last_value = "2026-01-01T00:00:00Z"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_doppler_source.assert_called_once()
+        kwargs = mock_doppler_source.call_args.kwargs
+        assert kwargs["api_token"] == "dp.pt.token"
+        assert kwargs["endpoint"] == "activity_logs"
+        assert kwargs["resumable_source_manager"] is manager
+        assert kwargs["db_incremental_field_last_value"] == "2026-01-01T00:00:00Z"
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.doppler.source.doppler_source")
+    def test_source_for_pipeline_omits_cursor_when_not_incremental(self, mock_doppler_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "projects"
+        inputs.should_use_incremental_field = False
+        inputs.db_incremental_field_last_value = "2026-01-01T00:00:00Z"
+
+        self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
+
+        assert mock_doppler_source.call_args.kwargs["db_incremental_field_last_value"] is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -1267,7 +1267,7 @@ class DolibarrSourceConfig(config.Config):
 
 @config.config
 class DopplerSourceConfig(config.Config):
-    pass
+    api_token: str
 
 
 @config.config


### PR DESCRIPTION
## Problem

Doppler was scaffolded in #71137 as a hidden stub (`unreleasedSource=True`, no fields, no sync logic). Platform and security teams want Doppler's activity and config-change history in the warehouse for audit, change tracking, and compliance, alongside its org/project structure as dimension tables.

**Why:** part of the batch effort to turn the scaffolded engineering/support sources into working connectors; Doppler is a low-difficulty REST source with clear audit-oriented demand.

## Changes

Implements the Doppler source end-to-end and ships it visible with `releaseStatus=ReleaseStatus.ALPHA` (the `unreleasedSource=True` line is deleted):

- **8 tables**: `projects`, `environments`, `configs`, `activity_logs`, `workplace_users`, `groups`, `service_accounts`, `invites`. Secret values are never synced.
- **`ResumableSource`** with page-number resume state saved after each yielded batch, plus a stable project-slug bookmark for the per-project fan-out (`environments`, `configs` require a `project` param; rows already carry `project`, giving composite primary keys for free).
- **Incremental sync for `activity_logs` only**: Doppler exposes no server-side timestamp filter, but the log is append-only and returned newest-first, so incremental runs page from the top and stop once a page reaches the last-synced `created_at` watermark (`sort_mode="desc"`, merge dedupes the boundary). Everything else is full refresh.
- All HTTP goes through `make_tracked_session()`; tenacity retries on 429/5xx/transport errors; 401/403 mapped to non-retryable errors; `validate_credentials` probes `/v3/me` (works with every Doppler token type).
- `canonical_descriptions.py` for all 8 tables, `lists_tables_without_credentials=True` so the public docs render the table catalog, regenerated `DopplerSourceConfig`, SOURCES.md moved to Implemented.

Companion doc PR: [PostHog/posthog.com#18532](https://github.com/PostHog/posthog.com/pull/18532) (`docsUrl` matches its slug; `audit_source_docs` passes against that checkout for Doppler).

> [!NOTE]
> Endpoint shapes, pagination params, and response keys were verified against Doppler's published OpenAPI spec (embedded in docs.doppler.com) rather than an authenticated live account — I had no Doppler credentials, so a couple of conservative choices: `per_page` stays at the documented default of 20 (no documented max), and the newest-first ordering of `/v3/logs` is asserted from the docs/dashboard behavior with a code comment noting it. The `webhooks` list endpoint has a completely empty response schema in Doppler's spec, so that stream was left out rather than guessing a data key that could silently sync zero rows.

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/doppler/` — 44 tests pass.
  - Transport tests guard: pagination termination (short page vs empty page for the no-`per_page` users endpoint), resume-from-saved-page and save-after-yield ordering (crash re-yields, never skips), fan-out project bookmarking incl. restart on a deleted bookmark project, watermark stop-at-boundary (drops already-synced rows, no extra page request, keeps unparseable rows), naive/aware watermark coercion (a naive comparison would raise `TypeError` mid-sync), and per-endpoint `SourceResponse` shape (composite primary keys, desc sort for logs) — none of which any existing test covers, since the source had no logic before.
  - Source tests cover schema modes (only `activity_logs` incremental, append never offered), credential-validation status mapping, non-retryable error matching, docs catalog rendering, and pipeline argument plumbing.
- Registry-level suites pass (`test_source_categories`, `test_ci_core_coupled_sources`, `test_generated_configs` — the two `test_stripe_config` failures pre-exist on the base branch).
- `ruff check` / `ruff format` clean on all changed files. I couldn't run `hogli ci:preflight` (no `node_modules`/hogli in this environment) or connect to a live Doppler account.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Handled in [PostHog/posthog.com#18532](https://github.com/PostHog/posthog.com/pull/18532).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task). Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/documenting-warehouse-sources`. Modeled on the `aha` source (closest existing shape: page-number pagination, page-based resume state); yields raw `list[dict]` pages instead of a source-level `Batcher` per current skill guidance. Considered and rejected: shipping a `webhooks` table (undocumented response schema — silent-empty-sync risk) and `supports_append` on `activity_logs` (crash-resume re-yields the last batch, which append would duplicate).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*