### PR TITLE
fix(web-analytics): restrict no-join lazy compute to uuidv7 session ids

### DIFF
--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -72,6 +72,10 @@ _check_lazy_precompute_eligible = check_common_eligible
 # its events that spill past midnight — the HAVING clause attributes the session
 # to its start hour, but the events scan needs the trailing events to compute
 # correct `$session_duration` / `$pageview_count` / `$is_bounce`.
+# Only UUIDv7 session ids enter the no-join shape (version nibble check on both
+# sides): the events side derives the hour bucket from the v7-embedded timestamp,
+# which is garbage for v4/custom UUIDs — the join shape bucketed those via real
+# session timestamps, so excluding them symmetrically keeps both sides consistent.
 # Filtered cache keys (a `$host` user filter or applied test-account filters) keep the
 # join shape below: those filters constrain which sessions qualify and can only be
 # evaluated on the events side, so the two-scan template would cache wrong session
@@ -133,6 +137,7 @@ FROM (
     WHERE and(
         {events_session_id} IS NOT NULL,
         events.$session_id_uuid IS NOT NULL,
+        equals(bitAnd(bitShiftRight(events.$session_id_uuid, 76), 15), 7),
         {event_type_filter},
         timestamp >= {time_window_min},
         timestamp < ({time_window_max} + toIntervalMinute({pad_minutes})),
@@ -151,6 +156,7 @@ LEFT JOIN (
     WHERE and(
         sessions.$start_timestamp >= {time_window_min},
         sessions.$start_timestamp < {time_window_max},
+        equals(bitAnd(bitShiftRight(sessions.session_id_v7, 76), 15), 7),
         or(sessions.$pageview_count > 0, sessions.$screen_count > 0),
     )
     GROUP BY time_window_start

--- a/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_paths_lazy_precompute.py
@@ -334,6 +334,7 @@ FROM (
     WHERE and(
         {events_session_id} IS NOT NULL,
         events.$session_id_uuid IS NOT NULL,
+        equals(bitAnd(bitShiftRight(events.$session_id_uuid, 76), 15), 7),
         {event_type_filter},
         timestamp >= {time_window_min},
         timestamp < ({time_window_max} + toIntervalMinute({pad_minutes})),
@@ -356,6 +357,7 @@ LEFT JOIN (
     WHERE and(
         sessions.$start_timestamp >= {time_window_min},
         sessions.$start_timestamp < {time_window_max},
+        equals(bitAnd(bitShiftRight(sessions.session_id_v7, 76), 15), 7),
         or(sessions.$pageview_count > 0, sessions.$screen_count > 0),
     )
     GROUP BY time_window_start, breakdown_value


### PR DESCRIPTION
## Problem

#71115 merged just before its last review round was pushed: the no-join lazy compute templates derive the hour bucket from the timestamp embedded in the session UUID, which is only meaningful for UUIDv7. For teams with valid-but-non-v7 session ids (UUIDv4 or custom), the high bits decode to garbage timestamps - those sessions mis-bucket or silently drop, where the old join shape bucketed them via real session timestamps. Flagged by Greptile (P1) and Codex (P2 x2) on #71115; the threads were resolved against this fix, but the merge landed one commit early.

## Changes

Adds a UUID version-nibble guard (`bitAnd(bitShiftRight(id, 76), 15) = 7`) to **both sides** of both no-join templates (overview + paths) - events and sessions symmetrically, so neither side counts sessions the other excludes. For posthog-js traffic (always v7) the guards are no-ops; non-v7 sessions fall out of the no-join precompute consistently instead of mis-bucketing.

## How did you test this code?

- Both lazy round-trip suites re-run with the guards: 76 passed (compute -> read value assertions through the guarded templates).
- Cherry-picked verbatim from the reviewed-but-unmerged commit on the #71115 branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The fix existed on the #71115 branch when its review threads were resolved, but the PR was merged at the prior head; this re-lands it. Skills invoked: /writing-tests.