### PR TITLE
fix(devex): fail hogbox preview fast when hogland has no capacity

### DIFF
--- a/tools/hogbox-preview/hogbox_preview/hogland_backend.py
+++ b/tools/hogbox-preview/hogbox_preview/hogland_backend.py
@@ -56,6 +56,27 @@ _WRITE_CHUNK = 48 * 1024 * 1024
 _CREATE_5XX_ATTEMPTS = 3
 _CREATE_5XX_BACKOFF_SECONDS = (5, 15)  # slept BEFORE attempts 2 and 3
 
+# A capacity 503 is NOT a "retry me" 5xx like the placement failures above: the
+# server already burned ~4 minutes internally (auction retry budget, see
+# hogplane's discovery.ErrNoCapacity / orchestrator.retryAuction) before giving
+# up, so 3 client-side retries would tie up the CI runner for 12+ minutes and
+# leave 3 failed boxes behind. The preview workflow's sticky comment already
+# tells the user it'll retry on the next push, so fail fast here instead.
+# Match on hogplane's stable error text (see discovery.ErrNoCapacity in the
+# hogland repo) rather than only the 503 status, since other transient 5xx
+# (placement EOF, etc.) also come back as 503-or-500 and must keep retrying.
+_NO_CAPACITY_MESSAGE_SUBSTRING = "no hogd has capacity"
+
+
+def _is_no_capacity_error(exc: ServerError) -> bool:
+    """True if `exc` is hogland's "no capacity right now" 503, not some other
+    transient 5xx. Defensive: any introspection failure here just falls back to
+    the existing retry-every-5xx behaviour."""
+    try:
+        return _NO_CAPACITY_MESSAGE_SUBSTRING in str(exc)
+    except Exception:
+        return False
+
 
 def _ephemeral_ssh_pubkey() -> str:
     """A throwaway ed25519 public key.
@@ -202,11 +223,24 @@ class HoglandBackend(PreviewBackend):
         immediately. Each attempt draws a fresh unique box name via
         _create_kwargs, so a 5xx-failed attempt — which leaves a failed box
         holding its name for up to an hour — can't make the retry 409 against its
-        own corpse."""
+        own corpse.
+
+        A "no capacity" 503 is the one 5xx that must NOT be retried here: the
+        server already spent ~4 minutes on an auction retry budget before
+        raising it, so retrying 3x would burn 12+ minutes of runner time and
+        leave 3 failed boxes for one doomed run. Fail immediately with a clear
+        message — the caller already tells the user this'll retry on the next
+        push."""
         for attempt in range(_CREATE_5XX_ATTEMPTS):
             try:
                 return self._client.create(**self._create_kwargs())
-            except ServerError:
+            except ServerError as exc:
+                if _is_no_capacity_error(exc):
+                    raise ServerError(
+                        "hogland has no capacity right now; will retry on the next push",
+                        status_code=exc.status_code,
+                        body=exc.body,
+                    ) from exc
                 if attempt == _CREATE_5XX_ATTEMPTS - 1:
                     raise  # out of retries — surface the 5xx
                 time.sleep(_CREATE_5XX_BACKOFF_SECONDS[attempt])

--- a/tools/hogbox-preview/tests/test_hogland_backend.py
+++ b/tools/hogbox-preview/tests/test_hogland_backend.py
@@ -317,5 +317,64 @@ class CreateRetriesTransient5xxTest(unittest.TestCase):
         self.assertEqual(attempts["n"], 1)
 
 
+@unittest.skipUnless(HAVE_SDK, "posthog-hogland SDK not installed")
+class CreateFailsFastOnNoCapacityTest(unittest.TestCase):
+    """A capacity 503 already cost ~4 minutes server-side (auction retry
+    budget) before hogland gave up, so it must raise on the first attempt
+    instead of burning 3x that in runner time. Every other 5xx keeps
+    retrying — see CreateRetriesTransient5xxTest."""
+
+    def _stub_ssh(self):
+        from hogbox_preview import hogland_backend
+
+        return unittest.mock.patch.object(
+            hogland_backend, "_ephemeral_ssh_pubkey", return_value="ssh-ed25519 AAAA fake"
+        )
+
+    def test_capacity_503_raises_immediately(self):
+        from hogbox_preview import hogland_backend
+        from hogland import ServerError
+
+        attempts = {"n": 0}
+
+        def create(**_kwargs):
+            attempts["n"] += 1
+            raise ServerError(
+                "no hogd has capacity: scale-up did not produce a willing hogd within 5m0s",
+                status_code=503,
+            )
+
+        client = _FakeClient(create=create)
+        backend = _make_backend(client)
+
+        with self._stub_ssh(), unittest.mock.patch.object(hogland_backend.time, "sleep") as sleep:
+            with self.assertRaises(ServerError) as ctx:
+                backend._restore_fresh()
+
+        self.assertEqual(attempts["n"], 1)
+        sleep.assert_not_called()
+        self.assertIn("no capacity", str(ctx.exception))
+        self.assertIn("retry", str(ctx.exception))
+
+    def test_generic_5xx_still_retries_three_times(self):
+        from hogbox_preview import hogland_backend
+        from hogland import ServerError
+
+        attempts = {"n": 0}
+
+        def create(**_kwargs):
+            attempts["n"] += 1
+            raise ServerError("placement failed: place: EOF", status_code=500)
+
+        client = _FakeClient(create=create)
+        backend = _make_backend(client)
+
+        with self._stub_ssh(), unittest.mock.patch.object(hogland_backend.time, "sleep"):
+            with self.assertRaises(ServerError):
+                backend._restore_fresh()
+
+        self.assertEqual(attempts["n"], hogland_backend._CREATE_5XX_ATTEMPTS)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Yesterday's hogland capacity outage (49 min) showed a rough edge in the hogbox-preview backend: the box create/restore retry loop in `hogland_backend.py` treats every 5xx `ServerError` as transient and retries up to 3 times (5s/15s backoff). A "no capacity" 503 isn't like the other transient 5xx though — hogland already spends ~4 minutes server-side on an auction retry budget before giving up on it. So one doomed preview run during an outage burned 12+ minutes of GitHub runner time and left 3 failed boxes behind instead of 1.

The preview workflow's sticky PR comment already tells users it'll retry on the next push, so failing fast on capacity errors is the right call, not a UX regression.

## Changes

- Detect hogland's "no capacity" 503 by matching the stable error text hogplane raises (`no hogd has capacity`, from `discovery.ErrNoCapacity` in the hogland repo) and fail immediately with a clear message instead of retrying.
- Every other transient 5xx (e.g. placement failing on a node dying mid-restore) keeps retrying exactly as before.
- Detection is defensive: any failure to introspect the exception falls back to the existing retry-everything behavior, so this can't make things worse if the error shape ever changes.

## How did you test this code?

Added two tests to `tools/hogbox-preview/tests/test_hogland_backend.py`:
- a capacity 503 raises on the first attempt (no sleep, no retry)
- a generic 5xx still retries all 3 attempts, unchanged

Ran the tool's own test suite (not the full posthog suite):

```
cd tools/hogbox-preview && uv run --with posthog-hogland python -m unittest discover tests -v
```

29 tests, all passing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude Code to trace the capacity-503 error text from the hogbox-preview retry loop through to hogplane's `discovery.ErrNoCapacity` / `orchestrator.retryAuction` in the hogland repo, confirm the SDK surfaces it via `ServerError`'s message (RFC 7807 `detail`), and implement + test the fast-fail path against the existing retry test patterns in `test_hogland_backend.py`.
