### PR TITLE
chore(insights): drop obsolete posthog_insightcachingstate table

### DIFF
--- a/products/product_analytics/backend/migrations/0003_drop_insightcachingstate_table.py
+++ b/products/product_analytics/backend/migrations/0003_drop_insightcachingstate_table.py
@@ -1,0 +1,20 @@
+# Drops the posthog_insightcachingstate table. The model was removed from Django state in
+# 0002_delete_insightcachingstate (#70453, deployed 2026-07-14), which kept the table alive
+# for one deploy cycle so in-flight old pods could keep writing. That window has long passed:
+# nothing reads or writes the table, and the surviving FK on dashboard_tile_id was the last
+# thing making DashboardTile hard-deletes fail. Dropping the table removes it for good.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("product_analytics", "0002_delete_insightcachingstate"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS posthog_insightcachingstate;",
+            reverse_sql=migrations.RunSQL.noop,  # obsolete table, no reverse
+        ),
+    ]

--- a/products/product_analytics/backend/migrations/max_migration.txt
+++ b/products/product_analytics/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0002_delete_insightcachingstate
+0003_drop_insightcachingstate_table


### PR DESCRIPTION
## Problem

Moving a dashboard tile could crash with an `IntegrityError`. `move_tile` hard-deletes the stale soft-deleted tile occupying the destination's unique slot, and #70453 removed the `InsightCachingState` model from Django state while intentionally keeping the `posthog_insightcachingstate` table and its FK alive for the rolling deploy. With the model gone Django no longer cascades to those rows, so the surviving `dashboard_tile_id` FK (default `NO ACTION`) rejects the delete.

This is the planned follow-up drop to that state-only removal (see the note in #70453). It fixes the crash by removing the FK entirely, rather than working around it in application code.

## Changes

- New `RunSQL` migration dropping `posthog_insightcachingstate` (which also drops the `posthog_insightcachingstate_lookup` partial index). `DROP TABLE IF EXISTS`, no reverse - the table is obsolete.

The model and all readers/writers were removed in #70453 (stacked on #69416). The table has been write-dead since, and it is a leaf table (no inbound FKs), so a plain drop is safe.

> [!NOTE]
> Deploy window is satisfied: #70453 merged 2026-07-14 and has been live in both prod-us and prod-eu for well over a full deploy cycle. Verified current prod is a descendant of its merge commit (`behind_by: 0`).

Compared to patching `DashboardTile.delete()`, dropping the table fixes the `move_tile` crash and the latent bulk/cascade-delete variants at once, and leaves no interim cleanup code to remove later.

## How did you test this code?

No local DB or Django in the authoring sandbox, so I could not run the suite or `sqlmigrate` locally - CI will run the migration. The migration is a pure `RunSQL` drop with no state operations, so `makemigrations` reports no drift by construction. Verified deploy timing via the project's GIT deploy annotations and GitHub commit ancestry, and confirmed no remaining references to the table across Python, `nodejs`, `rust`, `go`, and `services`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. Internal cache bookkeeping table, no user-facing change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thomas asked for alternatives to #71266, then asked me (Claude) to investigate whether just dropping the table now was safe, and to implement it. I invoked `/django-migrations` and followed its retire-a-table procedure (state-only `DeleteModel` already shipped in #70453, this is the `RunSQL` drop). I checked deploy safety with `/checking-deploy-timing` against the project's deploy annotations and confirmed prod ancestry of the #70453 merge commit, and grepped for external (non-Django) writers and inbound FKs before concluding a plain drop is safe.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
