### PR TITLE
feat(review-hog): trigger reviews via pull_request_target

### DIFF
--- a/.github/workflows/review-hog.yml
+++ b/.github/workflows/review-hog.yml
@@ -9,12 +9,13 @@
 # here — the only secret is the shared trigger token. Publishing happens server-side via the PostHog
 # GitHub App installation token.
 #
-# Safety: `pull_request` (not `pull_request_target`) means fork PRs receive no secrets, so they cannot
-# trigger; the `if:` also hard-gates forks; and applying the label needs write access.
+# Safety: `pull_request_target` always runs the base branch's version of this file, so a PR cannot
+# edit its own trigger, and it fires even when the PR has merge conflicts. It does expose secrets to
+# fork PRs, so the `if:` hard-gates forks — safe because this job never checks out or runs PR code.
 name: ReviewHog
 
 on:
-    pull_request:
+    pull_request_target:
         types: [labeled]
 
 # No GitHub permissions needed — the job only makes an outbound authenticated request; the review is
@@ -45,7 +46,7 @@ jobs:
                   PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
                   if [ -z "$REVIEWHOG_TRIGGER_TOKEN" ]; then
-                    echo "::error::REVIEWHOG_TRIGGER_TOKEN secret is not set (or unavailable on a fork PR)." >&2
+                    echo "::error::REVIEWHOG_TRIGGER_TOKEN secret is not set." >&2
                     exit 1
                   fi
                   payload="$(jq -n --arg repo "$REPO" --argjson pr "$PR_NUMBER" '{repo: $repo, pr_number: $pr}')"

--- a/.github/workflows/review-hog.yml
+++ b/.github/workflows/review-hog.yml
@@ -18,8 +18,8 @@ on:
     pull_request_target:
         types: [labeled]
 
-# No GitHub permissions needed — the job only makes an outbound authenticated request; the review is
-# fetched and published server-side via the PostHog GitHub App installation token.
+# No GitHub permissions by default — the trigger job only makes an outbound authenticated request;
+# the review is fetched and published server-side via the PostHog GitHub App installation token.
 permissions: {}
 
 concurrency:
@@ -58,3 +58,27 @@ jobs:
                     -H "Authorization: Bearer $REVIEWHOG_TRIGGER_TOKEN" \
                     -H "Content-Type: application/json" \
                     -d "$payload"
+
+    # The trigger job skips bot-applied labels silently; explain why and strip the label so a
+    # human can re-add it deliberately.
+    bot-labeler-skip:
+        name: Explain skipped bot label
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            issues: write
+        if: >-
+            github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+            && github.event.sender.type == 'Bot'
+            && github.event.label.name == 'reviewhog'
+        steps:
+            - name: Comment and strip label
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  set -euo pipefail
+                  gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+                    -f body="ReviewHog reviews start only when a human adds the \`reviewhog\` label, so this bot-applied label was removed. Re-add it yourself to start a review."
+                  gh api -X DELETE "repos/$REPO/issues/$PR_NUMBER/labels/reviewhog"

--- a/.github/workflows/review-hog.yml
+++ b/.github/workflows/review-hog.yml
@@ -14,6 +14,8 @@
 # fork PRs, so the `if:` hard-gates forks — safe because this job never checks out or runs PR code.
 name: ReviewHog
 
+# Sanctioned use — no job checks out or runs PR code; see the Safety note above.
+# nosemgrep: github-actions-pull-request-target
 on:
     pull_request_target:
         types: [labeled]

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -2157,10 +2157,12 @@ github-actions[bot] trick), and its Action carries **one** secret (no Anthropic 
    the review is **pinned to the reviewed `head_sha`** via `commit=repo_obj.get_commit(head_sha)`. Fork rejection is
    authoritative in the **fetch activity** (`PRMetadata.is_fork`, non-retryable `ApplicationError` before the report
    row is created).
-4. ✅ **The Action:** `.github/workflows/review-hog.yml` — `on: pull_request [labeled]`,
+4. ✅ **The Action:** `.github/workflows/review-hog.yml` — `on: pull_request_target [labeled]`,
    `permissions: {}`, per-PR concurrency, `if:` gates (human-applied label + non-fork; any author — unmapped authors
-   resolve via the acting-user fallback), one `curl` with the bearer secret. `pull_request` (not
-   `pull_request_target`) ⇒ forks get no secret ⇒ can't trigger.
+   resolve via the acting-user fallback), one `curl` with the bearer secret. `pull_request_target` runs the base
+   branch's version of the file (a PR can't edit its own trigger) and fires even on conflicted PRs; it exposes
+   secrets to fork PRs, so the non-fork `if:` gate is the fork barrier — safe because the job never runs PR code.
+   Residual gap: stacked PRs whose base branch predates this file still dispatch nothing (no workflow on the base).
    **2026-07-14 update:** `synchronize` dropped (ADR 0002) — pushes no longer re-trigger; re-review = re-add the
    label (or mark an already-labeled draft ready).
 5. ⏳ **Later (v2):** label lifecycle (strip-on-non-approval / keep-on-error / dismiss-stale-on-push). (`synchronize` /

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -2163,8 +2163,10 @@ github-actions[bot] trick), and its Action carries **one** secret (no Anthropic 
    branch's version of the file (a PR can't edit its own trigger) and fires even on conflicted PRs; it exposes
    secrets to fork PRs, so the non-fork `if:` gate is the fork barrier — safe because the job never runs PR code.
    Residual gap: stacked PRs whose base branch predates this file still dispatch nothing (no workflow on the base).
+   A paired `bot-labeler-skip` job (Stamphog's pattern) turns the bot-labeler skip into feedback: it comments why
+   and strips the label so a human can re-add it.
    **2026-07-14 update:** `synchronize` dropped (ADR 0002) — pushes no longer re-trigger; re-review = re-add the
-   label (or mark an already-labeled draft ready).
+   label.
 5. ⏳ **Later (v2):** label lifecycle (strip-on-non-approval / keep-on-error / dismiss-stale-on-push). (`synchronize` /
    `ready_for_review` events are already wired in step 4.) Then **Stage 5b** (iterate-on-same-PR validation).
 

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -175,6 +175,10 @@ def _find_marker_comment(
         installation_id=installation_id,
         endpoint="/repos/{owner}/{repo}/issues/{issue_number}/comments",
     ):
+        # Adopt only app-bot comments: anyone can paste the marker on a public repo, and the
+        # returned id gets PATCHed — matching a stranger's comment would overwrite it.
+        if (comment.get("user") or {}).get("type") != "Bot":
+            continue
         if marker in (comment.get("body") or ""):
             return comment.get("id")
     return None

--- a/products/review_hog/backend/tests/test_status_comment.py
+++ b/products/review_hog/backend/tests/test_status_comment.py
@@ -201,13 +201,16 @@ class TestEnsureStatusComment(BaseTest):
         self, mock_request: MagicMock, mock_paginated: MagicMock, mock_integration: MagicMock
     ) -> None:
         # Crash between POST and saving the id: the marker scan must find the orphan, or every retry
-        # posts a duplicate status comment.
+        # posts a duplicate status comment. It must only adopt app-bot comments — a human comment
+        # carrying a pasted marker would otherwise get clobbered by the next edit.
         _wire_auth(mock_integration)
         report = self._report()
+        marker = status_marker(str(report.id))
         mock_paginated.return_value = iter(
             [
-                {"id": 1, "body": "unrelated"},
-                {"id": 888, "body": f"hello\n{status_marker(str(report.id))}"},
+                {"id": 1, "body": "unrelated", "user": {"login": "someone", "type": "User"}},
+                {"id": 7, "body": f"pasted copy: {marker}", "user": {"login": "prankster", "type": "User"}},
+                {"id": 888, "body": f"hello\n{marker}", "user": {"login": "posthog[bot]", "type": "Bot"}},
             ]
         )
 


### PR DESCRIPTION
## Problem
- We weren't able to work with stacked PRs or PRs with merge conflicts

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Now we can

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
