### PR TITLE
fix(flags): address review feedback on cohort_membership gating

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -556,6 +556,9 @@ class CohortFiltersField(serializers.JSONField):
     pass
 
 
+# Keep in sync with CohortConditionFlags / Cohort.compute_condition_type in
+# products/cohorts/backend/models/cohort.py — pydantic can't share that TypedDict directly,
+# so a new flag added to one won't raise a type error if the other is missed.
 class CohortConditionTypeFlags(BaseModel, extra="forbid"):
     person_properties: bool = Field(description="The filters include a person property or person_metadata condition.")
     behavioral: bool = Field(

--- a/posthog/dags/tests/test_backfill_internal_test_users_cohort.py
+++ b/posthog/dags/tests/test_backfill_internal_test_users_cohort.py
@@ -1,0 +1,23 @@
+import pytest
+
+from dagster import build_op_context
+
+from posthog.dags.backfill_internal_test_users_cohort import (
+    _INTERNAL_TEST_USERS_FILTERS,
+    create_internal_test_users_cohorts_op,
+)
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+
+from products.cohorts.backend.models.cohort import Cohort, CohortKind
+
+
+@pytest.mark.django_db
+def test_create_internal_test_users_cohorts_op_sets_condition_type_on_bulk_created_rows():
+    org = Organization.objects.create(name="test-org-internal-test-users")
+    team = Team.objects.create(organization=org, name="test-team-internal-test-users")
+
+    create_internal_test_users_cohorts_op(build_op_context(), [team.id])
+
+    cohort = Cohort.objects.get(team=team, kind=CohortKind.INTERNAL_TEST_USERS)
+    assert cohort.condition_type == Cohort.compute_condition_type(_INTERNAL_TEST_USERS_FILTERS)

--- a/posthog/management/commands/test/test_resave_cohorts.py
+++ b/posthog/management/commands/test/test_resave_cohorts.py
@@ -171,6 +171,22 @@ class TestResaveCohortsCommandSingleTeam(BaseTest):
         assert behavioral_filter_4["bytecode"] == ["_H", HOGQL_BYTECODE_VERSION, 32, "page_view", 32, "event", 1, 1, 11]
         assert behavioral_filter_4["conditionHash"] is not None
 
+    def test_resave_backfills_null_condition_type_with_no_other_change(self):
+        team: Team = self.team
+
+        cohort = Cohort.objects.create(team=team, name="rt", filters=_make_realtime_filters())
+        Cohort.objects.filter(id=cohort.id).update(condition_type=None)
+
+        call_command("resave_cohorts", team_id=team.id)
+
+        cohort.refresh_from_db()
+        assert cohort.condition_type == {
+            "person_properties": True,
+            "behavioral": True,
+            "lifecycle": False,
+            "cohorts": False,
+        }
+
 
 class TestResaveCohortsCommandWithDependencies(BaseTest):
     def test_cohort_dependency_blocks_realtime(self):

--- a/products/cohorts/backend/models/cohort.py
+++ b/products/cohorts/backend/models/cohort.py
@@ -286,15 +286,17 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
     def save(self, *args: Any, **kwargs: Any) -> None:
         """Keep `condition_type` derived from `filters` on every save, so any creation path
         (the cohorts API, management commands, or a direct `Cohort.objects.create(...)`)
-        ends up with a consistent classification, not just the API serializer's flow."""
+        ends up with a consistent classification, not just the API serializer's flow.
+
+        `cohort_type` isn't derived here — it's computed by the API serializer
+        (`validate_filters_and_compute_realtime_support`) — so a direct `Cohort.objects.create(...)`
+        gets a fresh `condition_type` but a stale/absent `cohort_type`."""
         # update_fields can arrive positionally (4th positional, after force_insert/force_update/using)
         # or as a keyword. Intercept it so _maintain_behavioral_shape can extend the frozen set.
         update_fields = args[3] if len(args) > 3 else kwargs.get("update_fields")
-        if update_fields is None:
+        if update_fields is None or "filters" in update_fields:
             self.condition_type = Cohort.compute_condition_type(self.filters)
-        elif "filters" in update_fields:
-            self.condition_type = Cohort.compute_condition_type(self.filters)
-            if "condition_type" not in update_fields:
+            if update_fields is not None and "condition_type" not in update_fields:
                 update_fields = [*update_fields, "condition_type"]
 
         maintained_update_fields = self._maintain_behavioral_shape(update_fields)

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -396,8 +396,10 @@ pub struct Config {
     // `Cohort::uses_realtime_membership()` also requires `condition_type` to flag a
     // behavioral/lifecycle condition. `condition_type` wasn't backfilled when it was added, so
     // any cohort that hasn't been saved since must be resaved (`python manage.py resave_cohorts
-    // --team-id <id>`) before allowlisting a team here, or its behavioral cohorts will read as
-    // condition_type = NULL and fall back to legacy dynamic evaluation.
+    // --team-id <id>`) for every team in REALTIME_COHORT_EVALUATION_TEAM_IDS, including any
+    // already allowlisted at deploy time — otherwise its behavioral cohorts read as
+    // condition_type = NULL and fall back to legacy dynamic evaluation, which resolves every
+    // person as a non-member rather than just evaluating slower.
     #[envconfig(from = "REALTIME_COHORT_EVALUATION_TEAM_IDS", default = "none")]
     pub realtime_cohort_evaluation_team_ids: TeamIdCollection,
 


### PR DESCRIPTION
## Problem

[#70554](https://github.com/PostHog/posthog/pull/70554) merged before haacked's review pass finished. Several concrete, low-risk suggestions were left on the merged PR and hadn't been addressed.

## Changes

- Add a `resave_cohorts` test covering the actual scenario the no-backfill migration relies on: a row with a stale/NULL `condition_type` that's the only thing out of date. Every existing test in that file creates cohorts via `Cohort.objects.create(...)`, which already sets `condition_type` through `save()`, so the backfill branch was never exercised.
- Add a test for `create_internal_test_users_cohorts_op`'s `bulk_create` path — the only place `condition_type` is set by hand, since `bulk_create` bypasses `Cohort.save()`.
- Add a cross-reference comment between `CohortConditionTypeFlags` (pydantic, OpenAPI-facing) and `CohortConditionFlags` (TypedDict, `compute_condition_type`'s return type) — the same shape is declared twice with no type-level guard against drift.
- Collapse `Cohort.save()`'s duplicated `condition_type` derivation (two branches computing the same thing) into one condition, and note why `cohort_type` (derived in the API serializer) and `condition_type` (derived in `save()`) live in different places.
- Clarify the `REALTIME_COHORT_EVALUATION_TEAM_IDS` config comment: the `resave_cohorts` step matters for any team already allowlisted at deploy time, not just ones added afterward — a stale `condition_type` causes behavioral cohorts to evaluate every person as a non-member, not just evaluate slower.

Two other review threads asked open design questions (a 4-boolean flag shape vs. a single bool; persisting `condition_type` vs. computing it on the fly in Rust) rather than pointing at a concrete bug. Replied on the original PR threads with the actual reasoning instead of reshaping the just-shipped API schema in a same-day follow-up.

## How did you test this code?

- `ruff check` / `ruff format --check` pass on all changed Python files.
- Hand-verified the `Cohort.save()` branch collapse is behavior-preserving for all three `update_fields` cases (`None`, containing `"filters"`, not containing `"filters"`).
- Couldn't run the Django test suite or `cargo build` in this sandbox (no runnable Django/Rust toolchain available) — the two new tests follow existing patterns in the same files (`test_resave_cohorts.py`, sibling dagster-op tests under `posthog/dags/tests/`) and CI will run them.

## Docs update

N/A — no user-facing behavior change, comment/test/doc-comment only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Sonnet 5).
- Skills invoked: `/writing-tests` before adding the two new tests.
- Scoped with the PR author: confirmed the two schema-shape review questions were open design discussion rather than bugs, so this PR sticks to the concrete, low-risk fixes and answers those two threads in place instead of changing the shipped API shape.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*