### PR TITLE
fix(data-imports): stop next-url paginator from re-appending original params

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
@@ -53,6 +53,12 @@ class BaseNextUrlPaginator(BasePaginator):
     def update_request(self, request: Request) -> None:
         if self._next_url is not None:
             request.url = self._next_url
+            # The next-page URL is self-contained — it already carries every query
+            # param needed. Drop the original params so `prepare_request` doesn't
+            # re-append them to the URL each page; some APIs echo the received query
+            # back into their next link, so re-appending compounds one copy per page
+            # until the URL grows large enough for the server to reject it.
+            request.params = {}
 
 
 class HeaderLinkPaginator(BaseNextUrlPaginator):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from requests import Request, Response
+from requests import PreparedRequest, Request, Response, Session
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
     HeaderLinkPaginator,
@@ -70,6 +70,40 @@ class TestJSONResponsePaginator:
 
     def test_json_link_paginator_is_alias(self) -> None:
         assert JSONLinkPaginator is JSONResponsePaginator
+
+    def test_clears_original_params_when_following_next_url(self) -> None:
+        # The initial request carries query params (e.g. per_page + an incremental
+        # filter). Once the paginator switches to the server's self-contained next
+        # URL, those params must be dropped — otherwise prepare_request re-appends
+        # them to the already-complete URL, and an API that echoes the query back
+        # into its next link compounds a duplicate every page (observed: an Intercom
+        # activity_logs URL grew hundreds of `created_at_after=0` copies until 500).
+        p = JSONResponsePaginator(next_url_path="pages.next")
+        next_url = "https://api.example.com/logs?per_page=150&created_at_after=0&page=2"
+        p.update_state(_make_response({"pages": {"next": next_url}, "activity_logs": []}))
+        req = Request(
+            method="GET",
+            url="https://api.example.com/logs",
+            params={"per_page": 150, "created_at_after": 0},
+        )
+        p.update_request(req)
+
+        prepared: PreparedRequest = Session().prepare_request(req)
+        assert prepared.url is not None
+        assert prepared.url.count("created_at_after") == 1
+        assert prepared.url.count("per_page") == 1
+
+    def test_header_link_paginator_clears_original_params(self) -> None:
+        p = HeaderLinkPaginator()
+        resp = _make_response()
+        resp.headers["Link"] = '<https://api.example.com/page2?per_page=150>; rel="next"'
+        p.update_state(resp)
+        req = Request(method="GET", url="https://api.example.com/page1", params={"per_page": 150})
+        p.update_request(req)
+
+        prepared: PreparedRequest = Session().prepare_request(req)
+        assert prepared.url is not None
+        assert prepared.url.count("per_page") == 1
 
 
 class TestJSONResponseCursorPaginator:


### PR DESCRIPTION
## Problem

An Intercom `activity_logs` import failed with `RESTClientRetryableError: HTTP 500`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f683e-6845-7ee2-aecc-6bbd0f790844)). The failing request URL had `created_at_after=0` repeated hundreds of times and a trailing `page=231`:

```
https://api.intercom.io/admins/activity_logs?per_page=150&created_at_after=0&created_at_after=0&…&page=231&per_page=150&created_at_after=0
```

That malformed URL is our doing, not the customer's config or credentials. It originates in the shared REST pagination code (`rest_client.py` `_send_request`), reached from the normal import path, so it is not specific to one source.

Root cause is `BaseNextUrlPaginator.update_request` in `sources/common/rest_source/paginators.py`. The next-url paginators (`JSONResponsePaginator`, `HeaderLinkPaginator`) set `request.url` to the server's self-contained next-page URL but never clear the original `request.params`. `requests.Session.prepare_request` then appends those params to the already-complete URL on every page. Intercom echoes the received query back into its `pages.next` link, so each round trip adds one more `created_at_after=0`. By page 231 the URL is long enough that Intercom returns a 500.

Because a next-page link already carries every param it needs, re-appending the originals is always wrong for this paginator family. This bites any next-url stream that starts with query params and pages far enough — Intercom `activity_logs` is where it showed up because it filters via `created_at_after` and can span many pages.

## Changes

Clear `request.params` when following a next URL, so the self-contained link is used verbatim:

```diff
 def update_request(self, request: Request) -> None:
     if self._next_url is not None:
         request.url = self._next_url
+        request.params = {}
```

This matches upstream dlt, which clears params on the base next-url paginator for exactly this reason. Auth query params are unaffected — they are re-applied per request by the auth object at prepare time, not carried in `request.params`.

> [!NOTE]
> This does not touch the retry policy. Genuine transient 5xx/429s stay retryable as before.

## How did you test this code?

Added two cases to `TestJSONResponsePaginator` / `TestHeaderLinkPaginator` in `test_paginators.py`. Each starts a request with query params, follows a self-contained next URL, then prepares the request through a real `requests.Session` and asserts each param appears exactly once in the final URL. These catch a regression back to the param-accumulation bug — dropping the fix makes the incremental filter param appear twice and then compound per page.

I (Claude) could not run the full pytest suite here (Django isn't installed in this environment). I verified the paginator logic in isolation against `requests` 2.33: confirmed the fixed code yields exactly one copy of each param, and that the pre-fix behavior reproduces the duplication (`created_at_after` twice after one page). `ruff check` and `ruff format` pass. CI will run the suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) confirmed the issue in PostHog error tracking (stack trace, exception type, source frame, recency), read the Intercom source and the shared REST pagination code, then classified it: not a credentials/config/upstream error, but a real pagination bug in shared code. Fixed it at the base-class layer since it affects every next-url source, not just Intercom.

Invoked the `/writing-tests` skill before adding tests. Checked for duplicate open PRs by exception type, message phrase, source path, and the source maintainer's open PRs. The closest was #71332 (`fix(square): repeat original query params on paginated requests`) — I read it and confirmed it is a different source with an opposite, cursor-in-params contract and unrelated code, not a duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
