### PR TITLE
fix(oauth): derive MCP consent scopes from both tool catalogs

### DIFF
--- a/posthog/api/oauth/mcp_resource_scopes.py
+++ b/posthog/api/oauth/mcp_resource_scopes.py
@@ -14,11 +14,17 @@ from posthog.settings.base_variables import BASE_DIR
 
 logger = structlog.get_logger(__name__)
 
-# The MCP server builds its RFC 9728 `scopes_supported` from this same committed
-# artifact (services/mcp/src/tools/toolDefinitions.ts reads it too). Deriving the
-# consent list from it here keeps the authorization server's promise sourced from
-# its own state instead of a runtime fetch to the resource server.
-_TOOL_DEFINITIONS_PATH = os.path.join(BASE_DIR, "services", "mcp", "schema", "generated-tool-definitions.json")
+# The MCP server builds its RFC 9728 `scopes_supported` from these same committed
+# artifacts (services/mcp/src/tools/toolDefinitions.ts merges both). Deriving the
+# consent list from them here keeps the authorization server's promise sourced from
+# its own state instead of a runtime fetch to the resource server. Both files are
+# needed: hand-written tools (e.g. read-data-schema) live in tool-definitions.json
+# and are the only users of some scopes, so reading the generated file alone drops
+# their scopes from the consent default.
+_TOOL_DEFINITIONS_PATHS = (
+    os.path.join(BASE_DIR, "services", "mcp", "schema", "tool-definitions.json"),
+    os.path.join(BASE_DIR, "services", "mcp", "schema", "generated-tool-definitions.json"),
+)
 
 # Keep in sync with services/mcp/src/lib/routing.ts regional MCP hostnames.
 PRODUCTION_MCP_HOSTS = frozenset(
@@ -58,12 +64,14 @@ def is_trusted_posthog_mcp_resource(resource_url: str) -> bool:
 
 @lru_cache(maxsize=1)
 def _tool_required_scopes() -> frozenset[str]:
-    with open(_TOOL_DEFINITIONS_PATH) as definitions_file:
-        definitions = json.load(definitions_file)
-
-    return frozenset(
-        scope for definition in definitions.values() for scope in (definition.get("required_scopes") or [])
-    )
+    scopes: set[str] = set()
+    for path in _TOOL_DEFINITIONS_PATHS:
+        with open(path) as definitions_file:
+            definitions = json.load(definitions_file)
+        scopes.update(
+            scope for definition in definitions.values() for scope in (definition.get("required_scopes") or [])
+        )
+    return frozenset(scopes)
 
 
 def mcp_advertised_scopes() -> list[str]:

--- a/posthog/api/oauth/mcp_resource_scopes.py
+++ b/posthog/api/oauth/mcp_resource_scopes.py
@@ -64,14 +64,15 @@ def is_trusted_posthog_mcp_resource(resource_url: str) -> bool:
 
 @lru_cache(maxsize=1)
 def _tool_required_scopes() -> frozenset[str]:
-    scopes: set[str] = set()
+    # Keyed merge, later files winning — same precedence as the MCP server's
+    # getToolDefinitions() ({ ...handwritten, ...generated }), so a hand-written
+    # tool overridden by a generated one doesn't leak its scopes into consent.
+    merged: dict[str, dict] = {}
     for path in _TOOL_DEFINITIONS_PATHS:
         with open(path) as definitions_file:
-            definitions = json.load(definitions_file)
-        scopes.update(
-            scope for definition in definitions.values() for scope in (definition.get("required_scopes") or [])
-        )
-    return frozenset(scopes)
+            merged.update(json.load(definitions_file))
+
+    return frozenset(scope for definition in merged.values() for scope in (definition.get("required_scopes") or []))
 
 
 def mcp_advertised_scopes() -> list[str]:

--- a/posthog/api/oauth/test_mcp_resource_scopes.py
+++ b/posthog/api/oauth/test_mcp_resource_scopes.py
@@ -1,3 +1,7 @@
+import os
+import json
+import tempfile
+
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
@@ -63,6 +67,29 @@ class TestMcpResourceScopes(SimpleTestCase):
         self.assertIn("event_definition:read", scopes)
         self.assertIn("property_definition:read", scopes)
         self.assertGreater(len(scopes), 50)
+
+    def test_tool_required_scopes_merges_by_tool_name_with_generated_winning(self):
+        # A hand-written tool overridden by a generated one must not leak its
+        # scopes: the MCP server's getToolDefinitions() keyed merge drops the
+        # overridden definition, so a per-file scope union would advertise
+        # consent scopes no active tool requires.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            handwritten = os.path.join(tmp_dir, "handwritten.json")
+            generated = os.path.join(tmp_dir, "generated.json")
+            with open(handwritten, "w") as f:
+                json.dump({"tool": {"required_scopes": ["overridden:read"]}}, f)
+            with open(generated, "w") as f:
+                json.dump({"tool": {"required_scopes": ["active:read"]}}, f)
+
+            with patch(
+                "posthog.api.oauth.mcp_resource_scopes._TOOL_DEFINITIONS_PATHS",
+                (handwritten, generated),
+            ):
+                _tool_required_scopes.cache_clear()
+                try:
+                    self.assertEqual(_tool_required_scopes(), frozenset({"active:read"}))
+                finally:
+                    _tool_required_scopes.cache_clear()
 
     def test_build_oauth_mcp_consent_context_success(self):
         context = build_oauth_mcp_consent_context("https://mcp.posthog.com/mcp")

--- a/posthog/api/oauth/test_mcp_resource_scopes.py
+++ b/posthog/api/oauth/test_mcp_resource_scopes.py
@@ -50,13 +50,18 @@ class TestMcpResourceScopes(SimpleTestCase):
         )
 
     def test_advertised_scopes_derives_from_real_committed_catalog(self):
-        # Guards the cross-service artifact path and shape: if
-        # services/mcp/schema/generated-tool-definitions.json moves or changes
-        # structure, this fails loudly instead of silently advertising nothing.
+        # Guards the cross-service artifact paths and shape: if the files under
+        # services/mcp/schema/ move or change structure, this fails loudly
+        # instead of silently advertising nothing.
         _tool_required_scopes.cache_clear()
         scopes = mcp_advertised_scopes()
         self.assertIn("openid", scopes)
         self.assertIn("notebook:read", scopes)
+        # Required only by hand-written tools (read-data-schema in
+        # tool-definitions.json) — absent if the union reads only the
+        # generated catalog.
+        self.assertIn("event_definition:read", scopes)
+        self.assertIn("property_definition:read", scopes)
         self.assertGreater(len(scopes), 50)
 
     def test_build_oauth_mcp_consent_context_success(self):


### PR DESCRIPTION
## Problem

The MCP consent-screen scope preload from https://github.com/PostHog/posthog/pull/65601 builds its default scope list from `services/mcp/schema/generated-tool-definitions.json` only.
Hand-written MCP tools live in `services/mcp/schema/tool-definitions.json`, and `read-data-schema` is the only tool in the catalog requiring `event_definition:read` and `property_definition:read`.
Since no generated tool requires those two scopes, they were missing from the pre-filled consent list, so a client that omits `scope` on `/oauth/authorize` and accepts the defaults gets a token that cannot call `read-data-schema` (scope-blocked tools are silently hidden from `tools/list`).

Surfaced via https://github.com/PostHog/posthog/issues/71311.

## Changes

`_tool_required_scopes()` in `posthog/api/oauth/mcp_resource_scopes.py` now merges both committed catalogs (`tool-definitions.json` + `generated-tool-definitions.json`) keyed by tool name, generated definitions winning, then collects `required_scopes` from the merged set.
This matches the MCP server's `getToolDefinitions()` precedence (`{ ...handwritten, ...generated }`) exactly, so a hand-written tool overridden by a generated one doesn't leak its scopes into consent.

## How did you test this code?

Extended and added tests in `posthog/api/oauth/test_mcp_resource_scopes.py`:

- Real-catalog test now asserts `event_definition:read` and `property_definition:read` appear in `mcp_advertised_scopes()`. These scopes are required only by a hand-written tool, so this fails if the derivation ever reads only the generated catalog again (it fails against the previous implementation).
- New merge-precedence test: a tool defined in both catalogs must contribute only the generated definition's scopes. This fails if the keyed merge is ever simplified back to a per-file union, which would advertise consent scopes no active tool requires.

`pytest posthog/api/oauth/test_mcp_resource_scopes.py` - 8 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session investigating https://github.com/PostHog/posthog/issues/71311.
The reporter's `tools/list` was missing `read-data-schema`; tracing their sessions showed grants without `property_definition:read`, and reviewing the consent preload path showed the default list is built from the generated catalog only.
Skills invoked: /pr-ready, /writing-tests.
Considered reading `tool-definitions-all.json` instead (it is generated with the same precedence) - rejected because it is a docs-site build artifact, not a runtime input; the two runtime catalogs are what the MCP server itself loads.
An adversarial Codex review caught that the first version used a per-file scope union rather than the MCP server's keyed merge; fixed in the second commit.
Verified the Django image ships both files (the Dockerfile copies the whole `services/mcp/schema` directory).
