### PR TITLE
fix(posthog-ai): infer support ticket target area from conversation

### DIFF
--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/prompts.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/prompts.py
@@ -7,22 +7,76 @@ Your goal is to create a clear, concise summary that helps a support agent under
 4. The current state of the issue
 """.strip()
 
-SUPPORT_SUMMARIZER_USER_PROMPT = """
+# Keep in sync with TARGET_AREA_TO_NAME in frontend/src/lib/components/Support/supportLogic.ts.
+# The frontend validates the emitted key against that list and falls back to no topic on mismatch,
+# so drift here degrades gracefully (the user picks the topic manually).
+SUPPORT_TICKET_TOPICS = """
+- login: Authentication (incl. login, sign-up, invites)
+- analytics_platform: Analytics platform features (incl. alerts, subscriptions, exports)
+- billing: Billing
+- cohorts: Cohorts
+- data_ingestion: Data ingestion
+- health_overview: Health overview
+- data_management: Data management (incl. events, actions, properties)
+- mobile: Mobile
+- notebooks: Notebooks
+- onboarding: Onboarding
+- platform_addons: Platform addons
+- sdk: SDK / implementation
+- setup-wizard: Setup wizard
+- ai_gateway: AI gateway
+- llm-analytics: AI observability / LLM analytics
+- apps: Apps (incl. integrations, plugins, webhooks)
+- batch_exports: Destinations (batch exports)
+- cdp_destinations: Destinations (real-time)
+- data_modeling: Data modeling (views, matviews, endpoints)
+- data_warehouse: Data warehouse (sources, incl. external integrations like Stripe, Hubspot, ad platforms)
+- error_tracking: Error tracking product
+- experiments: Experiments
+- feature_flags: Feature flags
+- group_analytics: Group analytics
+- customer_analytics: Customer analytics
+- heatmaps: Heatmaps
+- logs: Logs
+- posthog-ai: PostHog AI (the assistant itself)
+- posthog-mcp: PostHog MCP
+- analytics: Product analytics (incl. insights, dashboards)
+- revenue_analytics: Revenue analytics
+- session_replay: Session replay (incl. recordings)
+- signals: Signals
+- slack: Slack app
+- surveys: Surveys
+- toolbar: Toolbar
+- web_analytics: Web analytics
+- workflows: Workflows / messaging
+""".strip()
+
+SUPPORT_SUMMARIZER_USER_PROMPT = f"""
 Create a brief, actionable summary of this conversation for a support ticket.
 
 Format:
-- Exactly 2 labeled sections separated by a blank line
+- Exactly 3 labeled sections separated by blank lines
 - Section 1: "**Issue**:" followed by the user's problem and relevant technical details (error messages, event names, property names, etc.)
 - Section 2: "**Status**:" followed by what PostHog AI attempted and the current state of the request
+- Section 3: "**Topic**:" followed by exactly one topic key from the list below, chosen for the product area the user's issue is actually about
 - Always refer to yourself as "PostHog AI" (never "the AI" or "I")
 - Write in third person perspective
 - Do NOT include bullet points or "Recommended next steps" sections
 - Plain text only, no markdown formatting
 
+Topic selection:
+- Choose the topic for the product area the issue is about, NOT the channel it was reported through. Only use "posthog-ai" when the issue is about PostHog AI itself (e.g. the assistant gave wrong answers or misbehaved).
+- If no topic clearly fits, omit the "**Topic**:" section entirely so the user can pick one themselves.
+
+Valid topic keys:
+{SUPPORT_TICKET_TOPICS}
+
 <good_example>
 **Issue:** The user is trying to create a funnel insight to track their checkout flow but is seeing a "No data" message despite having events. They confirmed that the events "$pageview" and "purchase_completed" exist in their project with data from the last 7 days.
 
 **Status:** PostHog AI helped verify the events exist and suggested checking the funnel step order and date range filters. The issue remains unresolved - the user still sees no data in their funnel even after adjusting the date range to 30 days.
+
+**Topic:** analytics
 </good_example>
 
 <bad_example>
@@ -37,12 +91,17 @@ The user asked about funnels and I helped them.
 ### Recommended next steps:
 - Check the documentation
 - Contact support if issues persist
+
+### Topic
+This was reported via PostHog AI so the topic is posthog-ai.
 </bad_example>
 
 <good_example>
-Issue: The user reported that their PostHog session recordings are not capturing clicks on their React application. They are using posthog-js version 1.96.0 and have autocapture enabled. The console shows no errors.
+**Issue:** The user reported that their PostHog session recordings are not capturing clicks on their React application. They are using posthog-js version 1.96.0 and have autocapture enabled. The console shows no errors.
 
-Status: PostHog AI suggested checking that the "Record user sessions" toggle is enabled in project settings and verified the SDK initialization code looks correct. The user confirmed session recording is enabled but clicks are still not appearing in the recordings timeline.
+**Status:** PostHog AI suggested checking that the "Record user sessions" toggle is enabled in project settings and verified the SDK initialization code looks correct. The user confirmed session recording is enabled but clicks are still not appearing in the recordings timeline.
+
+**Topic:** session_replay
 </good_example>
 
 <bad_example>

--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/prompts.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/prompts.py
@@ -8,8 +8,8 @@ Your goal is to create a clear, concise summary that helps a support agent under
 """.strip()
 
 # Keep in sync with TARGET_AREA_TO_NAME in frontend/src/lib/components/Support/supportLogic.ts.
-# The frontend validates the emitted key against that list and falls back to no topic on mismatch,
-# so drift here degrades gracefully (the user picks the topic manually).
+# The frontend validates the emitted key against that list; unknown keys parse as null and the
+# support form falls back to its default target area, so drift here degrades gracefully.
 SUPPORT_TICKET_TOPICS = """
 - login: Authentication (incl. login, sign-up, invites)
 - analytics_platform: Analytics platform features (incl. alerts, subscriptions, exports)
@@ -55,10 +55,10 @@ SUPPORT_SUMMARIZER_USER_PROMPT = f"""
 Create a brief, actionable summary of this conversation for a support ticket.
 
 Format:
-- Exactly 3 labeled sections separated by blank lines
+- 2 or 3 labeled sections separated by blank lines
 - Section 1: "**Issue**:" followed by the user's problem and relevant technical details (error messages, event names, property names, etc.)
 - Section 2: "**Status**:" followed by what PostHog AI attempted and the current state of the request
-- Section 3: "**Topic**:" followed by exactly one topic key from the list below, chosen for the product area the user's issue is actually about
+- Section 3 (optional): "**Topic**:" followed by exactly one topic key from the list below, chosen for the product area the user's issue is actually about
 - Always refer to yourself as "PostHog AI" (never "the AI" or "I")
 - Write in third person perspective
 - Do NOT include bullet points or "Recommended next steps" sections

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -302,6 +302,7 @@ function LegacyThread({ showTrailers }: { showTrailers: boolean }): JSX.Element 
                                         conversationId={conversationId}
                                         traceId={traceId}
                                         summary={ticketSummaryData.summary}
+                                        targetArea={ticketSummaryData.targetArea}
                                     />
                                 ))}
                         </React.Fragment>

--- a/frontend/src/scenes/max/TicketPrompt.tsx
+++ b/frontend/src/scenes/max/TicketPrompt.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
 
 import { SupportForm } from 'lib/components/Support/SupportForm'
-import { supportLogic } from 'lib/components/Support/supportLogic'
+import { SupportTicketTargetArea, supportLogic } from 'lib/components/Support/supportLogic'
 
 import { maxThreadLogic } from './maxThreadLogic'
 
@@ -20,6 +20,8 @@ interface TicketPromptProps {
     summary?: string
     /** If provided, pre-populate the input field with this text */
     initialText?: string
+    /** Target area inferred from the conversation; falls back to product analytics when absent */
+    targetArea?: SupportTicketTargetArea | null
 }
 
 /**
@@ -27,7 +29,13 @@ interface TicketPromptProps {
  * - If `summary` is provided: shows "Create support ticket" button with pre-filled summary
  * - If no `summary`: shows input field for user to describe their issue
  */
-export function TicketPrompt({ conversationId, traceId, summary, initialText }: TicketPromptProps): JSX.Element {
+export function TicketPrompt({
+    conversationId,
+    traceId,
+    summary,
+    initialText,
+    targetArea,
+}: TicketPromptProps): JSX.Element {
     const [issueText, setIssueText] = useState(initialText ?? '')
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [isSupportModalOpen, setIsSupportModalOpen] = useState(false)
@@ -80,7 +88,7 @@ export function TicketPrompt({ conversationId, traceId, summary, initialText }: 
             name: '',
             email: '',
             kind: 'bug',
-            target_area: 'posthog-ai',
+            target_area: targetArea ?? 'analytics',
             severity_level: 'low',
             message: messageContent,
             tags: ['raised_from_posthog_ai_chat'],

--- a/frontend/src/scenes/max/ticketUtils.test.ts
+++ b/frontend/src/scenes/max/ticketUtils.test.ts
@@ -1,33 +1,64 @@
 import { ThreadMessage } from './maxLogic'
-import { getTicketSummaryData } from './ticketUtils'
+import { getTicketSummaryData, parseTicketTargetArea } from './ticketUtils'
 
 const human = (content: string): ThreadMessage => ({ type: 'human', content }) as unknown as ThreadMessage
 const ai = (content: string): ThreadMessage => ({ type: 'ai', content }) as unknown as ThreadMessage
 
 const SUMMARY = 'PostHog AI Support Ticket Summary:\n\nIssue: Session recordings are not appearing in the dashboard.'
+const SUMMARY_WITH_TOPIC = `${SUMMARY}\n\n**Topic:** session_replay`
 const DENIAL =
     'The `/ticket` command is available for customers on paid plans or active trials. You can upgrade your plan in the billing settings, or ask the community at https://posthog.com/questions for help. If your issue is about billing, you can always contact our support team through the in-app help panel.'
 
-describe('getTicketSummaryData', () => {
-    it('does not treat an eligibility denial as a ticket summary', () => {
-        const thread = [
-            human('How do I create an insight?'),
-            ai('You can create an insight by...'),
-            human('/ticket'),
-            ai(DENIAL),
-        ]
+describe('ticketUtils', () => {
+    describe('getTicketSummaryData', () => {
+        it('does not treat an eligibility denial as a ticket summary', () => {
+            const thread = [
+                human('How do I create an insight?'),
+                ai('You can create an insight by...'),
+                human('/ticket'),
+                ai(DENIAL),
+            ]
 
-        expect(getTicketSummaryData(thread, false)).toBeNull()
+            expect(getTicketSummaryData(thread, false)).toBeNull()
+        })
+
+        it('returns the summary when the response after /ticket is a real summary', () => {
+            const thread = [
+                human('How do I create an insight?'),
+                ai('You can create an insight by...'),
+                human('/ticket'),
+                ai(SUMMARY),
+            ]
+
+            expect(getTicketSummaryData(thread, false)).toEqual({ summary: SUMMARY, messageIndex: 3, targetArea: null })
+        })
+
+        it('extracts the target area from the summary topic line', () => {
+            const thread = [
+                human('My recordings are missing'),
+                ai('Let me check that...'),
+                human('/ticket'),
+                ai(SUMMARY_WITH_TOPIC),
+            ]
+
+            expect(getTicketSummaryData(thread, false)).toEqual({
+                summary: SUMMARY_WITH_TOPIC,
+                messageIndex: 3,
+                targetArea: 'session_replay',
+            })
+        })
     })
 
-    it('returns the summary when the response after /ticket is a real summary', () => {
-        const thread = [
-            human('How do I create an insight?'),
-            ai('You can create an insight by...'),
-            human('/ticket'),
-            ai(SUMMARY),
-        ]
-
-        expect(getTicketSummaryData(thread, false)).toEqual({ summary: SUMMARY, messageIndex: 3 })
+    describe('parseTicketTargetArea', () => {
+        it.each([
+            ['bold topic line with valid area', 'Issue: foo\n\n**Topic:** data_warehouse', 'data_warehouse'],
+            ['plain topic line with valid area', 'Issue: foo\n\nTopic: session_replay', 'session_replay'],
+            ['case and whitespace variations', 'Issue: foo\n\ntopic:   Data_Warehouse  ', 'data_warehouse'],
+            ['unknown area is rejected', 'Issue: foo\n\nTopic: quantum_computing', null],
+            ['no topic line', 'Issue: foo\n\nStatus: bar', null],
+            ['topic mentioned mid-sentence is ignored', 'Issue: the topic: billing came up in chat', null],
+        ])('%s', (_name, content, expected) => {
+            expect(parseTicketTargetArea(content)).toBe(expected)
+        })
     })
 })

--- a/frontend/src/scenes/max/ticketUtils.ts
+++ b/frontend/src/scenes/max/ticketUtils.ts
@@ -1,14 +1,36 @@
+import { SupportTicketTargetArea, TARGET_AREA_OPTIONS } from 'lib/components/Support/supportLogic'
+
 import { ThreadMessage } from './maxLogic'
 
 export interface TicketSummaryData {
     summary?: string
     discarded?: boolean
     messageIndex: number
+    targetArea?: SupportTicketTargetArea | null
 }
 
 export interface TicketPromptData {
     needed: boolean
     initialText?: string
+}
+
+/**
+ * Parses the "Topic: <area>" line the /ticket summarizer appends, returning the
+ * target area only if it matches a known support target area.
+ */
+export function parseTicketTargetArea(content: string): SupportTicketTargetArea | null {
+    for (const rawLine of content.split('\n')) {
+        const line = rawLine.replace(/\*/g, '').trim()
+        const match = line.match(/^topic:\s*(.+)$/i)
+        if (match) {
+            const area = match[1].trim().toLowerCase()
+            if (TARGET_AREA_OPTIONS.some((option) => option.value === area)) {
+                return area as SupportTicketTargetArea
+            }
+            return null
+        }
+    }
+    return null
 }
 
 /**
@@ -129,6 +151,7 @@ export function getTicketSummaryData(
             return {
                 summary,
                 messageIndex: ticketCommandIndex + 1,
+                targetArea: parseTicketTargetArea(responseMessage.content),
             }
         }
     }


### PR DESCRIPTION
## Problem

When PostHog AI opens a support ticket on a user's behalf via the `/ticket` command, every ticket lands in Zendesk with `Target area: posthog-ai`, regardless of what the issue is actually about. E.g. a ticket about a data warehouse integration, for example, gets routed to the PostHog AI area instead of `data_warehouse` (origin example: [Zendesk ticket 62434](https://posthoghelp.zendesk.com/agent/tickets/62434), visible to PostHog staff).

I was spending too much time re-categorizing tickets so pushing this fix even though we've only got two days left.

Root cause: the frontend hardcoded `target_area: 'posthog-ai'` when opening the support modal from the `/ticket` flow. Nothing anywhere inferred the area from the conversation.

## Changes

- The `/ticket` summarizer prompt now asks the model to append a third `**Topic:** <key>` section, choosing one key from the canonical support target-area list (copied into the prompt with a keep-in-sync note pointing at `supportLogic.ts`). It is told to pick the product area the issue is about, not the channel it was reported through, to use `posthog-ai` only when the assistant itself misbehaved, and to omit the line when nothing fits.
- New `parseTicketTargetArea()` in `ticketUtils.ts` parses that line (tolerant of bold markers, case, and whitespace) and validates the key against `TARGET_AREA_OPTIONS`. Unknown keys resolve to null, so prompt drift degrades gracefully instead of sending invalid values to Zendesk.
- `TicketPrompt` prefills the support form with the parsed area and falls back to `analytics` (product analytics) when classification is unavailable, such as the first-message `/ticket` flow where there is no conversation to classify. The user can still change the topic in the form before submitting.
- The Topic line intentionally stays in the ticket body, so support agents can see what the AI suggested and correct misroutes.

Out of scope, deliberately: the thumbs-down feedback flow (`FeedbackPrompt`) keeps `posthog-ai`, since feedback about the assistant is correctly that area. The Conversations submission path is untouched.

## How did you test this code?

- TDD: wrote the new Jest cases first (red), then implemented. `frontend/src/scenes/max/ticketUtils.test.ts` gains parameterized parser cases (bold/plain/case/whitespace variants, unknown key rejected, mid-sentence "topic:" ignored) plus a wiring case asserting `getTicketSummaryData` returns the parsed area. These catch a regression no existing test did: a summarizer format drift or an invalid key slipping through the parser would silently misroute tickets.
- Full `scenes/max` Jest suite passes (442 tests, 20 suites). Backend `/ticket` command tests pass (10 tests). Ruff clean.
- Not manually tested end to end: the classification comes from a live LLM call in the `/ticket` command, and the local environment lacked the API keys to exercise it. The parser and form wiring are covered by the automated tests above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the `/ticket` target-area behavior, so no docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) with Steven directing. Skills invoked: `/writing-tests`. Subagents used: Explore (traced the ticket-creation path across `ee/hogai`, `scenes/max`, `supportLogic`, and the Conversations widget API) and code-reviewer (approved; verified all 38 prompt topic keys match the frontend list and traced the fallback through both `TicketPrompt` flows).

Decisions along the way: Steven initially asked for a `support` fallback area, but `support` is a ticket kind, not a target area, so we settled on `analytics` as the fallback. An earlier iteration used a null fallback that forced the user to pick a topic via form validation; Steven preferred a sensible default over forced choice. We considered structured output for the classification but kept the string-based Topic line since the whole `/ticket` flow already works by message-content detection, and it avoids extending the frozen LangGraph message plumbing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
