### PR TITLE
fix(google_ads): treat invalid-credentials 401 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
@@ -97,6 +97,10 @@ class GoogleAdsSource(
             # contains the bare "UNAUTHENTICATED" token, so the gRPC-status keys above don't catch it.
             # Retrying cannot recover — the user must reconnect their Google Ads account.
             "Request is missing required authentication credential": "Your Google Ads connection could not be authenticated. Please reconnect your Google Ads account.",
+            # The other gapic-wrapped Unauthenticated variant, str() "401 Request had invalid authentication
+            # credentials. ..." — raised when the OAuth access token itself is rejected. Same story: no bare
+            # "UNAUTHENTICATED" token, retrying cannot recover, the user must reconnect their Google Ads account.
+            "Request had invalid authentication credentials": "Your Google Ads connection could not be authenticated. Please reconnect your Google Ads account.",
         }
 
     # TODO: clean up google ads source to not have two auth config options

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -215,14 +215,28 @@ class TestGoogleAdsNonRetryableErrors:
                 "token, login cookie or other valid authentication credential. See "
                 "https://developers.google.com/identity/sign-in/web/devconsole-project."
             ),
+            # The other gapic-wrapped Unauthenticated message, seen on the sync path when the OAuth
+            # access token is rejected — same "401 {message}" shape, no bare UNAUTHENTICATED token.
+            (
+                "401 Request had invalid authentication credentials. Expected OAuth 2 access "
+                "token, login cookie or other valid authentication credential. See "
+                "https://developers.google.com/identity/sign-in/web/devconsole-project."
+            ),
         ],
     )
     def test_missing_auth_credential_is_non_retryable(self, error_msg):
         is_non_retryable = any(pattern in error_msg for pattern in self.non_retryable.keys())
         assert is_non_retryable, f"Expected error to be non-retryable: {error_msg}"
 
-    def test_missing_auth_credential_has_friendly_message(self):
-        friendly = self.non_retryable["Request is missing required authentication credential"]
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "Request is missing required authentication credential",
+            "Request had invalid authentication credentials",
+        ],
+    )
+    def test_auth_credential_patterns_have_friendly_message(self, pattern):
+        friendly = self.non_retryable[pattern]
         assert friendly is not None
         assert "reconnect" in friendly.lower()
 
@@ -261,6 +275,7 @@ class TestGoogleAdsNonRetryableErrors:
             "invalid_grant",
             "access_not_configured",
             "Request is missing required authentication credential",
+            "Request had invalid authentication credentials",
         ],
     )
     def test_documented_patterns_present(self, pattern):


### PR DESCRIPTION
## Problem

A data warehouse Google Ads sync whose OAuth access token has been rejected keeps retrying a problem it can never recover from, and re-captures a new error-tracking event on every attempt.

On the sync path, `GoogleAdsService.search` surfaces the rejected token as `google.api_core.exceptions.Unauthenticated`, whose `str()` is:

```
401 Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.
```

`GoogleAdsSource.get_non_retryable_errors()` already has a case for the *sibling* gapic message, `"Request is missing required authentication credential"`, but not this one. gapic renders the wrapped `UNAUTHENTICATED` status as `"401 {message}"`, so the string never carries the bare `UNAUTHENTICATED` token that the gRPC-status keys match. The result: this message matched no key, stayed retryable, and produced a retry loop plus repeated captured exceptions (the observed events showed a very high attempt count).

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f69cd-aa31-7b11-aa36-47fe2978e146

The stack originates in this source's code (`import_data_sync.py` → `pipelines/pipeline/pipeline.py` → `sources/google_ads/google_ads.py`), so this is a real classification gap, not noise from serialized log context.

## Changes

- Add `"Request had invalid authentication credentials"` to `GoogleAdsSource.get_non_retryable_errors()`, returning the same reconnect prompt the `"Request is missing required authentication credential"` variant already uses.

This is a user/upstream error: the credentials are invalid, retrying re-sends the same rejected token, and the only fix is for the user to reconnect their Google Ads account. The match is a stable, low-false-positive substring of Google's auth-error text with no URLs, ids, or timestamps. Transient gRPC failures (`UNAVAILABLE`, `INTERNAL`, `DEADLINE_EXCEEDED`, connection resets) are untouched and stay retryable.

## How did you test this code?

`.venv/bin/python -m pytest ...::TestGoogleAdsNonRetryableErrors` — 36 passed.

Added coverage in `test_google_ads_source.py`:
- A parametrized case in `test_missing_auth_credential_is_non_retryable` asserting the real gapic `"401 Request had invalid authentication credentials. ..."` string is classified non-retryable. Regression it catches: if the new key is dropped, this production message silently becomes retryable again and resumes the retry-storm / error-tracking churn. No existing case exercised this message (the prior case only covered the "missing required" wording).
- Replaced the single-variant friendly-message test with a parametrized `test_auth_credential_patterns_have_friendly_message` covering both auth keys, and added the new key to `test_documented_patterns_present`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while triaging a Google Ads import error from error tracking. Confirmed the failure originates in the source's sync path (not just serialized log context) by reading the captured stack frames, then traced how `internal_error` (`str(e.cause)`) is matched against `get_non_retryable_errors()` in `external_data_job.py` to prove the existing keys miss this message. Invoked `/writing-tests` to gate the added coverage.

Checked open PRs for duplicates: #67538 fixes the interactive `validate_credentials()` path (and frontend toast handling), not the sync `get_non_retryable_errors()`, and #67533 classifies the unrelated `INVALID_ARGUMENT` (400) error. Neither adds this 401 invalid-credentials message to the sync classifier.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
