### PR TITLE
fix(data-imports): treat OpenRouter no-organization 404 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/source.py
@@ -38,6 +38,15 @@ _MANAGEMENT_KEY_REQUIRED = (
     "read the models and providers catalogs."
 )
 
+# The organization members and workspaces endpoints resolve only when the management key's account
+# belongs to an OpenRouter organization; an account without one gets a 404. Retrying can't create an
+# organization, so we stop and tell the customer.
+_NO_ORGANIZATION = (
+    "Your OpenRouter account isn't part of an organization, so the organization members and workspaces "
+    "tables can't be synced. Disable these tables, or reconnect with a management key that belongs to an "
+    "organization."
+)
+
 
 @SourceRegistry.register
 class OpenRouterSource(ResumableSource[OpenRouterSourceConfig, OpenRouterResumeConfig]):
@@ -88,6 +97,11 @@ Use a **management API key** (create one under [Settings -> Management Keys](htt
             # status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://openrouter.ai": "Your OpenRouter API key is invalid or has been revoked. Create a new key in your OpenRouter dashboard, then reconnect.",
             "403 Client Error: Forbidden for url: https://openrouter.ai": "Your OpenRouter API key is missing the management scope needed to sync this data. Use a management API key (Settings -> Management Keys), then reconnect.",
+            # Match the org-scoped paths specifically, not a bare host 404, so a genuine bad path on
+            # another endpoint still surfaces instead of being silently disabled. The query string is
+            # dropped as the volatile part.
+            "404 Client Error: Not Found for url: https://openrouter.ai/api/v1/organization/members": _NO_ORGANIZATION,
+            "404 Client Error: Not Found for url: https://openrouter.ai/api/v1/workspaces": _NO_ORGANIZATION,
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/tests/test_openrouter_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/tests/test_openrouter_source.py
@@ -64,9 +64,34 @@ class TestOpenRouterSource:
         schemas = self.source.get_schemas(self.config, self.team_id, names=["models", "activity"])
         assert {s.name for s in schemas} == {"models", "activity"}
 
-    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error"])
+    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error", "404 Client Error"])
     def test_non_retryable_errors(self, expected_key):
         assert any(expected_key in key for key in self.source.get_non_retryable_errors())
+
+    @pytest.mark.parametrize(
+        "raw_error,is_non_retryable",
+        [
+            # Real raise_for_status() strings carry the offset/limit query the org endpoints page with;
+            # the keys must still match them as a substring the way external_data_job.py classifies.
+            (
+                "404 Client Error: Not Found for url: https://openrouter.ai/api/v1/organization/members?offset=0&limit=100",
+                True,
+            ),
+            (
+                "404 Client Error: Not Found for url: https://openrouter.ai/api/v1/workspaces?offset=0&limit=100",
+                True,
+            ),
+            # A 404 on a catalog endpoint would be a real path bug, not a missing organization — it must
+            # stay retryable rather than be silently disabled.
+            ("404 Client Error: Not Found for url: https://openrouter.ai/api/v1/models", False),
+        ],
+    )
+    def test_404_classification(self, raw_error, is_non_retryable):
+        errors = self.source.get_non_retryable_errors()
+        matches = [msg for key, msg in errors.items() if key in raw_error]
+        assert bool(matches) is is_non_retryable
+        if is_non_retryable:
+            assert "organization" in (matches[0] or "").lower()
 
     def test_validate_credentials_invalid_key(self):
         with _patch_key_info(None):


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` in the OpenRouter data-warehouse import source:

```
404 Client Error: Not Found for url: https://openrouter.ai/api/v1/organization/members?offset=0&limit=<redacted>
```

Issue: [019f69f8-40ac-7721-88f4-acd9b6e27d4e](https://us.posthog.com/project/2/error_tracking/019f69f8-40ac-7721-88f4-acd9b6e27d4e). It fired across several teams.

The `_fetch` helper in `openrouter.py` calls `raise_for_status()` on the 404. Only 401 and 403 are classified as non-retryable today, so the 404 kept retrying a failure that can never succeed.

## Changes

The path and pagination are correct. OpenRouter's docs confirm `GET /api/v1/organization/members` exists and takes `offset`/`limit` exactly as we send them. The endpoint lists members of the organization tied to the authenticated management key, so a valid management key whose account is not part of an organization gets a 404. The sibling org-scoped `/workspaces` endpoint behaves the same way. Neither can be fixed by retrying, so this is an upstream/account condition, the direct analog of the existing 403 "missing management scope" case.

I added the two org-scoped 404 paths to `get_non_retryable_errors` in the OpenRouter source, mapped to one actionable message telling the customer their account is not part of an organization and to disable those tables (or reconnect with a management key that belongs to one). When matched, the pipeline disables the schema and surfaces the message instead of retrying.

I matched the specific paths rather than a bare-host 404 on purpose: a 404 on a catalog endpoint (`/models`, `/providers`) would be a real path bug, and it should keep surfacing rather than be silently disabled.

## How did you test this code?

Automated only (I am an agent and did not run a live sync). Added and ran unit tests in `test_openrouter_source.py`:

- Extended the existing `test_non_retryable_errors` parametrization to include the `404 Client Error` key.
- Added `test_404_classification`, which feeds the real `raise_for_status()` strings (with the `offset`/`limit` query the org endpoints page with) through the same substring match `external_data_job.py` uses. It asserts the org-scoped 404s are recognized as non-retryable and carry the org message, and that a 404 on a catalog endpoint stays retryable.

These guard the regression where the key string drifts from the real error format (so the 404 stops matching and retries forever), and the anti-swallow guarantee for catalog paths. No existing test covered either.

```
66 passed in 3.44s
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (PostHog Code). The top in-app frame pointed at `openrouter.py:_fetch`. I confirmed the issue and impact via the error-tracking MCP tools, read the source and its settings, and checked OpenRouter's API reference to establish the endpoint and params are correct, so this is an account condition rather than a wrong-URL bug.

Considered a graceful skip (treat the 404 as an empty table) but chose non-retryable to mirror the existing 403 handling and give the customer a clear reason instead of a silently empty table. Invoked the `/writing-tests` skill before adding tests. Ruled out duplicates by scanning open data-warehouse PRs, including the maintainer's own.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
