### PR TITLE
fix(posthog-ai): tolerate trailing punctuation in ticket topic parsing

### DIFF
--- a/frontend/src/scenes/max/ticketUtils.test.ts
+++ b/frontend/src/scenes/max/ticketUtils.test.ts
@@ -54,7 +54,19 @@ describe('ticketUtils', () => {
             ['bold topic line with valid area', 'Issue: foo\n\n**Topic:** data_warehouse', 'data_warehouse'],
             ['plain topic line with valid area', 'Issue: foo\n\nTopic: session_replay', 'session_replay'],
             ['case and whitespace variations', 'Issue: foo\n\ntopic:   Data_Warehouse  ', 'data_warehouse'],
+            ['trailing period is stripped', 'Issue: foo\n\nTopic: session_replay.', 'session_replay'],
+            [
+                'trailing parenthetical is ignored',
+                'Issue: foo\n\n**Topic:** data_warehouse (Stripe integration)',
+                'data_warehouse',
+            ],
+            [
+                'trailing comma and prose are ignored',
+                'Issue: foo\n\nTopic: feature_flags, most likely',
+                'feature_flags',
+            ],
             ['unknown area is rejected', 'Issue: foo\n\nTopic: quantum_computing', null],
+            ['unknown area with trailing prose is rejected', 'Issue: foo\n\nTopic: quantum_computing (maybe)', null],
             ['no topic line', 'Issue: foo\n\nStatus: bar', null],
             ['topic mentioned mid-sentence is ignored', 'Issue: the topic: billing came up in chat', null],
         ])('%s', (_name, content, expected) => {

--- a/frontend/src/scenes/max/ticketUtils.ts
+++ b/frontend/src/scenes/max/ticketUtils.ts
@@ -23,7 +23,13 @@ export function parseTicketTargetArea(content: string): SupportTicketTargetArea 
         const line = rawLine.replace(/\*/g, '').trim()
         const match = line.match(/^topic:\s*(.+)$/i)
         if (match) {
-            const area = match[1].trim().toLowerCase()
+            // Keys are single whitespace-free tokens, so take the first token and strip trailing
+            // punctuation — the model sometimes appends a period or parenthetical
+            const area = match[1]
+                .trim()
+                .split(/\s+/)[0]
+                .replace(/[.,;:!?)\]]+$/, '')
+                .toLowerCase()
             if (TARGET_AREA_OPTIONS.some((option) => option.value === area)) {
                 return area as SupportTicketTargetArea
             }


### PR DESCRIPTION
## Problem

Follow-up to [#71288](https://github.com/PostHog/posthog/pull/71288), addressing a reviewer note from that PR's approval. `parseTicketTargetArea()` required the entire post-`Topic:` remainder to equal a target-area key exactly, so model chattiness like a trailing period or parenthetical failed validation:

```
**Topic:** data_warehouse (Stripe integration)  →  analytics
**Topic:** session_replay.                      →  analytics
```

Because unknown output now falls back to the `analytics` default, a chatty-but-correct classification silently reintroduces the misroute #71288 exists to fix. And since the live summarizer couldn't be exercised locally, this wouldn't surface until prod.

## Changes

Every valid target-area key is a single whitespace-free token, so the parser now takes the first whitespace-delimited token and strips trailing punctuation (`. , ; : ! ? ) ]`) before validating. Validation itself is unchanged, still an exact match against `TARGET_AREA_OPTIONS`, so the set of accepted keys is identical; only noisy-but-valid outputs now survive. Hyphenated keys (`setup-wizard`, `posthog-ai`, `llm-analytics`) are unaffected since the strip class contains no hyphen or underscore.

## How did you test this code?

TDD: added three parameterized Jest cases (trailing period, trailing parenthetical, trailing comma + prose) plus a negative case (unknown key with trailing prose still rejected), confirmed them red, then implemented. These catch the regression no prior test did: a valid key followed by punctuation or prose being silently discarded. Full `ticketUtils` suite passes 13/13. Not manually tested against the live summarizer, same local API-key limitation as #71288.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe this internal parsing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) with Steven directing, in the same session that produced #71288. The issue was raised in the team-support approval review on #71288 (itself citing a Claude review), and my own pre-commit code review of #71288 had flagged the same edge as "acceptable" — the fallback change from null to analytics is what turned it into a real misroute risk. Skills invoked: `/writing-tests`. A code-reviewer subagent approved this change, verifying all 38 target-area keys are single-token and unaffected by the punctuation strip.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
