### PR TITLE
fix(data-warehouse): make self-managed column read failure actionable

### DIFF
--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -848,7 +848,10 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
         if isinstance(err, CHQueryErrorTooManySimultaneousQueries):
             raise err
 
-        raise Exception("Could not get columns")
+        raise Exception(
+            "Could not read the files from your storage bucket. Check that the files URL pattern, file format, "
+            "and credentials are correct, then try again."
+        )
 
 
 @database_sync_to_async


### PR DESCRIPTION
## Problem

When schema/column detection fails for a self-managed storage source (S3, Google Cloud Storage, Azure Blob, Cloudflare R2), the wizard surfaced a generic `Could not get columns` error. Specific failure modes (access denied, missing file, bad bucket, CSV quote mismatch) already map to actionable messages, but the last-resort fallback gave the user nothing to act on. Session observations of real onboarding show users hitting this message repeatedly while iterating on their file URL pattern and credentials, with no hint about what to change.

## Changes

Replace the `Could not get columns` fallback with an actionable message pointing at the three inputs that determine detection: the files URL pattern, the file format, and the credentials. The message is provider-neutral since all self-managed storage backends funnel through this path, and it also reads correctly for the row-count introspection call site that shares the same fallback.

## How did you test this code?

Copy-only change to an exception message. Ran `ruff check` and `ruff format --check` on the touched file. No test or frontend code matched the old string, so nothing else needed updating.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code while triaging data-warehouse new-source onboarding friction from Replay Vision session summaries. The recurring dead-end error surfaced by a real self-managed storage onboarding session was traced from the wizard through `DataWarehouseTable.get_columns` to the `_safe_expose_ch_error` fallback in `products/warehouse_sources/backend/models/table.py`. Only the fallback string was changed; the existing per-error mappings (which are already actionable) were left untouched. Verified no open PR already addressed this fallback.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
