### PR TITLE
fix(tasks): lower task-run-stream MAXLEN from 20k to 5k to cap redis memory

### DIFF
--- a/products/tasks/backend/logic/stream/redis_stream.py
+++ b/products/tasks/backend/logic/stream/redis_stream.py
@@ -16,7 +16,7 @@ logger = structlog.get_logger(__name__)
 
 # Keep enough live history for users who open an in-progress run late while
 # still bounding Redis growth to the sandbox lifetime.
-TASK_RUN_STREAM_MAX_LENGTH = 20_000
+TASK_RUN_STREAM_MAX_LENGTH = 5_000
 TASK_RUN_STREAM_TIMEOUT = SANDBOX_TTL_SECONDS
 TASK_RUN_STREAM_SEQUENCE_TIMEOUT = int(SANDBOX_EVENT_INGEST_TOKEN_TTL.total_seconds())
 TASK_RUN_STREAM_PREFIX = "task-run-stream:"

--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -105,7 +105,7 @@ STREAM_CONNECTION_DURATION_BUCKETS = [
     7_200.0,
     21_600.0,
 ]
-# Stream length is capped at TASK_RUN_STREAM_MAX_LENGTH (~20k); the top buckets
+# Stream length is capped at TASK_RUN_STREAM_MAX_LENGTH (~5k); the top buckets
 # show how close real runs get to the trim threshold.
 STREAM_LENGTH_BUCKETS = [10.0, 50.0, 100.0, 500.0, 1_000.0, 2_500.0, 5_000.0, 10_000.0, 15_000.0, 20_000.0]
 

--- a/services/agent-proxy/src/hono/metrics.ts
+++ b/services/agent-proxy/src/hono/metrics.ts
@@ -47,7 +47,7 @@ export const taskRunStreamConnectionDurationSeconds = new Histogram({
     registers: [register],
 })
 
-// Stream length is capped at TASK_RUN_STREAM_MAX_LENGTH (~20k); the top
+// Stream length is capped at TASK_RUN_STREAM_MAX_LENGTH (~5k); the top
 // buckets show how close real runs get to the trim threshold.
 export const taskRunStreamLengthOnConnect = new Histogram({
     name: 'posthog_tasks_task_run_stream_length_on_connect',

--- a/services/agent-proxy/src/lib/constants.ts
+++ b/services/agent-proxy/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const STREAM_TTL_SECONDS = 6 * 60 * 60 // 21600
 export const SEQUENCE_TTL_SECONDS = STREAM_TTL_SECONDS + 3600 // 25200
 
 // Redis XADD MAXLEN ~ (approximate trim, not exact).
-export const STREAM_MAX_LENGTH = 20_000
+export const STREAM_MAX_LENGTH = 5_000
 
 // XREAD tuning
 export const READ_COUNT = 16


### PR DESCRIPTION
## Problem

On 2026-07-15 `tasks-prod-redis` (prod-us) paged `RedisMemoryUsage`, spiking from a ~31% baseline to a **92% peak (9.05 GB / 9.80 GB)** in ~25 min before draining back

## Change

Lower `TASK_RUN_STREAM_MAX_LENGTH` from 20,000 → 5,000.

we trim sooner for longer tasks.