### PR TITLE
feat(cli): read dotenv file path from POSTHOG_CLI_DOTENV_FILE

### DIFF
--- a/cli/.sampo/changesets/dotenv-file-env-var.md
+++ b/cli/.sampo/changesets/dotenv-file-env-var.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+The dotenv credentials file can now also be pointed at with the `POSTHOG_CLI_DOTENV_FILE` environment variable, equivalent to passing `--dotenv-file` — for callers that control the environment but not the command line (e.g. an Xcode build phase invoking the iOS SDK's upload-symbols.sh).

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,7 +42,7 @@ Options:
       --no-fail                  Disable non-zero exit codes on errors. Use with caution
       --skip-ssl-verification    Skip SSL certificate verification when talking to the PostHog API. Use only with self-signed certificates
       --rate-limit <RATE_LIMIT>  Set the number of requests per minute for the Posthog API Client [env: POSTHOG_CLIENT_RATE_LIMIT=]
-      --dotenv-file <PATH>       Load PostHog credentials from this dotenv-style file when not present in the process environment. Prefer this over the `--env-file` alias: the npm package runs the binary through a `node` wrapper, and Node's own built-in `--env-file` flag intercepts that spelling
+      --dotenv-file <PATH>       Load PostHog credentials from this dotenv-style file when not present in the process environment. Prefer this over the `--env-file` alias: the npm package runs the binary through a `node` wrapper, and Node's own built-in `--env-file` flag intercepts that spelling. Also settable as `POSTHOG_CLI_DOTENV_FILE`, for callers that control the environment but not the command line (e.g. an Xcode build phase invoking the iOS SDK's upload-symbols.sh) [env: POSTHOG_CLI_DOTENV_FILE=]
       --dry-run[=<DRY_RUN>]      Skip artifact processing and upload (sourcemap, dSYM, hermes, proguard) without contacting PostHog or requiring credentials. Intended for CI gates that bundle to catch regressions but must not (or cannot) upload. Not for release builds. Pass it before the subcommand (`posthog-cli --dry-run hermes upload ...`) or set `POSTHOG_CLI_DRY_RUN`. This is distinct from the `exp endpoints` `--dry-run`, which previews endpoint changes [env: POSTHOG_CLI_DRY_RUN=] [default: false] [possible values: true, false]
   -h, --help                     Print help
   -V, --version                  Print version
@@ -56,7 +56,7 @@ You can authenticate with PostHog interactively for using the CLI locally, but i
 - `POSTHOG_CLI_API_KEY`: [A posthog personal API key.](https://posthog.com/docs/api#private-endpoint-authentication) (also accepts `POSTHOG_CLI_TOKEN` for backward compatibility)
 - `POSTHOG_CLI_PROJECT_ID`: The ID number of the project/environment to connect to. E.g. the "2" in `https://us.posthog.com/project/2` (also accepts `POSTHOG_CLI_ENV_ID` for backward compatibility)
 
-These variables can also be loaded from a dotenv-style file via `--dotenv-file <PATH>` (e.g. `posthog-cli --dotenv-file .env query ...`). The process environment always wins; the file is only consulted if the required variables aren't set. `POSTHOG_CLI_HOST` is only read from the same source that supplied the rest, so a stray host in the file cannot redirect a key supplied by the process env.
+These variables can also be loaded from a dotenv-style file via `--dotenv-file <PATH>` (e.g. `posthog-cli --dotenv-file .env query ...`) or the `POSTHOG_CLI_DOTENV_FILE` environment variable. The process environment always wins; the file is only consulted if the required variables aren't set. `POSTHOG_CLI_HOST` is only read from the same source that supplied the rest, so a stray host in the file cannot redirect a key supplied by the process env.
 
 Full precedence: CLI args → process env → `--dotenv-file` → `~/.posthog/credentials.json` (from `posthog-cli login`).
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -38,7 +38,14 @@ pub struct Cli {
     /// Load PostHog credentials from this dotenv-style file when not present in the process
     /// environment. Prefer this over the `--env-file` alias: the npm package runs the binary
     /// through a `node` wrapper, and Node's own built-in `--env-file` flag intercepts that spelling.
-    #[arg(long = "dotenv-file", alias = "env-file", value_name = "PATH")]
+    /// Also settable as `POSTHOG_CLI_DOTENV_FILE`, for callers that control the environment but
+    /// not the command line (e.g. an Xcode build phase invoking the iOS SDK's upload-symbols.sh).
+    #[arg(
+        long = "dotenv-file",
+        alias = "env-file",
+        value_name = "PATH",
+        env = "POSTHOG_CLI_DOTENV_FILE"
+    )]
     env_file: Option<PathBuf>,
 
     /// Skip artifact processing and upload (sourcemap, dSYM, hermes, proguard) without contacting
@@ -517,6 +524,19 @@ mod tests {
         assert_eq!(
             arg.get_env(),
             Some(std::ffi::OsStr::new("POSTHOG_CLI_DRY_RUN"))
+        );
+    }
+
+    #[test]
+    fn env_file_flag_is_wired_to_env_var() {
+        let cmd = Cli::command();
+        let arg = cmd
+            .get_arguments()
+            .find(|a| a.get_id().as_str() == "env_file")
+            .expect("env_file arg should exist");
+        assert_eq!(
+            arg.get_env(),
+            Some(std::ffi::OsStr::new("POSTHOG_CLI_DOTENV_FILE"))
         );
     }
 


### PR DESCRIPTION
Instead of `--dotenv-file abc` you can now use env var `POSTHOG_CLI_DOTENV_FILE`

We needed it for ios wizard work and I thought about adding an argument to our shared upload source maps build script baked inside posthog-ios but then I thought it might come in handy for some other strange use cases so why not have it on the CLI