### PR TITLE
feat(wizard): update PR agent prompt to handle skills, CLI env var setup, and config file examples

### DIFF
--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -242,16 +242,13 @@ Double-check the exact CLI syntax for the provider you detected - many commands 
 `vercel env add`) take the target environment as a positional argument and read the value from
 stdin, so passing the value as a positional would silently set the wrong thing.
 
-```markdown
-### Setting environment variables via a local CLI
-
-If you are used to running commands locally to configure your environment variables, then you can
-do it as follows for Vercel (the value is piped in; `production` is the target environment):
+Add a "Setting environment variables via a local CLI" subsection that tells the reader they can run
+commands locally instead of using the dashboard. For Vercel the commands look like this (the value
+is piped in; `production` is the target environment):
 
 ```bash
 echo "phc_abc123def456" | npx vercel env add NEXT_PUBLIC_POSTHOG_TOKEN production
 echo "https://us.i.posthog.com" | npx vercel env add NEXT_PUBLIC_POSTHOG_HOST production
-```
 ```
 
 For any other language (assume a technical reader - be direct, no env-var explainer):

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -15,7 +15,7 @@ WIZARD_HEAD_BRANCH_PREFIX = "posthog/instrumentation-"
 
 
 def generate_wizard_head_branch() -> str:
-    """A unique PR head branch for a wizard run; the random suffix only prevents
+    """A unique PR head branch for a wizard run; the random suffix is here to prevent
     collisions with existing branches in the user's repo."""
     return f"{WIZARD_HEAD_BRANCH_PREFIX}{secrets.token_hex(3)}"
 
@@ -25,7 +25,8 @@ WIZARD_PR_AGENT_PROMPT = f"""
 
 PostHog's setup wizard has already run in this repository and integrated PostHog. The working tree
 contains its uncommitted changes: modified source files, an updated package manifest, installed
-dependencies, a `posthog-setup-report.md` summary, and possibly a `.posthog-events.json` plan.
+dependencies, a `posthog-setup-report.md` summary. It'll also possibly contain a
+`.posthog-events.json` plan and some skills definitions under `.claude/skills/*`.
 
 The wizard's full console output is saved to `/tmp/wizard-cloud-run/wizard-output.log` (outside the
 repository, so it can never be committed). Read it whenever you need to understand what the wizard
@@ -86,6 +87,8 @@ are actually in the repository.
 
 4. Do NOT commit `posthog-setup-report.md` or `.posthog-events.json` - they are local reference
    only. Leave them untracked or exclude them from staging.
+5. Do NOT commit any of the skills included under `.claude/skills/*` or any other folder used
+   by local harnesses to store skills. Leave them untracked or exclude them from staging.
 
 **Checkpoint:** the commit exists on `{WIZARD_HEAD_BRANCH_PLACEHOLDER}` and
 contains neither reference file:
@@ -102,7 +105,8 @@ git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-outpu
 1. Identify how the codebase is deployed to production.
 2. If you can automatically configure the required PostHog environment variables in a file that
    will be read in production, do so, and commit that change to the same branch as a SEPARATE
-   commit.
+   commit. This includes any changes to `.env`, `wrangler.jsonc`, `docker-compose.yml`,
+   or any other file that is used to configure the production environment.
 3. If you can't configure them automatically, do not commit anything in this step - instead write
    down in your notes which variables are needed and what values they must be set to,
    for use in the PR description in Step 4.
@@ -183,10 +187,12 @@ nothing about environment variables, so the reader cannot tell whether anything 
 
 ### Examples of the env-var section when you could NOT configure them automatically
 
-This happens when the deployment does not read a committed file like `.env.production` - e.g. the
-env vars live in a hosting dashboard (Vercel, Netlify, Heroku, Fly.io) or in infrastructure config
-you cannot see from the repo. Name the platform you detected, list every variable with its exact
-value, and tell the reader where to put them. Calibrate to the audience.
+This happens when the deployment does not read a committed file like `.env.production`,
+`wrangler.jsonc`, `docker-compose.yml`, or any other file that is used to configure the production
+environment - e.g. the env vars live in a hosting dashboard (Vercel, Netlify, Heroku, Fly.io)
+or in infrastructure config you cannot see from the repo. Name the platform you detected,
+list every variable with its exact value, and tell the reader where to put them. Calibrate to the
+audience.
 
 For a Javascript project (assume a non-technical reader - explain what env vars are and walk
 through the exact clicks):
@@ -214,6 +220,24 @@ To set them:
    click **Save**.
 4. Redeploy the app (Deployments tab, "..." menu on the latest deployment, **Redeploy**) - the new
    settings only take effect on the next deployment.
+```
+
+If there's a way to set these environment variables via a local CLI - like it's common for Vercel,
+Netlify, Heroku, Fly.io, etc. - then suggest using that instead of the dashboard.
+
+The following example is for Vercel, but you should use the appropriate command for the hosting provider
+you've inferred from the codebase.
+
+```markdown
+### Setting environment variables via a local CLI
+
+If you are used to running commands locally to configure your environment variables, then you can
+do it as follows for Vercel:
+
+```bash
+npx vercel env add NEXT_PUBLIC_POSTHOG_TOKEN phc_abc123def456
+npx vercel env add NEXT_PUBLIC_POSTHOG_HOST https://us.i.posthog.com
+```
 ```
 
 For any other language (assume a technical reader - be direct, no env-var explainer):

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -20,13 +20,14 @@ def generate_wizard_head_branch() -> str:
     return f"{WIZARD_HEAD_BRANCH_PREFIX}{secrets.token_hex(3)}"
 
 
-WIZARD_PR_AGENT_PROMPT = f"""
+WIZARD_PR_AGENT_PROMPT = rf"""
 # Context
 
 PostHog's setup wizard has already run in this repository and integrated PostHog. The working tree
 contains its uncommitted changes: modified source files, an updated package manifest, installed
 dependencies, a `posthog-setup-report.md` summary. It'll also possibly contain a
-`.posthog-events.json` plan and some skills definitions under `.claude/skills/*`.
+`.posthog-events.json` plan and some skills definitions under a harness skills folder such as
+`.claude/skills/*` or `.agents/skills/*`.
 
 The wizard's full console output is saved to `/tmp/wizard-cloud-run/wizard-output.log` (outside the
 repository, so it can never be committed). Read it whenever you need to understand what the wizard
@@ -87,17 +88,26 @@ are actually in the repository.
 
 4. Do NOT commit `posthog-setup-report.md` or `.posthog-events.json` - they are local reference
    only. Leave them untracked or exclude them from staging.
-5. Do NOT commit any of the skills included under `.claude/skills/*` or any other folder used
-   by local harnesses to store skills. Leave them untracked or exclude them from staging.
+5. Do NOT commit any of the skills included under a harness skills folder like `.claude/skills/*`
+   or `.agents/skills/*` (any `.<harness>/skills/` path). Leave them untracked or exclude them
+   from staging.
 
-**Checkpoint:** the commit exists on `{WIZARD_HEAD_BRANCH_PLACEHOLDER}` and
-contains neither reference file:
+**Checkpoint:** the commit exists on `{WIZARD_HEAD_BRANCH_PLACEHOLDER}` and contains none of the
+forbidden files. Run the two checks separately so you can see exactly which kind leaked if either
+fails:
 
 ```bash
 git rev-parse --abbrev-ref HEAD          # prints: {WIZARD_HEAD_BRANCH_PLACEHOLDER}
-git show --stat HEAD                     # lists the wizard's files
-git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' && echo "FAIL: forbidden files committed" || echo "OK: no forbidden files"
-# expected: OK: no forbidden files (the grep finding nothing is the pass case)
+git show --stat HEAD                      # lists the wizard's files
+
+# 1. Reference files (local-only summaries/plans/logs):
+git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' && echo "FAIL: reference files committed" || echo "OK: no reference files"
+
+# 2. Harness skills folders (.claude/skills/, .agents/skills/, any .<harness>/skills/):
+git show --stat HEAD | grep -E '\.[^/]+/skills/' && echo "FAIL: skills files committed" || echo "OK: no skills files"
+
+# expected: both print OK (the grep finding nothing is the pass case). If either FAILs, unstage
+# those paths, amend the commit, and re-run this checkpoint.
 ```
 
 ## Step 3 - Configure environment variables for production
@@ -228,15 +238,19 @@ Netlify, Heroku, Fly.io, etc. - then suggest using that instead of the dashboard
 The following example is for Vercel, but you should use the appropriate command for the hosting provider
 you've inferred from the codebase.
 
+Double-check the exact CLI syntax for the provider you detected - many commands (including
+`vercel env add`) take the target environment as a positional argument and read the value from
+stdin, so passing the value as a positional would silently set the wrong thing.
+
 ```markdown
 ### Setting environment variables via a local CLI
 
 If you are used to running commands locally to configure your environment variables, then you can
-do it as follows for Vercel:
+do it as follows for Vercel (the value is piped in; `production` is the target environment):
 
 ```bash
-npx vercel env add NEXT_PUBLIC_POSTHOG_TOKEN phc_abc123def456
-npx vercel env add NEXT_PUBLIC_POSTHOG_HOST https://us.i.posthog.com
+echo "phc_abc123def456" | npx vercel env add NEXT_PUBLIC_POSTHOG_TOKEN production
+echo "https://us.i.posthog.com" | npx vercel env add NEXT_PUBLIC_POSTHOG_HOST production
 ```
 ```
 


### PR DESCRIPTION
## Improve PR agent prompt with skills exclusion, env var guidance, and CLI suggestions

### Changes

**Skills files exclusion**
The PR agent is now instructed not to commit any files under `.claude/skills/*` or similar folders used by local harnesses to store skills, treating them the same as `posthog-setup-report.md` and `.posthog-events.json`. The docstring for `generate_wizard_head_branch` was also lightly reworded for clarity.

**Expanded env var file examples**
References to files that configure the production environment (e.g. `wrangler.jsonc`, `docker-compose.yml`) are now explicitly called out alongside `.env` in both the commit step instructions and the "could not configure automatically" section, making it clearer when the agent should attempt an automatic commit vs. fall back to documenting variables manually.

**CLI-based env var suggestion**
When environment variables cannot be committed automatically, the agent is now prompted to suggest a local CLI approach (e.g. `npx vercel env add ...`) as an alternative to navigating a hosting dashboard. A Vercel example is included, with a note to adapt it to whichever provider is detected from the codebase.

**Updated wizard working tree description**
The description of what the wizard leaves in the working tree now mentions `.claude/skills/*` alongside the existing artifacts.