### PR TITLE
feat(agent-platform): add Slack connector foundation

### DIFF
--- a/products/agent_platform/backend/migrations/0013_agent_slack_connector.py
+++ b/products/agent_platform/backend/migrations/0013_agent_slack_connector.py
@@ -1,0 +1,118 @@
+import uuid
+
+import django.db.models.manager
+import django.db.models.deletion
+import django.contrib.postgres.fields
+import django.db.models.functions.datetime
+from django.db import migrations, models
+
+import posthog.models.utils
+import posthog.helpers.encrypted_fields
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("agent_platform", "0012_agentsession_search_text_turn_count"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AgentSlackConnector",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("team_id", models.BigIntegerField(db_index=True)),
+                ("slack_workspace_id", models.TextField()),
+                (
+                    "public_routing_id",
+                    models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+                ),
+                ("slack_app_id", models.TextField(blank=True, null=True)),
+                ("bot_user_id", models.TextField(blank=True, null=True)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "pending"),
+                            ("provisioning", "provisioning"),
+                            ("install_pending", "install_pending"),
+                            ("active", "active"),
+                            ("reinstall_required", "reinstall_required"),
+                            ("revoked", "revoked"),
+                            ("error", "error"),
+                        ],
+                        db_default="pending",
+                        default="pending",
+                        max_length=32,
+                    ),
+                ),
+                (
+                    "installed_scopes",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=models.TextField(), db_default=models.Value("{}"), default=list, size=None
+                    ),
+                ),
+                (
+                    "desired_scopes",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=models.TextField(), db_default=models.Value("{}"), default=list, size=None
+                    ),
+                ),
+                (
+                    "encrypted_credentials",
+                    posthog.helpers.encrypted_fields.EncryptedTextField(blank=True, null=True),
+                ),
+                ("last_error", models.TextField(blank=True, db_default="", default="")),
+                ("created_by_id", models.BigIntegerField(blank=True, null=True)),
+                ("installed_at", models.DateTimeField(blank=True, null=True)),
+                ("revoked_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "created_at",
+                    models.DateTimeField(
+                        auto_now_add=True,
+                        db_default=django.db.models.functions.datetime.Now(),
+                    ),
+                ),
+                (
+                    "updated_at",
+                    models.DateTimeField(
+                        auto_now=True,
+                        db_default=django.db.models.functions.datetime.Now(),
+                    ),
+                ),
+                (
+                    "application",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="slack_connectors",
+                        to="agent_platform.agentapplication",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "agent_slack_connector",
+                "indexes": [models.Index(fields=["team_id", "status"], name="asc_team_status_idx")],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("application", "slack_workspace_id"),
+                        name="agent_slack_connector_app_workspace_unique",
+                    ),
+                    models.UniqueConstraint(
+                        condition=models.Q(("slack_app_id__isnull", False)),
+                        fields=("slack_app_id",),
+                        name="agent_slack_connector_app_id_unique",
+                    ),
+                ],
+            },
+            managers=[
+                ("all_teams", django.db.models.manager.Manager()),
+            ],
+        ),
+    ]

--- a/products/agent_platform/backend/migrations/max_migration.txt
+++ b/products/agent_platform/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0012_agentsession_search_text_turn_count
+0013_agent_slack_connector

--- a/products/agent_platform/backend/models.py
+++ b/products/agent_platform/backend/models.py
@@ -19,6 +19,8 @@ were dropped pending a rethink — see the commented-out routes in `routes.py`.
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Q, Value
@@ -33,6 +35,16 @@ REVISION_STATE_CHOICES = [
     ("ready", "ready"),
     ("live", "live"),
     ("archived", "archived"),
+]
+
+SLACK_CONNECTOR_STATUS_CHOICES = [
+    ("pending", "pending"),
+    ("provisioning", "provisioning"),
+    ("install_pending", "install_pending"),
+    ("active", "active"),
+    ("reinstall_required", "reinstall_required"),
+    ("revoked", "revoked"),
+    ("error", "error"),
 ]
 
 # Mirrors the JSONB default the node session writer relies on.
@@ -159,6 +171,55 @@ class AgentRevision(ProductTeamModel, UUIDModel):
 
     def __str__(self) -> str:
         return f"{self.application_id}@{str(self.id)[:8]} ({self.state})"
+
+
+class AgentSlackConnector(ProductTeamModel, UUIDModel):
+    """Durable Slack identity and installation state for one agent application."""
+
+    application = models.ForeignKey(
+        AgentApplication,
+        on_delete=models.CASCADE,
+        related_name="slack_connectors",
+    )
+    slack_workspace_id = models.TextField()
+    public_routing_id = models.UUIDField(default=uuid4, unique=True, editable=False)
+    slack_app_id = models.TextField(null=True, blank=True)
+    bot_user_id = models.TextField(null=True, blank=True)
+    status = models.CharField(
+        max_length=32,
+        choices=SLACK_CONNECTOR_STATUS_CHOICES,
+        default="pending",
+        db_default="pending",
+    )
+    installed_scopes = ArrayField(models.TextField(), default=list, db_default=Value("{}"))
+    desired_scopes = ArrayField(models.TextField(), default=list, db_default=Value("{}"))
+    encrypted_credentials: EncryptedTextField = EncryptedTextField(null=True, blank=True)
+    last_error = models.TextField(blank=True, default="", db_default="")
+    created_by_id = models.BigIntegerField(null=True, blank=True)
+    installed_at = models.DateTimeField(null=True, blank=True)
+    revoked_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True, db_default=Now())
+    updated_at = models.DateTimeField(auto_now=True, db_default=Now())
+
+    class Meta:
+        db_table = "agent_slack_connector"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["application", "slack_workspace_id"],
+                name="agent_slack_connector_app_workspace_unique",
+            ),
+            models.UniqueConstraint(
+                fields=["slack_app_id"],
+                condition=Q(slack_app_id__isnull=False),
+                name="agent_slack_connector_app_id_unique",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["team_id", "status"], name="asc_team_status_idx"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.application_id}:{self.slack_workspace_id}"
 
 
 # ─── Runtime ──────────────────────────────────────────────────────────

--- a/products/agent_platform/backend/presentation/serializers.py
+++ b/products/agent_platform/backend/presentation/serializers.py
@@ -22,7 +22,7 @@ from rest_framework import serializers
 
 from posthog.models import User
 
-from ..models import REVISION_STATE_CHOICES, AgentApplication, AgentRevision
+from ..models import REVISION_STATE_CHOICES, AgentApplication, AgentRevision, AgentSlackConnector
 
 # Opaque random slug: leading letter (DNS-label-safe) + lowercase alphanumerics.
 # No dashes, so it can't be misread as the `<slug>-<revHex>` revision form, and
@@ -215,6 +215,54 @@ class AgentApplicationSerializer(serializers.ModelSerializer):
             return super().update(instance, validated_data)
         except IntegrityError as e:
             raise serializers.ValidationError({"slug": "An agent with this slug already exists."}) from e
+
+
+class CreateAgentSlackConnectorRequestSerializer(serializers.Serializer):
+    slack_workspace_id = serializers.CharField(
+        max_length=32,
+        trim_whitespace=True,
+        help_text="Slack workspace ID that the dedicated agent app will be installed into, for example `T01234567`.",
+    )
+
+
+class AgentSlackConnectorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AgentSlackConnector
+        fields = [
+            "id",
+            "application",
+            "slack_workspace_id",
+            "public_routing_id",
+            "slack_app_id",
+            "bot_user_id",
+            "status",
+            "installed_scopes",
+            "desired_scopes",
+            "last_error",
+            "installed_at",
+            "revoked_at",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+        extra_kwargs = {
+            "id": {"help_text": "Stable PostHog identifier for this connector."},
+            "application": {"help_text": "Agent application that owns the dedicated Slack app."},
+            "slack_workspace_id": {"help_text": "Slack workspace where the agent app is installed."},
+            "public_routing_id": {
+                "help_text": "Opaque routing identifier used by stable connector-level Slack webhook URLs."
+            },
+            "slack_app_id": {"help_text": "Slack app ID after provisioning, or null while pending."},
+            "bot_user_id": {"help_text": "Slack bot user ID after installation, or null while pending."},
+            "status": {"help_text": "Current provisioning and installation state of the Slack connector."},
+            "installed_scopes": {"help_text": "OAuth scopes granted by the current Slack installation."},
+            "desired_scopes": {"help_text": "OAuth scopes required by the agent's desired Slack manifest."},
+            "last_error": {"help_text": "Latest provisioning or installation error, empty when healthy."},
+            "installed_at": {"help_text": "When Slack installation completed, or null while uninstalled."},
+            "revoked_at": {"help_text": "When Slack access was revoked, or null while connected."},
+            "created_at": {"help_text": "When the connector record was created."},
+            "updated_at": {"help_text": "When the connector record was last updated."},
+        }
 
 
 def agent_ingress_route_url(slug: str, path: str) -> str | None:

--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -47,6 +47,7 @@ from drf_spectacular.utils import (
     inline_serializer,
 )
 from rest_framework import (
+    mixins,
     renderers,
     serializers as drf_serializers,
     status,
@@ -87,12 +88,14 @@ from ..logic.skill_editing import (
 )
 from ..logic.skill_resolution import assert_skill_refs_readable, resolve_skill_ref, stamp_skill_provenance
 from ..logic.spec_schema import missing_required_secrets
-from ..models import AgentApplication, AgentIdentityCredential, AgentRevision
+from ..models import AgentApplication, AgentIdentityCredential, AgentRevision, AgentSlackConnector
 from .serializers import (
     MAX_SKILL_REFS,
     AgentApplicationSerializer,
     AgentRevisionSerializer,
+    AgentSlackConnectorSerializer,
     CloneFromRequestSerializer,
+    CreateAgentSlackConnectorRequestSerializer,
     DecideApprovalRequestSerializer,
     DryRunToolRequestSerializer,
     ImportBundleRequestSerializer,
@@ -1714,6 +1717,58 @@ class AgentApplicationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
 
 @extend_schema(tags=["agent_platform"])
+class AgentSlackConnectorViewSet(
+    TeamAndOrgViewSetMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Registers the durable Slack connector that the PostHog Slack app provisions."""
+
+    scope_object = "agents"
+    scope_object_write_actions = ["create"]
+    scope_object_read_actions = ["list", "retrieve"]
+    serializer_class = AgentSlackConnectorSerializer
+    queryset = AgentSlackConnector.all_teams.all()
+
+    def _should_skip_parents_filter(self) -> bool:
+        return True
+
+    def get_application(self) -> AgentApplication:
+        application = _resolve_application(
+            AgentApplication.all_teams.filter(team_id=self.team_id, archived=False),
+            self.kwargs.get("parent_lookup_application_id") or self.kwargs.get("application_id"),
+        )
+        if application is None:
+            raise NotFound("Application not found")
+        return application
+
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        return queryset.filter(team_id=self.team_id, application=self.get_application()).order_by("created_at")
+
+    @extend_schema(
+        request=CreateAgentSlackConnectorRequestSerializer,
+        responses={
+            200: AgentSlackConnectorSerializer,
+            201: AgentSlackConnectorSerializer,
+        },
+    )
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        body = CreateAgentSlackConnectorRequestSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        application = self.get_application()
+        connector, created = AgentSlackConnector.objects.for_team(self.team_id).get_or_create(
+            application=application,
+            slack_workspace_id=body.validated_data["slack_workspace_id"],
+            defaults={
+                "team_id": self.team_id,
+                "created_by_id": request.user.id,
+            },
+        )
+        response = AgentSlackConnectorSerializer(connector, context=self.get_serializer_context())
+        return Response(response.data, status=status.HTTP_201_CREATED if created else status.HTTP_200_OK)
+
+
 class AgentRevisionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     """Revisions of an agent. Created in `draft`, promoted through
     `ready → live` once the bundle has been uploaded + frozen.

--- a/products/agent_platform/backend/routes.py
+++ b/products/agent_platform/backend/routes.py
@@ -6,6 +6,7 @@ from products.agent_platform.backend.presentation.views import (
     AgentMemoryViewSet,
     AgentNativeToolsViewSet,
     AgentRevisionViewSet,
+    AgentSlackConnectorViewSet,
 )
 
 # Skill / custom-tool template registry is disabled pending a rethink.
@@ -29,6 +30,12 @@ def register_routes(routers: RouterRegistry) -> None:
         r"memory",
         AgentMemoryViewSet,
         "project_agent_application_memory",
+        ["project_id", "application_id"],
+    )
+    agent_applications.register(
+        r"slack_connectors",
+        AgentSlackConnectorViewSet,
+        "project_agent_application_slack_connectors",
         ["project_id", "application_id"],
     )
     routers.projects.register(

--- a/products/agent_platform/backend/tests/test_slack_connectors.py
+++ b/products/agent_platform/backend/tests/test_slack_connectors.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from posthog.models import Organization, Team
+
+from ..models import AgentApplication, AgentSlackConnector
+
+
+class TestAgentSlackConnectorAPI(APIBaseTest):
+    databases = {
+        "default",
+        "agent_platform_db_writer",
+        "agent_platform_db_reader",
+    }
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.application = AgentApplication.all_teams.create(
+            team_id=self.team.id,
+            slug="slack-connector-agent",
+            name="Slack connector agent",
+            description="",
+        )
+        self.url = f"/api/projects/{self.team.id}/agent_applications/{self.application.id}/slack_connectors/"
+
+    def test_repeated_registration_returns_the_same_connector(self) -> None:
+        first = self.client.post(self.url, {"slack_workspace_id": "T01234567"}, format="json")
+        second = self.client.post(self.url, {"slack_workspace_id": "T01234567"}, format="json")
+
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED, first.content)
+        self.assertEqual(second.status_code, status.HTTP_200_OK, second.content)
+        self.assertEqual(second.json()["id"], first.json()["id"])
+        self.assertEqual(second.json()["public_routing_id"], first.json()["public_routing_id"])
+        self.assertEqual(
+            AgentSlackConnector.all_teams.filter(
+                application=self.application,
+                slack_workspace_id="T01234567",
+            ).count(),
+            1,
+        )
+
+    def test_retrieve_never_returns_encrypted_credentials(self) -> None:
+        connector = AgentSlackConnector.all_teams.create(
+            team_id=self.team.id,
+            application=self.application,
+            slack_workspace_id="T01234567",
+            encrypted_credentials=json.dumps({"bot_token": "xoxb-secret", "signing_secret": "signing-secret"}),
+        )
+
+        response = self.client.get(f"{self.url}{connector.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertNotIn("encrypted_credentials", response.json())
+        self.assertNotIn("xoxb-secret", response.content.decode())
+        self.assertNotIn("signing-secret", response.content.decode())
+
+    def test_application_from_another_team_cannot_register_a_connector(self) -> None:
+        other_org = Organization.objects.create(name="other-org")
+        other_team = Team.objects.create(organization=other_org, name="other-team")
+        foreign_application = AgentApplication.all_teams.create(
+            team_id=other_team.id,
+            slug="foreign-slack-connector-agent",
+            name="Foreign Slack connector agent",
+            description="",
+        )
+        url = f"/api/projects/{self.team.id}/agent_applications/{foreign_application.id}/slack_connectors/"
+
+        response = self.client.post(url, {"slack_workspace_id": "T01234567"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.content)
+        self.assertFalse(AgentSlackConnector.all_teams.filter(application=foreign_application).exists())

--- a/products/agent_platform/frontend/generated/api.schemas.ts
+++ b/products/agent_platform/frontend/generated/api.schemas.ts
@@ -578,6 +578,96 @@ export interface NewDraftRevisionRequestApi {
 }
 
 /**
+ * * `pending` - pending
+ * * `provisioning` - provisioning
+ * * `install_pending` - install_pending
+ * * `active` - active
+ * * `reinstall_required` - reinstall_required
+ * * `revoked` - revoked
+ * * `error` - error
+ */
+export type AgentSlackConnectorStatusEnumApi =
+    (typeof AgentSlackConnectorStatusEnumApi)[keyof typeof AgentSlackConnectorStatusEnumApi]
+
+export const AgentSlackConnectorStatusEnumApi = {
+    Pending: 'pending',
+    Provisioning: 'provisioning',
+    InstallPending: 'install_pending',
+    Active: 'active',
+    ReinstallRequired: 'reinstall_required',
+    Revoked: 'revoked',
+    Error: 'error',
+} as const
+
+export interface AgentSlackConnectorApi {
+    /** Stable PostHog identifier for this connector. */
+    readonly id: string
+    /** Agent application that owns the dedicated Slack app. */
+    readonly application: string
+    /** Slack workspace where the agent app is installed. */
+    readonly slack_workspace_id: string
+    /** Opaque routing identifier used by stable connector-level Slack webhook URLs. */
+    readonly public_routing_id: string
+    /**
+     * Slack app ID after provisioning, or null while pending.
+     * @nullable
+     */
+    readonly slack_app_id: string | null
+    /**
+     * Slack bot user ID after installation, or null while pending.
+     * @nullable
+     */
+    readonly bot_user_id: string | null
+    /** Current provisioning and installation state of the Slack connector.
+     *
+     * * `pending` - pending
+     * * `provisioning` - provisioning
+     * * `install_pending` - install_pending
+     * * `active` - active
+     * * `reinstall_required` - reinstall_required
+     * * `revoked` - revoked
+     * * `error` - error */
+    readonly status: AgentSlackConnectorStatusEnumApi
+    /** OAuth scopes granted by the current Slack installation. */
+    readonly installed_scopes: readonly string[]
+    /** OAuth scopes required by the agent's desired Slack manifest. */
+    readonly desired_scopes: readonly string[]
+    /** Latest provisioning or installation error, empty when healthy. */
+    readonly last_error: string
+    /**
+     * When Slack installation completed, or null while uninstalled.
+     * @nullable
+     */
+    readonly installed_at: string | null
+    /**
+     * When Slack access was revoked, or null while connected.
+     * @nullable
+     */
+    readonly revoked_at: string | null
+    /** When the connector record was created. */
+    readonly created_at: string
+    /** When the connector record was last updated. */
+    readonly updated_at: string
+}
+
+export interface PaginatedAgentSlackConnectorListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: AgentSlackConnectorApi[]
+}
+
+export interface CreateAgentSlackConnectorRequestApi {
+    /**
+     * Slack workspace ID that the dedicated agent app will be installed into, for example `T01234567`.
+     * @maxLength 32
+     */
+    slack_workspace_id: string
+}
+
+/**
  * Resolved creator (id, first_name, email) from `created_by_id`, or null if unset or the user was deleted.
  * @nullable
  */
@@ -1231,6 +1321,17 @@ export type AgentMemoryReadTableParams = {
 }
 
 export type AgentApplicationsRevisionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type AgentApplicationsSlackConnectorsListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/agent_platform/frontend/generated/api.ts
+++ b/products/agent_platform/frontend/generated/api.ts
@@ -26,6 +26,7 @@ import type {
     AgentApplicationsSessionLogsParams,
     AgentApplicationsSessionsListParams,
     AgentApplicationsSessionsRetrieveParams,
+    AgentApplicationsSlackConnectorsListParams,
     AgentApplicationsSpecSchemaParams,
     AgentApplicationsStatsParams,
     AgentApprovalsDecideResponseApi,
@@ -54,16 +55,19 @@ import type {
     AgentRevisionSlackManifestResponseApi,
     AgentRevisionSystemPromptResponseApi,
     AgentRevisionValidateResponseApi,
+    AgentSlackConnectorApi,
     AgentTableRowsResponseApi,
     AgentTablesListResponseApi,
     AgentUsersListApi,
     CloneFromRequestApi,
+    CreateAgentSlackConnectorRequestApi,
     DecideApprovalRequestApi,
     DryRunToolRequestApi,
     ImportBundleRequestApi,
     NewDraftRevisionRequestApi,
     PaginatedAgentApplicationListApi,
     PaginatedAgentRevisionListApi,
+    PaginatedAgentSlackConnectorListApi,
     PatchedAgentApplicationApi,
     PatchedAgentMemoryUpdateRequestApi,
     PatchedAgentRevisionApi,
@@ -1484,6 +1488,91 @@ export const agentApplicationsRevisionsNewDraftCreate = async (
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(newDraftRevisionRequestApi),
     })
+}
+
+export const getAgentApplicationsSlackConnectorsListUrl = (
+    projectId: string,
+    applicationId: string,
+    params?: AgentApplicationsSlackConnectorsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/agent_applications/${applicationId}/slack_connectors/?${stringifiedParams}`
+        : `/api/projects/${projectId}/agent_applications/${applicationId}/slack_connectors/`
+}
+
+/**
+ * Registers the durable Slack connector that the PostHog Slack app provisions.
+ */
+export const agentApplicationsSlackConnectorsList = async (
+    projectId: string,
+    applicationId: string,
+    params?: AgentApplicationsSlackConnectorsListParams,
+    options?: RequestInit
+): Promise<PaginatedAgentSlackConnectorListApi> => {
+    return apiMutator<PaginatedAgentSlackConnectorListApi>(
+        getAgentApplicationsSlackConnectorsListUrl(projectId, applicationId, params),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
+}
+
+export const getAgentApplicationsSlackConnectorsCreateUrl = (projectId: string, applicationId: string) => {
+    return `/api/projects/${projectId}/agent_applications/${applicationId}/slack_connectors/`
+}
+
+/**
+ * Registers the durable Slack connector that the PostHog Slack app provisions.
+ */
+export const agentApplicationsSlackConnectorsCreate = async (
+    projectId: string,
+    applicationId: string,
+    createAgentSlackConnectorRequestApi: CreateAgentSlackConnectorRequestApi,
+    options?: RequestInit
+): Promise<AgentSlackConnectorApi> => {
+    return apiMutator<AgentSlackConnectorApi>(getAgentApplicationsSlackConnectorsCreateUrl(projectId, applicationId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(createAgentSlackConnectorRequestApi),
+    })
+}
+
+export const getAgentApplicationsSlackConnectorsRetrieveUrl = (
+    projectId: string,
+    applicationId: string,
+    id: string
+) => {
+    return `/api/projects/${projectId}/agent_applications/${applicationId}/slack_connectors/${id}/`
+}
+
+/**
+ * Registers the durable Slack connector that the PostHog Slack app provisions.
+ */
+export const agentApplicationsSlackConnectorsRetrieve = async (
+    projectId: string,
+    applicationId: string,
+    id: string,
+    options?: RequestInit
+): Promise<AgentSlackConnectorApi> => {
+    return apiMutator<AgentSlackConnectorApi>(
+        getAgentApplicationsSlackConnectorsRetrieveUrl(projectId, applicationId, id),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
 }
 
 export const getAgentApplicationsRetrieveUrl = (projectId: string, id: string) => {

--- a/products/agent_platform/frontend/generated/api.zod.ts
+++ b/products/agent_platform/frontend/generated/api.zod.ts
@@ -536,6 +536,18 @@ export const AgentApplicationsRevisionsNewDraftCreateBody = /* @__PURE__ */ zod
     )
 
 /**
+ * Registers the durable Slack connector that the PostHog Slack app provisions.
+ */
+export const agentApplicationsSlackConnectorsCreateBodySlackWorkspaceIdMax = 32
+
+export const AgentApplicationsSlackConnectorsCreateBody = /* @__PURE__ */ zod.object({
+    slack_workspace_id: zod
+        .string()
+        .max(agentApplicationsSlackConnectorsCreateBodySlackWorkspaceIdMax)
+        .describe('Slack workspace ID that the dedicated agent app will be installed into, for example `T01234567`.'),
+})
+
+/**
  * Agent applications — the deployable unit of the platform.
  *
  * URLs:

--- a/services/mcp/definitions/agent_platform.yaml
+++ b/services/mcp/definitions/agent_platform.yaml
@@ -624,6 +624,15 @@ tools:
             `conversation_total_turns` tells you how much was hidden, and `usage_total` is still computed over the full
             untrimmed conversation so cost reporting stays accurate. Playbook: read the `debugging-sessions` playbook
             via `agent-resolve-resource` for the failure taxonomy and how to read the logs.
+    agent-applications-slack-connectors-create:
+        operation: agent_applications_slack_connectors_create
+        enabled: false
+    agent-applications-slack-connectors-list:
+        operation: agent_applications_slack_connectors_list
+        enabled: false
+    agent-applications-slack-connectors-retrieve:
+        operation: agent_applications_slack_connectors_retrieve
+        enabled: false
     agent-applications-spec-schema:
         operation: agent_applications_spec_schema
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8784,6 +8784,79 @@ export namespace Schemas {
       Sandbox: 'sandbox',
     } as const;
 
+    /**
+     * * `pending` - pending
+     * * `provisioning` - provisioning
+     * * `install_pending` - install_pending
+     * * `active` - active
+     * * `reinstall_required` - reinstall_required
+     * * `revoked` - revoked
+     * * `error` - error
+     */
+    export type AgentSlackConnectorStatusEnum = typeof AgentSlackConnectorStatusEnum[keyof typeof AgentSlackConnectorStatusEnum];
+
+
+    export const AgentSlackConnectorStatusEnum = {
+      Pending: 'pending',
+      Provisioning: 'provisioning',
+      InstallPending: 'install_pending',
+      Active: 'active',
+      ReinstallRequired: 'reinstall_required',
+      Revoked: 'revoked',
+      Error: 'error',
+    } as const;
+
+    export interface AgentSlackConnector {
+      /** Stable PostHog identifier for this connector. */
+      readonly id: string;
+      /** Agent application that owns the dedicated Slack app. */
+      readonly application: string;
+      /** Slack workspace where the agent app is installed. */
+      readonly slack_workspace_id: string;
+      /** Opaque routing identifier used by stable connector-level Slack webhook URLs. */
+      readonly public_routing_id: string;
+      /**
+         * Slack app ID after provisioning, or null while pending.
+         * @nullable
+         */
+      readonly slack_app_id: string | null;
+      /**
+         * Slack bot user ID after installation, or null while pending.
+         * @nullable
+         */
+      readonly bot_user_id: string | null;
+      /** Current provisioning and installation state of the Slack connector.
+       *
+       * * `pending` - pending
+       * * `provisioning` - provisioning
+       * * `install_pending` - install_pending
+       * * `active` - active
+       * * `reinstall_required` - reinstall_required
+       * * `revoked` - revoked
+       * * `error` - error */
+      readonly status: AgentSlackConnectorStatusEnum;
+      /** OAuth scopes granted by the current Slack installation. */
+      readonly installed_scopes: readonly string[];
+      /** OAuth scopes required by the agent's desired Slack manifest. */
+      readonly desired_scopes: readonly string[];
+      /** Latest provisioning or installation error, empty when healthy. */
+      readonly last_error: string;
+      /**
+         * When Slack installation completed, or null while uninstalled.
+         * @nullable
+         */
+      readonly installed_at: string | null;
+      /**
+         * When Slack access was revoked, or null while connected.
+         * @nullable
+         */
+      readonly revoked_at: string | null;
+      /** When the connector record was created. */
+      readonly created_at: string;
+      /** When the connector record was last updated. */
+      readonly updated_at: string;
+    }
+
     export interface AgentTableHeader {
       /** Table name. */
       name: string;
@@ -14385,6 +14458,14 @@ export namespace Schemas {
       SameOrigin: 'same_origin',
       GithubRepo: 'github_repo',
     } as const;
+
+    export interface CreateAgentSlackConnectorRequest {
+      /**
+         * Slack workspace ID that the dedicated agent app will be installed into, for example `T01234567`.
+         * @maxLength 32
+         */
+      slack_workspace_id: string;
+    }
 
     export interface CreateAppInput {
       /** Name of the app. */
@@ -34691,6 +34772,15 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: AgentRevision[];
+    }
+
+    export interface PaginatedAgentSlackConnectorList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: AgentSlackConnector[];
     }
 
     export interface PaginatedAlertList {
@@ -66878,6 +66968,17 @@ export namespace Schemas {
     };
 
     export type AgentApplicationsRevisionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type AgentApplicationsSlackConnectorsListParams = {
     /**
      * Number of results to return per page.
      */


### PR DESCRIPTION
## Problem

The managed Slack app plan in [#70855](https://github.com/PostHog/posthog/pull/70855) needs a durable application-level resource before the existing PostHog Slack app can orchestrate provisioning. Slack identity, installation state, and credentials must outlive individual agent revisions and stay outside agent context.

## Changes

- Add a team-scoped `AgentSlackConnector` model with stable routing identity, lifecycle state, scopes, Slack identifiers, and encrypted credential storage.
- Add idempotent create, list, and retrieve endpoints nested under an agent application. Repeated registration for the same application and Slack workspace returns the existing connector.
- Generate frontend and MCP API types. The MCP operations remain disabled until the provisioning lifecycle is implemented.
- Add API coverage for idempotency, secret non-exposure, and tenant isolation.

This is the first implementation PR stacked on [#70855](https://github.com/PostHog/posthog/pull/70855). A follow-up can wire the existing PostHog Slack app into this control-plane resource and add provisioning, OAuth, and stable ingress behavior.

## How did you test this code?

- `ruff check` and `ruff format --check` on the changed Python files.
- `python -m py_compile` on the changed Python files.
- `TEST=1 DEBUG=1 python manage.py makemigrations agent_platform --check --dry-run` reports no model drift.
- `TEST=1 DEBUG=1 ./bin/hogli build:openapi` regenerated frontend and MCP types.
- `pnpm --filter=@posthog/mcp lint-tool-names` passes.
- `git diff --check` passes.
- `TEST=1 DEBUG=1 ./bin/hogli test products/agent_platform/backend/tests/test_slack_connectors.py` collected all three tests, but database setup could not run because the local Postgres host was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The design and implementation sequence are documented in the parent proposal, [#70855](https://github.com/PostHog/posthog/pull/70855). This foundation does not add user-facing behavior yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex CLI through PostHog Code. Invoked `/django-migrations`, `/improving-drf-endpoints`, `/writing-tests`, `/setup-web-tests`, and `/implementing-mcp-tools`.

The slice intentionally stops at the durable connector resource and API. It assumes the existing PostHog Slack app will become the orchestration entry point, while deferring Slack provisioning credentials, OAuth, webhook ingress, and transient secret input to follow-up stacked PRs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
