### PR TITLE
feat(skills): add is_global visibility field to LLMSkill

### DIFF
--- a/products/skills/backend/migrations/0004_llmskill_is_global.py
+++ b/products/skills/backend/migrations/0004_llmskill_is_global.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("skills", "0003_backfill_scout_category"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="llmskill",
+            name="is_global",
+            field=models.BooleanField(db_default=False, default=False),
+        ),
+    ]

--- a/products/skills/backend/migrations/0005_llmskill_global_latest_index.py
+++ b/products/skills/backend/migrations/0005_llmskill_global_latest_index.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index builds cannot run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("skills", "0004_llmskill_is_global"),
+    ]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="llmskill",
+            index=models.Index(
+                condition=models.Q(("deleted", False), ("is_global", True), ("is_latest", True)),
+                fields=["name"],
+                name="llm_skill_global_latest",
+            ),
+        ),
+    ]

--- a/products/skills/backend/migrations/max_migration.txt
+++ b/products/skills/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_backfill_scout_category
+0005_llmskill_global_latest_index

--- a/products/skills/backend/models/skills.py
+++ b/products/skills/backend/models/skills.py
@@ -35,6 +35,16 @@ class LLMSkill(UUIDModel):
                 name="unique_llm_skill_latest_per_team",
             ),
         ]
+        indexes = [
+            # Serves the cross-team fan-out for globally-visible skills (list, by-name resolution,
+            # marketplace clone, MCP list). The set is small and staff-curated, so a partial index
+            # over just the active latest globals keeps every reader's OR-arm off a full-table scan.
+            models.Index(
+                fields=["name"],
+                condition=Q(is_global=True, is_latest=True, deleted=False),
+                name="llm_skill_global_latest",
+            ),
+        ]
 
     # Required by Agent Skills spec (https://agentskills.io/specification)
     name = models.CharField(max_length=64)
@@ -57,6 +67,12 @@ class LLMSkill(UUIDModel):
     # Versioning (same pattern as LLMPrompt)
     version = models.PositiveIntegerField(default=1)
     is_latest = models.BooleanField(default=True)
+
+    # Staff-only visibility promotion, the "make visible to everyone" analog of a global dashboard
+    # template. When true, every version of this skill is readable by any team, not just its owning
+    # team — but the owning team (and staff) still own all writes. Carried forward across versions
+    # like `category`, so publishing a new version keeps the skill visible.
+    is_global = models.BooleanField(default=False, db_default=False)
 
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
     created_by = models.ForeignKey(


### PR DESCRIPTION
## Problem

We want PostHog staff to publish a skill so every customer can see and use it, the same way a dashboard template can be made global. This first PR lays the data-model foundation. No behavior change yet.

## Changes

- Add `is_global` (boolean, `default=False`, `db_default=False`) to `LLMSkill` — the "make visible to everyone" flag, held per row and carried across versions like `category`.
- Add a partial index (`llm_skill_global_latest`) over active, latest, global rows for the cross-team read fan-out that later PRs rely on.
- Two migrations: the column add, then the index built concurrently via `SafeAddIndexConcurrently` (`atomic = False`) so a retry stays idempotent.

The column is dormant here. Nothing reads or writes it until the backend PR stacked on top.

## How did you test this code?

Automated (run by me, the agent):
- `makemigrations skills --check` reports no drift. `sqlmigrate` shows `ADD COLUMN ... DEFAULT false NOT NULL` (no stray `DROP DEFAULT`) and `CREATE INDEX CONCURRENTLY ... WHERE (NOT deleted AND is_global AND is_latest)`.
- Applied both migrations to the local dev DB: `skills.0004 ... OK`, `skills.0005 ... OK`.
- Existing `products/skills/backend` tests still pass.

No manual testing — the column has no runtime behavior on its own.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. Internal data-model change, no user-facing surface yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @ceyniustranberg, implemented by Claude (PostHog Code). First of a 3-PR stack: model → backend → frontend. Invoked the `/django-migrations` skill, which is why the index ships as its own concurrent migration rather than inline with the column add. Kept `LLMSkill.team` non-null (unlike `DashboardTemplate`, which nulls team for globals) so tenant isolation and the existing per-team unique constraints hold, and a global skill stays owned by its authoring team.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
