### PR TITLE
feat(conversations): channel-aware reply placeholder and send logo

### DIFF
--- a/products/conversations/frontend/components/Channels/ChannelsTag.tsx
+++ b/products/conversations/frontend/components/Channels/ChannelsTag.tsx
@@ -13,12 +13,22 @@ export function getChannelThreadUrl(ticket: Ticket | null): string | undefined {
     return undefined
 }
 
-const channelIcon: Record<TicketChannel, JSX.Element> = {
+export const channelIcon: Record<TicketChannel, JSX.Element> = {
     widget: <IconComment />,
     slack: <IconSlack />,
     teams: <IconMicrosoftTeams />,
     email: <IconLetter />,
     github: <IconGithub />,
+}
+
+export function getReplyPlaceholder(channel?: TicketChannel): string {
+    if (channel === 'slack') {
+        return 'Reply in Slack...'
+    }
+    if (channel === 'teams') {
+        return 'Reply in Microsoft Teams...'
+    }
+    return 'Type your message...'
 }
 
 const channelDetailLabel: Record<TicketChannelDetail, string> = {

--- a/products/conversations/frontend/components/Channels/ChannelsTag.tsx
+++ b/products/conversations/frontend/components/Channels/ChannelsTag.tsx
@@ -21,14 +21,21 @@ export const channelIcon: Record<TicketChannel, JSX.Element> = {
     github: <IconGithub />,
 }
 
+// Channels a team member replies back into externally, branded on the composer
+// (placeholder text + send-button logo). Others fall back to the generic composer.
+const replyChannelLabel: Partial<Record<TicketChannel, string>> = {
+    slack: 'Slack',
+    teams: 'Microsoft Teams',
+    github: 'GitHub',
+}
+
 export function getReplyPlaceholder(channel?: TicketChannel): string {
-    if (channel === 'slack') {
-        return 'Reply in Slack...'
-    }
-    if (channel === 'teams') {
-        return 'Reply in Microsoft Teams...'
-    }
-    return 'Type your message...'
+    const label = channel ? replyChannelLabel[channel] : undefined
+    return label ? `Reply in ${label}...` : 'Type your message...'
+}
+
+export function hasReplyChannelBranding(channel?: TicketChannel): channel is TicketChannel {
+    return !!channel && channel in replyChannelLabel
 }
 
 const channelDetailLabel: Record<TicketChannelDetail, string> = {

--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -2,7 +2,7 @@ import { JSONContent } from '@tiptap/core'
 
 import { LemonCard } from '@posthog/lemon-ui'
 
-import type { AiReplyFeedbackRating, ChatMessage, Ticket, TicketStatus } from '../../types'
+import type { AiReplyFeedbackRating, ChatMessage, Ticket, TicketChannel, TicketStatus } from '../../types'
 import { MessageInput } from './MessageInput'
 import { MessageList } from './MessageList'
 
@@ -24,6 +24,8 @@ export interface ChatViewProps {
     header?: React.ReactNode
     minHeight?: string
     maxHeight?: string
+    /** Channel the ticket came from; drives the reply placeholder and send-button logo */
+    channel?: TicketChannel
     /** Whether to show the "Send as private" option in the message input */
     showPrivateOption?: boolean
     /** Number of team messages that haven't been read by the customer */
@@ -69,6 +71,7 @@ export function ChatView({
     header,
     minHeight,
     maxHeight,
+    channel,
     showPrivateOption = false,
     unreadCustomerCount,
     showDeliveryStatus = false,
@@ -114,6 +117,7 @@ export function ChatView({
                 <MessageInput
                     onSendMessage={onSendMessage}
                     messageSending={messageSending}
+                    channel={channel}
                     showPrivateOption={showPrivateOption}
                     draftContent={draftContent}
                     onDraftChange={onDraftChange}

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -261,7 +261,7 @@ export function MessageInput({
                         ) : showChannelLogo ? (
                             <span className="inline-flex items-center gap-1.5">
                                 {buttonText}
-                                <span className="text-sm">{channelIcon[channel]}</span>
+                                <span className="text-sm dark:grayscale">{channelIcon[channel]}</span>
                             </span>
                         ) : (
                             buttonText

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -7,7 +7,8 @@ import { LemonButton, LemonCheckbox, LemonSwitch, Tooltip } from '@posthog/lemon
 import { RichContentEditorType } from 'lib/components/RichContentEditor/types'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 
-import type { TicketStatus } from '../../types'
+import type { TicketChannel, TicketStatus } from '../../types'
+import { channelIcon, getReplyPlaceholder } from '../Channels/ChannelsTag'
 import { SupportEditor, serializeToMarkdown } from '../Editor'
 
 export interface MessageInputProps {
@@ -20,6 +21,8 @@ export interface MessageInputProps {
     ) => void
     messageSending: boolean
     placeholder?: string
+    /** Channel the ticket came from; drives the default placeholder and the send-button logo */
+    channel?: TicketChannel
     buttonText?: string
     minRows?: number
     /** Whether to show the "Send as private" checkbox */
@@ -51,7 +54,8 @@ export interface MessageInputProps {
 export function MessageInput({
     onSendMessage,
     messageSending,
-    placeholder = 'Type your message...',
+    placeholder,
+    channel,
     buttonText = 'Send',
     minRows = 3,
     showPrivateOption = false,
@@ -80,6 +84,8 @@ export function MessageInput({
     const isPrivate = controlledIsPrivate ?? localIsPrivate
     const setIsPrivate = onPrivateChange ?? setLocalIsPrivate
 
+    const resolvedPlaceholder = placeholder ?? (isPrivate ? 'Type your private note...' : getReplyPlaceholder(channel))
+    const showChannelLogo = !isPrivate && (channel === 'slack' || channel === 'teams')
     const sendVerb = isPrivate ? 'Attach' : 'Send'
 
     const handleSubmit = (statusAfterSend?: TicketStatus): void => {
@@ -167,7 +173,7 @@ export function MessageInput({
         <div>
             <SupportEditor
                 initialContent={draftContent}
-                placeholder={placeholder}
+                placeholder={resolvedPlaceholder}
                 onCreate={(editor) => {
                     editorRef.current = editor
                     if (draftContent) {
@@ -250,7 +256,16 @@ export function MessageInput({
                                 : undefined
                         }
                     >
-                        {isPrivate ? 'Attach' : buttonText}
+                        {isPrivate ? (
+                            'Attach'
+                        ) : showChannelLogo ? (
+                            <span className="inline-flex items-center gap-1.5">
+                                {buttonText}
+                                <span className="text-sm">{channelIcon[channel]}</span>
+                            </span>
+                        ) : (
+                            buttonText
+                        )}
                     </LemonButton>
                 </div>
             </div>

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -8,7 +8,7 @@ import { RichContentEditorType } from 'lib/components/RichContentEditor/types'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 
 import type { TicketChannel, TicketStatus } from '../../types'
-import { channelIcon, getReplyPlaceholder } from '../Channels/ChannelsTag'
+import { channelIcon, getReplyPlaceholder, hasReplyChannelBranding } from '../Channels/ChannelsTag'
 import { SupportEditor, serializeToMarkdown } from '../Editor'
 
 export interface MessageInputProps {
@@ -85,7 +85,7 @@ export function MessageInput({
     const setIsPrivate = onPrivateChange ?? setLocalIsPrivate
 
     const resolvedPlaceholder = placeholder ?? (isPrivate ? 'Type your private note...' : getReplyPlaceholder(channel))
-    const showChannelLogo = !isPrivate && (channel === 'slack' || channel === 'teams')
+    const showChannelLogo = !isPrivate && hasReplyChannelBranding(channel)
     const sendVerb = isPrivate ? 'Attach' : 'Send'
 
     const handleSubmit = (statusAfterSend?: TicketStatus): void => {

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -200,6 +200,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         olderMessagesLoading={olderMessagesLoading}
                         onSendMessage={sendMessage}
                         onLoadOlderMessages={loadOlderMessages}
+                        channel={ticket?.channel_source}
                         showPrivateOption
                         unreadCustomerCount={ticket?.unread_customer_count}
                         showDeliveryStatus={ticket?.channel_source === 'widget'}


### PR DESCRIPTION
## Problem

The ticket reply box always showed the generic placeholder "Type your message...". A ticket can come from different channels (Slack, Microsoft Teams, email, in-app widget, GitHub), and when replying to a Slack, Teams, or GitHub thread it wasn't obvious the reply was being posted back to that external channel.

## Changes

The reply box now makes the destination clear.

- Placeholder reflects the channel: "Reply in Slack...", "Reply in Microsoft Teams...", "Reply in GitHub...", falling back to "Type your message..." for other/unknown channels.
- The Send button carries the channel logo (Slack / Teams / GitHub) to its right, sized down to match the button text, and desaturated in dark mode so the brand colors don't clash with the solid Send button.
- Private notes stay generic: placeholder becomes "Type your private note..." and no channel logo shows, since a private note never leaves the app.

Which channels get branding is driven by one `replyChannelLabel` map in `ChannelsTag`, so adding a future branded channel is a one-line edit. `channel` is plumbed `SupportTicketScene` → `ChatView` → `MessageInput` off the ticket's existing `channel_source`. No backend, API, or generated-type changes.

The logo sits inside the button content (not the `sideIcon` slot) so the button's symmetric horizontal padding applies to both edges: the space to the right of the logo equals the space to the left of "Send".

## Screenshots

Reply composer per channel, in light and dark mode:

| Channel | Light | Dark |
| --- | --- | --- |
| Slack | ![Slack reply placeholder, light mode](https://raw.githubusercontent.com/PostHog/pr-assets/9bd5b5eec5b0e2d63be7acdcd714291ebe83628d/2026/07/f4e5d9b0-1a7f-4c32-86b4-874e58940569.png) | ![Slack reply placeholder, dark mode](https://raw.githubusercontent.com/PostHog/pr-assets/987f0eefa6888dedbdf5bbfc11b1185a29688aeb/2026/07/29284623-8ab4-4339-b38a-70935e9c7c1d.png) |
| Microsoft Teams | ![Teams reply placeholder, light mode](https://raw.githubusercontent.com/PostHog/pr-assets/b3e782160fffdaed49c02794e6be7351b214a53d/2026/07/7ed0668b-d778-4e6a-8e76-fc338b312018.png) | ![Teams reply placeholder, dark mode](https://raw.githubusercontent.com/PostHog/pr-assets/71b6371263c6478d2c83980d66c5e67aa23729f7/2026/07/ffeacd81-0ea6-4042-93d8-00e7b2b85a35.png) |
| GitHub | ![GitHub reply placeholder, light mode](https://raw.githubusercontent.com/PostHog/pr-assets/ac4f1043cbdd148c5f2862867c99c8e319cb0aeb/2026/07/109af4a3-421c-4b14-884b-dffb5bc9b3ce.png) | ![GitHub reply placeholder, dark mode](https://raw.githubusercontent.com/PostHog/pr-assets/ab73c13fca822ebd0f288b1326b18c73541376eb/2026/07/8c8d51c6-2f55-4866-a529-d83f8a2a78d2.png) |
| Widget & email (fallback) | ![Fallback reply placeholder, light mode](https://raw.githubusercontent.com/PostHog/pr-assets/da12dd7fbd1dd3b7c1b019015f55cd500b3e9e36/2026/07/62d45abb-4948-40d7-be74-e460147329ec.png) | ![Fallback reply placeholder, dark mode](https://raw.githubusercontent.com/PostHog/pr-assets/7ce190c8dd690b8b47037522bdcc7a0a5951b137/2026/07/2ff2cf69-4f92-4398-82cf-935b74b89bdd.png) |
| Private note | ![Private note placeholder, light mode](https://raw.githubusercontent.com/PostHog/pr-assets/ccb4a792e7743e3a94956e18ddc90d7df7a1893c/2026/07/6273b224-3d67-446f-bba4-751a02a3ff8f.png) | ![Private note placeholder, dark mode](https://raw.githubusercontent.com/PostHog/pr-assets/9f110bd106fbc26f5ca9f62c3fc20c327ab45855/2026/07/cf1353e6-8f16-4c47-b52f-da25031368be.png) |

## How did you test this code?

`pnpm --filter=@posthog/frontend typescript:check` passes clean. I seeded local tickets across all five channel modes (widget, email, slack, teams, github) to eyeball the composer per channel and the private-note override. The screenshots above were captured from a Storybook story of the composer. No new automated tests were added - the change is thin presentational prop wiring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Xander directed the work: initial ask was a channel-aware placeholder with the channel logo, later extended to GitHub. We landed on the logo living on the Send button (the TipTap placeholder is plain-text-only via `content: attr(data-placeholder)`, so a logo can't sit in the placeholder itself). Follow-ups refined it: private-note mode overrides to "Type your private note..." with no logo, the logo moved from the `sideIcon` slot into the button content so its right padding matches the left padding of the text, and it's desaturated in dark mode so brand colors don't clash with the solid Send button. Since the branch was first opened the composer changed on master (send-and-set-status split button, private-note alignment), so it was rebased onto latest master and the reply logic re-reconciled against those changes. No repo skills were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
