### PR TITLE
fix(clerk): stop paginator crashing on empty response body

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
@@ -75,6 +75,13 @@ class ClerkPaginator(BasePaginator):
             request.params["offset"] = self._offset
 
     def update_state(self, response: Response, data: list[Any] | None = None) -> None:
+        # A successful response with an empty body means there are no more rows.
+        # rest_client already treats this as an empty page (body=None); mirror
+        # that here instead of re-parsing and raising JSONDecodeError.
+        if not response.content or not response.content.strip():
+            self._has_next_page = False
+            return
+
         res = response.json()
 
         if not res:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -49,6 +49,19 @@ class TestClerkPaginator:
         assert paginator._has_next_page is has_next
         assert paginator._offset == expected_offset
 
+    def test_update_state_stops_on_empty_body(self) -> None:
+        # A 2xx response with an empty body must stop pagination, not crash on
+        # response.json() (Clerk returns this and it reached update_state raw).
+        response = Response()
+        response.status_code = 200
+        response._content = b""
+        paginator = ClerkPaginator(limit=100)
+
+        paginator.update_state(response)
+
+        assert paginator.has_next_page is False
+        assert paginator._offset == 0
+
     @pytest.mark.parametrize(
         ("label", "seeded_offset", "expected_offset_param"),
         [


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` originating in the Clerk data warehouse import source, at `ClerkPaginator.update_state` (`clerk.py:78`).

The paginator's `update_state` re-parses the HTTP response with `response.json()` to read `total_count` and item counts. When Clerk returns a successful (2xx) response with an **empty body**, that call raises `JSONDecodeError` and fails the import.

The shared `rest_client` already handles this case: it treats an empty body on an otherwise-successful response as a complete "no data" answer and hands the paginator an empty page. But because `update_state` parses the response a second time on its own, it never benefits from that handling and crashes.

This reaches `update_state` only after `raise_for_status()` has already passed, so it's a genuine 2xx-with-empty-body response, not an auth or credential problem. That makes it a code-robustness fix, not a `NonRetryableErrors` case.

## Changes

`ClerkPaginator.update_state` now short-circuits and stops pagination when the response content is empty, before re-parsing. This mirrors the existing `rest_client` contract (empty body means no more rows) and matches how sibling paginators (`OffsetPaginator`, `JSONResponsePaginator`) guard their own `response.json()` calls.

```diff
 def update_state(self, response: Response, data: list[Any] | None = None) -> None:
+    if not response.content or not response.content.strip():
+        self._has_next_page = False
+        return
+
     res = response.json()
```

## How did you test this code?

Added one regression test, `TestClerkPaginator::test_update_state_stops_on_empty_body`, which drives `update_state` with a real `requests.Response` carrying an empty body. It reproduces the exact production error (`JSONDecodeError: Expecting value: line 1 column 1 (char 0)`) against the old code and passes with the fix.

The pre-existing `("empty_body", None, ...)` parametrized case only mocked `response.json()` to *return* `None`, so it never exercised the raise path — the new test closes that gap at the same (pure paginator) layer.

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/` — 36 passed
- `ruff check` / `ruff format --check` — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Clerk import source. I (Claude) confirmed the crash originates in `clerk.py` `update_state`, traced the call path through the shared `rest_client` (which already tolerates empty bodies), and confirmed the paginator's independent re-parse was the fragile spot. Decided this is a fixable bug rather than a `NonRetryableErrors` addition because the failure only occurs on a successful 2xx response. Checked open PRs (including the maintainer's) for an existing fix to this path and found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
