### PR TITLE
feat(error-tracking): handle ingestion notifications concurrently

### DIFF
--- a/rust/cymbal/src/modes/notifications/config.rs
+++ b/rust/cymbal/src/modes/notifications/config.rs
@@ -33,6 +33,11 @@ pub struct NotificationsConfig {
     #[envconfig(default = "")]
     pub internal_api_secret: String,
 
+    /// Maximum notification groups handled concurrently within a fetched
+    /// batch. Notifications for the same issue are never handled concurrently.
+    #[envconfig(default = "16")]
+    pub max_concurrent_notifications: usize,
+
     /// HTTP bind port for liveness, readiness, and Prometheus metrics.
     #[envconfig(from = "METRICS_PORT", default = "9102")]
     pub metrics_port: u16,

--- a/rust/cymbal/src/modes/notifications/consumer_loop.rs
+++ b/rust/cymbal/src/modes/notifications/consumer_loop.rs
@@ -25,8 +25,10 @@ const NOTIFICATIONS_FETCH_BATCH_TIMEOUT: Duration = Duration::from_millis(250);
 /// sequential, so per-issue ordering is preserved. Offsets are stored per
 /// partition only up to the first failure and committed after each batch, so a
 /// crash never skips an unhandled message. Serde and empty failures are
-/// auto-stored as poison pills inside `json_recv_batch`, so this loop also
-/// commits those stored offsets.
+/// auto-stored as poison pills inside `json_recv_batch`; clean batches commit
+/// those stored offsets too, but a failed batch commits only the explicit
+/// success prefix — a pill's fetch-time store can sit past the failed message
+/// and must not be committed ahead of it.
 pub async fn consume_loop(
     consumer: SingleTopicConsumer,
     context: NotificationsContext,
@@ -67,7 +69,7 @@ async fn handle_notification_batch(
     max_concurrency: usize,
 ) {
     // Poison pills already had their offsets stored inside `json_recv_batch`;
-    // count them so they get committed even when nothing else succeeds.
+    // count them so clean batches commit them even when nothing else succeeds.
     let mut stored = 0usize;
     let mut messages = Vec::new();
 
@@ -140,6 +142,9 @@ async fn handle_notification_batch(
     );
 
     let mut first_error = None;
+    // Per-partition next-offsets of the stored successes; offsets ascend per
+    // partition, so the last insert holds the max.
+    let mut committable: HashMap<i32, i64> = HashMap::new();
     for (outcome, store) in outcomes.into_iter().zip(storable) {
         if let Some(error) = outcome.error {
             first_error.get_or_insert(error);
@@ -148,23 +153,44 @@ async fn handle_notification_batch(
         if !store {
             continue;
         }
+        let (partition, next_offset) = (outcome.offset.partition(), outcome.offset.get_value() + 1);
         // `commit_consumer_state` only commits offsets explicitly stored on the consumer.
         if let Err(e) = outcome.offset.store() {
             panic!("failed to store notification offset: {e}");
         }
+        committable.insert(partition, next_offset);
         stored += 1;
     }
 
-    if stored > 0 {
-        if let Err(e) = consumer.commit() {
+    let Some(error) = first_error else {
+        // `stored` may be poison pills alone; guard the commit — committing with
+        // nothing stored fails with NO_OFFSET.
+        if stored > 0 {
+            if let Err(e) = consumer.commit() {
+                panic!("failed to commit notification offsets: {e}");
+            }
+            debug!(count = stored, "committed notification offsets");
+        }
+        return;
+    };
+
+    // A state-wide commit here would also publish poison-pill offsets auto-stored
+    // at fetch time inside `json_recv_batch`, which can sit past the failed
+    // message on the same partition and permanently skip it. Commit only the
+    // explicit success prefix; pill stores die with the panic and the pills are
+    // redelivered, re-skipped, and committed by a later clean batch.
+    let offsets: Vec<(i32, i64)> = committable.into_iter().collect();
+    if !offsets.is_empty() {
+        if let Err(e) = consumer.commit_partition_offsets(&offsets) {
             panic!("failed to commit notification offsets: {e}");
         }
-        debug!(count = stored, "committed notification offsets");
+        debug!(
+            count = offsets.len(),
+            "committed notification success-prefix offsets before panic"
+        );
     }
 
-    if let Some(error) = first_error {
-        panic!("failed to handle notification: {error}");
-    }
+    panic!("failed to handle notification: {error}");
 }
 
 /// Group items by key, preserving each group's original item order. Group

--- a/rust/cymbal/src/modes/notifications/consumer_loop.rs
+++ b/rust/cymbal/src/modes/notifications/consumer_loop.rs
@@ -1,9 +1,12 @@
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use common_kafka::kafka_consumer::{Offset, RecvErr, SingleTopicConsumer};
+use futures::stream::{self, StreamExt};
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
 
+use crate::core::error::UnhandledError;
 use crate::core::types::notification::IngestionNotification;
 use crate::modes::notifications::context::NotificationsContext;
 use crate::modes::notifications::handler::handle_notification;
@@ -16,16 +19,21 @@ const NOTIFICATIONS_HANDLE_ERRORS_TOTAL: &str = "cymbal_notifications_handle_err
 const NOTIFICATIONS_COMMIT_BATCH_SIZE: usize = 100;
 const NOTIFICATIONS_FETCH_BATCH_TIMEOUT: Duration = Duration::from_millis(250);
 
-/// Receive messages until shutdown. Offsets are stored only after successful
-/// handling, then explicitly committed after each fetched batch. Serde and empty
-/// failures are auto-stored as poison pills inside `json_recv_batch`, so this
-/// loop also explicitly commits those stored offsets.
+/// Receive messages until shutdown. Each fetched batch is split into per-issue
+/// groups (the producer partitions by `team_id:issue_id`), which are handled
+/// concurrently up to `max_concurrency`; messages within a group stay
+/// sequential, so per-issue ordering is preserved. Offsets are stored per
+/// partition only up to the first failure and committed after each batch, so a
+/// crash never skips an unhandled message. Serde and empty failures are
+/// auto-stored as poison pills inside `json_recv_batch`, so this loop also
+/// commits those stored offsets.
 pub async fn consume_loop(
     consumer: SingleTopicConsumer,
     context: NotificationsContext,
+    max_concurrency: usize,
     mut shutdown_rx: watch::Receiver<bool>,
 ) {
-    let mut pending_offsets = 0usize;
+    let max_concurrency = max_concurrency.max(1);
 
     loop {
         tokio::select! {
@@ -33,7 +41,6 @@ pub async fn consume_loop(
             changed = shutdown_rx.changed() => {
                 if changed.is_err() || *shutdown_rx.borrow() {
                     info!("notifications consumer shutting down");
-                    commit_pending_offsets(&consumer, &mut pending_offsets, "shutdown");
                     break;
                 }
             }
@@ -41,48 +48,44 @@ pub async fn consume_loop(
                 NOTIFICATIONS_COMMIT_BATCH_SIZE,
                 NOTIFICATIONS_FETCH_BATCH_TIMEOUT,
             ) => {
-                handle_notification_batch(&consumer, &context, batch, &mut pending_offsets).await;
-                commit_pending_offsets(&consumer, &mut pending_offsets, "batch");
+                handle_notification_batch(&consumer, &context, batch, max_concurrency).await;
             }
         }
     }
+}
+
+struct MessageOutcome {
+    batch_index: usize,
+    offset: Offset,
+    error: Option<UnhandledError>,
 }
 
 async fn handle_notification_batch(
     consumer: &SingleTopicConsumer,
     context: &NotificationsContext,
     batch: Vec<Result<(IngestionNotification, Offset), RecvErr>>,
-    pending_offsets: &mut usize,
+    max_concurrency: usize,
 ) {
-    for result in batch {
+    // Poison pills already had their offsets stored inside `json_recv_batch`;
+    // count them so they get committed even when nothing else succeeds.
+    let mut stored = 0usize;
+    let mut messages = Vec::new();
+
+    for (batch_index, result) in batch.into_iter().enumerate() {
         match result {
             Ok((notification, offset)) => {
                 log_notification_summary(&notification);
                 metrics::counter!(NOTIFICATIONS_RECEIVED_TOTAL).increment(1);
-                match handle_notification(context, notification).await {
-                    Ok(()) => {
-                        metrics::counter!(NOTIFICATIONS_HANDLED_TOTAL).increment(1);
-                        // `commit_consumer_state` only commits offsets explicitly stored on the consumer.
-                        if let Err(e) = offset.store() {
-                            panic!("failed to store notification offset: {e}");
-                        }
-                        *pending_offsets += 1;
-                    }
-                    Err(e) => {
-                        metrics::counter!(NOTIFICATIONS_HANDLE_ERRORS_TOTAL).increment(1);
-                        commit_pending_offsets(consumer, pending_offsets, "before_panic");
-                        panic!("failed to handle notification: {e}");
-                    }
-                }
+                messages.push((batch_index, notification, offset));
             }
             Err(RecvErr::Serde(e)) => {
                 warn!(error = %e, "notification serde error (poison pill skipped)");
                 metrics::counter!(NOTIFICATIONS_SKIPPED_TOTAL, "reason" => "serde").increment(1);
-                *pending_offsets += 1;
+                stored += 1;
             }
             Err(RecvErr::Empty) => {
                 metrics::counter!(NOTIFICATIONS_SKIPPED_TOTAL, "reason" => "empty").increment(1);
-                *pending_offsets += 1;
+                stored += 1;
             }
             Err(RecvErr::Kafka(e)) => {
                 error!(error = %e, "notifications kafka error");
@@ -91,26 +94,113 @@ async fn handle_notification_batch(
             }
         }
     }
+
+    let groups = group_preserving_order(messages, |(_, notification, _)| {
+        notification.partition_key()
+    });
+
+    // A failure aborts the rest of its group: later notifications for the same
+    // issue must not be handled (or have offsets stored) ahead of the failed
+    // one — they redeliver after the panic below.
+    let mut outcomes: Vec<MessageOutcome> = stream::iter(groups.into_iter().map(|group| async {
+        let mut outcomes = Vec::with_capacity(group.len());
+        for (batch_index, notification, offset) in group {
+            match handle_notification(context, notification).await {
+                Ok(()) => {
+                    metrics::counter!(NOTIFICATIONS_HANDLED_TOTAL).increment(1);
+                    outcomes.push(MessageOutcome {
+                        batch_index,
+                        offset,
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    metrics::counter!(NOTIFICATIONS_HANDLE_ERRORS_TOTAL).increment(1);
+                    outcomes.push(MessageOutcome {
+                        batch_index,
+                        offset,
+                        error: Some(e),
+                    });
+                    break;
+                }
+            }
+        }
+        outcomes
+    }))
+    .buffer_unordered(max_concurrency)
+    .concat()
+    .await;
+
+    outcomes.sort_by_key(|outcome| outcome.batch_index);
+
+    let storable: Vec<bool> = storable_offsets(
+        outcomes
+            .iter()
+            .map(|outcome| (outcome.offset.partition(), outcome.error.is_none())),
+    );
+
+    let mut first_error = None;
+    for (outcome, store) in outcomes.into_iter().zip(storable) {
+        if let Some(error) = outcome.error {
+            first_error.get_or_insert(error);
+            continue;
+        }
+        if !store {
+            continue;
+        }
+        // `commit_consumer_state` only commits offsets explicitly stored on the consumer.
+        if let Err(e) = outcome.offset.store() {
+            panic!("failed to store notification offset: {e}");
+        }
+        stored += 1;
+    }
+
+    if stored > 0 {
+        if let Err(e) = consumer.commit() {
+            panic!("failed to commit notification offsets: {e}");
+        }
+        debug!(count = stored, "committed notification offsets");
+    }
+
+    if let Some(error) = first_error {
+        panic!("failed to handle notification: {error}");
+    }
 }
 
-fn commit_pending_offsets(
-    consumer: &SingleTopicConsumer,
-    pending_offsets: &mut usize,
-    reason: &str,
-) {
-    if *pending_offsets == 0 {
-        return;
+/// Group items by key, preserving each group's original item order. Group
+/// order follows first appearance, keeping batches deterministic.
+fn group_preserving_order<T, K: Fn(&T) -> String>(items: Vec<T>, key_fn: K) -> Vec<Vec<T>> {
+    let mut key_indexes: HashMap<String, usize> = HashMap::new();
+    let mut groups: Vec<Vec<T>> = Vec::new();
+
+    for item in items {
+        let key = key_fn(&item);
+        let index = *key_indexes.entry(key).or_insert_with(|| {
+            groups.push(Vec::new());
+            groups.len() - 1
+        });
+        groups[index].push(item);
     }
 
-    if let Err(e) = consumer.commit() {
-        panic!("failed to commit notification offsets: {e}");
-    }
+    groups
+}
 
-    debug!(
-        count = *pending_offsets,
-        reason, "committed notification offsets"
-    );
-    *pending_offsets = 0;
+/// Given `(partition, succeeded)` per message in batch (= per-partition offset)
+/// order, mark which offsets are safe to store: within a partition, only
+/// messages before the first failure. Storing a later offset would mark the
+/// failed message as processed and Kafka would never redeliver it.
+fn storable_offsets(outcomes: impl Iterator<Item = (i32, bool)>) -> Vec<bool> {
+    let mut blocked: HashSet<i32> = HashSet::new();
+
+    outcomes
+        .map(|(partition, succeeded)| {
+            if !succeeded {
+                blocked.insert(partition);
+                return false;
+            }
+            !blocked.contains(&partition)
+        })
+        .collect()
 }
 
 fn log_notification_summary(notification: &IngestionNotification) {
@@ -143,5 +233,50 @@ fn log_notification_summary(notification: &IngestionNotification) {
                 "received error-tracking ingestion notification"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storable_offsets_blocks_partition_after_failure_only() {
+        // Partitions interleaved in offset order: a failure on partition 0 must
+        // block later partition-0 offsets (or redelivery would skip the failed
+        // message) while partition 1 keeps storing.
+        let outcomes = vec![
+            (0, true),
+            (1, true),
+            (0, false),
+            (1, true),
+            (0, true),
+            (0, true),
+            (1, false),
+            (1, true),
+        ];
+
+        let storable = storable_offsets(outcomes.into_iter());
+
+        assert_eq!(
+            storable,
+            vec![true, true, false, true, false, false, false, false]
+        );
+    }
+
+    #[test]
+    fn group_preserving_order_keeps_per_key_order() {
+        let items = vec![("a", 1), ("b", 2), ("a", 3), ("c", 4), ("b", 5)];
+
+        let groups = group_preserving_order(items, |(key, _)| key.to_string());
+
+        assert_eq!(
+            groups,
+            vec![
+                vec![("a", 1), ("a", 3)],
+                vec![("b", 2), ("b", 5)],
+                vec![("c", 4)],
+            ]
+        );
     }
 }

--- a/rust/cymbal/src/modes/notifications/consumer_loop.rs
+++ b/rust/cymbal/src/modes/notifications/consumer_loop.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use common_kafka::kafka_consumer::{Offset, RecvErr, SingleTopicConsumer};
@@ -59,7 +60,17 @@ pub async fn consume_loop(
 struct MessageOutcome {
     batch_index: usize,
     offset: Offset,
-    error: Option<UnhandledError>,
+    result: HandleResult,
+}
+
+enum HandleResult {
+    Handled,
+    Failed(UnhandledError),
+    /// Not attempted because an earlier failure was already observed. Emitting
+    /// an outcome keeps the message visible to `storable_offsets`, so a later
+    /// success on its partition can't be committed past it; it redelivers
+    /// after the panic.
+    Skipped,
 }
 
 async fn handle_notification_batch(
@@ -101,29 +112,40 @@ async fn handle_notification_batch(
         notification.partition_key()
     });
 
-    // A failure aborts the rest of its group: later notifications for the same
-    // issue must not be handled (or have offsets stored) ahead of the failed
-    // one — they redeliver after the panic below.
+    // The whole batch panics (and redelivers) on any failure, so once one is
+    // observed, handling more messages only creates side effects that will be
+    // emitted again on redelivery. Stop starting new work: everything not yet
+    // in flight is skipped, bounding duplicates to the groups already running.
+    // This also halts the failed group itself, preserving per-issue ordering.
+    let failed = AtomicBool::new(false);
     let mut outcomes: Vec<MessageOutcome> = stream::iter(groups.into_iter().map(|group| async {
         let mut outcomes = Vec::with_capacity(group.len());
         for (batch_index, notification, offset) in group {
+            if failed.load(Ordering::Relaxed) {
+                outcomes.push(MessageOutcome {
+                    batch_index,
+                    offset,
+                    result: HandleResult::Skipped,
+                });
+                continue;
+            }
             match handle_notification(context, notification).await {
                 Ok(()) => {
                     metrics::counter!(NOTIFICATIONS_HANDLED_TOTAL).increment(1);
                     outcomes.push(MessageOutcome {
                         batch_index,
                         offset,
-                        error: None,
+                        result: HandleResult::Handled,
                     });
                 }
                 Err(e) => {
                     metrics::counter!(NOTIFICATIONS_HANDLE_ERRORS_TOTAL).increment(1);
+                    failed.store(true, Ordering::Relaxed);
                     outcomes.push(MessageOutcome {
                         batch_index,
                         offset,
-                        error: Some(e),
+                        result: HandleResult::Failed(e),
                     });
-                    break;
                 }
             }
         }
@@ -135,20 +157,25 @@ async fn handle_notification_batch(
 
     outcomes.sort_by_key(|outcome| outcome.batch_index);
 
-    let storable: Vec<bool> = storable_offsets(
-        outcomes
-            .iter()
-            .map(|outcome| (outcome.offset.partition(), outcome.error.is_none())),
-    );
+    let storable: Vec<bool> = storable_offsets(outcomes.iter().map(|outcome| {
+        (
+            outcome.offset.partition(),
+            matches!(outcome.result, HandleResult::Handled),
+        )
+    }));
 
     let mut first_error = None;
     // Per-partition next-offsets of the stored successes; offsets ascend per
     // partition, so the last insert holds the max.
     let mut committable: HashMap<i32, i64> = HashMap::new();
     for (outcome, store) in outcomes.into_iter().zip(storable) {
-        if let Some(error) = outcome.error {
-            first_error.get_or_insert(error);
-            continue;
+        match outcome.result {
+            HandleResult::Failed(error) => {
+                first_error.get_or_insert(error);
+                continue;
+            }
+            HandleResult::Skipped => continue,
+            HandleResult::Handled => {}
         }
         if !store {
             continue;

--- a/rust/cymbal/src/modes/notifications/mod.rs
+++ b/rust/cymbal/src/modes/notifications/mod.rs
@@ -50,7 +50,13 @@ pub async fn run(config: NotificationsConfig) {
     let metrics_handle =
         spawn_metrics_server(config.metrics_port, shutdown_rx.clone(), draining.clone());
 
-    consume_loop(consumer, context, shutdown_rx).await;
+    consume_loop(
+        consumer,
+        context,
+        config.max_concurrent_notifications,
+        shutdown_rx,
+    )
+    .await;
 
     let _ignored = shutdown_tx.send(true);
     if let Err(err) = metrics_handle.await {


### PR DESCRIPTION
## Changes

Before - we walked messages strictly one by one. We awaited kafka produces so we were capped at ~170ms per message which gives 6 messages / second.

After - we batch messages into groups (by partition key so by team:issue) up to 16 concurrency. Stuff related to the same issue preserves order (I think it's not extremely important but let's keep this bulletproof).

There was also a bug in comiting offset with poison pill within a batch - a poison pill after a failed message on the same partition got its fetch-time-stored offset committed before the panic, permanently skipping the failed message. Failed batches now commit only explicit success-prefix offsets via commit_partition_offsets; the pill redelivers and commits on the next clean batch. Verified locally against Kafka.

## How did you test this code?

Robot:
- `cargo test -p cymbal --lib` — 232 passed, including 2 new unit tests:
  - `storable_offsets_blocks_partition_after_failure_only` — guards the offset-skip data-loss bug: if someone changes offset storage to store all successes regardless of an earlier failure in the same partition, this fails.
  - `group_preserving_order_keeps_per_key_order` — guards per-issue ordering: fails if grouping stops preserving intra-key order (e.g. switching to unordered per-message concurrency).
- `cargo check -p cymbal`, `cargo clippy -p cymbal --all-targets`, `cargo fmt --check` — clean.

Me:
- manually created new issue. Confirmed that notification was propagated

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal consumer behavior, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Claude Fable 5) after a production investigation of EU notifications-consumer lag; `/writing-tests` was invoked before adding tests. Design decisions: concurrency is per issue group rather than per partition (8 partitions would cap the win at 8x; per-issue matches the producer's ordering key so it's the finest-grained split that preserves intended ordering), and per message was rejected because it would reorder same-issue notifications. The panic-on-error crash-and-redeliver model was deliberately kept; only offset storage changed, to the per-partition success prefix needed for concurrent safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)