### PR TITLE
fix(data-warehouse): stop the schema modal paginator from paging the sources table

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/OverviewTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/OverviewTab.tsx
@@ -215,6 +215,9 @@ export function OverviewTab(): JSX.Element {
                 </div>
                 {managedWarehouseDataStatus.sources.sources.length ? (
                     <LemonTable
+                        // Distinct id so this table's pagination/sort URL params don't collide with
+                        // the schema modal's table (both default to ?page/?order otherwise).
+                        id="managed-warehouse-imported-sources"
                         embedded
                         columns={sourceSummaryColumns}
                         dataSource={managedWarehouseDataStatus.sources.sources}

--- a/frontend/src/scenes/data-warehouse/scene/SourceSchemasModal.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/SourceSchemasModal.tsx
@@ -38,6 +38,9 @@ export function SourceSchemasModal(): JSX.Element {
                 </LemonBanner>
             ) : (
                 <LemonTable
+                    // Distinct id so the modal paginator/sort drives only this table via its own
+                    // URL params, not the Overview tab's imported-sources table behind it.
+                    id="managed-warehouse-source-schemas"
                     dataSource={sourceSchemas}
                     columns={sourceSchemaColumns}
                     loading={sourceSchemasLoading}


### PR DESCRIPTION
## Problem

On the Data ops Overview tab, two bugs in the "Imported source tables" area:

1. **The schema modal's paginator also pages the sources table behind it.** Opening a source's schema modal and clicking next/prev on its paginator moved the imported-sources summary table to the same page.
2. **Dismissing the modal snaps the page to a different scroll position.**

Both are the same root cause. `LemonTable` stores its current page and sort in the URL search params, keyed by the table's `id` (`<id>_page` / `<id>_order`), falling back to a bare `?page` / `?order` when no `id` is given. Neither the summary table (`OverviewTab.tsx`) nor the modal table (`SourceSchemasModal.tsx`) passed an `id`, so **both read and wrote the same `?page` param**. Paging the modal pushed `?page=2`, the summary table read it and changed page too (bug 1), and the summary table's scroll-on-page-change effect (`LemonTable.tsx`) then scrolled the underlying page — which you notice as a scroll snap once the modal is dismissed (bug 2). Sorting collided the same way via `?order`.

## Changes

Give each table a distinct `id` (`managed-warehouse-imported-sources` and `managed-warehouse-source-schemas`) so their pagination and sort state live in separate URL params and stop cross-driving each other. This is exactly what the `id` prop is documented for ("add uniqueness to search params").

No behavior change to either table on its own — just decoupled state.

## How did you test this code?

I (Claude, driven by Eric) traced the root cause through `LemonTable` / `usePagination` (the shared `?page`/`?order` param) and `LemonModal` (ruled out body-scroll-lock and focus-restore as the cause of bug 2 — no such CSS/config exists). The fix is a two-line addition of an existing optional `id?: string` prop.

I did not run the app end-to-end. Full frontend `typescript:check` in a fresh worktree is dominated by missing kea-typegen output (unrelated, pre-existing), but the two changed files report zero type errors, and adding an optional string prop is type-safe. No test added: the fix is a declarative wiring correction (a missing prop), not logic — a test would only assert LemonTable's documented `id`→param behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Eric reported the two modal bugs. I root-caused both to the shared default `?page`/`?order` LemonTable URL params, confirmed bug 2 was a downstream effect (not a modal scroll-lock issue), and fixed it by giving each table a distinct `id`. Done on a worktree off latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
