### PR TITLE
fix(square): repeat original query params on paginated requests

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/square/square.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/square/square.py
@@ -195,9 +195,10 @@ def get_rows(
 
     restarts_remaining = MAX_CURSOR_RESTARTS
     while True:
-        # Square encodes the original query in the cursor, so subsequent pages are
-        # requested with the cursor alone — re-sending filters/sort can error.
-        params = {"cursor": cursor} if cursor else initial_params
+        # Square ties a cursor to the exact query it was issued for, so every follow-up
+        # request must repeat the original params and add the cursor. Sending the cursor
+        # alone drops sort/filter/limit, which Square rejects as an incompatible cursor.
+        params = {**initial_params, "cursor": cursor} if cursor else initial_params
         try:
             data = fetch_page(params)
         except SquareInvalidCursorError:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/square/test_square.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/square/test_square.py
@@ -205,10 +205,12 @@ class TestGetRowsPagination:
         ]
         sent_params = self._drive("payments", manager, responses)
 
-        # First request carries the query params; subsequent pages carry cursor only.
-        assert "cursor" not in sent_params[0]
-        assert sent_params[1] == {"cursor": "cur-1"}
-        assert sent_params[2] == {"cursor": "cur-2"}
+        # First request carries the query params; follow-up pages repeat them unchanged
+        # and add the cursor. Square rejects a cursor sent with a changed parameter set.
+        base = {"sort_order": "ASC", "limit": "50"}
+        assert sent_params[0] == base
+        assert sent_params[1] == {**base, "cursor": "cur-1"}
+        assert sent_params[2] == {**base, "cursor": "cur-2"}
 
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [SquareResumeConfig(cursor="cur-1"), SquareResumeConfig(cursor="cur-2")]
@@ -221,7 +223,7 @@ class TestGetRowsPagination:
         responses = [_make_response({"payments": [{"id": "p9"}]})]
         sent_params = self._drive("payments", manager, responses)
 
-        assert sent_params == [{"cursor": "cur-resumed"}]
+        assert sent_params == [{"sort_order": "ASC", "limit": "50", "cursor": "cur-resumed"}]
         manager.load_state.assert_called_once()
 
     def test_terminal_single_page_does_not_save_state(self) -> None:
@@ -264,10 +266,12 @@ class TestGetRowsPagination:
         sent_params = self._drive("customers", manager, responses)
 
         # First request uses the stale cursor and is rejected; the retry drops the
-        # cursor and re-issues the original query, then pages normally.
-        assert sent_params[0] == {"cursor": "stale-cursor"}
-        assert "cursor" not in sent_params[1]
-        assert sent_params[2] == {"cursor": "cur-1"}
+        # cursor and re-issues the original query, then pages normally. Every request
+        # carries the original query params, with the cursor added on follow-ups.
+        base = {"sort_field": "CREATED_AT", "sort_order": "ASC", "limit": "50"}
+        assert sent_params[0] == {**base, "cursor": "stale-cursor"}
+        assert sent_params[1] == base
+        assert sent_params[2] == {**base, "cursor": "cur-1"}
 
     def test_invalid_cursor_restart_evicts_stale_cursor_within_single_page(self) -> None:
         # When the restart finishes within a single page there's no fresh next_cursor
@@ -301,7 +305,7 @@ class TestGetRowsPagination:
         sent_params = self._drive("payments", manager, responses)
 
         assert "cursor" not in sent_params[0]
-        assert sent_params[1] == {"cursor": "cur-1"}
+        assert sent_params[1] == {"sort_order": "ASC", "limit": "50", "cursor": "cur-1"}
         # The restart drops the cursor and seeds begin_time from the last seen created_at
         # rather than issuing a bare full restart.
         assert "cursor" not in sent_params[2]
@@ -325,9 +329,10 @@ class TestGetRowsPagination:
         sent_params = self._drive("customers", manager, responses)
 
         # stale cursor rejected -> restart -> page (cur-1) -> cur-1 rejected -> restart -> final page.
-        assert sent_params[0] == {"cursor": "stale-cursor"}
+        base = {"sort_field": "CREATED_AT", "sort_order": "ASC", "limit": "50"}
+        assert sent_params[0] == {**base, "cursor": "stale-cursor"}
         assert "cursor" not in sent_params[1]
-        assert sent_params[2] == {"cursor": "cur-1"}
+        assert sent_params[2] == {**base, "cursor": "cur-1"}
         assert "cursor" not in sent_params[3]
 
     def test_invalid_cursor_gives_up_after_restart_budget_exhausted(self) -> None:


### PR DESCRIPTION
## Problem

Square imports were failing with `SquareInvalidCursorError: Square rejected the pagination cursor for customers`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f676d-fc02-7940-a4a3-54260729bcac)). The failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/square/square.py` (`fetch_page`), reached from the normal import path (`get_rows` → `fetch_page`).

Root cause is our pagination, not the customer's credentials or config. Square ties a pagination cursor to the exact query it was issued for. Their own guidance is blunt about it: "All the request parameters must be the same or the cursor will not work." We were doing the opposite. On the first page we send the query params (`sort_field`, `sort_order`, `limit`); on every follow-up page we sent the cursor *alone*, dropping those params. That parameter change makes Square reject the cursor as incompatible (a 400 with `field: cursor`), which our `_is_invalid_cursor_error` classifies as an invalid cursor.

Because the mismatch is deterministic, the in-code restart loop just re-hits it on page 2 every time, burns through the restart budget, and re-raises. This bites any stream that spans more than one page, which is why `customers` (no server-side time filter, so a full multi-page scan) is where it shows up.

## Changes

In `get_rows`, follow-up page requests now repeat the original query params and add the cursor, instead of sending the cursor by itself:

```diff
-        params = {"cursor": cursor} if cursor else initial_params
+        params = {**initial_params, "cursor": cursor} if cursor else initial_params
```

This matches Square's contract: identical params across every page of a paginated query, cursor added on follow-ups. Sending the same params plus the cursor is the documented-correct approach for their GET list endpoints, so it fixes `customers` without changing behavior for `payments`/`refunds` (whose params, including `begin_time`, are likewise carried through unchanged).

> [!NOTE]
> This does not touch the retry policy. Genuine cursor expiry (Square's ~5 minute cursor lifetime) is still handled by the existing restart-and-resume logic.

## How did you test this code?

Updated the `TestGetRowsPagination` unit tests to assert that follow-up requests repeat the original params and add the cursor (they previously asserted the cursor-alone behavior, i.e. they encoded the bug). These now catch a regression back to cursor-alone. Covered both a full-refresh stream (`customers`) and the incremental streams (`payments`), including the invalid-cursor restart and last-seen reseed paths.

I (Claude) could not run the suite in this environment (Django isn't installed here), so I verified the exact params each request sends by tracing `get_rows`/`_build_initial_params` control flow against the responses each test feeds in. `ruff check` passes. CI will run the tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) confirmed the issue in PostHog error tracking (full stack trace, exception type, affected sources, recency), read the Square source implementation and the import pipeline's error-handling path, then classified it: not a credentials/config/upstream error (so not a `NonRetryableErrors` addition), but a real pagination bug in our code.

I verified the root cause against Square's official pagination guide and a Square staff forum answer ("All the request parameters must be the same or the cursor will not work") before changing the request shape, since the existing code comment claimed the opposite. Kept the change scoped to the request-params construction; deliberately left the retry/restart machinery and cursor-expiry handling alone. Checked for duplicate open PRs (by exception type, message phrase, source path, and the source maintainer's open PRs) and found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
