### PR TITLE
fix(replay): keep score export queries below size limit

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -1,4 +1,5 @@
 import os
+import json
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -13,6 +14,9 @@ from clickhouse_pool import ChPool
 
 if TYPE_CHECKING:
     from clickhouse_connect.driver import Client as HttpClient
+    from clickhouse_connect.driver.external import ExternalData
+
+    from posthog.clickhouse.client.execute import ClickHouseExternalTable
 
 from posthog.clickhouse.workload import Workload
 from posthog.settings import data_stores
@@ -132,6 +136,34 @@ def get_clickhouse_creds(user: ClickHouseUser) -> tuple[str, str]:
     return __user_dict[user] if user in __user_dict else __user_dict[ClickHouseUser.DEFAULT]
 
 
+def _to_clickhouse_connect_external_data(
+    external_tables: list["ClickHouseExternalTable"] | None,
+) -> "ExternalData | None":
+    """Encode clickhouse-driver external tables for clickhouse-connect's HTTP transport."""
+    if not external_tables:
+        return None
+
+    from clickhouse_connect.driver.external import ExternalData  # noqa: PLC0415
+
+    external_data = ExternalData()
+    for table in external_tables:
+        columns = [column for column, _ in table["structure"]]
+        payload = b"\n".join(
+            json.dumps(
+                {column: row[column] for column in columns},
+                separators=(",", ":"),
+            ).encode()
+            for row in table["data"]
+        )
+        external_data.add_file(
+            file_name=table["name"],
+            data=payload,
+            fmt="JSONEachRow",
+            structure=[f"{column} {ch_type}" for column, ch_type in table["structure"]],
+        )
+    return external_data
+
+
 class ProxyClient:
     def __init__(self, client: "HttpClient"):
         self._client = client
@@ -151,7 +183,13 @@ class ProxyClient:
             if settings is None:
                 settings = {}
             settings["query_id"] = query_id
-        result = self._client.query(query=query, parameters=params, settings=settings, column_oriented=columnar)
+        result = self._client.query(
+            query=query,
+            parameters=params,
+            settings=settings,
+            column_oriented=columnar,
+            external_data=_to_clickhouse_connect_external_data(external_tables),
+        )
 
         # we must play with result summary here
         written_rows = int(result.summary.get("written_rows", 0))

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -3,9 +3,13 @@ import json
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
-from enum import StrEnum
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum, StrEnum
 from functools import cache
+from ipaddress import IPv4Address, IPv6Address
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from django.conf import settings
 
@@ -151,6 +155,7 @@ def _to_clickhouse_connect_external_data(
         payload = b"\n".join(
             json.dumps(
                 {column: row[column] for column in columns},
+                default=_external_table_json_default,
                 separators=(",", ":"),
             ).encode()
             for row in table["data"]
@@ -162,6 +167,18 @@ def _to_clickhouse_connect_external_data(
             structure=[f"{column} {ch_type}" for column, ch_type in table["structure"]],
         )
     return external_data
+
+
+def _external_table_json_default(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat(sep=" ")
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (Decimal, UUID, IPv4Address, IPv6Address)):
+        return str(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
 class ProxyClient:

--- a/posthog/clickhouse/client/test/test_connection.py
+++ b/posthog/clickhouse/client/test/test_connection.py
@@ -25,6 +25,17 @@ def test_insert_with_http_client():
         sync_execute("DROP TABLE IF EXISTS _test_http_insert")
 
 
+def test_http_client_forwards_external_tables():
+    with get_http_client(database="default") as client:
+        result = sync_execute(
+            "SELECT id FROM _test_ext ORDER BY id",
+            flush=False,
+            sync_client=client,
+            external_tables=[{"name": "_test_ext", "structure": [("id", "Int64")], "data": [{"id": 2}, {"id": 5}]}],
+        )
+    assert result == [(2,), (5,)]
+
+
 def test_connection_pool_creation_without_offline_cluster(settings):
     settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST = None
 

--- a/posthog/clickhouse/client/test/test_connection.py
+++ b/posthog/clickhouse/client/test/test_connection.py
@@ -1,3 +1,7 @@
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import UUID
+
 import pytest
 
 from posthog.clickhouse.client.connection import (
@@ -34,6 +38,43 @@ def test_http_client_forwards_external_tables():
             external_tables=[{"name": "_test_ext", "structure": [("id", "Int64")], "data": [{"id": 2}, {"id": 5}]}],
         )
     assert result == [(2,), (5,)]
+
+
+def test_http_client_serializes_typed_external_table_values():
+    identifier = UUID("12345678-1234-5678-1234-567812345678")
+    with get_http_client(database="default") as client:
+        result = sync_execute(
+            """
+            SELECT
+                toString(recorded_at),
+                toString(recorded_on),
+                toString(amount),
+                toString(identifier)
+            FROM _test_typed_ext
+            """,
+            flush=False,
+            sync_client=client,
+            external_tables=[
+                {
+                    "name": "_test_typed_ext",
+                    "structure": [
+                        ("recorded_at", "DateTime64(6, 'UTC')"),
+                        ("recorded_on", "Date"),
+                        ("amount", "Decimal(18, 4)"),
+                        ("identifier", "UUID"),
+                    ],
+                    "data": [
+                        {
+                            "recorded_at": datetime(2026, 7, 16, 9, 57, 49, 123456, tzinfo=UTC),
+                            "recorded_on": date(2026, 7, 16),
+                            "amount": Decimal("12.3400"),
+                            "identifier": identifier,
+                        }
+                    ],
+                }
+            ],
+        )
+    assert result == [("2026-07-16 09:57:49.123456", "2026-07-16", "12.34", str(identifier))]
 
 
 def test_connection_pool_creation_without_offline_cluster(settings):

--- a/posthog/temporal/session_replay/surfacing_score_export_sweep/activities.py
+++ b/posthog/temporal/session_replay/surfacing_score_export_sweep/activities.py
@@ -23,6 +23,7 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.execute import ClickHouseExternalTable
 from posthog.models import Team
 from posthog.temporal.session_replay.surfacing_score_export_sweep import sql as export_sql
 from posthog.temporal.session_replay.surfacing_score_export_sweep.constants import (
@@ -114,6 +115,15 @@ _Cursor = tuple[str, int]
 _FIRST_PAGE: _Cursor = ("", 0)
 
 
+def _opted_in_teams_external_table(team_ids: list[int]) -> ClickHouseExternalTable:
+    """Build a query-scoped team table that keeps the rendered SQL bounded."""
+    return {
+        "name": export_sql.OPTED_IN_TEAMS_EXTERNAL_TABLE,
+        "structure": export_sql.OPTED_IN_TEAMS_EXTERNAL_STRUCTURE,
+        "data": [{"team_id": team_id} for team_id in team_ids],
+    }
+
+
 def _fetch_page(spec: ExportPartitionSpec, team_ids: list[int], cursor: _Cursor) -> list[_ScoredRow]:
     return cast(
         list[_ScoredRow],
@@ -122,7 +132,6 @@ def _fetch_page(spec: ExportPartitionSpec, team_ids: list[int], cursor: _Cursor)
             {
                 "of_chunks": spec.of_chunks,
                 "chunk_id": spec.chunk_id,
-                "team_ids": team_ids,
                 "day_start": f"{spec.day} 00:00:00",
                 "cursor_session_id": cursor[0],
                 "cursor_team_id": cursor[1],
@@ -132,6 +141,7 @@ def _fetch_page(spec: ExportPartitionSpec, team_ids: list[int], cursor: _Cursor)
                 "max_execution_time": CH_EXPORT_QUERY_TIMEOUT_S,
                 "max_memory_usage": CH_EXPORT_QUERY_MAX_MEMORY_BYTES,
             },
+            external_tables=[_opted_in_teams_external_table(team_ids)],
         ),
     )
 

--- a/posthog/temporal/session_replay/surfacing_score_export_sweep/sql.py
+++ b/posthog/temporal/session_replay/surfacing_score_export_sweep/sql.py
@@ -2,12 +2,28 @@
 
 SESSION_REPLAY_EVENTS_TABLE = "session_replay_events"
 
+# Name of the query-scoped external data table that carries the AI-training
+# opted-in team ids. The list is sent alongside the request (see
+# `sync_execute(external_tables=...)`) so the rendered query stays bounded as
+# the number of opted-in teams grows.
+OPTED_IN_TEAMS_EXTERNAL_TABLE = "__ph_opted_in_teams"
+
+# ClickHouse structure of the external table above; `team_id` matches the
+# `session_replay_events.team_id` Int64 column.
+OPTED_IN_TEAMS_EXTERNAL_STRUCTURE: list[tuple[str, str]] = [("team_id", "Int64")]
+
 
 def fetch_scored_sessions_page_sql(replay_events_table: str = SESSION_REPLAY_EVENTS_TABLE) -> str:
     """One keyset-paginated page of a (day, hash bucket) export slice.
-    Bound parameters: %(of_chunks)s, %(chunk_id)s, %(team_ids)s,
+    Bound parameters: %(of_chunks)s, %(chunk_id)s,
     %(day_start)s ('YYYY-MM-DD 00:00:00', UTC), %(cursor_session_id)s,
     %(cursor_team_id)s, %(page_size)s.
+
+    The opted-in team-id filter reads from the `__ph_opted_in_teams` external
+    data table sent with the request. Both references use
+    `GLOBAL IN` so the initiator resolves the external table (which only lives on
+    the initiator) and broadcasts the ids to every shard of the distributed
+    `session_replay_events` table.
 
     The cursor predicate and ORDER BY use the same (session_id, team_id) tuple,
     so pages tile the partition exactly; a page shorter than page_size means
@@ -31,7 +47,7 @@ SELECT
     max(surfacing_score) AS score
 FROM {replay_events_table}
 WHERE cityHash64(session_id) %% %(of_chunks)s = %(chunk_id)s
-  AND team_id IN %(team_ids)s
+  AND team_id GLOBAL IN (SELECT team_id FROM {OPTED_IN_TEAMS_EXTERNAL_TABLE})
   AND (session_id, team_id) > (%(cursor_session_id)s, %(cursor_team_id)s)
   AND min_first_timestamp >= toDateTime(%(day_start)s, 'UTC')
   AND min_first_timestamp < toDateTime(%(day_start)s, 'UTC') + toIntervalDay(2)
@@ -39,7 +55,7 @@ WHERE cityHash64(session_id) %% %(of_chunks)s = %(chunk_id)s
     SELECT team_id, session_id
     FROM {replay_events_table}
     WHERE cityHash64(session_id) %% %(of_chunks)s = %(chunk_id)s
-      AND team_id IN %(team_ids)s
+      AND team_id GLOBAL IN (SELECT team_id FROM {OPTED_IN_TEAMS_EXTERNAL_TABLE})
       AND min_first_timestamp >= toDateTime(%(day_start)s, 'UTC')
       AND is_deleted = 1
   )

--- a/posthog/temporal/tests/session_replay/surfacing_score_export_sweep/test_export.py
+++ b/posthog/temporal/tests/session_replay/surfacing_score_export_sweep/test_export.py
@@ -8,8 +8,10 @@ import pytest
 import pyarrow.parquet as pq
 from parameterized import parameterized
 
+from posthog.temporal.session_replay.surfacing_score_export_sweep import sql as export_sql
 from posthog.temporal.session_replay.surfacing_score_export_sweep.activities import (
     _PARQUET_SCHEMA,
+    _opted_in_teams_external_table,
     _page_table,
     export_days,
 )
@@ -85,3 +87,16 @@ class TestPartitionParquet:
         table = pq.read_table(io.BytesIO(_write_pages([])))
         assert table.num_rows == 0
         assert table.schema.names == ["session_id", "team_id", "started_at", "surfacing_score"]
+
+
+class TestOptedInTeamFilter:
+    def test_page_sql_never_inlines_the_team_id_list(self) -> None:
+        sql = export_sql.fetch_scored_sessions_page_sql()
+        assert "%(team_ids)s" not in sql
+        assert sql.count(f"team_id GLOBAL IN (SELECT team_id FROM {export_sql.OPTED_IN_TEAMS_EXTERNAL_TABLE})") == 2
+
+    def test_external_table_carries_team_ids_out_of_band(self) -> None:
+        table = _opted_in_teams_external_table([7, 42])
+        assert table["name"] == export_sql.OPTED_IN_TEAMS_EXTERNAL_TABLE
+        assert table["structure"] == [("team_id", "Int64")]
+        assert table["data"] == [{"team_id": 7}, {"team_id": 42}]


### PR DESCRIPTION
## Problem

The surfacing-score export sends the full AI-training opted-in team list as a ClickHouse query parameter in two places. Client-side substitution makes the rendered SQL grow with every opted-in team and can exceed ClickHouse `max_query_size` before the query runs.

Moving the list to a query-scoped external table also requires the HTTP ClickHouse adapter to forward `external_tables`. That adapter currently drops them.

```mermaid
flowchart LR
    A[Score export activity] -->|team IDs substituted twice| B[Rendered SQL]
    B --> C[ClickHouse parser]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B phRed;
    class C phYellow;
```

## Changes

- Send opted-in team IDs as a query-scoped external table and filter with `GLOBAL IN` on the distributed replay table.
- Translate the existing clickhouse-driver external-table format to clickhouse-connect `ExternalData` for HTTP queries, including typed values accepted by the native driver.
- Add regression coverage for bounded SQL, external-table contents, typed serialization, and end-to-end HTTP forwarding.

```mermaid
flowchart LR
    A[Score export activity] -->|bounded SQL| B[HTTP ClickHouse client]
    A -->|external table data| B
    B --> C[ClickHouse]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B phRed;
    class C phYellow;
```

## How did you test this code?

- `hogli test posthog/temporal/tests/session_replay/surfacing_score_export_sweep/test_export.py posthog/clickhouse/client/test/test_connection.py::test_http_client_forwards_external_tables posthog/clickhouse/client/test/test_connection.py::test_http_client_serializes_typed_external_table_values` - 12 passed.
- `ty check` on all changed Python files.
- `hogli ci:preflight --strict --against origin/master`.

The new tests catch query growth from inlined team IDs, HTTP transport loss of query-scoped external data, and serialization failures for valid typed values.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change. This is an internal query transport fix with no user-facing API or configuration change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex investigated the failed export, implemented and tested the fix, and used the repository `/writing-tests` skill. The implementation keeps the existing external-table contract and adds the missing HTTP conversion so both native and HTTP ClickHouse transports preserve bounded query text.