### PR TITLE
feat(data-warehouse): implement swarmia import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -441,6 +441,7 @@ the row lists both.
 | surveymonkey                     | HTTP                        | requests                                                        | ✅                          |
 | surveysparrow                    | HTTP                        | requests                                                        | ✅                          |
 | svix                             | HTTP                        | requests                                                        | ✅                          |
+| swarmia                          | HTTP                        | requests                                                        | ✅                          |
 | taboola                          | HTTP                        | requests                                                        | ✅                          |
 | tavus                            | HTTP                        | requests                                                        | ✅                          |
 | teamtailor                       | HTTP                        | requests                                                        | ✅                          |
@@ -918,7 +919,6 @@ doesn't conflict with concurrent PRs.
 - surveymonkey
 - survicate
 - svix
-- swarmia
 - swonkie
 - synthesia
 - systeme

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -4115,7 +4115,7 @@ class SvixSourceConfig(config.Config):
 
 @config.config
 class SwarmiaSourceConfig(config.Config):
-    pass
+    api_key: str
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/canonical_descriptions.py
@@ -1,0 +1,92 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+_DOCS_URL = "https://help.swarmia.com/settings/integrations/swarmia-apis/export-api"
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "pull_requests": {
+        "description": "Per-team pull request metrics aggregated over complete ISO weeks (Monday to Sunday).",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "start_date": "First day of the reporting window (inclusive).",
+            "end_date": "Last day of the reporting window (inclusive).",
+            "parent_teams": "Parent team(s) of the team, when the organization uses a team hierarchy.",
+            "team": "Name of the team the metrics are aggregated for.",
+            "cycle_time_seconds": "Average time from first commit to deployed change, in seconds.",
+            "review_rate_percent": "Share of merged pull requests that were reviewed, as a percentage.",
+            "time_to_first_review_seconds": "Average time from review request to first review, in seconds.",
+            "prs_merged_per_week": "Average number of pull requests merged per week in the window.",
+            "merge_time_seconds": "Average time from pull request creation to merge, in seconds.",
+            "prs_in_progress": "Number of pull requests in progress during the window.",
+            "contributors": "Number of contributors active in the window.",
+        },
+    },
+    "dora": {
+        "description": "Organization-level DORA metrics aggregated over complete ISO weeks (Monday to Sunday).",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "start_date": "First day of the reporting window (inclusive).",
+            "end_date": "Last day of the reporting window (inclusive).",
+            "deployment_frequency_per_day": "Average number of deployments per day in the window.",
+            "change_lead_time_minutes": "Average time from first commit to production deployment, in minutes.",
+            "average_time_to_deploy_minutes": "Average time from merge to production deployment, in minutes.",
+            "change_failure_rate_percent": "Share of deployments causing a failure in production, as a percentage.",
+            "mean_time_to_recovery_minutes": "Average time to recover from a production failure, in minutes.",
+            "deployment_count": "Total number of deployments in the window.",
+        },
+    },
+    "investment": {
+        "description": "Investment balance statistics per investment category, aggregated over complete calendar months using Swarmia's Effort model (monthly FTE). Data for a month is generated around the 10th day of the following month.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "start_date": "First day of the reporting month (inclusive).",
+            "end_date": "Last day of the reporting month (inclusive).",
+            "investment_category": "Investment category the effort is attributed to.",
+            "fte_months": "Full-time-equivalent months of effort attributed to the category.",
+            "relative_percentage": "Share of the organization's total effort attributed to the category, as a percentage.",
+            "commits": "Number of commits attributed to the category.",
+            "pull_request_comments": "Number of pull request comments attributed to the category.",
+            "pull_request_creations": "Number of pull requests created, attributed to the category.",
+            "pull_request_merges": "Number of pull requests merged, attributed to the category.",
+            "pull_request_reviews": "Number of pull request reviews attributed to the category.",
+        },
+    },
+    "capex": {
+        "description": "Software capitalization report: one row per employee per capitalizable issue per calendar month.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "month": "The reporting month.",
+            "employee_id": "Employee identifier from Swarmia.",
+            "name": "Employee name.",
+            "email": "Employee email address.",
+            "capitalizable_work": "Title of the issue the capitalizable work is attributed to.",
+            "developer_months": "Developer months of effort attributed to the issue in the month.",
+            "additional_context": "Value of the additional context field configured in Swarmia (Jira only).",
+        },
+    },
+    "capex_employees": {
+        "description": "Total full-time-equivalents per employee per month for software capitalization, unpivoted from Swarmia's one-column-per-month CSV into one row per employee per month.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "employee_id": "Employee identifier from Swarmia.",
+            "name": "Employee name.",
+            "email": "Employee email address.",
+            "month": "The reporting month (first day of the month).",
+            "fte": "Total full-time-equivalents for the employee in the month.",
+        },
+    },
+    "fte": {
+        "description": "Effort report: full-time-equivalent effort per author per issue per calendar month, grouped by the highest-level issue (subtask effort rolls up to its Epic or Story).",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "month": "The reporting month.",
+            "author_id": "Author identifier from Swarmia.",
+            "email": "Author email address.",
+            "fte": "Full-time-equivalent effort the author spent on the issue in the month.",
+            "custom_field": "Value of the configured custom field, inherited from the nearest parent issue when missing.",
+            "swarmia_issue_type": "Swarmia's issue type classification for the issue.",
+            "issue_key": "Key of the issue the effort is attributed to.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/settings.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
+
+# Swarmia's Export API returns time-windowed aggregate reports (CSV), not paginated entity lists.
+# Each endpoint is synced by iterating fixed, complete windows (ISO weeks, calendar months, or
+# years) so a row's identity — its window bounds plus its grouping columns — is stable across runs.
+
+WindowStyle = Literal["week", "month", "year"]
+TimeframeParamStyle = Literal["date_range", "month", "year"]
+
+_END_DATE_INCREMENTAL: list[IncrementalField] = [
+    {
+        "label": "end_date",
+        "type": IncrementalFieldType.Date,
+        "field": "end_date",
+        "field_type": IncrementalFieldType.Date,
+    },
+]
+
+
+@dataclass
+class SwarmiaEndpointConfig:
+    name: str
+    path: str
+    window: WindowStyle
+    # How the window is passed to the API: startDate/endDate (YYYY-MM-DD), month=YYYY-MM, or year=YYYY.
+    timeframe_param: TimeframeParamStyle
+    primary_keys: list[str]
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    # How far back the first sync (or a full refresh) reaches, in days.
+    default_lookback_days: int = 365
+    # Partition key for incremental endpoints; a window's start date never changes.
+    partition_key: Optional[str] = None
+    # Re-read window applied to the incremental watermark at schema creation. Swarmia recomputes
+    # recent report data (e.g. FTE-based reports are generated ~10th of the following month, and a
+    # late-registered incident can restate a past window's change failure rate), so incremental runs
+    # re-pull a trailing window; merge dedupes on the primary key.
+    default_incremental_lookback_seconds: Optional[int] = None
+    # capex/employees returns one column per month of the year; unpivot those into
+    # {employee_id, name, email, month, fte} rows so the table schema is year-independent.
+    unpivot_month_columns: bool = False
+    description: Optional[str] = None
+
+
+SWARMIA_ENDPOINTS: dict[str, SwarmiaEndpointConfig] = {
+    "pull_requests": SwarmiaEndpointConfig(
+        name="pull_requests",
+        path="/reports/pullRequests",
+        window="week",
+        timeframe_param="date_range",
+        primary_keys=["start_date", "end_date", "team"],
+        incremental_fields=_END_DATE_INCREMENTAL,
+        partition_key="start_date",
+        default_incremental_lookback_seconds=14 * 24 * 60 * 60,
+        description="Per-team pull request metrics (cycle time, review rate, merge time), one row per team per complete ISO week",
+    ),
+    "dora": SwarmiaEndpointConfig(
+        name="dora",
+        path="/reports/dora",
+        window="week",
+        timeframe_param="date_range",
+        primary_keys=["start_date", "end_date"],
+        incremental_fields=_END_DATE_INCREMENTAL,
+        partition_key="start_date",
+        default_incremental_lookback_seconds=14 * 24 * 60 * 60,
+        description="Organization-level DORA metrics (deployment frequency, change lead time, change failure rate, MTTR), one row per complete ISO week",
+    ),
+    "investment": SwarmiaEndpointConfig(
+        name="investment",
+        path="/reports/investment",
+        window="month",
+        timeframe_param="date_range",
+        primary_keys=["start_date", "end_date", "investment_category"],
+        incremental_fields=_END_DATE_INCREMENTAL,
+        partition_key="start_date",
+        # FTE data for a month is generated ~10th of the following month and can be regenerated.
+        default_incremental_lookback_seconds=45 * 24 * 60 * 60,
+        description="Investment balance (FTE months per investment category), one row per category per complete calendar month. Data for a month is available around the 10th of the following month",
+    ),
+    "capex": SwarmiaEndpointConfig(
+        name="capex",
+        path="/reports/capex",
+        window="month",
+        timeframe_param="date_range",
+        primary_keys=["month", "employee_id", "capitalizable_work"],
+        default_lookback_days=730,
+        description="Software capitalization report, one row per employee per capitalizable issue per complete calendar month. Full refresh only: Swarmia regenerates FTE data and the issue title is not a stable identifier",
+    ),
+    "capex_employees": SwarmiaEndpointConfig(
+        name="capex_employees",
+        path="/reports/capex/employees",
+        window="year",
+        timeframe_param="year",
+        primary_keys=["month", "employee_id"],
+        default_lookback_days=1095,
+        unpivot_month_columns=True,
+        description="Total FTEs per employee per month for software capitalization, unpivoted to one row per employee per month",
+    ),
+    "fte": SwarmiaEndpointConfig(
+        name="fte",
+        path="/reports/fte",
+        window="month",
+        timeframe_param="month",
+        primary_keys=["month", "author_id", "issue_key"],
+        default_lookback_days=730,
+        description="Effort report (FTE per author per issue), one row per author per issue per complete calendar month. Full refresh only: Swarmia regenerates FTE data for past months",
+    ),
+}
+
+ENDPOINTS = tuple(SWARMIA_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in SWARMIA_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/source.py
@@ -1,19 +1,44 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SwarmiaSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+    SWARMIA_ENDPOINTS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.swarmia import (
+    SwarmiaResumeConfig,
+    check_credentials,
+    check_endpoint_access,
+    swarmia_source,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class SwarmiaSource(SimpleSource[SwarmiaSourceConfig]):
+class SwarmiaSource(ResumableSource[SwarmiaSourceConfig, SwarmiaResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SWARMIA
@@ -24,7 +49,109 @@ class SwarmiaSource(SimpleSource[SwarmiaSourceConfig]):
             name=SchemaExternalDataSourceType.SWARMIA,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="Swarmia",
+            releaseStatus=ReleaseStatus.ALPHA,
+            keywords=["dora", "engineering metrics", "developer productivity"],
+            caption="""Enter your Swarmia API token to pull your engineering metrics reports (pull requests, DORA, investment balance, software capitalization, and effort) into the PostHog Data warehouse.
+
+You can create an API token in your Swarmia workspace under **Settings** → **API tokens**.
+
+Some reports (investment balance, software capitalization, effort) map to Swarmia features that may not be enabled on every plan — tables your token can't access are flagged in the table picker.
+""",
             iconPath="/static/services/swarmia.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/swarmia",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "401 Client Error: Unauthorized for url: https://app.swarmia.com": "Your Swarmia API token is invalid or has been revoked. Create a new token under Settings → API tokens in Swarmia, then reconnect.",
+            "403 Client Error: Forbidden for url: https://app.swarmia.com": "Your Swarmia API token can't access this report. It may require a Swarmia plan or feature that isn't enabled for your organization.",
+        }
+
+    def get_schemas(
+        self,
+        config: SwarmiaSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        def _build_schema(endpoint: str) -> SourceSchema:
+            endpoint_config = SWARMIA_ENDPOINTS[endpoint]
+            has_incremental = bool(INCREMENTAL_FIELDS.get(endpoint))
+            return SourceSchema(
+                name=endpoint,
+                supports_incremental=has_incremental,
+                # Incremental runs re-pull a trailing window of restated report data; only merge
+                # dedupes those rows on the primary key, append would materialize duplicates.
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                description=endpoint_config.description,
+                default_incremental_lookback_seconds=endpoint_config.default_incremental_lookback_seconds,
+            )
+
+        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: SwarmiaSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        status = check_credentials(config.api_key)
+        if status is not None and status < 400:
+            return True, None
+        if status == 401:
+            return False, "Invalid Swarmia API token"
+        if status == 403:
+            # A valid token can be denied a specific report by plan gating; only fail when a
+            # specific schema was asked for. Per-table access is surfaced by get_endpoint_permissions.
+            if schema_name is not None:
+                return False, "Your Swarmia API token can't access this report"
+            return True, None
+        return False, "Could not connect to the Swarmia API"
+
+    def get_endpoint_permissions(
+        self, config: SwarmiaSourceConfig, team_id: int, endpoints: list[str]
+    ) -> dict[str, str | None]:
+        return check_endpoint_access(config.api_key, endpoints)
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[SwarmiaResumeConfig]:
+        return ResumableSourceManager[SwarmiaResumeConfig](inputs, SwarmiaResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: SwarmiaSourceConfig,
+        resumable_source_manager: ResumableSourceManager[SwarmiaResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return swarmia_source(
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/swarmia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/swarmia.py
@@ -1,0 +1,409 @@
+import io
+import re
+import csv
+import dataclasses
+from collections.abc import Iterator
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.settings import (
+    SWARMIA_ENDPOINTS,
+    SwarmiaEndpointConfig,
+)
+
+SWARMIA_BASE_URL = "https://app.swarmia.com/api/v0"
+
+REQUEST_TIMEOUT_SECONDS = 60
+
+
+class SwarmiaRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class SwarmiaResumeConfig:
+    # ISO date (YYYY-MM-DD) of the start of the next window to fetch. Saved after each window's rows
+    # are yielded, so a crash resumes at the first window whose rows may not have been committed.
+    next_window_start: str
+
+
+# Documented CSV headers mapped to warehouse-friendly column names. Undocumented headers fall
+# through to `_normalize_column`.
+_COLUMN_RENAMES: dict[str, str] = {
+    "Start Date": "start_date",
+    "End Date": "end_date",
+    "Parent Team(s)": "parent_teams",
+    "Team": "team",
+    "Cycle Time (s)": "cycle_time_seconds",
+    "Review Rate (%)": "review_rate_percent",
+    "Time to first review (s)": "time_to_first_review_seconds",
+    "PRs merged / week": "prs_merged_per_week",
+    "Merge Time (s)": "merge_time_seconds",
+    "PRs in progress": "prs_in_progress",
+    "Contributors": "contributors",
+    "Deployment Frequency (per day)": "deployment_frequency_per_day",
+    "Change Lead Time Minutes": "change_lead_time_minutes",
+    "Average Time to Deploy Minutes": "average_time_to_deploy_minutes",
+    "Change Failure Rate (%)": "change_failure_rate_percent",
+    "Mean Time to Recovery Minutes": "mean_time_to_recovery_minutes",
+    "Deployment Count": "deployment_count",
+    "Investment Category": "investment_category",
+    "FTE months": "fte_months",
+    "Relative Percentage": "relative_percentage",
+    "Commits": "commits",
+    "Pull Request Comments": "pull_request_comments",
+    "Pull Request Creations": "pull_request_creations",
+    "Pull Request Merges": "pull_request_merges",
+    "Pull Request Reviews": "pull_request_reviews",
+    "Month": "month",
+    "Employee ID": "employee_id",
+    "Name": "name",
+    "Email": "email",
+    "Capitalizable work": "capitalizable_work",
+    "Developer months": "developer_months",
+    "Additional context": "additional_context",
+    "Author ID": "author_id",
+    "FTE": "fte",
+    "Custom field": "custom_field",
+    "Swarmia issue type": "swarmia_issue_type",
+    "Issue key": "issue_key",
+}
+
+# Window-bound columns parsed to dates so incremental watermarks and partitioning work on real
+# date values rather than strings.
+_DATE_COLUMNS = {"start_date", "end_date", "month"}
+
+# Metric columns parsed as floats. Always float (never int) so a column's Arrow type can't flip
+# between integer and double across batches or syncs.
+_FLOAT_COLUMNS = {
+    "cycle_time_seconds",
+    "review_rate_percent",
+    "time_to_first_review_seconds",
+    "prs_merged_per_week",
+    "merge_time_seconds",
+    "prs_in_progress",
+    "contributors",
+    "deployment_frequency_per_day",
+    "change_lead_time_minutes",
+    "average_time_to_deploy_minutes",
+    "change_failure_rate_percent",
+    "mean_time_to_recovery_minutes",
+    "deployment_count",
+    "fte_months",
+    "relative_percentage",
+    "commits",
+    "pull_request_comments",
+    "pull_request_creations",
+    "pull_request_merges",
+    "pull_request_reviews",
+    "developer_months",
+    "fte",
+}
+
+
+def _normalize_column(name: str) -> str:
+    normalized = name.strip().replace("%", "percent").replace("/", " per ")
+    normalized = re.sub(r"[^0-9a-zA-Z]+", "_", normalized).strip("_").lower()
+    return normalized or "column"
+
+
+def _rename_column(name: str) -> str:
+    return _COLUMN_RENAMES.get(name.strip(), _normalize_column(name))
+
+
+def _parse_date(value: str) -> date | None:
+    """Parse the date formats Swarmia reports use: YYYY-MM-DD, or YYYY-MM for month columns."""
+    text = value.strip()
+    for fmt in ("%Y-%m-%d", "%Y-%m"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _convert_value(column: str, value: str | None) -> Any:
+    if value is None:
+        return None
+    text = value.strip()
+    if text == "":
+        return None
+    if column in _DATE_COLUMNS:
+        return _parse_date(text) or text
+    if column in _FLOAT_COLUMNS:
+        try:
+            return float(text)
+        except ValueError:
+            return text
+    return text
+
+
+def _get_headers(api_key: str) -> dict[str, str]:
+    # Bearer header rather than the documented ?token= query param — proxies may log query strings.
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "text/csv",
+    }
+
+
+@retry(
+    retry=retry_if_exception_type(
+        (
+            SwarmiaRetryableError,
+            requests.ReadTimeout,
+            requests.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        )
+    ),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_csv(
+    session: requests.Session,
+    path: str,
+    params: dict[str, str],
+    headers: dict[str, str],
+    logger: FilteringBoundLogger,
+) -> list[dict[str, str]]:
+    url = f"{SWARMIA_BASE_URL}{path}"
+    if params:
+        url = f"{url}?{urlencode(params)}"
+
+    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise SwarmiaRetryableError(f"Swarmia API error (retryable): status={response.status_code}, url={url}")
+
+    if not response.ok:
+        logger.error(f"Swarmia API error: status={response.status_code}, body={response.text[:500]}, url={url}")
+        response.raise_for_status()
+
+    return list(csv.DictReader(io.StringIO(response.text)))
+
+
+def _rows_from_csv(config: SwarmiaEndpointConfig, raw_rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+    if config.unpivot_month_columns:
+        return _unpivot_month_columns(raw_rows)
+
+    rows: list[dict[str, Any]] = []
+    for raw_row in raw_rows:
+        row: dict[str, Any] = {}
+        for raw_column, value in raw_row.items():
+            if raw_column is None:
+                continue
+            column = _rename_column(raw_column)
+            row[column] = _convert_value(column, value)
+        rows.append(row)
+    return rows
+
+
+def _unpivot_month_columns(raw_rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+    """Melt capex/employees rows ({Employee ID, Name, Email, <one column per month>}) into one row
+    per employee per month, so the table schema doesn't change with the requested year."""
+    rows: list[dict[str, Any]] = []
+    for raw_row in raw_rows:
+        identity: dict[str, Any] = {}
+        months: list[tuple[date, Any]] = []
+        for raw_column, value in raw_row.items():
+            if raw_column is None:
+                continue
+            month = _parse_date(raw_column)
+            if month is not None:
+                months.append((month, _convert_value("fte", value)))
+            else:
+                column = _rename_column(raw_column)
+                identity[column] = _convert_value(column, value)
+        for month, fte in months:
+            rows.append({**identity, "month": month, "fte": fte})
+    return rows
+
+
+def _coerce_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        parsed = _parse_date(value[:10])
+        if parsed:
+            return parsed
+    return None
+
+
+def _week_start(day: date) -> date:
+    return day - timedelta(days=day.weekday())
+
+
+def _month_start(day: date) -> date:
+    return day.replace(day=1)
+
+
+def _next_month(day: date) -> date:
+    if day.month == 12:
+        return date(day.year + 1, 1, 1)
+    return date(day.year, day.month + 1, 1)
+
+
+def _build_windows(config: SwarmiaEndpointConfig, range_start: date, today: date) -> list[tuple[date, date]]:
+    """Build the complete (fully in the past) windows covering `range_start`..yesterday.
+
+    Only complete windows are fetched: a partial window's end date shifts every day, which would
+    give the same logical row a new primary key on every sync and pile up overlapping rows.
+    """
+    windows: list[tuple[date, date]] = []
+    if config.window == "week":
+        start = _week_start(range_start)
+        while start + timedelta(days=6) < today:
+            windows.append((start, start + timedelta(days=6)))
+            start += timedelta(days=7)
+    elif config.window == "month":
+        start = _month_start(range_start)
+        while _next_month(start) - timedelta(days=1) < today:
+            windows.append((start, _next_month(start) - timedelta(days=1)))
+            start = _next_month(start)
+    else:  # year — capex/employees reports the current (partial) year fine, one row per employee
+        for year in range(range_start.year, today.year + 1):
+            windows.append((date(year, 1, 1), date(year, 12, 31)))
+    return windows
+
+
+def _window_params(config: SwarmiaEndpointConfig, window_start: date, window_end: date) -> dict[str, str]:
+    if config.timeframe_param == "month":
+        return {"month": window_start.strftime("%Y-%m")}
+    if config.timeframe_param == "year":
+        return {"year": str(window_start.year)}
+    return {"startDate": window_start.isoformat(), "endDate": window_end.isoformat()}
+
+
+def check_credentials(api_key: str) -> int | None:
+    """Probe the cheapest report with the token. Returns the HTTP status, or None on network failure."""
+    try:
+        response = make_tracked_session(redact_values=(api_key,)).get(
+            f"{SWARMIA_BASE_URL}/reports/pullRequests?{urlencode({'timeframe': 'last_7_days'})}",
+            headers=_get_headers(api_key),
+            timeout=10,
+        )
+        return response.status_code
+    except Exception:
+        return None
+
+
+def check_endpoint_access(api_key: str, endpoints: list[str]) -> dict[str, str | None]:
+    """Probe each report with a minimal window. Some reports (investment, capex, effort) map to
+    plan-gated Swarmia features, so a valid token can still be denied per report."""
+    session = make_tracked_session(redact_values=(api_key,))
+    headers = _get_headers(api_key)
+    today = datetime.now(UTC).date()
+    last_month_start = _month_start(_month_start(today) - timedelta(days=1))
+
+    results: dict[str, str | None] = {}
+    for endpoint in endpoints:
+        config = SWARMIA_ENDPOINTS.get(endpoint)
+        if config is None:
+            results[endpoint] = None
+            continue
+        if config.timeframe_param == "date_range" and config.window == "week":
+            params = {"timeframe": "last_7_days"}
+        else:
+            window_end = _next_month(last_month_start) - timedelta(days=1)
+            params = _window_params(config, last_month_start, window_end)
+        try:
+            response = session.get(
+                f"{SWARMIA_BASE_URL}{config.path}?{urlencode(params)}",
+                headers=headers,
+                timeout=10,
+            )
+        except Exception:
+            # A network blip is not a missing permission; report reachable rather than scaring the user.
+            results[endpoint] = None
+            continue
+        if response.status_code in (401, 403):
+            results[endpoint] = (
+                "Your Swarmia API token can't access this report. It may require a plan or feature "
+                "that isn't enabled for your organization."
+            )
+        else:
+            results[endpoint] = None
+    return results
+
+
+def get_rows(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[SwarmiaResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> Iterator[Any]:
+    config = SWARMIA_ENDPOINTS[endpoint]
+    session = make_tracked_session(redact_values=(api_key,))
+    headers = _get_headers(api_key)
+    today = datetime.now(UTC).date()
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume is not None:
+        range_start = date.fromisoformat(resume.next_window_start)
+        logger.debug(f"Swarmia: resuming {endpoint} from window start {range_start}")
+    elif should_use_incremental_field and (watermark := _coerce_date(db_incremental_field_last_value)) is not None:
+        # The watermark is the last fully-synced window's end date (any schema-level lookback is
+        # already subtracted by the framework); windows re-align to their grid below, and re-pulled
+        # windows merge-dedupe on the primary key.
+        range_start = watermark + timedelta(days=1)
+    else:
+        range_start = today - timedelta(days=config.default_lookback_days)
+
+    windows = _build_windows(config, range_start, today)
+
+    for index, (window_start, window_end) in enumerate(windows):
+        params = _window_params(config, window_start, window_end)
+        raw_rows = _fetch_csv(session, config.path, params, headers, logger)
+        rows = _rows_from_csv(config, raw_rows)
+        if rows:
+            yield rows
+        # Save AFTER yielding so a crash re-fetches (and merge dedupes) the last window rather than
+        # skipping it.
+        if index + 1 < len(windows):
+            resumable_source_manager.save_state(
+                SwarmiaResumeConfig(next_window_start=windows[index + 1][0].isoformat())
+            )
+
+
+def swarmia_source(
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[SwarmiaResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    endpoint_config = SWARMIA_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        ),
+        primary_keys=endpoint_config.primary_keys,
+        # Windows are iterated oldest-first, so the incremental watermark (max end_date) advances
+        # monotonically batch by batch.
+        sort_mode="asc",
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if endpoint_config.partition_key else None,
+        partition_format="month" if endpoint_config.partition_key else None,
+        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/swarmia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/swarmia.py
@@ -154,6 +154,14 @@ def _get_headers(api_key: str) -> dict[str, str]:
     }
 
 
+def _make_session(api_key: str) -> requests.Session:
+    # capture=False keeps requests metered and logged but excludes them from HTTP sample capture:
+    # Swarmia CSV exports carry free-text issue titles and custom fields that scrubadub can't reliably
+    # redact, so the raw bodies must never land in the shared HTTP-sample store. Requests stay metered
+    # and logged; only the sampled payload is dropped. The token is redacted everywhere it appears.
+    return make_tracked_session(redact_values=(api_key,), capture=False)
+
+
 @retry(
     retry=retry_if_exception_type(
         (
@@ -173,7 +181,7 @@ def _fetch_csv(
     params: dict[str, str],
     headers: dict[str, str],
     logger: FilteringBoundLogger,
-) -> list[dict[str, str]]:
+) -> list[dict[str | None, str]]:
     url = f"{SWARMIA_BASE_URL}{path}"
     if params:
         url = f"{url}?{urlencode(params)}"
@@ -190,7 +198,7 @@ def _fetch_csv(
     return list(csv.DictReader(io.StringIO(response.text)))
 
 
-def _rows_from_csv(config: SwarmiaEndpointConfig, raw_rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+def _rows_from_csv(config: SwarmiaEndpointConfig, raw_rows: list[dict[str | None, str]]) -> list[dict[str, Any]]:
     if config.unpivot_month_columns:
         return _unpivot_month_columns(raw_rows)
 
@@ -206,7 +214,7 @@ def _rows_from_csv(config: SwarmiaEndpointConfig, raw_rows: list[dict[str, str]]
     return rows
 
 
-def _unpivot_month_columns(raw_rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+def _unpivot_month_columns(raw_rows: list[dict[str | None, str]]) -> list[dict[str, Any]]:
     """Melt capex/employees rows ({Employee ID, Name, Email, <one column per month>}) into one row
     per employee per month, so the table schema doesn't change with the requested year."""
     rows: list[dict[str, Any]] = []
@@ -287,7 +295,7 @@ def _window_params(config: SwarmiaEndpointConfig, window_start: date, window_end
 def check_credentials(api_key: str) -> int | None:
     """Probe the cheapest report with the token. Returns the HTTP status, or None on network failure."""
     try:
-        response = make_tracked_session(redact_values=(api_key,)).get(
+        response = _make_session(api_key).get(
             f"{SWARMIA_BASE_URL}/reports/pullRequests?{urlencode({'timeframe': 'last_7_days'})}",
             headers=_get_headers(api_key),
             timeout=10,
@@ -300,7 +308,7 @@ def check_credentials(api_key: str) -> int | None:
 def check_endpoint_access(api_key: str, endpoints: list[str]) -> dict[str, str | None]:
     """Probe each report with a minimal window. Some reports (investment, capex, effort) map to
     plan-gated Swarmia features, so a valid token can still be denied per report."""
-    session = make_tracked_session(redact_values=(api_key,))
+    session = _make_session(api_key)
     headers = _get_headers(api_key)
     today = datetime.now(UTC).date()
     last_month_start = _month_start(_month_start(today) - timedelta(days=1))
@@ -345,7 +353,7 @@ def get_rows(
     db_incremental_field_last_value: Any = None,
 ) -> Iterator[Any]:
     config = SWARMIA_ENDPOINTS[endpoint]
-    session = make_tracked_session(redact_values=(api_key,))
+    session = _make_session(api_key)
     headers = _get_headers(api_key)
     today = datetime.now(UTC).date()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import date
 
 import pytest
@@ -27,6 +28,10 @@ _TRACKED_SESSION_PATH = (
     "products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.swarmia.make_tracked_session"
 )
 
+# The tenacity `@retry` decorator wraps the real function; `__wrapped__` reaches the undecorated
+# body so these tests exercise a single call without the retry loop.
+_fetch_csv_direct = _fetch_csv.__wrapped__  # type: ignore[attr-defined]
+
 PULL_REQUESTS_CSV = (
     "Start Date,End Date,Parent Team(s),Team,Cycle Time (s),Review Rate (%),Time to first review (s),"
     "PRs merged / week,Merge Time (s),PRs in progress,Contributors\n"
@@ -41,7 +46,7 @@ def _mock_response(status_code: int = 200, text: str = "") -> MagicMock:
     response.ok = status_code < 400
     response.text = text
     response.raise_for_status.side_effect = (
-        requests.HTTPError(f"{status_code} Client Error") if status_code >= 400 else None
+        requests.HTTPError(f"{status_code} Client Error", response=response) if status_code >= 400 else None
     )
     return response
 
@@ -83,7 +88,7 @@ class TestColumnHandling:
         assert _convert_value(column, value) == expected
 
     def test_unpivot_capex_employees_rows(self) -> None:
-        raw_rows = [
+        raw_rows: list[dict[str | None, str]] = [
             {"Employee ID": "E1", "Name": "Alice", "Email": "alice@example.com", "2026-01-01": "0.5", "2026-02-01": ""}
         ]
         rows = _rows_from_csv(SWARMIA_ENDPOINTS["capex_employees"], raw_rows)
@@ -163,7 +168,7 @@ class TestFetchCsv:
         session.get.return_value = _mock_response(status_code)
 
         with pytest.raises(SwarmiaRetryableError):
-            _fetch_csv.__wrapped__(session, "/reports/dora", {}, {}, MagicMock())
+            _fetch_csv_direct(session, "/reports/dora", {}, {}, MagicMock())
 
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403)])
     def test_auth_errors_raise_http_error(self, _name: str, status_code: int) -> None:
@@ -171,13 +176,13 @@ class TestFetchCsv:
         session.get.return_value = _mock_response(status_code)
 
         with pytest.raises(requests.HTTPError):
-            _fetch_csv.__wrapped__(session, "/reports/dora", {}, {}, MagicMock())
+            _fetch_csv_direct(session, "/reports/dora", {}, {}, MagicMock())
 
     def test_parses_csv_rows(self) -> None:
         session = MagicMock()
         session.get.return_value = _mock_response(200, "A,B\n1,2\n")
 
-        rows = _fetch_csv.__wrapped__(session, "/reports/dora", {"startDate": "2026-06-29"}, {}, MagicMock())
+        rows = _fetch_csv_direct(session, "/reports/dora", {"startDate": "2026-06-29"}, {}, MagicMock())
 
         assert rows == [{"A": "1", "B": "2"}]
         assert "startDate=2026-06-29" in session.get.call_args[0][0]
@@ -339,6 +344,43 @@ class TestCredentialChecks:
         mock_make_session.return_value.get.side_effect = requests.ConnectionError("boom")
 
         assert check_endpoint_access("token", ["dora"]) == {"dora": None}
+
+
+class TestHttpSampleCaptureDisabled:
+    # Swarmia CSV exports carry free-text issue titles and custom fields that scrubadub can't
+    # reliably redact, so every request path must opt out of HTTP sample capture (capture=False)
+    # while still redacting the token. A regression here silently leaks customer data to the
+    # shared sample store, so assert the contract at the session boundary for each entry point.
+    @parameterized.expand(
+        [
+            (
+                "get_rows",
+                lambda: list(
+                    get_rows(
+                        api_key="token",
+                        endpoint="pull_requests",
+                        logger=MagicMock(),
+                        resumable_source_manager=_mock_manager(),
+                    )
+                ),
+            ),
+            ("check_credentials", lambda: check_credentials("token")),
+            ("check_endpoint_access", lambda: check_endpoint_access("token", ["pull_requests"])),
+        ]
+    )
+    @freeze_time("2026-07-15T12:00:00Z")
+    @patch(_TRACKED_SESSION_PATH)
+    def test_every_request_path_disables_capture_and_redacts_token(
+        self, _name: str, invoke: Callable[[], object], mock_make_session: MagicMock
+    ) -> None:
+        mock_make_session.return_value.get.return_value = _mock_response(200, PULL_REQUESTS_CSV)
+
+        invoke()
+
+        assert mock_make_session.call_count >= 1
+        for call in mock_make_session.call_args_list:
+            assert call.kwargs["capture"] is False
+            assert call.kwargs["redact_values"] == ("token",)
 
 
 class TestSwarmiaSourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia.py
@@ -1,0 +1,371 @@
+from datetime import date
+
+import pytest
+from freezegun import freeze_time
+from unittest.mock import MagicMock, patch
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.settings import SWARMIA_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.swarmia import (
+    SwarmiaResumeConfig,
+    SwarmiaRetryableError,
+    _build_windows,
+    _convert_value,
+    _fetch_csv,
+    _rename_column,
+    _rows_from_csv,
+    _window_params,
+    check_credentials,
+    check_endpoint_access,
+    get_rows,
+    swarmia_source,
+)
+
+_TRACKED_SESSION_PATH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.swarmia.make_tracked_session"
+)
+
+PULL_REQUESTS_CSV = (
+    "Start Date,End Date,Parent Team(s),Team,Cycle Time (s),Review Rate (%),Time to first review (s),"
+    "PRs merged / week,Merge Time (s),PRs in progress,Contributors\n"
+    "2026-06-29,2026-07-05,Platform,Team A,3600,80.5,600,5,7200,3,7\n"
+    "2026-06-29,2026-07-05,Platform,Team B,1800,100,300,2,900,1,4\n"
+)
+
+
+def _mock_response(status_code: int = 200, text: str = "") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = status_code < 400
+    response.text = text
+    response.raise_for_status.side_effect = (
+        requests.HTTPError(f"{status_code} Client Error") if status_code >= 400 else None
+    )
+    return response
+
+
+def _mock_manager(resume: SwarmiaResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock()
+    manager.can_resume.return_value = resume is not None
+    manager.load_state.return_value = resume
+    return manager
+
+
+class TestColumnHandling:
+    @parameterized.expand(
+        [
+            ("documented_rename", "Cycle Time (s)", "cycle_time_seconds"),
+            ("plural_parens", "Parent Team(s)", "parent_teams"),
+            ("percent_rename", "Change Failure Rate (%)", "change_failure_rate_percent"),
+            ("slash_rename", "PRs merged / week", "prs_merged_per_week"),
+            ("unknown_header_fallback", "Some New Metric (%)", "some_new_metric_percent"),
+            ("unknown_header_slash", "Bugs / sprint", "bugs_per_sprint"),
+        ]
+    )
+    def test_rename_column(self, _name: str, header: str, expected: str) -> None:
+        assert _rename_column(header) == expected
+
+    @parameterized.expand(
+        [
+            ("date_column", "start_date", "2026-06-29", date(2026, 6, 29)),
+            ("month_column_yyyy_mm", "month", "2026-06", date(2026, 6, 1)),
+            ("unparseable_date_passthrough", "month", "June 2026", "June 2026"),
+            ("float_column", "cycle_time_seconds", "3600", 3600.0),
+            ("float_column_decimal", "review_rate_percent", "80.5", 80.5),
+            ("non_numeric_metric_passthrough", "fte", "n/a", "n/a"),
+            ("empty_becomes_none", "team", "", None),
+            ("string_column", "team", "Team A", "Team A"),
+        ]
+    )
+    def test_convert_value(self, _name: str, column: str, value: str, expected: object) -> None:
+        assert _convert_value(column, value) == expected
+
+    def test_unpivot_capex_employees_rows(self) -> None:
+        raw_rows = [
+            {"Employee ID": "E1", "Name": "Alice", "Email": "alice@example.com", "2026-01-01": "0.5", "2026-02-01": ""}
+        ]
+        rows = _rows_from_csv(SWARMIA_ENDPOINTS["capex_employees"], raw_rows)
+
+        assert rows == [
+            {
+                "employee_id": "E1",
+                "name": "Alice",
+                "email": "alice@example.com",
+                "month": date(2026, 1, 1),
+                "fte": 0.5,
+            },
+            {
+                "employee_id": "E1",
+                "name": "Alice",
+                "email": "alice@example.com",
+                "month": date(2026, 2, 1),
+                "fte": None,
+            },
+        ]
+
+
+@freeze_time("2026-07-15T12:00:00Z")  # a Wednesday
+class TestBuildWindows:
+    @parameterized.expand(
+        [
+            # Mid-week start aligns down to Monday; the current (incomplete) ISO week is excluded.
+            (
+                "week_alignment_and_completeness",
+                "pull_requests",
+                date(2026, 6, 30),
+                [(date(2026, 6, 29), date(2026, 7, 5)), (date(2026, 7, 6), date(2026, 7, 12))],
+            ),
+            # The current (incomplete) month is excluded.
+            (
+                "month_completeness",
+                "investment",
+                date(2026, 6, 10),
+                [(date(2026, 6, 1), date(2026, 6, 30))],
+            ),
+            ("start_in_future_yields_nothing", "pull_requests", date(2026, 8, 1), []),
+            # The current (partial) year is included: capex/employees reports elapsed months.
+            (
+                "year_windows_include_current_year",
+                "capex_employees",
+                date(2025, 3, 1),
+                [(date(2025, 1, 1), date(2025, 12, 31)), (date(2026, 1, 1), date(2026, 12, 31))],
+            ),
+        ]
+    )
+    def test_build_windows(
+        self, _name: str, endpoint: str, range_start: date, expected: list[tuple[date, date]]
+    ) -> None:
+        assert _build_windows(SWARMIA_ENDPOINTS[endpoint], range_start, date(2026, 7, 15)) == expected
+
+
+class TestWindowParams:
+    @parameterized.expand(
+        [
+            (
+                "date_range",
+                "pull_requests",
+                {"startDate": "2026-06-29", "endDate": "2026-07-05"},
+            ),
+            ("month_param", "fte", {"month": "2026-06"}),
+            ("year_param", "capex_employees", {"year": "2026"}),
+        ]
+    )
+    def test_window_params(self, _name: str, endpoint: str, expected: dict[str, str]) -> None:
+        assert _window_params(SWARMIA_ENDPOINTS[endpoint], date(2026, 6, 29), date(2026, 7, 5)) == expected
+
+
+class TestFetchCsv:
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 502)])
+    def test_retryable_statuses_raise_retryable_error(self, _name: str, status_code: int) -> None:
+        session = MagicMock()
+        session.get.return_value = _mock_response(status_code)
+
+        with pytest.raises(SwarmiaRetryableError):
+            _fetch_csv.__wrapped__(session, "/reports/dora", {}, {}, MagicMock())
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403)])
+    def test_auth_errors_raise_http_error(self, _name: str, status_code: int) -> None:
+        session = MagicMock()
+        session.get.return_value = _mock_response(status_code)
+
+        with pytest.raises(requests.HTTPError):
+            _fetch_csv.__wrapped__(session, "/reports/dora", {}, {}, MagicMock())
+
+    def test_parses_csv_rows(self) -> None:
+        session = MagicMock()
+        session.get.return_value = _mock_response(200, "A,B\n1,2\n")
+
+        rows = _fetch_csv.__wrapped__(session, "/reports/dora", {"startDate": "2026-06-29"}, {}, MagicMock())
+
+        assert rows == [{"A": "1", "B": "2"}]
+        assert "startDate=2026-06-29" in session.get.call_args[0][0]
+
+
+@freeze_time("2026-07-15T12:00:00Z")
+class TestGetRows:
+    @patch(_TRACKED_SESSION_PATH)
+    def test_incremental_sync_fetches_complete_windows_after_watermark(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+        session.get.return_value = _mock_response(200, PULL_REQUESTS_CSV)
+        manager = _mock_manager()
+
+        batches = list(
+            get_rows(
+                api_key="token",
+                endpoint="pull_requests",
+                logger=MagicMock(),
+                resumable_source_manager=manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 6, 28),
+            )
+        )
+
+        requested_urls = [call.args[0] for call in session.get.call_args_list]
+        assert len(requested_urls) == 2
+        assert "startDate=2026-06-29&endDate=2026-07-05" in requested_urls[0]
+        assert "startDate=2026-07-06&endDate=2026-07-12" in requested_urls[1]
+
+        assert len(batches) == 2
+        first_row = batches[0][0]
+        assert first_row["start_date"] == date(2026, 6, 29)
+        assert first_row["end_date"] == date(2026, 7, 5)
+        assert first_row["team"] == "Team A"
+        assert first_row["cycle_time_seconds"] == 3600.0
+        assert first_row["review_rate_percent"] == 80.5
+
+    @patch(_TRACKED_SESSION_PATH)
+    def test_saves_resume_state_after_each_window_except_last(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+        session.get.return_value = _mock_response(200, PULL_REQUESTS_CSV)
+        manager = _mock_manager()
+
+        list(
+            get_rows(
+                api_key="token",
+                endpoint="pull_requests",
+                logger=MagicMock(),
+                resumable_source_manager=manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 6, 28),
+            )
+        )
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [SwarmiaResumeConfig(next_window_start="2026-07-06")]
+
+    @patch(_TRACKED_SESSION_PATH)
+    def test_resumes_from_saved_window_start(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+        session.get.return_value = _mock_response(200, PULL_REQUESTS_CSV)
+        manager = _mock_manager(resume=SwarmiaResumeConfig(next_window_start="2026-07-06"))
+
+        list(
+            get_rows(
+                api_key="token",
+                endpoint="pull_requests",
+                logger=MagicMock(),
+                resumable_source_manager=manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 1, 1),
+            )
+        )
+
+        requested_urls = [call.args[0] for call in session.get.call_args_list]
+        assert len(requested_urls) == 1
+        assert "startDate=2026-07-06&endDate=2026-07-12" in requested_urls[0]
+
+    @patch(_TRACKED_SESSION_PATH)
+    def test_monthly_endpoint_uses_month_param(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+        session.get.return_value = _mock_response(
+            200, "Month,Author ID,Email,FTE,Swarmia issue type,Issue key\n2026-06,A1,a@example.com,0.25,Epic,ENG-1\n"
+        )
+        manager = _mock_manager(resume=SwarmiaResumeConfig(next_window_start="2026-06-01"))
+
+        batches = list(
+            get_rows(
+                api_key="token",
+                endpoint="fte",
+                logger=MagicMock(),
+                resumable_source_manager=manager,
+            )
+        )
+
+        assert "month=2026-06" in session.get.call_args[0][0]
+        assert batches[0][0] == {
+            "month": date(2026, 6, 1),
+            "author_id": "A1",
+            "email": "a@example.com",
+            "fte": 0.25,
+            "swarmia_issue_type": "Epic",
+            "issue_key": "ENG-1",
+        }
+
+    @patch(_TRACKED_SESSION_PATH)
+    def test_header_only_csv_yields_nothing(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+        session.get.return_value = _mock_response(200, "Start Date,End Date,Deployment Count\n")
+        manager = _mock_manager()
+
+        batches = list(
+            get_rows(
+                api_key="token",
+                endpoint="dora",
+                logger=MagicMock(),
+                resumable_source_manager=manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 6, 28),
+            )
+        )
+
+        assert batches == []
+
+
+class TestCredentialChecks:
+    @parameterized.expand([("valid", 200), ("unauthorized", 401), ("forbidden", 403)])
+    @patch(_TRACKED_SESSION_PATH)
+    def test_check_credentials_returns_status(self, _name: str, status_code: int, mock_make_session: MagicMock) -> None:
+        mock_make_session.return_value.get.return_value = _mock_response(status_code)
+
+        assert check_credentials("token") == status_code
+
+    @patch(_TRACKED_SESSION_PATH)
+    def test_check_credentials_network_failure_returns_none(self, mock_make_session: MagicMock) -> None:
+        mock_make_session.return_value.get.side_effect = requests.ConnectionError("boom")
+
+        assert check_credentials("token") is None
+
+    @freeze_time("2026-07-15T12:00:00Z")
+    @patch(_TRACKED_SESSION_PATH)
+    def test_check_endpoint_access_flags_denied_reports(self, mock_make_session: MagicMock) -> None:
+        session = mock_make_session.return_value
+
+        def _get(url: str, **kwargs: object) -> MagicMock:
+            if "/reports/capex" in url:
+                return _mock_response(403)
+            return _mock_response(200, "Start Date,End Date\n")
+
+        session.get.side_effect = _get
+
+        results = check_endpoint_access("token", ["pull_requests", "capex"])
+
+        assert results["pull_requests"] is None
+        assert results["capex"] is not None and "can't access" in results["capex"]
+
+    @patch(_TRACKED_SESSION_PATH)
+    def test_check_endpoint_access_network_blip_is_not_a_permission_error(self, mock_make_session: MagicMock) -> None:
+        mock_make_session.return_value.get.side_effect = requests.ConnectionError("boom")
+
+        assert check_endpoint_access("token", ["dora"]) == {"dora": None}
+
+
+class TestSwarmiaSourceResponse:
+    @parameterized.expand(
+        [
+            ("pull_requests", ["start_date", "end_date", "team"], "start_date"),
+            ("dora", ["start_date", "end_date"], "start_date"),
+            ("investment", ["start_date", "end_date", "investment_category"], "start_date"),
+            ("capex", ["month", "employee_id", "capitalizable_work"], None),
+            ("capex_employees", ["month", "employee_id"], None),
+            ("fte", ["month", "author_id", "issue_key"], None),
+        ]
+    )
+    def test_source_response_shape(self, endpoint: str, primary_keys: list[str], partition_key: str | None) -> None:
+        response = swarmia_source(
+            api_key="token",
+            endpoint=endpoint,
+            logger=MagicMock(),
+            resumable_source_manager=_mock_manager(),
+        )
+
+        assert response.name == endpoint
+        assert response.primary_keys == primary_keys
+        assert response.sort_mode == "asc"
+        if partition_key:
+            assert response.partition_keys == [partition_key]
+            assert response.partition_mode == "datetime"
+        else:
+            assert response.partition_keys is None
+            assert response.partition_mode is None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia_source.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
-from posthog.schema import ReleaseStatus, SourceFieldInputConfigType
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SwarmiaSourceConfig
@@ -58,9 +58,11 @@ class TestSwarmiaSource:
     def test_source_config_has_secret_api_key_field(self) -> None:
         fields = self.source.get_source_config.fields
         assert len(fields) == 1
-        assert fields[0].name == "api_key"
-        assert fields[0].type == SourceFieldInputConfigType.PASSWORD
-        assert fields[0].required is True
+        field = fields[0]
+        assert isinstance(field, SourceFieldInputConfig)
+        assert field.name == "api_key"
+        assert field.type == SourceFieldInputConfigType.PASSWORD
+        assert field.required is True
 
     @parameterized.expand(
         [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/test_swarmia_source.py
@@ -1,0 +1,144 @@
+from typing import Any
+
+from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import SwarmiaSourceConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.canonical_descriptions import (
+    CANONICAL_DESCRIPTIONS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.source import SwarmiaSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.swarmia import SwarmiaResumeConfig
+from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalFieldType
+
+_SOURCE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.swarmia.source"
+
+
+def _make_inputs(
+    schema_name: str = "pull_requests",
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> SourceInputs:
+    return SourceInputs(
+        schema_name=schema_name,
+        schema_id="schema-id",
+        source_id="source-id",
+        team_id=1,
+        should_use_incremental_field=should_use_incremental_field,
+        db_incremental_field_last_value=db_incremental_field_last_value,
+        db_incremental_field_earliest_value=None,
+        incremental_field="end_date" if should_use_incremental_field else None,
+        incremental_field_type=IncrementalFieldType.Date if should_use_incremental_field else None,
+        job_id="job-id",
+        logger=MagicMock(),
+        reset_pipeline=False,
+    )
+
+
+class TestSwarmiaSource:
+    def setup_method(self) -> None:
+        self.source = SwarmiaSource()
+        self.config = SwarmiaSourceConfig(api_key="token")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.SWARMIA
+
+    def test_source_config_is_released_alpha(self) -> None:
+        config = self.source.get_source_config
+        assert config.label == "Swarmia"
+        assert not config.unreleasedSource
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/swarmia"
+
+    def test_source_config_has_secret_api_key_field(self) -> None:
+        fields = self.source.get_source_config.fields
+        assert len(fields) == 1
+        assert fields[0].name == "api_key"
+        assert fields[0].type == SourceFieldInputConfigType.PASSWORD
+        assert fields[0].required is True
+
+    @parameterized.expand(
+        [
+            ("pull_requests", True),
+            ("dora", True),
+            ("investment", True),
+            ("capex", False),
+            ("capex_employees", False),
+            ("fte", False),
+        ]
+    )
+    def test_get_schemas_incremental_support(self, endpoint: str, supports_incremental: bool) -> None:
+        schemas = {s.name: s for s in self.source.get_schemas(self.config, team_id=1)}
+
+        schema = schemas[endpoint]
+        assert schema.supports_incremental is supports_incremental
+        # Re-pulled trailing windows must be merged (deduped on primary key), never appended.
+        assert schema.supports_append is False
+        if supports_incremental:
+            assert [f["field"] for f in schema.incremental_fields] == ["end_date"]
+
+    def test_get_schemas_returns_all_endpoints_and_filters_by_name(self) -> None:
+        assert {s.name for s in self.source.get_schemas(self.config, team_id=1)} == set(ENDPOINTS)
+        assert [s.name for s in self.source.get_schemas(self.config, team_id=1, names=["dora"])] == ["dora"]
+
+    @parameterized.expand(
+        [
+            ("valid_token", 200, None, True),
+            ("invalid_token", 401, None, False),
+            ("forbidden_at_create_is_accepted", 403, None, True),
+            ("forbidden_for_specific_schema_fails", 403, "investment", False),
+            ("network_failure", None, None, False),
+        ]
+    )
+    @patch(f"{_SOURCE_MODULE}.check_credentials")
+    def test_validate_credentials(
+        self,
+        _name: str,
+        status: int | None,
+        schema_name: str | None,
+        expected_valid: bool,
+        mock_check: MagicMock,
+    ) -> None:
+        mock_check.return_value = status
+
+        valid, error = self.source.validate_credentials(self.config, team_id=1, schema_name=schema_name)
+
+        assert valid is expected_valid
+        if not expected_valid:
+            assert error
+
+    def test_get_resumable_source_manager_binds_resume_config(self) -> None:
+        manager = self.source.get_resumable_source_manager(_make_inputs())
+        assert manager._data_class is SwarmiaResumeConfig
+
+    @patch(f"{_SOURCE_MODULE}.swarmia_source")
+    def test_source_for_pipeline_passes_incremental_value_only_when_enabled(self, mock_source: MagicMock) -> None:
+        manager = MagicMock()
+
+        inputs = _make_inputs(should_use_incremental_field=True, db_incremental_field_last_value="2026-06-28")
+        self.source.source_for_pipeline(self.config, manager, inputs)
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["api_key"] == "token"
+        assert kwargs["endpoint"] == "pull_requests"
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["db_incremental_field_last_value"] == "2026-06-28"
+
+        inputs = _make_inputs(should_use_incremental_field=False, db_incremental_field_last_value="2026-06-28")
+        self.source.source_for_pipeline(self.config, manager, inputs)
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["should_use_incremental_field"] is False
+        assert kwargs["db_incremental_field_last_value"] is None
+
+    def test_non_retryable_errors_cover_auth_failures(self) -> None:
+        errors = self.source.get_non_retryable_errors()
+        assert "401 Client Error: Unauthorized for url: https://app.swarmia.com" in errors
+        assert "403 Client Error: Forbidden for url: https://app.swarmia.com" in errors
+
+    def test_canonical_descriptions_match_endpoint_catalog(self) -> None:
+        # A canonical entry keyed off a name not in the catalog is silently unused (typo guard).
+        assert set(CANONICAL_DESCRIPTIONS.keys()) == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

Data teams using Swarmia want their engineering effectiveness reports (DORA metrics, PR metrics, investment balance, software capitalization, effort) in the warehouse so they can blend them with delivery, finance, and headcount data. The Swarmia source was scaffolded in #71137 but had no sync logic.

**Why:** completes the scaffolded Swarmia connector so it's actually connectable and syncable, as part of the batch implementing the scaffolded engineering/support sources.

## Changes

Implements the Swarmia source end-to-end over Swarmia's [Export API v0](https://help.swarmia.com/settings/integrations/swarmia-apis/export-api), which is unusual for a REST source in two ways: responses are CSV (not JSON), and every endpoint is a time-windowed aggregate report rather than a paginated entity list. That shape drove the architecture:

- `settings.py` — declarative endpoint catalog: `pull_requests`, `dora` (ISO-week windows), `investment`, `capex`, `fte` (calendar-month windows), `capex_employees` (year windows). Primary keys are the window bounds plus the row's grouping columns.
- `swarmia.py` — bespoke transport: tracked `requests` session (`make_tracked_session`), tenacity retries on 429/5xx, CSV parsing with documented-header renames (`Cycle Time (s)` → `cycle_time_seconds`) plus a deterministic fallback for undocumented headers, date/float coercion (floats only, so Arrow column types can't flip between int and double across syncs), and an unpivot for `capex/employees` (whose raw CSV has one column per month of the year).
- Sync model: only **complete** windows are fetched — a partial window's end date shifts daily, which would mint a new primary key for the same logical row every sync. `ResumableSource` with a next-window-start cursor saved after each yielded batch, so crashed jobs resume without refetching.
- Incremental sync (server-side `startDate`/`endDate` filter) for `pull_requests`, `dora`, and `investment`, watermarked on `end_date` with a trailing re-read window since Swarmia regenerates recent report data (FTE data lands ~10th of the following month). `capex`, `capex_employees`, and `fte` are full refresh only: they're FTE-based (restated after the fact) and `capex` has no reliably unique key (rows are keyed by issue *title*).
- `source.py` — released visible with `releaseStatus=ReleaseStatus.ALPHA` (scaffold's `unreleasedSource=True` removed), static schema catalog (`lists_tables_without_credentials = True`), credential validation against the cheapest report, per-table access probes (`get_endpoint_permissions`) because investment/capex/effort reports can be plan-gated, and non-retryable 401/403 errors.
- `canonical_descriptions.py` — table/column descriptions from the official API docs for AI enrichment and the public docs table list.
- `SOURCES.md` — swarmia moved from Scaffolded to Implemented (HTTP / requests / tracked ✅).

Companion doc PR in posthog.com adds `contents/docs/cdp/sources/swarmia.md` (matching `docsUrl`).

> [!NOTE]
> Endpoint behavior was verified against Swarmia's current API docs and an unauthenticated probe of the live API (confirms the 401 error shape); I didn't have a real Swarmia token, so CSV column names and window filtering follow the documented formats. Conservative choices (full refresh for the restated FTE reports, float-only numeric coercion, header-rename fallback) are noted in code comments, and the source ships as alpha.

## How did you test this code?

- `hogli test products/warehouse_sources/backend/temporal/data_imports/sources/swarmia/tests/` — 64 passed.
- `hogli test .../sources/tests/test_source_categories.py .../common/test/test_source_config_generator.py` — 1715 passed (registry-wide guards).
- `ruff check --fix`, `ruff format`, and `hogli ci:preflight --fix` — clean.
- `python manage.py audit_source_docs` against the posthog.com doc — no swarmia findings (pre-existing failures for other in-flight sources remain).

New tests and the regressions they catch: window-grid tests catch partial/misaligned windows that would mint duplicate primary keys; resume/save-state tests catch state saved before yield (data loss on crash) or not resuming from the saved window; CSV conversion tests catch header-rename and type-coercion drift; credential tests pin the 401-invalid vs 403-plan-gated distinction; the `SourceResponse` shape test catches primary-key/partition drift per endpoint. No existing tests covered this source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Companion posthog.com PR adds the user-facing doc for this source.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Implemented with Claude Code following the `/implementing-warehouse-sources`, `/writing-tests`, and `/documenting-warehouse-sources` skills. Key decisions: modeled the aggregate reports as fixed-grid complete windows (ISO weeks / calendar months) instead of a rolling window so row identity is stable; kept the FTE-based monthly reports (capex, capex_employees, fte) full-refresh rather than incremental because Swarmia regenerates that data after the fact and the capex key (issue title) isn't reliably unique; unpivoted capex/employees' per-month columns into rows so the table schema doesn't change every year. Rejected the generic `rest_source.RESTClient` path since responses are CSV and unpaginated.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
