### PR TITLE
refactor(experiments): route flag variant updates through the flag facade

### DIFF
--- a/.semgrep/rules/devex/feature-flags-no-raw-filters-access.yaml
+++ b/.semgrep/rules/devex/feature-flags-no-raw-filters-access.yaml
@@ -33,7 +33,6 @@ rules:
               - '**/migrations/**'
               # Baseline: pre-existing offenders being migrated behind the flag
               # facade. Shrink this list — never grow it.
-              - '/posthog/api/web_experiment.py'
               - '/posthog/tasks/update_survey_adaptive_sampling.py'
               - '/posthog/tasks/update_survey_iteration.py'
               - '/products/early_access_features/backend/api.py'

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 
 from posthog.test.base import APIBaseTest
@@ -378,6 +379,62 @@ class TestWebExperiment(APIBaseTest):
         # But variants changes should be present
         variant_changes = [c for c in changes if c["field"] == "variants"]
         assert len(variant_changes) == 1
+
+    @parameterized.expand(
+        [
+            ("as_created", None),
+            (
+                "release_conditions_and_payloads",
+                {
+                    "groups": [
+                        {
+                            "properties": [
+                                {"key": "email", "type": "person", "value": "@posthog.com", "operator": "icontains"}
+                            ],
+                            "rollout_percentage": 50,
+                            "variant": "test",
+                            "aggregation_group_type_index": None,
+                        },
+                        {"properties": [], "rollout_percentage": 100, "aggregation_group_type_index": None},
+                    ],
+                    "payloads": {"test": '{"color": "blue"}'},
+                },
+            ),
+            ("empty_release_conditions", {"groups": []}),
+        ]
+    )
+    def test_variant_update_round_trips_existing_flag_filters(self, _name, filters_override):
+        response = self._create_web_experiment("Round trip")
+        experiment_id = response.json()["id"]
+        web_experiment = WebExperiment.objects.get(id=experiment_id)
+        feature_flag = web_experiment.feature_flag
+        if filters_override:
+            feature_flag.filters = {**feature_flag.filters, **filters_override}
+            feature_flag.save()
+        filters_before = deepcopy(feature_flag.filters)
+
+        update_response = self.client.patch(
+            f"/api/projects/{self.team.id}/web_experiments/{experiment_id}/",
+            data={
+                "variants": {
+                    "control": {"rollout_percentage": 40},
+                    "test": {"rollout_percentage": 60},
+                },
+            },
+            format="json",
+        )
+
+        assert update_response.status_code == status.HTTP_200_OK, update_response.json()
+        feature_flag.refresh_from_db()
+        assert feature_flag.filters == {
+            **filters_before,
+            "multivariate": {
+                "variants": [
+                    {"key": "control", "rollout_percentage": 40},
+                    {"key": "test", "rollout_percentage": 60},
+                ]
+            },
+        }
 
     def test_accepts_safe_html_with_formatting(self):
         """Test that safe HTML with complex formatting is accepted and preserved"""

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, patch
@@ -380,29 +381,29 @@ class TestWebExperiment(APIBaseTest):
         variant_changes = [c for c in changes if c["field"] == "variants"]
         assert len(variant_changes) == 1
 
-    @parameterized.expand(
-        [
-            ("as_created", None),
-            (
-                "release_conditions_and_payloads",
-                {
-                    "groups": [
-                        {
-                            "properties": [
-                                {"key": "email", "type": "person", "value": "@posthog.com", "operator": "icontains"}
-                            ],
-                            "rollout_percentage": 50,
-                            "variant": "test",
-                            "aggregation_group_type_index": None,
-                        },
-                        {"properties": [], "rollout_percentage": 100, "aggregation_group_type_index": None},
-                    ],
-                    "payloads": {"test": '{"color": "blue"}'},
-                },
-            ),
-            ("empty_release_conditions", {"groups": []}),
-        ]
-    )
+    _ROUND_TRIP_FILTER_CASES: list[tuple[str, dict[str, Any] | None]] = [
+        ("as_created", None),
+        (
+            "release_conditions_and_payloads",
+            {
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "email", "type": "person", "value": "@posthog.com", "operator": "icontains"}
+                        ],
+                        "rollout_percentage": 50,
+                        "variant": "test",
+                        "aggregation_group_type_index": None,
+                    },
+                    {"properties": [], "rollout_percentage": 100, "aggregation_group_type_index": None},
+                ],
+                "payloads": {"test": '{"color": "blue"}'},
+            },
+        ),
+        ("empty_release_conditions", {"groups": []}),
+    ]
+
+    @parameterized.expand(_ROUND_TRIP_FILTER_CASES)
     def test_variant_update_round_trips_existing_flag_filters(self, _name, filters_override):
         response = self._create_web_experiment("Round trip")
         experiment_id = response.json()["id"]

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -20,7 +20,8 @@ from posthog.utils_cors import cors_response
 
 from products.experiments.backend.models.experiment import Experiment
 from products.experiments.backend.models.web_experiment import WebExperiment
-from products.feature_flags.backend.api.feature_flag import FeatureFlagSerializer
+from products.feature_flags.backend.facade.api import create_flag, update_flag
+from products.feature_flags.backend.facade.filters import replace_variant_distribution
 
 # XSS vector patterns, paired with the error message shown when one matches:
 # script tags (opening and closing), event handlers (onclick, onerror, etc.),
@@ -181,29 +182,25 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
             "multivariate": self.get_variants_for_feature_flag(validated_data),
         }
 
-        # Ensure the request method is set correctly for validation
-        self.context["request"].method = "POST"
-
-        feature_flag_serializer = FeatureFlagSerializer(
-            data={
+        team = self.context["get_team"]()
+        feature_flag = create_flag(
+            {
                 "key": self.get_feature_flag_name(validated_data.get("name", "")),
                 "name": f"Feature Flag for Experiment {validated_data['name']}",
                 "filters": filters,
                 "active": False,
                 "creation_context": "web_experiments",
             },
-            context=self.context,
+            team=team,
+            user=self.context["request"].user,
+            request=self.context["request"],
         )
-
-        feature_flag_serializer.is_valid(raise_exception=True)
-        feature_flag = feature_flag_serializer.save()
 
         # Get team's default stats method setting
         from posthog.models.team.extensions import get_or_create_team_extension
 
         from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 
-        team = Team.objects.get(id=self.context["team_id"])
         config = get_or_create_team_extension(team, TeamExperimentsConfig)
         default_method = config.default_experiment_stats_method or "bayesian"
         stats_config = {
@@ -228,21 +225,17 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
         variants = validated_data.get("variants", None)
         if variants is not None and isinstance(variants, dict):
             feature_flag = instance.feature_flag
-            filters = {
-                "groups": feature_flag.filters.get("groups", None),
-                "multivariate": self.get_variants_for_feature_flag(validated_data),
-            }
-
-            # Ensure the request method is set correctly for validation
-            self.context["request"].method = "PATCH"
-            existing_flag_serializer = FeatureFlagSerializer(
-                feature_flag,
-                data={"filters": filters},
-                partial=True,
-                context=self.context,
+            filters = replace_variant_distribution(
+                feature_flag.get_filters(),
+                self.get_variants_for_feature_flag(validated_data)["variants"],
             )
-            existing_flag_serializer.is_valid(raise_exception=True)
-            existing_flag_serializer.save()
+            update_flag(
+                feature_flag,
+                {"filters": filters},
+                team=self.context["get_team"](),
+                user=self.context["request"].user,
+                request=self.context["request"],
+            )
 
         instance = super().update(instance, validated_data)
         return instance

--- a/products/feature_flags/backend/facade/filters.py
+++ b/products/feature_flags/backend/facade/filters.py
@@ -113,6 +113,18 @@ def groups_carry_restriction_marker(current_filters: dict, *, marker_key: str) -
     return bool(groups) and all(group.get(marker_key) is True for group in groups)
 
 
+def replace_variant_distribution(current_filters: dict, variants: list[dict]) -> dict:
+    """Rebuild ``multivariate.variants`` from ``variants``, leaving every other filters key untouched.
+
+    A caller that only owns the variant distribution — e.g. web experiments syncing
+    variant rollout percentages — carries ``groups`` (release conditions), ``payloads``,
+    aggregation index, and anything else over as-is, so it can't accidentally drop flag
+    configuration it doesn't know about. ``variants`` are deepcopied so the returned
+    filters never alias the caller's dicts.
+    """
+    return {**current_filters, "multivariate": {"variants": deepcopy(variants)}}
+
+
 def set_holdout(current_filters: dict, *, holdout_id: int | None, exclusion_percentage: float | None) -> dict:
     """Set (or clear) the flag-level ``holdout`` object on the filters.
 

--- a/products/feature_flags/backend/test/test_facade.py
+++ b/products/feature_flags/backend/test/test_facade.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Any
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
@@ -357,7 +358,7 @@ class TestReplaceVariantDistribution:
         }
 
     def test_does_not_alias_input(self):
-        current_filters = {
+        current_filters: dict[str, Any] = {
             "groups": [{"properties": [], "rollout_percentage": 100}],
             "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
         }

--- a/products/feature_flags/backend/test/test_facade.py
+++ b/products/feature_flags/backend/test/test_facade.py
@@ -19,6 +19,7 @@ from products.feature_flags.backend.facade.api import (
 from products.feature_flags.backend.facade.filters import (
     group_cohort_restriction_blocker,
     groups_carry_restriction_marker,
+    replace_variant_distribution,
     restrict_groups_to_cohort,
     set_holdout,
     strip_group_cohort_restriction,
@@ -319,6 +320,54 @@ class TestFilterTransforms:
 
         assert result == {"groups": [{"properties": []}], "holdout": expected}
         assert filters["holdout"] == {"id": 1, "exclusion_percentage": 5}
+
+
+class TestReplaceVariantDistribution:
+    def test_rebuilds_variants_preserving_everything_else(self):
+        current_filters = {
+            "groups": [
+                {
+                    "properties": [
+                        {"key": "email", "type": "person", "value": "@posthog.com", "operator": "icontains"}
+                    ],
+                    "rollout_percentage": 50,
+                    "variant": "test",
+                }
+            ],
+            "payloads": {"test": '{"color": "blue"}'},
+            "multivariate": {
+                "variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ]
+            },
+            "aggregation_group_type_index": None,
+            "holdout": None,
+        }
+        new_variants = [
+            {"key": "control", "rollout_percentage": 30},
+            {"key": "test", "rollout_percentage": 70},
+        ]
+
+        result = replace_variant_distribution(current_filters, new_variants)
+
+        assert result["multivariate"] == {"variants": new_variants}
+        assert {k: v for k, v in result.items() if k != "multivariate"} == {
+            k: v for k, v in current_filters.items() if k != "multivariate"
+        }
+
+    def test_does_not_alias_input(self):
+        current_filters = {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
+        }
+        new_variants = [{"key": "control", "rollout_percentage": 100}]
+
+        result = replace_variant_distribution(current_filters, new_variants)
+        result["multivariate"]["variants"][0]["rollout_percentage"] = 0
+
+        assert new_variants == [{"key": "control", "rollout_percentage": 100}]
+        assert current_filters["multivariate"]["variants"][0]["rollout_percentage"] == 100
 
 
 class TestExperimentRuleFromFilters:


### PR DESCRIPTION
## Problem

The web experiments API builds `FeatureFlagSerializer` payloads and drives the serializer by hand when creating a flag and when syncing variant rollout percentages, digging directly into `feature_flag.filters` along the way.
Raw filters access outside the feature flags product is being burned down behind the `feature-flags-no-raw-filters-access` semgrep guard (#70128): consumers should route flag writes through the flag facade so validation, approval gating, and activity logging apply in one place, and filters-schema knowledge stays inside the flag product.

## Changes

- New pure transform `replace_variant_distribution(current_filters, variants)` in `products/feature_flags/backend/facade/filters.py`: rebuilds `multivariate.variants` from the given variants and carries every other filters key (release condition `groups`, `payloads`, aggregation index, ...) over untouched.
- `posthog/api/web_experiment.py` now routes both flag writes through the facade:
  - create path builds the same flag payload and calls `create_flag(...)`
  - update path uses `replace_variant_distribution(feature_flag.get_filters(), ...)` + `update_flag(...)` instead of rebuilding a `{"groups": ..., "multivariate": ...}` dict and driving `FeatureFlagSerializer` manually
- Dropped the `request.method` mutation hack: the facade passes the real request through, and the real methods hit the same validation branches for these payload shapes.

> [!NOTE]
> Two behavior notes on the update path.
>
> 1. The old path sent only `groups` + `multivariate` to the flag serializer, so any other filters keys (for example `payloads` added via the flag UI) were silently dropped from the flag on every web-experiment variant update. The transform now preserves them. Flags created by this API only carry the normalized keys, so their persisted outcome is unchanged.
> 2. The old path wrote `groups: None` when the flag's filters had no `groups` key at all. Verified empirically against `FeatureFlagSerializer.validate_filters` with a PATCH context: `groups: None`, `groups: []`, and absent `groups` do NOT normalize identically. `None` raises an unhandled `TypeError` (500, nothing persisted), `[]` persists empty groups, and an absent key triggers the partial-update early return (flag left untouched). The no-`groups`-key shape is unreachable through the serializer (`validate_filters` always materializes `groups`), so this only affects flags edited directly at the model level. I preserved the persisted outcome: nothing is written to the flag either way. The transform omits the key, so the previously crashing request now leaves the flag untouched instead of 500ing.

## How did you test this code?

- New parameterized round-trip test `test_variant_update_round_trips_existing_flag_filters` (as-created shape, release conditions + payloads, empty release conditions): asserts the flag's persisted filters after a web-experiment variant PATCH equal the pre-update filters with only `multivariate` rebuilt. This guards the main risk of the migration, serializer validation rejecting or normalization mangling shapes the old hand-driven path accepted. No existing test asserted the flag's persisted filters after a variant update.
- New `TestReplaceVariantDistribution` transform tests in `test_facade.py`: catch a regression where the transform drops filters keys (the old data-loss behavior) or aliases the caller's dicts.
- Ran `pytest posthog/api/test/test_web_experiment.py products/feature_flags/backend/test/test_facade.py`: 38 passed.
- Ran the `feature-flags-no-raw-filters-access` semgrep rule from #70128 with the `posthog/api/web_experiment.py` baseline exclude removed, against `posthog/api/web_experiment.py` and the facade package: 0 findings.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: internal refactor, no user-facing behavior or documented API change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Claude session linked in the commit trailer). Skills invoked: `/improving-drf-endpoints` before editing the DRF serializer, `/writing-tests` before adding tests.

Notes for reviewers:

- Stacked on #70124 (which provides `facade/filters.py` and the gated `create_flag`/`update_flag`), itself part of the #70123 facade stack, as part of the `feature-flags-no-raw-filters-access` baseline burndown.
- The baseline exclude line for `posthog/api/web_experiment.py` in the rule (#70128) gets removed at restack once the rule merges; local semgrep verification already shows 0 findings.
- The `groups: None` question was settled empirically by driving `FeatureFlagSerializer` directly with `None`/`[]`/absent `groups` on a PATCH context and observing the persisted filters (results in the note above).
