### PR TITLE
refactor(flags): swap raw filters reads for model accessors

### DIFF
--- a/.semgrep/rules/devex/feature-flags-no-raw-filters-access.yaml
+++ b/.semgrep/rules/devex/feature-flags-no-raw-filters-access.yaml
@@ -33,18 +33,13 @@ rules:
               - '**/migrations/**'
               # Baseline: pre-existing offenders being migrated behind the flag
               # facade. Shrink this list — never grow it.
-              - '/ee/hogai/context/experiment/context.py'
               - '/posthog/api/web_experiment.py'
-              - '/posthog/management/commands/fix_invalid_flag_property_types.py'
-              - '/posthog/models/product_intent/product_intent.py'
               - '/posthog/tasks/update_survey_adaptive_sampling.py'
               - '/posthog/tasks/update_survey_iteration.py'
               - '/products/early_access_features/backend/api.py'
               - '/products/early_access_features/backend/apps.py'
               - '/products/experiments/backend/experiment_service.py'
               - '/products/experiments/backend/experiment_summary_data_service.py'
-              - '/products/experiments/backend/hogql_queries/experiment_query_runner.py'
-              - '/products/experiments/backend/max_tools.py'
               - '/products/product_tours/backend/api/product_tour.py'
       patterns:
           - pattern-either:

--- a/ee/hogai/context/experiment/context.py
+++ b/ee/hogai/context/experiment/context.py
@@ -133,8 +133,7 @@ class ExperimentContext:
 
         stats_method = get_experiment_stats_method(experiment)
 
-        multivariate = experiment.feature_flag.filters.get("multivariate", {})
-        variants = [v.get("key") for v in multivariate.get("variants", []) if v.get("key")]
+        variants = [v.get("key") for v in experiment.feature_flag.variants if v.get("key")]
 
         lines.append(f"## Experiment: {experiment.name}")
         lines.append(f"**ID:** {experiment.id}")

--- a/posthog/management/commands/fix_invalid_flag_property_types.py
+++ b/posthog/management/commands/fix_invalid_flag_property_types.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
                             unfixable_count += 1
 
             if modified:
-                flag.filters = filters
+                flag.filters = filters  # nosemgrep: feature-flags-no-raw-filters-access -- data-repair command that fixes the filters JSON itself
                 flags_to_update.append(flag)
 
         if live_run and flags_to_update:

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -155,7 +155,7 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
         # To activate we need at least 2 filter groups across all flags
         total_groups = 0
         for flag in feature_flags:
-            total_groups += len(flag.filters.get("groups", []))
+            total_groups += len(flag.conditions)
 
         return total_groups >= 2
 

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -186,7 +186,7 @@ class ExperimentQueryRunner(QueryRunner):
         self.as_of = as_of if as_of is not None else (self.experiment.end_date or datetime.now(UTC))
         self.feature_flag = self.experiment.feature_flag
         self.feature_flag_key = self.feature_flag.key_without_tombstone()
-        self.group_type_index = self.feature_flag.filters.get("aggregation_group_type_index")
+        self.group_type_index = self.feature_flag.aggregation_group_type_index
         self.entity_key = get_entity_key(self.group_type_index)
 
         # Holdout is intentionally not appended: holdout users were never exposed to

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -331,8 +331,7 @@ class ExperimentSummaryTool(MaxTool):
     ) -> tuple[str, dict[str, Any]]:
         """Build the final result tuple with artifact metadata."""
         stats_method = get_experiment_stats_method(experiment)
-        multivariate = experiment.feature_flag.filters.get("multivariate", {})
-        variants = [v.get("key") for v in multivariate.get("variants", []) if v.get("key")]
+        variants = [v.get("key") for v in experiment.feature_flag.variants if v.get("key")]
 
         return formatted_data, {
             "experiment_id": experiment.id,
@@ -438,10 +437,7 @@ class SessionReplaySummaryTool(MaxTool):
                 return "❌ Experiment has not started yet. No session replays available.", output.model_dump()
 
             # Get variants from feature flag
-            feature_flag = experiment.feature_flag
-            multivariate = feature_flag.filters.get("multivariate", {})
-            variants = multivariate.get("variants", [])
-            variant_keys = [v["key"] for v in variants]
+            variant_keys = [v["key"] for v in experiment.feature_flag.variants]
 
             if not variant_keys:
                 output = SessionReplaySummaryOutput(


### PR DESCRIPTION
## Problem

#70128 adds a semgrep rule banning raw `FeatureFlag.filters` access outside `products/feature_flags/`, with a `paths.exclude` baseline of pre-existing offenders that must shrink over time.
This PR burns down 5 files from that baseline.

## Changes

Mechanical, behavior-preserving swaps of raw `filters` JSON digging for the model's public accessors (`flag.variants`, `flag.conditions`, `flag.aggregation_group_type_index`):

- `ee/hogai/context/experiment/context.py` — variant-key extraction via `flag.variants` (same pattern the file already uses elsewhere) instead of `filters.get("multivariate", {})`
- `posthog/models/product_intent/product_intent.py` — `len(flag.conditions)` instead of `len(flag.filters.get("groups", []))`; the queryset's `.only("id", "filters")` still loads everything `conditions` reads
- `products/experiments/backend/hogql_queries/experiment_query_runner.py` — `flag.aggregation_group_type_index` property instead of `filters.get("aggregation_group_type_index")` (exact drop-in, same default of `None`)
- `products/experiments/backend/max_tools.py` — two variant-extraction sites moved to `flag.variants`
- `posthog/management/commands/fix_invalid_flag_property_types.py` — kept as raw access with an inline justified `nosemgrep`: this one-off data-repair command exists to rewrite malformed `filters` JSON that the serializer would reject, so no accessor or facade path fits

All 5 files removed from the rule's baseline in `.semgrep/rules/devex/feature-flags-no-raw-filters-access.yaml`.

> [!NOTE]
> Stacked on #70128 (base branch is `chore/flags-filters-semgrep-guard`) so the semgrep CI job itself proves these files are clean. Retarget to master lands automatically when the base merges.

## How did you test this code?

- `semgrep --config .semgrep/rules/devex/feature-flags-no-raw-filters-access.yaml` over the 5 migrated files: 0 findings
- `semgrep --test .semgrep/rules/devex/`: 6/6 rule fixture tests pass
- Existing tests only, no new tests (behavior-preserving refactor):
  - `posthog/models/test/test_product_intent.py` + `ee/hogai/context/experiment/test/test_format.py`: 78 passed
  - `products/experiments/backend/test/test_max_tools.py`: 26 passed
  - `products/experiments/backend/hogql_queries/test/experiment_query_runner/test_base.py`: 36 passed, 44 snapshots passed (covers the group aggregation path that reads `aggregation_group_type_index`)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, no user-facing or API behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code ([session](https://claude.ai/code/session_01NLuhrCgA9U41Em5HiNPmDr)).
The accessors' semantics were checked against the model before each swap (`variants` is null-safe and returns `[]` for missing or null `multivariate`, `conditions` reads `filters["groups"]`, `aggregation_group_type_index` defaults to `None`).
The management command was deliberately kept on raw access with a justified `nosemgrep` rather than forced through an accessor, since its whole job is repairing invalid `filters` JSON.
Two other baseline files touched by in-flight experiment PRs were intentionally left alone to avoid conflicts.

