### PR TITLE
feat(surveys): let Max create hosted (external) surveys

### DIFF
--- a/products/surveys/backend/max_tools.py
+++ b/products/surveys/backend/max_tools.py
@@ -220,21 +220,26 @@ def _build_targeting_conditions(
 
 
 SURVEY_CREATION_TOOL_DESCRIPTION = dedent("""
-    Create and optionally launch an in-app survey.
+    Create and optionally launch a survey.
 
     # When to use
     - The user wants to create a new survey
     - The user mentions NPS, CSAT, PMF, or feedback surveys
+    - The user wants a hosted survey with a shareable link
 
     # Design principles
-    These are in-app surveys shown as overlays. Keep to 1-3 questions.
-    DO NOT set should_launch=true unless the user explicitly asks to launch.
+    Keep to 1-3 questions. DO NOT set should_launch=true unless the user explicitly asks to launch.
 
     # Survey types
-    - "popover" (default): small overlay that appears on the page — use this for most surveys
-    - "widget": persistent tab/button on the page edge, good for always-available feedback
+    - "popover" (default): small in-app overlay that appears on the page — use this for most surveys
+    - "widget": persistent in-app tab/button on the page edge, good for always-available feedback
+    - "external_survey": a hosted standalone page with a shareable public link — use this when the
+      user wants to send a survey via a link (email, social, QR code) rather than show it inside their app
     - "api": headless, no UI — for custom implementations only
-    Note: hosted surveys (standalone pages with a shareable link) are not yet supported by this tool. If a user asks, let them know it's coming soon.
+
+    # Targeting
+    Targeting (target_url, feature flags, device types, wait period) only applies to in-app surveys.
+    It does not apply to "external_survey" hosted surveys and is ignored for them.
 
     # Semantic question types
     - "nps": 0-10 numeric rating (Net Promoter Score)
@@ -258,7 +263,9 @@ class CreateSurveyToolArgs(BaseModel):
     name: str = Field(description="Survey name")
     description: str = Field(default="", description="Brief survey description")
     questions: list[SimpleSurveyQuestion] = Field(description="List of questions")
-    survey_type: Literal["popover", "widget", "api"] = Field(default="popover", description="Survey display type")
+    survey_type: Literal["popover", "widget", "external_survey", "api"] = Field(
+        default="popover", description="Survey display type"
+    )
     should_launch: bool = Field(default=False, description="Launch immediately after creation")
     target_url: str | None = Field(default=None, description="URL path to target (e.g. '/pricing')")
     target_url_match: Literal["exact", "contains", "regex"] | None = Field(
@@ -313,15 +320,20 @@ class CreateSurveyTool(MaxTool):
             "enable_partial_responses": True,
         }
 
-        if linked_flag_id is not None:
-            survey_data["linked_flag_id"] = linked_flag_id
-
         if responses_limit is not None:
             survey_data["responses_limit"] = responses_limit
 
-        conditions = _build_targeting_conditions(target_url, target_url_match, linked_flag_variant, wait_period_days)
-        if conditions:
-            survey_data["conditions"] = conditions
+        # Hosted (external) surveys are standalone pages with no in-app display context, so the
+        # backend rejects flag/URL/device targeting on them. Skip targeting entirely for those.
+        if survey_type != Survey.SurveyType.EXTERNAL_SURVEY:
+            if linked_flag_id is not None:
+                survey_data["linked_flag_id"] = linked_flag_id
+
+            conditions = _build_targeting_conditions(
+                target_url, target_url_match, linked_flag_variant, wait_period_days
+            )
+            if conditions:
+                survey_data["conditions"] = conditions
 
         if self.context.get("insight_id"):
             survey_data["linked_insight_id"] = self.context["insight_id"]
@@ -374,7 +386,18 @@ class CreateSurveyTool(MaxTool):
                 survey_url = f"/surveys/guided/{survey_id}"
             else:
                 survey_url = f"/surveys/{survey_id}?edit=true"
-            return f"Survey '{created_survey.name}' created{launch_msg} successfully! [View survey]({survey_url})", {
+
+            message = f"Survey '{created_survey.name}' created{launch_msg} successfully! [View survey]({survey_url})"
+            if survey_type == Survey.SurveyType.EXTERNAL_SURVEY:
+                # The public shareable link only works once the survey is running.
+                share_hint = (
+                    "Its public shareable link is on the survey page."
+                    if should_launch
+                    else "Launch it to activate its public shareable link, which you'll find on the survey page."
+                )
+                message = f"{message} {share_hint}"
+
+            return message, {
                 "survey_id": created_survey.id,
                 "survey_name": created_survey.name,
                 "survey_type": survey_type,

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -346,6 +346,54 @@ class TestSurveyCreatorTool(BaseTest):
 
     @pytest.mark.django_db
     @pytest.mark.asyncio
+    async def test_create_external_survey(self):
+        tool = self._setup_tool()
+
+        content, artifact = await tool._arun_impl(
+            name="Hosted Feedback",
+            questions=[SimpleSurveyQuestion(type="open", question="How was your experience?")],
+            survey_type="external_survey",
+        )
+
+        assert "successfully" in content
+        assert "shareable link" in content
+        assert artifact["survey_type"] == "external_survey"
+
+        survey = await sync_to_async(Survey.objects.get)(id=artifact["survey_id"])
+        assert survey.type == "external_survey"
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_create_external_survey_ignores_in_app_targeting(self):
+        tool = self._setup_tool()
+
+        # Targeting is invalid for external surveys server-side; the tool must drop it rather than
+        # pass it through and trigger a validation error.
+        flag = await sync_to_async(FeatureFlag.objects.create)(
+            team=self.team,
+            key="hosted-flag",
+            name="Hosted Flag",
+            created_by=self.user,
+        )
+
+        content, artifact = await tool._arun_impl(
+            name="Hosted Feedback",
+            questions=[SimpleSurveyQuestion(type="open", question="How was your experience?")],
+            survey_type="external_survey",
+            target_url="/pricing",
+            target_url_match="contains",
+            linked_flag_id=flag.id,
+            wait_period_days=7,
+        )
+
+        assert "successfully" in content
+        survey = await sync_to_async(Survey.objects.get)(id=artifact["survey_id"])
+        assert survey.type == "external_survey"
+        assert survey.linked_flag_id is None
+        assert not survey.conditions
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
     async def test_create_survey_sanitizes_question_html(self):
         tool = self._setup_tool()
 


### PR DESCRIPTION
## Problem

A user asked PostHog AI (Max) in survey mode to create a hosted survey (a standalone page with a shareable link) and hit a hard "not yet supported" message. But hosted (`external_survey`) surveys are fully supported everywhere else — the backend model, the DRF API, and the MCP survey tool all accept them. Only the Max survey-creation tool artificially restricted itself to `popover` / `widget` / `api`.

## Changes

- Add `external_survey` to the accepted `survey_type` values on the survey-creation MaxTool.
- Rewrite the tool description so hosted surveys are a documented option (link/email/social/QR use case) instead of a "coming soon" dead end.
- Skip in-app targeting (URL match, linked feature flag, device types, wait period) for hosted surveys — the backend rejects those fields on external surveys, so the tool now drops them rather than passing them through and failing validation.
- Tailor the success message for hosted surveys to point at where the public shareable link lives (and note it activates once the survey is launched).

## How did you test this code?

Added two backend unit tests to `TestSurveyCreatorTool`:
- `test_create_external_survey` — a hosted survey is created with `type == "external_survey"` and the response mentions the shareable link.
- `test_create_external_survey_ignores_in_app_targeting` — passing URL/flag/wait-period targeting alongside `external_survey` creates the survey with no `linked_flag` and empty `conditions`, rather than erroring.

The tests are modeled directly on the existing passing tests in the same file. I was not able to run the test suite in this environment (the PostHog dev stack / database isn't installed here), so they have not been executed locally — please rely on CI. `ruff format` passes on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread where a user reported Max refusing to create a hosted survey. Traced the restriction to `products/surveys/backend/max_tools.py` (the `create_survey` MaxTool), confirmed `external_survey` is already accepted by the backend serializer (`products/surveys/backend/api/survey.py`) and the MCP tool, and verified the external-survey validation rules (prohibited targeting/appearance fields) to decide that the tool should silently drop in-app targeting for hosted surveys rather than surface an error. Consulted the `debugging-surveys` skill for repo/context orientation. Did not run a migration; no schema change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1784147394131219)*
