### PR TITLE
chore: promote the actual important impersonation actions

### DIFF
--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -177,11 +177,17 @@
         border-radius: var(--radius);
     }
 
-    &__expiry.LemonButton {
-        --lemon-button-color: var(--color-text-tertiary);
-        --lemon-button-font-size: var(--text-xs);
+    &__expiry {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        font-size: var(--text-xs);
+        color: var(--color-text-tertiary);
 
-        align-self: flex-start;
+        // Match the refresh icon to the subtle expiry text.
+        .LemonButton {
+            --lemon-button-color: var(--color-text-tertiary);
+        }
     }
 }
 

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -163,16 +163,16 @@
         color: var(--text-primary);
     }
 
-    // The change-user menu trigger sits inline in the "Signed in as …" sentence,
-    // so it reads as the (clickable) email rather than a standalone button.
-    &__user-trigger.LemonButton {
+    &__inline-trigger.LemonButton {
         display: inline-flex;
-        max-width: 100%;
         min-height: auto;
-        padding: 0 0.25rem;
         font-size: inherit;
-        font-weight: 600;
         vertical-align: baseline;
+    }
+
+    &__user-trigger.LemonButton {
+        max-width: 100%;
+        font-weight: 600;
         border: 1px solid var(--color-border-warning);
         border-radius: var(--radius);
     }

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -1,4 +1,6 @@
 .ImpersonationNotice {
+    --impersonation-notice-border-accent: var(--color-border-warning);
+
     display: flex;
     width: 26rem;
     background-color: var(--color-bg-surface-primary);
@@ -38,6 +40,8 @@
     }
 
     &--read-write {
+        --impersonation-notice-border-accent: var(--color-border-error);
+
         .ImpersonationNotice__sidebar {
             background: var(--danger);
         }
@@ -173,7 +177,7 @@
     &__user-trigger.LemonButton {
         max-width: 100%;
         font-weight: 600;
-        border: 1px solid var(--color-border-warning);
+        border: 1px solid var(--impersonation-notice-border-accent);
         border-radius: var(--radius);
     }
 

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.scss
@@ -176,6 +176,13 @@
         border: 1px solid var(--color-border-warning);
         border-radius: var(--radius);
     }
+
+    &__expiry.LemonButton {
+        --lemon-button-color: var(--color-text-tertiary);
+        --lemon-button-font-size: var(--text-xs);
+
+        align-self: flex-start;
+    }
 }
 
 @keyframes ImpersonationNotice__fadeScaleIn {

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -41,7 +41,15 @@ function ChangeUserMenuItemLabel({ member }: { member: OrganizationMemberType })
     )
 }
 
-function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: () => void }): JSX.Element {
+function CountDown({
+    datetime,
+    callback,
+    className,
+}: {
+    datetime: dayjs.Dayjs
+    callback?: () => void
+    className?: string
+}): JSX.Element {
     const [now, setNow] = useState(() => dayjs())
     const { isVisible: isPageVisible } = usePageVisibility()
 
@@ -70,7 +78,7 @@ function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: (
         }
     }, [pastCountdown, callback])
 
-    return <span className="tabular-nums text-warning">{countdown}</span>
+    return <span className={cn('tabular-nums', className)}>{countdown}</span>
 }
 
 function LoginAsContent({
@@ -211,24 +219,22 @@ function ImpersonationNoticeContent(): JSX.Element {
                     </>
                 )}
                 .
-                {user?.is_impersonated_until && (
-                    <>
-                        {' '}
-                        Expires in{' '}
-                        <LemonButton
-                            size="xsmall"
-                            sideIcon={<IconRefresh />}
-                            onClick={() => loadUser()}
-                            loading={userLoading}
-                            tooltip="Refresh"
-                            className="ImpersonationNotice__inline-trigger text-warning"
-                        >
-                            <CountDown datetime={dayjs(user.is_impersonated_until)} callback={handleSessionExpired} />
-                        </LemonButton>
-                        .
-                    </>
-                )}
             </p>
+            {user?.is_impersonated_until && (
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconRefresh />}
+                    onClick={() => loadUser()}
+                    loading={userLoading}
+                    tooltip="Refresh"
+                    className="ImpersonationNotice__expiry"
+                >
+                    <span>
+                        Expires in{' '}
+                        <CountDown datetime={dayjs(user.is_impersonated_until)} callback={handleSessionExpired} />
+                    </span>
+                </LemonButton>
+            )}
             <div className="flex gap-2 justify-end">
                 {isReadOnly && (
                     <LemonButton

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -3,7 +3,7 @@ import './ImpersonationNotice.scss'
 import { useActions, useValues } from 'kea'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconChevronDown, IconCollapse, IconEllipsis, IconWarning } from '@posthog/icons'
+import { IconChevronDown, IconCollapse, IconRefresh, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonMenu, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { DraggableWithSnapZones, DraggableWithSnapZonesRef } from 'lib/components/DraggableWithSnapZones'
@@ -149,6 +149,7 @@ function ImpersonationNoticeContent(): JSX.Element {
     const {
         closeUpgradeModal,
         upgradeImpersonation,
+        openUpgradeModal,
         setSessionExpired,
         returnToPostHog,
         changeUser,
@@ -198,7 +199,7 @@ function ImpersonationNoticeContent(): JSX.Element {
                         loading={isChangingUser}
                         tooltip={`Currently impersonating ${user?.email} - click to switch user`}
                         truncate
-                        className="ImpersonationNotice__user-trigger text-warning"
+                        className="ImpersonationNotice__inline-trigger ImpersonationNotice__user-trigger text-warning"
                     >
                         {user?.email}
                     </LemonButton>
@@ -214,17 +215,33 @@ function ImpersonationNoticeContent(): JSX.Element {
                     <>
                         {' '}
                         Expires in{' '}
-                        <CountDown datetime={dayjs(user.is_impersonated_until)} callback={handleSessionExpired} />.
+                        <LemonButton
+                            size="xsmall"
+                            sideIcon={<IconRefresh />}
+                            onClick={() => loadUser()}
+                            loading={userLoading}
+                            tooltip="Refresh"
+                            className="ImpersonationNotice__inline-trigger text-warning"
+                        >
+                            <CountDown datetime={dayjs(user.is_impersonated_until)} callback={handleSessionExpired} />
+                        </LemonButton>
+                        .
                     </>
                 )}
             </p>
             <div className="flex gap-2 justify-end">
-                <LemonButton type="secondary" size="small" onClick={() => loadUser()} loading={userLoading}>
-                    Refresh
-                </LemonButton>
+                {isReadOnly && (
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={() => openUpgradeModal()}
+                        tooltip="Upgrade your impersonation session to have read-write permissions"
+                    >
+                        Upgrade to read-write
+                    </LemonButton>
+                )}
                 <LemonButton
-                    type="secondary"
-                    status="danger"
+                    type="primary"
                     size="small"
                     onClick={() => logout()}
                     sideAction={{
@@ -284,7 +301,7 @@ export function ImpersonationNotice(): JSX.Element | null {
         ticketContext,
         adminLoginUrls,
     } = useValues(impersonationNoticeLogic)
-    const { minimize, maximize, openUpgradeModal, setPageVisible } = useActions(impersonationNoticeLogic)
+    const { minimize, maximize, setPageVisible } = useActions(impersonationNoticeLogic)
 
     const { isVisible: isPageVisible } = usePageVisibility()
 
@@ -355,18 +372,6 @@ export function ImpersonationNotice(): JSX.Element | null {
                         <div className="ImpersonationNotice__header">
                             <IconWarning className="ImpersonationNotice__warning-icon" />
                             <span className="ImpersonationNotice__title">{title}</span>
-                            {isImpersonated && isReadOnly && (
-                                <LemonMenu
-                                    items={[
-                                        {
-                                            label: 'Upgrade to read-write',
-                                            onClick: openUpgradeModal,
-                                        },
-                                    ]}
-                                >
-                                    <LemonButton size="xsmall" icon={<IconEllipsis />} />
-                                </LemonMenu>
-                            )}
                             <LemonButton size="xsmall" icon={<IconCollapse />} onClick={handleMinimize} />
                         </div>
                         <div className="ImpersonationNotice__content">

--- a/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
+++ b/frontend/src/layout/navigation/ImpersonationNotice/ImpersonationNotice.tsx
@@ -41,15 +41,7 @@ function ChangeUserMenuItemLabel({ member }: { member: OrganizationMemberType })
     )
 }
 
-function CountDown({
-    datetime,
-    callback,
-    className,
-}: {
-    datetime: dayjs.Dayjs
-    callback?: () => void
-    className?: string
-}): JSX.Element {
+function CountDown({ datetime, callback }: { datetime: dayjs.Dayjs; callback?: () => void }): JSX.Element {
     const [now, setNow] = useState(() => dayjs())
     const { isVisible: isPageVisible } = usePageVisibility()
 
@@ -78,7 +70,7 @@ function CountDown({
         }
     }, [pastCountdown, callback])
 
-    return <span className={cn('tabular-nums', className)}>{countdown}</span>
+    return <span className="tabular-nums">{countdown}</span>
 }
 
 function LoginAsContent({
@@ -221,19 +213,20 @@ function ImpersonationNoticeContent(): JSX.Element {
                 .
             </p>
             {user?.is_impersonated_until && (
-                <LemonButton
-                    size="xsmall"
-                    icon={<IconRefresh />}
-                    onClick={() => loadUser()}
-                    loading={userLoading}
-                    tooltip="Refresh"
-                    className="ImpersonationNotice__expiry"
-                >
+                <div className="ImpersonationNotice__expiry">
                     <span>
                         Expires in{' '}
                         <CountDown datetime={dayjs(user.is_impersonated_until)} callback={handleSessionExpired} />
                     </span>
-                </LemonButton>
+                    <LemonButton
+                        type="secondary"
+                        size="xxsmall"
+                        icon={<IconRefresh />}
+                        onClick={() => loadUser()}
+                        loading={userLoading}
+                        tooltip="Refresh"
+                    />
+                </div>
             )}
             <div className="flex gap-2 justify-end">
                 {isReadOnly && (


### PR DESCRIPTION
## Problem

The important impersonation actions - i.e. upgrading to read/write are hidden in a context menu behind an extra click.

Refreshing the session is rarely done because it happens automatically on navigation, and also we have the reimpersonate modal now when it does expire in the background.

https://posthog.slack.com/archives/C075D3C5HST/p1784190333423819

## Changes

Make it better!

<img width="906" height="362" alt="CleanShot 2026-07-16 at 11 59 55@2x" src="https://github.com/user-attachments/assets/f32cbe06-dcd8-4417-8544-a7ab11ddac74" />



