### PR TITLE
fix(tasks): label sandbox provisioning logs with the custom base image

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -46,6 +46,7 @@ def _get_image_source_label(
     provider: str | None,
     resume_snapshot_external_id: str | None,
     snapshot: SandboxSnapshot | None,
+    custom_image_name: str | None = None,
 ) -> str:
     if resume_snapshot_external_id:
         return f"resume snapshot {resume_snapshot_external_id}"
@@ -53,6 +54,9 @@ def _get_image_source_label(
     if snapshot is not None:
         external_id = snapshot.external_id or str(snapshot.id)
         return f"repository snapshot {external_id}"
+
+    if custom_image_name:
+        return f"custom base image {custom_image_name}"
 
     if provider == "docker":
         return "local Docker sandbox image"
@@ -124,7 +128,8 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         snapshot_source = "none"
         snapshot_kind = SNAPSHOT_KIND_FILESYSTEM
         snapshot_mount_path: str | None = None
-        if has_repo and github_integration_id is not None:
+        # Repo-setup snapshots come from default-base sandboxes; restoring one would drop the custom image.
+        if has_repo and github_integration_id is not None and not ctx.custom_image_name:
             assert repository is not None
             with StepTimer("snapshot_lookup") as snapshot_lookup_timer:
                 snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(github_integration_id, [repository])
@@ -249,11 +254,14 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
                 snapshot_mount_path = run_state.resume_snapshot_mount_path()
 
         provider = getattr(settings, "SANDBOX_PROVIDER", None)
+        use_vm_sandbox = ctx.use_modal_vm_sandbox
+        custom_image_name = ctx.custom_image_name if use_vm_sandbox else None
         image_source_label = _get_image_source_label(
             has_repo=has_repo,
             provider=provider,
             resume_snapshot_external_id=resume_snapshot_ext_id,
             snapshot=snapshot if not resume_snapshot_ext_id else None,
+            custom_image_name=custom_image_name,
         )
 
         if resume_snapshot_ext_id:
@@ -267,7 +275,9 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
 
         config = SandboxConfig(
             name=get_sandbox_name_for_task(ctx.task_id),
-            template=SandboxTemplate.DEFAULT_BASE,
+            template=SandboxTemplate.VM_BASE if use_vm_sandbox else SandboxTemplate.DEFAULT_BASE,
+            custom_image_name=custom_image_name,
+            vm_runtime=use_vm_sandbox,
             environment_variables=environment_variables,
             snapshot_external_id=resume_snapshot_ext_id,
             snapshot_kind=snapshot_kind,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -208,6 +208,17 @@ def _get_image_source_label(
     return "base_image", "published sandbox base image"
 
 
+def get_fresh_image_source_for_context(ctx: TaskProcessingContext) -> tuple[str, str]:
+    """Image source and label for a sandbox provisioned fresh (no snapshot) from this context."""
+    return _get_image_source_label(
+        has_repo=ctx.repository is not None,
+        provider=getattr(settings, "SANDBOX_PROVIDER", None),
+        resume_snapshot_external_id=None,
+        snapshot=None,
+        custom_image_name=ctx.custom_image_name if ctx.use_modal_vm_sandbox else None,
+    )
+
+
 def _build_environment_variables(
     ctx: TaskProcessingContext, task: Task, github_token: str, access_token: str
 ) -> dict[str, str]:

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -73,6 +73,8 @@ def _build_context(
     use_modal_resume_snapshots: bool = True,
     sandbox_event_ingest_enabled: bool = False,
     environment: str | None = None,
+    use_modal_vm_sandbox: bool = False,
+    custom_image_name: str | None = None,
 ) -> TaskProcessingContext:
     return TaskProcessingContext(
         task_id="task-id",
@@ -89,6 +91,8 @@ def _build_context(
         _branch="feature-branch",
         use_modal_resume_snapshots=use_modal_resume_snapshots,
         sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
+        use_modal_vm_sandbox=use_modal_vm_sandbox,
+        custom_image_name=custom_image_name,
     )
 
 
@@ -1134,13 +1138,22 @@ class TestProcessTaskWorkflowUnit:
 
         assert inject_fresh_tokens_on_resume not in activity_calls
 
+    @pytest.mark.parametrize(
+        "custom_image_name, expected_image_source, expected_image_source_label",
+        [
+            (None, "base_image", "published sandbox base image"),
+            ("sandbox-custom-abc", "custom_image", "custom base image sandbox-custom-abc"),
+        ],
+    )
     async def test_get_sandbox_for_repository_falls_back_to_fresh_sandbox_when_resume_injection_fails(
-        self, monkeypatch
+        self, monkeypatch, custom_image_name, expected_image_source, expected_image_source_label
     ):
         workflow = ProcessTaskWorkflow()
         workflow._context = _build_context(
             github_integration_id=123,
             state={"snapshot_external_id": "im-abc123", "resume_from_run_id": "previous-run-id"},
+            use_modal_vm_sandbox=custom_image_name is not None,
+            custom_image_name=custom_image_name,
         )
 
         prepared = PrepareSandboxForRepositoryOutput(
@@ -1205,6 +1218,8 @@ class TestProcessTaskWorkflowUnit:
         assert fresh_prepared.snapshot_external_id is None
         assert fresh_prepared.used_snapshot is False
         assert fresh_prepared.should_create_snapshot is True
+        assert fresh_prepared.image_source == expected_image_source
+        assert fresh_prepared.image_source_label == expected_image_source_label
         assert clone_repository_in_sandbox in activity_calls
 
     async def test_get_sandbox_for_repository_propagates_non_dead_sandbox_failures(self, monkeypatch):

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -53,6 +53,7 @@ from .activities.provision_sandbox import (
     checkout_branch_in_sandbox,
     clone_repository_in_sandbox,
     create_sandbox_for_repository,
+    get_fresh_image_source_for_context,
     inject_fresh_tokens_on_resume,
     invalidate_resume_snapshot,
     prepare_sandbox_for_repository,
@@ -927,6 +928,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 )
                 await self._cleanup_sandbox(created.sandbox_id)
                 self._sandbox_id_for_cleanup = None
+                fresh_image_source, fresh_image_source_label = get_fresh_image_source_for_context(self.context)
                 prepared = replace(
                     prepared,
                     snapshot_id=None,
@@ -936,8 +938,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     snapshot_kind=SNAPSHOT_KIND_FILESYSTEM,
                     snapshot_mount_path=None,
                     snapshot_source="none",
-                    image_source="base_image",
-                    image_source_label="published sandbox base image",
+                    image_source=fresh_image_source,
+                    image_source_label=fresh_image_source_label,
                 )
                 await self._emit_progress(
                     "sandbox",


### PR DESCRIPTION
## Problem

Cloud task runs configured with a custom base image could still show `Provisioning sandbox from published sandbox base image (image build may take a few minutes on first run)` in the run's debug logs, instead of naming the custom image actually being used.

## Changes

- The resume-snapshot fallback in `ProcessTaskWorkflow` re-provisions a fresh sandbox that honors the context's custom image, but relabeled it as `base_image` / "published sandbox base image". It now derives the image source from the run context, so custom-image runs keep a truthful label (in logs and in the sandbox tags built from `image_source`).
- The legacy combined `get_sandbox_for_repository` activity ignored custom images entirely. It now mirrors the split prepare/create path: skips repo-setup snapshots for custom-image runs (restoring one would silently drop the image), provisions with the VM template + custom image, and labels the log line accordingly.