### PR TITLE
feat(web-analytics): roll no-join fast paths to all eu cloud teams

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1168,10 +1168,9 @@ WEB_ANALYTICS_NO_JOIN_TEAM_IDS: list[int] = [
 # Percentage-of-teams rollout for the no-join fast paths, on top of the explicit
 # allowlist above. Bucketing is deterministic per team (team_id % 100) so everyone
 # on a team sees numbers from the same code path. 0 disables (allowlist only),
-# 100 enrolls every team. Defaults to 50 on US Cloud (verified region); EU stays 0
-# until its ClickHouse upgrade converges and the fast paths are verified there.
+# 100 enrolls every team. Defaults to 100 on US and EU Cloud; self-hosted stays 0.
 # Env var overrides in either direction and is the kill switch.
-_NO_JOIN_DEFAULT_ROLLOUT_PERCENT = 100 if (CLOUD_DEPLOYMENT or "").upper() == "US" and not TEST else 0
+_NO_JOIN_DEFAULT_ROLLOUT_PERCENT = 100 if (CLOUD_DEPLOYMENT or "").upper() in ("US", "EU") and not TEST else 0
 WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT: int = get_from_env(
     "WEB_ANALYTICS_NO_JOIN_ROLLOUT_PERCENT", _NO_JOIN_DEFAULT_ROLLOUT_PERCENT, type_cast=int
 )


### PR DESCRIPTION
## Problem

The no-join fast paths run at 100% of US Cloud teams (#70940) with clean evidence (p50 384ms / p95 815ms / max 741 MiB vs 33 GiB join footprints; zero fast-path failures). EU has been at 0% pending its ClickHouse 26.6 upgrade.

## Changes

One line: the 100% rollout default now covers EU Cloud as well. Env var remains the kill switch; self-hosted unaffected.

> [!WARNING]
> Recommend holding the merge until the EU 26.6 upgrade fully converges: the mixed-version identifier-normalization error storm was still active as of 2026-07-15 ~17:00 UTC (16.8k `NotFoundColumnInBlock` errors that hour). Landing new query shapes mid-storm would make any EU errors unattributable. Once the storm flatlines, merge and verify via the `stats_table_no_join_*` / `web_overview_no_join_query` tags exactly as done for US.

## How did you test this code?

- Settings-only; bucketing behavior covered by `TestWebOverviewNoJoinRolloutPercent` (3 passed).
- US production evidence at 100% is the substantive validation; EU verification happens post-deploy via query tags per the team's evaluation skill.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Lucas asked for the EU 100% PR; the merge-timing caveat above reflects the still-active EU upgrade storm measured from exception telemetry at PR time.