### PR TITLE
chore(workflows): add cyclotron index for the reschedule sweep predicate

### DIFF
--- a/rust/cyclotron-node-migrations/20260716000001_add_action_reschedule_index.sql
+++ b/rust/cyclotron-node-migrations/20260716000001_add_action_reschedule_index.sql
@@ -16,6 +16,13 @@
 --
 -- Partial on status = 'available': only parked rows are sweepable, and it keeps the
 -- index off the write path of every terminal-state transition.
+--
+-- Recovery note: if this CONCURRENTLY build is ever interrupted, it leaves the index
+-- INVALID and a rerun's IF NOT EXISTS will NOT rebuild it. A drop-first statement can't
+-- fix that here - sqlx runs a no-transaction migration as one implicitly-transactional
+-- batch, so CONCURRENTLY statements must be alone in their file, and a separate drop
+-- migration wouldn't re-run on retry. Recover manually:
+--   DROP INDEX CONCURRENTLY idx_cyclotron_jobs_action_reschedule;  -- then re-run migrations
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_action_reschedule
     ON cyclotron_jobs (function_id, action_id, scheduled)
     WHERE status = 'available';

--- a/rust/cyclotron-node-migrations/20260716000001_add_action_reschedule_index.sql
+++ b/rust/cyclotron-node-migrations/20260716000001_add_action_reschedule_index.sql
@@ -1,0 +1,21 @@
+-- no-transaction
+--
+-- Supports the timing-edit reschedule sweep (CyclotronV2Manager.rescheduleParkedJobs),
+-- whose queries filter parked rows by
+--   function_id = $1 AND action_id = ANY($2) AND status = 'available' AND scheduled > $3
+-- (team_id is also in the predicate, but function_id — a per-workflow UUID — is already
+-- maximally selective, so team_id is left to a residual filter over the tiny result).
+--
+-- Without this, the planner narrows via idx_cyclotron_jobs_function_id and heap-filters
+-- action_id/status/scheduled. The email fair-dequeue composite migration (20260622000001)
+-- measured that fallback at ~4x buffer reads / ~10x execution time; the sweep repeats the
+-- predicate up to maxChunksPerCall + 2 times per call against workflows with parked
+-- backlogs in the hundreds of thousands, on the same table the workers dequeue from.
+-- `scheduled` as a trailing key column makes the sweep's `scheduled > $x` an Index Cond
+-- (walked-past rows eliminated in-index), for the same reason as 20260622000001.
+--
+-- Partial on status = 'available': only parked rows are sweepable, and it keeps the
+-- index off the write path of every terminal-state transition.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_action_reschedule
+    ON cyclotron_jobs (function_id, action_id, scheduled)
+    WHERE status = 'available';


### PR DESCRIPTION
## Problem

#71293 adds a reschedule sweep whose queries filter `cyclotron_jobs` by `function_id`, `action_id`, `status`, and `scheduled`. `action_id` has never been indexed, so at the scale the sweep is built for (parked backlogs into the hundreds of thousands) each call would repeat a heap-filtered scan up to ~22 times against the live queue table. Raised as a must-fix by ReviewHog on #71293; the migrations-separation check (correctly) refuses to let the migration ship in the same PR as the service code, hence this standalone PR.

## Changes

One sqlx migration for the cyclotron-node database:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_action_reschedule
    ON cyclotron_jobs (function_id, action_id, scheduled)
    WHERE status = 'available';
```

Partial on `status = 'available'` (only parked rows are sweepable, and it keeps the index off the write path of terminal transitions), `scheduled` as a trailing key column so the sweep's range predicate lands in the Index Cond rather than a heap filter - same reasoning, and same `CREATE INDEX CONCURRENTLY` / `-- no-transaction` pattern, as the email fair-dequeue composite index (`20260622000001`). `team_id` is deliberately left out: `function_id` is a per-workflow UUID and already maximally selective, so `team_id` stays a cheap residual filter.

**Ordering:** should merge before #71293's feature is exercised, but nothing breaks without it - the sweep's queries fall back to the existing `function_id` index plus a heap filter, just slower.

## How did you test this code?

Ran the migration against the local cyclotron-node test database, seeded 50k parked rows (mixed action_ids, one workflow), and confirmed via `EXPLAIN` that the planner uses a bitmap index scan with all three columns in the Index Cond and only `team_id` as a residual filter. The full cyclotron-v2 Jest suite (113 tests) passes against the migrated schema. No new tests: an index has no behavior of its own to pin, and the queries it serves are covered in #71293.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - the module README note pointing at this index ships with #71293.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Split out of #71293 after the migrations-separation check flagged the sqlx migration + nodejs service code combination; the index itself was ReviewHog's (valid) must-fix finding there.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*