### PR TITLE
fix(data-warehouse): don't repartition a table pending a corruption revive

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
@@ -147,6 +147,16 @@ async def maybe_flag_for_repartition(
     omitted it is evaluated lazily, only once the table is confirmed over budget.
     """
     try:
+        # A table pending a corruption revive must heal before it's rewritten — flagging it here would
+        # re-arm the revive loop after the heal clears the marker. Skip; the healed table is evaluated
+        # normally on a later run.
+        if schema.delta_revive_required is not None:
+            await logger.adebug(
+                f"repartition: skipped detection, table pending corruption revive schema_id={schema.id}",
+                schema_id=str(schema.id),
+            )
+            return
+
         partition_bytes = await asyncio.to_thread(measure_partition_bytes, delta_table)
         if not partition_bytes:
             await logger.adebug(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
@@ -217,6 +217,38 @@ class TestRepartitionOOMHistoryTrigger:
         else:
             assert schema.repartition_pending is None
 
+    def test_pending_revive_skips_detection(self, team):
+        # A table pending a corruption revive must not be flagged for repartition — the extract activity
+        # heals it, and flagging here would re-arm the revive the moment the heal clears the marker.
+        schema = _make_schema(
+            team,
+            {
+                "partitioning_enabled": True,
+                "partition_mode": "md5",
+                "partition_count": 2,
+                "partitioning_keys": ["id"],
+                "delta_revive_required": {
+                    "reason": "repartition_scan_missing_data_file",
+                    "missing_path": "x/p.parquet",
+                },
+            },
+        )
+        for _ in range(3):  # enough OOMs to flag a within-budget table if the revive guard weren't there
+            ExternalDataSchemaOOMEvent.objects.for_team(schema.team_id).create(team_id=schema.team_id, schema=schema)
+
+        with tempfile.TemporaryDirectory() as d:
+            delta = _write_partitioned_delta(f"{d}/t", ["0", "1"])
+            with (
+                patch.object(ctrl, "target_partition_bytes", return_value=10**12),
+                patch.object(ctrl, "repartition_oom_threshold", return_value=3),
+                patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
+                patch.object(ctrl, "capture_repartition_event"),
+            ):
+                self._detect(team, schema, delta)
+
+        schema.refresh_from_db()
+        assert schema.repartition_pending is None
+
 
 # An Exception-derived cancellation, named exactly `CancelledError`: models how `async_to_sync` can
 # surface a worker-shutdown cancel so it slips past a plain BaseException catch. `_is_cancellation`
@@ -255,6 +287,36 @@ class TestRepartitionActivity:
             patch.object(repartition_table, "repartition_table_in_place", new=mocked),
             patch.object(repartition_table, "capture_repartition_event"),
             patch.object(repartition_table, "is_auto_repartition_enabled", return_value=False),
+            patch.object(repartition_table, "maybe_flag_for_repartition") as flag,
+        ):
+            ActivityEnvironment().run(maybe_repartition_table_activity, self._inputs(team, schema))
+        mocked.assert_not_called()
+        flag.assert_not_called()
+
+    def test_noop_when_revive_pending(self, team):
+        # A table pending a corruption revive skips the whole activity — no detection, no rewrite — even
+        # with a repartition already queued, so it can't interleave with the extract's heal and re-arm
+        # the non-billable revive loop.
+        schema = _make_schema(
+            team,
+            {
+                "repartition_pending": {
+                    "partition_mode": "md5",
+                    "partition_keys": ["id"],
+                    "trigger_reason": "oom_history",
+                },
+                "delta_revive_required": {
+                    "reason": "repartition_scan_missing_data_file",
+                    "missing_path": "x/p.parquet",
+                },
+            },
+        )
+        mocked = AsyncMock()
+        with (
+            patch.object(repartition_table, "HeartbeaterSync"),
+            patch.object(repartition_table, "repartition_table_in_place", new=mocked),
+            patch.object(repartition_table, "capture_repartition_event"),
+            patch.object(repartition_table, "is_auto_repartition_enabled", return_value=True),
             patch.object(repartition_table, "maybe_flag_for_repartition") as flag,
         ):
             ActivityEnvironment().run(maybe_repartition_table_activity, self._inputs(team, schema))

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -196,6 +196,17 @@ def _maybe_repartition_table(inputs: RepartitionActivityInputs, logger: Filterin
         )
         return
 
+    # A table with a pending corruption revive must heal first — the extract activity resets it and
+    # rebuilds from source. Repartitioning it here would interleave with that heal and re-hollow the
+    # table, re-arming the revive marker every run (a non-billable revive loop). Skip until the revive
+    # clears the marker; the healed table is repartitioned normally on a later run.
+    if schema.delta_revive_required is not None:
+        logger.info(
+            f"repartition: skipped, table pending corruption revive schema_id={schema.id}",
+            schema_id=str(schema.id),
+        )
+        return
+
     # Log the rollout-flag verdict (and the recorded/budget sizes) so it's clear from the Syncs UI why a
     # table does or doesn't repartition — a disabled flag is the most common reason for a no-op. Note
     # `max_partition_bytes` here is the last *recorded* value (can be stale); the gate no longer trusts


### PR DESCRIPTION
## Problem

Two self-healing mechanisms fight over the same table and create a loop that marks syncs non-billable indefinitely.

- When a repartition scan finds a hollow partition (the Delta log references a data file that's gone from S3), it sets a `delta_revive_required` marker on the schema (#70237).
- The extract activity's `handle_corrupted_delta_log` is then meant to reset the table and rebuild it from source in the next sync, marking that one job non-billable ("the corruption is our fault, not the customer's") and clearing the marker.

But nothing stopped the **repartition** from continuing to run on a table that's pending a revive. An OOM-triggered repartition (which currently re-fires on every cooldown, see #71116) keeps claiming and rewriting the same table, re-hollowing it and re-arming `delta_revive_required` before the heal can settle. Each of those revive syncs is `billable=False`, so the non-billable job count climbs across the fleet.

A real schema stuck in this loop: a `delta_revive_required` marker from one day, and a fresh `repartition_claim` (with `repartition_pending.trigger_reason = "oom_history"`) from the next — the repartition kept re-claiming a table that should have been left alone to heal.

## Changes

Make the repartition machinery yield to the revive: skip any table with `delta_revive_required` set, at both entry points.

- `maybe_flag_for_repartition` (detection, incl. the post-load path) returns early — a table pending a revive isn't measured or flagged.
- `maybe_repartition_table_activity` (the pre-extraction activity) returns early — no detection, no rewrite, no claim, even if a repartition was already queued.

Once the extract's heal clears the marker, the table is repartitioned normally on a later run.

> [!NOTE]
> Pairs with #71116 (OOM re-trigger fix). This PR stops the repartition from interleaving with a heal in progress; #71116 stops the OOM trigger from pointlessly re-flagging the table in the first place. Either one alone reduces the loop; together they close it.

## How did you test this code?

Two tests in `test_repartition_controller.py`, mirroring the existing detection/activity tests:

- `test_pending_revive_skips_detection` — a within-budget schema with 3 OOMs (enough to flag via the OOM trigger) plus `delta_revive_required` set is **not** flagged (`repartition_pending` stays `None`).
- `test_noop_when_revive_pending` — the activity, given a schema with `delta_revive_required` set and a repartition already queued, calls neither the detector nor the rewrite (`repartition_table_in_place`).

I (actually Claude) couldn't run the Django/temporal suite locally — this checkout's venv is Python 3.12 and master needs 3.13, so collection fails on a typing incompatibility — so these run in CI. Locally: `ruff check`/`ruff format` clean and `py_compile` on the changed modules. Both tests copy the setup of adjacent passing tests (`test_repeated_ooms_flag_a_within_budget_table`, `test_noop_when_flag_disabled`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal pipeline behavior, no user-facing docs under `docs/` affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom noticed a table's `delta_revive_required` marker persisting across successful syncs, alongside a fleet-wide spike in `billable=False` jobs starting when the self-heal (#70237) shipped. Tracing it showed the revive and the repartition racing over the same table: the repartition keeps re-hollowing it, so the marker (and the non-billable revive) never settles. The guard is the mutual-exclusion half of the fix; the OOM re-trigger loop (#71116) is the other half.

The change lives on code newer than my local branch, so it's built off master in a fresh worktree. Skill invoked: `/writing-tests`.
