### PR TITLE
fix(shopify): report missing store instead of bad credentials on 404

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
@@ -46,6 +46,15 @@ SHOPIFY_ACCESS_TOKEN_AUTH_ERROR = (
     "app was uninstalled. Please reconnect your Shopify integration."
 )
 
+# Raised when the OAuth token endpoint returns 404 — there is no store at
+# `<store-id>.myshopify.com`, so the store id is wrong or the store no longer exists.
+# Reconnecting the app can't fix a bad store id, so this is surfaced separately from the
+# credentials error above (both are matched by `get_non_retryable_errors` to fail fast).
+SHOPIFY_STORE_NOT_FOUND_ERROR = (
+    "Couldn't find a Shopify store at that address. Check that your store id (the "
+    "'my-store' in 'my-store.myshopify.com') is correct and the store is still active."
+)
+
 # Substring of the GraphQL error Shopify returns when the connected access token lacks the
 # scope needed to read a field, e.g. "Access denied for fulfillmentOrders field." or
 # "Access denied for paymentTerms field. Required access: `read_payment_terms` access scope."
@@ -336,7 +345,12 @@ def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, sho
     }
     access_res = make_tracked_session().post(access_token_url, data=access_data)
     if not access_res.ok:
-        # A 4xx means the app credentials are invalid/revoked (e.g. the app was
+        # A 404 means there's no store at this subdomain — the store id is wrong or the store
+        # is gone. Reconnecting the app can't fix that, so point the user at the store id
+        # instead of telling them their credentials are bad.
+        if access_res.status_code == 404:
+            raise Exception(f"{SHOPIFY_STORE_NOT_FOUND_ERROR} (HTTP 404)")
+        # Any other 4xx means the app credentials are invalid/revoked (e.g. the app was
         # uninstalled) — re-auth is the only fix, so surface a non-retryable message.
         if 400 <= access_res.status_code < 500 and access_res.status_code != 429:
             raise Exception(f"{SHOPIFY_ACCESS_TOKEN_AUTH_ERROR} (HTTP {access_res.status_code})")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
@@ -28,6 +28,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.sh
     SHOPIFY_GRAPHQL_ACCESS_DENIED_ERROR,
     SHOPIFY_PAYMENT_REQUIRED_ERROR_MATCH,
     SHOPIFY_PAYMENT_REQUIRED_ERROR_MESSAGE,
+    SHOPIFY_STORE_NOT_FOUND_ERROR,
     ShopifyPermissionError,
     ShopifyResumeConfig,
     check_endpoint_permissions as check_shopify_endpoint_permissions,
@@ -62,6 +63,9 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
             # 4xx from Shopify's OAuth token endpoint — invalid/revoked app credentials.
             # Retrying cannot recover; the user must reconnect the integration.
             SHOPIFY_ACCESS_TOKEN_AUTH_ERROR: SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
+            # 404 from the same endpoint — no store at this subdomain. Retrying cannot
+            # recover; the user must correct the store id.
+            SHOPIFY_STORE_NOT_FOUND_ERROR: SHOPIFY_STORE_NOT_FOUND_ERROR,
             # GraphQL "Access denied for <field> field" — the access token is missing the
             # scope required to read this resource. The scope can't change on retry, so fail
             # fast and tell the user to reconnect with the required permissions.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -5,6 +5,7 @@ from requests.exceptions import ChunkedEncodingError, SSLError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
+    SHOPIFY_STORE_NOT_FOUND_ERROR,
     ShopifyRetryableError,
     _get_shopify_access_token,
 )
@@ -31,7 +32,7 @@ def _patched_token_call(response: mock.MagicMock):
     return _patched_token_post(mock.MagicMock(return_value=response))
 
 
-@pytest.mark.parametrize("status_code", [400, 401, 403, 404])
+@pytest.mark.parametrize("status_code", [400, 401, 403])
 def test_get_access_token_4xx_is_non_retryable(status_code):
     with _patched_token_call(_mock_response(status_code, ok=False)):
         with pytest.raises(Exception) as exc_info:
@@ -42,6 +43,23 @@ def test_get_access_token_4xx_is_non_retryable(status_code):
     patterns = ShopifySource().get_non_retryable_errors()
     assert any(pattern in error_message for pattern in patterns), (
         f"4xx token error '{error_message}' should match a non-retryable pattern"
+    )
+
+
+def test_get_access_token_404_reports_missing_store():
+    # A 404 means the store subdomain doesn't resolve to a real store — a distinct,
+    # non-retryable failure that reconnecting the app can't fix, so it must surface the
+    # store-not-found message rather than the credentials error.
+    with _patched_token_call(_mock_response(404, ok=False)):
+        with pytest.raises(Exception) as exc_info:
+            _get_shopify_access_token("store", "client-id", "client-secret")
+
+    error_message = str(exc_info.value)
+    assert SHOPIFY_STORE_NOT_FOUND_ERROR in error_message
+    assert SHOPIFY_ACCESS_TOKEN_AUTH_ERROR not in error_message
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert any(pattern in error_message for pattern in patterns), (
+        f"404 token error '{error_message}' should match a non-retryable pattern"
     )
 
 


### PR DESCRIPTION
## Problem

When creating a Shopify data-warehouse source, a 404 from Shopify's OAuth token endpoint was reported to the user as _"the app credentials are invalid or the app was uninstalled. Please reconnect your Shopify integration."_

That message misattributes the cause. The token URL is `https://<store-id>.myshopify.com/admin/oauth/access_token`, so a 404 means there is no store at that subdomain (the store id is wrong or the store no longer exists), not that the app credentials are bad. Reconnecting the integration can't fix a wrong store id, so the user is sent down a dead end. This showed up in real source-creation failures alongside store-id typos.

## Changes

- Split the 404 case out of the generic 4xx handling in `_get_shopify_access_token`. A 404 now raises a distinct, actionable store-not-found message that points at the store id; other 4xx responses (invalid/revoked credentials) keep the existing reconnect message.
- Registered the new message in `ShopifySource.get_non_retryable_errors` so the sync path also fails fast on it rather than retrying.

**Why:** the previous message pointed users at the wrong fix for a common, distinct failure, so it needed to name the real cause.

## How did you test this code?

Automated only (I'm Claude, an agent — no manual testing). Updated the parameterized token test so 400/401/403 still assert the credentials message and added a case asserting a 404 surfaces the store-not-found message and is still classified non-retryable. Ran the Shopify token and non-retryable-error tests locally:

```
products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
33 passed
```

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged data-warehouse source-creation failures and found this 404 misattribution in the Shopify token flow. Kept the change minimal: a message-and-branch split in the token helper plus the matching non-retryable entry, no change to retry or sync behavior. The store-not-found message deliberately does not echo the user's store id back.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*