### PR TITLE
feat(skills): add global visibility controls to the skills UI

### DIFF
--- a/products/skills/frontend/LLMSkillScene.stories.tsx
+++ b/products/skills/frontend/LLMSkillScene.stories.tsx
@@ -67,6 +67,8 @@ const SKILL: LLMSkillApi = {
     allowed_tools: ['read', 'shell'],
     metadata: {},
     category: '',
+    is_global: false,
+    team_id: 1,
     files: [
         { path: 'scripts/extract.sh', content_type: 'text/x-shellscript' },
         { path: 'references/pdf-spec.md', content_type: 'text/markdown' },
@@ -103,6 +105,8 @@ const SKILL_LIST_ENTRY: LLMSkillListApi = {
     allowed_tools: SKILL.allowed_tools,
     metadata: {},
     category: SKILL.category,
+    is_global: SKILL.is_global,
+    team_id: SKILL.team_id,
     outline: SKILL.outline,
     version: SKILL.version,
     created_by: SKILL.created_by,

--- a/products/skills/frontend/LLMSkillScene.tsx
+++ b/products/skills/frontend/LLMSkillScene.tsx
@@ -8,6 +8,7 @@ import {
     IconColumns,
     IconDocument,
     IconDownload,
+    IconGlobe,
     IconPencil,
     IconPlus,
     IconTrash,
@@ -27,7 +28,9 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { lazyWithRetry } from 'lib/utils/retryImport'
 import { SceneExport } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -42,7 +45,7 @@ import type { SkillFormFileValues } from './llmSkillLogic'
 import { SkillLogicProps, SkillMode, isSkill, llmSkillLogic } from './llmSkillLogic'
 import { SKILL_NAME_MAX_LENGTH, SKILL_DESCRIPTION_MAX_LENGTH } from './skillConstants'
 import { skillFileLogic } from './skillFileLogic'
-import { openArchiveSkillDialog } from './skillSceneComponents'
+import { openArchiveSkillDialog, openSkillVisibilityDialog } from './skillSceneComponents'
 
 const MonacoDiffEditor = lazyWithRetry(() => import('lib/components/MonacoDiffEditor'))
 
@@ -73,11 +76,26 @@ export function LLMSkillScene(): JSX.Element {
         canLoadMoreVersions,
         fileContentsLoading,
         downloadingZip,
+        settingVisibility,
     } = useValues(llmSkillLogic)
     const { searchParams } = useValues(router)
+    const { user } = useValues(userLogic)
+    const { currentTeamId } = useValues(teamLogic)
 
-    const { submitSkillForm, deleteSkill, setMode, setSkillFormValues, loadMoreVersions, downloadSkill } =
-        useActions(llmSkillLogic)
+    const {
+        submitSkillForm,
+        deleteSkill,
+        setMode,
+        setSkillFormValues,
+        loadMoreVersions,
+        downloadSkill,
+        setGlobalVisibility,
+    } = useActions(llmSkillLogic)
+
+    // A global skill surfaced from another team is read-only here — only its owning project can
+    // edit it, and only staff can change its visibility (and only from the owning project).
+    const isOwnedByCurrentTeam = isSkill(skill) && skill.team_id === currentTeamId
+    const canManageVisibility = !!user?.is_staff && isOwnedByCurrentTeam
 
     if (isSkillMissing) {
         return <NotFound object="skill" />
@@ -99,49 +117,57 @@ export function LLMSkillScene(): JSX.Element {
                 name={skill && 'name' in skill ? skill.name : 'Skill'}
                 resourceType={{ type: 'llm_analytics' }}
                 isLoading={skillLoading}
+                nameSuffix={
+                    isSkill(skill) && skill.is_global ? (
+                        <LemonTag type="highlight" icon={<IconGlobe />} size="medium">
+                            Global
+                        </LemonTag>
+                    ) : undefined
+                }
                 actions={
                     <>
-                        {isSkill(skill) && skill.is_latest ? (
-                            <AccessControlAction
-                                resourceType={AccessControlResourceType.LlmAnalytics}
-                                minAccessLevel={AccessControlLevel.Editor}
-                            >
-                                <LemonButton
-                                    type="primary"
-                                    icon={<IconPencil />}
-                                    onClick={() => setMode(SkillMode.Edit)}
-                                    size="small"
-                                    data-attr="llma-skill-edit-button"
+                        {isOwnedByCurrentTeam &&
+                            (isSkill(skill) && skill.is_latest ? (
+                                <AccessControlAction
+                                    resourceType={AccessControlResourceType.LlmAnalytics}
+                                    minAccessLevel={AccessControlLevel.Editor}
                                 >
-                                    Edit latest
-                                </LemonButton>
-                            </AccessControlAction>
-                        ) : (
-                            <AccessControlAction
-                                resourceType={AccessControlResourceType.LlmAnalytics}
-                                minAccessLevel={AccessControlLevel.Editor}
-                            >
-                                <LemonButton
-                                    type="primary"
-                                    onClick={() => {
-                                        if (isSkill(skill)) {
-                                            setSkillFormValues({
-                                                name: skill.name,
-                                                description: skill.description,
-                                                body: skill.body,
-                                                license: skill.license || '',
-                                                compatibility: skill.compatibility || '',
-                                            })
-                                            setMode(SkillMode.Edit)
-                                        }
-                                    }}
-                                    size="small"
-                                    data-attr="llma-skill-use-as-latest-button"
+                                    <LemonButton
+                                        type="primary"
+                                        icon={<IconPencil />}
+                                        onClick={() => setMode(SkillMode.Edit)}
+                                        size="small"
+                                        data-attr="llma-skill-edit-button"
+                                    >
+                                        Edit latest
+                                    </LemonButton>
+                                </AccessControlAction>
+                            ) : (
+                                <AccessControlAction
+                                    resourceType={AccessControlResourceType.LlmAnalytics}
+                                    minAccessLevel={AccessControlLevel.Editor}
                                 >
-                                    Use as latest
-                                </LemonButton>
-                            </AccessControlAction>
-                        )}
+                                    <LemonButton
+                                        type="primary"
+                                        onClick={() => {
+                                            if (isSkill(skill)) {
+                                                setSkillFormValues({
+                                                    name: skill.name,
+                                                    description: skill.description,
+                                                    body: skill.body,
+                                                    license: skill.license || '',
+                                                    compatibility: skill.compatibility || '',
+                                                })
+                                                setMode(SkillMode.Edit)
+                                            }
+                                        }}
+                                        size="small"
+                                        data-attr="llma-skill-use-as-latest-button"
+                                    >
+                                        Use as latest
+                                    </LemonButton>
+                                </AccessControlAction>
+                            ))}
 
                         {isSkill(skill) && (
                             <LemonButton
@@ -157,21 +183,45 @@ export function LLMSkillScene(): JSX.Element {
                             </LemonButton>
                         )}
 
-                        <AccessControlAction
-                            resourceType={AccessControlResourceType.LlmAnalytics}
-                            minAccessLevel={AccessControlLevel.Editor}
-                        >
+                        {canManageVisibility && isSkill(skill) && (
                             <LemonButton
                                 type="secondary"
-                                status="danger"
-                                icon={<IconTrash />}
-                                onClick={() => openArchiveSkillDialog(deleteSkill)}
+                                icon={<IconGlobe />}
+                                onClick={() =>
+                                    openSkillVisibilityDialog(!skill.is_global, () =>
+                                        setGlobalVisibility(!skill.is_global)
+                                    )
+                                }
+                                loading={settingVisibility}
                                 size="small"
-                                data-attr="llma-skill-delete-button"
+                                tooltip={
+                                    skill.is_global
+                                        ? 'Restrict this skill to this project'
+                                        : 'Make this skill visible to every PostHog customer'
+                                }
+                                data-attr="llma-skill-visibility-button"
                             >
-                                Archive
+                                {skill.is_global ? 'Make private' : 'Make visible to everyone'}
                             </LemonButton>
-                        </AccessControlAction>
+                        )}
+
+                        {isOwnedByCurrentTeam && (
+                            <AccessControlAction
+                                resourceType={AccessControlResourceType.LlmAnalytics}
+                                minAccessLevel={AccessControlLevel.Editor}
+                            >
+                                <LemonButton
+                                    type="secondary"
+                                    status="danger"
+                                    icon={<IconTrash />}
+                                    onClick={() => openArchiveSkillDialog(deleteSkill)}
+                                    size="small"
+                                    data-attr="llma-skill-delete-button"
+                                >
+                                    Archive
+                                </LemonButton>
+                            </AccessControlAction>
+                        )}
                     </>
                 }
             />

--- a/products/skills/frontend/LLMSkillsScene.tsx
+++ b/products/skills/frontend/LLMSkillsScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import { useMemo, useRef } from 'react'
 
-import { IconDownload, IconPlusSmall, IconUpload } from '@posthog/icons'
+import { IconDownload, IconGlobe, IconPlusSmall, IconUpload } from '@posthog/icons'
 import { LemonDivider, LemonModal, LemonSwitch, LemonTabs, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -16,6 +16,7 @@ import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { SceneExport } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -61,6 +62,7 @@ function buildSkillColumns(
     duplicateSkill: (name: string, newName: string) => void,
     deleteSkill: (name: string) => void,
     downloadSkillZip: (name: string) => void,
+    currentTeamId: number | null,
     options?: { showScoutOrigin?: boolean }
 ): LemonTableColumns<LLMSkillListApi> {
     return [
@@ -71,9 +73,16 @@ function buildSkillColumns(
             width: '20%',
             render: function renderName(_, skill) {
                 return (
-                    <Link to={skillUrl(skill.name)} className="font-semibold" data-attr="llma-skill-name-link">
-                        {skill.name}
-                    </Link>
+                    <div className="flex items-center gap-2">
+                        <Link to={skillUrl(skill.name)} className="font-semibold" data-attr="llma-skill-name-link">
+                            {skill.name}
+                        </Link>
+                        {skill.is_global && (
+                            <LemonTag type="highlight" icon={<IconGlobe />}>
+                                Global
+                            </LemonTag>
+                        )}
+                    </div>
                 )
             },
         },
@@ -150,55 +159,61 @@ function buildSkillColumns(
                                     Download .zip
                                 </LemonButton>
 
-                                <AccessControlAction
-                                    resourceType={AccessControlResourceType.LlmAnalytics}
-                                    minAccessLevel={AccessControlLevel.Editor}
-                                >
-                                    <LemonButton
-                                        onClick={() => {
-                                            LemonDialog.openForm({
-                                                title: 'Duplicate skill',
-                                                initialValues: {
-                                                    newName: `${skill.name}-copy`,
-                                                },
-                                                content: (
-                                                    <LemonField name="newName" label="New skill name">
-                                                        <LemonInput
-                                                            data-attr="llma-skill-duplicate-name"
-                                                            placeholder="my-skill-copy"
-                                                            maxLength={SKILL_NAME_MAX_LENGTH}
-                                                            autoFocus
-                                                        />
-                                                    </LemonField>
-                                                ),
-                                                errors: {
-                                                    newName: (name: string) => validateSkillName(name),
-                                                },
-                                                onSubmit: async ({ newName }) => {
-                                                    duplicateSkill(skill.name, newName)
-                                                },
-                                            })
-                                        }}
-                                        data-attr="llma-skill-dropdown-duplicate"
-                                        fullWidth
-                                    >
-                                        Duplicate
-                                    </LemonButton>
-                                </AccessControlAction>
+                                {/* Duplicate and archive act on the owning team's skill, so a global surfaced
+                                    from another team is view/download-only here. */}
+                                {skill.team_id === currentTeamId && (
+                                    <>
+                                        <AccessControlAction
+                                            resourceType={AccessControlResourceType.LlmAnalytics}
+                                            minAccessLevel={AccessControlLevel.Editor}
+                                        >
+                                            <LemonButton
+                                                onClick={() => {
+                                                    LemonDialog.openForm({
+                                                        title: 'Duplicate skill',
+                                                        initialValues: {
+                                                            newName: `${skill.name}-copy`,
+                                                        },
+                                                        content: (
+                                                            <LemonField name="newName" label="New skill name">
+                                                                <LemonInput
+                                                                    data-attr="llma-skill-duplicate-name"
+                                                                    placeholder="my-skill-copy"
+                                                                    maxLength={SKILL_NAME_MAX_LENGTH}
+                                                                    autoFocus
+                                                                />
+                                                            </LemonField>
+                                                        ),
+                                                        errors: {
+                                                            newName: (name: string) => validateSkillName(name),
+                                                        },
+                                                        onSubmit: async ({ newName }) => {
+                                                            duplicateSkill(skill.name, newName)
+                                                        },
+                                                    })
+                                                }}
+                                                data-attr="llma-skill-dropdown-duplicate"
+                                                fullWidth
+                                            >
+                                                Duplicate
+                                            </LemonButton>
+                                        </AccessControlAction>
 
-                                <AccessControlAction
-                                    resourceType={AccessControlResourceType.LlmAnalytics}
-                                    minAccessLevel={AccessControlLevel.Editor}
-                                >
-                                    <LemonButton
-                                        status="danger"
-                                        onClick={() => openArchiveSkillDialog(() => deleteSkill(skill.name))}
-                                        data-attr="llma-skill-dropdown-delete"
-                                        fullWidth
-                                    >
-                                        Archive
-                                    </LemonButton>
-                                </AccessControlAction>
+                                        <AccessControlAction
+                                            resourceType={AccessControlResourceType.LlmAnalytics}
+                                            minAccessLevel={AccessControlLevel.Editor}
+                                        >
+                                            <LemonButton
+                                                status="danger"
+                                                onClick={() => openArchiveSkillDialog(() => deleteSkill(skill.name))}
+                                                data-attr="llma-skill-dropdown-delete"
+                                                fullWidth
+                                            >
+                                                Archive
+                                            </LemonButton>
+                                        </AccessControlAction>
+                                    </>
+                                )}
                             </>
                         }
                     />
@@ -443,6 +458,7 @@ export function LLMSkillsScene(): JSX.Element {
         visibleCategoryTabs,
     } = useValues(llmSkillsLogic)
     const { searchParams } = useValues(router)
+    const { currentTeamId } = useValues(teamLogic)
     const skillUrl = (name: string): string => combineUrl(urls.skill(name), searchParams).url
     const fileInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -451,9 +467,12 @@ export function LLMSkillsScene(): JSX.Element {
     // Memoize columns so the array reference doesn't change every render — otherwise every
     // nested LemonTable inside the grouped tree reconciles on each parent re-render.
     const columns = useMemo(
-        () => buildSkillColumns(skillUrl, duplicateSkill, deleteSkill, downloadSkillZip, { showScoutOrigin }),
+        () =>
+            buildSkillColumns(skillUrl, duplicateSkill, deleteSkill, downloadSkillZip, currentTeamId, {
+                showScoutOrigin,
+            }),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [searchParams, duplicateSkill, deleteSkill, downloadSkillZip, showScoutOrigin]
+        [searchParams, duplicateSkill, deleteSkill, downloadSkillZip, currentTeamId, showScoutOrigin]
     )
 
     const showGroupedView = filters.group_by_prefix && groupedSkills && !skillsLoading

--- a/products/skills/frontend/llmSkillLogic.ts
+++ b/products/skills/frontend/llmSkillLogic.ts
@@ -13,6 +13,7 @@ import {
     llmSkillsNameArchiveCreate,
     llmSkillsNameFilesRetrieve,
     llmSkillsNamePartialUpdate,
+    llmSkillsNameVisibilityCreate,
     llmSkillsResolveNameRetrieve,
 } from 'products/skills/frontend/generated/api'
 import type {
@@ -137,6 +138,8 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
         setCompareVersion: (compareVersion: number | null) => ({ compareVersion }),
         downloadSkill: true,
         setDownloadingZip: (downloadingZip: boolean) => ({ downloadingZip }),
+        setGlobalVisibility: (isGlobal: boolean) => ({ isGlobal }),
+        setSettingVisibility: (settingVisibility: boolean) => ({ settingVisibility }),
     }),
 
     reducers(({ props }) => ({
@@ -199,6 +202,12 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
             false,
             {
                 setDownloadingZip: (_, { downloadingZip }) => downloadingZip,
+            },
+        ],
+        settingVisibility: [
+            false,
+            {
+                setSettingVisibility: (_, { settingVisibility }) => settingVisibility,
             },
         ],
     })),
@@ -421,6 +430,34 @@ export const llmSkillLogic = kea<llmSkillLogicType>([
                 lemonToast.error(detail || (e instanceof Error ? e.message : 'Failed to export skill'))
             } finally {
                 actions.setDownloadingZip(false)
+            }
+        },
+
+        setGlobalVisibility: async ({ isGlobal }) => {
+            const skill = values.skill
+            if (props.skillName === 'new' || !isSkill(skill)) {
+                return
+            }
+            actions.setSettingVisibility(true)
+            try {
+                const updated = await llmSkillsNameVisibilityCreate(String(ApiConfig.getCurrentTeamId()), skill.name, {
+                    is_global: isGlobal,
+                })
+                const current = values.skill
+                if (isSkill(current)) {
+                    actions.setSkill({ ...current, is_global: updated.is_global })
+                }
+                lemonToast.success(
+                    isGlobal ? 'Skill is now visible to everyone.' : 'Skill is now private to this project.'
+                )
+                llmSkillsLogic.findMounted()?.actions.loadSkills(false)
+            } catch (e) {
+                console.error('Failed to update skill visibility', e)
+                const detail =
+                    e !== null && typeof e === 'object' && 'detail' in e ? (e as { detail?: string }).detail : undefined
+                lemonToast.error(detail || 'Failed to update skill visibility')
+            } finally {
+                actions.setSettingVisibility(false)
             }
         },
 

--- a/products/skills/frontend/skillSceneComponents.tsx
+++ b/products/skills/frontend/skillSceneComponents.tsx
@@ -11,3 +11,23 @@ export function openArchiveSkillDialog(onConfirm: () => void): void {
         secondaryButton: { children: 'Cancel' },
     })
 }
+
+export function openSkillVisibilityDialog(isGlobal: boolean, onConfirm: () => void): void {
+    LemonDialog.open(
+        isGlobal
+            ? {
+                  title: 'Make this skill visible to everyone?',
+                  description:
+                      'Every PostHog customer will be able to see and use this skill in their own projects. ' +
+                      'Only PostHog staff can do this.',
+                  primaryButton: { children: 'Make visible to everyone', onClick: onConfirm },
+                  secondaryButton: { children: 'Cancel' },
+              }
+            : {
+                  title: 'Make this skill private?',
+                  description: "It will stop appearing in other customers' projects and go back to this project only.",
+                  primaryButton: { children: 'Make private', onClick: onConfirm },
+                  secondaryButton: { children: 'Cancel' },
+              }
+    )
+}


### PR DESCRIPTION
## Problem

Staff need to flip a skill to "visible to everyone" straight from the skill, and everyone needs to see which skills are global and which are read-only in their project. Wires the backend capability into the Skills UI.

> [!NOTE]
> Top of a 3-PR stack: #71358 (model) → #71359 (backend) → this. Targets the backend branch, so its diff is UI-only. Consumes the generated types added in #71359.

## Changes

- **Staff toggle on the skill scene:** a "Make visible to everyone" / "Make private" button (staff-only, with a confirm dialog and in-flight loading state) that calls the visibility endpoint and updates the skill in place.
- **"Global" badge** on the skill scene title and on rows in the skills list.
- **Read-only for consumers:** a global skill surfaced from another team hides edit, archive, and duplicate. Ownership is `skill.team_id === currentTeamId`; download stays available to everyone.

<!-- Screenshots: this is a visual change, but I (the agent) can't run the app to capture them. A reviewer should grab shots of the staff toggle (both states), the Global badge, and a consumer's read-only view before marking ready. -->

## How did you test this code?

Automated (run by me, the agent):
- `tsgo --noEmit` reports no `products/skills` type errors; kea logic types regenerated for the new `setGlobalVisibility` action and `settingVisibility` state.
- oxlint + oxfmt clean on the changed files (CI toolchain versions).

I could not run the app or capture screenshots. No Jest/Playwright added: the new behavior is a staff-gated button plus ownership-gated rendering, both thin wrappers over the endpoint from #71359, which is covered by backend tests. A reviewer should verify the toggle, badge, and read-only view visually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. No public docs cover the skills store UI yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @ceyniustranberg, implemented by Claude (PostHog Code). Third of a 3-PR stack (model → backend → frontend). Invoked `/adopting-generated-api-types` — the visibility call uses the generated `llmSkillsNameVisibilityCreate` and the `is_global` / `team_id` fields from the generated schemas, no handwritten API types. Business logic lives in `llmSkillLogic` (kea), not the component. Gating edit/archive/duplicate on `team_id === currentTeamId` is what makes a consumed global read-only instead of showing write buttons that would 404 against the owning team.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
