### PR TITLE
fix(postgres): retry a still-recovering standby on reconnect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -359,24 +359,54 @@ def _is_connection_limit_error(error: BaseException) -> bool:
     return any(substring in message for substring in _CONNECTION_LIMIT_ERROR_SUBSTRINGS)
 
 
+# Connect-time "server not ready" refusals: PostgreSQL rejects a *new* connection with SQLSTATE
+# 57P03 (cannot_connect_now) while it is still coming up — a primary or standby booting ("the
+# database system is starting up"), a server replaying WAL after a crash ("the database system is
+# in recovery mode"), or a hot standby that has accepted the connection attempt but not yet reached
+# a consistent recovery point ("the database system is not yet accepting connections", DETAIL
+# "Consistent recovery state has not been yet reached"). All are transient: the server begins
+# accepting connections within seconds once startup/recovery completes, so a fresh connect after a
+# short backoff succeeds. libpq surfaces these as a bare OperationalError at connect time (no
+# SQLSTATE-mapped subclass), so match on the stable message. Deliberately NOT the permanent
+# hot-standby-disabled refusal — that reads "the database system is not accepting connections"
+# (no "yet") with DETAIL "Hot standby mode is disabled" and stays non-retryable (see source.py's
+# `get_non_retryable_errors`); none of the substrings below appear in it.
+_SERVER_STARTING_UP_ERROR_SUBSTRINGS = (
+    "the database system is starting up",
+    "the database system is not yet accepting connections",
+    "the database system is in recovery mode",
+)
+
+
+def _is_server_starting_up_error(error: BaseException) -> bool:
+    if not isinstance(error, psycopg.OperationalError):
+        return False
+    message = " ".join(str(arg) for arg in error.args).lower()
+    return any(substring in message for substring in _SERVER_STARTING_UP_ERROR_SUBSTRINGS)
+
+
 def _is_dropped_or_connect_timeout(error: BaseException) -> bool:
     """Transient connect-path failures the import/read reconnect recovers from in process.
 
-    A mid-stream drop (`_is_connection_dropped_error`), a connect-time timeout, or a connect-time
-    connection-limit refusal (`_is_connection_limit_error`). psycopg raises `ConnectionTimeout`
-    ("connection timeout expired") only while *establishing* a connection, never mid-query, so on the
-    import/read path it's transient: the source was reachable moments earlier in the same sync, and
-    the reconnect just needs retrying. Connection-limit refusals ("sorry, too many clients already",
-    etc.) are likewise transient — a slot frees the moment another connection closes. Used by the
-    read/sync connect retry (`_connect_with_dropped_retry`) and the `offset_chunking` reconnect. The
-    schema-discovery path retries drops and connection-limit refusals too (via
-    `_is_dropped_or_connection_limit`) but deliberately keeps failing fast on connect-time *timeouts*,
-    where a timeout usually means an unreachable host / unconfigured firewall (see `PostgresErrors`
-    and `get_non_retryable_errors`).
+    A mid-stream drop (`_is_connection_dropped_error`), a connect-time timeout, a connect-time
+    connection-limit refusal (`_is_connection_limit_error`), or a connect-time "server not ready"
+    refusal while the source is still starting up / recovering (`_is_server_starting_up_error`).
+    psycopg raises `ConnectionTimeout` ("connection timeout expired") only while *establishing* a
+    connection, never mid-query, so on the import/read path it's transient: the source was reachable
+    moments earlier in the same sync, and the reconnect just needs retrying. Connection-limit
+    refusals ("sorry, too many clients already", etc.) and server-still-starting-up refusals ("the
+    database system is not yet accepting connections", etc.) are likewise transient — a slot frees
+    the moment another connection closes, and the server begins accepting connections once
+    startup/recovery finishes. Used by the read/sync connect retry (`_connect_with_dropped_retry`)
+    and the `offset_chunking` reconnect. The schema-discovery path retries drops, connection-limit
+    refusals and server-startup refusals too (via `_is_dropped_or_connection_limit`) but deliberately
+    keeps failing fast on connect-time *timeouts*, where a timeout usually means an unreachable host /
+    unconfigured firewall (see `PostgresErrors` and `get_non_retryable_errors`).
     """
     return (
         _is_connection_dropped_error(error)
         or _is_connection_limit_error(error)
+        or _is_server_starting_up_error(error)
         or isinstance(error, psycopg.errors.ConnectionTimeout)
     )
 
@@ -384,15 +414,19 @@ def _is_dropped_or_connect_timeout(error: BaseException) -> bool:
 def _is_dropped_or_connection_limit(error: BaseException) -> bool:
     """Transient conditions the background schema-discovery retry recovers from in process.
 
-    A mid-stream drop (`_is_connection_dropped_error`) or a connection-limit refusal
-    (`_is_connection_limit_error`). Both are transient — a slot frees as connections close, and a
-    pooler-cached login failure clears once the upstream has capacity — so discovery retries them on
+    A mid-stream drop (`_is_connection_dropped_error`), a connection-limit refusal
+    (`_is_connection_limit_error`), or a "server not ready" refusal while the source is still
+    starting up / recovering (`_is_server_starting_up_error`). All are transient — a slot frees as
+    connections close, a pooler-cached login failure clears once the upstream has capacity, and the
+    server begins accepting connections once startup/recovery finishes — so discovery retries them on
     a fresh connection instead of failing the activity and surfacing captured error-tracking noise.
     Unlike the read/sync connect path (`_is_dropped_or_connect_timeout`), a connect-time *timeout* is
     deliberately excluded: during discovery a timeout usually means a now-unreachable host, which
     should fail fast rather than burn the retry budget.
     """
-    return _is_connection_dropped_error(error) or _is_connection_limit_error(error)
+    return (
+        _is_connection_dropped_error(error) or _is_connection_limit_error(error) or _is_server_starting_up_error(error)
+    )
 
 
 def _is_recovery_conflict_error(error: BaseException) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -381,6 +381,10 @@ class TestPostgresSourceNonRetryableErrors:
             # can hit on a hot-standby-disabled replica is non-retryable (see the permanent cases below).
             "consuming input failed: SSL SYSCALL error: EOF detected",
             "the connection is lost",
+            # A hot standby still reaching a consistent recovery point (SQLSTATE 57P03). Transient —
+            # it accepts connections once recovery completes — so unlike the permanent
+            # hot-standby-disabled refusal it must stay out of NonRetryableErrors.
+            'connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL:  the database system is not yet accepting connections DETAIL:  Consistent recovery state has not been yet reached.',
         ],
     )
     def test_transient_connection_errors_are_retryable(self, source, error_msg):
@@ -1414,6 +1418,20 @@ class TestDroppedOrConnectTimeout:
             # The new case: the read-path reconnect that bootstraps offset-chunking recovery times
             # out establishing the socket. Transient — the source was reachable moments earlier.
             psycopg.errors.ConnectionTimeout("connection timeout expired"),
+            # A hot standby that hasn't yet reached a consistent recovery point refuses the
+            # reconnect with SQLSTATE 57P03 (cannot_connect_now). Transient — it starts accepting
+            # connections once recovery completes — so the offset-chunking reconnect must retry it
+            # in-process instead of failing the whole activity.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "127.0.0.1", port 5432 failed: '
+                "FATAL:  the database system is not yet accepting connections "
+                "DETAIL:  Consistent recovery state has not been yet reached."
+            ),
+            # Sibling 57P03 refusals while the source is booting / crash-recovering.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL:  the database system is starting up"
+            ),
         ],
     )
     def test_transient_connect_path_errors_are_retryable(self, error):
@@ -1427,6 +1445,15 @@ class TestDroppedOrConnectTimeout:
             ),
             # A statement timeout is not a connect timeout — it must not be absorbed here.
             psycopg.errors.QueryCanceled("canceling statement due to statement timeout"),
+            # A standby started with hot_standby=off refuses every connection permanently — it reads
+            # "not accepting connections" (no "yet") with DETAIL "Hot standby mode is disabled". It
+            # must NOT be treated as a transient server-startup refusal, so it fails fast to the
+            # non-retryable classification rather than burning the in-process reconnect budget.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL:  the database system is not accepting connections "
+                "DETAIL:  Hot standby mode is disabled."
+            ),
         ],
     )
     def test_permanent_and_non_connect_errors_are_not_retryable(self, error):


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError` from the Postgres data-warehouse import source:

> connection failed: connection to server at "…", port … failed: FATAL: the database system is not yet accepting connections
> DETAIL: Consistent recovery state has not been yet reached.

This is SQLSTATE 57P03 (`cannot_connect_now`): a hot standby that has accepted the connection attempt but hasn't yet replayed enough WAL to reach a consistent recovery point. It's transient — the standby starts serving reads within seconds once recovery completes.

The stack shows it firing on the reconnect that bootstraps the offset-chunking recovery path (`get_rows → offset_chunking → get_connection`). That path exists precisely to recover in-process from a mid-stream drop without re-running the whole activity from offset 0. But the transient-connect classifier didn't recognise this 57P03 refusal, so it escaped the reconnect loop, failed the activity, and got captured as error-tracking noise. Its siblings — connection-limit refusals and connect-time timeouts — are already retried in that same loop, so this was a gap, not a policy.

## Changes

Added `_is_server_starting_up_error` matching the stable 57P03 "server not ready" messages (`the database system is starting up`, `… is not yet accepting connections`, `… is in recovery mode`), and wired it into both transient-connect classifiers (`_is_dropped_or_connect_timeout` for the read/sync reconnect, `_is_dropped_or_connection_limit` for schema discovery). The reconnect loops already back off and cap retries, so a standby coming up now recovers in place instead of failing the run.

> [!NOTE]
> The permanent hot-standby-disabled refusal is deliberately left out. That one reads `the database system is not accepting connections` (no "yet") with DETAIL `Hot standby mode is disabled`, and stays non-retryable via `get_non_retryable_errors` — a standby with `hot_standby = off` never serves reads until its config changes. None of the new substrings appear in that message, so the split is clean.

This stays retryable — it is **not** added to `NonRetryableErrors`.

## How did you test this code?

Extended existing parametrized unit tests (no new DB-touching tests needed — these predicates are pure functions):

- `TestDroppedOrConnectTimeout::test_transient_connect_path_errors_are_retryable` — added the observed 57P03 message plus the `starting up` sibling. Catches the regression directly: without the fix, the offset-chunking reconnect fails the activity on a still-recovering standby.
- `TestDroppedOrConnectTimeout::test_permanent_and_non_connect_errors_are_not_retryable` — added the permanent hot-standby-disabled refusal. Guards against a future broadening to `not accepting connections` that would wrongly retry a permanent error in-process.
- `test_transient_connection_errors_are_retryable` — added the observed message to confirm it stays out of `NonRetryableErrors`.

Ran the affected suites locally: `TestDroppedOrConnectTimeout` and `TestPostgresSourceNonRetryableErrors`, 111 passed. Ruff check + format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking issue by Claude (Claude Code). Confirmed the failure originates in the postgres source's reconnect path via the full stack trace, read the surrounding retryability logic, and decided this is a fixable fragility (transient error escaping in-process recovery) rather than a `NonRetryableErrors` case. The main design decision was scoping the substring match to the transient "server coming up" wordings while explicitly not colliding with the permanent hot-standby-disabled refusal the codebase already classifies as non-retryable. Invoked the `/writing-tests` skill before extending the tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
