### PR TITLE
feat(tasks): add runtime_adapter label to run token metrics

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -105,9 +105,11 @@ RUN set -eux; \
 ENV AGENTSH_SERVER=http://127.0.0.1:18080
 
 # Install rtk (https://github.com/rtk-ai/rtk), a proxy that compresses the output of
-# common dev commands before it reaches the model. The agent auto-detects it on PATH
-# and routes eligible Bash commands through it; POSTHOG_RTK=0 (set per run from the
-# task processing context) opts a run out.
+# common dev commands before it reaches the model. Claude runs auto-detect it on PATH
+# and route eligible Bash commands through it via a PreToolUse rewrite hook; Codex has
+# no command-rewrite channel, so its runs are told to prefix eligible commands in the
+# developer instructions instead. POSTHOG_RTK=0 (set per run from the task processing
+# context) opts a run out of both.
 ARG RTK_VERSION=0.43.0
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -71,6 +71,16 @@ def _bool_label(value: bool | None) -> str:
     return "true" if value else "false"
 
 
+_ALLOWED_RUNTIME_ADAPTERS = {"claude", "codex"}
+
+
+def _runtime_adapter_label(value: str | None) -> str:
+    """Bounded label: unexpected values collapse to "other" to cap cardinality."""
+    if not value:
+        return "unknown"
+    return value if value in _ALLOWED_RUNTIME_ADAPTERS else "other"
+
+
 def increment_snapshot_usage(
     used_snapshot: bool,
     *,
@@ -139,6 +149,7 @@ def record_run_token_usage(
     origin_product: str | None,
     run_environment: str | None,
     rtk_enabled: bool | None,
+    runtime_adapter: str | None,
     status: str | None,
 ) -> None:
     """Record a terminal run's token expenditure (from ``TaskRun.state.token_usage``).
@@ -150,6 +161,7 @@ def record_run_token_usage(
             "origin_product": origin_product or "unknown",
             "run_environment": run_environment or "unknown",
             "rtk_enabled": _bool_label(rtk_enabled),
+            "runtime_adapter": _runtime_adapter_label(runtime_adapter),
             "status": status or "unknown",
         }
         for kind, key in _RUN_TOKEN_KINDS.items():

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -96,6 +96,7 @@ class TestUpdateTaskRunStatusActivity:
             **(test_task_run.state or {}),
             "token_usage": dict(TOKEN_USAGE),
             "rtk_effective": True,
+            "runtime_adapter": "codex",
         }
         test_task_run.save(update_fields=["state"])
 
@@ -116,6 +117,7 @@ class TestUpdateTaskRunStatusActivity:
         assert props["run_environment"] == test_task_run.environment
         mock_record.assert_called_once()
         assert mock_record.call_args.kwargs["rtk_enabled"] is True
+        assert mock_record.call_args.kwargs["runtime_adapter"] == "codex"
         assert mock_record.call_args.kwargs["status"] == status
 
     @pytest.mark.django_db(transaction=True)

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -104,11 +104,13 @@ def _capture_terminal_analytics(task_run: TaskRun, input: UpdateTaskRunStatusInp
         state = task_run.state if isinstance(task_run.state, dict) else {}
         usage = state.get("token_usage")
         if isinstance(usage, dict):
+            adapter = state.get("runtime_adapter")
             record_run_token_usage(
                 usage,
                 origin_product=task_run.task.origin_product,
                 run_environment=task_run.environment,
                 rtk_enabled=task_run.effective_rtk(),
+                runtime_adapter=adapter if isinstance(adapter, str) else None,
                 status=input.status,
             )
     except Exception:


### PR DESCRIPTION
## Problem

The terminal-run token metrics (`tasks_run_total_tokens`, `tasks_run_tokens_total`) carry an `rtk_enabled` cohort label but no runtime adapter, so the rtk cohort panels on the cloud-background-agents-runs dashboard can't separate Claude runs (where rtk is applied deterministically via a PreToolUse rewrite hook) from Codex runs (where rtk adoption is instruction-level, added in [PostHog/code#3491](https://github.com/PostHog/code/pull/3491)). Without the split there's no way to see whether the Codex integration actually moves tokens per run.

**Why:** rtk command-output compression is being extended to cloud Codex runs, and the per-adapter cohort is the graph that validates (or falsifies) that change.

## Changes

- `record_run_token_usage` now takes the run's `runtime_adapter` (read from `TaskRun.state`, where run creation already persists it) and labels both token metrics with it, bounded to `claude`/`codex`/`other`/`unknown` to cap cardinality.
- Corrected the sandbox `Dockerfile.sandbox-base` comment that claimed "the agent" auto-detects rtk on PATH — that is true only for Claude; Codex has no command-rewrite channel and is instructed instead.

Companion dashboard change (splitting the rtk cohort panels by this label) goes to the grafana-dashboards repo.