### PR TITLE
feat(tracing): report usage events and harden operation detail scene

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2901,6 +2901,8 @@ const api = {
                 // false (default) groups by trace_id and returns root spans; true returns every
                 // matching span (root and child) flat. See products/tracing/backend logic.py.
                 flatSpans?: boolean
+                // true omits the per-span attribute maps — use when only scalar span fields are read.
+                excludeAttributes?: boolean
             },
             signal?: AbortSignal
         ): Promise<{
@@ -2918,12 +2920,14 @@ const api = {
                 statusCodes?: number[]
                 filterGroup?: PropertyGroupFilter
                 offset?: number
-            }
+            },
+            signal?: AbortSignal
         ): Promise<{ results: Record<string, any>[]; hasMore: boolean; nextOffset?: number | null }> {
             return new ApiRequest()
                 .tracingSpans()
                 .withAction(`trace/${traceId}`)
                 .create({
+                    signal,
                     data: {
                         ...query,
                         dateRange: query?.dateRange ?? { date_from: '-24h' },

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1258,8 +1258,19 @@ export const productUrls = {
     slackTaskContext: (): string => '/slack-task-context',
     toolbarLaunch: (): string => '/toolbar',
     tracing: (): string => '/tracing',
-    tracingOperation: (serviceName: string, spanName: string): string =>
-        combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
+    tracingOperation: (
+        serviceName: string,
+        spanName: string,
+        dateRange?: {
+            date_from?: string | null
+            date_to?: string | null
+        }
+    ): string =>
+        combineUrl('/tracing/operation', {
+            service: serviceName,
+            name: spanName,
+            ...(dateRange ? { dateRange: JSON.stringify(dateRange) } : {}),
+        }).url,
     userInterviews: (): string => '/user_research',
     userInterview: (id: string): string => `/user_research/${id}`,
     userInterviewResponse: (topicId: string, responseId: string): string =>

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -211,10 +211,6 @@ class _TracingTimeseriesQueryBodySerializer(serializers.Serializer):
     )
 
 
-class _TracingTimeseriesRequestSerializer(serializers.Serializer):
-    query = _TracingTimeseriesQueryBodySerializer(help_text="The sparkline / duration-histogram query to execute.")
-
-
 class _TracingDurationHistogramQueryBodySerializer(_TracingTimeseriesQueryBodySerializer):
     rootSpans = serializers.BooleanField(
         required=False,
@@ -944,13 +940,28 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         except (ValidationError, ValueError, ParseError):
             filter_group = None
 
+        root_spans = query_data.get("rootSpans", True)
         response = run_duration_histogram_query(
             team=self.team,
             date_range=date_range,
             service_names=query_data.get("serviceNames", None),
             status_codes=query_data.get("statusCodes", None),
             filter_group=filter_group,
-            root_spans=query_data.get("rootSpans", True),
+            root_spans=root_spans,
+        )
+
+        report_user_action(
+            request.user,
+            "tracing duration histogram queried",
+            {
+                "buckets_count": len(response.results),
+                "root_spans": root_spans,
+                "has_filter_group": bool(query_data.get("filterGroup")),
+                "service_names_count": len(query_data.get("serviceNames") or []),
+                "status_codes_count": len(query_data.get("statusCodes") or []),
+            },
+            team=self.team,
+            request=request,
         )
 
         return Response({"results": response.results}, status=status.HTTP_200_OK)
@@ -985,6 +996,19 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             compare_filter=compare_filter,
             filter_group=filter_group,
             service_names=query_data.get("serviceNames", None),
+        )
+
+        report_user_action(
+            request.user,
+            "tracing aggregation queried",
+            {
+                "results_count": len(response.results),
+                "has_compare": bool(query_data.get("compareFilter")),
+                "has_filter_group": bool(query_data.get("filterGroup")),
+                "service_names_count": len(query_data.get("serviceNames") or []),
+            },
+            team=self.team,
+            request=request,
         )
 
         return Response(
@@ -1187,6 +1211,19 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         # Self-time needs a span's children present. On a paged (truncated) trace it overstates for
         # spans whose children fall on a later page — an accepted bound, same as the prior 2000 cap.
         annotate_self_time(results)
+
+        report_user_action(
+            request.user,
+            "tracing trace fetched",
+            {
+                "spans_count": len(results),
+                "has_more": has_more,
+                "is_paginated": offset > 0,
+                "has_filter_group": bool(query_data.get("filterGroup")),
+            },
+            team=self.team,
+            request=request,
+        )
 
         return Response(
             {

--- a/products/tracing/frontend/OperationHistogram.tsx
+++ b/products/tracing/frontend/OperationHistogram.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 
-import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
+import { Sparkline } from 'lib/components/Sparkline'
 
 import {
     formatBucketLabel,
@@ -11,6 +11,7 @@ import {
     type TracingDurationHistogramData,
 } from './durationBuckets'
 import type { DurationRange } from './operationFilters'
+import { categoryDurationXScale } from './TracingSparkline'
 
 interface OperationHistogramProps {
     data: TracingDurationHistogramData
@@ -18,24 +19,8 @@ interface OperationHistogramProps {
     selection: DurationRange | null
     onSelect: (selection: DurationRange) => void
     onClear: () => void
-}
-
-// Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is already
-// log-spaced, so a plain category axis renders it evenly (mirrors TracingSparkline).
-function withCategoryXScale(scale: AnyScaleOptions): AnyScaleOptions {
-    return {
-        ...scale,
-        type: 'category',
-        ticks: {
-            display: true,
-            maxRotation: 0,
-            maxTicksLimit: 8,
-            font: {
-                size: 10,
-                lineHeight: 1,
-            },
-        },
-    } as AnyScaleOptions
+    /** Clearing the selection refetches samples — disable the button while that's in flight. */
+    samplesLoading?: boolean
 }
 
 export function OperationHistogram({
@@ -44,6 +29,7 @@ export function OperationHistogram({
     selection,
     onSelect,
     onClear,
+    samplesLoading = false,
 }: OperationHistogramProps): JSX.Element {
     const onSelectionChange = useCallback(
         ({ startIndex, endIndex }: { startIndex: number; endIndex: number }): void => {
@@ -65,8 +51,12 @@ export function OperationHistogram({
         const startIndexRaw = bucketsNs.indexOf(snapDurationToBucket(selection.minNs))
         // maxNs is the exclusive upper edge — the highlight ends at the bar before it.
         const endIndexRaw = bucketsNs.indexOf(snapDurationToBucket(selection.maxNs))
-        const startIndex = startIndexRaw === -1 ? 0 : startIndexRaw
-        const endIndex = endIndexRaw === -1 ? bucketsNs.length : endIndexRaw
+        // An off-axis edge clamps toward its near end; a selection entirely off the axis
+        // (e.g. persisted before a date change reshaped the distribution) collapses to
+        // start >= end and renders no highlight.
+        const startIndex = startIndexRaw !== -1 ? startIndexRaw : selection.minNs <= bucketsNs[0] ? 0 : bucketsNs.length
+        const endIndex =
+            endIndexRaw !== -1 ? endIndexRaw : selection.maxNs > bucketsNs[bucketsNs.length - 1] ? bucketsNs.length : 0
         if (startIndex >= endIndex) {
             return null
         }
@@ -82,7 +72,12 @@ export function OperationHistogram({
                         <span className="text-xs font-mono">
                             {formatBucketLabel(selection.minNs)} – {formatBucketLabel(selection.maxNs)}
                         </span>
-                        <LemonButton size="xsmall" type="tertiary" onClick={onClear}>
+                        <LemonButton
+                            size="xsmall"
+                            type="tertiary"
+                            onClick={onClear}
+                            disabledReason={samplesLoading ? 'Loading samples…' : undefined}
+                        >
                             Clear
                         </LemonButton>
                     </>
@@ -97,7 +92,7 @@ export function OperationHistogram({
                         data={data.data}
                         className="w-full h-full"
                         onSelectionChange={onSelectionChange}
-                        withXScale={withCategoryXScale}
+                        withXScale={categoryDurationXScale}
                         renderLabel={(label) => label}
                         tooltipRowCutoff={100}
                         hideZerosInTooltip

--- a/products/tracing/frontend/OperationsTable.tsx
+++ b/products/tracing/frontend/OperationsTable.tsx
@@ -24,8 +24,13 @@ function formatRate(count: number, windowMs: number): string {
     return `${humanFriendlyNumber(perSec * 3600, 1)}/hr`
 }
 
-function errorRate(row: AggregatedSpanRow): number {
+export function errorRate(row: AggregatedSpanRow): number {
     return row.count > 0 ? row.error_count / row.count : 0
+}
+
+// Sub-1% rates get an extra decimal so small-but-nonzero rates don't render as 0.0%.
+export function formatErrorRate(rate: number): string {
+    return `${(rate * 100).toFixed(rate > 0 && rate < 0.01 ? 2 : 1)}%`
 }
 
 const durationCell =
@@ -68,11 +73,7 @@ function buildColumns(windowMs: number): VirtualizedTableColumn<AggregatedSpanRo
             sorter: (a, b) => errorRate(a) - errorRate(b),
             render: (row) => {
                 const rate = errorRate(row)
-                return (
-                    <span className={rate > 0 ? 'text-danger' : 'text-muted'}>
-                        {`${(rate * 100).toFixed(rate > 0 && rate < 0.01 ? 2 : 1)}%`}
-                    </span>
-                )
+                return <span className={rate > 0 ? 'text-danger' : 'text-muted'}>{formatErrorRate(rate)}</span>
             },
         },
         {

--- a/products/tracing/frontend/TracingOperationScene.tsx
+++ b/products/tracing/frontend/TracingOperationScene.tsx
@@ -15,6 +15,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { OperationHistogram } from './OperationHistogram'
+import { errorRate, formatErrorRate } from './OperationsTable'
 import { formatDuration, TraceWaterfallView } from './TraceWaterfallView'
 import { tracingOperationSceneLogic, type TracingOperationSceneLogicProps } from './tracingOperationSceneLogic'
 
@@ -57,18 +58,16 @@ export function TracingOperationScene(): JSX.Element {
     } = useValues(tracingOperationSceneLogic)
     const { setDateRange, setDurationSelection, setSampleIndex, selectSpan } = useActions(tracingOperationSceneLogic)
 
-    if (!spanName) {
+    if (!spanName || !serviceName) {
         return (
             <SceneContent>
                 <div className="flex flex-col items-center gap-1 py-16">
-                    <span>This link is missing an operation name.</span>
+                    <span>This link is missing an operation or service name.</span>
                     <Link to={urls.tracing()}>Back to tracing</Link>
                 </div>
             </SceneContent>
         )
     }
-
-    const errorRate = operationStats && operationStats.count > 0 ? operationStats.error_count / operationStats.count : 0
 
     return (
         <SceneContent>
@@ -94,10 +93,7 @@ export function TracingOperationScene(): JSX.Element {
             {operationStats && (
                 <div className="flex gap-8">
                     <StatBlock label="Requests" value={humanFriendlyNumber(operationStats.count)} />
-                    <StatBlock
-                        label="Error rate"
-                        value={`${(errorRate * 100).toFixed(errorRate > 0 && errorRate < 0.01 ? 2 : 1)}%`}
-                    />
+                    <StatBlock label="Error rate" value={formatErrorRate(errorRate(operationStats))} />
                     <StatBlock label="p50" value={formatDuration(operationStats.p50_duration_nano)} />
                     <StatBlock label="p95" value={formatDuration(operationStats.p95_duration_nano)} />
                     <StatBlock label="p99" value={formatDuration(operationStats.p99_duration_nano)} />
@@ -109,6 +105,7 @@ export function TracingOperationScene(): JSX.Element {
                 selection={durationSelection}
                 onSelect={setDurationSelection}
                 onClear={() => setDurationSelection(null)}
+                samplesLoading={samplesLoading}
             />
             <SceneDivider />
             {samples.length === 0 && samplesLoading ? (
@@ -128,7 +125,7 @@ export function TracingOperationScene(): JSX.Element {
                             }
                         />
                         <span className="text-sm whitespace-nowrap">
-                            {samples.length > 0 ? sampleIndex + 1 : 0} of {samples.length}
+                            {sampleIndex + 1} of {samples.length}
                             {samplesHaveMore ? '+' : ''}
                         </span>
                         <LemonButton

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -215,7 +215,9 @@ function TracingSceneContents(): JSX.Element {
                                 loading={aggregationLoading}
                                 windowMs={operationsWindowMs}
                                 onRowClick={(row) =>
-                                    router.actions.push(urls.tracingOperation(row.service_name, row.name))
+                                    router.actions.push(
+                                        urls.tracingOperation(row.service_name, row.name, filters.dateRange)
+                                    )
                                 }
                             />
                         ) : compareActive ? (

--- a/products/tracing/frontend/TracingSparkline.tsx
+++ b/products/tracing/frontend/TracingSparkline.tsx
@@ -14,6 +14,25 @@ import { type TracingDurationHistogramData, type VisibleDurationRange, snapDurat
 import { SparklineCompareOverlay } from './SparklineCompareOverlay'
 import type { TracingSparklineData, VisibleSpanTimeRange } from './tracingDataLogic'
 
+// Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is already
+// log-spaced, so a plain category axis renders it evenly. Shared with OperationHistogram
+// so the two duration histograms render identically.
+export function categoryDurationXScale(scale: AnyScaleOptions): AnyScaleOptions {
+    return {
+        ...scale,
+        type: 'category',
+        ticks: {
+            display: true,
+            maxRotation: 0,
+            maxTicksLimit: 8,
+            font: {
+                size: 10,
+                lineHeight: 1,
+            },
+        },
+    } as AnyScaleOptions
+}
+
 interface CompareConfig {
     fullStartMs: number
     fullEndMs: number
@@ -68,21 +87,7 @@ export function TracingSparkline({
     const withXScale = useCallback(
         (scale: AnyScaleOptions): AnyScaleOptions => {
             if (durationMode) {
-                // Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is
-                // already log-spaced, so a plain category axis renders it evenly.
-                return {
-                    ...scale,
-                    type: 'category',
-                    ticks: {
-                        display: true,
-                        maxRotation: 0,
-                        maxTicksLimit: 8,
-                        font: {
-                            size: 10,
-                            lineHeight: 1,
-                        },
-                    },
-                } as AnyScaleOptions
+                return categoryDurationXScale(scale)
             }
             return {
                 ...scale,

--- a/products/tracing/frontend/durationBuckets.ts
+++ b/products/tracing/frontend/durationBuckets.ts
@@ -1,4 +1,4 @@
-// Pure helpers for the duration-histogram sparkline (JON-36). The list sorted by duration pairs
+// Pure helpers for the duration-histogram sparkline. The list sorted by duration pairs
 // with a histogram of trace counts per logarithmic duration bucket; everything here is pure so it
 // can be unit-tested without the kea logic's import graph.
 
@@ -15,10 +15,13 @@ export interface TracingDurationHistogramData {
     labels: string[]
 }
 
-export interface VisibleDurationRange {
+/** A `[minNs, maxNs)` duration range in nanoseconds — the shared currency of selection and filtering. */
+export interface DurationRange {
     minNs: number
     maxNs: number
 }
+
+export type VisibleDurationRange = DurationRange
 
 const BUCKET_MANTISSAS = [1, 2, 5]
 
@@ -114,9 +117,7 @@ export function pivotDurationHistogram(
 
 /** Exclusive upper edge of a 1-2-5 bucket — the next bucket on the series (1→2, 2→5, 5→10). */
 export function bucketUpperBound(bucketNs: number): number {
-    const decade = Math.pow(10, Math.floor(Math.log10(Math.max(bucketNs, 1))))
-    const mantissa = bucketNs / decade
-    return Math.round(mantissa < 2 ? 2 * decade : mantissa < 5 ? 5 * decade : 10 * decade)
+    return fillBucketSeries(bucketNs, bucketNs * 10)[1]
 }
 
 /**
@@ -128,7 +129,7 @@ export function selectionToDurationRange(
     bucketsNs: number[],
     startIndex: number,
     endIndex: number
-): { minNs: number; maxNs: number } | null {
+): DurationRange | null {
     if (bucketsNs.length === 0) {
         return null
     }

--- a/products/tracing/frontend/operationFilters.ts
+++ b/products/tracing/frontend/operationFilters.ts
@@ -6,10 +6,9 @@ import {
     SpanPropertyFilter,
 } from '~/types'
 
-export interface DurationRange {
-    minNs: number
-    maxNs: number
-}
+import type { DurationRange } from './durationBuckets'
+
+export type { DurationRange } from './durationBuckets'
 
 const NS_PER_MS = 1_000_000
 

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -53,9 +53,9 @@ export interface VisibleSpanTimeRange {
 
 const DEFAULT_PAGE_SIZE = 100
 export const PREFETCH_SPANS = 20
-const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
+export const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 
-function isUserInitiatedError(error: unknown): boolean {
+export function isUserInitiatedError(error: unknown): boolean {
     const errorStr = String(error).toLowerCase()
     return error === NEW_QUERY_STARTED_ERROR_MESSAGE || errorStr.includes('abort')
 }
@@ -624,6 +624,9 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
                             serviceNames:
                                 values.filters.serviceNames.length > 0 ? values.filters.serviceNames : undefined,
                             filterGroup: values.queryFilterGroup as PropertyGroupFilter,
+                            // Match the population the list shows (and the sparkline counts):
+                            // root spans in Traces view, every matching span in Spans view.
+                            rootSpans: values.filters.viewMode === 'traces',
                         },
                         controller.signal
                     )

--- a/products/tracing/frontend/tracingOperationSceneLogic.test.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.test.ts
@@ -80,7 +80,8 @@ describe('tracingOperationSceneLogic', () => {
                         },
                     ],
                 },
-            })
+            }),
+            expect.anything()
         )
     })
 
@@ -91,7 +92,7 @@ describe('tracingOperationSceneLogic', () => {
         expect(logic.values.sampleTraceSpansLoading).toBe(true)
 
         await logic.asyncActions.fetchSampleTrace({ sample: logic.values.currentSample! })
-        expect(getTraceSpy).toHaveBeenLastCalledWith('trace-2', expect.anything())
+        expect(getTraceSpy).toHaveBeenLastCalledWith('trace-2', expect.anything(), expect.anything())
         expect(logic.values.selectedSpanId).toBe('span-2')
     })
 

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -6,12 +6,14 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { dataColorVars } from 'lib/colors'
+import { objectsEqual } from 'lib/utils/objects'
 
 import { AggregatedSpanRow, DateRange } from '~/queries/schema/schema-general'
 
 import { type DurationHistogramRow, pivotDurationHistogram, type TracingDurationHistogramData } from './durationBuckets'
 import { type DurationRange, operationFilterGroup } from './operationFilters'
 import { traceLookupDateRange } from './traceLinks'
+import { isUserInitiatedError, NEW_QUERY_STARTED_ERROR_MESSAGE } from './tracingDataLogic'
 import { DEFAULT_DATE_RANGE } from './tracingFiltersLogic'
 import type { tracingOperationSceneLogicType } from './tracingOperationSceneLogicType'
 import type { Span } from './types'
@@ -22,6 +24,22 @@ export interface TracingOperationSceneLogicProps {
 }
 
 const SAMPLE_LIMIT = 100
+
+// One tracked AbortController per loader: re-issuing a fetch aborts the superseded request
+// (not just discards its result), and unmount aborts whatever is still in flight.
+function trackedSignal(cache: Record<string, any>, key: string): AbortSignal {
+    let controller!: AbortController
+    cache.disposables.add(
+        () => {
+            controller = new AbortController()
+            return () => controller.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+        },
+        key,
+        // In-flight requests must survive tab switches — only supersession or unmount aborts.
+        { pauseOnPageHidden: false }
+    )
+    return controller.signal
+}
 
 export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
     props({} as TracingOperationSceneLogicProps),
@@ -34,22 +52,26 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
         setSampleIndex: (index: number) => ({ index }),
         selectSpan: (spanId: string | null) => ({ spanId }),
         setSamplesHaveMore: (hasMore: boolean) => ({ hasMore }),
+        loadCurrentSampleTrace: true,
     }),
 
-    loaders(({ props, values, actions }) => ({
+    loaders(({ props, values, actions, cache }) => ({
         rawHistogram: [
             [] as DurationHistogramRow[],
             {
                 fetchHistogram: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.durationHistogram({
-                        dateRange: values.dateRange,
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, null),
-                        // Span-level: operations are often child spans, and the samples query
-                        // below is span-level too — both must count the same population.
-                        rootSpans: false,
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.durationHistogram(
+                        {
+                            dateRange: values.dateRange,
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, null),
+                            // Span-level: operations are often child spans, and the samples query
+                            // below is span-level too — both must count the same population.
+                            rootSpans: false,
+                        },
+                        trackedSignal(cache, 'fetchHistogram')
+                    )
                     breakpoint()
                     return response.results
                 },
@@ -59,16 +81,22 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             [] as Span[],
             {
                 fetchSamples: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.listSpans({
-                        dateRange: values.dateRange,
-                        orderBy: 'timestamp',
-                        orderDirection: 'DESC',
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, values.durationSelection),
-                        flatSpans: true,
-                        limit: SAMPLE_LIMIT,
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.listSpans(
+                        {
+                            dateRange: values.dateRange,
+                            orderBy: 'timestamp',
+                            orderDirection: 'DESC',
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, values.durationSelection),
+                            flatSpans: true,
+                            limit: SAMPLE_LIMIT,
+                            // Samples only feed the pager header (5 scalar fields); the waterfall
+                            // loads the full trace separately, so skip the heavy attribute maps.
+                            excludeAttributes: true,
+                        },
+                        trackedSignal(cache, 'fetchSamples')
+                    )
                     breakpoint()
                     actions.setSamplesHaveMore(!!response.hasMore)
                     return response.results as Span[]
@@ -79,12 +107,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             null as AggregatedSpanRow | null,
             {
                 fetchStats: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.aggregate({
-                        dateRange: values.dateRange,
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, null),
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.aggregate(
+                        {
+                            dateRange: values.dateRange,
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, null),
+                        },
+                        trackedSignal(cache, 'fetchStats')
+                    )
                     breakpoint()
                     return response.results.find((row) => row.name === props.spanName) ?? null
                 },
@@ -94,10 +125,14 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             [] as Span[],
             {
                 fetchSampleTrace: async ({ sample }: { sample: Span }, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.getTrace(sample.trace_id, {
-                        dateRange: traceLookupDateRange(sample.timestamp),
-                    })
+                    await breakpoint(100) // debounce rapid pager clicks
+                    const response = await api.tracing.getTrace(
+                        sample.trace_id,
+                        {
+                            dateRange: traceLookupDateRange(sample.timestamp),
+                        },
+                        trackedSignal(cache, 'fetchSampleTrace')
+                    )
                     breakpoint()
                     return response.results as Span[]
                 },
@@ -144,6 +179,19 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             actions.fetchSamples()
             actions.fetchStats()
         },
+        loadCurrentSampleTrace: () => {
+            const sample = values.currentSample
+            if (!sample) {
+                return
+            }
+            // Adjacent samples often share a trace (a child operation hit N times per request) —
+            // re-anchor on the already-loaded trace instead of refetching it.
+            if (values.sampleTraceSpans[0]?.trace_id === sample.trace_id) {
+                actions.selectSpan(sample.span_id)
+                return
+            }
+            actions.fetchSampleTrace({ sample })
+        },
         fetchSamplesSuccess: ({ samples }) => {
             if (samples.length === 0) {
                 actions.selectSpan(null)
@@ -154,14 +202,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
                 actions.setSampleIndex(0)
                 return
             }
-            if (values.currentSample) {
-                actions.fetchSampleTrace({ sample: values.currentSample })
-            }
+            actions.loadCurrentSampleTrace()
         },
         setSampleIndex: () => {
-            if (values.currentSample) {
-                actions.fetchSampleTrace({ sample: values.currentSample })
+            // While samples are (re)loading, the index points into the outgoing result set;
+            // fetchSamplesSuccess (or fetchSamplesFailure) loads the trace for the resolved index.
+            if (values.samplesLoading) {
+                return
             }
+            actions.loadCurrentSampleTrace()
         },
         fetchSampleTraceSuccess: () => {
             // Anchor the waterfall on the operation's own span — for child operations the
@@ -169,23 +218,38 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             actions.selectSpan(values.currentSample?.span_id ?? null)
         },
         fetchHistogramFailure: ({ error }) => {
-            lemonToast.error(`Failed to load latency distribution: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load latency distribution: ${error}`)
+            }
         },
         fetchSamplesFailure: ({ error }) => {
+            if (isUserInitiatedError(error)) {
+                return
+            }
             lemonToast.error(`Failed to load sample traces: ${error}`)
+            // The failed refetch already blanked the waterfall (see the sampleTraceSpans reducer);
+            // reload the trace for the retained samples so the scene stays usable.
+            actions.loadCurrentSampleTrace()
         },
         fetchStatsFailure: ({ error }) => {
-            lemonToast.error(`Failed to load operation stats: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load operation stats: ${error}`)
+            }
         },
         fetchSampleTraceFailure: ({ error }) => {
-            lemonToast.error(`Failed to load trace: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load trace: ${error}`)
+            }
         },
     })),
 
     actionToUrl(({ values }) => {
         const withSelectionParams = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => {
-            const { min, max, sample, ...rest } = router.values.searchParams
+            const { min, max, sample, dateRange, ...rest } = router.values.searchParams
             const params: Record<string, any> = { ...rest }
+            if (!objectsEqual(values.dateRange, DEFAULT_DATE_RANGE)) {
+                params.dateRange = JSON.stringify(values.dateRange)
+            }
             if (values.durationSelection) {
                 params.min = values.durationSelection.minNs
                 params.max = values.durationSelection.maxNs
@@ -196,6 +260,7 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             return [router.values.location.pathname, params, router.values.hashParams, { replace: true }]
         }
         return {
+            setDateRange: withSelectionParams,
             setDurationSelection: withSelectionParams,
             setSampleIndex: withSelectionParams,
         }
@@ -206,10 +271,24 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             if (method === 'REPLACE') {
                 return // our own actionToUrl writes
             }
+            // Restore the date range first: setDateRange resets sampleIndex.
+            if (searchParams.dateRange) {
+                try {
+                    const dateRange =
+                        typeof searchParams.dateRange === 'string'
+                            ? JSON.parse(searchParams.dateRange)
+                            : searchParams.dateRange
+                    if (!objectsEqual(dateRange, values.dateRange)) {
+                        actions.setDateRange(dateRange)
+                    }
+                } catch {
+                    // Malformed param — keep the current range.
+                }
+            }
             const minNs = parseInt(String(searchParams.min), 10)
             const maxNs = parseInt(String(searchParams.max), 10)
             const selection = !isNaN(minNs) && !isNaN(maxNs) ? { minNs, maxNs } : null
-            if (JSON.stringify(selection) !== JSON.stringify(values.durationSelection)) {
+            if (!objectsEqual(selection, values.durationSelection)) {
                 actions.setDurationSelection(selection)
             }
             const sample = parseInt(String(searchParams.sample), 10)
@@ -219,13 +298,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
         },
     })),
 
-    afterMount(({ actions, values }) => {
+    afterMount(({ actions, props }) => {
+        // A malformed link renders the scene's missing-params fallback; don't query for it.
+        if (!props.spanName || !props.serviceName) {
+            return
+        }
+        // URL restore may have dispatched these already in this same tick — the loaders'
+        // leading breakpoint coalesces the duplicates into one request each.
         actions.fetchHistogram()
         actions.fetchStats()
-        // A deep link restores the selection via urlToAction, whose listener already fetches
-        // samples — only fetch directly when mounting without one.
-        if (!values.durationSelection) {
-            actions.fetchSamples()
-        }
+        actions.fetchSamples()
     }),
 ])

--- a/products/tracing/manifest.tsx
+++ b/products/tracing/manifest.tsx
@@ -37,8 +37,16 @@ export const manifest: ProductManifest = {
         tracing: (): string => '/tracing',
         // Query params rather than path segments: span names ("GET /api/stats") contain slashes
         // and arbitrary characters that break path routing.
-        tracingOperation: (serviceName: string, spanName: string): string =>
-            combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
+        tracingOperation: (
+            serviceName: string,
+            spanName: string,
+            dateRange?: { date_from?: string | null; date_to?: string | null }
+        ): string =>
+            combineUrl('/tracing/operation', {
+                service: serviceName,
+                name: spanName,
+                ...(dateRange ? { dateRange: JSON.stringify(dateRange) } : {}),
+            }).url,
     },
     fileSystemTypes: {},
     treeItemsNew: [],


### PR DESCRIPTION
## Problem

The operation detail scene shipped in #67757, but its backend endpoints (duration-histogram, aggregate, per-trace) fire no `report_user_action`, so we can't tell whether anyone uses the scene — or any of these endpoints — across web, API, and MCP callers. A review pass over the scene also surfaced a handful of state-sync bugs and duplicated helpers.

## Changes

Instrumentation: the duration-histogram, aggregate, and per-trace endpoints now fire `tracing duration histogram queried`, `tracing aggregation queried`, and `tracing trace fetched`, matching the existing `tracing query executed` pattern so usage segments by `access_method` (web, personal API key, MCP). The now-unreferenced timeseries request serializer is dropped.

Hardening from the review pass:

- The date range carries through the operation URL, so detail stats match the row clicked on the Operations tab, and deep links restore it.
- A persisted duration selection that falls entirely off a reshaped histogram axis renders no highlight (previously it highlighted the whole chart).
- Links missing the service param get the missing-params fallback instead of silently querying `serviceNames: ['']`.
- A failed samples refetch reloads the waterfall for the retained samples instead of leaving it permanently blank.
- Superseded requests are aborted server-side via per-loader `AbortController`s (matching `tracingDataLogic`), adjacent samples sharing a trace reuse the loaded waterfall, and the samples query passes `excludeAttributes` since the scene reads only scalar span fields.
- The trace-list duration histogram counts the population the active view shows: root spans in Traces view, every matching span in Spans view.
- Shared helpers replace copies: category duration axis config, error-rate formatting, and the duration-range type.

## How did you test this code?

Automated, run locally against current master:

- `products/tracing/backend/tests/test_duration_histogram.py` (3 tests) — endpoint bucketing incl. the `rootSpans=false` path.
- 56 frontend tests across `durationBuckets.test.ts`, `tracingOperationSceneLogic.test.ts`, and `tracingDataLogic.test.ts` — includes the drag-selection refetch/pager-reset and sample-paging waterfall-anchor regressions.
- `ruff` and `oxlint`/`oxfmt` clean on changed files.

I have not manually re-verified against the live app since rebasing onto current master; the earlier iteration of these changes was manually verified on a seeded local stack.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/using-kea-disposables`, plus simplify and multi-angle code-review passes whose confirmed findings are the hardening list above.

This PR replaces #71103, which was accidentally opened from a branch cut from a stale master and re-presented the whole (already merged) feature as new. This branch cherry-picks only the genuinely new work onto current master. Decisions worth knowing: instrumentation lives in the backend viewset rather than frontend `posthog.capture` so usage is visible across all access methods, and the histogram endpoint keeps `rootSpans=true` as its default so existing callers keep trace-level distributions. Deliberately skipped as out of scope: single-bucket drag selection (needs a shared `Sparkline` change), migrating the handwritten `api.tracing` client block to generated types, and deduplicating the repeated `report_user_action`/filter-group boilerplate in the tracing viewset.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*