### PR TITLE
fix(replay-vision): fade out the collapsed digest instead of hard-clipping

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerDigestCard.tsx
@@ -151,7 +151,15 @@ export function ScannerDigestCard({
                     </>
                 }
             />
-            <div className={expanded ? undefined : 'max-h-60 overflow-hidden'}>
+            {/* The mask's fixed offsets (vs percentages) keep short, unclipped digests fully opaque:
+                content under 12rem never reaches the fade band that softens the 15rem (max-h-60) cut. */}
+            <div
+                className={
+                    expanded
+                        ? undefined
+                        : 'max-h-60 overflow-hidden [mask-image:linear-gradient(to_bottom,black_12rem,transparent_15rem)]'
+                }
+            >
                 {/* LLM/replay-derived content: render non-PostHog images as links, not auto-fetched <img>s. */}
                 <LemonMarkdown className="text-sm" disableImages>
                     {latestRun.synthesized_markdown}


### PR DESCRIPTION
## Problem

The scanner page's daily digest card collapses long summaries with `max-h-60` + `overflow-hidden`, which slices the markdown off mid-line - a hard cut with no visual hint that there's more below beyond the "Show more" button.

## Changes

The collapsed container gets a CSS `mask-image` gradient: fully opaque until 12rem, fading to transparent at the 15rem clip line. Expanding removes the mask along with the height cap.

Two deliberate choices:

- **Mask over a background-colored overlay.** An overlay has to match whatever is behind the card and breaks quietly in dark mode; a mask fades the content itself, so it's correct on any background. Same technique as the onboarding breadcrumbs' horizontal overflow fade.
- **Fixed offsets over percentages.** The fade band only exists between 12rem and 15rem, so a digest shorter than 12rem never reaches it and renders fully opaque. A percentage gradient would fade the tail of every digest, including ones that aren't clipped at all.

No screenshot upload since the visible content is a dogfood digest; the effect is the standard soft fade at the bottom of the collapsed card.

## How did you test this code?

Styling-only change (one className); no automated tests apply. I (Claude) verified oxlint and oxfmt pass. Not yet verified visually in a running app - worth a quick look at a scanner page with a long digest before marking ready.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Replay Vision is flag-gated and undocumented, so no docs to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) from the PR author's request to soften the collapsed digest's hard cut. Considered a `bg-gradient-to-t` overlay first (the session-player UserActivity pattern) and rejected it for the background-matching problem above.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

