### PR TITLE
fix(ci): preserve selective storybook file filters

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -458,7 +458,14 @@ jobs:
                   if [ "$MODE" = "selective" ]; then
                       # test-storybook is jest-based; positional path args filter the run to
                       # only those story files before Jest distributes them across shards.
-                      mapfile -d '' -t AFFECTED_FILES < <(jq -j '.[] | ., "\u0000"' <<< "$AFFECTED_FILES_JSON")
+                      affected_files_path=$(mktemp)
+                      node -e 'for (const file of JSON.parse(process.env.AFFECTED_FILES_JSON)) process.stdout.write(`${file}\0`)' > "$affected_files_path"
+                      mapfile -d '' -t AFFECTED_FILES < "$affected_files_path"
+                      rm "$affected_files_path"
+                      if [ "${#AFFECTED_FILES[@]}" -eq 0 ]; then
+                          echo "::error::Selective mode did not provide affected story files"
+                          exit 1
+                      fi
                       pnpm --filter=@posthog/storybook test:visual:ci:update --browsers ${{ matrix.browser }} --shard ${{ matrix.shard }}/${{ matrix.shard_count }} -- "${AFFECTED_FILES[@]}"
                   else
                       pnpm --filter=@posthog/storybook test:visual:ci:update --browsers ${{ matrix.browser }} --shard ${{ matrix.shard }}/${{ matrix.shard_count }}


### PR DESCRIPTION
## Problem

Draft Storybook runs can select a reduced shard matrix, but the visual regression container does not include `jq`. The file parser therefore produces no positional test filters and the reduced shards run the full suite.

**Why:** Selective runs should execute only the affected stories so draft CI remains fast and predictable.

## Changes

- Parse the affected-story JSON with the Node runtime already installed in the job.
- Fail explicitly when selective mode produces an empty file list instead of silently running every story.

## How did you test this code?

- Ran a local smoke test covering null-delimited paths, including a path containing a space.
- Ran pinned `actionlint` 1.7.12 against `.github/workflows/ci-storybook.yml`.
- Ran `bin/hogli lint:workflows`.
- Ran `bin/hogli ci:preflight --fix` with the branch even with `master`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change is needed because this fixes internal CI execution behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code investigated engineering analytics and GitHub Actions logs, then implemented the targeted workflow fix. The `/authoring-ci-workflows`, `/diagnosing-ci-and-merge-bottlenecks`, and `/querying-posthog-data` skills guided the investigation, workflow conventions, and validation approach.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
