### PR TITLE
feat(skills): let staff make skills visible to everyone

### DIFF
--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -26,6 +26,23 @@ MAX_SKILL_FILE_COUNT = 50
 SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 
+def _mask_foreign_global_author(instance: LLMSkill, context: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+    """Hide the authoring staff member on a global skill surfaced in another team's project.
+
+    A global skill is readable cross-team, but its `created_by` (name + email) is the publishing
+    PostHog staff member and must not leak to consuming customers. The owning team still sees it.
+    """
+    if not instance.is_global or "created_by" not in data:
+        return data
+    get_team = context.get("get_team")
+    if get_team is None:
+        return data
+    viewer_team = get_team()
+    if viewer_team is not None and instance.team_id != viewer_team.id:
+        data["created_by"] = None
+    return data
+
+
 def validate_skill_name_value(value: str) -> str:
     if value.lower() in RESERVED_SKILL_NAMES:
         raise serializers.ValidationError(
@@ -420,6 +437,10 @@ class LLMSkillSerializer(serializers.ModelSerializer):
             "metadata": {"help_text": "Arbitrary key-value metadata."},
         }
 
+    def to_representation(self, instance: LLMSkill) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        return _mask_foreign_global_author(instance, self.context, data)
+
     def get_is_latest(self, instance: LLMSkill) -> bool:
         return bool(getattr(instance, "is_latest", False))
 
@@ -536,6 +557,10 @@ class LLMSkillVersionSummarySerializer(serializers.ModelSerializer):
             "is_latest",
         ]
         read_only_fields = fields
+
+    def to_representation(self, instance: LLMSkill) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        return _mask_foreign_global_author(instance, self.context, data)
 
 
 class LLMSkillImportSerializer(serializers.Serializer):

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -346,6 +346,18 @@ class LLMSkillSerializer(serializers.ModelSerializer):
         "not writable via the API. Empty for an ordinary skill. Groups skills into their own surface "
         "(e.g. the Scouts tab) independently of the skill name.",
     )
+    is_global = serializers.BooleanField(
+        read_only=True,
+        help_text="Whether this skill is visible to every team, not just its owning team. Only PostHog staff "
+        "can change this, via the visibility action — it is never writable through create or publish. "
+        "A team viewing a global skill it does not own sees it read-only.",
+    )
+    team_id = serializers.IntegerField(
+        read_only=True,
+        help_text="ID of the team that owns this skill. For a global skill surfaced in another team's project, "
+        "this differs from the requesting team — compare it to the current project to tell whether the skill "
+        "is editable here.",
+    )
     files = serializers.SerializerMethodField(
         help_text="Bundled files manifest. Each entry is path + content_type only; fetch content via /llm_skills/name/{name}/files/{path}/.",
     )
@@ -365,6 +377,8 @@ class LLMSkillSerializer(serializers.ModelSerializer):
             "allowed_tools",
             "metadata",
             "category",
+            "is_global",
+            "team_id",
             "files",
             "outline",
             "version",
@@ -379,6 +393,8 @@ class LLMSkillSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "id",
+            "is_global",
+            "team_id",
             "files",
             "outline",
             "version",
@@ -536,6 +552,14 @@ class LLMSkillDuplicateSerializer(serializers.Serializer):
 
     def validate_new_name(self, value: str) -> str:
         return validate_skill_name_value(value)
+
+
+class LLMSkillVisibilitySerializer(serializers.Serializer):
+    is_global = serializers.BooleanField(
+        help_text="Set true to make this skill visible to every team (the 'make visible to everyone' "
+        "action), or false to restrict it back to its owning team. Applies to all versions of the skill. "
+        "Staff-only.",
+    )
 
 
 class LLMSkillResolveResponseSerializer(serializers.Serializer):

--- a/products/skills/backend/api/skill_services.py
+++ b/products/skills/backend/api/skill_services.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from django.db import IntegrityError, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from posthog.models import Team, User
@@ -89,14 +89,28 @@ def apply_skill_body_edits(body: str, edits: list[dict[str, str]]) -> str:
     return text
 
 
-def get_active_skill_queryset(team: Team) -> QuerySet[LLMSkill]:
-    return annotate_llm_skill_version_history_metadata(
-        LLMSkill.objects.filter(team=team, deleted=False).select_related("created_by")
-    )
+def _shadow_globals(team: Team, queryset: QuerySet[LLMSkill]) -> QuerySet[LLMSkill]:
+    """A team's own skill shadows a same-named global from another team.
+
+    Drops global rows (owned by a different team) whose name the current team already owns, so
+    reads never surface two skills with the same name and by-name resolution stays deterministic.
+    The team's own skills — including one it made global itself — are never shadowed.
+    """
+    own_names = LLMSkill.objects.filter(team=team, deleted=False).values("name")
+    return queryset.exclude(Q(is_global=True) & ~Q(team=team) & Q(name__in=own_names))
 
 
-def get_latest_skills_queryset(team: Team) -> QuerySet[LLMSkill]:
-    return get_active_skill_queryset(team).filter(is_latest=True)
+def get_active_skill_queryset(team: Team, *, include_global: bool = False) -> QuerySet[LLMSkill]:
+    base = LLMSkill.objects.filter(deleted=False).select_related("created_by")
+    if include_global:
+        base = _shadow_globals(team, base.filter(Q(team=team) | Q(is_global=True)))
+    else:
+        base = base.filter(team=team)
+    return annotate_llm_skill_version_history_metadata(base)
+
+
+def get_latest_skills_queryset(team: Team, *, include_global: bool = False) -> QuerySet[LLMSkill]:
+    return get_active_skill_queryset(team, include_global=include_global).filter(is_latest=True)
 
 
 def get_skill_by_name_from_db(
@@ -106,18 +120,19 @@ def get_skill_by_name_from_db(
     version_id: str | None = None,
     *,
     include_archived: bool = False,
+    include_global: bool = False,
 ) -> LLMSkill | None:
-    queryset = get_active_skill_queryset(team).filter(name=skill_name)
+    queryset = get_active_skill_queryset(team, include_global=include_global).filter(name=skill_name)
 
     if version_id is not None:
         # `include_archived` honours a pin to one immutable version row even after
         # the skill was archived (soft-deleted across all versions) — so a frozen
         # agent's fork can still re-freeze against the exact version it shipped.
-        rows = (
-            LLMSkill.objects.filter(team=team, name=skill_name, id=version_id)
-            if include_archived
-            else queryset.filter(id=version_id)
-        )
+        if include_archived:
+            archived_scope = Q(team=team) | Q(is_global=True) if include_global else Q(team=team)
+            rows = LLMSkill.objects.filter(archived_scope, name=skill_name, id=version_id)
+        else:
+            rows = queryset.filter(id=version_id)
         if version is not None:
             rows = rows.filter(version=version)
         return rows.order_by("created_at", "id").first()
@@ -135,12 +150,14 @@ def resolve_versions_page(
     limit: int,
     offset: int | None = None,
     before_version: int | None = None,
+    include_global: bool = False,
 ) -> tuple[list[LLMSkill], bool]:
-    queryset = (
-        LLMSkill.objects.filter(team=team, name=skill_name, deleted=False)
-        .select_related("created_by")
-        .order_by("-version", "-created_at", "-id")
-    )
+    base = LLMSkill.objects.filter(name=skill_name, deleted=False)
+    if include_global:
+        base = _shadow_globals(team, base.filter(Q(team=team) | Q(is_global=True)))
+    else:
+        base = base.filter(team=team)
+    queryset = base.select_related("created_by").order_by("-version", "-created_at", "-id")
 
     if before_version is not None:
         queryset = queryset.filter(version__lt=before_version)
@@ -248,6 +265,9 @@ def publish_skill_version(
             # Categorization is a property of the skill, not the version — carry it forward so editing
             # a scout (or any categorized skill) doesn't drop it out of its tab.
             category=current_latest.category,
+            # Visibility is likewise a property of the skill, not the version — carry it forward so
+            # publishing a new version of a global skill keeps it visible to everyone.
+            is_global=current_latest.is_global,
             version=current_latest.version + 1,
             is_latest=True,
             created_by=user,
@@ -482,6 +502,7 @@ def _create_next_version_with_files(
         allowed_tools=current_latest.allowed_tools,
         metadata=current_latest.metadata,
         category=current_latest.category,
+        is_global=current_latest.is_global,
         version=current_latest.version + 1,
         is_latest=True,
         created_by=user,
@@ -599,3 +620,29 @@ def archive_skill(team: Team, skill_name: str) -> list[int]:
             updated_at=timezone.now(),
         )
     return skill_versions
+
+
+def set_skill_visibility(team: Team, skill_name: str, *, is_global: bool) -> LLMSkill:
+    """Flip a skill's cross-team visibility. Staff-gated at the view layer.
+
+    Visibility is a property of the skill, not a single version, so it's stamped on every active
+    version of (team, name). `updated_at` is bumped (the `.update()` bypasses auto_now) so consumer
+    marketplace clones — whose plugin version is max(updated_at) over their visible skills — advance
+    and re-pull when a skill becomes (or stops being) global. Returns the refreshed latest version.
+    """
+    with transaction.atomic():
+        rows = list(
+            LLMSkill.objects.select_for_update()
+            .filter(team=team, name=skill_name, deleted=False)
+            .values_list("pk", flat=True)
+        )
+        if not rows:
+            raise LLMSkillNotFoundError()
+        LLMSkill.objects.filter(team=team, name=skill_name, deleted=False).update(
+            is_global=is_global,
+            updated_at=timezone.now(),
+        )
+    latest = get_active_skill_queryset(team).filter(name=skill_name, is_latest=True).first()
+    if latest is None:
+        raise LLMSkillNotFoundError()
+    return latest

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -250,7 +250,10 @@ class LLMSkillViewSet(
         return cast(dict[str, Any], LLMSkillSerializer(skill, context=self.get_serializer_context()).data)
 
     def _serialize_version_summaries(self, skills: list[LLMSkill]) -> list[dict[str, Any]]:
-        return cast(list[dict[str, Any]], LLMSkillVersionSummarySerializer(skills, many=True).data)
+        return cast(
+            list[dict[str, Any]],
+            LLMSkillVersionSummarySerializer(skills, many=True, context=self.get_serializer_context()).data,
+        )
 
     def _get_requested_version_params(self, request: Request) -> dict[str, Any]:
         serializer = LLMSkillFetchQuerySerializer(data=request.query_params)

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -61,6 +61,7 @@ from .skill_serializers import (
     LLMSkillResolveResponseSerializer,
     LLMSkillSerializer,
     LLMSkillVersionSummarySerializer,
+    LLMSkillVisibilitySerializer,
     validate_allowed_tool,
     validate_skill_body_size,
     validate_skill_file_path,
@@ -86,6 +87,7 @@ from .skill_services import (
     publish_skill_version,
     rename_skill_file,
     resolve_versions_page,
+    set_skill_visibility,
 )
 
 logger = structlog.get_logger(__name__)
@@ -268,7 +270,9 @@ class LLMSkillViewSet(
     def _get_list_queryset(self, request: Request) -> QuerySet[LLMSkill]:
         params = self._get_list_params(request)
 
-        queryset = get_latest_skills_queryset(self.team)
+        # Global skills (staff-published, owned by another team) surface in every team's list,
+        # read-only; a team's own same-named skill shadows the global (handled in the service layer).
+        queryset = get_latest_skills_queryset(self.team, include_global=True)
 
         search = params.get("search", "").strip()
         if search:
@@ -322,7 +326,7 @@ class LLMSkillViewSet(
     def get_by_name(self, request: Request, skill_name: str = "", **kwargs) -> Response:
         version_params = self._get_requested_version_params(request)
         version = cast(int | None, version_params.get("version"))
-        skill = get_skill_by_name_from_db(self.team, skill_name, version)
+        skill = get_skill_by_name_from_db(self.team, skill_name, version, include_global=True)
 
         if skill is None and _is_uuid(skill_name):
             redirect = self._redirect_to_name(request, skill_name)
@@ -335,7 +339,7 @@ class LLMSkillViewSet(
         return Response(self._serialize_skill(skill))
 
     def _redirect_to_name(self, request: Request, skill_name: str) -> Response | None:
-        skill_by_id = get_active_skill_queryset(self.team).filter(id=skill_name).first()
+        skill_by_id = get_active_skill_queryset(self.team, include_global=True).filter(id=skill_name).first()
         if skill_by_id is None:
             return None
         # Use a relative path (no build_absolute_uri) to avoid embedding the
@@ -461,6 +465,7 @@ class LLMSkillViewSet(
             skill_name=skill_name,
             version=version,
             version_id=str(version_id) if version_id else None,
+            include_global=True,
         )
         if skill is None:
             return self._skill_not_found_response(skill_name)
@@ -474,6 +479,7 @@ class LLMSkillViewSet(
             limit=limit,
             offset=offset,
             before_version=before_version,
+            include_global=True,
         )
         return Response(
             {
@@ -493,7 +499,7 @@ class LLMSkillViewSet(
     def export(self, request: Request, skill_name: str = "", **kwargs) -> Response | HttpResponse:
         version_params = self._get_requested_version_params(request)
         version = cast(int | None, version_params.get("version"))
-        skill = get_skill_by_name_from_db(self.team, skill_name, version)
+        skill = get_skill_by_name_from_db(self.team, skill_name, version, include_global=True)
         if skill is None:
             return self._skill_not_found_response(skill_name)
 
@@ -806,6 +812,57 @@ class LLMSkillViewSet(
         )
         return Response(self._serialize_skill(new_skill), status=status.HTTP_201_CREATED)
 
+    @extend_schema(request=LLMSkillVisibilitySerializer, responses={200: LLMSkillSerializer})
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_path=r"name/(?P<skill_name>[^/]+)/visibility",
+        required_scopes=["llm_skill:write"],
+    )
+    @llma_track_latency("llma_skills_set_visibility")
+    @monitor(feature=None, endpoint="llma_skills_set_visibility", method="POST")
+    def set_visibility(self, request: Request, skill_name: str = "", **kwargs) -> Response:
+        """Staff-only: make a skill visible to every team, or restrict it back to its owning team.
+
+        The "make visible to everyone" analog of a global dashboard template. Operates on the skill
+        as it exists in the current project, so an un-publish must be issued from the owning project.
+        """
+        auth_error = self._ensure_web_authenticated(request)
+        if auth_error is not None:
+            return auth_error
+
+        user = cast(User, request.user)
+        if not user.is_staff:
+            return Response(
+                {"detail": "Only PostHog staff can change a skill's global visibility."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        payload = LLMSkillVisibilitySerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+        is_global = payload.validated_data["is_global"]
+
+        try:
+            skill = set_skill_visibility(self.team, skill_name, is_global=is_global)
+        except LLMSkillNotFoundError:
+            return self._skill_not_found_response(skill_name)
+
+        props = {**_skill_analytics_props(skill), "is_global": is_global}
+        logger.info(
+            "llma_skill_visibility_changed",
+            team_id=self.team.id,
+            user_id=user.id,
+            **props,
+        )
+        report_user_action(
+            user,
+            "llma skill visibility changed",
+            props,
+            team=self.team,
+            request=request,
+        )
+        return Response(self._serialize_skill(skill))
+
     @extend_schema(
         parameters=[LLMSkillFetchQuerySerializer],
         responses={200: LLMSkillFileSerializer},
@@ -825,7 +882,7 @@ class LLMSkillViewSet(
     def get_file(self, request: Request, skill_name: str = "", file_path: str = "", **kwargs) -> Response:
         version_params = self._get_requested_version_params(request)
         version = cast(int | None, version_params.get("version"))
-        skill = get_skill_by_name_from_db(self.team, skill_name, version)
+        skill = get_skill_by_name_from_db(self.team, skill_name, version, include_global=True)
         if skill is None:
             return self._skill_not_found_response(skill_name)
 

--- a/products/skills/backend/api/test/test_global_visibility.py
+++ b/products/skills/backend/api/test/test_global_visibility.py
@@ -1,5 +1,6 @@
 from posthog.test.base import APIBaseTest, BaseTest
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Organization, Team, User
@@ -165,3 +166,59 @@ class TestLLMSkillGlobalVisibilityAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert LLMSkill.objects.get(team=self.team, name="shared").deleted is False
+
+    @parameterized.expand(
+        [
+            ("publish", "patch", "", {"body": "# hijacked", "base_version": 1}),
+            ("create_file", "post", "/files", {"path": "scripts/x.sh", "content": "hijacked"}),
+        ]
+    )
+    def test_non_owner_cannot_write_to_a_global_skill(
+        self, _name: str, method: str, suffix: str, payload: dict
+    ) -> None:
+        # Reads include globals, but writes must stay owner-scoped — a consumer resolving a global
+        # from another team and then editing/publishing it must 404, never mutate the owner's row.
+        # Archive is covered above; this locks the remaining write verbs against the same regression.
+        _create_skill(self.team, name="shared", is_global=True, created_by=self.user, body="# original")
+        other_team, other_user = self._consumer_team()
+        self.client.force_login(other_user)
+
+        url = f"/api/environments/{other_team.id}/llm_skills/name/shared{suffix}"
+        response = getattr(self.client, method)(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        owner_skill = LLMSkill.objects.get(team=self.team, name="shared", is_latest=True)
+        assert owner_skill.version == 1
+        assert owner_skill.body == "# original"
+
+    @parameterized.expand([("detail", "name/shared/"), ("list", "")])
+    def test_foreign_team_does_not_see_global_skill_author(self, _name: str, path: str) -> None:
+        # created_by is the publishing PostHog staff member (name + email); it must not leak to
+        # consuming customers who see the global skill in their own project.
+        _create_skill(self.team, name="shared", is_global=True, created_by=self.user)
+        other_team, other_user = self._consumer_team()
+        self.client.force_login(other_user)
+
+        response = self.client.get(f"/api/environments/{other_team.id}/llm_skills/{path}")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        skill = next(s for s in body["results"] if s["name"] == "shared") if path == "" else body
+        assert skill["created_by"] is None
+
+    def test_foreign_team_does_not_see_global_skill_version_authors(self) -> None:
+        _create_skill(self.team, name="shared", is_global=True, created_by=self.user)
+        other_team, other_user = self._consumer_team()
+        self.client.force_login(other_user)
+
+        response = self.client.get(f"/api/environments/{other_team.id}/llm_skills/resolve/name/shared")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["skill"]["created_by"] is None
+        assert all(version["created_by"] is None for version in body["versions"])
+
+    def test_owning_team_still_sees_global_skill_author(self) -> None:
+        _create_skill(self.team, name="shared", is_global=True, created_by=self.user)
+
+        response = self.client.get(self._url("name/shared/"))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["created_by"]["id"] == self.user.id

--- a/products/skills/backend/api/test/test_global_visibility.py
+++ b/products/skills/backend/api/test/test_global_visibility.py
@@ -1,0 +1,167 @@
+from posthog.test.base import APIBaseTest, BaseTest
+
+from rest_framework import status
+
+from posthog.models import Organization, Team, User
+
+from ...api.skill_services import (
+    LLMSkillNotFoundError,
+    create_skill_file,
+    get_latest_skills_queryset,
+    get_skill_by_name_from_db,
+    publish_skill_version,
+    set_skill_visibility,
+)
+from ...models.skills import LLMSkill
+
+
+def _create_skill(
+    team: Team,
+    *,
+    name: str = "my-skill",
+    is_global: bool = False,
+    version: int = 1,
+    is_latest: bool = True,
+    body: str = "# body",
+    created_by: User | None = None,
+) -> LLMSkill:
+    return LLMSkill.objects.create(
+        team=team,
+        name=name,
+        description="d",
+        body=body,
+        version=version,
+        is_latest=is_latest,
+        is_global=is_global,
+        created_by=created_by,
+    )
+
+
+class TestLLMSkillVisibilityService(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.other_org = Organization.objects.create(name="Consumer Org")
+        self.other_team = Team.objects.create(organization=self.other_org, name="Consumer Team")
+
+    def test_set_skill_visibility_flags_every_version_and_toggles_back(self) -> None:
+        _create_skill(self.team, name="foo", version=1, is_latest=False)
+        _create_skill(self.team, name="foo", version=2, is_latest=True)
+
+        set_skill_visibility(self.team, "foo", is_global=True)
+        assert set(LLMSkill.objects.filter(team=self.team, name="foo").values_list("is_global", flat=True)) == {True}
+
+        set_skill_visibility(self.team, "foo", is_global=False)
+        assert set(LLMSkill.objects.filter(team=self.team, name="foo").values_list("is_global", flat=True)) == {False}
+
+    def test_set_skill_visibility_missing_skill_raises(self) -> None:
+        with self.assertRaises(LLMSkillNotFoundError):
+            set_skill_visibility(self.team, "nope", is_global=True)
+
+    def test_global_skill_reaches_other_team_only_when_globals_included(self) -> None:
+        _create_skill(self.team, name="shared", is_global=True)
+
+        # Team-scoped by default: another team can't see it.
+        assert get_latest_skills_queryset(self.other_team).filter(name="shared").count() == 0
+        assert get_skill_by_name_from_db(self.other_team, "shared") is None
+
+        # Included once globals are requested.
+        assert get_latest_skills_queryset(self.other_team, include_global=True).filter(name="shared").count() == 1
+        resolved = get_skill_by_name_from_db(self.other_team, "shared", include_global=True)
+        assert resolved is not None
+        assert resolved.is_global is True
+
+    def test_local_skill_shadows_same_named_global(self) -> None:
+        _create_skill(self.team, name="dup", is_global=True)
+        own = _create_skill(self.other_team, name="dup")
+
+        latest = get_latest_skills_queryset(self.other_team, include_global=True).filter(name="dup")
+        assert latest.count() == 1
+        assert latest.first().pk == own.pk
+
+        resolved = get_skill_by_name_from_db(self.other_team, "dup", include_global=True)
+        assert resolved is not None
+        assert resolved.pk == own.pk
+
+    def test_owning_team_is_not_shadowed_from_its_own_global(self) -> None:
+        skill = _create_skill(self.team, name="mine", is_global=True)
+        latest = get_latest_skills_queryset(self.team, include_global=True).filter(name="mine")
+        assert latest.count() == 1
+        assert latest.first().pk == skill.pk
+
+    def test_publish_carries_global_visibility_forward(self) -> None:
+        _create_skill(self.team, name="foo", is_global=True, created_by=self.user)
+        published = publish_skill_version(self.team, user=self.user, skill_name="foo", body="# v2", base_version=1)
+        assert published.version == 2
+        assert published.is_global is True
+
+    def test_file_edit_carries_global_visibility_forward(self) -> None:
+        _create_skill(self.team, name="foo", is_global=True, created_by=self.user)
+        updated = create_skill_file(self.team, user=self.user, skill_name="foo", path="scripts/x.py", content="y")
+        assert updated.version == 2
+        assert updated.is_global is True
+
+
+class TestLLMSkillGlobalVisibilityAPI(APIBaseTest):
+    def _url(self, path: str = "") -> str:
+        return f"/api/environments/{self.team.id}/llm_skills/{path}"
+
+    def _make_staff(self) -> None:
+        self.user.is_staff = True
+        self.user.save()
+
+    def _consumer_team(self) -> tuple[Team, User]:
+        org = Organization.objects.create(name="Consumer Org")
+        team = Team.objects.create(organization=org, name="Consumer Team")
+        user = User.objects.create_and_join(org, "consumer@example.com", None, "Consumer")
+        return team, user
+
+    def test_staff_can_toggle_global_visibility(self) -> None:
+        self._make_staff()
+        _create_skill(self.team, name="foo", created_by=self.user)
+
+        made_global = self.client.post(self._url("name/foo/visibility/"), {"is_global": True}, format="json")
+        assert made_global.status_code == status.HTTP_200_OK
+        assert made_global.json()["is_global"] is True
+        assert LLMSkill.objects.get(team=self.team, name="foo").is_global is True
+
+        made_private = self.client.post(self._url("name/foo/visibility/"), {"is_global": False}, format="json")
+        assert made_private.status_code == status.HTTP_200_OK
+        assert made_private.json()["is_global"] is False
+        assert LLMSkill.objects.get(team=self.team, name="foo").is_global is False
+
+    def test_non_staff_cannot_make_skill_global(self) -> None:
+        assert self.user.is_staff is False
+        _create_skill(self.team, name="foo", created_by=self.user)
+
+        response = self.client.post(self._url("name/foo/visibility/"), {"is_global": True}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert LLMSkill.objects.get(team=self.team, name="foo").is_global is False
+
+    def test_visibility_on_missing_skill_returns_404(self) -> None:
+        self._make_staff()
+        response = self.client.post(self._url("name/ghost/visibility/"), {"is_global": True}, format="json")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_other_team_sees_and_reads_a_global_skill(self) -> None:
+        _create_skill(self.team, name="shared", is_global=True, created_by=self.user)
+        other_team, other_user = self._consumer_team()
+        self.client.force_login(other_user)
+
+        listed = self.client.get(f"/api/environments/{other_team.id}/llm_skills/")
+        assert listed.status_code == status.HTTP_200_OK
+        assert "shared" in [s["name"] for s in listed.json()["results"]]
+
+        fetched = self.client.get(f"/api/environments/{other_team.id}/llm_skills/name/shared/")
+        assert fetched.status_code == status.HTTP_200_OK
+        assert fetched.json()["is_global"] is True
+
+    def test_non_owner_cannot_archive_a_global_skill(self) -> None:
+        _create_skill(self.team, name="shared", is_global=True, created_by=self.user)
+        other_team, other_user = self._consumer_team()
+        self.client.force_login(other_user)
+
+        response = self.client.post(f"/api/environments/{other_team.id}/llm_skills/name/shared/archive/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert LLMSkill.objects.get(team=self.team, name="shared").deleted is False

--- a/products/skills/backend/api/test/test_marketplace_endpoints.py
+++ b/products/skills/backend/api/test/test_marketplace_endpoints.py
@@ -351,6 +351,50 @@ class TestMarketplaceVersion(APIBaseTest):
         assert after >= before
 
 
+class TestMarketplaceGlobalSkills(APIBaseTest):
+    def _owner_team(self) -> Team:
+        owner_org = Organization.objects.create(name="Owner Org")
+        return Team.objects.create(organization=owner_org, name="Owner Team")
+
+    def test_global_skill_from_another_team_is_served_to_this_teams_clone(self):
+        owner_team = self._owner_team()
+        LLMSkill.objects.create(
+            team=owner_team,
+            name="global-skill",
+            description="Shared everywhere.",
+            body="b",
+            version=1,
+            is_latest=True,
+            is_global=True,
+        )
+        tree = build_team_marketplace_tree(self.team)
+        assert "plugins/posthog-skill-store/skills/global-skill/SKILL.md" in tree
+
+    def test_local_skill_shadows_a_same_named_global_in_the_clone(self):
+        owner_team = self._owner_team()
+        LLMSkill.objects.create(
+            team=owner_team,
+            name="dup",
+            description="global",
+            body="GLOBAL-BODY",
+            version=1,
+            is_latest=True,
+            is_global=True,
+        )
+        LLMSkill.objects.create(
+            team=self.team,
+            name="dup",
+            description="local",
+            body="LOCAL-BODY",
+            version=1,
+            is_latest=True,
+            created_by=self.user,
+        )
+        skill_md = build_team_marketplace_tree(self.team)["plugins/posthog-skill-store/skills/dup/SKILL.md"]
+        assert "LOCAL-BODY" in skill_md
+        assert "GLOBAL-BODY" not in skill_md
+
+
 class TestMarketplaceInstallCommand(APIBaseTest):
     def _url(self) -> str:
         return f"/api/environments/{self.team.id}/llm_skills/marketplace/install-command"

--- a/products/skills/backend/marketplace/adapters.py
+++ b/products/skills/backend/marketplace/adapters.py
@@ -7,7 +7,7 @@ serialization and git synthesis stay unit-testable without booting the app.
 from typing import Any
 
 from django.core.cache import cache
-from django.db.models import Max
+from django.db.models import Max, Q
 
 import structlog
 from rest_framework import serializers
@@ -91,8 +91,15 @@ def build_team_marketplace_tree(team: Team, version: str | None = None) -> FileT
         version = _team_plugin_version(team)
 
     # Lean query: the marketplace only needs the latest live skills, not the version-history
-    # annotations / created_by join that get_latest_skills_queryset adds.
-    skills = list(LLMSkill.objects.filter(team=team, deleted=False, is_latest=True).order_by("name"))
+    # annotations / created_by join that get_latest_skills_queryset adds. Includes globally-visible
+    # skills published by another team, but a team's own same-named skill shadows the global (git
+    # trees can't hold two dirs with the same skill name) — mirrors _shadow_globals in the service layer.
+    own_names = LLMSkill.objects.filter(team=team, deleted=False).values("name")
+    skills = list(
+        LLMSkill.objects.filter(Q(team=team) | Q(is_global=True), deleted=False, is_latest=True)
+        .exclude(Q(is_global=True) & ~Q(team=team) & Q(name__in=own_names))
+        .order_by("name")
+    )
 
     files_by_skill = _files_by_skill_id(skills)
 
@@ -182,5 +189,7 @@ def _team_plugin_version(team: Team) -> str:
     # monotonic and reflects archives. Deriving it from only live skills would regress the version
     # when the most-recently-updated skill is archived. Milliseconds (not seconds) so two edits
     # within the same second still produce distinct versions and clients don't miss an update.
-    latest = LLMSkill.objects.filter(team=team).aggregate(latest=Max("updated_at"))["latest"]
+    # Globals are included (set_skill_visibility bumps their updated_at) so a team's clone re-versions
+    # when a skill it consumes becomes — or stops being — globally visible.
+    latest = LLMSkill.objects.filter(Q(team=team) | Q(is_global=True)).aggregate(latest=Max("updated_at"))["latest"]
     return compute_plugin_version(int(latest.timestamp() * 1000)) if latest is not None else "1.0.0"

--- a/products/skills/backend/tools/skills.py
+++ b/products/skills/backend/tools/skills.py
@@ -286,7 +286,8 @@ class ListLLMSkillsTool(MaxTool):
         return "\n".join(lines), None
 
     def _list_skills(self, search: str | None) -> list[LLMSkill]:
-        queryset = get_latest_skills_queryset(self._team)
+        # Include globally-visible skills so agents on any team discover staff-published skills too.
+        queryset = get_latest_skills_queryset(self._team, include_global=True)
         if search:
             queryset = queryset.filter(Q(name__icontains=search) | Q(description__icontains=search))
         # Fetch one extra row so we can distinguish "exactly at the cap" from "truncated".
@@ -313,7 +314,7 @@ class GetLLMSkillTool(MaxTool):
     def _fetch_skill_with_files(
         self, skill_name: str, version: int | None
     ) -> tuple[LLMSkill | None, list[LLMSkillFile]]:
-        skill = get_skill_by_name_from_db(self._team, skill_name, version)
+        skill = get_skill_by_name_from_db(self._team, skill_name, version, include_global=True)
         if skill is None:
             return None, []
         files = list(LLMSkillFile.objects.filter(skill=skill).order_by("path"))
@@ -358,7 +359,7 @@ class GetLLMSkillFileTool(MaxTool):
         )
 
     def _fetch_skill_file(self, skill_name: str, file_path: str, version: int | None) -> LLMSkillFile | None:
-        skill = get_skill_by_name_from_db(self._team, skill_name, version)
+        skill = get_skill_by_name_from_db(self._team, skill_name, version, include_global=True)
         if skill is None:
             return None
         return LLMSkillFile.objects.filter(skill=skill, path=file_path).first()

--- a/products/skills/backend/tools/test_skills.py
+++ b/products/skills/backend/tools/test_skills.py
@@ -2,7 +2,7 @@ from posthog.test.base import BaseTest
 
 from asgiref.sync import async_to_sync
 
-from posthog.models import Team
+from posthog.models import Organization, Team
 
 from products.skills.backend.models.skills import LLMSkill, LLMSkillFile
 from products.skills.backend.tools.skills import (
@@ -78,6 +78,22 @@ class TestListLLMSkillsTool(BaseTest):
         result, _ = _run(tool)
 
         assert "private-skill" not in result
+
+    def test_lists_global_skill_from_another_team(self):
+        owner_org = Organization.objects.create(name="Owner Org")
+        owner_team = Team.objects.create(organization=owner_org, name="Owner Team")
+        LLMSkill.objects.create(
+            team=owner_team,
+            name="global-skill",
+            description="Shared everywhere.",
+            body="body",
+            is_global=True,
+        )
+
+        tool = ListLLMSkillsTool(team=self.team, user=self.user)
+        result, _ = _run(tool)
+
+        assert "global-skill" in result
 
 
 class TestGetLLMSkillTool(BaseTest):

--- a/products/skills/frontend/generated/api.schemas.ts
+++ b/products/skills/frontend/generated/api.schemas.ts
@@ -109,6 +109,10 @@ export interface LLMSkillListApi {
     metadata?: LLMSkillListApiMetadata
     /** Server-owned classification — set by the producing system (the Signals harness stamps "scout"), not writable via the API. Empty for an ordinary skill. Groups skills into their own surface (e.g. the Scouts tab) independently of the skill name. */
     readonly category: string
+    /** Whether this skill is visible to every team, not just its owning team. Only PostHog staff can change this, via the visibility action — it is never writable through create or publish. A team viewing a global skill it does not own sees it read-only. */
+    readonly is_global: boolean
+    /** ID of the team that owns this skill. For a global skill surfaced in another team's project, this differs from the requesting team — compare it to the current project to tell whether the skill is editable here. */
+    readonly team_id: number
     /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
     readonly outline: readonly LLMSkillOutlineEntryApi[]
     readonly version: number
@@ -184,6 +188,10 @@ export interface LLMSkillCreateApi {
     metadata?: LLMSkillCreateApiMetadata
     /** Server-owned classification — set by the producing system (the Signals harness stamps "scout"), not writable via the API. Empty for an ordinary skill. Groups skills into their own surface (e.g. the Scouts tab) independently of the skill name. */
     readonly category: string
+    /** Whether this skill is visible to every team, not just its owning team. Only PostHog staff can change this, via the visibility action — it is never writable through create or publish. A team viewing a global skill it does not own sees it read-only. */
+    readonly is_global: boolean
+    /** ID of the team that owns this skill. For a global skill surfaced in another team's project, this differs from the requesting team — compare it to the current project to tell whether the skill is editable here. */
+    readonly team_id: number
     /** Bundled files to include with the initial version (scripts, references, assets). */
     files?: LLMSkillFileInputApi[]
     /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
@@ -246,6 +254,10 @@ export interface LLMSkillApi {
     metadata?: LLMSkillApiMetadata
     /** Server-owned classification — set by the producing system (the Signals harness stamps "scout"), not writable via the API. Empty for an ordinary skill. Groups skills into their own surface (e.g. the Scouts tab) independently of the skill name. */
     readonly category: string
+    /** Whether this skill is visible to every team, not just its owning team. Only PostHog staff can change this, via the visibility action — it is never writable through create or publish. A team viewing a global skill it does not own sees it read-only. */
+    readonly is_global: boolean
+    /** ID of the team that owns this skill. For a global skill surfaced in another team's project, this differs from the requesting team — compare it to the current project to tell whether the skill is editable here. */
+    readonly team_id: number
     /** Bundled files manifest. Each entry is path + content_type only; fetch content via /llm_skills/name/{name}/files/{path}/. */
     readonly files: readonly LLMSkillFileManifestApi[]
     /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
@@ -445,6 +457,11 @@ export interface LLMSkillFileApi {
     content: string
     /** @maxLength 100 */
     content_type?: string
+}
+
+export interface LLMSkillVisibilityApi {
+    /** Set true to make this skill visible to every team (the 'make visible to everyone' action), or false to restrict it back to its owning team. Applies to all versions of the skill. Staff-only. */
+    is_global: boolean
 }
 
 export interface LLMSkillVersionSummaryApi {

--- a/products/skills/frontend/generated/api.ts
+++ b/products/skills/frontend/generated/api.ts
@@ -19,6 +19,7 @@ import type {
     LLMSkillMarketplaceCommandApi,
     LLMSkillMarketplaceIssueApi,
     LLMSkillResolveResponseApi,
+    LLMSkillVisibilityApi,
     LlmSkillsListParams,
     LlmSkillsNameExportRetrieveParams,
     LlmSkillsNameFilesDestroyParams,
@@ -367,6 +368,30 @@ export const llmSkillsNameFilesDestroy = async (
     return apiMutator<LLMSkillApi>(getLlmSkillsNameFilesDestroyUrl(projectId, skillName, filePath, params), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+export const getLlmSkillsNameVisibilityCreateUrl = (projectId: string, skillName: string) => {
+    return `/api/projects/${projectId}/llm_skills/name/${skillName}/visibility/`
+}
+
+/**
+ * Staff-only: make a skill visible to every team, or restrict it back to its owning team.
+ *
+ * The "make visible to everyone" analog of a global dashboard template. Operates on the skill
+ * as it exists in the current project, so an un-publish must be issued from the owning project.
+ */
+export const llmSkillsNameVisibilityCreate = async (
+    projectId: string,
+    skillName: string,
+    lLMSkillVisibilityApi: LLMSkillVisibilityApi,
+    options?: RequestInit
+): Promise<LLMSkillApi> => {
+    return apiMutator<LLMSkillApi>(getLlmSkillsNameVisibilityCreateUrl(projectId, skillName), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(lLMSkillVisibilityApi),
     })
 }
 

--- a/products/skills/frontend/generated/api.zod.ts
+++ b/products/skills/frontend/generated/api.zod.ts
@@ -246,3 +246,17 @@ export const LlmSkillsNameFilesRenameCreateBody = /* @__PURE__ */ zod.object({
             'Latest version you are editing from. If provided, the request fails with 409 when another write has landed in the meantime.'
         ),
 })
+
+/**
+ * Staff-only: make a skill visible to every team, or restrict it back to its owning team.
+ *
+ * The "make visible to everyone" analog of a global dashboard template. Operates on the skill
+ * as it exists in the current project, so an un-publish must be issued from the owning project.
+ */
+export const LlmSkillsNameVisibilityCreateBody = /* @__PURE__ */ zod.object({
+    is_global: zod
+        .boolean()
+        .describe(
+            "Set true to make this skill visible to every team (the 'make visible to everyone' action), or false to restrict it back to its owning team. Applies to all versions of the skill. Staff-only."
+        ),
+})

--- a/products/skills/mcp/tools.yaml
+++ b/products/skills/mcp/tools.yaml
@@ -18,6 +18,9 @@ tools:
     llm-skills-name-export-retrieve:
         operation: llm_skills_name_export_retrieve
         enabled: false
+    llm-skills-name-visibility-create:
+        operation: llm_skills_name_visibility_create
+        enabled: false
     skill-archive:
         operation: llm_skills_name_archive_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -32703,6 +32703,10 @@ export namespace Schemas {
       metadata?: LLMSkillMetadata;
       /** Server-owned classification — set by the producing system (the Signals harness stamps "scout"), not writable via the API. Empty for an ordinary skill. Groups skills into their own surface (e.g. the Scouts tab) independently of the skill name. */
       readonly category: string;
+      /** Whether this skill is visible to every team, not just its owning team. Only PostHog staff can change this, via the visibility action — it is never writable through create or publish. A team viewing a global skill it does not own sees it read-only. */
+      readonly is_global: boolean;
+      /** ID of the team that owns this skill. For a global skill surfaced in another team's project, this differs from the requesting team — compare it to the current project to tell whether the skill is editable here. */
+      readonly team_id: number;
       /** Bundled files manifest. Each entry is path + content_type only; fetch content via /llm_skills/name/{name}/files/{path}/. */
       readonly files: readonly LLMSkillFileManifest[];
       /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
@@ -32771,6 +32775,10 @@ export namespace Schemas {
       metadata?: LLMSkillCreateMetadata;
       /** Server-owned classification — set by the producing system (the Signals harness stamps "scout"), not writable via the API. Empty for an ordinary skill. Groups skills into their own surface (e.g. the Scouts tab) independently of the skill name. */
       readonly category: string;
+      /** Whether this skill is visible to every team, not just its owning team. Only PostHog staff can change this, via the visibility action — it is never writable through create or publish. A team viewing a global skill it does not own sees it read-only. */
+      readonly is_global: boolean;
+      /** ID of the team that owns this skill. For a global skill surfaced in another team's project, this differs from the requesting team — compare it to the current project to tell whether the skill is editable here. */
+      readonly team_id: number;
       /** Bundled files to include with the initial version (scripts, references, assets). */
       files?: LLMSkillFileInput[];
       /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
@@ -32898,6 +32906,10 @@ export namespace Schemas {
       metadata?: LLMSkillListMetadata;
       /** Server-owned classification — set by the producing system (the Signals harness stamps "scout"), not writable via the API. Empty for an ordinary skill. Groups skills into their own surface (e.g. the Scouts tab) independently of the skill name. */
       readonly category: string;
+      /** Whether this skill is visible to every team, not just its owning team. Only PostHog staff can change this, via the visibility action — it is never writable through create or publish. A team viewing a global skill it does not own sees it read-only. */
+      readonly is_global: boolean;
+      /** ID of the team that owns this skill. For a global skill surfaced in another team's project, this differs from the requesting team — compare it to the current project to tell whether the skill is editable here. */
+      readonly team_id: number;
       /** Flat list of markdown headings parsed from the skill body. Useful as a lightweight table of contents. */
       readonly outline: readonly LLMSkillOutlineEntry[];
       readonly version: number;
@@ -32998,6 +33010,11 @@ export namespace Schemas {
       skill: LLMSkill;
       versions: LLMSkillVersionSummary[];
       has_more: boolean;
+    }
+
+    export interface LLMSkillVisibility {
+      /** Set true to make this skill visible to every team (the 'make visible to everyone' action), or false to restrict it back to its owning team. Applies to all versions of the skill. Staff-only. */
+      is_global: boolean;
     }
 
     export interface LLMTaggerConfig {


### PR DESCRIPTION
## Problem

Staff need a way to publish a skill to every customer, and customers need those global skills to show up where they already work with skills. Builds on the dormant `is_global` field from the model PR.

> [!NOTE]
> Stacked on #71358 (model). Review that first — this PR targets that branch, so its diff is backend-only.

## Changes

- **Staff-only toggle:** `POST /api/projects/{team_id}/llm_skills/name/{name}/visibility` with `{ "is_global": bool }`. Gated on `user.is_staff` (same gate global dashboard templates use). Flips `is_global` across every version of the skill and bumps `updated_at` so consumer marketplace clones re-version.
- **Reads include globals:** list, by-name resolve, `.zip` export, file fetch, the marketplace git clone, and the MCP `skill-list` / get tools now surface globally-visible skills from other teams, via an opt-in `include_global` flag threaded through the service layer.
- **Local shadows global:** a team's own skill shadows a same-named global (git trees can't hold two dirs with one name, and by-name resolution must stay deterministic). Writes stay owner-scoped, so a non-owner editing or archiving a global just 404s.
- Exposes `is_global` and `team_id` read-only on the serializer so the UI (next PR) can tell whether the current project owns a skill. Regenerated frontend + MCP types included.

## How did you test this code?

Automated (run by me, the agent):
- New `products/skills/backend/api/test/test_global_visibility.py` (12 cases): staff toggles `is_global` on all versions; non-staff gets 403; missing skill 404; a global reaches another team via list/by-name only with `include_global`; local shadows global; owning team is not shadowed from its own global; `is_global` carries forward across a published version and a file edit; another team sees + reads a global over the API; a non-owner cannot archive a global (404).
- Added marketplace cases (global served to another team's clone, local-shadows-global in the tree) and an MCP `list` case (global from another team is listed).
- Full existing `products/skills` backend suite still green (86 + additions).
- `hogli build:openapi` is idempotent against the committed generated files.

No manual API calls — all coverage is automated.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. No public docs cover the skills store visibility model yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @ceyniustranberg, implemented by Claude (PostHog Code). Second of a 3-PR stack (model → backend → frontend). Invoked `/improving-drf-endpoints` (serializer/viewset annotations, `help_text`, typed request/response for the new action) and `/writing-tests` (gated each new test to a named regression, kept the queryset/shadow/carry-forward logic at the cheap service level and only the staff gate + cross-team wiring at the endpoint level). Chose an opt-in `include_global` param over broadening the base queryset so write paths stay strictly team-scoped by default. Name-shadowing is the one real subtlety — a global and a same-named local would otherwise collide in the list, the marketplace tree, and by-name resolution.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
