### PR TITLE
fix(error-tracking): skip fingerprint embeddings for manual fingerprints and elixir

### DIFF
--- a/rust/cymbal/src/core/metric_consts.rs
+++ b/rust/cymbal/src/core/metric_consts.rs
@@ -108,6 +108,9 @@ pub const SIGNAL_EMITTED: &str = "cymbal_signal_emitted";
 pub const SIGNAL_EMIT_FAILED: &str = "cymbal_signal_emit_failed";
 pub const SIGNAL_EMIT_RESPONSE: &str = "cymbal_signal_emit_response";
 
+// Fingerprint embedding metrics
+pub const FINGERPRINT_EMBEDDING_SKIPPED: &str = "cymbal_fingerprint_embedding_skipped";
+
 // Stages Name.
 // We want to keep previous value for comparison, can be changed later on
 pub const HTTP_EXCEPTION_PIPELINE: &str = "cymbal_http_exception_pipeline";

--- a/rust/cymbal/src/modes/notifications/side_effects.rs
+++ b/rust/cymbal/src/modes/notifications/side_effects.rs
@@ -4,12 +4,20 @@ use common_kafka::kafka_producer::{send_iter_to_kafka, KafkaContext, KafkaProduc
 use common_types::embedding::{EmbeddingModel, EmbeddingRequest};
 use rdkafka::producer::FutureProducer;
 use rdkafka::types::RDKafkaErrorCode;
+use serde_json::Value;
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::core::error::UnhandledError;
+use crate::metric_consts::FINGERPRINT_EMBEDDING_SKIPPED;
 use crate::modes::notifications::stacktrace::print_stacktrace;
 use crate::modes::notifications::types::NotificationIssue;
+use crate::modes::processing::fingerprinting::FingerprintRecordPart;
 use crate::types::OutputErrProps;
+
+/// SDKs whose fingerprint embeddings we don't generate — their events don't
+/// produce stack traces useful for embedding-based similarity grouping.
+const EMBEDDING_DISABLED_LIBS: &[&str] = &["posthog-elixir"];
 
 struct IssueLifecycleInternalEvent<'a, I: NotificationIssue> {
     event: &'static str,
@@ -26,6 +34,17 @@ pub async fn send_new_fingerprint_event<I: NotificationIssue>(
     issue: &I,
     output_props: &OutputErrProps,
 ) -> Result<(), UnhandledError> {
+    if let Some(reason) = skip_fingerprint_embedding_reason(output_props) {
+        metrics::counter!(FINGERPRINT_EMBEDDING_SKIPPED, "reason" => reason).increment(1);
+        debug!(
+            team_id = issue.team_id(),
+            fingerprint = %output_props.fingerprint,
+            reason,
+            "skipping fingerprint embedding request"
+        );
+        return Ok(());
+    }
+
     let request = fingerprint_embedding_request(issue, output_props);
 
     let res = send_iter_to_kafka(producer, embedding_worker_topic, &[request])
@@ -36,6 +55,27 @@ pub async fn send_new_fingerprint_event<I: NotificationIssue>(
         return Err(UnhandledError::KafkaProduceError(err));
     }
     Ok(())
+}
+
+/// Returns the reason a fingerprint embedding request should be skipped, or
+/// `None` if it should be sent. We don't embed manually-fingerprinted issues
+/// (grouped by the user's own key, so similarity grouping doesn't apply) nor
+/// events from SDKs in `EMBEDDING_DISABLED_LIBS`.
+fn skip_fingerprint_embedding_reason(output_props: &OutputErrProps) -> Option<&'static str> {
+    if output_props
+        .fingerprint_record
+        .iter()
+        .any(|part| matches!(part, FingerprintRecordPart::Manual))
+    {
+        return Some("manual_fingerprint");
+    }
+
+    let lib = output_props.other.get("$lib").and_then(Value::as_str);
+    if lib.is_some_and(|lib| EMBEDDING_DISABLED_LIBS.contains(&lib)) {
+        return Some("disabled_sdk");
+    }
+
+    None
 }
 
 fn fingerprint_embedding_request<I: NotificationIssue>(
@@ -206,5 +246,59 @@ async fn send_internal_event_with_producer<I: NotificationIssue>(
             Ok(())
         }
         Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn props_with(record: Vec<FingerprintRecordPart>, lib: Option<&str>) -> OutputErrProps {
+        let mut props = OutputErrProps {
+            fingerprint_record: record,
+            ..Default::default()
+        };
+        if let Some(lib) = lib {
+            props
+                .other
+                .insert("$lib".to_string(), Value::String(lib.to_string()));
+        }
+        props
+    }
+
+    #[test]
+    fn sends_embedding_for_automatic_fingerprint() {
+        let props = props_with(
+            vec![FingerprintRecordPart::Exception {
+                id: None,
+                pieces: vec!["boom".to_string()],
+            }],
+            Some("posthog-python"),
+        );
+        assert_eq!(skip_fingerprint_embedding_reason(&props), None);
+    }
+
+    #[test]
+    fn skips_embedding_for_manual_fingerprint() {
+        let props = props_with(vec![FingerprintRecordPart::Manual], Some("posthog-python"));
+        assert_eq!(
+            skip_fingerprint_embedding_reason(&props),
+            Some("manual_fingerprint")
+        );
+    }
+
+    #[test]
+    fn skips_embedding_for_elixir_sdk() {
+        let props = props_with(
+            vec![FingerprintRecordPart::Exception {
+                id: None,
+                pieces: vec!["boom".to_string()],
+            }],
+            Some("posthog-elixir"),
+        );
+        assert_eq!(
+            skip_fingerprint_embedding_reason(&props),
+            Some("disabled_sdk")
+        );
     }
 }

--- a/rust/cymbal/src/modes/notifications/side_effects.rs
+++ b/rust/cymbal/src/modes/notifications/side_effects.rs
@@ -58,9 +58,10 @@ pub async fn send_new_fingerprint_event<I: NotificationIssue>(
 }
 
 /// Returns the reason a fingerprint embedding request should be skipped, or
-/// `None` if it should be sent. We don't embed manually-fingerprinted issues
-/// (grouped by the user's own key, so similarity grouping doesn't apply) nor
-/// events from SDKs in `EMBEDDING_DISABLED_LIBS` (they emit too many issues).
+/// `None` if it should be sent. We don't embed issues grouped by a fingerprint
+/// the user controls — manual fingerprints and custom grouping rules — since
+/// embedding-based similarity grouping doesn't apply to them, nor events from
+/// SDKs in `EMBEDDING_DISABLED_LIBS` (they emit too many issues).
 fn skip_fingerprint_embedding_reason(output_props: &OutputErrProps) -> Option<&'static str> {
     if output_props
         .fingerprint_record
@@ -68,6 +69,14 @@ fn skip_fingerprint_embedding_reason(output_props: &OutputErrProps) -> Option<&'
         .any(|part| matches!(part, FingerprintRecordPart::Manual))
     {
         return Some("manual_fingerprint");
+    }
+
+    if output_props
+        .fingerprint_record
+        .iter()
+        .any(|part| matches!(part, FingerprintRecordPart::Custom { .. }))
+    {
+        return Some("custom_grouping_rule");
     }
 
     let lib = output_props.other.get("$lib").and_then(Value::as_str);
@@ -284,6 +293,20 @@ mod tests {
         assert_eq!(
             skip_fingerprint_embedding_reason(&props),
             Some("manual_fingerprint")
+        );
+    }
+
+    #[test]
+    fn skips_embedding_for_custom_grouping_rule() {
+        let props = props_with(
+            vec![FingerprintRecordPart::Custom {
+                rule_id: Uuid::nil(),
+            }],
+            Some("posthog-python"),
+        );
+        assert_eq!(
+            skip_fingerprint_embedding_reason(&props),
+            Some("custom_grouping_rule")
         );
     }
 

--- a/rust/cymbal/src/modes/notifications/side_effects.rs
+++ b/rust/cymbal/src/modes/notifications/side_effects.rs
@@ -15,8 +15,8 @@ use crate::modes::notifications::types::NotificationIssue;
 use crate::modes::processing::fingerprinting::FingerprintRecordPart;
 use crate::types::OutputErrProps;
 
-/// SDKs whose fingerprint embeddings we don't generate — their events don't
-/// produce stack traces useful for embedding-based similarity grouping.
+/// SDKs whose fingerprint embeddings we don't generate — they emit too many
+/// distinct issues, so embedding every fingerprint isn't worth the cost.
 const EMBEDDING_DISABLED_LIBS: &[&str] = &["posthog-elixir"];
 
 struct IssueLifecycleInternalEvent<'a, I: NotificationIssue> {
@@ -60,7 +60,7 @@ pub async fn send_new_fingerprint_event<I: NotificationIssue>(
 /// Returns the reason a fingerprint embedding request should be skipped, or
 /// `None` if it should be sent. We don't embed manually-fingerprinted issues
 /// (grouped by the user's own key, so similarity grouping doesn't apply) nor
-/// events from SDKs in `EMBEDDING_DISABLED_LIBS`.
+/// events from SDKs in `EMBEDDING_DISABLED_LIBS` (they emit too many issues).
 fn skip_fingerprint_embedding_reason(output_props: &OutputErrProps) -> Option<&'static str> {
     if output_props
         .fingerprint_record


### PR DESCRIPTION
## Problem

Cymbal's notification mode fires a fingerprint embedding request to the embedding worker every time a new error tracking issue is created. Two cases don't benefit from those embeddings:

- **Manual fingerprints** — the issue is grouped by a key the user supplied, so embedding-based similarity grouping doesn't apply.
- **Elixir SDK events** — these don't produce stack traces useful for embedding-based grouping.

Generating and storing embeddings for these is wasted work.

## Changes

`send_new_fingerprint_event` now bails out early (returning `Ok(())` without producing to Kafka) when either condition holds:

- the issue's `$exception_fingerprint_record` contains a `Manual` part, or
- the event's `$lib` is in `EMBEDDING_DISABLED_LIBS` (currently just `posthog-elixir`).

Skips are counted via a new `cymbal_fingerprint_embedding_skipped` metric with a `reason` label (`manual_fingerprint` / `disabled_sdk`) and logged at debug level.

The two conditions are independent: an embedding is skipped if *either* is true.

## How did you test this code?

Added unit tests for the pure decision function `skip_fingerprint_embedding_reason` covering the automatic-fingerprint (sends), manual-fingerprint (skips), and elixir-SDK (skips) cases.

I (Claude) could not compile or run the Rust test suite in this environment — `cargo` isn't available here — so I verified every API used (`NotificationIssue::team_id`, `FingerprintRecordPart::Manual`, `OutputErrProps.other`, `is_some_and`, the `metrics`/`tracing` macros) against existing usages in the crate. Please run `cargo test -p cymbal side_effects` before merging.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code). No repo skills were required — the change is confined to the Rust cymbal crate's notification side effects.

Decisions along the way:
- Put the guard inside `send_new_fingerprint_event` rather than at the call site in `handle_issue_created`, so the "don't embed" rule lives next to the embedding request and any future caller inherits it.
- Modeled the SDK exclusion as a list constant (`EMBEDDING_DISABLED_LIBS`) so more SDKs can be added without touching logic.
- Interpreted "manual and elixir" as two independent skip conditions (OR), since they're unrelated cases where embeddings add no value.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
