### PR TITLE
perf(insights): serve cached insight results as raw JSON without parse round trip

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from dataclasses import dataclass
+from typing import Literal, Optional, overload
 
 import structlog
 import pydantic_core
@@ -42,6 +43,66 @@ from common.hogvm.python.debugger import color_bytecode
 logger = structlog.get_logger(__name__)
 
 
+@dataclass(frozen=True)
+class RawCachedQueryResponse:
+    """A cached query response whose `results` field is carried as raw JSON bytes.
+
+    `response.results` holds an empty-list placeholder; `raw_results` is the JSON-encoded
+    results segment straight from the cache, ready to be embedded into a JSON response
+    (e.g. via orjson.Fragment) without a parse/re-serialize round trip. Only produced when
+    a caller passes allow_raw_results=True.
+    """
+
+    response: BaseModel
+    raw_results: bytes
+
+
+# The overloads keep the public contract at `dict | BaseModel` for the vast majority of
+# callers: only allow_raw_results=True can produce a RawCachedQueryResponse.
+@overload
+def process_query_dict(
+    team: Team,
+    query_json: dict,
+    *,
+    dashboard_filters_json: Optional[dict] = ...,
+    variables_override_json: Optional[dict] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: Literal[False] = ...,
+) -> dict | BaseModel: ...
+
+
+@overload
+def process_query_dict(
+    team: Team,
+    query_json: dict,
+    *,
+    dashboard_filters_json: Optional[dict] = ...,
+    variables_override_json: Optional[dict] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: bool,
+) -> dict | BaseModel | RawCachedQueryResponse: ...
+
+
 def process_query_dict(
     team: Team,
     query_json: dict,
@@ -59,7 +120,8 @@ def process_query_dict(
     cache_age_seconds: Optional[int] = None,
     pagination_cursor: Optional[str] = None,
     analytics_props: Optional[AnalyticsProps] = None,
-) -> dict | BaseModel:
+    allow_raw_results: bool = False,
+) -> dict | BaseModel | RawCachedQueryResponse:
     upgraded_query_json = upgrade(query_json)
     try:
         model = QuerySchemaRoot.model_validate(upgraded_query_json)
@@ -111,7 +173,52 @@ def process_query_dict(
         cache_age_seconds=cache_age_seconds,
         pagination_cursor=pagination_cursor,
         analytics_props=analytics_props,
+        allow_raw_results=allow_raw_results,
     )
+
+
+@overload
+def process_query_model(
+    team: Team,
+    query: BaseModel,
+    *,
+    dashboard_filters: Optional[DashboardFilter] = ...,
+    variables_override: Optional[list[HogQLVariable]] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: Literal[False] = ...,
+) -> dict | BaseModel: ...
+
+
+@overload
+def process_query_model(
+    team: Team,
+    query: BaseModel,
+    *,
+    dashboard_filters: Optional[DashboardFilter] = ...,
+    variables_override: Optional[list[HogQLVariable]] = ...,
+    limit_context: Optional[LimitContext] = ...,
+    execution_mode: ExecutionMode = ...,
+    user: Optional[User] = ...,
+    user_access_control: Optional[UserAccessControl] = ...,
+    query_id: Optional[str] = ...,
+    insight_id: Optional[int] = ...,
+    dashboard_id: Optional[int] = ...,
+    is_query_service: bool = ...,
+    cache_age_seconds: Optional[int] = ...,
+    pagination_cursor: Optional[str] = ...,
+    analytics_props: Optional[AnalyticsProps] = ...,
+    allow_raw_results: bool,
+) -> dict | BaseModel | RawCachedQueryResponse: ...
 
 
 def process_query_model(
@@ -131,8 +238,9 @@ def process_query_model(
     cache_age_seconds: Optional[int] = None,
     pagination_cursor: Optional[str] = None,
     analytics_props: Optional[AnalyticsProps] = None,
-) -> dict | BaseModel:
-    result: dict | BaseModel
+    allow_raw_results: bool = False,
+) -> dict | BaseModel | RawCachedQueryResponse:
+    result: dict | BaseModel | RawCachedQueryResponse
 
     if isinstance(query, HogQLAutocomplete):
         _, database = resolve_database_for_connection(
@@ -203,6 +311,7 @@ def process_query_model(
                 is_query_service=is_query_service,
                 cache_age_seconds=cache_age_seconds,
                 analytics_props=analytics_props,
+                allow_raw_results=allow_raw_results,
             )
         elif execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
             # Caching is handled by query runners, so in this case we can only return a cache miss
@@ -232,6 +341,8 @@ def process_query_model(
         if pagination_cursor:
             query_runner.apply_pagination_cursor(pagination_cursor)
         query_runner.is_query_service = is_query_service
+        if allow_raw_results:
+            query_runner.serve_raw_cached_results = True
 
         result = query_runner.run(
             execution_mode=execution_mode,
@@ -242,5 +353,8 @@ def process_query_model(
             cache_age_seconds=cache_age_seconds,
             analytics_props=analytics_props,
         )
+        raw_results = query_runner.raw_cached_results_bytes
+        if raw_results is not None and isinstance(result, BaseModel):
+            return RawCachedQueryResponse(response=result, raw_results=raw_results)
 
     return result

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -950,6 +950,9 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             "insight_variables": InsightVariable.objects.filter(team=resource.team).all(),
             "export_cache_keys": export_cache_keys,
             "shared_link_user": shared_link_user,
+            # exported_data is embedded into the page with stdlib json.dumps, which cannot
+            # serialize raw cached result bytes (orjson.Fragment)
+            "require_parsed_results": True,
         }
         exported_data: dict[str, Any] = {"type": "embed" if embedded else "scene"}
 

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+import orjson
 import structlog
 from pydantic import BaseModel
 
@@ -7,7 +8,7 @@ from posthog.schema import CacheMissResponse, DashboardFilter
 
 from posthog.hogql.constants import LimitContext
 
-from posthog.api.services.query import ExecutionMode, process_query_dict
+from posthog.api.services.query import ExecutionMode, RawCachedQueryResponse, process_query_dict
 from posthog.clickhouse.query_tagging import get_team_query_tags, tag_queries
 from posthog.event_usage import AnalyticsProps
 from posthog.hogql_queries.query_runner import get_query_runner_or_none, response_results_contain_models
@@ -87,6 +88,7 @@ def calculate_for_query_based_insight(
     query_override: Optional[dict] = None,
     cache_age_seconds: Optional[int] = None,
     analytics_props: Optional[AnalyticsProps] = None,
+    allow_raw_results: bool = False,
 ) -> "InsightResult":
     from posthog.caching.fetch_from_cache import InsightResult, NothingInCacheResult
 
@@ -124,7 +126,13 @@ def calculate_for_query_based_insight(
         limit_context=LimitContext.QUERY_ASYNC,
         cache_age_seconds=cache_age_seconds,
         analytics_props=analytics_props,
+        allow_raw_results=allow_raw_results,
     )
+
+    raw_results: Optional[bytes] = None
+    if isinstance(process_response, RawCachedQueryResponse):
+        raw_results = process_response.raw_results
+        process_response = process_response.response
 
     if isinstance(process_response, CacheMissResponse):
         return NothingInCacheResult(
@@ -137,13 +145,19 @@ def calculate_for_query_based_insight(
         # Pull fields off the model instead, converting just the small nested models to dicts
         # (which is what model_dump produced before). The response class may not carry every
         # field (legacy insights shape), hence the getattr defaults.
-        result = getattr(process_response, "results", None)
-        if result is not None and response_results_contain_models(type(process_response)):
-            # Model-typed results (e.g. RetentionResult, PathsLink) must be dumped to dicts
-            # like model_dump did — DRF's JSON encoder would otherwise mangle them into
-            # (field, value) tuple arrays. Results whose annotation is plain data (the huge
-            # trends/funnels payloads, or scalar/dict-shaped results) pass through untouched.
-            result = _dump_nested_models(result)
+        if raw_results is not None:
+            # orjson.Fragment embeds the cached results bytes into the JSON response as-is,
+            # skipping the parse/re-serialize round trip. Callers passing allow_raw_results
+            # guarantee the result feeds an orjson renderer.
+            result: Any = orjson.Fragment(raw_results)
+        else:
+            result = getattr(process_response, "results", None)
+            if result is not None and response_results_contain_models(type(process_response)):
+                # Model-typed results (e.g. RetentionResult, PathsLink) must be dumped to dicts
+                # like model_dump did — DRF's JSON encoder would otherwise mangle them into
+                # (field, value) tuple arrays. Results whose annotation is plain data (the huge
+                # trends/funnels payloads, or scalar/dict-shaped results) pass through untouched.
+                result = _dump_nested_models(result)
         return InsightResult(
             result=result,
             has_more=getattr(process_response, "hasMore", None),

--- a/posthog/caching/fetch_from_cache.py
+++ b/posthog/caching/fetch_from_cache.py
@@ -18,8 +18,73 @@ insight_cache_read_counter = Counter(
     labelnames=["result"],
 )
 
+# Split cache format: magic + flags byte + 4-byte big-endian header length + header JSON + results JSON.
+# Storing `results` as a separate JSON segment lets cache hits skip parsing (and later re-serializing)
+# the results payload, which dominates CPU for large cached insights. Blobs without the magic prefix
+# are the legacy single-JSON format and stay readable.
+QUERY_CACHE_SPLIT_MAGIC = b"PHQC2\x00"
+_SPLIT_FLAG_CUSTOM_NAMES = 0b00000001
 
-def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]:
+
+@dataclass(frozen=True)
+class SplitCachedResponse:
+    header: dict
+    results_bytes: Optional[bytes]
+    """Raw JSON bytes of the `results` field; None means `header` is the full legacy response."""
+    results_have_custom_names: bool = False
+    """Whether any series/step in results carries a non-null custom_name (so a cache hit may need patching)."""
+
+
+def _item_has_custom_name(item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if item.get("custom_name") is not None:
+        return True
+    action = item.get("action")
+    return isinstance(action, dict) and action.get("custom_name") is not None
+
+
+def results_have_custom_names(results: list) -> bool:
+    for item in results:
+        if _item_has_custom_name(item):
+            return True
+        if isinstance(item, list) and any(_item_has_custom_name(step) for step in item):
+            return True
+    return False
+
+
+def encode_split_cached_response(response: dict) -> bytes:
+    serializer = OrjsonJsonSerializer({})
+    results = response["results"]
+    header = {key: value for key, value in response.items() if key != "results"}
+    flags = _SPLIT_FLAG_CUSTOM_NAMES if results_have_custom_names(results) else 0
+    header_bytes = serializer.dumps(header)
+    return (
+        QUERY_CACHE_SPLIT_MAGIC
+        + bytes([flags])
+        + len(header_bytes).to_bytes(4, "big")
+        + header_bytes
+        + serializer.dumps(results)
+    )
+
+
+def split_cached_response_bytes(cached_response_bytes: bytes) -> SplitCachedResponse:
+    serializer = OrjsonJsonSerializer({})
+    if not cached_response_bytes.startswith(QUERY_CACHE_SPLIT_MAGIC):
+        return SplitCachedResponse(header=serializer.loads(cached_response_bytes), results_bytes=None)
+    offset = len(QUERY_CACHE_SPLIT_MAGIC)
+    flags = cached_response_bytes[offset]
+    header_length = int.from_bytes(cached_response_bytes[offset + 1 : offset + 5], "big")
+    header_start = offset + 5
+    header = serializer.loads(cached_response_bytes[header_start : header_start + header_length])
+    return SplitCachedResponse(
+        header=header,
+        results_bytes=cached_response_bytes[header_start + header_length :],
+        results_have_custom_names=bool(flags & _SPLIT_FLAG_CUSTOM_NAMES),
+    )
+
+
+def fetch_split_cached_response_by_key(cache_key: str, team_id: int) -> Optional[SplitCachedResponse]:
     query_cache = get_query_cache()
     try:
         cached_response_bytes = query_cache.get(cache_key)
@@ -35,7 +100,7 @@ def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]
         return None
 
     try:
-        return OrjsonJsonSerializer({}).loads(cached_response_bytes)
+        return split_cached_response_bytes(cached_response_bytes)
     except Exception:
         logger.exception(
             "query_cache_deserialize_error",
@@ -44,6 +109,20 @@ def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]
             exc_info=True,
         )
         return None
+
+
+def fetch_cached_response_by_key(cache_key: str, team_id: int) -> Optional[dict]:
+    split = fetch_split_cached_response_by_key(cache_key, team_id)
+    if split is None:
+        return None
+    if split.results_bytes is None:
+        return split.header
+    try:
+        split.header["results"] = OrjsonJsonSerializer({}).loads(split.results_bytes)
+    except Exception:
+        logger.exception("query_cache_deserialize_error", cache_key=cache_key, team_id=team_id, exc_info=True)
+        return None
+    return split.header
 
 
 @dataclass(frozen=True)

--- a/posthog/caching/test/test_query_cache_format.py
+++ b/posthog/caching/test/test_query_cache_format.py
@@ -1,0 +1,32 @@
+from posthog.test.base import BaseTest
+
+from django.test import override_settings
+
+from posthog.caching.fetch_from_cache import fetch_cached_response_by_key, fetch_split_cached_response_by_key
+from posthog.hogql_queries.query_cache_factory import get_query_cache_manager
+
+
+class TestQueryCacheWriteFormat(BaseTest):
+    def test_writes_legacy_format_until_split_writes_enabled(self):
+        # Old readers treat split-format entries as cache misses and recompute, so shipping
+        # split writes before every reader understands the format causes a cache-load spike
+        # on deploy. Split writes must stay opt-in via QUERY_CACHE_SPLIT_FORMAT_WRITES.
+        response = {"is_cached": False, "results": [{"data": [1]}], "cache_key": "k"}
+        manager = get_query_cache_manager(team=self.team, cache_key=f"cache_format_test_{self.team.pk}", insight_id=1)
+
+        manager.set_cache_data(response=response, target_age=None)
+        split = fetch_split_cached_response_by_key(manager.cache_key, self.team.pk)
+        assert split is not None
+        assert split.results_bytes is None
+        assert split.header["results"] == [{"data": [1]}]
+
+        with override_settings(QUERY_CACHE_SPLIT_FORMAT_WRITES=True):
+            manager.set_cache_data(response=response, target_age=None)
+        split = fetch_split_cached_response_by_key(manager.cache_key, self.team.pk)
+        assert split is not None
+        assert split.results_bytes == b'[{"data":[1]}]'
+        assert fetch_cached_response_by_key(manager.cache_key, self.team.pk) == {
+            "is_cached": False,
+            "results": [{"data": [1]}],
+            "cache_key": "k",
+        }

--- a/posthog/hogql_queries/query_cache.py
+++ b/posthog/hogql_queries/query_cache.py
@@ -1,7 +1,10 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
-from typing import NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional
+
+if TYPE_CHECKING:
+    from posthog.caching.fetch_from_cache import SplitCachedResponse
 
 from django.conf import settings
 
@@ -176,7 +179,16 @@ class DjangoCacheQueryCacheManager(QueryCacheManagerBase):
     """
 
     def set_cache_data(self, *, response: dict, target_age: Optional[datetime]) -> None:
-        fresh_response_serialized = OrjsonJsonSerializer({}).dumps(response)
+        from posthog.caching.fetch_from_cache import encode_split_cached_response
+
+        if settings.QUERY_CACHE_SPLIT_FORMAT_WRITES and isinstance(response.get("results"), list):
+            # Split format keeps `results` as its own JSON segment so cache hits can skip
+            # parsing it — see fetch_from_cache.SplitCachedResponse. Write-gated so a deploy
+            # ships split-capable readers everywhere before any pod writes the new format
+            # (old readers treat split entries as misses and recompute).
+            fresh_response_serialized = encode_split_cached_response(response)
+        else:
+            fresh_response_serialized = OrjsonJsonSerializer({}).dumps(response)
         data_size = len(fresh_response_serialized)
 
         # Set cache with per-team size limit enforcement
@@ -202,3 +214,8 @@ class DjangoCacheQueryCacheManager(QueryCacheManagerBase):
         from posthog.caching.fetch_from_cache import fetch_cached_response_by_key
 
         return fetch_cached_response_by_key(self.cache_key, self.team_id)
+
+    def get_cache_data_split(self) -> Optional["SplitCachedResponse"]:
+        from posthog.caching.fetch_from_cache import fetch_split_cached_response_by_key
+
+        return fetch_split_cached_response_by_key(self.cache_key, self.team_id)

--- a/posthog/hogql_queries/query_cache_base.py
+++ b/posthog/hogql_queries/query_cache_base.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from typing import Optional
 
 from posthog import redis
+from posthog.caching.fetch_from_cache import SplitCachedResponse
 
 
 class QueryCacheManagerBase(ABC):
@@ -105,3 +106,10 @@ class QueryCacheManagerBase(ABC):
     def get_cache_data(self) -> Optional[dict]:
         """Retrieve query results from cache."""
         pass
+
+    def get_cache_data_split(self) -> Optional[SplitCachedResponse]:
+        """Retrieve cached results, keeping the results segment as raw bytes when the backend supports it."""
+        data = self.get_cache_data()
+        if data is None:
+            return None
+        return SplitCachedResponse(header=data, results_bytes=None)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -7,6 +7,7 @@ from time import perf_counter
 from types import UnionType
 from typing import Any, Generic, NamedTuple, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args, get_origin
 
+import orjson
 import posthoganalytics
 from prometheus_client import Counter, Histogram
 from pydantic import BaseModel, ConfigDict
@@ -1344,6 +1345,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     # query service means programmatic access and /query endpoint
     is_query_service: bool = False
     workload: Workload
+    # Opt-in (set by process_query_model): on a cache hit, keep the results segment of the
+    # cached response as raw JSON bytes in raw_cached_results_bytes instead of parsing it,
+    # leaving a `results=[]` placeholder on the returned model.
+    serve_raw_cached_results: bool = False
+    raw_cached_results_bytes: Optional[bytes] = None
 
     def __init__(
         self,
@@ -1416,6 +1422,12 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         return hasattr(data, "is_cached") or (  # Duck typing for backwards compatibility with `CachedQueryResponse`
             isinstance(data, dict) and "is_cached" in data
         )
+
+    def _query_has_series_custom_names(self) -> bool:
+        series = getattr(self.query, "series", None)
+        if not series:
+            return False
+        return any(getattr(s, "custom_name", None) is not None for s in series)
 
     @property
     def _limit_context_aliased_for_cache(self) -> LimitContext:
@@ -1490,14 +1502,45 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     ) -> Optional[CR | CacheMissResponse]:
         CachedResponse: type[CR] = self.cached_response_type
         cached_response: CR | CacheMissResponse
-        cached_response_candidate = cache_manager.get_cache_data()
+        cached_response_candidate: Optional[dict]
+        self.raw_cached_results_bytes = None
+        raw_results: Optional[bytes] = None
+        if self.serve_raw_cached_results:
+            # Serving results as raw bytes skips parsing (and later re-serializing) the results
+            # payload. Only safe when the caller opted in AND validation of the parsed results
+            # wouldn't add protection (the response class types them as plain data — for
+            # model-typed results, e.g. retention, validating a `[]` placeholder would bypass
+            # the schema-drift check that triggers recomputation) AND neither the query nor
+            # the cached results carry custom series names — otherwise
+            # apply_series_custom_names below must be able to patch the parsed results.
+            split_candidate = cache_manager.get_cache_data_split()
+            if split_candidate is None:
+                cached_response_candidate = None
+            else:
+                cached_response_candidate = split_candidate.header
+                if split_candidate.results_bytes is not None:
+                    if (
+                        response_results_contain_models(CachedResponse)
+                        or split_candidate.results_have_custom_names
+                        or self._query_has_series_custom_names()
+                    ):
+                        cached_response_candidate["results"] = orjson.loads(split_candidate.results_bytes)
+                    else:
+                        raw_results = split_candidate.results_bytes
+        else:
+            cached_response_candidate = cache_manager.get_cache_data()
 
         if self.is_cached_response(cached_response_candidate):
+            assert cached_response_candidate is not None
+            if raw_results is not None:
+                cached_response_candidate["results"] = []
             cached_response_candidate["is_cached"] = True
             # When rolling out schema changes, cached responses may not match the new schema.
             # Trigger recomputation in this case.
             try:
                 cached_response = CachedResponse(**cached_response_candidate)
+                if raw_results is not None:
+                    self.raw_cached_results_bytes = raw_results
             except Exception as e:
                 capture_exception(Exception(f"Error parsing cached response: {e}"))
                 cached_response = CacheMissResponse(cache_key=cache_manager.cache_key)
@@ -1570,7 +1613,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 )
                 return cached_response
 
-        # Nothing useful out of cache, nor async query status
+        # Nothing useful out of cache, nor async query status. A recomputation follows, so the
+        # cached raw results (if any) must not leak onto the fresh response.
+        self.raw_cached_results_bytes = None
         return None
 
     def _call_with_rate_limits(self, *, dashboard_id: Optional[int]) -> tuple[R, float]:

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -577,6 +577,13 @@ FLAGS_CACHE_MISS_TTL = int(os.getenv("FLAGS_CACHE_MISS_TTL", str(60 * 60 * 24)))
 LLM_PROMPTS_CACHE_TTL = int(os.getenv("LLM_PROMPTS_CACHE_TTL", str(60 * 60 * 24)))  # 1 day
 LLM_PROMPTS_CACHE_MISS_TTL = int(os.getenv("LLM_PROMPTS_CACHE_MISS_TTL", str(60 * 5)))  # 5 minutes
 
+# Rollout gate for the split query-cache format (header + raw results segments). Every deploy
+# can READ both formats, but old readers treat split entries as cache misses and recompute —
+# so writes stay in the legacy format until all readers understand the split one. Flip this on
+# only once the split-capable reader is fully deployed; safe to flip back off (readers keep
+# understanding both formats).
+QUERY_CACHE_SPLIT_FORMAT_WRITES: bool = get_from_env("QUERY_CACHE_SPLIT_FORMAT_WRITES", False, type_cast=str_to_bool)
+
 CACHES = {
     "default": {
         # IMPORTANT: If any of these settings change, make sure the

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -2339,9 +2339,11 @@ class DashboardsViewSet(
         metadata_serializer = DashboardMetadataSerializer(dashboard, context=self.get_serializer_context())
         metadata_data = metadata_serializer.data
 
-        # Create serializer context for tiles
+        # Create serializer context for tiles. Tiles are rendered with SafeJSONRenderer below,
+        # so raw cached results (orjson.Fragment) are safe even though the negotiated renderer
+        # is the SSE one.
         context = self.get_serializer_context()
-        context.update({"dashboard": dashboard})
+        context.update({"dashboard": dashboard, "raw_results_supported": True})
 
         # Get tiles with proper prefetch
         tiles = DashboardTile.dashboard_queryset(dashboard.tiles.all()).prefetch_related(
@@ -2768,6 +2770,9 @@ class DashboardsViewSet(
 
         context = self.get_serializer_context()
         context["dashboard"] = dashboard
+        # _format_insight_for_llm consumes results as Python data, so raw cached
+        # result bytes (orjson.Fragment) must not be used here.
+        context["require_parsed_results"] = True
 
         tiles = DashboardTile.dashboard_queryset(dashboard.tiles.all()).prefetch_related(
             Prefetch(

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -115,6 +115,7 @@ from posthog.rbac.user_access_control import (
     UserAccessControlSerializerMixin,
     access_level_satisfied_for_resource,
 )
+from posthog.renderers import SafeJSONRenderer
 from posthog.resource_limits import LimitKey, check_count_limit
 from posthog.schema_migrations.upgrade import upgrade
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -1122,6 +1123,18 @@ class InsightSerializer(InsightBasicSerializer):
                 request_user_access_control = (
                     getattr(view, "user_access_control", None) if isinstance(request_user, User) else None
                 )
+                # Raw cached results (orjson.Fragment) are only valid when the response is
+                # rendered by orjson: SafeJSONRenderer directly, or a caller that declares it
+                # renders tiles with SafeJSONRenderer itself (the SSE tile stream sets
+                # raw_results_supported — SSE content negotiation alone doesn't guarantee an
+                # orjson boundary). Pretty-printed output (?indent=) would not indent inside a
+                # fragment, so keep the parsed path there.
+                accepted_renderer = getattr(self.context["request"], "accepted_renderer", None)
+                allow_raw_results = (
+                    (isinstance(accepted_renderer, SafeJSONRenderer) or bool(self.context.get("raw_results_supported")))
+                    and not self.context["request"].query_params.get("indent")
+                    and not self.context.get("require_parsed_results")
+                )
                 with tags_context(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.INSIGHT, **shared_tags):
                     return calculate_for_query_based_insight(
                         insight,
@@ -1135,6 +1148,7 @@ class InsightSerializer(InsightBasicSerializer):
                         tile_filters_override=tile_filters_override,
                         cache_age_seconds=shared_cache_age_seconds,
                         analytics_props=get_request_analytics_properties(self.context["request"]),
+                        allow_raw_results=allow_raw_results,
                     )
             except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
                 raise ValidationError(str(e), getattr(e, "code_name", None))

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -527,6 +527,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 tile_filters_override={},
                 cache_age_seconds=None,
                 analytics_props=ANY,
+                allow_raw_results=False,
             )
 
         with patch(
@@ -548,6 +549,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 tile_filters_override={},
                 cache_age_seconds=int(SHARED_FORCE_BLOCKING_STALENESS_WINDOW.total_seconds()),
                 analytics_props=ANY,
+                allow_raw_results=False,
             )
 
     def test_get_shared_insight_with_force_refresh_returns_200(self) -> None:
@@ -609,6 +611,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 tile_filters_override={},
                 cache_age_seconds=int(SHARED_FORCE_BLOCKING_STALENESS_WINDOW.total_seconds()),
                 analytics_props=ANY,
+                allow_raw_results=False,
             )
 
     def test_get_insight_by_short_id(self) -> None:


### PR DESCRIPTION
## TL;DR (eli5)

When you open an insight or a big dashboard where the charts are already cached, the server used to unpack every cached chart from JSON into Python objects, re-check them, and re-pack them back into JSON — three times the work for zero change in what you see. This change stores the cached results as their own JSON chunk and, on a cache hit, passes those bytes straight into the response without unpacking them. Same bytes out, ~2x faster on large dashboards. It ships **off by default** and is flipped on only once every server can read the new format.

## Context

This is the **third and last** of three independent, behavior-preserving optimizations extracted from the bundled PR #70967 (which together cut large cached-dashboard GET wall time ~65%):

- Opt 1 — skip full-response `model_dump` → merged in #71051
- Opt 2 — reuse tile serializer across tiles → merged in #71022
- **Opt 3 (this PR) — serve cached results as raw JSON** — the biggest single win.

## Problem

Cached query responses were stored as one JSON blob, so every dashboard/insight cache hit paid `orjson.loads` on the full results payload, pydantic re-validation, and a re-serialization at render time — the dominant CPU cost on large dashboards (70–80 tiles).

## Changes

1. **Split cache format** (`fetch_from_cache.py`): cached responses are stored as `magic + flags byte + 4-byte header length + header JSON + results JSON`. Legacy single-JSON blobs stay readable; old readers treat split blobs as cache misses and recompute.
2. **Raw pass-through on hit**: when the insight serializer opts in, only the header is validated and the results segment is embedded into the response via `orjson.Fragment`, skipping the parse → validate → re-serialize round trip.
3. **Gating** (safety): the raw path is only used for orjson renderers (`SafeJSONRenderer` / the SSE tile stream), and skipped for `?indent=`, the shared-page stdlib-`json.dumps` template (`require_parsed_results`), `run_insights` LLM formatting, model-typed results (retention, paths, … — keeps the schema-drift recomputation check), and whenever the query or cached results carry series `custom_name`s (those need parsed patching).
4. **Rollout gate**: split-format **writes** are gated behind `QUERY_CACHE_SPLIT_FORMAT_WRITES` (default **off**). Every deploy ships split-capable readers first; writes flip on only once the reader is fully rolled out, so a mixed-version window can't churn the cache. Safe to flip back off (readers understand both formats).

Result on a 70-tile cached dashboard GET (local repro): median wall **787ms → 345ms**, p90 **2.2s → 0.44s** (the parse/copy churn also drove GC pauses). Response bytes verified identical between the raw and parsed paths.

## How did you test this code?

- `ty` type check passes (the `@overload`s keep `process_query_dict`/`process_query_model` at `dict | BaseModel` for existing callers; only `allow_raw_results=True` widens the return).
- New `posthog/caching/test/test_query_cache_format.py` — asserts legacy writes until `QUERY_CACHE_SPLIT_FORMAT_WRITES=True`, then split write + round-trip.
- `posthog/caching/test/test_calculate_results.py`, `posthog/hogql_queries/test/test_query_runner.py`, dashboard cache/stream tests, and the N+1 tests (`test_insight_alerts_do_not_nplus1_dashboard_gets`, `test_adding_insights_is_not_nplus1_for_gets`) — all pass, query counts unchanged.
- `products/product_analytics/backend/api/test/test_insight.py -k "cach or refresh or shared"` — 12 passed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*