### PR TITLE
fix(mcp-analytics): render tool report charts across the selected window

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -28406,10 +28406,14 @@
         },
         "MCPToolDailyStatsQuery": {
             "additionalProperties": false,
-            "description": "Per-day activity series for a single MCP tool over the last 30 days.",
+            "description": "Per-bucket activity series for a single MCP tool over the selected window.",
             "properties": {
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
+                },
+                "interval": {
+                    "$ref": "#/definitions/IntervalType",
+                    "description": "Bucket granularity for the series. The frontend passes getDefaultInterval so a sub-day window buckets by hour/minute instead of collapsing to a single day point. Defaults to day."
                 },
                 "kind": {
                     "const": "MCPToolDailyStatsQuery",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2789,12 +2789,15 @@ export interface MCPToolDailyStatsQueryResponse extends AnalyticsQueryResponseBa
     results: MCPToolDailyStatItem[]
 }
 
-/** Per-day activity series for a single MCP tool over the last 30 days. */
+/** Per-bucket activity series for a single MCP tool over the selected window. */
 export interface MCPToolDailyStatsQuery extends DataNode<MCPToolDailyStatsQueryResponse> {
     kind: NodeKind.MCPToolDailyStatsQuery
     /** The effective tool name to scope to (matched against the single-exec-resolved tool name). */
     toolName: string
     dateRange?: DateRange
+    /** Bucket granularity for the series. The frontend passes getDefaultInterval so a sub-day window
+     * buckets by hour/minute instead of collapsing to a single day point. Defaults to day. */
+    interval?: IntervalType
 }
 
 export type CachedMCPToolDailyStatsQueryResponse = CachedQueryResponse<MCPToolDailyStatsQueryResponse>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -24174,6 +24174,14 @@ class MCPToolDailyStatsQuery(BaseModel):
         extra="forbid",
     )
     dateRange: DateRange | None = None
+    interval: IntervalType | None = Field(
+        default=None,
+        description=(
+            "Bucket granularity for the series. The frontend passes getDefaultInterval"
+            " so a sub-day window buckets by hour/minute instead of collapsing to a"
+            " single day point. Defaults to day."
+        ),
+    )
     kind: Literal["MCPToolDailyStatsQuery"] = "MCPToolDailyStatsQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     response: MCPToolDailyStatsQueryResponse | None = None

--- a/products/mcp_analytics/backend/hogql_queries/tool_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_tables.py
@@ -375,10 +375,14 @@ class MCPToolDailyStatsQueryRunner(AnalyticsQueryRunner[MCPToolDailyStatsQueryRe
         return mcp_query_date_range(self.team, self.query.dateRange)
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        # Bucket granularity comes from the frontend's getDefaultInterval, so a sub-day window buckets
+        # by hour/minute instead of collapsing to a single day point. dateTrunc respects the team
+        # timezone, so the buckets line up with the frontend's gap-fill keys. Defaults to day.
+        interval = self.query.interval.value if self.query.interval else "day"
         return parse_select(
             """
             SELECT
-                toString(toDate(timestamp)) AS day,
+                toString(dateTrunc({interval}, timestamp)) AS day,
                 count() AS calls,
                 {_IS_ERROR} AS errors,
                 {_P50} AS p50,
@@ -391,6 +395,7 @@ class MCPToolDailyStatsQueryRunner(AnalyticsQueryRunner[MCPToolDailyStatsQueryRe
             ORDER BY day
             """,
             placeholders={
+                "interval": ast.Constant(value=interval),
                 "_CONVERSATION_ID": parse_expr(_CONVERSATION_ID),
                 "_IS_ERROR": parse_expr(_IS_ERROR),
                 "_P50": parse_expr(_P50),

--- a/products/mcp_analytics/backend/hogql_queries/tool_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_tables.py
@@ -378,6 +378,9 @@ class MCPToolDailyStatsQueryRunner(AnalyticsQueryRunner[MCPToolDailyStatsQueryRe
         # Bucket granularity comes from the frontend's getDefaultInterval, so a sub-day window buckets
         # by hour/minute instead of collapsing to a single day point. dateTrunc respects the team
         # timezone, so the buckets line up with the frontend's gap-fill keys. Defaults to day.
+        # Explicit generous LIMIT so a fine interval over a wide window (reachable via the interval
+        # field, e.g. hourly over a quarter from an MCP caller) isn't silently cut to the default 100
+        # rows — which, with ORDER BY day ASC, would drop the most recent buckets.
         interval = self.query.interval.value if self.query.interval else "day"
         return parse_select(
             """
@@ -393,6 +396,7 @@ class MCPToolDailyStatsQueryRunner(AnalyticsQueryRunner[MCPToolDailyStatsQueryRe
             WHERE {where}
             GROUP BY day
             ORDER BY day
+            LIMIT 10000
             """,
             placeholders={
                 "interval": ast.Constant(value=interval),

--- a/products/mcp_analytics/backend/tests/test_tool_tables.py
+++ b/products/mcp_analytics/backend/tests/test_tool_tables.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 
 from posthog.schema import (
     DateRange,
+    IntervalType,
     MCPToolDailyStatsQuery,
     MCPToolDescriptionsQuery,
     MCPToolFailuresQuery,
@@ -336,6 +337,27 @@ class TestMCPToolDailyStatsQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Clickho
         assert rows[0].calls == 1
         assert rows[1].calls == 2
         assert rows[1].sessions == 2
+
+    def test_buckets_by_hour_when_interval_is_hour(self) -> None:
+        # Two calls in the same day but different hours split into two hourly buckets — a sub-day
+        # window would otherwise collapse to a single day point. Guards the interval plumbing.
+        now = datetime.now(tz=UTC)
+        _emit_tool_call(self.team, distinct_id="d1", session_id="s1", timestamp=now - timedelta(hours=1, minutes=30))
+        _emit_tool_call(self.team, distinct_id="d2", session_id="s2", timestamp=now - timedelta(minutes=5))
+        flush_persons_and_events()
+
+        runner = MCPToolDailyStatsQueryRunner(
+            query=MCPToolDailyStatsQuery(
+                toolName="query_run", dateRange=DateRange(date_from="-6h"), interval=IntervalType.HOUR
+            ),
+            team=self.team,
+        )
+        rows = runner.calculate().results
+
+        assert len(rows) == 2
+        assert rows[0].day < rows[1].day
+        assert rows[0].calls == 1
+        assert rows[1].calls == 1
 
 
 class TestMCPToolDescriptionsQueryRunner(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin, APIBaseTest):

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
@@ -350,8 +350,10 @@ const meta: Meta = {
                         return [200, { results: SESSION_RESULTS }]
                     }
                     // Tool quality tab queries — checked before the dashboard's
-                    // p95 tool table so the more specific markers win.
-                    if (query.includes('toDate(timestamp) AS day')) {
+                    // p95 tool table so the more specific markers win. The daily series
+                    // buckets by dateTrunc at the active interval; `AS day,` + the p99
+                    // quantile uniquely identify it (the per-tool table has neither).
+                    if (query.includes('quantile(0.99)') && query.includes('AS day,')) {
                         return [200, { results: DAILY_STATS }]
                     }
                     if (query.includes('p99_duration_ms')) {

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -6,6 +6,7 @@ import { LemonDivider, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
     type Series,
+    type TimeInterval,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
 } from '@posthog/quill-charts'
@@ -36,7 +37,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { SceneExport } from '~/scenes/sceneTypes'
 
-import { formatBucketLabel, formatMs, formatMsAsSeconds } from './dashboard/formatters'
+import { formatMs, formatMsAsSeconds } from './dashboard/formatters'
 import { HarnessLogo, HarnessPill } from './dashboard/harness'
 import { MetricTile } from './dashboard/MetricTile'
 import { mcpAnalyticsFeaturePreviewGate } from './featurePreviewGate'
@@ -49,6 +50,7 @@ import {
     mcpAnalyticsToolDetailLogic,
 } from './mcpAnalyticsToolDetailLogic'
 import { mcpToolQualityUrlWithDates } from './mcpAnalyticsToolQualityLogic'
+import { formatBucketLabel } from './timeBuckets'
 
 export const scene: SceneExport<MCPAnalyticsToolDetailLogicProps> = {
     component: MCPAnalyticsToolDetail,
@@ -201,18 +203,20 @@ function StatTiles({
     daily,
     theme,
     dateRangeLabel,
+    interval,
 }: {
     summary: ToolSummary | null
     loading: boolean
     daily: DailyChartData
     theme: ChartTheme
     dateRangeLabel: string
+    interval: TimeInterval
 }): JSX.Element {
     const calls = summary?.calls ?? 0
     const errors = summary?.errors ?? 0
     const errorRate = calls ? (errors / calls) * 100 : 0
     const errorRateDaily = daily.calls.map((c, i) => (c ? (daily.errors[i] / c) * 100 : 0))
-    const sparkLabels = daily.labels.map(formatBucketLabel)
+    const sparkLabels = daily.labels.map((label) => formatBucketLabel(label, interval))
 
     const tiles: {
         label: string
@@ -357,7 +361,11 @@ function DescriptionBlock({
     )
 }
 
-function trendChartConfig(timezone: string, yAxis?: TimeSeriesLineChartConfig['yAxis']): TimeSeriesLineChartConfig {
+function trendChartConfig(
+    timezone: string,
+    interval: TimeInterval,
+    yAxis?: TimeSeriesLineChartConfig['yAxis']
+): TimeSeriesLineChartConfig {
     return {
         curve: 'monotone',
         showAxisLines: true,
@@ -365,7 +373,7 @@ function trendChartConfig(timezone: string, yAxis?: TimeSeriesLineChartConfig['y
         showCrosshair: true,
         showGrid: true,
         yAxis,
-        xAxis: { interval: 'day', timezone },
+        xAxis: { interval, timezone },
         tooltip: { placement: 'cursor' },
     }
 }
@@ -460,6 +468,7 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
         topUserRowsLoading,
         dateRangeLabel,
         dateFilter,
+        interval,
     } = useValues(mcpAnalyticsToolDetailLogic({ toolName }))
     const { timezone } = useValues(teamLogic)
 
@@ -472,10 +481,10 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
         () => seriesFor(dailyChartData, theme, ['p50', 'p95']),
         [dailyChartData, theme]
     )
-    const countsConfig = useChartConfig(() => trendChartConfig(timezone), [timezone])
+    const countsConfig = useChartConfig(() => trendChartConfig(timezone, interval), [timezone, interval])
     const latencyConfig = useChartConfig(
-        () => trendChartConfig(timezone, { tickFormatter: formatMsAsSeconds }),
-        [timezone]
+        () => trendChartConfig(timezone, interval, { tickFormatter: formatMsAsSeconds }),
+        [timezone, interval]
     )
 
     return (
@@ -499,6 +508,7 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
                     daily={dailyChartData}
                     theme={theme}
                     dateRangeLabel={dateRangeLabel}
+                    interval={interval}
                 />
             </div>
 

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
@@ -93,7 +93,7 @@ function ChartsScopeHeader(): JSX.Element {
 }
 
 export function MCPAnalyticsToolQuality(): JSX.Element {
-    const { dailyChartData, dailyStatsLoading } = useValues(mcpAnalyticsToolQualityLogic)
+    const { dailyChartData, dailyStatsLoading, interval } = useValues(mcpAnalyticsToolQualityLogic)
     const { timezone } = useValues(teamLogic)
 
     const theme = useChartTheme()
@@ -102,7 +102,13 @@ export function MCPAnalyticsToolQuality(): JSX.Element {
         <div className="flex flex-col gap-4" data-quill>
             <FilterBar />
             <ChartsScopeHeader />
-            <ToolQualityCharts data={dailyChartData} loading={dailyStatsLoading} theme={theme} timezone={timezone} />
+            <ToolQualityCharts
+                data={dailyChartData}
+                loading={dailyStatsLoading}
+                theme={theme}
+                timezone={timezone}
+                interval={interval}
+            />
             <ToolQualityTable />
         </div>
     )

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
@@ -13,8 +13,8 @@ function stat(overrides: Partial<DailyToolStat> & { day: string }): DailyToolSta
 }
 
 describe('buildDailyChartData', () => {
-    it('returns empty series for no rows', () => {
-        expect(buildDailyChartData([])).toEqual({
+    it('returns empty series for no rows, so the empty state shows', () => {
+        expect(buildDailyChartData([], ['2026-06-01 00:00:00'], 'UTC')).toEqual({
             labels: [],
             calls: [],
             errors: [],
@@ -25,32 +25,32 @@ describe('buildDailyChartData', () => {
         })
     })
 
-    it('passes a single day through unchanged', () => {
-        const rows = [stat({ day: '2026-06-01', calls: 10, errors: 2, p50: 100, p95: 300, users: 3, sessions: 4 })]
-        expect(buildDailyChartData(rows)).toEqual({
-            labels: ['2026-06-01'],
-            calls: [10],
-            errors: [2],
-            p50: [100],
-            p95: [300],
-            users: [3],
-            sessions: [4],
+    // Guards the "sparklines lose their line" regression: with one active day, projecting onto the
+    // full window's day keys pads the axis out (counts→0, latency→NaN) so the line still renders.
+    it('projects rows onto day bucket keys, padding empty days', () => {
+        const rows = [stat({ day: '2026-06-03', calls: 5, errors: 0, p50: 50, p95: 150, users: 1, sessions: 1 })]
+        const keys = ['2026-06-01 00:00:00', '2026-06-02 00:00:00', '2026-06-03 00:00:00', '2026-06-04 00:00:00']
+        expect(buildDailyChartData(rows, keys, 'UTC')).toEqual({
+            labels: keys,
+            calls: [0, 0, 5, 0],
+            errors: [0, 0, 0, 0],
+            p50: [NaN, NaN, 50, NaN],
+            p95: [NaN, NaN, 150, NaN],
+            users: [0, 0, 1, 0],
+            sessions: [0, 0, 1, 0],
         })
     })
 
-    it('gap-fills interior missing days (counts→0, latency→NaN) with a contiguous day axis', () => {
+    // Sub-day windows bucket by hour: hourly rows must line up with hourly keys, so "12 hours
+    // collapses to a single point" can't come back.
+    it('lines up hourly rows with hourly bucket keys', () => {
         const rows = [
-            stat({ day: '2026-06-01', calls: 10, errors: 1, p50: 100, p95: 200, users: 2, sessions: 3 }),
-            stat({ day: '2026-06-03', calls: 5, errors: 0, p50: 50, p95: 150, users: 1, sessions: 1 }),
+            stat({ day: '2026-06-03 10:00:00', calls: 12, errors: 2, p50: 80, p95: 200, users: 4, sessions: 5 }),
         ]
-        expect(buildDailyChartData(rows)).toEqual({
-            labels: ['2026-06-01', '2026-06-02', '2026-06-03'],
-            calls: [10, 0, 5],
-            errors: [1, 0, 0],
-            p50: [100, NaN, 50],
-            p95: [200, NaN, 150],
-            users: [2, 0, 1],
-            sessions: [3, 0, 1],
-        })
+        const keys = ['2026-06-03 09:00:00', '2026-06-03 10:00:00', '2026-06-03 11:00:00']
+        const data = buildDailyChartData(rows, keys, 'UTC')
+        expect(data.calls).toEqual([0, 12, 0])
+        expect(data.p95).toEqual([NaN, 200, NaN])
+        expect(data.sessions).toEqual([0, 5, 0])
     })
 })

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
@@ -14,7 +14,7 @@ function stat(overrides: Partial<DailyToolStat> & { day: string }): DailyToolSta
 
 describe('buildDailyChartData', () => {
     it('returns empty series for no rows, so the empty state shows', () => {
-        expect(buildDailyChartData([], ['2026-06-01 00:00:00'], 'UTC')).toEqual({
+        expect(buildDailyChartData([], ['2026-06-01 00:00:00'])).toEqual({
             labels: [],
             calls: [],
             errors: [],
@@ -30,7 +30,7 @@ describe('buildDailyChartData', () => {
     it('projects rows onto day bucket keys, padding empty days', () => {
         const rows = [stat({ day: '2026-06-03', calls: 5, errors: 0, p50: 50, p95: 150, users: 1, sessions: 1 })]
         const keys = ['2026-06-01 00:00:00', '2026-06-02 00:00:00', '2026-06-03 00:00:00', '2026-06-04 00:00:00']
-        expect(buildDailyChartData(rows, keys, 'UTC')).toEqual({
+        expect(buildDailyChartData(rows, keys)).toEqual({
             labels: keys,
             calls: [0, 0, 5, 0],
             errors: [0, 0, 0, 0],
@@ -48,7 +48,7 @@ describe('buildDailyChartData', () => {
             stat({ day: '2026-06-03 10:00:00', calls: 12, errors: 2, p50: 80, p95: 200, users: 4, sessions: 5 }),
         ]
         const keys = ['2026-06-03 09:00:00', '2026-06-03 10:00:00', '2026-06-03 11:00:00']
-        const data = buildDailyChartData(rows, keys, 'UTC')
+        const data = buildDailyChartData(rows, keys)
         expect(data.calls).toEqual([0, 12, 0])
         expect(data.p95).toEqual([NaN, 200, NaN])
         expect(data.sessions).toEqual([0, 5, 0])

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -4,7 +4,7 @@ import { urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
-import { dateFilterToText, dateStringToDayJs } from 'lib/utils/dateFilters'
+import { dateFilterToText, dateStringToDayJs, getDefaultInterval } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -20,8 +20,10 @@ import {
     MCPToolTopUserItem,
     NodeKind,
 } from '~/queries/schema/schema-general'
+import { IntervalType } from '~/types'
 
 import type { mcpAnalyticsToolDetailLogicType } from './mcpAnalyticsToolDetailLogicType'
+import { buildBucketKeys, normalizeBucket } from './timeBuckets'
 
 export interface ToolSummary {
     calls: number
@@ -74,21 +76,20 @@ const EMPTY_CHART_DATA: DailyChartData = {
 
 export type ResultRows = unknown[][]
 
-// Gap-fill the per-day rows into a continuous day axis (ClickHouse only returns days with data).
-// Counts fill with 0; latency fills with NaN so the chart skips the point instead of dipping to 0.
-export function buildDailyChartData(rows: DailyToolStat[]): DailyChartData {
+// Project the per-bucket rows onto the full set of interval buckets spanning the selected window
+// (ClickHouse only returns buckets with data). `bucketKeys` covers the whole window at the active
+// interval so the sparklines and trend charts match the chosen range — and always have enough points
+// to draw a line — even when the tool has data on only a bucket or two. Counts fill with 0; latency
+// fills with NaN so the chart skips the point instead of dipping to 0. Rows match by normalized
+// bucket key, so day, hour, and minute intervals all line up. No rows at all keeps the empty state.
+export function buildDailyChartData(rows: DailyToolStat[], bucketKeys: string[], timezone: string): DailyChartData {
     if (rows.length === 0) {
         return EMPTY_CHART_DATA
     }
-    const byDay = new Map(rows.map((r) => [r.day, r]))
-    const end = dayjs(rows[rows.length - 1].day)
-    const labels: string[] = []
-    for (let day = dayjs(rows[0].day); !day.isAfter(end); day = day.add(1, 'day')) {
-        labels.push(day.format('YYYY-MM-DD'))
-    }
-    const at = labels.map((day) => byDay.get(day))
+    const byBucket = new Map(rows.map((r) => [normalizeBucket(r.day, timezone), r]))
+    const at = bucketKeys.map((k) => byBucket.get(k))
     return {
-        labels,
+        labels: bucketKeys,
         calls: at.map((r) => r?.calls ?? 0),
         errors: at.map((r) => r?.errors ?? 0),
         p50: at.map((r) => (r ? r.p50 : NaN)),
@@ -213,6 +214,7 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
                         kind: NodeKind.MCPToolDailyStatsQuery,
                         toolName: props.toolName,
                         dateRange: values.dateRange,
+                        interval: values.interval,
                     })) as { results?: MCPToolDailyStatItem[] }
                     return (response?.results ?? []).map((r) => ({
                         day: r.day,
@@ -314,8 +316,23 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
         toolName: [() => [(_, props) => props.toolName], (toolName: string) => toolName],
 
         dailyChartData: [
-            (s) => [s.dailyStats],
-            (dailyStats: DailyToolStat[]): DailyChartData => buildDailyChartData(dailyStats),
+            (s) => [s.dailyStats, s.dateFilter, s.interval, teamLogic.selectors.timezone],
+            (
+                dailyStats: DailyToolStat[],
+                dateFilter: DateFilter,
+                interval: IntervalType,
+                timezone: string
+            ): DailyChartData => {
+                const bucketKeys = buildBucketKeys(dateFilter.dateFrom, dateFilter.dateTo, timezone, interval)
+                return buildDailyChartData(dailyStats, bucketKeys, timezone)
+            },
+        ],
+
+        // Grouping interval for the daily series — PostHog's standard auto-choice, matching the query's
+        // dateTrunc so a sub-day window buckets by hour/minute instead of collapsing to one day point.
+        interval: [
+            (s) => [s.dateFilter],
+            (dateFilter: DateFilter): IntervalType => getDefaultInterval(dateFilter.dateFrom, dateFilter.dateTo),
         ],
 
         // Resolve the `dateFilter` state (camelCase, nullable, may be relative like '-30d') into the

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -209,13 +209,17 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
         dailyStats: [
             [] as DailyToolStat[],
             {
-                loadDailyStats: async (): Promise<DailyToolStat[]> => {
+                // Guarded with breakpoint: dailyChartData builds its bucket keys from the *live* interval,
+                // so a superseded response fetched at a different interval (e.g. day → hour on a fast
+                // back/forward) would otherwise land and collapse a day's rows into one hourly bucket.
+                loadDailyStats: async (_: void, breakpoint): Promise<DailyToolStat[]> => {
                     const response = (await api.query({
                         kind: NodeKind.MCPToolDailyStatsQuery,
                         toolName: props.toolName,
                         dateRange: values.dateRange,
                         interval: values.interval,
                     })) as { results?: MCPToolDailyStatItem[] }
+                    breakpoint()
                     return (response?.results ?? []).map((r) => ({
                         day: r.day,
                         calls: r.calls,

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -82,11 +82,11 @@ export type ResultRows = unknown[][]
 // to draw a line — even when the tool has data on only a bucket or two. Counts fill with 0; latency
 // fills with NaN so the chart skips the point instead of dipping to 0. Rows match by normalized
 // bucket key, so day, hour, and minute intervals all line up. No rows at all keeps the empty state.
-export function buildDailyChartData(rows: DailyToolStat[], bucketKeys: string[], timezone: string): DailyChartData {
+export function buildDailyChartData(rows: DailyToolStat[], bucketKeys: string[]): DailyChartData {
     if (rows.length === 0) {
         return EMPTY_CHART_DATA
     }
-    const byBucket = new Map(rows.map((r) => [normalizeBucket(r.day, timezone), r]))
+    const byBucket = new Map(rows.map((r) => [normalizeBucket(r.day), r]))
     const at = bucketKeys.map((k) => byBucket.get(k))
     return {
         labels: bucketKeys,
@@ -324,7 +324,7 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
                 timezone: string
             ): DailyChartData => {
                 const bucketKeys = buildBucketKeys(dateFilter.dateFrom, dateFilter.dateTo, timezone, interval)
-                return buildDailyChartData(dailyStats, bucketKeys, timezone)
+                return buildDailyChartData(dailyStats, bucketKeys)
             },
         ],
 

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
@@ -26,8 +26,7 @@ describe('mcpAnalyticsToolQualityLogic', () => {
                     dailyStat({ day: '2026-06-05', calls: 100, errors: 10, p50: 200, p95: 900, p99: 2100 }),
                     dailyStat({ day: '2026-06-07', calls: 50, errors: 0, p50: 150, p95: 800, p99: 1500 }),
                 ],
-                ['2026-06-05 00:00:00', '2026-06-06 00:00:00', '2026-06-07 00:00:00'],
-                'UTC'
+                ['2026-06-05 00:00:00', '2026-06-06 00:00:00', '2026-06-07 00:00:00']
             )
             expect(data.labels).toEqual(['2026-06-05 00:00:00', '2026-06-06 00:00:00', '2026-06-07 00:00:00'])
             expect(data.calls).toEqual([100, 0, 50])
@@ -39,7 +38,7 @@ describe('mcpAnalyticsToolQualityLogic', () => {
         })
 
         it('returns empty series for empty bucket keys', () => {
-            expect(buildDailyChartData([], [], 'UTC').labels).toEqual([])
+            expect(buildDailyChartData([], []).labels).toEqual([])
         })
 
         // Sub-day windows bucket by hour: rows keyed to an hour must line up with hourly keys, so the
@@ -47,8 +46,7 @@ describe('mcpAnalyticsToolQualityLogic', () => {
         it('lines up hourly rows with hourly bucket keys', () => {
             const data = buildDailyChartData(
                 [dailyStat({ day: '2026-06-07 10:00:00', calls: 12, errors: 3, p50: 80, p95: 200, p99: 400 })],
-                ['2026-06-07 09:00:00', '2026-06-07 10:00:00', '2026-06-07 11:00:00'],
-                'UTC'
+                ['2026-06-07 09:00:00', '2026-06-07 10:00:00', '2026-06-07 11:00:00']
             )
             expect(data.calls).toEqual([0, 12, 0])
             expect(data.errors).toEqual([0, 3, 0])

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
@@ -20,39 +20,39 @@ function dailyStat(overrides: Partial<DailyToolStat> & { day: string }): DailyTo
 
 describe('mcpAnalyticsToolQualityLogic', () => {
     describe('buildDailyChartData', () => {
-        it('fills missing days so the x-axis stays linear', () => {
-            const data = buildDailyChartData([
-                dailyStat({ day: '2026-06-05', calls: 100, errors: 10, p50: 200, p95: 900, p99: 2100 }),
-                dailyStat({ day: '2026-06-07', calls: 50, errors: 0, p50: 150, p95: 800, p99: 1500 }),
-            ])
-            expect(data.labels).toEqual(['2026-06-05', '2026-06-06', '2026-06-07'])
+        it('projects rows onto the bucket keys, zero/NaN-filling gaps', () => {
+            const data = buildDailyChartData(
+                [
+                    dailyStat({ day: '2026-06-05', calls: 100, errors: 10, p50: 200, p95: 900, p99: 2100 }),
+                    dailyStat({ day: '2026-06-07', calls: 50, errors: 0, p50: 150, p95: 800, p99: 1500 }),
+                ],
+                ['2026-06-05 00:00:00', '2026-06-06 00:00:00', '2026-06-07 00:00:00'],
+                'UTC'
+            )
+            expect(data.labels).toEqual(['2026-06-05 00:00:00', '2026-06-06 00:00:00', '2026-06-07 00:00:00'])
             expect(data.calls).toEqual([100, 0, 50])
             expect(data.errors).toEqual([10, 0, 0])
-            // Gap days get NaN (skipped by the chart), not a dip to zero.
+            // Gap buckets get NaN (skipped by the chart), not a dip to zero.
             expect(data.successRate[0]).toBeCloseTo(90)
             expect(data.successRate[1]).toBeNaN()
             expect(data.p99).toEqual([2100, NaN, 1500])
         })
 
-        it('returns empty series for no rows', () => {
-            expect(buildDailyChartData([]).labels).toEqual([])
+        it('returns empty series for empty bucket keys', () => {
+            expect(buildDailyChartData([], [], 'UTC').labels).toEqual([])
         })
 
-        it('spans the full range when given one, zero-filling days outside the data', () => {
+        // Sub-day windows bucket by hour: rows keyed to an hour must line up with hourly keys, so the
+        // "12 hours collapses to a single point" bug can't come back.
+        it('lines up hourly rows with hourly bucket keys', () => {
             const data = buildDailyChartData(
-                [dailyStat({ day: '2026-06-07', calls: 50, errors: 0, p50: 150, p95: 800, p99: 1500 })],
-                { start: '2026-06-05', end: '2026-06-08' }
+                [dailyStat({ day: '2026-06-07 10:00:00', calls: 12, errors: 3, p50: 80, p95: 200, p99: 400 })],
+                ['2026-06-07 09:00:00', '2026-06-07 10:00:00', '2026-06-07 11:00:00'],
+                'UTC'
             )
-            expect(data.labels).toEqual(['2026-06-05', '2026-06-06', '2026-06-07', '2026-06-08'])
-            expect(data.calls).toEqual([0, 0, 50, 0])
-            expect(data.successRate[0]).toBeNaN()
-            expect(data.successRate[2]).toBeCloseTo(100)
-        })
-
-        it('zero-fills the whole range when there is no data at all', () => {
-            const data = buildDailyChartData([], { start: '2026-06-05', end: '2026-06-07' })
-            expect(data.labels).toEqual(['2026-06-05', '2026-06-06', '2026-06-07'])
-            expect(data.calls).toEqual([0, 0, 0])
+            expect(data.calls).toEqual([0, 12, 0])
+            expect(data.errors).toEqual([0, 3, 0])
+            expect(data.successRate[1]).toBeCloseTo(75)
         })
     })
 

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -132,12 +132,8 @@ const DEFAULT_SORT: SortState = { column: 'total_calls', direction: 'DESC' }
 // Counts fill with 0 (genuinely no activity); rate and latency fill with NaN so the chart skips the
 // point instead of drawing a misleading dip to zero. Rows match by normalized bucket key, so day,
 // hour, and minute intervals all line up.
-export function buildDailyChartData(
-    dailyStats: DailyToolStat[],
-    bucketKeys: string[],
-    timezone: string
-): DailyChartData {
-    const byBucket = new Map(dailyStats.map((r) => [normalizeBucket(r.day, timezone), r]))
+export function buildDailyChartData(dailyStats: DailyToolStat[], bucketKeys: string[]): DailyChartData {
+    const byBucket = new Map(dailyStats.map((r) => [normalizeBucket(r.day), r]))
     const rows = bucketKeys.map((k) => byBucket.get(k))
     return {
         labels: bucketKeys,
@@ -394,7 +390,7 @@ ORDER BY day
                 timezone: string
             ): DailyChartData => {
                 const bucketKeys = buildBucketKeys(dateFilter.dateFrom, dateFilter.dateTo, timezone, interval)
-                return buildDailyChartData(dailyStats, bucketKeys, timezone)
+                return buildDailyChartData(dailyStats, bucketKeys)
             },
         ],
     }),

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -3,18 +3,18 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, combineUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
-import { dayjs } from 'lib/dayjs'
-import { dateFilterToText, dateStringToDayJs } from 'lib/utils/dateFilters'
+import { dateFilterToText, getDefaultInterval } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { hogqlQuery } from '~/queries/query'
 import { HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 import { hogql } from '~/queries/utils'
-import { type AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+import { type AnyPropertyFilter, IntervalType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import toolQualityQueryTemplate from '../backend/templates/tool_quality.sql?raw'
 import type { mcpAnalyticsToolQualityLogicType } from './mcpAnalyticsToolQualityLogicType'
+import { buildBucketKeys, normalizeBucket } from './timeBuckets'
 
 // `$mcp_tool_category` is stamped onto every $mcp_tool_call event by the producer
 // (PostHog's MCP server from its catalog; external servers via the SDK). We read
@@ -126,46 +126,21 @@ export interface DailyChartData {
 const DEFAULT_DATE_FILTER: DateFilter = { dateFrom: '-7d', dateTo: null }
 const DEFAULT_SORT: SortState = { column: 'total_calls', direction: 'DESC' }
 
-const EMPTY_CHART_DATA: DailyChartData = {
-    labels: [],
-    calls: [],
-    errors: [],
-    successRate: [],
-    p50: [],
-    p95: [],
-    p99: [],
-}
-
-// Pivot per-day rows into chart series over a gap-free day axis: ClickHouse only
-// returns days that had events, so missing days are filled in to keep the x-axis
-// linear. Counts fill with 0 (genuinely no activity); rate and latency fill with
-// NaN so the chart skips the point instead of drawing a misleading dip to zero.
-// `range` spans the axis over the full selected window (so empty leading/trailing
-// days still show); without it, the axis spans only the days that have data.
+// Pivot per-bucket rows onto the full set of interval buckets spanning the selected window:
+// ClickHouse only returns buckets that had events, so `bucketKeys` (built from the window at the
+// active interval) keeps the x-axis linear and covering the whole range regardless of granularity.
+// Counts fill with 0 (genuinely no activity); rate and latency fill with NaN so the chart skips the
+// point instead of drawing a misleading dip to zero. Rows match by normalized bucket key, so day,
+// hour, and minute intervals all line up.
 export function buildDailyChartData(
     dailyStats: DailyToolStat[],
-    range?: { start: string; end: string }
+    bucketKeys: string[],
+    timezone: string
 ): DailyChartData {
-    let startDay: string
-    let endDay: string
-    if (range) {
-        startDay = range.start
-        endDay = range.end
-    } else if (dailyStats.length > 0) {
-        startDay = dailyStats[0].day
-        endDay = dailyStats[dailyStats.length - 1].day
-    } else {
-        return EMPTY_CHART_DATA
-    }
-    const byDay = new Map(dailyStats.map((r) => [r.day, r]))
-    const end = dayjs(endDay)
-    const labels: string[] = []
-    for (let day = dayjs(startDay); !day.isAfter(end); day = day.add(1, 'day')) {
-        labels.push(day.format('YYYY-MM-DD'))
-    }
-    const rows = labels.map((day) => byDay.get(day))
+    const byBucket = new Map(dailyStats.map((r) => [normalizeBucket(r.day, timezone), r]))
+    const rows = bucketKeys.map((k) => byBucket.get(k))
     return {
-        labels,
+        labels: bucketKeys,
         calls: rows.map((r) => r?.calls ?? 0),
         errors: rows.map((r) => r?.errors ?? 0),
         successRate: rows.map((r) => (r && r.calls ? ((r.calls - r.errors) / r.calls) * 100 : NaN)),
@@ -321,9 +296,11 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                     const properties = [...values.categoryProperties, ...toolProperty]
                     const response = (await api.query({
                         kind: NodeKind.HogQLQuery,
+                        // `values.interval` is a fixed IntervalType from getDefaultInterval, never user
+                        // input, so interpolating it into the dateTrunc is safe.
                         query: `
 SELECT
-    toDate(timestamp) AS day,
+    dateTrunc('${values.interval}', timestamp) AS day,
     count() AS calls,
     countIf(toBool(properties.$mcp_is_error)) AS errors,
     round(quantile(0.5)(toFloat(properties.$mcp_duration_ms))) AS p50,
@@ -383,6 +360,12 @@ ORDER BY day
             (dateFilter: DateFilter): string =>
                 dateFilterToText(dateFilter.dateFrom, dateFilter.dateTo, 'the selected range') ?? 'the selected range',
         ],
+        // Grouping interval for the daily chart — PostHog's standard auto-choice, so a sub-day window
+        // (e.g. last 12 hours) buckets hourly instead of collapsing to a single day point.
+        interval: [
+            (s) => [s.dateFilter],
+            (dateFilter: DateFilter): IntervalType => getDefaultInterval(dateFilter.dateFrom, dateFilter.dateTo),
+        ],
         scopeShare: [
             (s) => [s.categoryCounts, s.selectedCategories],
             (categoryCounts: CategoryCount[], selectedCategories: string[]): ScopeShare => {
@@ -403,14 +386,15 @@ ORDER BY day
             },
         ],
         dailyChartData: [
-            (s) => [s.dailyStats, s.dateFilter, teamLogic.selectors.timezone],
-            (dailyStats: DailyToolStat[], dateFilter: DateFilter, timezone: string): DailyChartData => {
-                const start = dateStringToDayJs(dateFilter.dateFrom, timezone)
-                const end =
-                    (dateFilter.dateTo ? dateStringToDayJs(dateFilter.dateTo, timezone) : dayjs().tz(timezone)) ??
-                    dayjs()
-                const range = start ? { start: start.format('YYYY-MM-DD'), end: end.format('YYYY-MM-DD') } : undefined
-                return buildDailyChartData(dailyStats, range)
+            (s) => [s.dailyStats, s.dateFilter, s.interval, teamLogic.selectors.timezone],
+            (
+                dailyStats: DailyToolStat[],
+                dateFilter: DateFilter,
+                interval: IntervalType,
+                timezone: string
+            ): DailyChartData => {
+                const bucketKeys = buildBucketKeys(dateFilter.dateFrom, dateFilter.dateTo, timezone, interval)
+                return buildDailyChartData(dailyStats, bucketKeys, timezone)
             },
         ],
     }),

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -14,7 +14,6 @@ import { HARNESS_BY_LABEL, harnessLogo } from './dashboard/harnessRegistry'
 import {
     type ActivityRow,
     type BucketRow,
-    buildBucketKeys,
     buildDailyActivity,
     buildKPIs,
     buildKpiWindow,
@@ -22,7 +21,6 @@ import {
     deltaPct,
     lastBucketIsInProgress,
     mcpDashboardOverviewLogic,
-    normalizeBucket,
     pickNotableSessions,
     type SessionRow,
     type ToolDailyRow,
@@ -181,32 +179,6 @@ describe('mcpDashboardOverviewLogic', () => {
         })
     })
 
-    describe('buildBucketKeys', () => {
-        it('emits one key per day across the resolved window, including empty trailing days', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
-            try {
-                expect(buildBucketKeys({ dateFrom: '-7d', dateTo: null }, 'UTC', 'day')).toEqual([
-                    '2026-06-11 00:00:00',
-                    '2026-06-12 00:00:00',
-                    '2026-06-13 00:00:00',
-                    '2026-06-14 00:00:00',
-                    '2026-06-15 00:00:00',
-                    '2026-06-16 00:00:00',
-                    '2026-06-17 00:00:00',
-                    '2026-06-18 00:00:00',
-                ])
-            } finally {
-                jest.useRealTimers()
-            }
-        })
-
-        it('truncates weekly buckets to ISO Monday starts (matching ClickHouse dateTrunc)', () => {
-            // 2026-06-01 is a Monday; every key should land on a Monday.
-            const keys = buildBucketKeys({ dateFrom: '2026-06-01', dateTo: '2026-06-21' }, 'UTC', 'week')
-            expect(keys).toEqual(['2026-06-01 00:00:00', '2026-06-08 00:00:00', '2026-06-15 00:00:00'])
-        })
-    })
-
     describe('buildDailyActivity', () => {
         it('projects rows onto the bucket keys, defaulting missing buckets to zero', () => {
             const rows: ActivityRow[] = [
@@ -265,34 +237,6 @@ describe('mcpDashboardOverviewLogic', () => {
             const now = dayjs.tz('2026-06-29 09:15:00', tz)
             expect(lastBucketIsInProgress(['2026-06-29 00:00:00'], tz, 'day', now)).toBe(false)
             expect(lastBucketIsInProgress([], tz, 'day', now)).toBe(false)
-        })
-    })
-
-    describe('normalizeBucket', () => {
-        // The query API serializes dateTrunc buckets as ISO datetimes; they must come back in the
-        // same format buildBucketKeys emits, otherwise the zero-fill join misses every bucket.
-        it.each([
-            ['2026-06-19T00:00:00Z', 'UTC', '2026-06-19 00:00:00'],
-            ['2026-06-19T00:00:00+00:00', 'UTC', '2026-06-19 00:00:00'],
-            ['2026-06-19T11:30:00Z', 'UTC', '2026-06-19 11:30:00'],
-        ])('normalizes %s (%s) to %s', (raw, timezone, expected) => {
-            expect(normalizeBucket(raw, timezone)).toBe(expected)
-        })
-
-        it('returns empty string for missing values', () => {
-            expect(normalizeBucket(null, 'UTC')).toBe('')
-            expect(normalizeBucket('', 'UTC')).toBe('')
-        })
-
-        it('produces keys that match buildBucketKeys so the activity join lands', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
-            try {
-                const bucketKeys = buildBucketKeys({ dateFrom: '-7d', dateTo: null }, 'UTC', 'day')
-                const normalized = normalizeBucket('2026-06-18T00:00:00Z', 'UTC')
-                expect(bucketKeys).toContain(normalized)
-            } finally {
-                jest.useRealTimers()
-            }
         })
     })
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -343,8 +343,11 @@ export function lastBucketIsInProgress(
 }
 
 export function normalizeBucket(raw: unknown, timezone: string): string {
+    // The raw value is a project-timezone wall clock (dateTrunc runs in the team timezone), so parse
+    // it AS that timezone. `dayjs(s).tz(tz)` reads it in the browser tz then converts, shifting day
+    // buckets off midnight so they match no key — the chart reads flat for non-project-tz viewers.
     const s = String(raw ?? '')
-    return s ? dayjs(s).tz(timezone).format(BUCKET_FORMAT) : ''
+    return s ? dayjs.tz(s, timezone).format(BUCKET_FORMAT) : ''
 }
 
 // Project the daily success/error rows onto the full set of buckets, defaulting empty buckets to 0.

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -5,7 +5,7 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { dayjs } from 'lib/dayjs'
-import { dateStringToComponents, dateStringToDayJs, getDefaultInterval } from 'lib/utils/dateFilters'
+import { getDefaultInterval } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -15,6 +15,7 @@ import { AnyPropertyFilter, IntervalType, TeamType } from '~/types'
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import type { MCPIntentClusterApi } from './generated/api.schemas'
 import type { mcpDashboardOverviewLogicType } from './mcpDashboardOverviewLogicType'
+import { BUCKET_FORMAT, buildBucketKeys, normalizeBucket, resolveWindow, startOfBucket } from './timeBuckets'
 
 export interface DateFilter {
     dateFrom: string | null
@@ -278,53 +279,9 @@ export function deltaPct(current: number, previous: number): number | null {
     return ((current - previous) / previous) * 100
 }
 
-// Resolve the filter to absolute bounds. Hour-level relative ranges ("-1h") are
-// rolling from now; dateStringToDayJs anchors relative dates to the start of the
-// day, which would inflate a "last hour" window to half a day. Day+ ranges keep
-// that start-of-day anchoring (the established behaviour).
-function resolveWindow(dateFilter: DateFilter, timezone: string): { start: dayjs.Dayjs; end: dayjs.Dayjs } {
-    const now = dayjs().tz(timezone)
-    const end = (dateFilter.dateTo ? dateStringToDayJs(dateFilter.dateTo, timezone) : now) ?? now
-    const components = dateStringToComponents(dateFilter.dateFrom)
-    if (components && components.unit === 'hour' && !dateFilter.dateTo) {
-        // components.amount is signed (negative for the past), so add() walks backwards.
-        return { start: now.add(components.amount, 'hour'), end: now }
-    }
-    const start = dateStringToDayJs(dateFilter.dateFrom, timezone) ?? now.subtract(7, 'day')
-    return { start, end }
-}
-
-// Truncate to the start of an interval bucket the same way ClickHouse's dateTrunc does, so the keys
-// we generate line up with the query's bucket strings. dayjs' startOf covers minute/hour/day/month;
-// only 'week' differs — dateTrunc('week') is ISO (Monday-start) while dayjs defaults to Sunday.
-function startOfBucket(d: dayjs.Dayjs, interval: IntervalType): dayjs.Dayjs {
-    if (interval === 'week') {
-        const day = d.day() // 0 = Sunday … 6 = Saturday
-        return d.startOf('day').subtract((day + 6) % 7, 'day')
-    }
-    return d.startOf(interval)
-}
-
-// The one format for bucket keys — must match ClickHouse dateTrunc's DateTime output so the
-// zero-fill join and the in-progress-tail comparison line up. Change it here, nowhere else.
-const BUCKET_FORMAT = 'YYYY-MM-DD HH:mm:ss'
-
-// Every bucket key across the resolved window [start, end] at the active interval, formatted to
-// match dateTrunc's DateTime output ('YYYY-MM-DD HH:mm:ss'). The activity and tool-usage series are
-// zero-filled against these so the x-axis spans the whole selected range instead of clipping to the
-// buckets that happened to have events.
-export function buildBucketKeys(dateFilter: DateFilter, timezone: string, interval: IntervalType): string[] {
-    const { start, end } = resolveWindow(dateFilter, timezone)
-    const last = startOfBucket(end, interval).valueOf()
-    const keys: string[] = []
-    let cursor = startOfBucket(start, interval)
-    // Bounded dashboard windows keep this small; the cap is just a guard against a pathological range.
-    for (let i = 0; cursor.valueOf() <= last && i < 100000; i++) {
-        keys.push(cursor.format(BUCKET_FORMAT))
-        cursor = cursor.add(1, interval)
-    }
-    return keys
-}
+// Window resolution, bucket keys, and the BUCKET_FORMAT contract are shared with the tab/detail
+// surfaces — see ./timeBuckets. The dashboard adds only the KPI-comparison window and in-progress
+// tail below, built on those shared primitives.
 
 // True when the final bucket is the current, still-running interval (open-ended window), so the
 // chart can dash that segment as "in progress" rather than letting the partial period read as data
@@ -340,14 +297,6 @@ export function lastBucketIsInProgress(
     }
     const currentBucket = startOfBucket(now.tz(timezone), interval).format(BUCKET_FORMAT)
     return bucketKeys[bucketKeys.length - 1] === currentBucket
-}
-
-export function normalizeBucket(raw: unknown, timezone: string): string {
-    // The raw value is a project-timezone wall clock (dateTrunc runs in the team timezone), so parse
-    // it AS that timezone. `dayjs(s).tz(tz)` reads it in the browser tz then converts, shifting day
-    // buckets off midnight so they match no key — the chart reads flat for non-project-tz viewers.
-    const s = String(raw ?? '')
-    return s ? dayjs.tz(s, timezone).format(BUCKET_FORMAT) : ''
 }
 
 // Project the daily success/error rows onto the full set of buckets, defaulting empty buckets to 0.
@@ -371,7 +320,7 @@ export interface KpiWindow {
 // `currentStartBucket` is the cutoff `buildKPIs` splits on — formatted to match
 // dateTrunc's DateTime output.
 export function buildKpiWindow(dateFilter: DateFilter, timezone: string, interval: IntervalType): KpiWindow {
-    const { start, end } = resolveWindow(dateFilter, timezone)
+    const { start, end } = resolveWindow(dateFilter.dateFrom, dateFilter.dateTo, timezone)
     // The selected period covers the inclusive buckets [start, end] — one more than
     // end.diff(start). Step the prior window back by that same count so the two
     // halves of the comparison span an equal number of buckets.
@@ -630,7 +579,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                     breakpoint()
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
-                        day: normalizeBucket(r[0], values.timezone),
+                        day: normalizeBucket(r[0]),
                         successes: Number(r[1] ?? 0),
                         errors: Number(r[2] ?? 0),
                     }))
@@ -649,7 +598,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
                     breakpoint()
                     const raw = (response?.results as unknown[][]) ?? []
                     return raw.map((r) => ({
-                        day: normalizeBucket(r[0], values.timezone),
+                        day: normalizeBucket(r[0]),
                         tool: String(r[1] ?? ''),
                         calls: Number(r[2] ?? 0),
                     }))
@@ -684,7 +633,7 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
         bucketKeys: [
             (s) => [s.dateFilter, s.timezone, s.interval],
             (dateFilter: DateFilter, timezone: string, interval: IntervalType): string[] =>
-                buildBucketKeys(dateFilter, timezone, interval),
+                buildBucketKeys(dateFilter.dateFrom, dateFilter.dateTo, timezone, interval),
         ],
         // Whether the activity chart's final bucket is the current, still-running interval — the
         // chart dashes that segment so a partial period doesn't read as a drop in tool calls.

--- a/products/mcp_analytics/frontend/timeBuckets.test.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.test.ts
@@ -4,16 +4,26 @@ import { buildBucketKeys, formatBucketLabel, normalizeBucket } from './timeBucke
 
 describe('timeBuckets', () => {
     describe('normalizeBucket', () => {
-        it('reads the bucket in the project timezone, not the browser tz, so day buckets stay at midnight', () => {
-            // The browser sits in a different tz than the project (UTC here). Parsing the raw string in
-            // the browser tz and converting would push the bucket off midnight and it would match no
-            // key — the flat-zero-sparkline bug. Guard: the wall clock must survive unchanged.
+        // Guards the flat-zero-sparkline bug: whether the query serializes the bucket as a naive
+        // datetime or a Z-stamped ISO, its wall-clock digits must survive verbatim — even when the
+        // browser sits in a different timezone than the project — or it matches no key.
+        it.each([
+            ['2026-06-18 00:00:00', '2026-06-18 00:00:00'], // naive (toString(dateTrunc))
+            ['2026-06-19T00:00:00Z', '2026-06-19 00:00:00'], // Z-stamped ISO (raw DateTime column)
+            ['2026-06-19T00:00:00+00:00', '2026-06-19 00:00:00'],
+            ['2026-06-19T11:30:00Z', '2026-06-19 11:30:00'],
+        ])('keeps %s as %s under a non-UTC browser tz', (raw, expected) => {
             dayjs.tz.setDefault('Europe/Athens')
             try {
-                expect(normalizeBucket('2026-06-18 00:00:00', 'UTC')).toBe('2026-06-18 00:00:00')
+                expect(normalizeBucket(raw)).toBe(expected)
             } finally {
                 dayjs.tz.setDefault('UTC')
             }
+        })
+
+        it('returns empty string for missing values', () => {
+            expect(normalizeBucket(null)).toBe('')
+            expect(normalizeBucket('')).toBe('')
         })
     })
 
@@ -27,6 +37,43 @@ describe('timeBuckets', () => {
             ])
         })
 
+        it('emits one key per day across a relative window, including empty trailing days', () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
+            try {
+                expect(buildBucketKeys('-7d', null, 'UTC', 'day')).toEqual([
+                    '2026-06-11 00:00:00',
+                    '2026-06-12 00:00:00',
+                    '2026-06-13 00:00:00',
+                    '2026-06-14 00:00:00',
+                    '2026-06-15 00:00:00',
+                    '2026-06-16 00:00:00',
+                    '2026-06-17 00:00:00',
+                    '2026-06-18 00:00:00',
+                ])
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('truncates weekly buckets to ISO Monday starts (matching ClickHouse dateTrunc)', () => {
+            // 2026-06-01 is a Monday; every key should land on a Monday.
+            expect(buildBucketKeys('2026-06-01', '2026-06-21', 'UTC', 'week')).toEqual([
+                '2026-06-01 00:00:00',
+                '2026-06-08 00:00:00',
+                '2026-06-15 00:00:00',
+            ])
+        })
+
+        // Guards the DST data-drop: cumulative add on a tz-aware cursor keeps the pre-DST offset and
+        // lands short after spring-forward, dropping the last day. Re-anchoring keeps every bucket.
+        it('spans a daily window crossing a spring-forward DST boundary without dropping a bucket', () => {
+            expect(buildBucketKeys('2026-03-07', '2026-03-09', 'America/New_York', 'day')).toEqual([
+                '2026-03-07 00:00:00',
+                '2026-03-08 00:00:00',
+                '2026-03-09 00:00:00',
+            ])
+        })
+
         it('spans a short window at minute granularity', () => {
             expect(buildBucketKeys('2026-06-01T09:00:00Z', '2026-06-01T09:04:00Z', 'UTC', 'minute')).toEqual([
                 '2026-06-01 09:00:00',
@@ -35,6 +82,16 @@ describe('timeBuckets', () => {
                 '2026-06-01 09:03:00',
                 '2026-06-01 09:04:00',
             ])
+        })
+
+        it('produces keys a normalized query bucket lands on', () => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
+            try {
+                const keys = buildBucketKeys('-7d', null, 'UTC', 'day')
+                expect(keys).toContain(normalizeBucket('2026-06-18T00:00:00Z'))
+            } finally {
+                jest.useRealTimers()
+            }
         })
     })
 

--- a/products/mcp_analytics/frontend/timeBuckets.test.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.test.ts
@@ -1,0 +1,48 @@
+import { dayjs } from 'lib/dayjs'
+
+import { buildBucketKeys, formatBucketLabel, normalizeBucket } from './timeBuckets'
+
+describe('timeBuckets', () => {
+    describe('normalizeBucket', () => {
+        it('reads the bucket in the project timezone, not the browser tz, so day buckets stay at midnight', () => {
+            // The browser sits in a different tz than the project (UTC here). Parsing the raw string in
+            // the browser tz and converting would push the bucket off midnight and it would match no
+            // key — the flat-zero-sparkline bug. Guard: the wall clock must survive unchanged.
+            dayjs.tz.setDefault('Europe/Athens')
+            try {
+                expect(normalizeBucket('2026-06-18 00:00:00', 'UTC')).toBe('2026-06-18 00:00:00')
+            } finally {
+                dayjs.tz.setDefault('UTC')
+            }
+        })
+    })
+
+    describe('buildBucketKeys', () => {
+        it('spans an absolute window at hour granularity, inclusive of both ends', () => {
+            expect(buildBucketKeys('2026-06-01T00:00:00Z', '2026-06-01T03:00:00Z', 'UTC', 'hour')).toEqual([
+                '2026-06-01 00:00:00',
+                '2026-06-01 01:00:00',
+                '2026-06-01 02:00:00',
+                '2026-06-01 03:00:00',
+            ])
+        })
+
+        it('spans a short window at minute granularity', () => {
+            expect(buildBucketKeys('2026-06-01T09:00:00Z', '2026-06-01T09:04:00Z', 'UTC', 'minute')).toEqual([
+                '2026-06-01 09:00:00',
+                '2026-06-01 09:01:00',
+                '2026-06-01 09:02:00',
+                '2026-06-01 09:03:00',
+                '2026-06-01 09:04:00',
+            ])
+        })
+    })
+
+    describe('formatBucketLabel', () => {
+        it('shows the time for sub-day intervals and the date otherwise', () => {
+            expect(formatBucketLabel('2026-06-01 09:30:00', 'minute')).toBe('Jun 1, 09:30')
+            expect(formatBucketLabel('2026-06-01 09:00:00', 'hour')).toBe('Jun 1, 09:00')
+            expect(formatBucketLabel('2026-06-01 00:00:00', 'day')).toBe('Jun 1')
+        })
+    })
+})

--- a/products/mcp_analytics/frontend/timeBuckets.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.ts
@@ -47,25 +47,36 @@ export function buildBucketKeys(
     interval: IntervalType
 ): string[] {
     const { start, end } = resolveWindow(dateFrom, dateTo, timezone)
+    const first = startOfBucket(start, interval)
     const last = startOfBucket(end, interval).valueOf()
     const keys: string[] = []
-    let cursor = startOfBucket(start, interval)
-    // Bounded windows keep this small; the cap is just a guard against a pathological range.
-    for (let i = 0; cursor.valueOf() <= last && i < 100000; i++) {
-        keys.push(cursor.format(BUCKET_FORMAT))
-        cursor = cursor.add(1, interval)
+    // Re-anchor each bucket from the window start instead of cumulatively adding to a timezone-aware
+    // cursor: Day.js keeps the original UTC offset across `add`, so a range crossing a DST boundary
+    // would otherwise drop a bucket (short by an hour) or repeat one. startOf() re-resolves the offset
+    // each step; the dedupe guards the fall-back hour that wall-clock-repeats. The cap bounds a
+    // pathological range.
+    for (let i = 0; i < 100000; i++) {
+        const bucket = startOfBucket(first.add(i, interval), interval)
+        if (bucket.valueOf() > last) {
+            break
+        }
+        const key = bucket.format(BUCKET_FORMAT)
+        if (key !== keys[keys.length - 1]) {
+            keys.push(key)
+        }
     }
     return keys
 }
 
 // Normalize a raw bucket string from a query (a date or datetime) to BUCKET_FORMAT so it joins the
-// generated keys regardless of how ClickHouse rendered it. The raw value is a project-timezone wall
-// clock (dateTrunc runs in the team timezone), so parse it AS that timezone — `dayjs(s).tz(tz)` would
-// read it in the browser tz and then convert, shifting day buckets off midnight so nothing matches
-// and the chart reads flat zero for anyone not sitting in the project timezone.
-export function normalizeBucket(raw: unknown, timezone: string): string {
+// generated keys regardless of how ClickHouse rendered it. The value already carries the project-tz
+// wall clock — either a naive datetime (toString(dateTrunc)) or a Z-stamped ISO (a raw DateTime
+// column) — so read it in UTC to keep those digits verbatim. dayjs.tz(s, tz) would treat a Z-stamped
+// value as an instant and convert it by the project offset, shifting buckets off the axis so nothing
+// matches (flat charts for non-UTC projects). buildBucketKeys formats keys as the same wall clock.
+export function normalizeBucket(raw: unknown): string {
     const s = String(raw ?? '')
-    return s ? dayjs.tz(s, timezone).format(BUCKET_FORMAT) : ''
+    return s ? dayjs.utc(s).format(BUCKET_FORMAT) : ''
 }
 
 // Human-readable axis/hover label for a bucket, showing the time only when the interval is sub-day.

--- a/products/mcp_analytics/frontend/timeBuckets.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.ts
@@ -1,0 +1,80 @@
+import { dayjs } from 'lib/dayjs'
+import { dateStringToComponents, dateStringToDayJs } from 'lib/utils/dateFilters'
+
+import { IntervalType } from '~/types'
+
+// Bucket key format matching ClickHouse dateTrunc's DateTime output, so the zero-fill keys we
+// generate line up with the query's bucket strings. One format for every interval — a day bucket
+// is just midnight. Change it here, nowhere else.
+export const BUCKET_FORMAT = 'YYYY-MM-DD HH:mm:ss'
+
+// Resolve a date filter to absolute bounds. Hour/minute/second relative ranges ("-1h") roll from
+// now; dateStringToDayJs anchors day+ ranges to the start of the day (the established behaviour).
+export function resolveWindow(
+    dateFrom: string | null,
+    dateTo: string | null,
+    timezone: string
+): { start: dayjs.Dayjs; end: dayjs.Dayjs } {
+    const now = dayjs().tz(timezone)
+    const end = (dateTo ? dateStringToDayJs(dateTo, timezone) : now) ?? now
+    const components = dateStringToComponents(dateFrom)
+    if (components && ['hour', 'minute', 'second'].includes(components.unit) && !dateTo) {
+        // components.amount is signed (negative for the past), so add() walks backwards.
+        return { start: now.add(components.amount, components.unit as dayjs.ManipulateType), end: now }
+    }
+    const start = dateStringToDayJs(dateFrom, timezone) ?? now.subtract(7, 'day')
+    return { start, end }
+}
+
+// Truncate to the start of an interval bucket the way ClickHouse's dateTrunc does, so generated keys
+// line up with the query's bucket strings. dayjs' startOf covers minute/hour/day/month; only 'week'
+// differs — dateTrunc('week') is ISO (Monday-start) while dayjs defaults to Sunday.
+export function startOfBucket(d: dayjs.Dayjs, interval: IntervalType): dayjs.Dayjs {
+    if (interval === 'week') {
+        const day = d.day() // 0 = Sunday … 6 = Saturday
+        return d.startOf('day').subtract((day + 6) % 7, 'day')
+    }
+    return d.startOf(interval)
+}
+
+// Every bucket key across the resolved window [start, end] at the active interval, formatted to match
+// dateTrunc's DateTime output. Series are zero-filled against these so the x-axis spans the whole
+// selected range instead of clipping to the buckets that happened to have events.
+export function buildBucketKeys(
+    dateFrom: string | null,
+    dateTo: string | null,
+    timezone: string,
+    interval: IntervalType
+): string[] {
+    const { start, end } = resolveWindow(dateFrom, dateTo, timezone)
+    const last = startOfBucket(end, interval).valueOf()
+    const keys: string[] = []
+    let cursor = startOfBucket(start, interval)
+    // Bounded windows keep this small; the cap is just a guard against a pathological range.
+    for (let i = 0; cursor.valueOf() <= last && i < 100000; i++) {
+        keys.push(cursor.format(BUCKET_FORMAT))
+        cursor = cursor.add(1, interval)
+    }
+    return keys
+}
+
+// Normalize a raw bucket string from a query (a date or datetime) to BUCKET_FORMAT so it joins the
+// generated keys regardless of how ClickHouse rendered it. The raw value is a project-timezone wall
+// clock (dateTrunc runs in the team timezone), so parse it AS that timezone — `dayjs(s).tz(tz)` would
+// read it in the browser tz and then convert, shifting day buckets off midnight so nothing matches
+// and the chart reads flat zero for anyone not sitting in the project timezone.
+export function normalizeBucket(raw: unknown, timezone: string): string {
+    const s = String(raw ?? '')
+    return s ? dayjs.tz(s, timezone).format(BUCKET_FORMAT) : ''
+}
+
+// Human-readable axis/hover label for a bucket, showing the time only when the interval is sub-day.
+export function formatBucketLabel(bucket: string, interval: IntervalType): string {
+    const d = dayjs(bucket)
+    if (!d.isValid()) {
+        return bucket
+    }
+    return interval === 'hour' || interval === 'minute' || interval === 'second'
+        ? d.format('MMM D, HH:mm')
+        : d.format('MMM D')
+}

--- a/products/mcp_analytics/frontend/tool-quality/ToolQualityCharts.tsx
+++ b/products/mcp_analytics/frontend/tool-quality/ToolQualityCharts.tsx
@@ -5,6 +5,7 @@ import {
     ChartLegend,
     type ChartTheme,
     type Series,
+    type TimeInterval,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
     legendItemsFromSeries,
@@ -17,7 +18,11 @@ import { Card, CardState } from '../dashboard/Card'
 import { formatMsAsSeconds } from '../dashboard/formatters'
 import { type DailyChartData } from '../mcpAnalyticsToolQualityLogic'
 
-function buildConfig(timezone: string, yAxis?: TimeSeriesLineChartConfig['yAxis']): TimeSeriesLineChartConfig {
+function buildConfig(
+    timezone: string,
+    interval: TimeInterval,
+    yAxis?: TimeSeriesLineChartConfig['yAxis']
+): TimeSeriesLineChartConfig {
     return {
         curve: 'monotone',
         showAxisLines: true,
@@ -25,7 +30,7 @@ function buildConfig(timezone: string, yAxis?: TimeSeriesLineChartConfig['yAxis'
         showCrosshair: true,
         showGrid: true,
         yAxis,
-        xAxis: { interval: 'day', timezone },
+        xAxis: { interval, timezone },
         tooltip: { placement: 'cursor' },
     }
 }
@@ -67,11 +72,13 @@ export function ToolQualityCharts({
     loading,
     theme,
     timezone,
+    interval,
 }: {
     data: DailyChartData
     loading: boolean
     theme: ChartTheme
     timezone: string
+    interval: TimeInterval
 }): JSX.Element {
     const isEmpty = data.labels.length === 0
 
@@ -95,12 +102,18 @@ export function ToolQualityCharts({
         [data, theme]
     )
 
-    const countsConfig = useChartConfig(() => buildConfig(timezone), [timezone])
+    const countsConfig = useChartConfig(() => buildConfig(timezone, interval), [timezone, interval])
     const percentConfig = useChartConfig(
-        () => buildConfig(timezone, { tickFormatter: (value: number) => formatPercentage(value, { compact: true }) }),
-        [timezone]
+        () =>
+            buildConfig(timezone, interval, {
+                tickFormatter: (value: number) => formatPercentage(value, { compact: true }),
+            }),
+        [timezone, interval]
     )
-    const latencyConfig = useChartConfig(() => buildConfig(timezone, { tickFormatter: formatMsAsSeconds }), [timezone])
+    const latencyConfig = useChartConfig(
+        () => buildConfig(timezone, interval, { tickFormatter: formatMsAsSeconds }),
+        [timezone, interval]
+    )
 
     return (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -31287,6 +31287,8 @@ export namespace Schemas {
 
     export interface MCPToolDailyStatsQuery {
       dateRange?: DateRange | null;
+      /** Bucket granularity for the series. The frontend passes getDefaultInterval so a sub-day window buckets by hour/minute instead of collapsing to a single day point. Defaults to day. */
+      interval?: IntervalType | null;
       kind?: 'MCPToolDailyStatsQuery';
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -533,8 +533,13 @@ const MCPToolStatsQuery = z.object({
         .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
 })
 
+const IntervalType = z.enum(['second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'])
+
 const MCPToolDailyStatsQuery = z.object({
     dateRange: DateRange.optional(),
+    interval: IntervalType.describe(
+        'Bucket granularity for the series. The frontend passes getDefaultInterval so a sub-day window buckets by hour/minute instead of collapsing to a single day point. Defaults to day.'
+    ).optional(),
     kind: z.literal('MCPToolDailyStatsQuery').default('MCPToolDailyStatsQuery'),
     toolName: z
         .string()


### PR DESCRIPTION
## Problem

The Tool quality tab and an individual tool's report weren't rendering their activity / latency charts correctly across the selected window. The headline tile numbers were right, but the charts read empty or flat:

- **Flat at zero for cross-timezone viewers.** Day buckets were parsed in the *browser's* timezone and then converted to the project timezone, shifting them off midnight so they matched no axis point — the whole series drew flat at zero for anyone not sitting in the project's timezone.
- **Sub-day windows collapsed.** "Last 12 hours" landed in a single daily bucket → one point, no trend.
- **No zero-fill across the window.** Empty buckets weren't filled, so a window with sparse data didn't span — a tool with one active day drew no continuous line.

<img width="1168" height="660" alt="Screenshot 2026-07-16 at 11 57 36" src="https://github.com/user-attachments/assets/479f0e0e-6344-4225-b8e5-d4a2869d8671" />


## Changes

<img width="1191" height="678" alt="Screenshot 2026-07-16 at 11 57 21" src="https://github.com/user-attachments/assets/231ccf3f-3771-4c41-9878-f7eeb7235113" />


- **Timezone.** Read the bucket keys in the project timezone (`dayjs.tz(s, tz)` instead of `dayjs(s).tz(tz)`), so points land on the axis. This is what unfroze the flat-zero series. Same one-line fix to the dashboard's own copy of the helper, which had the identical latent bug.
- **Zero-fill and span the window.** Count series (calls / errors / users / sessions) fill empty buckets with 0 so the line runs across the whole selected range. Latency (p50 / p95) intentionally leaves gaps (NaN) rather than a misleading 0 ms, so periods with no calls aren't drawn as real dips — with genuinely sparse data that shows as points rather than a continuous line, which is honest.
- **Bucket by the window's interval.** Group by `getDefaultInterval` (the app-wide auto-interval the dashboard already uses), so a sub-day window buckets by hour (minute under ~2h) instead of one day point; day+ windows are unchanged. A shared `timeBuckets.ts` builds the gap-filled axis, and the `MCPToolDailyStatsQuery` runner takes an `interval` and `dateTrunc`s to match the frontend keys.

> [!NOTE]
> Supersedes #71417 (the tool-report sparkline padding fix) — it rewrote the same `buildDailyChartData`, and the window-spanning axis is now produced by the interval-aware bucket keys. #71417 can be closed.

## How did you test this code?

Automated only — I (Claude) don't have a browser here.

- `timeBuckets` unit tests including a cross-timezone regression guard (runs under a non-UTC ambient tz to prove buckets don't shift — the flat-zero bug).
- Tab + tool-report logic tests: rows project onto day **and** hourly bucket keys (guards the "12 hours → one point" collapse).
- Backend runner test: `interval=hour` splits same-day calls into separate hourly buckets.
- Full `products/mcp_analytics/frontend` Jest suite (142) and the tool-tables backend suite (28) green; dashboard is otherwise a zero-diff and its 87 tests still pass. Frontend typecheck clean for the changed files.

Reviewer should eyeball a sub-day range (last 12 hours) on both the tab and a tool report, and confirm a custom absolute range still buckets sensibly. (Local seed data lands on a single day, so the latency chart there legitimately shows one point.)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgis drove this from the tool report while testing date ranges, where the charts read flat/empty. The timezone bug surfaced from the live app returning one bucket that never matched a key; fixed by parsing the bucket string as the project tz. Main decision: bucket by the standard `getDefaultInterval` rather than a bespoke interval picker — it's what the dashboard and web/marketing analytics already use, so all three MCP surfaces stay consistent (trade-off: "last 1 hour" shows a single hourly point, same as everywhere else in the app). Custom-range label formatting and tile-layout polish were deliberately left for a follow-up.

Invoked `/writing-tests` before adding the regression cases.
