### PR TITLE
fix(mcp-analytics): span tool report charts over the selected window

### DIFF
--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
@@ -53,4 +53,19 @@ describe('buildDailyChartData', () => {
             sessions: [3, 0, 1],
         })
     })
+
+    // Guards the "sparklines lose their line" regression: with only one active day, an axis that spans
+    // just the data would be a single point (no line). A window range pads it out so the line renders.
+    it('spans the full window when given a range, padding days without data', () => {
+        const rows = [stat({ day: '2026-06-03', calls: 5, errors: 0, p50: 50, p95: 150, users: 1, sessions: 1 })]
+        expect(buildDailyChartData(rows, { start: '2026-06-01', end: '2026-06-05' })).toEqual({
+            labels: ['2026-06-01', '2026-06-02', '2026-06-03', '2026-06-04', '2026-06-05'],
+            calls: [0, 0, 5, 0, 0],
+            errors: [0, 0, 0, 0, 0],
+            p50: [NaN, NaN, 50, NaN, NaN],
+            p95: [NaN, NaN, 150, NaN, NaN],
+            users: [0, 0, 1, 0, 0],
+            sessions: [0, 0, 1, 0, 0],
+        })
+    })
 })

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -76,14 +76,17 @@ export type ResultRows = unknown[][]
 
 // Gap-fill the per-day rows into a continuous day axis (ClickHouse only returns days with data).
 // Counts fill with 0; latency fills with NaN so the chart skips the point instead of dipping to 0.
-export function buildDailyChartData(rows: DailyToolStat[]): DailyChartData {
+// `range` spans the axis over the full selected window so the sparklines and trend charts match the
+// chosen range — and always have enough points to draw a line — even when the tool has data on only a
+// day or two; without it the axis spans just the days that have data (a single day draws no line).
+export function buildDailyChartData(rows: DailyToolStat[], range?: { start: string; end: string }): DailyChartData {
     if (rows.length === 0) {
         return EMPTY_CHART_DATA
     }
     const byDay = new Map(rows.map((r) => [r.day, r]))
-    const end = dayjs(rows[rows.length - 1].day)
+    const end = dayjs(range?.end ?? rows[rows.length - 1].day)
     const labels: string[] = []
-    for (let day = dayjs(rows[0].day); !day.isAfter(end); day = day.add(1, 'day')) {
+    for (let day = dayjs(range?.start ?? rows[0].day); !day.isAfter(end); day = day.add(1, 'day')) {
         labels.push(day.format('YYYY-MM-DD'))
     }
     const at = labels.map((day) => byDay.get(day))
@@ -314,8 +317,18 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
         toolName: [() => [(_, props) => props.toolName], (toolName: string) => toolName],
 
         dailyChartData: [
-            (s) => [s.dailyStats],
-            (dailyStats: DailyToolStat[]): DailyChartData => buildDailyChartData(dailyStats),
+            (s) => [s.dailyStats, s.dateFilter, teamLogic.selectors.timezone],
+            (dailyStats: DailyToolStat[], dateFilter: DateFilter, timezone: string): DailyChartData => {
+                const start =
+                    dateStringToDayJs(dateFilter.dateFrom, timezone) ?? dayjs().tz(timezone).subtract(30, 'day')
+                const end =
+                    (dateFilter.dateTo ? dateStringToDayJs(dateFilter.dateTo, timezone) : dayjs().tz(timezone)) ??
+                    dayjs().tz(timezone)
+                return buildDailyChartData(dailyStats, {
+                    start: start.format('YYYY-MM-DD'),
+                    end: end.format('YYYY-MM-DD'),
+                })
+            },
         ],
 
         // Resolve the `dateFilter` state (camelCase, nullable, may be relative like '-30d') into the


### PR DESCRIPTION
## Problem

On an individual tool's report, the tile sparklines and the reliability trend charts built their day axis from only the days that had data. When a tool had data on a single day in the selected window (common arriving from the Tool quality tab's 7-day default on a low-traffic tool), the series was one point, so the line couldn't draw and every tile lost its sparkline.

## Changes

Pad the day axis to the selected window (mirroring the Tool quality tab), gap-filling empty days, so the charts always match the chosen range and have enough points to render a line. The no-data empty state is preserved.

## How did you test this code?

Added a unit case to `mcpAnalyticsToolDetailLogic.test.ts` covering the single-active-day window (guards the "sparklines lose their line" regression the earlier tests didn't). Ran `hogli test products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts` — 4/4 pass. I (Claude) did not exercise this in a running frontend.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgis spotted the missing sparkline lines while reviewing the tool-quality date-persist work. I traced it to `dailyChartData` spanning only data-days instead of the selected window, then applied the same range-padding the Tool quality tab already uses. Invoked the `/writing-tests` skill before adding the regression case.
