### PR TITLE
feat(llm-gateway): report code_usage_subscribed on the usage endpoint

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -47,6 +47,11 @@ class UsageResponse(BaseModel):
     ai_credits: AiCreditsStatus
     is_rate_limited: bool
     is_pro: bool
+    # Whether the org pays for Code usage (usage-based billing). Clients use it
+    # to pick billing copy and to hide the free-tier meter for billed orgs,
+    # whose per-user limits are unbounded. Same bit enforcement reads, so the
+    # UI can never disagree with what a request would do.
+    code_usage_billed: bool = False
     billing_period_end: datetime | None = None
 
 
@@ -141,6 +146,7 @@ async def get_usage(
         ai_credits=AiCreditsStatus(exhausted=credits_exhausted),
         is_rate_limited=burst_status.exceeded or sustained_status.exceeded or credits_exhausted,
         is_pro=is_pro_plan(plan_info.plan_key),
+        code_usage_billed=quota_status.code_usage_billing_active,
         billing_period_end=billing_period_end,
     )
 

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -47,11 +47,7 @@ class UsageResponse(BaseModel):
     ai_credits: AiCreditsStatus
     is_rate_limited: bool
     is_pro: bool
-    # Whether the org pays for Code usage (usage-based billing). Clients use it
-    # to pick billing copy and to hide the free-tier meter for billed orgs,
-    # whose per-user limits are unbounded. Same bit enforcement reads, so the
-    # UI can never disagree with what a request would do.
-    code_usage_billed: bool = False
+    code_usage_subscribed: bool = False
     billing_period_end: datetime | None = None
 
 
@@ -146,7 +142,7 @@ async def get_usage(
         ai_credits=AiCreditsStatus(exhausted=credits_exhausted),
         is_rate_limited=burst_status.exceeded or sustained_status.exceeded or credits_exhausted,
         is_pro=is_pro_plan(plan_info.plan_key),
-        code_usage_billed=quota_status.code_usage_billing_active,
+        code_usage_subscribed=quota_status.code_usage_billing_active,
         billing_period_end=billing_period_end,
     )
 

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -425,7 +425,7 @@ class TestUsageEndpoint:
         assert resolver_mock.call_args.args[0] == "ai_credits"
 
     @pytest.mark.parametrize("billing_active", [True, False])
-    def test_code_usage_billed_reflects_billing_bit(
+    def test_code_usage_subscribed_reflects_billing_bit(
         self, authenticated_usage_client: TestClient, billing_active: bool
     ) -> None:
         """Clients pick billing copy and hide the free-tier meter off this
@@ -442,7 +442,7 @@ class TestUsageEndpoint:
             headers={"Authorization": "Bearer phx_test"},
         )
         assert response.status_code == 200
-        assert response.json()["code_usage_billed"] is billing_active
+        assert response.json()["code_usage_subscribed"] is billing_active
 
     def test_invalidate_plan_cache_calls_resolver(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -424,6 +424,26 @@ class TestUsageEndpoint:
         assert data["is_rate_limited"] is True
         assert resolver_mock.call_args.args[0] == "ai_credits"
 
+    @pytest.mark.parametrize("billing_active", [True, False])
+    def test_code_usage_billed_reflects_billing_bit(
+        self, authenticated_usage_client: TestClient, billing_active: bool
+    ) -> None:
+        """Clients pick billing copy and hide the free-tier meter off this
+        field, so it must carry the same bit enforcement reads."""
+        from llm_gateway.services.quota_resolver import QuotaResourceStatus
+
+        app = authenticated_usage_client.app
+        app.state.quota_resolver.get_resource_status = AsyncMock(
+            return_value=QuotaResourceStatus(limited=False, code_usage_billing_active=billing_active)
+        )
+
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        assert response.json()["code_usage_billed"] is billing_active
+
     def test_invalidate_plan_cache_calls_resolver(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.invalidate = AsyncMock()


### PR DESCRIPTION
## Problem

PostHog Code's billing UI needs to know whether the caller's org is subscribed to Code usage billing (payment method on file): it picks the usage-based billing copy ("add a payment method" vs "raise your billing limit") and decides whether to show the free-tier usage meter — subscribed orgs have no per-user caps to meter. The usage endpoint the app already polls doesn't carry that bit.

**Why:** cutover dependency for the PostHog Code usage-based billing client work; the desktop app reads this field (optional in its schema, so either side can ship first).

## Changes

`GET /v1/usage/{product}` now returns `code_usage_subscribed`, carrying the same `code_usage_billing_active` bit the endpoint already resolves for enforcement (#70946) — the org's subscription status (a payment method puts the org on the paid `posthog_code_usage` plan, whose product feature this reflects) — so the client's billing copy can never disagree with what a request would do. Additive with a `False` default; all existing consumers parse leniently. `is_pro` keeps its seat semantics untouched.

## How did you test this code?

Automated only: `tests/test_usage.py` (37 passed) including a parametrized case pinning `code_usage_subscribed` to the resolver's billing bit for both values — catches the field being dropped or wired to anything other than the enforcement bit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*