### PR TITLE
fix(error-tracking): declare quill charts dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3269,6 +3269,9 @@ importers:
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@posthog/quill-charts':
+        specifier: workspace:*
+        version: link:../../packages/quill/packages/charts
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)

--- a/products/error_tracking/package.json
+++ b/products/error_tracking/package.json
@@ -5,6 +5,7 @@
         "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
+        "@posthog/quill-charts": "workspace:*",
         "kea": "catalog:",
         "kea-forms": "catalog:",
         "kea-loaders": "catalog:",


### PR DESCRIPTION
## Problem

The error-tracking rate limit charts import @posthog/quill-charts directly, but the error-tracking product does not declare that workspace dependency. pnpm therefore does not create a product-local link, and Vite cannot resolve the import.

## Changes

Declare @posthog/quill-charts in the error-tracking product and update the pnpm lockfile.

## How did you test this code?

- Ran `pnpm install --frozen-lockfile` successfully.
- Ran `bin/hogli ci:preflight --fix` with no failures.
- Verified pnpm created the error-tracking product workspace link for @posthog/quill-charts.

No automated code test was added because this only corrects package metadata and lockfile state. No manual UI testing was performed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update is needed because this restores dependency resolution for an existing implementation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex diagnosed the missing workspace dependency and prepared the manifest and lockfile update. The `/submit-pr` skill was used for branch, validation, and PR submission workflow.