### PR TITLE
feat: Add new heatmaps creation flow

### DIFF
--- a/frontend/src/scenes/heatmaps/components/FilterPanel.tsx
+++ b/frontend/src/scenes/heatmaps/components/FilterPanel.tsx
@@ -259,7 +259,8 @@ export function FilterPanel({
             </div>
             {heatmapEmpty ? (
                 <LemonBanner type="info" className="mb-2">
-                    No data found. Try changing your filters or the URL above.
+                    No data found. Try a different date range or URL, or lower the "Viewport accuracy" in heatmap
+                    settings. A high value can hide data on pages with less traffic.
                 </LemonBanner>
             ) : null}
         </>

--- a/frontend/src/scenes/heatmaps/components/HeatmapAdvancedSettings.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapAdvancedSettings.tsx
@@ -10,6 +10,9 @@ export interface HeatmapAdvancedSettingsProps {
     dataUrlHelp: React.ReactNode
     consentHelp: React.ReactNode
     showForbiddenUrl?: boolean
+    showDataUrl?: boolean
+    showConsent?: boolean
+    header?: string
 }
 
 export function HeatmapAdvancedSettings({
@@ -17,6 +20,9 @@ export function HeatmapAdvancedSettings({
     dataUrlHelp,
     consentHelp,
     showForbiddenUrl = false,
+    showDataUrl = true,
+    showConsent = true,
+    header = 'Advanced settings',
 }: HeatmapAdvancedSettingsProps): JSX.Element {
     const { dataUrl, displayUrl, type, blockConsentModals, isBrowserUrlAuthorized } = useValues(heatmapLogic)
     const { setDataUrl, setDataUrlUserTouched, setBlockConsentModals } = useActions(heatmapLogic)
@@ -26,40 +32,44 @@ export function HeatmapAdvancedSettings({
             panels={[
                 {
                     key: 'advanced',
-                    header: 'Advanced settings',
+                    header,
                     content: (
                         <div className="flex flex-col gap-4">
-                            <div>
-                                <LemonLabel>Heatmap data URL</LemonLabel>
-                                <LemonInput
-                                    size="small"
-                                    placeholder={
-                                        displayUrl ? `Same as page URL: ${displayUrl}` : dataUrlPlaceholderFallback
-                                    }
-                                    value={dataUrl ?? ''}
-                                    onChange={(value) => {
-                                        setDataUrlUserTouched(true)
-                                        setDataUrl(value || null)
-                                    }}
-                                    fullWidth={true}
-                                />
-                                <div className="text-xs text-muted mt-1">{dataUrlHelp}</div>
-                                {showForbiddenUrl && dataUrl && !isBrowserUrlAuthorized ? (
-                                    <HeatmapsForbiddenURL />
-                                ) : null}
-                            </div>
-                            <div>
-                                <LemonSwitch
-                                    checked={blockConsentModals}
-                                    onChange={setBlockConsentModals}
-                                    label="Dismiss cookie & consent banners"
-                                    bordered
-                                    disabledReason={
-                                        type !== 'screenshot' ? 'Only available for screenshot heatmaps' : undefined
-                                    }
-                                />
-                                <div className="text-xs text-muted mt-1">{consentHelp}</div>
-                            </div>
+                            {showDataUrl ? (
+                                <div>
+                                    <LemonLabel>Heatmap data URL</LemonLabel>
+                                    <LemonInput
+                                        size="small"
+                                        placeholder={
+                                            displayUrl ? `Same as page URL: ${displayUrl}` : dataUrlPlaceholderFallback
+                                        }
+                                        value={dataUrl ?? ''}
+                                        onChange={(value) => {
+                                            setDataUrlUserTouched(true)
+                                            setDataUrl(value || null)
+                                        }}
+                                        fullWidth={true}
+                                    />
+                                    <div className="text-xs text-muted mt-1">{dataUrlHelp}</div>
+                                    {showForbiddenUrl && dataUrl && !isBrowserUrlAuthorized ? (
+                                        <HeatmapsForbiddenURL />
+                                    ) : null}
+                                </div>
+                            ) : null}
+                            {showConsent ? (
+                                <div>
+                                    <LemonSwitch
+                                        checked={blockConsentModals}
+                                        onChange={setBlockConsentModals}
+                                        label="Dismiss cookie & consent banners"
+                                        bordered
+                                        disabledReason={
+                                            type !== 'screenshot' ? 'Only available for screenshot heatmaps' : undefined
+                                        }
+                                    />
+                                    <div className="text-xs text-muted mt-1">{consentHelp}</div>
+                                </div>
+                            ) : null}
                         </div>
                     ),
                 },

--- a/frontend/src/scenes/heatmaps/components/HeatmapHeader.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapHeader.tsx
@@ -20,7 +20,7 @@ export function HeatmapHeader(): JSX.Element {
         type,
     } = useValues(heatmapLogic)
     const { iframeBanner } = useValues(heatmapsBrowserLogic)
-    const { setPageUrlDraft, applyPageUrlDraft, regenerateScreenshot } = useActions(heatmapLogic)
+    const { setPageUrlDraft, applyPageUrlDraft, regenerateScreenshot, changeCaptureMethod } = useActions(heatmapLogic)
 
     const draftIsEmpty = pageUrlDraft.trim() === ''
     const disabledReason = !isPageUrlDraftValid ? 'Enter a valid URL' : draftIsEmpty ? 'Enter a URL' : null
@@ -82,8 +82,15 @@ export function HeatmapHeader(): JSX.Element {
                     )}
                     {type === 'iframe' && iframeBanner?.level === 'error' && (
                         <div className="flex flex-col gap-2">
-                            <LemonBanner type="error">
-                                The page failed to load in an iframe (or is very slow). Some sites block being embedded.
+                            <LemonBanner
+                                type="error"
+                                action={{
+                                    children: 'Switch to screenshot',
+                                    onClick: () => changeCaptureMethod('screenshot'),
+                                }}
+                            >
+                                This page didn't load in the live preview. It may block embedding. If it is public,
+                                switch to Screenshot. If it requires login, use a session recording below.
                             </LemonBanner>
                             {displayUrl && !displayUrlIsPattern ? <HeatmapRecordingFallback url={displayUrl} /> : null}
                         </div>

--- a/frontend/src/scenes/heatmaps/components/HeatmapRecording.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapRecording.tsx
@@ -43,7 +43,7 @@ function UrlSearchHeader(): JSX.Element {
     )
 }
 
-export function HeatmapRecording(): JSX.Element {
+export function HeatmapRecording({ embedded = false }: { embedded?: boolean }): JSX.Element {
     const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
     const logicProps = { ref: iframeRef }
@@ -65,22 +65,26 @@ export function HeatmapRecording(): JSX.Element {
         )
     }
 
+    const content = (
+        <>
+            <HeatmapsWarnings />
+            <div className="overflow-hidden w-full min-h-screen">
+                <UrlSearchHeader />
+                <LemonDivider className="my-4" />
+                <FilterPanel
+                    clickmapSettings={clickmapAvailable ? <ClickmapSettings iframeRef={iframeRef} /> : undefined}
+                />
+                <LemonDivider className="my-4" />
+                <div className="relative flex flex-1 overflow-hidden min-h-screen">
+                    <FixedReplayHeatmapBrowser iframeRef={iframeRef} />
+                </div>
+            </div>
+        </>
+    )
+
     return (
         <BindLogic logic={heatmapsBrowserLogic} props={logicProps}>
-            <SceneContent>
-                <HeatmapsWarnings />
-                <div className="overflow-hidden w-full min-h-screen">
-                    <UrlSearchHeader />
-                    <LemonDivider className="my-4" />
-                    <FilterPanel
-                        clickmapSettings={clickmapAvailable ? <ClickmapSettings iframeRef={iframeRef} /> : undefined}
-                    />
-                    <LemonDivider className="my-4" />
-                    <div className="relative flex flex-1 overflow-hidden min-h-screen">
-                        <FixedReplayHeatmapBrowser iframeRef={iframeRef} />
-                    </div>
-                </div>
-            </SceneContent>
+            {embedded ? content : <SceneContent>{content}</SceneContent>}
         </BindLogic>
     )
 }

--- a/frontend/src/scenes/heatmaps/components/HeatmapRecordingFallback.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapRecordingFallback.tsx
@@ -1,29 +1,68 @@
 import { useActions, useValues } from 'kea'
 
 import { IconRewindPlay } from '@posthog/icons'
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { colonDelimitedDuration } from 'lib/utils/durations'
 
-import { heatmapRecordingFallbackLogic } from './heatmapRecordingFallbackLogic'
+import { buildRecordingFiltersForUrl, heatmapRecordingFallbackLogic } from './heatmapRecordingFallbackLogic'
 
-export function HeatmapRecordingFallback({ url }: { url: string }): JSX.Element | null {
-    const logic = heatmapRecordingFallbackLogic({ url })
-    const { matchingRecordings } = useValues(logic)
+export interface HeatmapRecordingFallbackProps {
+    url: string
+    showEmptyState?: boolean
+    guidedSelection?: boolean
+    onRecordingHandoff?: (matchingRecordingCount: number) => void
+}
+
+export function HeatmapRecordingFallback({
+    url,
+    showEmptyState = false,
+    guidedSelection = false,
+    onRecordingHandoff,
+}: HeatmapRecordingFallbackProps): JSX.Element | null {
+    const logic = heatmapRecordingFallbackLogic({ url, selectionMode: guidedSelection ? 'guided' : 'default' })
+    const { matchingRecordings, matchingRecordingsLoading } = useValues(logic)
     const { openRecording } = useActions(logic)
 
+    if (matchingRecordingsLoading && showEmptyState) {
+        return (
+            <div className="flex items-center gap-2 text-muted">
+                <Spinner /> Looking for recordings from the last 30 days
+            </div>
+        )
+    }
+
     if (!matchingRecordings?.length) {
-        return null
+        return showEmptyState ? (
+            <LemonBanner type="info">
+                <div className="flex flex-col gap-2">
+                    <p className="mb-0">
+                        We didn't find a recent recording that visited this page. Open Session replay with the
+                        visited-page filter applied to broaden your search or wait for a new recording.
+                    </p>
+                    <ViewRecordingsPlaylistButton
+                        filters={buildRecordingFiltersForUrl(url)}
+                        label="Find recordings in Session replay"
+                        type="secondary"
+                        size="small"
+                        className="w-fit"
+                        onClick={() => onRecordingHandoff?.(0)}
+                        data-attr="heatmap-recording-fallback-view-recordings"
+                    />
+                </div>
+            </LemonBanner>
+        ) : null
     }
 
     return (
         <LemonBanner type="info">
             <div className="flex flex-col gap-2">
                 <p className="mb-0">
-                    We found recent recordings of sessions that visited this page. You can build the heatmap from a
-                    recording instead: open one, scrub to the page you want as the background, then choose "View
-                    heatmap" in the player.
+                    {guidedSelection
+                        ? "Choose a recording below. We'll open it here, pause at the first matching page event, and return the background you choose here for review."
+                        : 'We found recent recordings that visited this page. Open one and choose “View heatmap” at the page state you want to analyze.'}
                 </p>
                 <div className="flex flex-wrap gap-2">
                     {matchingRecordings.map((recording) => (
@@ -33,9 +72,10 @@ export function HeatmapRecordingFallback({ url }: { url: string }): JSX.Element 
                             type="secondary"
                             size="small"
                             icon={<IconRewindPlay />}
-                            onClick={() => openRecording(recording.id)}
+                            onClick={() => openRecording(recording)}
                         >
                             <span className="flex items-center gap-1">
+                                {guidedSelection ? <span>Choose moment ·</span> : null}
                                 <TZLabel time={recording.start_time} />
                                 {recording.recording_duration ? (
                                     <span className="text-muted">

--- a/frontend/src/scenes/heatmaps/components/HeatmapsEnableCapture.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapsEnableCapture.tsx
@@ -1,0 +1,46 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
+import { teamLogic } from 'scenes/teamLogic'
+
+export function HeatmapsEnableCapture(): JSX.Element {
+    const { updateCurrentTeam } = useActions(teamLogic)
+    const { currentTeamLoading } = useValues(teamLogic)
+
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
+    if (restrictedReason) {
+        return (
+            <div className="flex flex-col gap-2">
+                <LemonButton type="primary" disabledReason={restrictedReason} data-attr="heatmaps-enable-capture">
+                    Enable heatmaps
+                </LemonButton>
+                <p className="text-muted text-xs mb-1">
+                    Only project admins can change this. Ask an admin, or turn it on directly in your SDK without admin
+                    access:
+                </p>
+                <CodeSnippet language={Language.JavaScript}>
+                    {`posthog.init('<ph_project_api_key>', {\n    api_host: '<ph_client_api_host>',\n    enable_heatmaps: true,\n})`}
+                </CodeSnippet>
+            </div>
+        )
+    }
+
+    return (
+        <LemonButton
+            type="primary"
+            onClick={() => updateCurrentTeam({ heatmaps_opt_in: true })}
+            loading={currentTeamLoading}
+            data-attr="heatmaps-enable-capture"
+        >
+            Enable heatmaps
+        </LemonButton>
+    )
+}

--- a/frontend/src/scenes/heatmaps/components/heatmapRecordingFallbackLogic.test.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapRecordingFallbackLogic.test.ts
@@ -1,6 +1,26 @@
-import { buildRecordingsQueryForUrl } from './heatmapRecordingFallbackLogic'
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import {
+    buildRecordingFiltersForUrl,
+    buildRecordingMatchingEventFiltersForUrl,
+    buildRecordingsQueryForUrl,
+    heatmapRecordingFallbackLogic,
+} from './heatmapRecordingFallbackLogic'
 
 describe('heatmapRecordingFallbackLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
     it('searches recordings by pages actually visited during the session, not just session start', () => {
         const query = buildRecordingsQueryForUrl('https://example.com/pricing')
         expect(query.properties).toEqual([
@@ -16,5 +36,72 @@ describe('heatmapRecordingFallbackLogic', () => {
         expect(query.kind).toBe('RecordingsQuery')
         expect(query.limit).toBe(3)
         expect(query.date_from).toBe('-30d')
+    })
+
+    it('opens Session replay with the same visited-page and lookback filters', () => {
+        expect(buildRecordingFiltersForUrl('https://example.com/pricing')).toEqual({
+            date_from: '-30d',
+            filter_group: {
+                type: 'AND',
+                values: [
+                    {
+                        type: 'AND',
+                        values: [
+                            {
+                                type: 'recording',
+                                key: 'visited_page',
+                                operator: 'icontains',
+                                value: ['https://example.com/pricing'],
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+    })
+
+    it('finds the first matching page event when choosing a recording background', () => {
+        expect(buildRecordingMatchingEventFiltersForUrl('https://example.com/pricing')).toEqual({
+            date_from: '-30d',
+            duration: [],
+            filter_group: {
+                type: 'AND',
+                values: [
+                    {
+                        type: 'AND',
+                        values: [
+                            {
+                                type: 'event',
+                                key: '$current_url',
+                                operator: 'icontains',
+                                value: ['https://example.com/pricing'],
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+    })
+
+    it('opens a guided player with the target page and matching count', async () => {
+        const recordings = [{ id: 'recording-one' }, { id: 'recording-two' }]
+        jest.spyOn(api.recordings, 'list').mockResolvedValue({ results: recordings } as any)
+        const modalLogic = sessionPlayerModalLogic
+        const logic = heatmapRecordingFallbackLogic({
+            url: 'https://example.com/pricing',
+            selectionMode: 'guided',
+        })
+        modalLogic.mount()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.openRecording(recordings[0])
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(modalLogic.values.modalContext).toEqual({
+            type: 'heatmap-background-selection',
+            targetUrl: 'https://example.com/pricing',
+            matchingRecordingCount: 2,
+        })
     })
 })

--- a/frontend/src/scenes/heatmaps/components/heatmapRecordingFallbackLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapRecordingFallbackLogic.ts
@@ -6,12 +6,20 @@ import api from 'lib/api'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 
 import { NodeKind, RecordingsQuery } from '~/queries/schema/schema-general'
-import { PropertyFilterType, PropertyOperator, SessionRecordingType } from '~/types'
+import {
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    RecordingUniversalFilters,
+    SessionRecordingType,
+    UniversalFilterValue,
+} from '~/types'
 
 import type { heatmapRecordingFallbackLogicType } from './heatmapRecordingFallbackLogicType'
 
 export type HeatmapRecordingFallbackLogicProps = {
     url: string
+    selectionMode?: 'default' | 'guided'
 }
 
 const RECORDING_FALLBACK_LOOKBACK = '-30d'
@@ -34,16 +42,52 @@ export function buildRecordingsQueryForUrl(url: string): RecordingsQuery {
     }
 }
 
+function buildRecordingFiltersForProperty(property: UniversalFilterValue): Partial<RecordingUniversalFilters> {
+    return {
+        date_from: RECORDING_FALLBACK_LOOKBACK,
+        filter_group: {
+            type: FilterLogicalOperator.And,
+            values: [
+                {
+                    type: FilterLogicalOperator.And,
+                    values: [property],
+                },
+            ],
+        },
+    }
+}
+
+export function buildRecordingFiltersForUrl(url: string): Partial<RecordingUniversalFilters> {
+    return buildRecordingFiltersForProperty({
+        type: PropertyFilterType.Recording,
+        key: 'visited_page',
+        operator: PropertyOperator.IContains,
+        value: [url],
+    })
+}
+
+export function buildRecordingMatchingEventFiltersForUrl(url: string): RecordingUniversalFilters {
+    return {
+        ...buildRecordingFiltersForProperty({
+            type: PropertyFilterType.Event,
+            key: '$current_url',
+            operator: PropertyOperator.IContains,
+            value: [url],
+        }),
+        duration: [],
+    } as RecordingUniversalFilters
+}
+
 export const heatmapRecordingFallbackLogic = kea<heatmapRecordingFallbackLogicType>([
     path(['scenes', 'heatmaps', 'components', 'heatmapRecordingFallbackLogic']),
     props({} as HeatmapRecordingFallbackLogicProps),
-    key((props) => props.url),
+    key((props) => `${props.selectionMode ?? 'default'}-${props.url}`),
     connect(() => ({
         actions: [sessionPlayerModalLogic, ['openSessionPlayer']],
     })),
     actions({
         loadMatchingRecordings: true,
-        openRecording: (recordingId: string) => ({ recordingId }),
+        openRecording: (recording: Pick<SessionRecordingType, 'id' | 'matching_events'>) => ({ recording }),
     }),
     loaders(({ props }) => ({
         matchingRecordings: [
@@ -58,15 +102,25 @@ export const heatmapRecordingFallbackLogic = kea<heatmapRecordingFallbackLogicTy
             },
         ],
     })),
-    listeners(({ actions }) => ({
+    listeners(({ actions, props, values }) => ({
         loadMatchingRecordingsSuccess: ({ matchingRecordings }) => {
             posthog.capture('in-app heatmap recording fallback searched', {
                 matching_recordings: matchingRecordings?.length ?? 0,
             })
         },
-        openRecording: ({ recordingId }) => {
+        openRecording: ({ recording }) => {
             posthog.capture('in-app heatmap recording fallback recording opened')
-            actions.openSessionPlayer({ id: recordingId })
+            actions.openSessionPlayer(
+                recording,
+                null,
+                props.selectionMode === 'guided'
+                    ? {
+                          type: 'heatmap-background-selection',
+                          targetUrl: props.url,
+                          matchingRecordingCount: values.matchingRecordings?.length ?? 0,
+                      }
+                    : null
+            )
         },
     })),
     afterMount(({ actions }) => {

--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.test.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.test.ts
@@ -1,0 +1,18 @@
+import { normalizeHeatmapDataUrl } from './heatmapsBrowserLogic'
+
+describe('normalizeHeatmapDataUrl', () => {
+    it.each([
+        ['example.com', null],
+        ['   ', null],
+        ['', null],
+        [null, null],
+        ['h', null],
+        ['https://', null],
+        ['https://example.com', { href: 'https://example.com/', matchType: 'exact' }],
+        ['https://example.com/pricing', { href: 'https://example.com/pricing', matchType: 'exact' }],
+        ['  https://example.com/pricing  ', { href: 'https://example.com/pricing', matchType: 'exact' }],
+        ['https://example.com/users/*', { href: 'https://example.com/users/*', matchType: 'pattern' }],
+    ] as const)('normalizeHeatmapDataUrl(%s) → %s', (input, expected) => {
+        expect(normalizeHeatmapDataUrl(input)).toEqual(expected)
+    })
+})

--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -50,6 +50,23 @@ const normalizeUrlPath = (urlObj: URL): string => {
     return urlObj.toString()
 }
 
+export const normalizeHeatmapDataUrl = (
+    url: string | null
+): { href: string; matchType: 'pattern' | 'exact' } | null => {
+    const trimmed = url?.trim()
+    if (!trimmed) {
+        return null
+    }
+    if (isUrlPattern(trimmed)) {
+        return { href: trimmed, matchType: 'pattern' }
+    }
+    try {
+        return { href: normalizeUrlPath(new URL(trimmed)), matchType: 'exact' }
+    } catch {
+        return null
+    }
+}
+
 export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
     path(['scenes', 'heatmaps', 'components', 'heatmapsBrowserLogic']),
     props({} as HeatmapsBrowserLogicProps),
@@ -362,17 +379,13 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
 
         setDataUrl: ({ url }) => {
             actions.maybeLoadTopUrls()
-            if (url?.trim().length) {
-                let normalizedUrl = url.trim()
-
-                const isPattern = isUrlPattern(normalizedUrl)
-                if (!isPattern) {
-                    const urlObj = new URL(normalizedUrl)
-                    normalizedUrl = normalizeUrlPath(urlObj)
-                }
-
-                actions.setHref(normalizedUrl)
-                actions.setHrefMatchType(isPattern ? 'pattern' : 'exact')
+            if (router.values.location.pathname === '/heatmaps/new') {
+                return
+            }
+            const normalized = normalizeHeatmapDataUrl(url)
+            if (normalized) {
+                actions.setHref(normalized.href)
+                actions.setHrefMatchType(normalized.matchType)
             }
         },
 

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapNewScene.stories.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapNewScene.stories.tsx
@@ -1,13 +1,113 @@
 import { Meta, StoryObj } from '@storybook/react'
+import { useActions, useValues } from 'kea'
+import { useEffect, useRef } from 'react'
 
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { App } from 'scenes/App'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { mswDecorator } from '~/mocks/browser'
+import { HeatmapType } from '~/types'
 
-const meta: Meta = {
-    component: App,
+import { HeatmapCreationStep, HeatmapPageAccess, heatmapCreationLogic } from './heatmapCreationLogic'
+import { heatmapLogic } from './heatmapLogic'
+
+interface HeatmapNewStoryProps {
+    captureEnabled: boolean
+    membershipLevel: OrganizationMembershipLevel
+    step: HeatmapCreationStep
+    pageAccess?: HeatmapPageAccess
+    backgroundType?: HeatmapType
+    authorizedUrls?: string[]
+    recordingBackgroundSelected?: boolean
+}
+
+function HeatmapNewStory({
+    captureEnabled,
+    membershipLevel,
+    step,
+    pageAccess,
+    backgroundType = 'screenshot',
+    authorizedUrls = [],
+    recordingBackgroundSelected = false,
+}: HeatmapNewStoryProps): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+    const { loadCurrentTeamSuccess } = useActions(teamLogic)
+    const { setDisplayUrl, setType } = useActions(heatmapLogic({ id: 'new' }))
+    const { applyStep, selectRecordingBackground, setPageAccess } = useActions(heatmapCreationLogic)
+    const configuredTeam = useRef(false)
+    const configuredWizard = useRef(false)
+
+    useEffect(() => {
+        if (currentTeam && !configuredTeam.current) {
+            configuredTeam.current = true
+            loadCurrentTeamSuccess({
+                ...currentTeam,
+                heatmaps_opt_in: captureEnabled,
+                effective_membership_level: membershipLevel,
+                app_urls: authorizedUrls,
+            })
+        }
+    }, [authorizedUrls, captureEnabled, currentTeam, loadCurrentTeamSuccess, membershipLevel])
+
+    useEffect(() => {
+        if (configuredWizard.current) {
+            return
+        }
+        configuredWizard.current = true
+        setDisplayUrl('https://example.com/pricing')
+        setType(backgroundType)
+        if (pageAccess) {
+            setPageAccess(pageAccess)
+        }
+        if (recordingBackgroundSelected) {
+            const storageKey = 'storybook-recording-background'
+            localStorage.setItem(
+                storageKey,
+                JSON.stringify({
+                    html: '<html><body style="margin:0;font-family:sans-serif;background:#f5f5f5"><main style="padding:48px"><h1>Signed-in account dashboard</h1><p>This is the page state selected from the session recording.</p><section style="margin-top:32px;padding:32px;background:white;border:1px solid #ddd;border-radius:8px"><h2>Workspace overview</h2><p>42 active projects</p></section></main></body></html>',
+                    width: 1280,
+                    height: 720,
+                    url: 'https://example.com/pricing',
+                })
+            )
+            selectRecordingBackground(storageKey, 2)
+        }
+        applyStep(step)
+    }, [
+        applyStep,
+        backgroundType,
+        pageAccess,
+        recordingBackgroundSelected,
+        selectRecordingBackground,
+        setDisplayUrl,
+        setPageAccess,
+        setType,
+        step,
+    ])
+
+    return <App />
+}
+
+const queryMock =
+    (matchingCount: number) =>
+    async ({ request }: { request: Request }): Promise<[number, Record<string, unknown>]> => {
+        const body = (await request.json()) as { query?: { query?: string } }
+        const query = body.query?.query ?? ''
+        return query.includes('FROM heatmaps')
+            ? [200, { results: [[matchingCount]] }]
+            : [200, { results: [['https://example.com/pricing', 120]] }]
+    }
+
+const meta: Meta<typeof HeatmapNewStory> = {
+    component: HeatmapNewStory,
     title: 'Scenes-App/Heatmap New',
+    args: {
+        captureEnabled: true,
+        membershipLevel: OrganizationMembershipLevel.Admin,
+        step: 'page',
+    },
     parameters: {
         layout: 'fullscreen',
         viewMode: 'story',
@@ -15,11 +115,114 @@ const meta: Meta = {
         testOptions: {
             waitForLoadersToDisappear: true,
         },
+        msw: {
+            mocks: {
+                post: {
+                    '/api/environments/:team_id/query/:kind': queryMock(24),
+                },
+            },
+        },
     },
     decorators: [mswDecorator({})],
 }
 export default meta
 
-type Story = StoryObj<{}>
+type Story = StoryObj<typeof HeatmapNewStory>
 
-export const NewForm: Story = {}
+export const CaptureDisabledAdmin: Story = {
+    args: {
+        captureEnabled: false,
+        membershipLevel: OrganizationMembershipLevel.Admin,
+    },
+}
+
+export const CaptureDisabledMember: Story = {
+    args: {
+        captureEnabled: false,
+        membershipLevel: OrganizationMembershipLevel.Member,
+    },
+}
+
+export const NoMatchingData: Story = {
+    parameters: {
+        msw: {
+            mocks: {
+                post: {
+                    '/api/environments/:team_id/query/:kind': queryMock(0),
+                },
+            },
+        },
+    },
+}
+
+export const PublicScreenshot: Story = {
+    args: {
+        step: 'background',
+        pageAccess: 'public',
+        backgroundType: 'screenshot',
+    },
+}
+
+export const UnauthorizedIframe: Story = {
+    args: {
+        step: 'background',
+        pageAccess: 'public',
+        backgroundType: 'iframe',
+        authorizedUrls: [],
+    },
+}
+
+export const AuthenticatedWithRecordings: Story = {
+    args: {
+        step: 'background',
+        pageAccess: 'login',
+    },
+    parameters: {
+        msw: {
+            mocks: {
+                get: {
+                    '/api/environments/:team_id/session_recordings': [
+                        200,
+                        {
+                            results: [
+                                {
+                                    id: 'recording-one',
+                                    start_time: '2026-07-13T17:30:00Z',
+                                    recording_duration: 125,
+                                },
+                                {
+                                    id: 'recording-two',
+                                    start_time: '2026-07-12T15:00:00Z',
+                                    recording_duration: 48,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        },
+    },
+}
+
+export const AuthenticatedWithoutRecordings: Story = {
+    args: {
+        step: 'background',
+        pageAccess: 'login',
+    },
+}
+
+export const Review: Story = {
+    args: {
+        step: 'review',
+        pageAccess: 'public',
+        backgroundType: 'screenshot',
+    },
+}
+
+export const AuthenticatedReview: Story = {
+    args: {
+        step: 'review',
+        pageAccess: 'login',
+        recordingBackgroundSelected: true,
+    },
+}

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapNewScene.tsx
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapNewScene.tsx
@@ -1,151 +1,570 @@
 import { useActions, useValues } from 'kea'
-import { useDebouncedCallback } from 'use-debounce'
 
-import { Spinner } from '@posthog/lemon-ui'
+import { IconCheckCircle, IconWarning } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonCard, LemonLabel, Spinner } from '@posthog/lemon-ui'
 
-import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
-import { Link } from 'lib/lemon-ui/Link'
+import { cn } from 'lib/utils/css-classes'
 import { HeatmapAdvancedSettings } from 'scenes/heatmaps/components/HeatmapAdvancedSettings'
-import { heatmapsBrowserLogic } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import { HeatmapRecording } from 'scenes/heatmaps/components/HeatmapRecording'
+import { HeatmapRecordingFallback } from 'scenes/heatmaps/components/HeatmapRecordingFallback'
+import { heatmapsBrowserLogic, isUrlPattern } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import { HeatmapsEnableCapture } from 'scenes/heatmaps/components/HeatmapsEnableCapture'
 import { HeatmapsInvalidURL } from 'scenes/heatmaps/components/HeatmapsInvalidURL'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
-import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
-import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { HeatmapType } from '~/types'
 
+import { HeatmapCreationStep, heatmapCreationLogic } from './heatmapCreationLogic'
 import { heatmapLogic } from './heatmapLogic'
+
+const CREATION_STEPS: { key: HeatmapCreationStep; label: string }[] = [
+    { key: 'page', label: 'Choose page' },
+    { key: 'background', label: 'Choose background' },
+    { key: 'review', label: 'Review and create' },
+]
+
+function HeatmapCreationStepper(): JSX.Element {
+    const { currentStep, furthestStep, pageAccess, recordingHeatmapOpen } = useValues(heatmapCreationLogic)
+    const { navigateToStep } = useActions(heatmapCreationLogic)
+    const currentIndex = CREATION_STEPS.findIndex(({ key }) => key === currentStep)
+    const furthestIndex = CREATION_STEPS.findIndex(({ key }) => key === furthestStep)
+
+    return (
+        <nav className="flex items-center justify-center mb-6" aria-label="Heatmap creation progress">
+            {CREATION_STEPS.map((step, index) => {
+                const isCompleted = index < currentIndex
+                const isCurrent = step.key === currentStep
+                const isAvailable = index <= furthestIndex
+                const label =
+                    step.key === 'review' && recordingHeatmapOpen
+                        ? 'Explore heatmap'
+                        : step.key === 'review' && pageAccess === 'login'
+                          ? 'Review background'
+                          : step.label
+
+                return (
+                    <div key={step.key} className="flex items-center">
+                        {index > 0 ? (
+                            <div
+                                className={cn(
+                                    'w-6 h-px transition-colors',
+                                    index <= currentIndex ? 'bg-success' : 'bg-border-primary'
+                                )}
+                            />
+                        ) : null}
+                        <button
+                            type="button"
+                            onClick={() => navigateToStep(step.key)}
+                            disabled={!isAvailable}
+                            className={cn(
+                                'flex items-center gap-1.5 px-2 py-1 rounded transition-colors',
+                                isAvailable && 'hover:bg-fill-button-tertiary-hover cursor-pointer',
+                                !isAvailable && 'cursor-not-allowed opacity-60'
+                            )}
+                            aria-current={isCurrent ? 'step' : undefined}
+                        >
+                            {isCompleted ? (
+                                <IconCheckCircle className="size-5 text-success" />
+                            ) : (
+                                <span
+                                    className={cn(
+                                        'flex items-center justify-center size-5 rounded-full text-xs font-semibold',
+                                        isCurrent
+                                            ? 'bg-accent text-primary-inverse ring-2 ring-accent/25'
+                                            : 'bg-surface-secondary text-secondary border border-primary'
+                                    )}
+                                >
+                                    {index + 1}
+                                </span>
+                            )}
+                            <span
+                                className={cn('text-sm', isCurrent ? 'font-semibold text-primary' : 'text-secondary')}
+                            >
+                                {label}
+                            </span>
+                        </button>
+                    </div>
+                )
+            })}
+        </nav>
+    )
+}
+
+function CaptureReadiness(): JSX.Element {
+    const { captureEnabled } = useValues(heatmapCreationLogic)
+
+    return captureEnabled ? (
+        <div className="flex items-center gap-2 text-success">
+            <IconCheckCircle className="size-5 shrink-0" />
+            <span>Heatmap capture is enabled for this project.</span>
+        </div>
+    ) : (
+        <LemonBanner type="warning">
+            <div className="flex flex-col gap-3">
+                <div>
+                    Heatmap capture is off for this project. You can still create this heatmap, but it will remain empty
+                    until capture is enabled.
+                </div>
+                <HeatmapsEnableCapture />
+            </div>
+        </LemonBanner>
+    )
+}
+
+function MatchingDataReadiness(): JSX.Element {
+    const { currentPageDataCheck, pageDataCheckLoading } = useValues(heatmapCreationLogic)
+    const { requestPageDataCheck } = useActions(heatmapCreationLogic)
+
+    if (pageDataCheckLoading) {
+        return (
+            <div className="flex items-center gap-2 text-muted">
+                <Spinner /> Checking for matching heatmap data from the last 30 days
+            </div>
+        )
+    }
+
+    if (!currentPageDataCheck) {
+        return (
+            <div className="flex items-center gap-2 text-muted">
+                <IconWarning className="size-5 shrink-0" />
+                Enter a valid page and heatmap data URL to check for matching data.
+            </div>
+        )
+    }
+
+    if (currentPageDataCheck.outcome === 'detected') {
+        return (
+            <div className="flex items-center gap-2 text-success">
+                <IconCheckCircle className="size-5 shrink-0" />
+                <span>
+                    Found {currentPageDataCheck.count?.toLocaleString()} matching interaction
+                    {currentPageDataCheck.count === 1 ? '' : 's'} from the last 30 days.
+                </span>
+            </div>
+        )
+    }
+
+    const checkAgain = {
+        children: 'Check again',
+        onClick: () => requestPageDataCheck('manual'),
+    }
+
+    return (
+        <LemonBanner type="warning" action={checkAgain}>
+            {currentPageDataCheck.outcome === 'none'
+                ? 'No matching heatmap data was found in the last 30 days. You can create the heatmap now and collect data later.'
+                : "We couldn't check for matching data. You can try again or continue creating the heatmap."}
+        </LemonBanner>
+    )
+}
+
+function ChoosePageStep(): JSX.Element {
+    const logic = heatmapLogic({ id: 'new' })
+    const { displayUrl, isDisplayUrlValid, displayUrlIsPattern, dataUrl } = useValues(logic)
+    const { setDisplayUrl } = useActions(logic)
+    const { topUrls, topUrlsLoading, noPageviews } = useValues(heatmapsBrowserLogic)
+    const { pageStepBlockReason } = useValues(heatmapCreationLogic)
+    const { continueFromPage } = useActions(heatmapCreationLogic)
+
+    return (
+        <LemonCard hoverEffect={false} className="max-w-3xl mx-auto">
+            <div className="flex flex-col gap-6">
+                <div>
+                    <h2 className="mb-1">Choose a page</h2>
+                    <p className="text-muted mb-0">
+                        Pick the page to display behind the heatmap. We'll also check whether it is ready to collect and
+                        show interaction data.
+                    </p>
+                </div>
+                <div>
+                    <LemonLabel>Page URL</LemonLabel>
+                    <LemonInputSelect
+                        mode="single"
+                        allowCustomValues
+                        disableEditing
+                        fullWidth
+                        placeholder="https://www.example.com/pricing"
+                        loading={topUrlsLoading}
+                        value={displayUrl ? [displayUrl] : []}
+                        onChange={(next) => setDisplayUrl(next[0] ?? '')}
+                        options={(topUrls ?? []).map(({ url }) => ({
+                            key: url,
+                            label: url,
+                            labelComponent: (
+                                <span className="block min-w-0 max-w-full truncate ph-no-capture" title={url}>
+                                    {url}
+                                </span>
+                            ),
+                        }))}
+                        title={topUrls?.length ? 'Most viewed pages' : undefined}
+                        popoverClassName="max-w-0"
+                        data-attr="heatmap-new-page-url"
+                    />
+                    {displayUrl && !isDisplayUrlValid ? (
+                        displayUrlIsPattern ? (
+                            <LemonBanner type="error" className="mt-2">
+                                The page URL can't contain wildcards. Add wildcards to the heatmap data URL below.
+                            </LemonBanner>
+                        ) : (
+                            <HeatmapsInvalidURL />
+                        )
+                    ) : null}
+                    {!displayUrl && noPageviews && !topUrlsLoading ? (
+                        <div className="text-xs text-muted mt-1">
+                            No pageview events have been received yet. You can enter a URL manually.
+                        </div>
+                    ) : null}
+                </div>
+
+                <div className="flex flex-col gap-3">
+                    <h3 className="mb-0">Readiness</h3>
+                    <CaptureReadiness />
+                    <MatchingDataReadiness />
+                </div>
+
+                <HeatmapAdvancedSettings
+                    dataUrlPlaceholderFallback="https://www.example.com/*"
+                    dataUrlHelp="Defaults to the page URL. Add * to combine data from multiple pages, for example https://www.example.com/users/*."
+                    consentHelp={null}
+                    showDataUrl
+                    showConsent={false}
+                    header="Heatmap data URL"
+                />
+                {dataUrl && pageStepBlockReason?.includes('heatmap data URL') ? (
+                    <LemonBanner type="error">Enter a complete URL including http:// or https://.</LemonBanner>
+                ) : null}
+
+                <div className="flex justify-end">
+                    <LemonButton
+                        type="primary"
+                        onClick={continueFromPage}
+                        disabledReason={pageStepBlockReason}
+                        data-attr="heatmap-creation-continue-page"
+                    >
+                        Continue
+                    </LemonButton>
+                </div>
+            </div>
+        </LemonCard>
+    )
+}
+
+function PublicBackgroundChoice(): JSX.Element {
+    const logic = heatmapLogic({ id: 'new' })
+    const { type } = useValues(logic)
+    const { setType } = useActions(logic)
+    const { isDisplayUrlAuthorized, authorizationDisabledReason } = useValues(heatmapCreationLogic)
+    const { authorizeDisplayUrl } = useActions(heatmapCreationLogic)
+    const { currentTeamLoading } = useValues(teamLogic)
+
+    return (
+        <div className="flex flex-col gap-4">
+            <LemonRadio
+                options={[
+                    {
+                        label: 'Screenshot',
+                        value: 'screenshot',
+                        description:
+                            'A headless browser captures the public page. Pages that require login may show the login screen.',
+                    },
+                    {
+                        label: 'Iframe',
+                        value: 'iframe',
+                        description:
+                            'Loads the page live. It must allow embedding and cannot use your signed-in browser session.',
+                    },
+                ]}
+                value={type}
+                onChange={(value: HeatmapType) => setType(value)}
+            />
+
+            {type === 'iframe' && !isDisplayUrlAuthorized ? (
+                <LemonBanner type="warning">
+                    <div className="flex flex-col gap-3">
+                        <div>
+                            The page URL's origin must be authorized before PostHog can embed it. Screenshot does not
+                            require authorization.
+                        </div>
+                        {authorizationDisabledReason ? (
+                            <div className="text-sm">
+                                Ask a web analytics editor to authorize this URL, or choose Screenshot.
+                            </div>
+                        ) : (
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                className="w-fit"
+                                onClick={authorizeDisplayUrl}
+                                loading={currentTeamLoading}
+                                data-attr="heatmap-authorize-display-url"
+                            >
+                                Authorize this URL
+                            </LemonButton>
+                        )}
+                    </div>
+                </LemonBanner>
+            ) : null}
+
+            {type === 'screenshot' ? (
+                <HeatmapAdvancedSettings
+                    dataUrlPlaceholderFallback=""
+                    dataUrlHelp={null}
+                    consentHelp="Ask the browser to close cookie or consent popups before capturing the screenshot. This can slow down or fail the render on some sites, so it is off by default."
+                    showDataUrl={false}
+                    showConsent
+                    header="Screenshot options"
+                />
+            ) : null}
+        </div>
+    )
+}
+
+function ChooseBackgroundStep(): JSX.Element {
+    const logic = heatmapLogic({ id: 'new' })
+    const { displayUrl } = useValues(logic)
+    const { pageAccess, backgroundStepBlockReason, recordingBackgroundData } = useValues(heatmapCreationLogic)
+    const { setPageAccess, continueFromBackground, goBack, markRecordingHandoff, navigateToStep } =
+        useActions(heatmapCreationLogic)
+
+    return (
+        <LemonCard hoverEffect={false} className="max-w-3xl mx-auto">
+            <div className="flex flex-col gap-6">
+                <div>
+                    <h2 className="mb-1">Choose a background</h2>
+                    <p className="text-muted mb-0">
+                        Tell us whether visitors need to sign in before they can see this page.
+                    </p>
+                </div>
+
+                <LemonRadio
+                    options={[
+                        {
+                            label: 'No, this page is public',
+                            value: 'public',
+                            description: 'Create a saved heatmap using a screenshot or live iframe.',
+                        },
+                        {
+                            label: 'Yes, this page requires login',
+                            value: 'login',
+                            description: 'Use a session recording so the signed-in page state is available.',
+                        },
+                    ]}
+                    value={pageAccess ?? undefined}
+                    onChange={setPageAccess}
+                />
+
+                {pageAccess === 'public' ? <PublicBackgroundChoice /> : null}
+                {pageAccess === 'login' && displayUrl ? (
+                    <div className="flex flex-col gap-4">
+                        <LemonBanner type="info">
+                            Session recordings preserve the signed-in page state. Choose a recording and we will guide
+                            you through selecting the exact moment to use as the background. We will bring that state
+                            back here for review before opening the heatmap. Recording backgrounds are not saved.
+                        </LemonBanner>
+                        <HeatmapRecordingFallback
+                            url={displayUrl}
+                            showEmptyState
+                            guidedSelection
+                            onRecordingHandoff={markRecordingHandoff}
+                        />
+                    </div>
+                ) : null}
+
+                <div className="flex justify-between">
+                    <LemonButton type="secondary" onClick={goBack}>
+                        Back
+                    </LemonButton>
+                    {pageAccess !== 'login' ? (
+                        <LemonButton
+                            type="primary"
+                            onClick={continueFromBackground}
+                            disabledReason={backgroundStepBlockReason}
+                            data-attr="heatmap-creation-continue-background"
+                        >
+                            Continue
+                        </LemonButton>
+                    ) : recordingBackgroundData ? (
+                        <LemonButton type="primary" onClick={() => navigateToStep('review')}>
+                            Continue
+                        </LemonButton>
+                    ) : null}
+                </div>
+            </div>
+        </LemonCard>
+    )
+}
+
+function ReviewStatus({ warning, children }: { warning?: boolean; children: React.ReactNode }): JSX.Element {
+    return (
+        <div className={cn('flex items-center gap-2', warning ? 'text-warning' : 'text-success')}>
+            {warning ? <IconWarning className="size-5 shrink-0" /> : <IconCheckCircle className="size-5 shrink-0" />}
+            <span>{children}</span>
+        </div>
+    )
+}
+
+function RecordingBackgroundPreview({ html }: { html: string }): JSX.Element {
+    return (
+        <div className="overflow-hidden rounded border bg-surface-secondary">
+            <iframe
+                srcDoc={html}
+                title="Selected session recording background"
+                sandbox="allow-same-origin"
+                tabIndex={-1}
+                className="w-full h-96 border-0 bg-white pointer-events-none ph-no-capture"
+            />
+        </div>
+    )
+}
+
+function ReviewStep(): JSX.Element {
+    const logic = heatmapLogic({ id: 'new' })
+    const { displayUrl, type, loading } = useValues(logic)
+    const { createHeatmap } = useActions(logic)
+    const {
+        captureEnabled,
+        hasMatchingData,
+        creationContext,
+        reviewBlockReason,
+        pageAccess,
+        recordingBackgroundData,
+        effectiveDataUrl,
+    } = useValues(heatmapCreationLogic)
+    const { goBack, openRecordingHeatmap } = useActions(heatmapCreationLogic)
+    const usesRecordingBackground = pageAccess === 'login' && !!recordingBackgroundData
+
+    return (
+        <LemonCard hoverEffect={false} className="max-w-3xl mx-auto">
+            <div className="flex flex-col gap-6">
+                <div>
+                    <h2 className="mb-1">{usesRecordingBackground ? 'Review background' : 'Review and create'}</h2>
+                    <p className="text-muted mb-0">
+                        {usesRecordingBackground
+                            ? 'Confirm the page state you selected before opening the heatmap.'
+                            : 'Readiness warnings will not stop creation. The heatmap will start showing interactions as data arrives.'}
+                    </p>
+                </div>
+
+                <dl className="grid grid-cols-[minmax(8rem,auto)_1fr] gap-x-4 gap-y-3">
+                    <dt className="font-semibold">Page</dt>
+                    <dd className="ph-no-capture break-all">{displayUrl}</dd>
+                    <dt className="font-semibold">Matching rule</dt>
+                    <dd>
+                        <span className="font-medium">
+                            {isUrlPattern(effectiveDataUrl ?? '') ? 'Pattern' : 'Exact URL'}:
+                        </span>{' '}
+                        <span className="ph-no-capture break-all">{effectiveDataUrl}</span>
+                    </dd>
+                    <dt className="font-semibold">Background</dt>
+                    <dd>
+                        {usesRecordingBackground
+                            ? 'Session recording'
+                            : type === 'screenshot'
+                              ? 'Screenshot'
+                              : 'Iframe'}
+                    </dd>
+                </dl>
+
+                {recordingBackgroundData ? <RecordingBackgroundPreview html={recordingBackgroundData.html} /> : null}
+
+                <div className="flex flex-col gap-2">
+                    <ReviewStatus warning={!captureEnabled}>
+                        {captureEnabled ? 'Heatmap capture is enabled.' : 'Heatmap capture is disabled.'}
+                    </ReviewStatus>
+                    <ReviewStatus warning={hasMatchingData !== true}>
+                        {hasMatchingData === true
+                            ? 'Matching data was found in the last 30 days.'
+                            : hasMatchingData === false
+                              ? 'No matching data was found in the last 30 days.'
+                              : 'Matching data could not be confirmed.'}
+                    </ReviewStatus>
+                </div>
+
+                <div className="flex justify-between">
+                    <LemonButton type="secondary" onClick={goBack} disabled={!usesRecordingBackground && loading}>
+                        Back
+                    </LemonButton>
+                    {usesRecordingBackground ? (
+                        <LemonButton
+                            type="primary"
+                            onClick={openRecordingHeatmap}
+                            disabledReason={reviewBlockReason}
+                            data-attr="open-recording-heatmap"
+                        >
+                            View heatmap
+                        </LemonButton>
+                    ) : (
+                        <LemonButton
+                            type="primary"
+                            onClick={() => createHeatmap(creationContext)}
+                            loading={loading}
+                            disabledReason={reviewBlockReason}
+                            data-attr="save-heatmap"
+                        >
+                            Create heatmap
+                        </LemonButton>
+                    )}
+                </div>
+            </div>
+        </LemonCard>
+    )
+}
+
+function RecordingHeatmapStep(): JSX.Element {
+    const { closeRecordingHeatmap, finishRecordingHeatmap } = useActions(heatmapCreationLogic)
+
+    return (
+        <div className="flex flex-col gap-4">
+            <LemonCard hoverEffect={false} className="sticky top-0 z-20">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div>
+                        <h2 className="mb-1">Explore your heatmap</h2>
+                        <p className="text-muted mb-0">
+                            This temporary heatmap uses the session recording moment you selected. It won't be added to
+                            your saved heatmaps.
+                        </p>
+                    </div>
+                    <div className="flex gap-2">
+                        <LemonButton type="secondary" onClick={closeRecordingHeatmap}>
+                            Back to review
+                        </LemonButton>
+                        <LemonButton type="primary" onClick={finishRecordingHeatmap}>
+                            Finish
+                        </LemonButton>
+                    </div>
+                </div>
+            </LemonCard>
+            <HeatmapRecording embedded />
+        </div>
+    )
+}
 
 export function HeatmapNewScene(): JSX.Element {
     const logic = heatmapLogic({ id: 'new' })
-    const { loading, displayUrl, isDisplayUrlValid, type, name, dataUrl, isBrowserUrlAuthorized, displayUrlIsPattern } =
-        useValues(logic)
-    const { setDisplayUrl, setType, setName, createHeatmap } = useActions(logic)
-    const { topUrls, topUrlsLoading, noPageviews } = useValues(heatmapsBrowserLogic)
-
-    const debouncedOnNameChange = useDebouncedCallback((name: string) => {
-        setName(name)
-    }, 500)
-
-    if (loading) {
-        return (
-            <SceneContent>
-                <Spinner />
-            </SceneContent>
-        )
-    }
+    const { name } = useValues(logic)
+    const { setName } = useActions(logic)
+    const { currentStep, recordingHeatmapOpen } = useValues(heatmapCreationLogic)
 
     return (
         <SceneContent>
             <SceneTitleSection
                 name={name}
-                resourceType={{
-                    type: 'heatmap',
-                }}
+                resourceType={{ type: 'heatmap' }}
                 description={null}
                 canEdit
                 forceEdit
-                onNameChange={debouncedOnNameChange}
-                forceBackTo={{
-                    name: 'Heatmaps',
-                    path: urls.heatmaps(),
-                    key: 'heatmaps',
-                }}
+                onNameChange={setName}
+                forceBackTo={{ name: 'Heatmaps', path: urls.heatmaps(), key: 'heatmaps' }}
             />
-            <SceneSection title="Page URL" description="URL to your website">
-                <LemonInputSelect
-                    mode="single"
-                    allowCustomValues
-                    disableEditing
-                    fullWidth
-                    placeholder="https://www.example.com"
-                    loading={topUrlsLoading}
-                    value={displayUrl ? [displayUrl] : []}
-                    onChange={(next) => setDisplayUrl(next[0] ?? '')}
-                    options={(topUrls ?? []).map(({ url }) => ({
-                        key: url,
-                        label: url,
-                        labelComponent: (
-                            <span className="block min-w-0 max-w-full truncate ph-no-capture" title={url}>
-                                {url}
-                            </span>
-                        ),
-                    }))}
-                    title={topUrls && topUrls.length > 0 ? 'Most viewed pages' : undefined}
-                    popoverClassName="max-w-0"
-                    data-attr="heatmap-new-page-url"
-                />
-                {displayUrl && !isDisplayUrlValid ? (
-                    displayUrlIsPattern ? (
-                        <LemonBanner type="error" className="mt-2">
-                            The page URL can't contain wildcards. Add wildcards to the heatmap data URL below instead.
-                        </LemonBanner>
-                    ) : (
-                        <HeatmapsInvalidURL />
-                    )
-                ) : null}
-                {!displayUrl && noPageviews && !topUrlsLoading ? (
-                    <div className="text-xs text-muted mt-1">No pageview events have been received yet.</div>
-                ) : null}
-            </SceneSection>
-            <SceneDivider />
-            <SceneSection title="Capture method" description="Choose how to display your page in the heatmap">
-                <LemonRadio
-                    options={[
-                        {
-                            label: 'Screenshot',
-                            value: 'screenshot',
-                            description: 'We will generate a full-page screenshot of your website',
-                        },
-                        {
-                            label: 'Iframe',
-                            value: 'iframe',
-                            description:
-                                'We will load your website in an iframe. Make sure you allow your website to be loaded in an iframe.',
-                        },
-                    ]}
-                    value={type}
-                    onChange={(value: HeatmapType) => setType(value)}
-                />
-                <LemonBanner type="info" className="mb-4">
-                    You can also generate a screenshot of your site directly from{' '}
-                    <Link to={urls.replay()} target="_blank">
-                        session replay
-                    </Link>{' '}
-                    by clicking the 'view heatmap' button above a recording.
-                </LemonBanner>
-            </SceneSection>
-            <SceneDivider />
-            <HeatmapAdvancedSettings
-                dataUrlPlaceholderFallback="https://www.example.com/*"
-                dataUrlHelp="Defaults to the page URL. Add * for wildcards to aggregate data from multiple pages — e.g. https://www.example.com/users/* aggregates all pages under /users/."
-                consentHelp="Ask the browser to close cookie/consent popups before capturing the screenshot. This can slow down or fail the render on some sites, so it's off by default."
-                showForbiddenUrl
-            />
-            <SceneDivider />
-            <div className="flex gap-2">
-                <LemonButton
-                    className="w-fit"
-                    type="primary"
-                    data-attr="save-heatmap"
-                    onClick={createHeatmap}
-                    loading={false}
-                    disabledReason={
-                        !isDisplayUrlValid || (!!dataUrl && !isBrowserUrlAuthorized)
-                            ? 'Invalid URL or forbidden URL'
-                            : !displayUrl
-                              ? 'URL is required'
-                              : null
-                    }
-                >
-                    Save
-                </LemonButton>
-            </div>
+            <HeatmapCreationStepper />
+            {currentStep === 'page' ? <ChoosePageStep /> : null}
+            {currentStep === 'background' ? <ChooseBackgroundStep /> : null}
+            {currentStep === 'review' ? recordingHeatmapOpen ? <RecordingHeatmapStep /> : <ReviewStep /> : null}
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.test.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.test.ts
@@ -1,0 +1,215 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import { getBackgroundStepBlockReason, getPageStepBlockReason, heatmapCreationLogic } from './heatmapCreationLogic'
+
+describe('heatmapCreationLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+        jest.spyOn(api, 'queryHogQL').mockResolvedValue({ results: [] } as any)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it.each([
+        ['missing page URL', null, true, null, true, 'Enter a page URL to continue'],
+        ['invalid page URL', 'example.com', false, null, true, 'Enter a valid page URL to continue'],
+        [
+            'invalid data URL',
+            'https://example.com',
+            true,
+            'example.com/*',
+            false,
+            'Enter a valid heatmap data URL to continue',
+        ],
+        ['valid exact URLs', 'https://example.com', true, 'https://example.com/pricing', true, null],
+        ['valid pattern data URL', 'https://example.com', true, 'https://example.com/*', true, null],
+    ])(
+        'applies structural page validation for %s',
+        (_case, displayUrl, isDisplayUrlValid, dataUrl, isDataUrlValid, expected) => {
+            expect(getPageStepBlockReason({ displayUrl, isDisplayUrlValid, dataUrl, isDataUrlValid })).toBe(expected)
+        }
+    )
+
+    it.each([
+        ['Screenshot without authorization', 'public', 'screenshot', false, false, null],
+        [
+            'Iframe without authorization',
+            'public',
+            'iframe',
+            false,
+            false,
+            'Authorize this URL or choose Screenshot to continue',
+        ],
+        ['authorized Iframe', 'public', 'iframe', true, false, null],
+        [
+            'login-required page without a recording',
+            'login',
+            'screenshot',
+            true,
+            false,
+            'Choose a session recording moment to continue',
+        ],
+        ['login-required page with a recording', 'login', 'screenshot', true, true, null],
+    ] as const)(
+        'applies background validation for %s',
+        (_case, pageAccess, type, isAuthorized, hasRecordingBackground, expected) => {
+            expect(
+                getBackgroundStepBlockReason({
+                    pageAccess,
+                    type,
+                    isDisplayUrlAuthorized: isAuthorized,
+                    hasRecordingBackground,
+                })
+            ).toBe(expected)
+        }
+    )
+
+    it('allows creation when the readiness check returns zero matching interactions', async () => {
+        const logic = heatmapCreationLogic
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        logic.actions.setDisplayUrl('https://example.com/pricing')
+        logic.actions.requestPageDataCheck('manual')
+
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.hasMatchingData).toBe(false)
+        expect(logic.values.pageStepBlockReason).toBeNull()
+    })
+
+    it('keeps a selected recording background in the wizard through the interactive heatmap', async () => {
+        const logic = heatmapCreationLogic
+        logic.mount()
+        const modalLogic = sessionPlayerModalLogic.findMounted()
+        expect(modalLogic).toBeTruthy()
+        logic.actions.setDisplayUrl('https://example.com/pricing')
+        logic.actions.setPageAccess('login')
+        const storageKey = 'recording-background'
+        localStorage.setItem(
+            storageKey,
+            JSON.stringify({
+                html: '<html><body>Pricing</body></html>',
+                width: 1280,
+                height: 720,
+                url: 'https://example.com/pricing',
+            })
+        )
+
+        modalLogic?.actions.openSessionPlayer({ id: 'recording-one' }, null, {
+            type: 'heatmap-background-selection',
+            targetUrl: 'https://example.com/pricing',
+            matchingRecordingCount: 2,
+        })
+        expect(logic.values.terminalOutcome).toBeNull()
+
+        modalLogic?.actions.completeHeatmapBackgroundSelection(storageKey)
+        await expectLogic(logic).toFinishAllListeners()
+        const startingPathname = router.values.location.pathname
+
+        expect(logic.values.currentStep).toBe('review')
+        expect(logic.values.recordingBackground).toEqual({ storageKey, matchingRecordingCount: 2 })
+        expect(logic.values.recordingBackgroundData?.html).toContain('Pricing')
+        expect(logic.values.terminalOutcome).toBeNull()
+
+        logic.actions.openRecordingHeatmap()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.recordingHeatmapOpen).toBe(true)
+        expect(logic.values.terminalOutcome).toBeNull()
+        expect(router.values.location.pathname).toBe(startingPathname)
+
+        logic.actions.closeRecordingHeatmap()
+        expect(logic.values.recordingHeatmapOpen).toBe(false)
+        expect(logic.values.recordingBackgroundData?.html).toContain('Pricing')
+
+        logic.actions.openRecordingHeatmap()
+        logic.actions.finishRecordingHeatmap()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.terminalOutcome).toBe('recording_handoff')
+        expect(router.values.location.pathname).toContain('/heatmaps')
+        expect(router.values.location.pathname).not.toContain('/heatmaps/new')
+    })
+
+    it('discards a readiness result after the effective data URL changes', async () => {
+        let resolveFirstCheck: ((value: { results: number[][] }) => void) | undefined
+        let markFirstCheckStarted: (() => void) | undefined
+        const firstCheck = new Promise<{ results: number[][] }>((resolve) => {
+            resolveFirstCheck = resolve
+        })
+        const firstCheckStarted = new Promise<void>((resolve) => {
+            markFirstCheckStarted = resolve
+        })
+        const queryMock = jest.mocked(api.queryHogQL)
+        const logic = heatmapCreationLogic
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        queryMock.mockClear()
+        queryMock.mockImplementationOnce(() => {
+            markFirstCheckStarted?.()
+            return firstCheck as ReturnType<typeof api.queryHogQL>
+        })
+        queryMock.mockResolvedValueOnce({ results: [[0]] } as any)
+
+        logic.actions.setDisplayUrl('https://example.com/first')
+        logic.actions.requestPageDataCheck('manual')
+        await firstCheckStarted
+
+        await expectLogic(logic, () => {
+            logic.actions.setDisplayUrl('https://example.com/second')
+            logic.actions.requestPageDataCheck('manual')
+        }).toDispatchActions(['checkPageDataSuccess'])
+
+        resolveFirstCheck?.({ results: [[12]] })
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.currentPageDataCheck).toEqual(
+            expect.objectContaining({
+                url: 'https://example.com/second',
+                outcome: 'none',
+            })
+        )
+        expect(logic.values.hasMatchingData).toBe(false)
+    })
+
+    it('clears an in-flight readiness check when the URL becomes invalid', async () => {
+        let resolveCheck: ((value: { results: number[][] }) => void) | undefined
+        let markCheckStarted: (() => void) | undefined
+        const pendingCheck = new Promise<{ results: number[][] }>((resolve) => {
+            resolveCheck = resolve
+        })
+        const checkStarted = new Promise<void>((resolve) => {
+            markCheckStarted = resolve
+        })
+        const logic = heatmapCreationLogic
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        jest.mocked(api.queryHogQL).mockImplementationOnce(() => {
+            markCheckStarted?.()
+            return pendingCheck as ReturnType<typeof api.queryHogQL>
+        })
+
+        logic.actions.setDisplayUrl('https://example.com/pricing')
+        logic.actions.requestPageDataCheck('manual')
+        await checkStarted
+
+        logic.actions.setDisplayUrl('not a URL')
+        await expectLogic(logic).toDispatchActions(['checkPageDataSuccess'])
+
+        expect(logic.values.currentPageDataCheck).toBeNull()
+        expect(logic.values.pageDataCheckLoading).toBe(false)
+
+        resolveCheck?.({ results: [[12]] })
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.currentPageDataCheck).toBeNull()
+    })
+})

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.ts
@@ -1,0 +1,529 @@
+import { actions, afterMount, beforeUnmount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+import posthog from 'posthog-js'
+
+import api from 'lib/api'
+import {
+    AuthorizedUrlListType,
+    authorizedUrlListLogic,
+    defaultAuthorizedUrlProperties,
+} from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
+import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+import { ReplayIframeData, heatmapsBrowserLogic, isUrlPattern } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { hogql } from '~/queries/utils'
+import { AccessControlLevel, AccessControlResourceType, HeatmapType } from '~/types'
+
+import type { heatmapCreationLogicType } from './heatmapCreationLogicType'
+import { HeatmapCreationContext, heatmapLogic } from './heatmapLogic'
+
+export type HeatmapCreationStep = 'page' | 'background' | 'review'
+export type HeatmapPageAccess = 'public' | 'login'
+export type HeatmapDataCheckTrigger = 'automatic' | 'manual'
+export type HeatmapDataCheckOutcome = 'detected' | 'none' | 'error'
+
+export interface HeatmapDataCheckResult {
+    url: string
+    matchType: 'exact' | 'pattern'
+    trigger: HeatmapDataCheckTrigger
+    outcome: HeatmapDataCheckOutcome
+    count: number | null
+}
+
+export interface HeatmapDataCheckPayload {
+    url: string | null
+    matchType: 'exact' | 'pattern'
+    trigger: HeatmapDataCheckTrigger
+}
+
+export interface RecordingBackgroundSelection {
+    storageKey: string
+    matchingRecordingCount: number
+}
+
+const STEP_ORDER: HeatmapCreationStep[] = ['page', 'background', 'review']
+
+const authorizedUrlsLogic = authorizedUrlListLogic({
+    ...defaultAuthorizedUrlProperties,
+    type: AuthorizedUrlListType.TOOLBAR_URLS,
+})
+
+export function heatmapUrlPatternToRegex(value: string): string {
+    let normalized = value
+    if (!normalized.startsWith('^')) {
+        normalized = `^${normalized}`
+    }
+    if (!normalized.endsWith('$')) {
+        normalized = `${normalized}$`
+    }
+    return Array.from(normalized)
+        .map((character, index) => (character === '*' && index > 0 && normalized[index - 1] !== '.' ? '.+' : character))
+        .join('')
+}
+
+export function getPageStepBlockReason({
+    displayUrl,
+    isDisplayUrlValid,
+    dataUrl,
+    isDataUrlValid,
+}: {
+    displayUrl: string | null
+    isDisplayUrlValid: boolean
+    dataUrl: string | null
+    isDataUrlValid: boolean
+}): string | null {
+    if (!displayUrl?.trim()) {
+        return 'Enter a page URL to continue'
+    }
+    if (!isDisplayUrlValid) {
+        return 'Enter a valid page URL to continue'
+    }
+    if (dataUrl?.trim() && !isDataUrlValid) {
+        return 'Enter a valid heatmap data URL to continue'
+    }
+    return null
+}
+
+export function getBackgroundStepBlockReason({
+    pageAccess,
+    type,
+    isDisplayUrlAuthorized,
+    hasRecordingBackground,
+}: {
+    pageAccess: HeatmapPageAccess | null
+    type: HeatmapType
+    isDisplayUrlAuthorized: boolean
+    hasRecordingBackground: boolean
+}): string | null {
+    if (!pageAccess) {
+        return 'Choose whether this page requires login'
+    }
+    if (pageAccess === 'login') {
+        return hasRecordingBackground ? null : 'Choose a session recording moment to continue'
+    }
+    if (type === 'iframe' && !isDisplayUrlAuthorized) {
+        return 'Authorize this URL or choose Screenshot to continue'
+    }
+    return null
+}
+
+export function getStoredRecordingBackground(storageKey: string | null): ReplayIframeData | null {
+    if (!storageKey) {
+        return null
+    }
+    try {
+        const data = JSON.parse(localStorage.getItem(storageKey) ?? 'null') as Partial<ReplayIframeData> | null
+        if (
+            !data ||
+            typeof data.html !== 'string' ||
+            !data.html.trim() ||
+            typeof data.width !== 'number' ||
+            typeof data.height !== 'number'
+        ) {
+            return null
+        }
+        return data as ReplayIframeData
+    } catch {
+        return null
+    }
+}
+
+export function getAuthorizationOrigin(url: string | null): string | null {
+    if (!url) {
+        return null
+    }
+    try {
+        return new URL(url).origin
+    } catch {
+        return null
+    }
+}
+
+interface WizardStepValues {
+    captureEnabled: boolean
+    hasMatchingData: boolean | null
+    pageAccess: HeatmapPageAccess | null
+    analyticsBackgroundType: HeatmapType | 'recording'
+}
+
+function captureWizardStepCompleted(
+    values: WizardStepValues,
+    step: HeatmapCreationStep,
+    overrides: { page_access?: HeatmapPageAccess; background_type?: HeatmapType | 'recording' } = {}
+): void {
+    posthog.capture('in-app heatmap creation wizard step completed', {
+        step,
+        capture_enabled: values.captureEnabled,
+        has_matching_data: values.hasMatchingData,
+        page_access: values.pageAccess,
+        background_type: values.analyticsBackgroundType,
+        ...overrides,
+    })
+}
+
+export const heatmapCreationLogic = kea<heatmapCreationLogicType>([
+    path(['scenes', 'heatmaps', 'scenes', 'heatmap', 'heatmapCreationLogic']),
+
+    connect(() => ({
+        values: [
+            heatmapLogic({ id: 'new' }),
+            ['dataUrl', 'displayUrl', 'isBrowserUrlValid', 'isDisplayUrlValid', 'loading', 'type'],
+            teamLogic,
+            ['currentTeam'],
+            authorizedUrlsLogic,
+            ['checkUrlIsAuthorized'],
+            sessionPlayerModalLogic,
+            ['modalContext'],
+        ],
+        actions: [
+            heatmapLogic({ id: 'new' }),
+            ['creationCompleted', 'setDataUrl', 'setDisplayUrl', 'setType'],
+            authorizedUrlsLogic,
+            ['addUrl'],
+            heatmapsBrowserLogic,
+            ['setReplayIframeData'],
+            sessionPlayerModalLogic,
+            ['completeHeatmapBackgroundSelection'],
+        ],
+    })),
+
+    actions({
+        applyStep: (step: HeatmapCreationStep) => ({ step }),
+        navigateToStep: (step: HeatmapCreationStep) => ({ step }),
+        continueFromPage: true,
+        continueFromBackground: true,
+        goBack: true,
+        setPageAccess: (pageAccess: HeatmapPageAccess) => ({ pageAccess }),
+        resetForPageChange: true,
+        requestPageDataCheck: (trigger: HeatmapDataCheckTrigger) => ({ trigger }),
+        authorizeDisplayUrl: true,
+        markRecordingHandoff: (matchingRecordingCount: number) => ({ matchingRecordingCount }),
+        selectRecordingBackground: (storageKey: string, matchingRecordingCount: number) => ({
+            storageKey,
+            matchingRecordingCount,
+        }),
+        openRecordingHeatmap: true,
+        showRecordingHeatmap: true,
+        closeRecordingHeatmap: true,
+        finishRecordingHeatmap: true,
+    }),
+
+    loaders(({ values }) => ({
+        pageDataCheck: [
+            null as HeatmapDataCheckResult | null,
+            {
+                checkPageData: async (
+                    payload: HeatmapDataCheckPayload,
+                    breakpoint
+                ): Promise<HeatmapDataCheckResult | null> => {
+                    const { url, matchType, trigger } = payload
+                    if (!url) {
+                        return null
+                    }
+                    await breakpoint(trigger === 'automatic' ? 500 : 0)
+                    if (url !== values.effectiveDataUrl) {
+                        return { url, matchType, trigger, outcome: 'error', count: null }
+                    }
+                    const query =
+                        matchType === 'pattern'
+                            ? hogql`SELECT count() FROM heatmaps WHERE match(current_url, ${heatmapUrlPatternToRegex(
+                                  url
+                              )}) AND timestamp >= now() - INTERVAL 30 DAY`
+                            : hogql`SELECT count() FROM heatmaps WHERE trimRight(current_url, '/') = trimRight(${url}, '/') AND timestamp >= now() - INTERVAL 30 DAY`
+                    let response: Awaited<ReturnType<typeof api.queryHogQL>> | null = null
+                    try {
+                        response = await api.queryHogQL(query, { scene: 'Heatmaps', productKey: 'heatmaps' })
+                    } catch {
+                        // A failed readiness check is educational and never blocks creation.
+                    }
+                    breakpoint()
+                    if (url !== values.effectiveDataUrl) {
+                        return { url, matchType, trigger, outcome: 'error', count: null }
+                    }
+                    if (!response) {
+                        return { url, matchType, trigger, outcome: 'error', count: null }
+                    }
+                    const results = response.results as unknown[][] | undefined
+                    const count = Number(results?.[0]?.[0] ?? 0)
+                    return {
+                        url,
+                        matchType,
+                        trigger,
+                        outcome: count > 0 ? 'detected' : 'none',
+                        count,
+                    }
+                },
+            },
+        ],
+    })),
+
+    reducers({
+        currentStep: [
+            'page' as HeatmapCreationStep,
+            {
+                applyStep: (_, { step }) => step,
+                resetForPageChange: () => 'page',
+            },
+        ],
+        furthestStep: [
+            'page' as HeatmapCreationStep,
+            {
+                applyStep: (state, { step }) => (STEP_ORDER.indexOf(step) > STEP_ORDER.indexOf(state) ? step : state),
+                resetForPageChange: () => 'page',
+            },
+        ],
+        pageAccess: [
+            null as HeatmapPageAccess | null,
+            {
+                setPageAccess: (_, { pageAccess }) => pageAccess,
+                resetForPageChange: () => null,
+            },
+        ],
+        recordingBackground: [
+            null as RecordingBackgroundSelection | null,
+            {
+                selectRecordingBackground: (_, { storageKey, matchingRecordingCount }) => ({
+                    storageKey,
+                    matchingRecordingCount,
+                }),
+                resetForPageChange: () => null,
+                setPageAccess: (state, { pageAccess }) => (pageAccess === 'login' ? state : null),
+            },
+        ],
+        recordingHeatmapOpen: [
+            false,
+            {
+                showRecordingHeatmap: () => true,
+                closeRecordingHeatmap: () => false,
+                resetForPageChange: () => false,
+                setPageAccess: (state, { pageAccess }) => (pageAccess === 'login' ? state : false),
+            },
+        ],
+        terminalOutcome: [
+            null as 'created' | 'recording_handoff' | null,
+            {
+                creationCompleted: () => 'created',
+                markRecordingHandoff: () => 'recording_handoff',
+            },
+        ],
+    }),
+
+    selectors({
+        effectiveDataUrl: [
+            (s) => [s.dataUrl, s.displayUrl],
+            (dataUrl, displayUrl): string | null => dataUrl?.trim() || displayUrl?.trim() || null,
+        ],
+        pageStepBlockReason: [
+            (s) => [s.displayUrl, s.isDisplayUrlValid, s.dataUrl, s.isBrowserUrlValid],
+            (displayUrl, isDisplayUrlValid, dataUrl, isBrowserUrlValid): string | null =>
+                getPageStepBlockReason({
+                    displayUrl,
+                    isDisplayUrlValid,
+                    dataUrl,
+                    isDataUrlValid: isBrowserUrlValid,
+                }),
+        ],
+        isDisplayUrlAuthorized: [
+            (s) => [s.displayUrl, s.checkUrlIsAuthorized],
+            (displayUrl, checkUrlIsAuthorized): boolean => (displayUrl ? checkUrlIsAuthorized(displayUrl) : false),
+        ],
+        authorizationDisabledReason: [
+            () => [],
+            (): string | null => {
+                if (inStorybook() || inStorybookTestRunner()) {
+                    return null
+                }
+                return getAccessControlDisabledReason(
+                    AccessControlResourceType.WebAnalytics,
+                    AccessControlLevel.Editor,
+                    undefined,
+                    false
+                )
+            },
+        ],
+        backgroundStepBlockReason: [
+            (s) => [s.pageAccess, s.type, s.isDisplayUrlAuthorized, s.recordingBackgroundData],
+            (pageAccess, type, isDisplayUrlAuthorized, recordingBackgroundData): string | null =>
+                getBackgroundStepBlockReason({
+                    pageAccess,
+                    type,
+                    isDisplayUrlAuthorized,
+                    hasRecordingBackground: !!recordingBackgroundData,
+                }),
+        ],
+        reviewBlockReason: [
+            (s) => [s.pageStepBlockReason, s.backgroundStepBlockReason],
+            (pageStepBlockReason, backgroundStepBlockReason): string | null =>
+                pageStepBlockReason ?? backgroundStepBlockReason,
+        ],
+        currentPageDataCheck: [
+            (s) => [s.pageDataCheck, s.effectiveDataUrl],
+            (pageDataCheck, effectiveDataUrl): HeatmapDataCheckResult | null =>
+                pageDataCheck?.url === effectiveDataUrl ? pageDataCheck : null,
+        ],
+        recordingBackgroundData: [
+            (s) => [s.recordingBackground],
+            (recordingBackground): ReplayIframeData | null =>
+                getStoredRecordingBackground(recordingBackground?.storageKey ?? null),
+        ],
+        analyticsBackgroundType: [
+            (s) => [s.pageAccess, s.type],
+            (pageAccess, type): HeatmapType | 'recording' => (pageAccess === 'login' ? 'recording' : type),
+        ],
+        hasMatchingData: [
+            (s) => [s.currentPageDataCheck],
+            (currentPageDataCheck): boolean | null =>
+                currentPageDataCheck?.outcome === 'detected'
+                    ? true
+                    : currentPageDataCheck?.outcome === 'none'
+                      ? false
+                      : null,
+        ],
+        captureEnabled: [(s) => [s.currentTeam], (currentTeam): boolean => !!currentTeam?.heatmaps_opt_in],
+        creationContext: [
+            (s) => [s.captureEnabled, s.hasMatchingData, s.type],
+            (captureEnabled, hasMatchingData, type): HeatmapCreationContext => ({
+                creation_flow: 'wizard',
+                capture_enabled: captureEnabled,
+                has_matching_data: hasMatchingData,
+                page_access: 'public',
+                background_type: type,
+            }),
+        ],
+    }),
+
+    listeners(({ actions, values }) => {
+        const onUrlChanged = (): void => {
+            actions.resetForPageChange()
+            actions.requestPageDataCheck('automatic')
+        }
+        return {
+            navigateToStep: ({ step }) => {
+                if (STEP_ORDER.indexOf(step) <= STEP_ORDER.indexOf(values.furthestStep)) {
+                    actions.applyStep(step)
+                }
+            },
+            continueFromPage: () => {
+                if (values.pageStepBlockReason) {
+                    return
+                }
+                captureWizardStepCompleted(values, 'page')
+                actions.applyStep('background')
+            },
+            continueFromBackground: () => {
+                if (values.backgroundStepBlockReason) {
+                    return
+                }
+                captureWizardStepCompleted(values, 'background')
+                actions.applyStep('review')
+            },
+            goBack: () => {
+                const currentIndex = STEP_ORDER.indexOf(values.currentStep)
+                if (currentIndex > 0) {
+                    actions.applyStep(STEP_ORDER[currentIndex - 1])
+                }
+            },
+            setPageAccess: ({ pageAccess }) => {
+                if (pageAccess === 'login') {
+                    actions.setType('screenshot')
+                }
+            },
+            resetForPageChange: () => {
+                actions.setType('screenshot')
+            },
+            setDisplayUrl: onUrlChanged,
+            setDataUrl: onUrlChanged,
+            requestPageDataCheck: ({ trigger }) => {
+                if (values.pageStepBlockReason || !values.effectiveDataUrl) {
+                    actions.checkPageData({ url: null, matchType: 'exact', trigger })
+                    return
+                }
+                actions.checkPageData({
+                    url: values.effectiveDataUrl,
+                    matchType: isUrlPattern(values.effectiveDataUrl) ? 'pattern' : 'exact',
+                    trigger,
+                })
+            },
+            checkPageDataSuccess: ({ pageDataCheck }) => {
+                if (!pageDataCheck || pageDataCheck.url !== values.effectiveDataUrl) {
+                    return
+                }
+                posthog.capture('in-app heatmap creation data checked', {
+                    trigger: pageDataCheck.trigger,
+                    result: pageDataCheck.outcome,
+                    match_type: pageDataCheck.matchType,
+                })
+            },
+            authorizeDisplayUrl: () => {
+                const origin = getAuthorizationOrigin(values.displayUrl)
+                if (!origin || values.authorizationDisabledReason || values.isDisplayUrlAuthorized) {
+                    return
+                }
+                actions.addUrl(origin)
+            },
+            markRecordingHandoff: ({ matchingRecordingCount }) => {
+                posthog.capture('in-app heatmap creation recording handoff', {
+                    matching_recording_count: matchingRecordingCount,
+                })
+            },
+            completeHeatmapBackgroundSelection: ({ storageKey }) => {
+                if (values.modalContext?.type !== 'heatmap-background-selection') {
+                    return
+                }
+                actions.selectRecordingBackground(storageKey, values.modalContext.matchingRecordingCount)
+                captureWizardStepCompleted(values, 'background', { page_access: 'login', background_type: 'recording' })
+                actions.applyStep('review')
+            },
+            openRecordingHeatmap: () => {
+                if (!values.recordingBackground || !values.recordingBackgroundData) {
+                    return
+                }
+                const replayIframeData = {
+                    ...values.recordingBackgroundData,
+                    url: values.effectiveDataUrl ?? values.recordingBackgroundData.url,
+                }
+                localStorage.setItem(values.recordingBackground.storageKey, JSON.stringify(replayIframeData))
+                actions.setReplayIframeData(replayIframeData)
+                actions.showRecordingHeatmap()
+            },
+            finishRecordingHeatmap: () => {
+                if (values.terminalOutcome || !values.recordingBackground || !values.recordingHeatmapOpen) {
+                    return
+                }
+                captureWizardStepCompleted(values, 'review', { page_access: 'login', background_type: 'recording' })
+                actions.markRecordingHandoff(values.recordingBackground.matchingRecordingCount)
+                router.actions.push(urls.heatmaps())
+            },
+            creationCompleted: () => {
+                captureWizardStepCompleted(values, 'review')
+            },
+        }
+    }),
+
+    afterMount(({ actions, values, cache }) => {
+        cache.wizardStarted = true
+        posthog.capture('in-app heatmap creation wizard started', {
+            capture_enabled: values.captureEnabled,
+        })
+        if (!values.pageStepBlockReason && values.effectiveDataUrl) {
+            actions.requestPageDataCheck('automatic')
+        }
+    }),
+
+    beforeUnmount(({ values, cache }) => {
+        if (cache.wizardStarted && !values.terminalOutcome) {
+            posthog.capture('in-app heatmap creation wizard abandoned', {
+                furthest_step: values.furthestStep,
+                capture_enabled: values.captureEnabled,
+                has_matching_data: values.hasMatchingData,
+                page_access: values.pageAccess,
+                background_type: values.analyticsBackgroundType,
+            })
+        }
+    }),
+])

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -2,7 +2,6 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
-import api from 'lib/api'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { DEFAULT_HEATMAP_WIDTH } from 'lib/components/IframedToolbarBrowser/utils'
@@ -10,12 +9,53 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { heatmapsBrowserLogic, isUrlPattern } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
 import { heatmapsSceneLogic } from 'scenes/heatmaps/scenes/heatmaps/heatmapsSceneLogic'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { HeatmapStatus, HeatmapType } from '~/types'
+
+import {
+    getHeatmapScreenshotsContentRetrieveUrl,
+    savedCreate,
+    savedPartialUpdate,
+    savedRegenerateCreate,
+    savedRetrieve,
+} from 'products/web_analytics/frontend/generated/api'
+import type { SavedHeatmapRequestApi } from 'products/web_analytics/frontend/generated/api.schemas'
 
 import type { heatmapLogicType } from './heatmapLogicType'
 
 const DEFAULT_HEATMAP_NAME = 'Untitled heatmap'
+
+export interface HeatmapCreationContext {
+    creation_flow: 'wizard'
+    capture_enabled: boolean
+    has_matching_data: boolean | null
+    page_access: 'public'
+    background_type: HeatmapType
+}
+
+function getApiErrorMessage(error: unknown, fallback: string): string {
+    if (typeof error === 'object' && error !== null && 'detail' in error && typeof error.detail === 'string') {
+        return error.detail
+    }
+    return fallback
+}
+
+function getCreationFailureCategory(error: unknown): 'validation' | 'permission' | 'rate_limit' | 'unknown' {
+    if (typeof error !== 'object' || error === null || !('status' in error) || typeof error.status !== 'number') {
+        return 'unknown'
+    }
+    if (error.status === 400) {
+        return 'validation'
+    }
+    if (error.status === 401 || error.status === 403) {
+        return 'permission'
+    }
+    if (error.status === 429) {
+        return 'rate_limit'
+    }
+    return 'unknown'
+}
 
 function isValidPageUrl(url: string | null): boolean {
     if (!url) {
@@ -41,7 +81,14 @@ export function resolveHeatmapExportUrl(
     origin: string = window.location.origin
 ): string {
     if (type === 'screenshot') {
-        return screenshotUrl ? new URL(screenshotUrl, origin).toString() : ''
+        if (!screenshotUrl) {
+            return ''
+        }
+        try {
+            return new URL(screenshotUrl, origin).toString()
+        } catch {
+            return ''
+        }
     }
     return displayUrl ?? ''
 }
@@ -53,7 +100,9 @@ export const heatmapLogic = kea<heatmapLogicType>([
     connect(() => ({
         values: [
             heatmapsBrowserLogic,
-            ['dataUrl', 'displayUrl', 'isBrowserUrlAuthorized'],
+            ['dataUrl', 'displayUrl', 'isBrowserUrlAuthorized', 'isBrowserUrlValid'],
+            teamLogic,
+            ['currentTeamIdStrict'],
             heatmapDataLogic({ context: 'in-app' }),
             [
                 'heatmapFilters',
@@ -77,7 +126,8 @@ export const heatmapLogic = kea<heatmapLogicType>([
     })),
     actions({
         load: true,
-        createHeatmap: true,
+        createHeatmap: (context: HeatmapCreationContext | null = null) => ({ context }),
+        creationCompleted: (shortId: string) => ({ shortId }),
         updateHeatmap: true,
         setLoading: (loading: boolean) => ({ loading }),
         setType: (type: HeatmapType) => ({ type }),
@@ -87,8 +137,8 @@ export const heatmapLogic = kea<heatmapLogicType>([
         setScreenshotUrl: (url: string | null) => ({ url }),
         setScreenshotError: (error: string | null) => ({ error }),
         setGeneratingScreenshot: (generating: boolean) => ({ generating }),
-        pollScreenshotStatus: (id: number, width?: number) => ({ id, width }),
-        setHeatmapId: (id: number | null) => ({ id }),
+        pollScreenshotStatus: (width?: number) => ({ width }),
+        setHeatmapId: (id: string | null) => ({ id }),
         setScreenshotLoaded: (screenshotLoaded: boolean) => ({ screenshotLoaded }),
         regenerateScreenshot: true,
         exportHeatmap: true,
@@ -110,7 +160,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
         generatingScreenshot: [false, { setGeneratingScreenshot: (_, { generating }) => generating }],
         // expose a screenshotLoading alias for UI compatibility
         screenshotLoading: [false as boolean, { setScreenshotUrl: () => false }],
-        heatmapId: [null as number | null, { setHeatmapId: (_, { id }) => id }],
+        heatmapId: [null as string | null, { setHeatmapId: (_, { id }) => id }],
         screenshotLoaded: [false, { setScreenshotLoaded: (_, { screenshotLoaded }) => screenshotLoaded }],
         containerWidth: [null as number | null, { setContainerWidth: (_, { containerWidth }) => containerWidth }],
         savedDisplayUrl: [null as string | null, { snapshotSavedDisplayUrl: (_, { displayUrl }) => displayUrl }],
@@ -124,7 +174,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values, props }) => ({
+    listeners(({ actions, values, props, cache }) => ({
         changeCaptureMethod: async ({ type }) => {
             actions.setType(type)
             if (type !== 'screenshot') {
@@ -144,16 +194,16 @@ export const heatmapLogic = kea<heatmapLogicType>([
             }
             actions.setLoading(true)
             try {
-                const item = await api.savedHeatmaps.get(props.id)
+                const item = await savedRetrieve(String(values.currentTeamIdStrict), String(props.id))
                 actions.setHeatmapId(item.id)
-                actions.setName(item.name)
+                actions.setName(item.name ?? DEFAULT_HEATMAP_NAME)
                 actions.setDataUrlUserTouched(true)
                 actions.setDisplayUrl(item.url)
-                actions.setDataUrl(item.data_url)
+                actions.setDataUrl(item.data_url ?? null)
                 actions.snapshotSavedDisplayUrl(item.url ?? null)
                 actions.setBlockConsentModals(item.block_consent_modals ?? false)
                 actions.snapshotSavedBlockConsentModals(item.block_consent_modals ?? false)
-                actions.setType(item.type)
+                actions.setType(item.type ?? 'screenshot')
                 posthog.capture('in-app heatmap viewed', {
                     heatmap_type: item.type,
                     heatmap_status: item.status,
@@ -162,7 +212,9 @@ export const heatmapLogic = kea<heatmapLogicType>([
                     const desiredWidth = values.widthOverride
                     if (item.status === 'completed' && item.has_content) {
                         actions.setScreenshotUrl(
-                            `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${item.id}/content/?width=${desiredWidth}`
+                            getHeatmapScreenshotsContentRetrieveUrl(String(values.currentTeamIdStrict), item.id, {
+                                width: desiredWidth,
+                            })
                         )
                         // trigger heatmap overlay load
                         actions.loadHeatmap()
@@ -170,7 +222,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                         actions.setScreenshotError(item.exception || 'Screenshot generation failed')
                     } else {
                         actions.setScreenshotError(null)
-                        actions.pollScreenshotStatus(item.id, desiredWidth)
+                        actions.pollScreenshotStatus(desiredWidth)
                     }
                 }
             } finally {
@@ -185,10 +237,12 @@ export const heatmapLogic = kea<heatmapLogicType>([
             const w = widthOverride ?? DEFAULT_HEATMAP_WIDTH
             actions.setScreenshotError(null)
             actions.setScreenshotUrl(
-                `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${values.heatmapId}/content/?width=${w}`
+                getHeatmapScreenshotsContentRetrieveUrl(String(values.currentTeamIdStrict), values.heatmapId, {
+                    width: w,
+                })
             )
         },
-        pollScreenshotStatus: async ({ id, width }, breakpoint) => {
+        pollScreenshotStatus: async ({ width }, breakpoint) => {
             let attempts = 0
             actions.setGeneratingScreenshot(true)
             // Multi-width renders open one Browserless session per width and can take a few minutes,
@@ -198,36 +252,26 @@ export const heatmapLogic = kea<heatmapLogicType>([
             while (attempts < maxAttempts) {
                 await breakpoint(pollIntervalMs)
                 try {
-                    const contentResponse = await api.heatmapScreenshots.getContent(id)
-                    if (contentResponse.success) {
+                    const screenshot = await savedRetrieve(String(values.currentTeamIdStrict), String(props.id))
+                    if (screenshot.status === 'completed' && screenshot.has_content) {
                         const w = width ?? DEFAULT_HEATMAP_WIDTH
                         actions.setScreenshotUrl(
-                            `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${id}/content/?width=${w}`
+                            getHeatmapScreenshotsContentRetrieveUrl(String(values.currentTeamIdStrict), screenshot.id, {
+                                width: w,
+                            })
                         )
                         actions.loadHeatmap()
                         actions.setGeneratingScreenshot(false)
                         break
-                    } else {
-                        const screenshot = contentResponse.data
-                        if (screenshot.status === 'completed' && screenshot.has_content) {
-                            const w = width ?? DEFAULT_HEATMAP_WIDTH
-                            actions.setScreenshotUrl(
-                                `/api/environments/${window.POSTHOG_APP_CONTEXT?.current_team?.id}/heatmap_screenshots/${screenshot.id}/content/?width=${w}`
-                            )
-                            actions.loadHeatmap()
-                            actions.setGeneratingScreenshot(false)
-                            break
-                        } else if (screenshot.status === 'failed') {
-                            actions.setScreenshotError(
-                                screenshot.exception || (screenshot as any).error || 'Screenshot generation failed'
-                            )
-                            actions.setGeneratingScreenshot(false)
-                            break
-                        }
+                    } else if (screenshot.status === 'failed') {
+                        actions.setScreenshotError(screenshot.exception || 'Screenshot generation failed')
+                        actions.setGeneratingScreenshot(false)
+                        break
                     }
                     attempts++
                 } catch (e) {
                     actions.setScreenshotError('Failed to check screenshot status')
+                    actions.setGeneratingScreenshot(false)
                     console.error(e)
                     break
                 }
@@ -235,7 +279,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
 
             if (attempts >= maxAttempts) {
                 actions.setGeneratingScreenshot(false)
-                actions.setScreenshotError('Screenshot is still generating — refresh to check, or try fewer widths.')
+                actions.setScreenshotError('Screenshot is still generating. Refresh to check, or try fewer widths.')
             }
         },
         regenerateScreenshot: async () => {
@@ -246,30 +290,38 @@ export const heatmapLogic = kea<heatmapLogicType>([
             actions.setScreenshotUrl(null)
             actions.setScreenshotLoaded(false)
             try {
-                await api.savedHeatmaps.regenerate(props.id)
-                actions.pollScreenshotStatus(values.heatmapId, values.widthOverride)
-            } catch (error: any) {
-                actions.setScreenshotError(error.detail || 'Failed to regenerate screenshot')
+                await savedRegenerateCreate(String(values.currentTeamIdStrict), String(props.id))
+                actions.pollScreenshotStatus(values.widthOverride)
+            } catch (error: unknown) {
+                actions.setScreenshotError(getApiErrorMessage(error, 'Failed to regenerate screenshot'))
             }
         },
-        createHeatmap: async () => {
+        createHeatmap: async ({ context }) => {
+            if (cache.creatingHeatmap) {
+                return
+            }
+            cache.creatingHeatmap = true
             actions.setLoading(true)
             try {
-                const data = {
+                const data: SavedHeatmapRequestApi = {
                     name: values.name || DEFAULT_HEATMAP_NAME,
                     url: values.displayUrl || '',
                     data_url: values.dataUrl,
                     type: values.type,
                     block_consent_modals: values.blockConsentModals,
                 }
-                const created = await api.savedHeatmaps.create(data)
-                posthog.capture('in-app heatmap created', { heatmap_type: values.type })
+                const created = await savedCreate(String(values.currentTeamIdStrict), data)
+                posthog.capture('in-app heatmap created', { heatmap_type: values.type, ...context })
+                actions.creationCompleted(created.short_id)
                 actions.loadSavedHeatmaps()
-                // Navigate to the created heatmap detail page
                 router.actions.push(`/heatmaps/${created.short_id}`)
-            } catch (error: any) {
-                lemonToast.error(error.detail || 'Failed to create heatmap')
+            } catch (error: unknown) {
+                posthog.capture('in-app heatmap creation failed', {
+                    failure_category: getCreationFailureCategory(error),
+                })
+                lemonToast.error(getApiErrorMessage(error, 'Failed to create heatmap'))
             } finally {
+                cache.creatingHeatmap = false
                 actions.setLoading(false)
             }
         },
@@ -278,14 +330,14 @@ export const heatmapLogic = kea<heatmapLogicType>([
             const previousSavedUrl = values.savedDisplayUrl
             const previousBlockConsentModals = values.savedBlockConsentModals
             try {
-                const data = {
+                const data: SavedHeatmapRequestApi = {
                     name: values.name || DEFAULT_HEATMAP_NAME,
                     url: values.displayUrl || '',
                     data_url: values.dataUrl,
                     type: values.type,
                     block_consent_modals: values.blockConsentModals,
                 }
-                const updated = await api.savedHeatmaps.update(props.id, data)
+                const updated = await savedPartialUpdate(String(values.currentTeamIdStrict), String(props.id), data)
                 actions.snapshotSavedDisplayUrl(updated.url ?? null)
                 actions.snapshotSavedBlockConsentModals(updated.block_consent_modals ?? false)
                 const renderInputChanged =
@@ -296,14 +348,14 @@ export const heatmapLogic = kea<heatmapLogicType>([
                     actions.setScreenshotLoaded(false)
                     actions.setScreenshotError(null)
                     if (values.heatmapId) {
-                        actions.pollScreenshotStatus(values.heatmapId, values.widthOverride)
+                        actions.pollScreenshotStatus(values.widthOverride)
                     }
                 }
-            } catch (error: any) {
+            } catch (error: unknown) {
                 if (values.displayUrl !== previousSavedUrl) {
                     actions.setDisplayUrl(previousSavedUrl)
                 }
-                lemonToast.error(error.detail || 'Failed to update heatmap')
+                lemonToast.error(getApiErrorMessage(error, 'Failed to update heatmap'))
             } finally {
                 actions.setLoading(false)
             }

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -48,6 +48,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         accessToken,
         onRecordingDeleted,
         playNextRecording,
+        skipToFirstMatchingEvent,
     } = props
 
     const playerRef = useRef<HTMLDivElement>(null)
@@ -66,6 +67,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         accessToken,
         onRecordingDeleted,
         playNextRecording,
+        skipToFirstMatchingEvent,
     }
 
     return (

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
@@ -5,6 +5,9 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { playerInspectorLogic } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
 import { sessionRecordingExperimentContextLogic } from 'scenes/session-recordings/player/player-meta/sessionRecordingExperimentContextLogic'
 import { sessionRecordingDataCoordinatorLogic } from 'scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic'
+import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+
+import { SessionRecordingType } from '~/types'
 
 import { setupSessionRecordingTest } from '../__mocks__/test-setup'
 
@@ -233,6 +236,46 @@ describe('playerInspectorLogic', () => {
                 .toMatchValues({
                     trackedWindow: 1,
                 })
+        })
+    })
+
+    describe('matching events', () => {
+        it('waits for the recording start before seeking to the first matching event', async () => {
+            const matchingProps = {
+                sessionRecordingId: '1',
+                playerKey: 'matching-event',
+                skipToFirstMatchingEvent: true,
+                matchingEventsMatchType: {
+                    matchType: 'uuid' as const,
+                    matchedEvents: [
+                        {
+                            uuid: 'matching-event',
+                            timestamp: '2025-01-01T00:00:10.000Z',
+                            session_id: '1',
+                            window_id: '1',
+                        },
+                    ],
+                },
+            }
+            const playerLogic = sessionRecordingPlayerLogic(matchingProps)
+            const matchingLogic = playerInspectorLogic(matchingProps)
+            playerLogic.mount()
+            matchingLogic.mount()
+
+            await expectLogic(matchingLogic).toDispatchActions(['loadMatchingEventsSuccess'])
+            await expectLogic(playerLogic).toNotHaveDispatchedActions(['seekToTime'])
+
+            dataLogic.actions.loadRecordingMetaSuccess({
+                id: '1',
+                start_time: '2025-01-01T00:00:00.000Z',
+                end_time: '2025-01-01T00:01:00.000Z',
+                recording_duration: 60,
+            } as SessionRecordingType)
+
+            await expectLogic(playerLogic).toDispatchActions([playerLogic.actionCreators.seekToTime(9000)])
+
+            matchingLogic.unmount()
+            playerLogic.unmount()
         })
     })
 

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -367,7 +367,13 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             sessionRecordingEventUsageLogic,
             ['reportRecordingInspectorItemExpanded'],
             sessionRecordingDataCoordinatorLogic(props),
-            ['loadFullEventData', 'setTrackedWindow', 'registerWindowId', 'loadEventsSuccess'],
+            [
+                'loadFullEventData',
+                'setTrackedWindow',
+                'registerWindowId',
+                'loadEventsSuccess',
+                'loadRecordingMetaSuccess',
+            ],
             sessionRecordingPlayerLogic(props),
             ['seekToTime', 'setSkippingToMatchingEvent'],
             playerInspectorLogsLogic(props),
@@ -426,6 +432,8 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
     actions(() => ({
         setItemExpanded: (index: number, expanded: boolean) => ({ index, expanded }),
         setSyncScrollPaused: (paused: boolean) => ({ paused }),
+        trySkipToFirstMatchingEvent: true,
+        markSkippedToFirstMatchingEvent: true,
     })),
     reducers(() => ({
         expandedItems: [
@@ -447,8 +455,15 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 setItemExpanded: () => true,
             },
         ],
+        hasSkippedToFirstMatchingEvent: [
+            false,
+            {
+                loadMatchingEvents: () => false,
+                markSkippedToFirstMatchingEvent: () => true,
+            },
+        ],
     })),
-    loaders(({ actions, values, props }) => ({
+    loaders(({ props }) => ({
         matchingEvents: [
             [] as MatchedRecordingEvent[] | null,
             {
@@ -459,31 +474,10 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                         return null
                     }
 
-                    const skipToEarliestEvent = (matchingEvents: MatchedRecordingEvent[]): void => {
-                        if (values.skipToFirstMatchingEvent && matchingEvents.length > 0) {
-                            const earliestMatchingEvent = matchingEvents.reduce((previous, current) =>
-                                previous.timestamp < current.timestamp ? previous : current
-                            )
-                            const { timeInRecording } = timeRelativeToStart(earliestMatchingEvent, values.start)
-                            const seekTime = ceilMsToClosestSecond(timeInRecording) - 1000
-
-                            // Only show the "skipping to matching event" overlay if we're actually skipping (> 1 second from start)
-                            if (seekTime > 1000) {
-                                actions.setSkippingToMatchingEvent(true)
-                                setTimeout(() => {
-                                    actions.setSkippingToMatchingEvent(false)
-                                }, 1500)
-                            }
-
-                            actions.seekToTime(seekTime)
-                        }
-                    }
-
                     if (matchType === 'uuid') {
                         if (!matchingEventsMatchType?.matchedEvents) {
                             console.error('UUID matching events type must include its array of matched events')
                         }
-                        skipToEarliestEvent(matchingEventsMatchType.matchedEvents)
                         return matchingEventsMatchType.matchedEvents
                     }
 
@@ -498,7 +492,6 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     }
 
                     const response = await api.recordings.getMatchingEvents(toParams(params))
-                    skipToEarliestEvent(response.results)
                     return response.results
                 },
             },
@@ -1530,7 +1523,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             (allItemsByItemType): boolean => allItemsByItemType['events']?.length > 0,
         ],
     })),
-    listeners(({ values, actions }) => ({
+    listeners(({ values, actions, cache }) => ({
         setItemExpanded: ({ index, expanded }) => {
             if (expanded) {
                 const group = values.displayGroups[index]
@@ -1557,6 +1550,39 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 actions.markLogsInitialLoadRequested()
                 actions.loadLogs()
             }
+        },
+        loadMatchingEventsSuccess: () => {
+            actions.trySkipToFirstMatchingEvent()
+        },
+        loadRecordingMetaSuccess: () => {
+            actions.trySkipToFirstMatchingEvent()
+        },
+        trySkipToFirstMatchingEvent: () => {
+            if (
+                !values.skipToFirstMatchingEvent ||
+                values.hasSkippedToFirstMatchingEvent ||
+                !values.start ||
+                !values.matchingEvents?.length
+            ) {
+                return
+            }
+
+            const earliestMatchingEvent = values.matchingEvents.reduce((previous, current) =>
+                previous.timestamp < current.timestamp ? previous : current
+            )
+            const { timeInRecording } = timeRelativeToStart(earliestMatchingEvent, values.start)
+            const seekTime = Math.max(0, ceilMsToClosestSecond(timeInRecording) - 1000)
+
+            actions.markSkippedToFirstMatchingEvent()
+            if (seekTime > 1000) {
+                actions.setSkippingToMatchingEvent(true)
+                cache.disposables.add(() => {
+                    const timerId = setTimeout(() => actions.setSkippingToMatchingEvent(false), 1500)
+                    return () => clearTimeout(timerId)
+                }, 'skippingToMatchingEvent')
+            }
+
+            actions.seekToTime(seekTime)
         },
     })),
     events(({ actions }) => ({

--- a/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
+++ b/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
@@ -3,6 +3,8 @@ import { useActions, useValues } from 'kea'
 import { IconX } from '@posthog/icons'
 import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 
+import { IconHeatmap } from 'lib/lemon-ui/icons'
+import { buildRecordingMatchingEventFiltersForUrl } from 'scenes/heatmaps/components/heatmapRecordingFallbackLogic'
 import { SessionRecordingPlayer } from 'scenes/session-recordings/player/SessionRecordingPlayer'
 
 import { SessionRecordingPlayerLogicProps, sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
@@ -17,8 +19,9 @@ import { sessionPlayerModalLogic } from './sessionPlayerModalLogic'
  *
  */
 export function SessionPlayerModal(): JSX.Element | null {
-    const { activeSessionRecording } = useValues(sessionPlayerModalLogic())
+    const { activeSessionRecording, modalContext } = useValues(sessionPlayerModalLogic())
     const { closeSessionPlayer } = useActions(sessionPlayerModalLogic())
+    const isChoosingHeatmapBackground = modalContext?.type === 'heatmap-background-selection'
 
     // activeSessionRecording?.matching_events should always be a single element array
     // but, we're filtering and using flatMap just in case
@@ -32,14 +35,22 @@ export function SessionPlayerModal(): JSX.Element | null {
     const logicProps: SessionRecordingPlayerLogicProps = {
         playerKey: 'modal',
         sessionRecordingId: activeSessionRecording?.id || '',
-        autoPlay: true,
-        matchingEventsMatchType: {
-            matchType: 'uuid',
-            matchedEvents: matchedEvents,
-        },
+        autoPlay: !isChoosingHeatmapBackground,
+        matchingEventsMatchType: isChoosingHeatmapBackground
+            ? {
+                  matchType: 'backend',
+                  filters: buildRecordingMatchingEventFiltersForUrl(modalContext.targetUrl),
+              }
+            : {
+                  matchType: 'uuid',
+                  matchedEvents: matchedEvents,
+              },
+        skipToFirstMatchingEvent: isChoosingHeatmapBackground,
     }
 
-    const { isFullScreen } = useValues(sessionRecordingPlayerLogic(logicProps))
+    const playerLogic = sessionRecordingPlayerLogic(logicProps)
+    const { isFullScreen, resolution, rootFrame } = useValues(playerLogic)
+    const { openHeatmap } = useActions(playerLogic)
 
     return (
         <LemonModal
@@ -54,8 +65,34 @@ export function SessionPlayerModal(): JSX.Element | null {
             zIndex="1161"
         >
             {!isFullScreen && (
-                <div className="flex items-center justify-end border-b bg-surface-primary px-1 py-0.5">
-                    <LemonButton icon={<IconX />} size="small" onClick={closeSessionPlayer} tooltip="Close" />
+                <div className="flex items-center justify-between gap-4 border-b bg-surface-primary px-3 py-2">
+                    {isChoosingHeatmapBackground ? (
+                        <div>
+                            <h3 className="mb-0">Choose the background</h3>
+                            <p className="mb-0 text-sm text-muted">
+                                The player pauses at the first matching page event. Scrub to the exact state you want,
+                                then use that moment as the heatmap background.
+                            </p>
+                        </div>
+                    ) : (
+                        <span />
+                    )}
+                    <div className="flex items-center gap-2 shrink-0">
+                        {isChoosingHeatmapBackground ? (
+                            <LemonButton
+                                type="primary"
+                                icon={<IconHeatmap />}
+                                onClick={openHeatmap}
+                                disabledReason={
+                                    !rootFrame || !resolution ? 'Wait for the recording to load' : undefined
+                                }
+                                data-attr="heatmap-use-recording-moment"
+                            >
+                                Use this moment as background
+                            </LemonButton>
+                        ) : null}
+                        <LemonButton icon={<IconX />} size="small" onClick={closeSessionPlayer} tooltip="Close" />
+                    </div>
                 </div>
             )}
             <LemonModal.Content embedded>

--- a/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.test.ts
@@ -53,5 +53,23 @@ describe('sessionPlayerModalLogic', () => {
                 logic.actionCreators.openSessionPlayer({ id: 'abc' }, 12345678),
             ])
         })
+
+        it('clears guided heatmap context when the player closes', () => {
+            expectLogic(logic, () =>
+                logic.actions.openSessionPlayer({ id: 'abc' }, null, {
+                    type: 'heatmap-background-selection',
+                    targetUrl: 'https://example.com/pricing',
+                    matchingRecordingCount: 3,
+                })
+            ).toMatchValues({
+                modalContext: {
+                    type: 'heatmap-background-selection',
+                    targetUrl: 'https://example.com/pricing',
+                    matchingRecordingCount: 3,
+                },
+            })
+
+            expectLogic(logic, () => logic.actions.closeSessionPlayer()).toMatchValues({ modalContext: null })
+        })
     })
 })

--- a/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/modal/sessionPlayerModalLogic.ts
@@ -13,17 +13,28 @@ interface QueryParams {
     timestamp?: number
 }
 
+export interface HeatmapBackgroundSelectionContext {
+    type: 'heatmap-background-selection'
+    targetUrl: string
+    matchingRecordingCount: number
+}
+
+export type SessionPlayerModalContext = HeatmapBackgroundSelectionContext | null
+
 export const sessionPlayerModalLogic = kea<sessionPlayerModalLogicType>([
     path(['scenes', 'session-recordings', 'sessionPlayerModalLogic']),
     actions({
         openSessionPlayer: (
             sessionRecording: Pick<SessionRecordingType, 'id' | 'matching_events'>,
-            initialTimestamp: number | null = null
+            initialTimestamp: number | null = null,
+            modalContext: SessionPlayerModalContext = null
         ) => ({
             sessionRecording,
             initialTimestamp,
+            modalContext,
         }),
         closeSessionPlayer: true,
+        completeHeatmapBackgroundSelection: (storageKey: string) => ({ storageKey }),
     }),
     reducers({
         activeSessionRecording: [
@@ -37,6 +48,13 @@ export const sessionPlayerModalLogic = kea<sessionPlayerModalLogicType>([
             null as number | null,
             {
                 openSessionPlayer: (_, { initialTimestamp }) => initialTimestamp,
+                closeSessionPlayer: () => null,
+            },
+        ],
+        modalContext: [
+            null as SessionPlayerModalContext,
+            {
+                openSessionPlayer: (_, { modalContext }) => modalContext,
                 closeSessionPlayer: () => null,
             },
         ],

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaTopSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaTopSettings.tsx
@@ -10,6 +10,7 @@ import { SESSION_RECORDINGS_TTL_WARNING_THRESHOLD_DAYS } from 'lib/constants'
 import { IconHeatmap } from 'lib/lemon-ui/icons'
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyDuration } from 'lib/utils/durations'
+import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { PlayerInspectorButton } from 'scenes/session-recordings/player/player-meta/PlayerInspectorButton'
 import {
     ModesWithInteractions,
@@ -153,6 +154,7 @@ export function PlayerMetaTopSettings(): JSX.Element {
         hoverModeIsEnabled,
         showPlayerChrome,
     } = useValues(sessionRecordingPlayerLogic)
+    const { modalContext } = useValues(sessionPlayerModalLogic)
     const { setPause, openHeatmap } = useActions(sessionRecordingPlayerLogic)
 
     const showControlsLayoutToggle = !!mode && ModesWithInteractions.includes(mode)
@@ -184,16 +186,18 @@ export function PlayerMetaTopSettings(): JSX.Element {
                     </div>
 
                     <div className="flex flex-row gap-0.5">
-                        <SettingsButton
-                            size="xsmall"
-                            icon={<IconHeatmap />}
-                            onClick={() => {
-                                setPause()
-                                openHeatmap()
-                            }}
-                            label="View heatmap"
-                            tooltip="Use the HTML from this point in the recording as the background for your heatmap data"
-                        />
+                        {modalContext?.type !== 'heatmap-background-selection' ? (
+                            <SettingsButton
+                                size="xsmall"
+                                icon={<IconHeatmap />}
+                                onClick={() => {
+                                    setPause()
+                                    openHeatmap()
+                                }}
+                                label="View heatmap"
+                                tooltip="Use the HTML from this point in the recording as the background for your heatmap data"
+                            />
+                        ) : null}
                         {withSidebar && <InspectDOM />}
                         {withSidebar && <PlayerInspectorButton />}
                     </div>

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -953,9 +953,11 @@ describe('sessionRecordingPlayerLogic', () => {
                     matchType: 'uuid',
                     matchedEvents: listOfMatchingEvents,
                 },
+                skipToFirstMatchingEvent: true,
             })
             logic.mount()
             await expectLogic(logic).toMatchValues({
+                skipToFirstMatchingEvent: true,
                 logicProps: expect.objectContaining({
                     matchingEventsMatchType: {
                         matchType: 'uuid',

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -145,6 +145,7 @@ export interface SessionRecordingPlayerLogicProps extends SessionRecordingDataCo
     pinned?: boolean
     setPinned?: (pinned: boolean) => void
     playNextRecording?: (automatic: boolean) => void
+    skipToFirstMatchingEvent?: boolean
 }
 
 const ReplayIframeDatakeyPrefix = 'ph_replay_fixed_heatmap_'
@@ -653,7 +654,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             config,
         }),
     }),
-    reducers(() => ({
+    reducers(({ props }) => ({
         // used in visual regression testing to make sure the player is paused
         pauseForced: [
             false as boolean,
@@ -662,7 +663,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             },
         ],
         skipToFirstMatchingEvent: [
-            false,
+            props.skipToFirstMatchingEvent ?? false,
             {
                 setSkipToFirstMatchingEvent: (_, { skipToFirstMatchingEvent }) => skipToFirstMatchingEvent,
             },
@@ -2470,9 +2471,15 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 url: values.currentURL,
             }
             localStorage.setItem(key, JSON.stringify(data))
+            const modalLogic = sessionPlayerModalLogic.findMounted()
+            if (modalLogic?.values.modalContext?.type === 'heatmap-background-selection') {
+                modalLogic.actions.completeHeatmapBackgroundSelection(key)
+                modalLogic.actions.closeSessionPlayer()
+                return
+            }
             // the player may be open in the global modal (e.g. from the heatmap recording
             // fallback); close it or the heatmap scene renders hidden beneath it
-            sessionPlayerModalLogic.findMounted()?.actions.closeSessionPlayer()
+            modalLogic?.actions.closeSessionPlayer()
             router.actions.push(urls.heatmapRecording(`iframeStorage=${key}`))
         },
 


### PR DESCRIPTION
## Problem
Heatmaps was consistently confusing and difficult to setup.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new onboarding flow + heatmap creation flow.


https://github.com/user-attachments/assets/41e53b3b-abaa-4ce0-b5c6-7cf6fcad0757


<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
