### PR TITLE
feat(data-warehouse): flag self-managed sources in the source catalog

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
@@ -59,7 +59,14 @@ const SourceTile = memo(function SourceTile({
                         </LemonButton>
                     </>
                 ) : (
-                    <SourceReleaseTag releaseStatus={item.releaseStatus} />
+                    <div className="flex flex-wrap items-center gap-1">
+                        {item.selfManaged && (
+                            <Tooltip title="Self-managed: your files stay in your own bucket and PostHog queries them there. The managed version copies the data into PostHog on a schedule.">
+                                <LemonTag type="muted">Self-managed</LemonTag>
+                            </Tooltip>
+                        )}
+                        <SourceReleaseTag releaseStatus={item.releaseStatus} />
+                    </div>
                 )}
             </div>
         </>

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
@@ -67,6 +67,8 @@ export interface CatalogItem {
     url: string
     disabledReason?: string | null
     existingSource?: boolean
+    /** Self-managed: the user keeps the data in their own bucket, PostHog only links to it. */
+    selfManaged?: boolean
 }
 
 export interface CatalogCategory {
@@ -177,6 +179,7 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                         keywords: MANUAL_SOURCE_KEYWORDS[source.type] ?? [],
                         status: 'stable',
                         url: urls.dataWarehouseSourceNew(source.type),
+                        selfManaged: true,
                     })
                 )
 


### PR DESCRIPTION
## Problem

The new-source catalog lists managed and self-managed sources side by side. When both versions of a store exist, the tiles are nearly indistinguishable: search "s3" and you get "S3" (self-managed, links files in your bucket) right next to "Amazon S3" (managed connector, copies data on a schedule). Nothing on the tile says which is which, and they both land in the File storage category, so they always show up together.

## Changes

Self-managed tiles now carry a muted "Self-managed" tag, with a tooltip spelling out the difference.

- `CatalogItem` gets an optional `selfManaged` flag, set only on the `manualConnectors` branch (`aws`, `google-cloud`, `cloudflare-r2`, `azure`).
- Managed sources come from `SourceConfig` via the wizard API and never set it, so no source-specific branching leaked into the shared tile.
- The tag renders next to `SourceReleaseTag`. The coming-soon branch is untouched: self-managed sources are always `stable`, so the two paths never overlap.

Not done here: the managed side has no counterpart label. Tagging one side reads fine when both are visible, but a lone Stripe tile is implicitly managed. Happy to add a "Managed" tag for symmetry if reviewers want it.

## How did you test this code?

Automated only, both run by the agent:

- `hogli test products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts` – 5 passed.
- `tsc --noEmit` on the frontend project, clean for both touched files.

No new tests. The change is a presentational tag driven by a flag set on one already-covered branch, and I couldn't name a realistic regression the existing catalog tests miss. No manual browser check was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. No user-facing behavior beyond the tile label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I had Claude (Claude Code, Opus 4.8) do this one. It scouted the catalog first, which mattered: self-managed sources never pass through `SourceConfig`, they're a hardcoded frontend list (`manualLinkSources`) that `sourceCatalogLogic` patches category, keywords, and icons onto. So the flag had to live on the catalog view model, not on the source config.

Rejected along the way: keying the tile off a source-name check, and adding "self-managed" search keywords (out of scope). Kept the diff to the two files that actually needed it.
