### PR TITLE
chore: Inline the switch user UX

### DIFF
--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -167,6 +167,7 @@
     // so it reads as the (clickable) email rather than a standalone button.
     &__user-trigger.LemonButton {
         display: inline-flex;
+        max-width: 100%;
         min-height: auto;
         padding: 0 0.125rem;
         font-size: inherit;

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -162,6 +162,17 @@
         line-height: 1.5;
         color: var(--text-primary);
     }
+
+    // The change-user menu trigger sits inline in the "Signed in as …" sentence,
+    // so it reads as the (clickable) email rather than a standalone button.
+    &__user-trigger.LemonButton {
+        display: inline-flex;
+        min-height: auto;
+        padding: 0 0.125rem;
+        font-size: inherit;
+        font-weight: 600;
+        vertical-align: baseline;
+    }
 }
 
 @keyframes ImpersonationNotice__fadeScaleIn {

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -169,10 +169,12 @@
         display: inline-flex;
         max-width: 100%;
         min-height: auto;
-        padding: 0 0.125rem;
+        padding: 0 0.25rem;
         font-size: inherit;
         font-weight: 600;
         vertical-align: baseline;
+        border: 1px solid var(--color-border-warning);
+        border-radius: var(--radius);
     }
 }
 

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -196,7 +196,8 @@ function ImpersonationNoticeContent(): JSX.Element {
                         size="xsmall"
                         sideIcon={<IconChevronDown />}
                         loading={isChangingUser}
-                        tooltip="Change user"
+                        tooltip={`Currently impersonating ${user?.email} - click to switch user`}
+                        truncate
                         className="ImpersonationNotice__user-trigger text-warning"
                     >
                         {user?.email}

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -1,7 +1,7 @@
 import './ImpersonationNotice.scss'
 
 import { useActions, useValues } from 'kea'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { IconChevronDown, IconCollapse, IconEllipsis, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonMenu, LemonTag, Tooltip } from '@posthog/lemon-ui'
@@ -68,7 +68,7 @@ function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: (
         if (pastCountdown) {
             callback?.() // oxlint-disable-line react-hooks/exhaustive-deps
         }
-    }, [pastCountdown])
+    }, [pastCountdown, callback])
 
     return <span className="tabular-nums text-warning">{countdown}</span>
 }
@@ -173,7 +173,7 @@ function ImpersonationNoticeContent(): JSX.Element {
                   onClick: () => setPendingUserId(member.user.id),
               }))
 
-    const handleSessionExpired = (): void => {
+    const handleSessionExpired = useCallback((): void => {
         if (user) {
             setSessionExpired({
                 email: user.email,
@@ -182,12 +182,26 @@ function ImpersonationNoticeContent(): JSX.Element {
                 reason: user.is_impersonated_reason ?? null,
             })
         }
-    }
+    }, [user, setSessionExpired])
 
     return (
         <>
             <p className="ImpersonationNotice__message">
-                Signed in as <span className="text-warning">{user?.email}</span>
+                Signed in as{' '}
+                <LemonMenu
+                    items={changeUserItems}
+                    onVisibilityChange={(visible) => visible && ensureAllMembersLoaded()}
+                >
+                    <LemonButton
+                        size="xsmall"
+                        sideIcon={<IconChevronDown />}
+                        loading={isChangingUser}
+                        tooltip="Change user"
+                        className="ImpersonationNotice__user-trigger text-warning"
+                    >
+                        {user?.email}
+                    </LemonButton>
+                </LemonMenu>
                 {user?.organization?.name && (
                     <>
                         {' '}
@@ -207,20 +221,6 @@ function ImpersonationNoticeContent(): JSX.Element {
                 <LemonButton type="secondary" size="small" onClick={() => loadUser()} loading={userLoading}>
                     Refresh
                 </LemonButton>
-                <LemonMenu
-                    items={changeUserItems}
-                    onVisibilityChange={(visible) => visible && ensureAllMembersLoaded()}
-                >
-                    <LemonButton
-                        type="secondary"
-                        size="small"
-                        sideIcon={<IconChevronDown />}
-                        loading={isChangingUser}
-                        tooltip="Change user"
-                    >
-                        User
-                    </LemonButton>
-                </LemonMenu>
                 <LemonButton
                     type="secondary"
                     status="danger"


### PR DESCRIPTION
## Problem

Switching user is something I've needed so infrequently, it doesn't make sense to make it one of the primary actions on the impersonation notice.

## Changes

Inline the switch user menu with the currently impersonated user's email.

https://github.com/user-attachments/assets/b7fe446e-1b89-4e5f-b50f-09414a432765

## How did you test this code?

Verified locally

