### PR TITLE
fix(replay-vision): prevent daily digest card flash on turn-on

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.test.ts
@@ -78,7 +78,7 @@ describe('scannerDigestLogic', () => {
         expect(logic.values.latestRunLoading).toEqual(false)
     })
 
-    it('one-click create sends the digest marker and defaults, then reloads the list', async () => {
+    it('one-click create sends the digest marker and defaults, then settles without a card flash', async () => {
         useMocks(mocksFor([]))
         mountLogic()
         await expectLogic(logic).toFinishAllListeners()
@@ -91,10 +91,12 @@ describe('scannerDigestLogic', () => {
                 },
             },
         })
+        // Optimistic insert + local run resolution instead of a refetch: refetching would blank the
+        // card (digest absent while the list reloads, then latestRunLoading true) and flash it.
         await expectLogic(logic, () => {
             logic.actions.createDigest()
         })
-            .toDispatchActions(['createDigestSuccess', 'loadActions'])
+            .toDispatchActions(['createDigestSuccess', 'addAction', 'loadLatestRunSuccess'])
             .toFinishAllListeners()
         expect(body).toMatchObject({
             name: 'Daily digest: my-scanner',
@@ -103,5 +105,8 @@ describe('scannerDigestLogic', () => {
             trigger_config: { rrule: 'FREQ=DAILY;BYHOUR=8;BYMINUTE=0' },
             delivery_config: [],
         })
+        // The card renders the created digest immediately (no null-rendering gap).
+        expect(logic.values.digest?.id).toEqual('d-new')
+        expect(logic.values.latestRunLoading).toEqual(false)
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerDigestLogic.ts
@@ -29,7 +29,7 @@ export const scannerDigestLogic = kea<scannerDigestLogicType>([
         values: [visionActionsLogic({ scannerId: props.scannerId }), ['visionActions', 'visionActionsLoading']],
         actions: [
             visionActionsLogic({ scannerId: props.scannerId }),
-            ['loadActions', 'loadActionsSuccess', 'toggleActionEnabled'],
+            ['loadActions', 'loadActionsSuccess', 'toggleActionEnabled', 'addAction'],
         ],
     })),
 
@@ -125,7 +125,7 @@ export const scannerDigestLogic = kea<scannerDigestLogicType>([
                 return
             }
             try {
-                await visionActionsCreate(String(teamId), {
+                const created = await visionActionsCreate(String(teamId), {
                     // Mirrors the backend provisioning defaults (digest.py) for scanners created before
                     // digests existed, or after the digest was deleted.
                     name: `Daily digest: ${props.scannerName}`.slice(0, 255),
@@ -139,7 +139,12 @@ export const scannerDigestLogic = kea<scannerDigestLogicType>([
                 })
                 actions.createDigestSuccess()
                 lemonToast.success('Daily digest turned on')
-                actions.loadActions()
+                // Insert the created digest optimistically instead of refetching the list — a refetch
+                // would blank the card (visionActionsLoading true, digest still absent) and flash it.
+                actions.addAction(created)
+                // A brand-new digest has no runs yet, so resolve the run state locally rather than
+                // fetching; this keeps the card from flashing through its latestRunLoading gap.
+                actions.loadLatestRunSuccess(null)
             } catch (error: any) {
                 actions.createDigestFailure()
                 lemonToast.error(`Couldn't turn on the daily digest${error?.detail ? `: ${error.detail}` : ''}`)

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -133,6 +133,7 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
         loadActions: true,
         loadActionsSuccess: (visionActions: VisionActionApi[]) => ({ visionActions }),
         loadActionsFailure: true,
+        addAction: (action: VisionActionApi) => ({ action }),
         toggleActionEnabled: (id: string) => ({ id }),
         revertActionEnabled: (id: string) => ({ id }),
         toggleActionEnabledDone: (id: string) => ({ id }),
@@ -145,6 +146,7 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
             [] as VisionActionApi[],
             {
                 loadActionsSuccess: (_, { visionActions }) => visionActions,
+                addAction: (state, { action }) => [...state, action],
                 deleteActionSuccess: (state, { id }) => state.filter((a) => a.id !== id),
                 // Optimistic flip on toggle; revert mirrors it back on failure.
                 toggleActionEnabled: (state, { id }) =>


### PR DESCRIPTION
## Problem

On a Replay Vision scanner page, clicking "Turn on daily digest" made the digest hero card flash: it fully disappeared, then reappeared in the "next digest arrives at 8am" state. The blink reads like an error and is jarring right after a deliberate click.

## Changes

The card was unmounting because `createDigest` refetched the whole actions list after the create POST. That refetch drove the card through two `null`-rendering windows in `ScannerDigestCard`:

1. `visionActionsLoading` flips true while `digest` is still absent (the created action isn't in the list until the reload lands) → card returns `null`.
2. Once the list reloads, `loadActionsSuccess` fires `loadLatestRun`, flipping `latestRunLoading` true while `latestRun` is null → card returns `null` again.

The refetch was unnecessary. `visionActionsCreate` already returns the fully serialized created action (including the read-only `next_run_at` the copy needs), and a brand-new digest has no runs. So instead of reloading:

- Added an `addAction` action + reducer to `visionActionsLogic` that appends a created action to the list, mirroring the existing optimistic `toggleActionEnabled` pattern.
- `createDigest` now captures the created object and dispatches `addAction(created)` + `loadLatestRunSuccess(null)` instead of `loadActions()`. `digest` resolves immediately and the run state settles locally, so neither `null` window opens.

The card now swaps in place: the button shows its own loading spinner, then it transitions straight to the "next digest arrives" state.

No backend or serializer changes, so no generated-type regeneration needed.

## How did you test this code?

- Updated the existing one-click-create logic test in `scannerDigestLogic.test.ts` to assert the new dispatch chain (`createDigestSuccess`, `addAction`, `loadLatestRunSuccess`) and, crucially, that after settling `digest` is populated and `latestRunLoading` is false — the two conditions that guarantee no flash. This catches a regression back to the refetch behavior. Ran it: 3/3 pass.
- Typecheck clean for the changed files (regenerated the gitignored kea `*LogicType` files for the new action).
- I (Claude) did not run the app to watch the transition manually — the behavior is covered by the logic-level assertions above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this card, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim reported the flash and directed the fix; I (Claude, via PostHog Code) traced the cause and implemented it. I explored the scanner-page logic to find that the flash came from `createDigest` calling `loadActions()`, then chose the optimistic-insert approach because `visionActionsLogic` already uses that exact pattern for `toggleActionEnabled` and `visionActionsCreate` returns the full created object — so no refetch is needed at all. Considered instead loosening the `visionActionsLoading && !digest` guard in the component, but that only closed one of the two flash windows, so I went with the logic-side fix that closes both.

Skills invoked: `/writing-tests` (before editing the logic test).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
