### PR TITLE
feat(error-tracking): migrate search dropdown to quill Popover

### DIFF
--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -598,6 +598,8 @@ Icon-only trigger — only the chevron toggles, so the label can be its own butt
 
 `PopoverContent` forwards `collisionAvoidance` to the positioner. Pass `fallbackAxisSide: 'none'` to keep a tall panel on its requested axis (e.g. below the trigger, flipping above only if it won't fit) instead of jumping beside the trigger when vertical space is tight: `collisionAvoidance={{ side: 'flip', align: 'shift', fallbackAxisSide: 'none' }}`.
 
+For a controlled popover anchored to something other than a `PopoverTrigger` (e.g. a search input that must keep its own focus and keyboard handling), pass `anchor` — an element ref or element — to `PopoverContent` and drop the trigger. Control open/close with `open`/`onOpenChange`, and use `initialFocus={false}` so opening doesn't pull focus off the anchor. `onOpenChange` receives `(open, details)`; filter `details.reason` (e.g. ignore `'outside-press'` when the press lands on the anchor) to stop clicks on the anchor from closing it.
+
 ### Tooltip
 
 ```tsx

--- a/packages/quill/packages/primitives/src/popover.tsx
+++ b/packages/quill/packages/primitives/src/popover.tsx
@@ -19,10 +19,14 @@ function PopoverContent({
     side = 'bottom',
     sideOffset = 4,
     collisionAvoidance,
+    anchor,
     container,
     ...props
 }: PopoverPrimitive.Popup.Props &
-    Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset' | 'collisionAvoidance'> &
+    Pick<
+        PopoverPrimitive.Positioner.Props,
+        'align' | 'alignOffset' | 'side' | 'sideOffset' | 'collisionAvoidance' | 'anchor'
+    > &
     Pick<PopoverPrimitive.Portal.Props, 'container'>): React.ReactElement {
     /*
      * `container` opt-in lets consumers mount the popover inside a
@@ -43,6 +47,7 @@ function PopoverContent({
                 side={side}
                 sideOffset={sideOffset}
                 collisionAvoidance={collisionAvoidance}
+                anchor={anchor}
                 className="isolate"
             >
                 <PopoverPrimitive.Popup

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -4,10 +4,10 @@ import { useDebouncedCallback } from 'use-debounce'
 
 import { LemonSegmentedButton } from '@posthog/lemon-ui'
 
-import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
-import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
+import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
 import { TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
+import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import { TaxonomicFilterGroupType, TaxonomicFilterLogicProps } from 'lib/components/TaxonomicFilter/types'
 import { taxonomicMenuPreferenceLogic } from 'lib/components/TaxonomicPopover/taxonomicMenuPreferenceLogic'

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -1,8 +1,9 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
-import { LemonDropdown, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { LemonSegmentedButton } from '@posthog/lemon-ui'
+import { Popover, PopoverContent } from '@posthog/quill'
 
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
 import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
@@ -57,7 +58,8 @@ const UniversalSearch = ({
     const { addGroupFilter } = useActions(universalFiltersLogic)
 
     const searchInputRef = useRef<HTMLInputElement | null>(null)
-    const floatingRef = useRef<HTMLDivElement | null>(null)
+    const anchorRef = useRef<HTMLDivElement | null>(null)
+    const popupRef = useRef<HTMLDivElement | null>(null)
 
     const onClose = (): void => {
         searchInputRef.current?.blur()
@@ -81,25 +83,59 @@ const UniversalSearch = ({
 
     const onChange = useDebouncedCallback((value: string) => setSearchQuery(value), 250)
 
+    // Manual outside-click handling. base-ui Popover's automatic outside-press
+    // dismiss is unreliable when the anchor isn't a real PopoverTrigger, so we
+    // cancel its firings (except Escape) in onOpenChange and close here instead.
+    // The content is portaled, so we walk the click target's ancestors looking
+    // for the popover content — and any nested quill portal (Select, menus) — to
+    // decide whether the click landed inside.
+    useEffect(() => {
+        if (!visible) {
+            return undefined
+        }
+        const handler = (event: PointerEvent): void => {
+            const target = event.target as Element | null
+            if (!target) {
+                return
+            }
+            if (
+                target.closest?.('[data-slot="popover-content"]') ||
+                target.closest?.('[data-quill-portal]') ||
+                anchorRef.current?.contains(target)
+            ) {
+                return
+            }
+            onClose()
+        }
+        // Defer one task so we don't catch the same click that just opened us.
+        const timer = window.setTimeout(() => document.addEventListener('pointerdown', handler, true), 0)
+        return () => {
+            window.clearTimeout(timer)
+            document.removeEventListener('pointerdown', handler, true)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [visible])
+
     return (
         <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>
             <div className="flex w-full min-w-0 items-center gap-1">
                 <FilterOperatorToggle />
-                <div className="min-w-0 flex-1">
-                    <LemonDropdown
-                        overlay={
-                            <div className="w-[400px] md:w-[600px]">
-                                <InfiniteSelectResults
-                                    focusInput={() => searchInputRef.current?.focus()}
-                                    taxonomicFilterLogicProps={taxonomicFilterLogicProps}
-                                    popupAnchorElement={floatingRef.current}
-                                />
-                            </div>
-                        }
-                        visible={visible}
-                        closeOnClickInside={false}
-                        floatingRef={floatingRef}
-                        onClickOutside={() => onClose()}
+                <div ref={anchorRef} className="min-w-0 flex-1">
+                    <Popover
+                        open={visible}
+                        onOpenChange={(open, details) => {
+                            if (open) {
+                                setVisible(true)
+                                return
+                            }
+                            // Escape closes; other dismiss reasons are handled by the
+                            // pointerdown listener above, so cancel base-ui's own dismiss.
+                            if (details?.reason === 'escape-key') {
+                                onClose()
+                                return
+                            }
+                            details?.cancel()
+                        }}
                     >
                         <TaxonomicFilterSearchInput
                             prefix={<UniversalFilterGroup taxonomicGroupTypes={taxonomicGroupTypes} />}
@@ -112,7 +148,22 @@ const UniversalSearch = ({
                             fullWidth
                             placeholder="Add a filter or search..."
                         />
-                    </LemonDropdown>
+                        <PopoverContent
+                            anchor={anchorRef}
+                            align="start"
+                            initialFocus={false}
+                            finalFocus={false}
+                            className="w-auto p-0"
+                        >
+                            <div ref={popupRef} className="w-[400px] md:w-[600px]">
+                                <InfiniteSelectResults
+                                    focusInput={() => searchInputRef.current?.focus()}
+                                    taxonomicFilterLogicProps={taxonomicFilterLogicProps}
+                                    popupAnchorElement={popupRef.current}
+                                />
+                            </div>
+                        </PopoverContent>
+                    </Popover>
                 </div>
             </div>
         </BindLogic>

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { LemonSegmentedButton } from '@posthog/lemon-ui'
-import { Popover, PopoverContent } from '@posthog/quill'
+import { Popover, PopoverContent } from 'lib/ui/quill'
 
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
 import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -3,16 +3,21 @@ import { useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { LemonSegmentedButton } from '@posthog/lemon-ui'
-import { Popover, PopoverContent } from 'lib/ui/quill'
 
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
 import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
+import { TaxonomicFilterHeadless } from 'lib/components/TaxonomicFilter/headless'
+import { TaxonomicFilterMenu } from 'lib/components/TaxonomicFilter/menu'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import { TaxonomicFilterGroupType, TaxonomicFilterLogicProps } from 'lib/components/TaxonomicFilter/types'
+import { taxonomicMenuPreferenceLogic } from 'lib/components/TaxonomicPopover/taxonomicMenuPreferenceLogic'
 import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { Popover, PopoverContent } from 'lib/ui/quill'
 
 import { FilterLogicalOperator, PropertyFilterType, UniversalFiltersGroup, UniversalFiltersGroupValue } from '~/types'
 
@@ -56,6 +61,9 @@ const UniversalSearch = ({
     const { searchQuery } = useValues(issueFiltersLogic)
     const { setSearchQuery } = useActions(issueFiltersLogic)
     const { addGroupFilter } = useActions(universalFiltersLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { useNewMenu } = useValues(taxonomicMenuPreferenceLogic)
+    const useQuillTaxonomicFilter = !!featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_MENU_REBUILD] && useNewMenu
 
     const searchInputRef = useRef<HTMLInputElement | null>(null)
     const anchorRef = useRef<HTMLDivElement | null>(null)
@@ -115,6 +123,41 @@ const UniversalSearch = ({
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [visible])
+
+    // Behind the taxonomic-filter-menu-rebuild flag (and the per-user new-menu
+    // preference), the search input + results list are the quill TaxonomicFilterMenu
+    // instead of the legacy TaxonomicFilterSearchInput + InfiniteSelectResults. It's a
+    // single-value picker, so each pick commits one filter via addGroupFilter and the
+    // selected-filter chips render beside the input rather than inside it.
+    if (useQuillTaxonomicFilter) {
+        return (
+            <div className="flex w-full min-w-0 flex-wrap items-center gap-1">
+                <FilterOperatorToggle />
+                <UniversalFilterGroup taxonomicGroupTypes={taxonomicGroupTypes} />
+                <div className="min-w-0 flex-1">
+                    <TaxonomicFilterHeadless.Root
+                        className="contents"
+                        bindRootProps={false}
+                        taxonomicGroupTypes={taxonomicGroupTypes}
+                        excludedProperties={{ [TaxonomicFilterGroupType.ErrorTrackingIssues]: ['assignee'] }}
+                        initialSearchQuery={searchQuery}
+                        onSearchQueryChange={onChange}
+                        autoSelectItem={false}
+                        onChange={(group, value, item) => {
+                            setSearchQuery('')
+                            addGroupFilter(group, value, item)
+                        }}
+                    >
+                        <TaxonomicFilterMenu
+                            triggerVariant="input"
+                            fullWidthTrigger
+                            placeholder="Add a filter or search..."
+                        />
+                    </TaxonomicFilterHeadless.Root>
+                </div>
+            </div>
+        )
+    }
 
     return (
         <BindLogic logic={taxonomicFilterLogic} props={taxonomicFilterLogicProps}>


### PR DESCRIPTION
## Problem

The error tracking issues search/filter bar (`FilterGroup`) rendered its suggestions dropdown with the legacy `LemonDropdown`, and the taxonomic search itself used the legacy `TaxonomicFilterSearchInput` + `InfiniteSelectResults`. We're moving menus, comboboxes, and anchored panels over to the quill design system, so this bar should follow.

## Changes

Two steps, both scoped to error tracking's filter bar plus one small additive quill primitive change.

- **Dropdown → quill Popover.** Swapped the `LemonDropdown` for a controlled, triggerless quill `Popover` anchored to the search input, so the input keeps its own focus and keyboard handling. Outside-click uses a manual `pointerdown` listener (Base UI's auto-dismiss is unreliable without a real trigger), mirroring the existing quill taxonomic-filter menu.
- **Taxonomic search → quill, behind the flag.** When `taxonomic-filter-menu-rebuild` and the per-user new-menu preference are on, the search + results now render the quill `TaxonomicFilterMenu` (input variant) wired through `TaxonomicFilterHeadless.Root`, committing each pick via `addGroupFilter`. The flag is still actively used elsewhere, so this gates cleanly; the legacy Lemon path stays as the fallback when it's off.
- **quill `PopoverContent` gains an `anchor` prop** so it can anchor to an element that isn't a `PopoverTrigger`. Documented in the primitives `AGENTS.md`.

> [!NOTE]
> The quill taxonomic filter is a single-value picker, so behind the flag the dropdown closes after each added filter and the selected-filter chips sit beside the input rather than inside it. The And/Any operator toggle, chip row, and value editing stay on the existing universal-filters components (no quill equivalent yet).

## How did you test this code?

CI (typecheck, formatting, bundle size, jest) is green. I (Claude) couldn't run the frontend build/typecheck locally in this environment, so I relied on CI to validate; I have not exercised the flagged path in a browser. Worth a manual pass with `taxonomic-filter-menu-rebuild` on: open the filter bar, search, add a filter, confirm it appears as a chip and the bar keeps working; and with the flag off, confirm the Lemon path is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 4.8) via PostHog Code. I read the quill primitives `AGENTS.md`/`CLAUDE.md` before touching the design system.

The taxonomic-search migration was scoped down deliberately: the quill rebuild (`TaxonomicFilterMenu` / `TaxonomicAutocomplete`) only covers single-value property selection — there's no quill equivalent for the chip row, operator toggle, or value editing — so those stay on the universal-filters components, and the picker is adapted to multi-add by committing each selection via `addGroupFilter`. Because the rebuild is still gated in production, error tracking adopts it behind the same flag + per-user preference (matching `ActionFilterRow`) rather than unconditionally. A couple of CI-only issues surfaced along the way and were fixed: `@posthog/quill` isn't resolvable from `products/` (imported via the `lib/ui/quill` barrel instead), and oxfmt sorts imports case-insensitively.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
