### PR TITLE
feat(review-hog): allow labeled reviews on bot-authored prs

### DIFF
--- a/.github/workflows/review-hog.yml
+++ b/.github/workflows/review-hog.yml
@@ -30,9 +30,11 @@ jobs:
         name: Trigger ReviewHog review
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        # Run only for the `reviewhog` label on a non-fork PR — any author (drafts and bots included).
+        # Run only when a human applies the `reviewhog` label to a non-fork PR — any author (drafts
+        # and bots included), but the labeler must be a person: the label is the explicit human request.
         if: >-
             github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+            && github.event.sender.type != 'Bot'
             && github.event.label.name == 'reviewhog'
         steps:
             - name: Trigger ReviewHog review

--- a/.github/workflows/review-hog.yml
+++ b/.github/workflows/review-hog.yml
@@ -1,16 +1,16 @@
 # ReviewHog label trigger.
 #
-# When a maintainer adds the `reviewhog` label to a non-fork PR (drafts included), this makes ONE
-# authenticated call to the PostHog `review_hog` trigger endpoint, which starts the review Temporal
-# workflow server-side and publishes the review back to the PR. One label add = one review: pushes
-# and ready-for-review deliberately do NOT re-trigger — re-reviewing is an explicit gesture (remove
-# and re-add the label), so a labeled PR can keep evolving without burning a review per event.
+# When a maintainer adds the `reviewhog` label to a non-fork PR (any author, drafts included), this
+# makes ONE authenticated call to the PostHog `review_hog` trigger endpoint, which starts the review
+# Temporal workflow server-side and publishes the review back to the PR. One label add = one review:
+# pushes and ready-for-review deliberately do NOT re-trigger — re-reviewing is an explicit gesture
+# (remove and re-add the label), so a labeled PR can keep evolving without burning a review per event.
 # Unlike Stamphog, the agent does NOT run in CI: there is no checkout, no app token, no Anthropic key
 # here — the only secret is the shared trigger token. Publishing happens server-side via the PostHog
 # GitHub App installation token.
 #
 # Safety: `pull_request` (not `pull_request_target`) means fork PRs receive no secrets, so they cannot
-# trigger; the `if:` also hard-gates forks and bots; and applying the label needs write access.
+# trigger; the `if:` also hard-gates forks; and applying the label needs write access.
 name: ReviewHog
 
 on:
@@ -30,12 +30,9 @@ jobs:
         name: Trigger ReviewHog review
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        # Run only for the `reviewhog` label on a non-fork, human-authored PR (drafts included).
+        # Run only for the `reviewhog` label on a non-fork PR — any author (drafts and bots included).
         if: >-
             github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-            && github.event.pull_request.user.type != 'Bot'
-            && !contains(github.event.pull_request.user.login, '[bot]')
-            && github.event.pull_request.user.login != 'posthog-bot'
             && github.event.label.name == 'reviewhog'
         steps:
             - name: Trigger ReviewHog review

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -2068,7 +2068,7 @@ pipeline just built + hardened).
 
 ```text
 reviewhog label on a non-fork PostHog/posthog PR
-  └─ .github/workflows/review-hog.yml   (gates: label==reviewhog, head.repo==base.repo, non-bot, concurrency; drafts allowed)
+  └─ .github/workflows/review-hog.yml   (gates: label==reviewhog, head.repo==base.repo, concurrency; drafts + bot authors allowed)
        └─ one authenticated curl  →  POST /api/review_hog/trigger  {repo, pr_number}   (Authorization: Bearer <secret>)
             └─ endpoint: verify shared secret · validate repo allowlist (forks blocked upstream by the Action
                  + downstream by the fetch activity) · resolve team-2 integration + run user
@@ -2134,8 +2134,9 @@ github-actions[bot] trick), and its Action carries **one** secret (no Anthropic 
    authoritative in the **fetch activity** (`PRMetadata.is_fork`, non-retryable `ApplicationError` before the report
    row is created).
 4. ✅ **The Action:** `.github/workflows/review-hog.yml` — `on: pull_request [labeled]`,
-   `permissions: {}`, per-PR concurrency, `if:` gates (label + non-fork + non-bot; drafts allowed), one `curl` with the
-   bearer secret. `pull_request` (not `pull_request_target`) ⇒ forks get no secret ⇒ can't trigger.
+   `permissions: {}`, per-PR concurrency, `if:` gates (label + non-fork; any author — unmapped authors resolve via
+   the acting-user fallback), one `curl` with the bearer secret. `pull_request` (not `pull_request_target`) ⇒ forks
+   get no secret ⇒ can't trigger.
    **2026-07-14 update:** `synchronize` dropped (ADR 0002) — pushes no longer re-trigger; re-review = re-add the
    label (or mark an already-labeled draft ready).
 5. ⏳ **Later (v2):** label lifecycle (strip-on-non-approval / keep-on-error / dismiss-stale-on-push). (`synchronize` /

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -2068,7 +2068,7 @@ pipeline just built + hardened).
 
 ```text
 reviewhog label on a non-fork PostHog/posthog PR
-  └─ .github/workflows/review-hog.yml   (gates: label==reviewhog, head.repo==base.repo, concurrency; drafts + bot authors allowed)
+  └─ .github/workflows/review-hog.yml   (gates: label==reviewhog by a human, head.repo==base.repo, concurrency; any author)
        └─ one authenticated curl  →  POST /api/review_hog/trigger  {repo, pr_number}   (Authorization: Bearer <secret>)
             └─ endpoint: verify shared secret · validate repo allowlist (forks blocked upstream by the Action
                  + downstream by the fetch activity) · resolve team-2 integration + run user
@@ -2134,9 +2134,9 @@ github-actions[bot] trick), and its Action carries **one** secret (no Anthropic 
    authoritative in the **fetch activity** (`PRMetadata.is_fork`, non-retryable `ApplicationError` before the report
    row is created).
 4. ✅ **The Action:** `.github/workflows/review-hog.yml` — `on: pull_request [labeled]`,
-   `permissions: {}`, per-PR concurrency, `if:` gates (label + non-fork; any author — unmapped authors resolve via
-   the acting-user fallback), one `curl` with the bearer secret. `pull_request` (not `pull_request_target`) ⇒ forks
-   get no secret ⇒ can't trigger.
+   `permissions: {}`, per-PR concurrency, `if:` gates (human-applied label + non-fork; any author — unmapped authors
+   resolve via the acting-user fallback), one `curl` with the bearer secret. `pull_request` (not
+   `pull_request_target`) ⇒ forks get no secret ⇒ can't trigger.
    **2026-07-14 update:** `synchronize` dropped (ADR 0002) — pushes no longer re-trigger; re-review = re-add the
    label (or mark an already-labeled draft ready).
 5. ⏳ **Later (v2):** label lifecycle (strip-on-non-approval / keep-on-error / dismiss-stale-on-push). (`synchronize` /


### PR DESCRIPTION
## Problem
- We can't review bot-authored PRs

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Now we can

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
