### PR TITLE
feat(aio): add 'generated' delivery status for target-less eval reports

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/delivery.py
@@ -430,7 +430,8 @@ def deliver_report(report_id: str, report_run_id: str) -> None:
         increment_delivery("slack", "failed")
 
     if not had_any_target:
-        report_run.delivery_status = EvaluationReportRun.DeliveryStatus.PENDING
+        # Report generated successfully, but no delivery target is configured, so there is nothing to send.
+        report_run.delivery_status = EvaluationReportRun.DeliveryStatus.GENERATED
     elif all_failed:
         report_run.delivery_status = EvaluationReportRun.DeliveryStatus.FAILED
     elif all_errors:

--- a/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_delivery.py
@@ -345,6 +345,24 @@ class TestDeliverReport(SimpleTestCase):
     @patch("posthog.temporal.ai_observability.eval_reports.delivery.deliver_slack_report")
     @patch("products.ai_observability.backend.models.evaluation_reports.EvaluationReportRun.objects")
     @patch("products.ai_observability.backend.models.evaluation_reports.EvaluationReport.objects")
+    def test_deliver_report_without_targets_marks_generated(self, mock_report_qs, mock_run_qs, mock_slack, mock_email):
+        report = self._make_report([])
+        run = self._make_report_run()
+
+        mock_report_qs.select_related.return_value.get.return_value = report
+        mock_run_qs.get.return_value = run
+
+        deliver_report("report-id", "run-id")
+
+        mock_email.assert_not_called()
+        mock_slack.assert_not_called()
+        self.assertEqual(run.delivery_status, "generated")
+        self.assertEqual(run.delivery_errors, [])
+
+    @patch("posthog.temporal.ai_observability.eval_reports.delivery.deliver_email_report")
+    @patch("posthog.temporal.ai_observability.eval_reports.delivery.deliver_slack_report")
+    @patch("products.ai_observability.backend.models.evaluation_reports.EvaluationReportRun.objects")
+    @patch("products.ai_observability.backend.models.evaluation_reports.EvaluationReport.objects")
     def test_deliver_report_handles_failures(self, mock_report_qs, mock_run_qs, _mock_slack, mock_email):
         targets = [{"type": "email", "value": "test@example.com"}]
         report = self._make_report(targets)

--- a/products/ai_observability/backend/api/evaluation_reports.py
+++ b/products/ai_observability/backend/api/evaluation_reports.py
@@ -515,7 +515,7 @@ class EvaluationReportRunSerializer(serializers.ModelSerializer):
             "period_start": {"help_text": "Start of the evaluation window covered by this report."},
             "period_end": {"help_text": "End of the evaluation window covered by this report."},
             "delivery_status": {
-                "help_text": "Delivery result: 'pending', 'delivered', 'partial_failure', or 'failed'."
+                "help_text": "Delivery result: 'pending', 'generated', 'delivered', 'partial_failure', or 'failed'."
             },
             "created_at": {"help_text": "When this report run was created."},
         }

--- a/products/ai_observability/backend/migrations/0022_add_generated_delivery_status.py
+++ b/products/ai_observability/backend/migrations/0022_add_generated_delivery_status.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("ai_observability", "0021_add_zeabur_provider")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="evaluationreportrun",
+            name="delivery_status",
+            field=models.CharField(
+                choices=[
+                    ("pending", "Pending"),
+                    ("generated", "Generated"),
+                    ("delivered", "Delivered"),
+                    ("partial_failure", "Partial Failure"),
+                    ("failed", "Failed"),
+                ],
+                default="pending",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/products/ai_observability/backend/migrations/max_migration.txt
+++ b/products/ai_observability/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0021_add_zeabur_provider
+0022_add_generated_delivery_status

--- a/products/ai_observability/backend/models/evaluation_reports.py
+++ b/products/ai_observability/backend/models/evaluation_reports.py
@@ -179,6 +179,7 @@ def validate_report_rrule(rrule_string: str) -> None:
 class EvaluationReportRun(UUIDTModel):
     class DeliveryStatus(models.TextChoices):
         PENDING = "pending"
+        GENERATED = "generated"
         DELIVERED = "delivered"
         PARTIAL_FAILURE = "partial_failure"
         FAILED = "failed"

--- a/products/ai_observability/frontend/evaluations/components/EvaluationReportViewer.tsx
+++ b/products/ai_observability/frontend/evaluations/components/EvaluationReportViewer.tsx
@@ -280,6 +280,7 @@ function MetricsCard({ metrics }: { metrics: EvaluationReportStoredMetrics }): J
 function DeliveryStatusBadge({ status }: { status: string }): JSX.Element {
     const statusMap: Record<string, { label: string; status: 'success' | 'warning' | 'danger' | 'muted' }> = {
         delivered: { label: 'Delivered', status: 'success' },
+        generated: { label: 'Generated', status: 'success' },
         pending: { label: 'Pending', status: 'muted' },
         partial_failure: { label: 'Partial failure', status: 'warning' },
         failed: { label: 'Failed', status: 'danger' },

--- a/products/ai_observability/frontend/evaluations/components/EvaluationReportsTab.tsx
+++ b/products/ai_observability/frontend/evaluations/components/EvaluationReportsTab.tsx
@@ -20,6 +20,7 @@ const STATUS_STYLES: Record<
     { label: string; type: 'success' | 'warning' | 'danger' | 'muted' }
 > = {
     delivered: { label: 'Delivered', type: 'success' },
+    generated: { label: 'Generated', type: 'success' },
     pending: { label: 'Pending', type: 'muted' },
     partial_failure: { label: 'Partial failure', type: 'warning' },
     failed: { label: 'Failed', type: 'danger' },

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -1316,6 +1316,7 @@ export interface EvaluationReportRunContentApi {
 
 /**
  * * `pending` - Pending
+ * * `generated` - Generated
  * * `delivered` - Delivered
  * * `partial_failure` - Partial Failure
  * * `failed` - Failed
@@ -1324,6 +1325,7 @@ export type DeliveryStatusEnumApi = (typeof DeliveryStatusEnumApi)[keyof typeof 
 
 export const DeliveryStatusEnumApi = {
     Pending: 'pending',
+    Generated: 'generated',
     Delivered: 'delivered',
     PartialFailure: 'partial_failure',
     Failed: 'failed',
@@ -1342,9 +1344,10 @@ export interface EvaluationReportRunApi {
     readonly period_start: string
     /** End of the evaluation window covered by this report. */
     readonly period_end: string
-    /** Delivery result: 'pending', 'delivered', 'partial_failure', or 'failed'.
+    /** Delivery result: 'pending', 'generated', 'delivered', 'partial_failure', or 'failed'.
      *
      * * `pending` - Pending
+     * * `generated` - Generated
      * * `delivered` - Delivered
      * * `partial_failure` - Partial Failure
      * * `failed` - Failed */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19360,6 +19360,7 @@ export namespace Schemas {
 
     /**
      * * `pending` - Pending
+     * * `generated` - Generated
      * * `delivered` - Delivered
      * * `partial_failure` - Partial Failure
      * * `failed` - Failed
@@ -19369,6 +19370,7 @@ export namespace Schemas {
 
     export const DeliveryStatusEnum = {
       Pending: 'pending',
+      Generated: 'generated',
       Delivered: 'delivered',
       PartialFailure: 'partial_failure',
       Failed: 'failed',
@@ -22911,9 +22913,10 @@ export namespace Schemas {
       readonly period_start: string;
       /** End of the evaluation window covered by this report. */
       readonly period_end: string;
-      /** Delivery result: 'pending', 'delivered', 'partial_failure', or 'failed'.
+      /** Delivery result: 'pending', 'generated', 'delivered', 'partial_failure', or 'failed'.
        *
        * * `pending` - Pending
+       * * `generated` - Generated
        * * `delivered` - Delivered
        * * `partial_failure` - Partial Failure
        * * `failed` - Failed */


### PR DESCRIPTION
## Problem

The **Status** column on evaluation reports shows each run's `delivery_status`. When a report has no delivery target configured, the run was left at `pending`, the model default. In the UI that reads as "delivery still in progress" forever, even though the report generated fine and there was simply nothing to deliver. Raised in a Slack thread while digging into what the Status column values actually mean.

## Changes

Add a distinct `generated` delivery status for the no-target case so the column tells the truth.

- New `DeliveryStatus.GENERATED`, set in `deliver_report` when a report has no delivery targets (previously fell through to `pending`).
- Frontend badges in `EvaluationReportsTab` and `EvaluationReportViewer` render it as a green "Generated" pill.
- Serializer help text and the generated OpenAPI enum updated to include the new value.

> [!NOTE]
> Existing runs already stored as `pending` are left as-is; only new runs get `generated`. No backfill.

## How did you test this code?

Added `test_deliver_report_without_targets_marks_generated` to `test_delivery.py`. It catches the regression where a target-less report is marked `pending` (or any other status) instead of `generated` — no existing delivery test exercised the no-target path (the others all cover email/slack success, failure, and partial failure).

I (Claude, via the PostHog Slack app) could not run the suite or linters in this environment (no flox/drf-spectacular/ruff available), so the OpenAPI type change in `api.schemas.ts` was hand-edited to match generator output rather than produced by `hogli build:openapi`. Worth a reviewer running `hogli build:openapi` to confirm no drift.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via the PostHog Slack app, directed by Radu. Skills invoked while shaping this: `/django-migrations` (for the `AlterField` choices migration) and `/writing-tests` (before adding the delivery test).

Decisions: chose a new enum value over re-labeling `pending` only at display time, because the run row alone can't distinguish "genuinely pending" from "no target" without the new state. Labeled it green ("success") rather than muted, since a target-less report generating is a healthy terminal outcome. Skipped a data backfill of historical `pending` runs to keep the migration a pure metadata `AlterField`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784131521779119)*
