### PR TITLE
fix(surveys): serve hosted survey stylesheet from raw static path

### DIFF
--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -9,10 +9,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon-16x16.png?v=2023-07-07">
     <link rel="mask-icon" href="/static/icons/safari-pinned-tab.svg?v=2023-07-07" color="#FF053C">
     <link rel="manifest" href="/static/site.webmanifest?v=2023-07-07">
-    {% comment %}
-    Reference the raw path, not the static templatetag: this file ships via frontend/public/ and is
-    served unhashed, so the manifest-hashed URL the static templatetag produces 404s in production.
-    {% endcomment %}
+    {# Raw path, not the static tag: frontend/public/ ships unhashed, so a manifest-hashed URL 404s. #}
     <link rel="stylesheet" href="/static/surveys/hosted-survey.css?v=1">
     <meta name="apple-mobile-web-app-title" content="{{ name }}">
     <meta name="application-name" content="{{ name }}">

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -1,4 +1,3 @@
-{% load static %}
 <!DOCTYPE html>
 <html lang="{{ display_language|default:'en' }}"{% if embed_mode %} class="embed-mode"{% endif %}>
 
@@ -10,7 +9,11 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon-16x16.png?v=2023-07-07">
     <link rel="mask-icon" href="/static/icons/safari-pinned-tab.svg?v=2023-07-07" color="#FF053C">
     <link rel="manifest" href="/static/site.webmanifest?v=2023-07-07">
-    <link rel="stylesheet" href="{% static 'surveys/hosted-survey.css' %}">
+    {% comment %}
+    Reference the raw path, not the static templatetag: this file ships via frontend/public/ and is
+    served unhashed, so the manifest-hashed URL the static templatetag produces 404s in production.
+    {% endcomment %}
+    <link rel="stylesheet" href="/static/surveys/hosted-survey.css?v=1">
     <meta name="apple-mobile-web-app-title" content="{{ name }}">
     <meta name="application-name" content="{{ name }}">
     <title>{{ name }}</title>


### PR DESCRIPTION
## Problem

The hosted (external) survey page renders unstyled and the browser console shows:

> Refused to apply style from `.../static/surveys/hosted-survey.<hash>.css` because its MIME type (`text/html`) is not a supported stylesheet MIME type, and strict MIME checking is enabled.

The template links its stylesheet with the `{% static %}` templatetag, which resolves to the manifest-hashed filename (`hosted-survey.<hash>.css`). But `hosted-survey.css` ships through `frontend/public/`, which the frontend build copies into the bundle **unhashed**, and only that raw filename is served in production. So the hashed URL 404s, the CDN returns an HTML error page, and strict MIME checking rejects it as a stylesheet. Every sibling asset in the same template (icons, webmanifest) already sidesteps this by using raw `/static/...` paths — the stylesheet line was the lone exception.

Reported from a hosted survey on maintenance-mode Surveys.

## Changes

Reference the stylesheet at its raw `/static/surveys/hosted-survey.css` path (with a `?v=` cache-buster) instead of via the `{% static %}` manifest lookup, matching the sibling `<link>` tags. Dropped the now-unused `{% load static %}`.

The CSS has no `url()`/`@import` references, so it never relied on manifest URL rewriting.

## How did you test this code?

- Verified against production: the hashed URL `hosted-survey.<hash>.css` returns `404` (`content-type: text/html`, nginx error page) while the raw `hosted-survey.css` returns `200 text/css`, and confirmed the manifest hash matches the md5 of both the deployed file and the repo source (so the manifest is correct — the hashed variant simply isn't served).
- Rendered `surveys/public_survey.html` through Django's template engine standalone: it parses and renders, emits `<link rel="stylesheet" href="/static/surveys/hosted-survey.css?v=1">`, and the explanatory `{% comment %}` block is stripped server-side (not leaked to the HTML output).
- No automated test suite was run in this environment (Django not installed in the session; validated with a throwaway Django install for template lexing only).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and authored by the PostHog Slack app (Claude). Diagnosed by fetching the live survey page and its stylesheet to confirm the 404/MIME mismatch, tracing `{% static %}` → `CompressedManifestStaticFilesStorage` in `posthog/settings/web.py`, and confirming `frontend/public/` assets are copied unhashed by `frontend/build.mjs`. Invoked the `/debugging-surveys` skill. Considered fixing the static pipeline to serve hashed `frontend/public/` assets, but that's an infra-wide change; matching the template's existing raw-path convention is the minimal, verifiable fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1784145410961869?thread_ts=1784145410.961869&cid=C07QD3LT8U9)*