### PR TITLE
chore(skills): slim the two mandatory-invoke skill bodies

### DIFF
--- a/.agents/skills/improving-drf-endpoints/SKILL.md
+++ b/.agents/skills/improving-drf-endpoints/SKILL.md
@@ -18,13 +18,6 @@ A missing `help_text` means an agent guessing at parameters.
 A bare `ListField()` means `z.unknown()` in the generated Zod schema.
 Getting the serializer right means every consumer — frontend types, MCP tools, API docs — gets correct types and descriptions automatically.
 
-## When to use
-
-- Editing or reviewing any file that defines a `Serializer` or `ViewSet`
-- Fixing OpenAPI spec warnings or generated type issues
-- Preparing an endpoint for MCP tool exposure
-- Code review of API changes
-
 ## Audit checklist
 
 ### Triage: check the generated output first
@@ -65,8 +58,8 @@ See [serializer-fields.md](references/serializer-fields.md) for patterns and exa
 12. **Error responses are typed** — use `OpenApiResponse(response=ErrorSerializer)`, not `OpenApiTypes.OBJECT`
 13. **List endpoints declare pagination** — reset with `pagination_class=None` on custom actions that don't paginate
 14. **Prefer `@validated_request`** over manual `serializer.is_valid()` + `@extend_schema` — it handles both in one decorator
-15. **ViewSets outside `products/` need `@extend_schema(extensions={"x-product": "<product>"})`** — ViewSets in `products/<name>/backend/` are auto-attributed via module path; ViewSets in `posthog/api/` or `ee/` aren't and must declare attribution explicitly via the `x-product` extension. Accepts a plain string (`"product_analytics"`) or `ProductKey.X` enum (kebab values are normalized). Don't use `tags=["<product>"]` to influence codegen routing — `tags` is for Swagger UI display only. Without `x-product`, the MCP scaffold and frontend type generator can't route the endpoint to the right product
-16. **`partial_update` `request=` override must be a superset of runtime write fields** — `extend_schema(request=CustomSerializer)` replaces drf-spectacular's inference from `serializer_class`; omitted fields disappear from OpenAPI, frontend types, and MCP tool schemas even when the runtime serializer still accepts them. After changing the override, run `hogli build:openapi` and verify generated MCP tool schemas still expose every OpenAPI body field
+15. **ViewSets outside `products/` need `@extend_schema(extensions={"x-product": "<product>"})`** — without it, the MCP scaffold and frontend type generator can't route the endpoint to the right product; `tags` doesn't influence routing (see [viewset-annotations.md](references/viewset-annotations.md#x-product-attribution))
+16. **`partial_update` `request=` override must be a superset of runtime write fields** — omitted fields silently disappear from generated types and MCP tool schemas; after changing it, run `hogli build:openapi` and verify (see [viewset-annotations.md](references/viewset-annotations.md#partial_update-request-overrides))
 
 **Streaming endpoints:** For SSE or streaming responses, use `@extend_schema(request=InputSerializer, responses={(200, "text/event-stream"): OpenApiTypes.STR})` to document the request schema even though the response can't be fully typed.
 
@@ -99,27 +92,13 @@ that has a `routes.py`. Adding a product needs no edit to core: create
 `PRODUCTS_APPS` (`posthog/settings/web.py`). Only core, non-product viewsets still
 register directly in `__init__.py`.
 
-**Why core discovers and calls the product (not the product calling core).** Core
-registers the four parents (`root` + `projects`/`environments`/`organizations`)
-first, then runs the discovery loop. Products only nest onto those parents and
-never onto each other, so discovery order is irrelevant. The registration is kept
-eager (it runs when `posthog.api` is first imported, i.e. on the first request) and
-deliberately _not_ moved into `AppConfig.ready()`: `ready()` runs inside
-`django.setup()` in every process, and registering a route imports its viewset, so
-that would pull the whole API into `setup()` everywhere — regressing the laziness
-that keeps the API out of Celery workers and management commands. See the
-`RouterRegistry` docstring and the discovery loop in `posthog/api/__init__.py` for
-the full reasoning.
-
 Do **not** register new endpoints under `environments_router`. Do **not** use the
 dual-route helper (`routers.register_legacy_dual_route`, or
 `register_legacy_dual_route_team_nested_viewset` in `__init__.py`) — it exists only
 for endpoints already exposed on both `/api/projects/` and `/api/environments/`
 before the rollback.
 
-If existing clients need `/api/environments/...` too, the OpenAPI postprocess
-hook at `posthog.api.documentation.preprocess_exclude_path_format` auto-marks
-the env-side path as `deprecated: true` whenever both routes exist.
+See [url-routing.md](references/url-routing.md) for the discovery architecture, why registration is eager rather than in `AppConfig.ready()`, and the env-alias deprecation mechanics.
 
 ### Facade products (DataclassSerializer)
 
@@ -129,36 +108,6 @@ For products using the facade pattern (e.g., `visual_review`) with `DataclassSer
 - Focus on **`help_text`** (dataclass fields don't carry it; add it on the serializer field overrides)
 - **`@validated_request`** is already the standard pattern — verify response serializers are declared
 - `@extend_schema` tags and descriptions still need to be set on viewset methods
-
-## Decision flowchart
-
-```dot
-digraph audit {
-    rankdir=TB
-    node [shape=diamond fontsize=10]
-    edge [fontsize=9]
-
-    start [label="Serializer or\nViewSet file?" shape=box]
-    is_model [label="ModelViewSet with\nserializer_class?"]
-    is_plain [label="Plain ViewSet or\ncustom @action?"]
-    is_facade [label="DataclassSerializer\n(facade product)?"]
-
-    check_fields [label="Check fields:\nhelp_text, ListField,\nJSONField, ChoiceField" shape=box]
-    add_schema [label="Add @validated_request\nor @extend_schema to\nevery method" shape=box]
-    check_help [label="Focus on help_text\nand response declarations" shape=box]
-    check_responses [label="Check response types,\npagination, error schemas" shape=box]
-
-    start -> is_model
-    is_model -> check_fields [label="yes"]
-    is_model -> is_plain [label="no"]
-    is_plain -> add_schema [label="yes"]
-    is_plain -> is_facade [label="no"]
-    is_facade -> check_help [label="yes"]
-    check_fields -> check_responses
-    add_schema -> check_fields
-    check_help -> check_responses
-}
-```
 
 ## Quick reference
 

--- a/.agents/skills/improving-drf-endpoints/references/url-routing.md
+++ b/.agents/skills/improving-drf-endpoints/references/url-routing.md
@@ -1,0 +1,28 @@
+# URL routing — discovery architecture and env-alias mechanics
+
+The rules (canonical path, `routes.py` registration snippet, the don'ts) are in the main skill; this is the background.
+
+## Why two path families exist
+
+PostHog briefly split projects and environments as separate concepts then rolled the split back.
+`/api/projects/:team_id/...` is the canonical path for any team-nested endpoint.
+`/api/environments/:team_id/...` is a backward-compat alias preserved only for clients that integrated against it during the split.
+
+## How product routes are discovered
+
+Product routes are auto-discovered — `posthog/api/__init__.py` iterates `INSTALLED_APPS` and calls `register_routes(routers)` on every `products.*` app that has a `routes.py`.
+Adding a product needs no edit to core: create `products/<name>/backend/routes.py` and make sure the product is in `PRODUCTS_APPS` (`posthog/settings/web.py`).
+Only core, non-product viewsets still register directly in `__init__.py`.
+
+**Why core discovers and calls the product (not the product calling core).**
+Core registers the four parents (`root` + `projects`/`environments`/`organizations`) first, then runs the discovery loop.
+Products only nest onto those parents and never onto each other, so discovery order is irrelevant.
+The registration is kept eager (it runs when `posthog.api` is first imported, i.e. on the first request) and deliberately _not_ moved into `AppConfig.ready()`: `ready()` runs inside `django.setup()` in every process, and registering a route imports its viewset, so that would pull the whole API into `setup()` everywhere — regressing the laziness that keeps the API out of Celery workers and management commands.
+See the `RouterRegistry` docstring and the discovery loop in `posthog/api/__init__.py` for the full reasoning.
+
+## Dual-route helpers and deprecation
+
+Do not register new endpoints under `environments_router`.
+Do not use the dual-route helper (`routers.register_legacy_dual_route`, or `register_legacy_dual_route_team_nested_viewset` in `__init__.py`) — it exists only for endpoints already exposed on both `/api/projects/` and `/api/environments/` before the rollback.
+
+If existing clients need `/api/environments/...` too, the OpenAPI postprocess hook at `posthog.api.documentation.preprocess_exclude_path_format` auto-marks the env-side path as `deprecated: true` whenever both routes exist.

--- a/.agents/skills/improving-drf-endpoints/references/viewset-annotations.md
+++ b/.agents/skills/improving-drf-endpoints/references/viewset-annotations.md
@@ -226,3 +226,21 @@ CI enforces zero warnings via `spectacular --fail-on-warn`.
 **Diagnostic tool:** run `python manage.py find_enum_collisions` to find unresolved
 collisions — it shows the field name, hash, enum values, hash path (ChoiceField vs
 type-hint), which components use it, and suggests the override format to add.
+
+## x-product attribution
+
+ViewSets in `products/<name>/backend/` are auto-attributed via module path; ViewSets in `posthog/api/` or `ee/` aren't and must declare attribution explicitly via the `x-product` extension:
+
+```python
+@extend_schema(extensions={"x-product": "product_analytics"})
+```
+
+Accepts a plain string (`"product_analytics"`) or `ProductKey.X` enum (kebab values are normalized).
+Don't use `tags=["<product>"]` to influence codegen routing — `tags` is for Swagger UI display only.
+Without `x-product`, the MCP scaffold and frontend type generator can't route the endpoint to the right product.
+
+## partial_update request overrides
+
+`extend_schema(request=CustomSerializer)` on `partial_update` replaces drf-spectacular's inference from `serializer_class`.
+The override must be a superset of the runtime write fields: omitted fields disappear from OpenAPI, frontend types, and MCP tool schemas even when the runtime serializer still accepts them.
+After changing the override, run `hogli build:openapi` and verify generated MCP tool schemas still expose every OpenAPI body field.

--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -51,9 +51,8 @@ Most low-value tests fall into one of these. Recognize and skip them.
    If the only reason to test a branch is the coverage report, the branch probably doesn't need a test — or the code is dead and should be deleted instead.
 
 5. **Cross-language source-scraping.**
-   Never read or regex-parse one language's source from another language's test — a Python test that `Path(...).read_text()`s a `.ts` file and matches `category: '...'`, a TS test that greps a `.py` file, and so on.
-   It couples two trees through a brittle string match that breaks on edits that change nothing about behavior (a rename, a reformat, a moved file, a comment), and it proves nothing about runtime — the two sides never actually run together in the test.
-   If two sides genuinely must agree on a set of values, give them **one source of truth** — a generated artifact or a checked-in data file both import — and assert against that. Otherwise let the drift surface where the two sides really meet (an API contract test, a rendered output, a round-trip), not by scraping the other language's source for strings.
+   Never read or regex-parse one language's source from another language's test (a Python test that `read_text()`s a `.ts` file and string-matches, or vice versa) — it breaks on behavior-neutral edits and proves nothing about runtime.
+   If two sides genuinely must agree on a set of values, give them **one source of truth** — a generated artifact or a checked-in data file both import — and assert against that.
 
 When the answer is "don't write it," the right move is often to **extend an existing test** (add a parameterized case) or **delete code** rather than test it.
 Both shrink the suite's surface.
@@ -69,7 +68,6 @@ pure function / unit  →  kea logic test  →  Django TestCase  →  ClickHouse
 ```
 
 The goal is a **ratio**, not a cap: many tests at the bottom, very few at the top.
-A thousand pure unit tests are cheaper and more reliable than ten that boot Django, which are cheaper than one Playwright run.
 Want more coverage? Add it at the bottom.
 
 **When something is hard to test cheaply, that's a design signal — extract, don't escalate.**
@@ -92,20 +90,9 @@ Escalating to the next rung is the last resort, not the default.
   - needing a connection visible across a real separate thread (`thread_sensitive`) → `async_to_sync(...)`, not `asyncio.run(...)`.
     Use `TransactionTestCase` only when the regression genuinely requires committed transaction boundaries that `TestCase` hides.
 - **DRF input-validation belongs in a `SimpleTestCase`, not an `APIBaseTest` round-trip.**
-  A test that posts a malformed body to an endpoint and asserts a 400 pays for `APIBaseTest` to build an Organization + Team + User in Postgres and wrap the test in a transaction — just to exercise validation that runs entirely in memory.
-  DRF field validators (`required`, type coercion, `choices`, `min/max`, regex) and `validate_<field>` methods run inside `Serializer(data=...).is_valid()` with no database and no request: field-level validation happens in `to_internal_value`, _before_ the object-level `validate()` that typically needs `self.context`. So an invalid-field case never reaches the DB-touching code.
-  Test the serializer directly and assert on `.errors`:
-
-  ```python
-  class TestTeamValidation(SimpleTestCase):  # no DB — not APIBaseTest
-      def test_sample_rate_too_many_digits(self) -> None:
-          s = TeamSerializer(data={"session_recording_sample_rate": "30001"}, partial=True)
-          assert not s.is_valid()
-          assert s.errors["session_recording_sample_rate"][0].code == "max_digits"
-  ```
-
-  When you push the case matrix down to the serializer, **keep (or add) one DB-backed endpoint test as a wiring guard** — that the viewset actually invokes this serializer, so a bad request is rejected with a 400. The no-DB serializer test proves the validation logic; it does _not_ prove the viewset is wired to that serializer (a refactor that drops the `serializer_class`, skips `is_valid()`, or stops calling `is_valid(raise_exception=True)` would pass every `SimpleTestCase` and still ship a broken endpoint). One endpoint case closes that gap; the matrix stays in the `SimpleTestCase`. For a query serializer instantiated inline (e.g. `Serializer(data=request.query_params).is_valid(raise_exception=True)`), the wiring guard is a bad-query-param → 400 assertion.
-  Two more caveats. First, `.errors` carries DRF's _raw_ code (`invalid`, `max_digits`); the `{"attr", "code", "detail", "type"}` HTTP envelope is rendered later by `exceptions-hog` (which maps `invalid` → `invalid_input`) — that rendering is framework behavior, so don't re-assert it per case (the wiring-guard test covers the envelope once). Second, validation that genuinely needs the DB stays at the endpoint — uniqueness checks, `PrimaryKeyRelatedField` queryset lookups, related-object existence, permission/team scoping, password-hash checks. Don't force those into a `SimpleTestCase`.
+  Field-level validation runs entirely in memory inside `Serializer(data=...).is_valid()` — test the serializer directly and assert on `.errors`, keeping one DB-backed endpoint test as a wiring guard that the viewset actually invokes the serializer.
+  DB-dependent validation (uniqueness, related-object lookups, permissions/scoping) stays at the endpoint.
+  See [serializer-validation-tests.md](references/serializer-validation-tests.md) for the pattern, the wiring-guard rationale, and the error-code caveats.
 
 - **Parameterize** repeated assertions with the `parameterized` library — don't copy-paste test bodies.
 - **No doc comments** in Python tests (house rule).
@@ -120,7 +107,7 @@ Escalating to the next rung is the last resort, not the default.
 - Prefer logic tests over component renders (see the ladder above).
 - `test.each` for variations rather than copied test bodies.
 - **Avoid `*ByRole(..., { name: ... })` on components that render a large DOM** (calendars, the taxonomic filter, whole scenes).
-  Role queries walk every element running `getComputedStyle`-based checks and accessible-name computation — seconds per query in jsdom, multiplied by every `waitFor`/`findBy*` retry; this pattern has produced single tests with 40s p95 in CI.
+  Accessible-name computation in jsdom costs seconds per query, multiplied by every `waitFor`/`findBy*` retry; this pattern has produced single tests with 40s p95 in CI.
   Prefer `getByText`, `getByTestId`/`data-attr` selectors, or `getByLabelText`; scope with `within(<small container>)` if a role query is genuinely needed.
   The `jest-no-byrole-name-queries` semgrep rule flags this.
 - **No huge snapshots.**

--- a/.agents/skills/writing-tests/references/serializer-validation-tests.md
+++ b/.agents/skills/writing-tests/references/serializer-validation-tests.md
@@ -1,0 +1,28 @@
+# DRF input-validation tests: SimpleTestCase, not APIBaseTest
+
+A test that posts a malformed body to an endpoint and asserts a 400 pays for `APIBaseTest` to build an Organization + Team + User in Postgres and wrap the test in a transaction — just to exercise validation that runs entirely in memory.
+
+DRF field validators (`required`, type coercion, `choices`, `min/max`, regex) and `validate_<field>` methods run inside `Serializer(data=...).is_valid()` with no database and no request: field-level validation happens in `to_internal_value`, _before_ the object-level `validate()` that typically needs `self.context`. So an invalid-field case never reaches the DB-touching code.
+
+Test the serializer directly and assert on `.errors`:
+
+```python
+class TestTeamValidation(SimpleTestCase):  # no DB — not APIBaseTest
+    def test_sample_rate_too_many_digits(self) -> None:
+        s = TeamSerializer(data={"session_recording_sample_rate": "30001"}, partial=True)
+        assert not s.is_valid()
+        assert s.errors["session_recording_sample_rate"][0].code == "max_digits"
+```
+
+## Keep one wiring guard at the endpoint
+
+When you push the case matrix down to the serializer, **keep (or add) one DB-backed endpoint test as a wiring guard** — that the viewset actually invokes this serializer, so a bad request is rejected with a 400.
+The no-DB serializer test proves the validation logic; it does _not_ prove the viewset is wired to that serializer (a refactor that drops the `serializer_class`, skips `is_valid()`, or stops calling `is_valid(raise_exception=True)` would pass every `SimpleTestCase` and still ship a broken endpoint).
+One endpoint case closes that gap; the matrix stays in the `SimpleTestCase`.
+For a query serializer instantiated inline (e.g. `Serializer(data=request.query_params).is_valid(raise_exception=True)`), the wiring guard is a bad-query-param → 400 assertion.
+
+## Caveats
+
+- `.errors` carries DRF's _raw_ code (`invalid`, `max_digits`); the `{"attr", "code", "detail", "type"}` HTTP envelope is rendered later by `exceptions-hog` (which maps `invalid` → `invalid_input`).
+  That rendering is framework behavior — don't re-assert it per case; the wiring-guard test covers the envelope once.
+- Validation that genuinely needs the DB stays at the endpoint — uniqueness checks, `PrimaryKeyRelatedField` queryset lookups, related-object existence, permission/team scoping, password-hash checks. Don't force those into a `SimpleTestCase`.


### PR DESCRIPTION
## Problem

`improving-drf-endpoints` and `writing-tests` are on the mandatory-invoke list in CLAUDE.md, so agents load them before nearly every DRF or test change — and review fan-outs load them again in each subagent. Their full body text is paid on every load and re-counted in context on every subsequent turn. In one measured Claude Code setup they accounted for ~15% of total token usage (9% + 6%), the two largest line items after MCP results.

Both bodies carried reference material inline: architecture rationale, worked examples, and multi-paragraph caveats that are only needed when an agent hits that specific situation.

## Changes

No rule or knowledge is deleted — everything cut from the bodies is relocated to `references/` files that agents read on demand:

- `improving-drf-endpoints/SKILL.md`: 10.7KB → 8.2KB (24% smaller). The URL-routing discovery architecture (why registration is eager, dual-route history) moves to a new `references/url-routing.md`; the long checklist items on `x-product` attribution and `partial_update` request overrides become one-liners pointing at new sections in `references/viewset-annotations.md`; the graphviz decision flowchart (restated the checklist) and the "When to use" section (restated the frontmatter description) are dropped.
- `writing-tests/SKILL.md`: 13.4KB → 10.9KB (19% smaller). The SimpleTestCase serializer-validation essay (code example, wiring-guard rationale, error-code caveats) moves to a new `references/serializer-validation-tests.md`, with a four-line rule + pointer left in the body; the TransactionTestCase and ByRole bullets are tightened without losing their sub-rules.

Every checklist item, house rule, and "don't" survives in the body; what moved is the *why* and the worked examples. Unchanged sentences keep their original line structure, so the diff shows only the real cuts.

## How did you test this code?

- Verified every `references/` link in both bodies resolves to an existing file and heading anchor
- `hogli ci:preflight --fix` passes (markdown formatting applied)
- Content-only change to agent instructions; no runtime surface

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The handbook testing conventions page is linked from the skill and unchanged; skill content moved between files within `.agents/skills/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) authored this after @sampennington found these two skills were the top skill line items in their token usage breakdown. The `/writing-skills` skill was invoked before editing. We chose relocation over deletion deliberately: these are the two most-loaded skills in the repo, so body size is the lever, but their enforcement value lives in the rules — every rule stays in the body, with rationale and examples one hop away in references. The frontmatter descriptions were left untouched to avoid regressing trigger accuracy.

