### PR TITLE
fix(datadog): retry 408 request timeout instead of failing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/datadog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/datadog.py
@@ -228,7 +228,9 @@ def get_rows(
     def fetch_page(page_url: str) -> Any:
         response = session.get(page_url, timeout=REQUEST_TIMEOUT_SECONDS)
 
-        if response.status_code == 429 or response.status_code >= 500:
+        # 408 is a transient request timeout on Datadog's side; retry it like 429/5xx rather than
+        # letting it raise_for_status() into a fatal, non-retried HTTPError.
+        if response.status_code in (408, 429) or response.status_code >= 500:
             raise DatadogRetryableError(f"Datadog API error (retryable): status={response.status_code}, url={page_url}")
 
         if not response.ok:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/tests/test_datadog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/tests/test_datadog.py
@@ -426,7 +426,7 @@ class TestFetchPageRetry:
             resp.json.return_value = {"data": [], "links": {}}
             resp.text = f"{status} body"
             if status >= 400:
-                resp.raise_for_status.side_effect = requests.HTTPError(f"{status} Client Error")
+                resp.raise_for_status.side_effect = requests.HTTPError(f"{status} Client Error", response=resp)
             return resp
 
         # Patch tenacity's backoff sleep so retries don't block the test.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/tests/test_datadog.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/datadog/tests/test_datadog.py
@@ -11,6 +11,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.datadog im
 from products.warehouse_sources.backend.temporal.data_imports.sources.datadog.datadog import (
     DEFAULT_SITE,
     DatadogResumeConfig,
+    DatadogRetryableError,
     _build_initial_params,
     _build_initial_url,
     _compute_next_url,
@@ -406,3 +407,56 @@ class TestGetRowsResume:
         pages = [{"data": [{"id": "9", "attributes": {}}], "links": {}}]
         with pytest.raises(ValueError, match="unexpected URL"):
             self._run("logs", pages, can_resume=True, resume_url=resume_url)
+
+
+class TestFetchPageRetry:
+    def _run(self, statuses: list[int]) -> list[int]:
+        manager = mock.MagicMock()
+        manager.can_resume.return_value = False
+        manager.load_state.return_value = None
+
+        seen: list[int] = []
+
+        def fake_get(url: str, headers: Any = None, timeout: Any = None) -> Any:
+            status = statuses[len(seen)]
+            seen.append(status)
+            resp = mock.MagicMock()
+            resp.status_code = status
+            resp.ok = status < 400
+            resp.json.return_value = {"data": [], "links": {}}
+            resp.text = f"{status} body"
+            if status >= 400:
+                resp.raise_for_status.side_effect = requests.HTTPError(f"{status} Client Error")
+            return resp
+
+        # Patch tenacity's backoff sleep so retries don't block the test.
+        with (
+            mock.patch.object(ddog, "make_tracked_session") as mock_session,
+            mock.patch("tenacity.nap.time.sleep"),
+        ):
+            mock_session.return_value.get.side_effect = fake_get
+            list(
+                ddog.get_rows(
+                    site="datadoghq.com",
+                    api_key="api",
+                    app_key="app",
+                    endpoint="logs",
+                    logger=mock.MagicMock(),
+                    resumable_source_manager=manager,
+                )
+            )
+        return seen
+
+    def test_408_is_retried_then_succeeds(self) -> None:
+        seen = self._run([408, 200])
+        assert seen == [408, 200]
+
+    def test_persistent_408_reraises_as_retryable(self) -> None:
+        with pytest.raises(DatadogRetryableError):
+            self._run([408, 408, 408, 408, 408])
+
+    def test_other_4xx_is_not_retried(self) -> None:
+        # A genuine client error stays fatal — HTTPError isn't retryable, so it never becomes
+        # DatadogRetryableError. Guards against widening the 408 fix to swallow all 4xx.
+        with pytest.raises(requests.HTTPError):
+            self._run([400])


### PR DESCRIPTION
## Problem

Datadog imports were hard-failing on transient timeouts. Error tracking surfaced an `HTTPError` raised in the Datadog source:

> `408 Client Error: Request Timeout for url: https://api.datadoghq.com/api/v2/logs/events?...`

Issue: https://us.posthog.com/project/2/error_tracking/019f6995-1d0b-7041-ae05-cc93fe2380ea

The stack ends in `fetch_page` at `datadog.py`, at the `response.raise_for_status()` line.

A 408 Request Timeout is a transient server-side signal — the request should be retried, not abandoned. But `fetch_page` only classified `429` and `5xx` as retryable. A 408 fell through to `raise_for_status()`, which raises `requests.HTTPError`. That type isn't in the retry set (`DatadogRetryableError`, `ReadTimeout`, `ConnectionError`), so tenacity reraised it immediately and the whole sync failed on the first blip.

## Changes

Treat 408 as retryable alongside 429 and 5xx, so it raises `DatadogRetryableError` and tenacity backs off and retries.

```diff
-        if response.status_code == 429 or response.status_code >= 500:
+        if response.status_code in (408, 429) or response.status_code >= 500:
             raise DatadogRetryableError(...)
```

This is a transient-infrastructure fix, not a credentials/config problem, so it stays retryable rather than going into `NonRetryableErrors`. The scope is kept to 408 — other 4xx client errors (bad request, unauthorized, forbidden) still fail fast, as they should.

## How did you test this code?

Automated only (I'm Claude, an agent — no manual/live testing against Datadog). Added a `TestFetchPageRetry` class exercising `get_rows` through a mocked session with tenacity's backoff sleep patched out:

- `test_408_is_retried_then_succeeds` — a 408 followed by a 200 recovers instead of failing. Catches a regression where 408 stops being retried.
- `test_persistent_408_reraises_as_retryable` — five 408s exhaust retries and reraise as `DatadogRetryableError`, confirming it's classified retryable (not a fatal `HTTPError`).
- `test_other_4xx_is_not_retried` — a 400 still raises `HTTPError`. Guards against widening the fix to swallow all 4xx.

Ran the full source test file: 55 passed. `ruff check` and `ruff format --check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) confirmed the issue in PostHog error tracking, read the stack trace end to end (real frame in `datadog.py:fetch_page`, not just serialized log context), and traced the pipeline call path into `get_rows`/`fetch_page`. Decided this is a fixable bug rather than a `NonRetryableErrors` case: 408 is a transient timeout that should be retried, consistent with how 429/5xx are already handled. Invoked the `/writing-tests` skill before adding the regression tests and kept the scope to 408 to avoid masking genuine client errors.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
