### PR TITLE
chore(data-warehouse): Update Anchor time display with timezone condition

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -999,7 +999,12 @@ function AnchorTimeField({
         <div className="flex flex-col gap-1">
             <div className="flex items-start justify-between gap-4">
                 <div className="flex flex-col">
-                    <span>Anchor time</span>
+                    <span>
+                        Anchor time
+                        {(currentTeam?.timezone === 'UTC' || currentTeam?.timezone === 'GMT') && (
+                            <span className="text-muted"> (UTC)</span>
+                        )}
+                    </span>
                     <span className="text-xs text-muted max-w-md">
                         Pin the sync schedule so runs start at a predictable time each day (useful for coordinating with
                         downstream jobs). Only applies to intervals longer than one hour.


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/62410 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/62727)

## Changes

Make it clearer that anchor time is UTC when that's the project timezone.

<img width="944" height="844" alt="CleanShot 2026-07-16 at 08 47 04@2x" src="https://github.com/user-attachments/assets/a3347fe5-b2a4-4eca-b373-13cfd35a5894" />

## Docs update

should make it clear in docs if it isn't already that anchor times can be set to UTC or project timezone.