### PR TITLE
fix(aio): guard trace LLM judge activity against stale DB connections

### DIFF
--- a/posthog/temporal/ai_observability/run_trace_evaluation.py
+++ b/posthog/temporal/ai_observability/run_trace_evaluation.py
@@ -62,6 +62,7 @@ from posthog.temporal.ai_observability.run_evaluation import (
     increment_trial_usage_and_notify,
 )
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.utils import close_db_connections
 
 from products.ai_observability.backend.models.evaluation_configs import (
     TRACE_EVAL_DEFAULT_WINDOW_SECONDS,
@@ -286,6 +287,7 @@ def build_trace_hog_globals(trace: LLMTrace, trace_id: str) -> dict[str, Any]:
 
 
 @temporalio.activity.defn
+@close_db_connections
 @posthoganalytics.scoped()
 def execute_trace_llm_judge_activity(inputs: ExecuteTraceEvaluationInputs) -> EvaluationActivityResult:
     """Fetch the whole trace and run the LLM judge over its transcript.


### PR DESCRIPTION
## Problem

The trace-level LLM judge activity (`execute_trace_llm_judge_activity`) queries Postgres — a `Team` lookup in `fetch_trace_for_evaluation`, plus `EvaluationConfig`/`LLMProviderKey` reads and a `last_used_at` write during model resolution — but it's the one activity in this module using neither `@close_db_connections` nor `database_sync_to_async`. Long-running Temporal workers don't go through Django's request cycle, so a pooled connection that was recycled or killed stays in the pool until the next query fails with `OperationalError`/`InterfaceError`. When that happens the activity fails and Temporal retries it.

Its single-event sibling `execute_llm_judge_activity` already guards against exactly this with `@close_db_connections`.

## Changes

Add the `@close_db_connections` decorator to `execute_trace_llm_judge_activity`, stacked below `@activity.defn` and above `@posthoganalytics.scoped()`, mirroring the sibling. The decorator evicts stale Django connections before and after the activity runs (and is a no-op under `settings.TEST`).

Note on cost: all DB access in this activity happens *before* the paid LLM completion, and there's no DB write after it — so a stale-connection failure can only occur before any tokens are spent. This change avoids a needless retry cycle on a transient connection blip; it doesn't change token behavior.

## How did you test this code?

No automated tests added. `@close_db_connections` is a no-op under `settings.TEST` (it must not tear down the connection that `transaction=True` fixtures rely on), so a unit test asserting connection eviction wouldn't exercise the real path, and asserting the decorator's mere presence would test an implementation detail. The change is a one-line decorator addition that matches an established, already-tested sibling pattern.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread triaging a P3 inbox item about the trace LLM judge crashing on dropped Postgres connections. I (the PostHog Slack app, via Claude) traced the activity and its sibling `execute_llm_judge_activity`, confirmed the trace activity is the lone one in `evaluation_llm_judge.py`/`run_trace_evaluation.py` missing any stale-connection handling, and verified all DB access precedes the LLM call so the token-waste concern doesn't apply. Chose the `@close_db_connections` decorator over `database_sync_to_async` because the activity is synchronous and the decorator is the direct match to the sibling.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1784151759093429?thread_ts=1784151759.093429&cid=C0B8ZE81ZT7)*
