### PR TITLE
chore(ci): add critical-path playwright specs for auth, keys, flags, ingestion

### DIFF
--- a/playwright/e2e/api-keys.spec.ts
+++ b/playwright/e2e/api-keys.spec.ts
@@ -1,0 +1,62 @@
+import { randomString } from '../utils'
+import { PlaywrightWorkspaceSetupResult, expect, test } from '../utils/workspace-test-base'
+
+test.describe('Personal API keys', () => {
+    let workspace: PlaywrightWorkspaceSetupResult | null = null
+
+    test.beforeAll(async ({ playwrightSetup }) => {
+        workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true, no_demo_data: true })
+    })
+
+    test.beforeEach(async ({ page, playwrightSetup }) => {
+        await playwrightSetup.login(page, workspace!)
+    })
+
+    test('key created in the UI authorizes the API and stops working after deletion', async ({ page, request }) => {
+        const label = randomString('e2e-key')
+        let apiKey = ''
+
+        await test.step('create a key with the all-access preset', async () => {
+            await page.goto('/settings/user-api-keys')
+            await page.getByRole('button', { name: 'Create personal API key' }).click()
+            await page.getByPlaceholder('For example "Reports bot" or "Zapier"').fill(label)
+            await page.getByRole('button', { name: 'All access', exact: true }).click()
+            await page.getByText('Select preset').click()
+            await page.locator('.Popover__content').getByText('All access').click()
+            await page.getByRole('button', { name: 'Create key' }).click()
+        })
+
+        await test.step('capture the one-time key value', async () => {
+            const dialog = page.locator('.LemonModal').filter({ hasText: 'Personal API key ready' })
+            await expect(dialog).toBeVisible()
+            const snippet = (await dialog.locator('code').textContent()) ?? ''
+            apiKey = snippet.match(/phx_\w+/)?.[0] ?? ''
+            expect(apiKey).toMatch(/^phx_/)
+            await page.keyboard.press('Escape')
+            await expect(dialog).not.toBeVisible()
+        })
+
+        await test.step('the key authorizes an API request', async () => {
+            const resp = await request.get('/api/users/@me/', {
+                headers: { Authorization: `Bearer ${apiKey}` },
+            })
+            expect(resp.status()).toBe(200)
+            expect((await resp.json()).email).toBe(workspace!.user_email)
+        })
+
+        await test.step('delete the key via the row menu', async () => {
+            const row = page.locator('tr', { hasText: label })
+            await row.locator('td').last().getByRole('button').click()
+            await page.getByRole('menuitem', { name: 'Delete' }).click()
+            await page.getByRole('button', { name: 'Permanently delete' }).click()
+            await expect(row).not.toBeVisible()
+        })
+
+        await test.step('the deleted key no longer authorizes', async () => {
+            const resp = await request.get('/api/users/@me/', {
+                headers: { Authorization: `Bearer ${apiKey}` },
+            })
+            expect(resp.status()).toBe(401)
+        })
+    })
+})

--- a/playwright/e2e/feature-flags.spec.ts
+++ b/playwright/e2e/feature-flags.spec.ts
@@ -1,0 +1,34 @@
+import { randomString } from '../utils'
+import { expect, test } from '../utils/workspace-test-base'
+
+// Flag evaluation (`/flags`) is served by the separate Rust flags service, which the
+// e2e environment does not wire up: the dev proxy resolves `feature-flags` to
+// host-gateway:3001 where nothing listens in CI, and the container reads the default
+// `posthog` database rather than the e2e one. Until that service is plumbed into the
+// e2e stack, this spec covers the browser-only creation path and stops at persistence.
+test.describe('Feature flags', () => {
+    test('a flag created in the UI is persisted and listed', async ({ page, playwrightSetup }) => {
+        const workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true, no_demo_data: true })
+        await playwrightSetup.login(page, workspace)
+        const flagKey = randomString('e2e-flag')
+
+        await test.step('create a 100% rollout flag via the UI', async () => {
+            await page.goto('/feature_flags')
+            await page.locator('[data-attr="new-feature-flag"]').click()
+            await page.locator('[data-attr="blank-feature-flag-template"]').click()
+            await page.locator('[data-attr="feature-flag-key"]').fill(flagKey)
+            await page.locator('[data-attr="rollout-percentage"]').fill('100')
+            const saveButton = page.locator('[data-attr="save-feature-flag"]').first()
+            await expect(saveButton).toBeEnabled()
+            await saveButton.click()
+            await page.waitForURL(/\/feature_flags\/\d+/)
+        })
+
+        await test.step('the flag appears enabled in the flags list', async () => {
+            await page.goto('/feature_flags')
+            const row = page.locator('table tbody tr').filter({ hasText: flagKey })
+            await expect(row).toBeVisible()
+            await expect(row).toContainText('100%')
+        })
+    })
+})

--- a/playwright/e2e/ingestion-capture.spec.ts
+++ b/playwright/e2e/ingestion-capture.spec.ts
@@ -1,0 +1,62 @@
+import { randomString } from '../utils'
+import { expect, test } from '../utils/workspace-test-base'
+
+// Capture and flags are served by separate Rust services fronted by the Caddy dev proxy,
+// not by the Django server Playwright's baseURL points at.
+const PROXY_BASE_URL = process.env.E2E_PROXY_URL || 'http://localhost:8010'
+
+test.describe('Event ingestion', () => {
+    test('an event sent to the real capture endpoint becomes queryable', async ({ request, playwrightSetup }) => {
+        test.setTimeout(120_000)
+        const workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true, no_demo_data: true })
+        const eventName = randomString('e2e_ingestion_')
+        const authHeaders = { Authorization: `Bearer ${workspace.personal_api_key}` }
+        let apiToken = ''
+
+        await test.step('fetch the team api token', async () => {
+            const team = await request.get(`/api/environments/${workspace.team_id}/`, { headers: authHeaders })
+            expect(team.ok()).toBe(true)
+            apiToken = (await team.json()).api_token
+        })
+
+        await test.step('send an event through the capture endpoint', async () => {
+            const captured = await request.post(`${PROXY_BASE_URL}/e/`, {
+                data: {
+                    api_key: apiToken,
+                    event: eventName,
+                    distinct_id: randomString('e2e-user-'),
+                    timestamp: new Date().toISOString(),
+                },
+            })
+            expect(captured.ok()).toBe(true)
+        })
+
+        await test.step('poll until the event has been ingested and is queryable', async () => {
+            await expect
+                .poll(
+                    async () => {
+                        const resp = await request.post(`/api/environments/${workspace.team_id}/query/`, {
+                            headers: authHeaders,
+                            data: {
+                                // Without this the endpoint serves a cached result for up to 5 minutes,
+                                // so the first poll's zero would be replayed for the rest of the window.
+                                refresh: 'force_blocking',
+                                query: {
+                                    kind: 'HogQLQuery',
+                                    query: `SELECT count() FROM events WHERE event = '${eventName}'`,
+                                },
+                            },
+                        })
+                        // A 4xx other than rate limiting means the query itself is bad — waiting won't fix it.
+                        if (resp.status() >= 400 && resp.status() < 500 && resp.status() !== 429) {
+                            throw new Error(`query endpoint returned ${resp.status()}: ${await resp.text()}`)
+                        }
+                        const body = await resp.json()
+                        return Number(body.results?.[0]?.[0] ?? 0)
+                    },
+                    { timeout: 90_000, intervals: [2_000, 5_000] }
+                )
+                .toBeGreaterThan(0)
+        })
+    })
+})

--- a/playwright/e2e/invite-signup.spec.ts
+++ b/playwright/e2e/invite-signup.spec.ts
@@ -1,0 +1,78 @@
+import { randomString } from '../utils'
+import { expect, test } from '../utils/workspace-test-base'
+
+test.describe('Invites', () => {
+    test('an invited teammate can sign up through the invite link and lands in the organization', async ({
+        page,
+        browser,
+        playwrightSetup,
+    }) => {
+        const workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true, no_demo_data: true })
+
+        // Force link-generation mode so the modal flow is deterministic regardless of
+        // whether the environment has an email service configured. Preflight is both
+        // server-rendered into POSTHOG_APP_CONTEXT and refreshed via the API, so patch both.
+        await page.addInitScript(() => {
+            let appContext: any = undefined
+            Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {
+                get() {
+                    if (appContext?.preflight) {
+                        appContext.preflight.email_service_available = false
+                    }
+                    return appContext
+                },
+                set(value) {
+                    appContext = value
+                },
+                configurable: true,
+            })
+        })
+        await page.route('**/_preflight*', async (route) => {
+            const response = await route.fetch()
+            const body = await response.json()
+            await route.fulfill({ response, json: { ...body, email_service_available: false } })
+        })
+
+        await playwrightSetup.login(page, workspace)
+        const inviteeEmail = `${randomString('invitee-')}@posthog.com`
+        let inviteUrl = ''
+
+        await test.step('generate an invite link from org settings', async () => {
+            await page.goto('/settings/organization-members')
+            await page.getByTestId('invite-teammate-button').click()
+            await page.getByTestId('invite-email-input').fill(inviteeEmail)
+            await page.getByTestId('invite-generate-invite-link').click()
+            await page.getByRole('button', { name: 'Done' }).click()
+        })
+
+        await test.step('read the invite link from the invites table', async () => {
+            const link = page.getByTestId('invite-link')
+            await expect(link).toBeVisible()
+            inviteUrl = (await link.textContent()) ?? ''
+            expect(inviteUrl).toMatch(/\/signup\/[0-9a-f-]{36}/)
+        })
+
+        await test.step('accept the invite in a fresh browser session', async () => {
+            const context = await browser.newContext()
+            const invitePage = await context.newPage()
+            await invitePage.goto(inviteUrl)
+            await invitePage.locator('[data-attr=password]').fill(`E2e!${randomString('pw-')}`)
+            await invitePage.locator('[data-attr=first_name]').fill('Invited Hedgehog')
+            await invitePage.locator('[data-attr=signup-role-at-organization]').click()
+            await invitePage.locator('.Popover__content').getByText('Engineering').click()
+            await invitePage.locator('[data-attr=password-signup]').click()
+            // Where signup lands depends on whether the server has an email backend configured:
+            // with one, it routes to email verification instead of logging the invitee straight in.
+            await invitePage.waitForURL(/\/(project|verify_email)\//, { timeout: 30000 })
+            await context.close()
+
+            // Membership is created when the invite is used, before that branch, so it holds either way.
+            const members = await page.request.get(`/api/organizations/${workspace.organization_id}/members/`)
+            expect(members.status()).toBe(200)
+            const emails = (await members.json()).results.map(
+                (member: { user: { email: string } }) => member.user.email
+            )
+            expect(emails).toContain(inviteeEmail)
+        })
+    })
+})

--- a/playwright/e2e/settings-danger-zone.spec.ts
+++ b/playwright/e2e/settings-danger-zone.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '../utils/workspace-test-base'
+
+test.describe('Project danger zone', () => {
+    test('deleting a project requires typed confirmation and actually deletes it', async ({
+        page,
+        playwrightSetup,
+    }) => {
+        const workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true, no_demo_data: true })
+        await playwrightSetup.loginAndNavigateToTeam(page, workspace)
+
+        let projectName = ''
+
+        await test.step('open the danger zone and the delete modal', async () => {
+            await page.goto('/settings/project-danger-zone')
+            const deleteButton = page.locator('[data-attr=delete-project-button]')
+            await expect(deleteButton).toBeVisible()
+            projectName = ((await deleteButton.innerText()) ?? '').replace(/^Delete\s+/, '').trim()
+            await deleteButton.click()
+            await expect(page.getByText('Delete the project and its data?')).toBeVisible()
+        })
+
+        await test.step('confirm stays disabled until the exact project name is typed', async () => {
+            const modal = page.locator('.LemonModal').filter({ hasText: 'Delete the project and its data?' })
+            const confirmButton = page.locator('[data-attr=delete-project-ok]')
+            await expect(confirmButton).toBeDisabled()
+            await modal.getByRole('textbox').fill('wrong-name')
+            await expect(confirmButton).toBeDisabled()
+            await modal.getByRole('textbox').fill(projectName)
+            await expect(confirmButton).toBeEnabled()
+        })
+
+        await test.step('confirming marks the project for deletion and locks it out', async () => {
+            await page.locator('[data-attr=delete-project-ok]').click()
+            // Deletion is async: the API marks is_pending_deletion and the app
+            // hard-navigates to the lockout screen.
+            await page.waitForURL(/\/project-pending-deletion/, { timeout: 20_000 })
+            const resp = await page.request.get(`/api/projects/${workspace.team_id}/`)
+            expect((await resp.json()).is_pending_deletion).toBe(true)
+        })
+    })
+})

--- a/playwright/e2e/two-factor.spec.ts
+++ b/playwright/e2e/two-factor.spec.ts
@@ -1,0 +1,71 @@
+import { createHmac } from 'crypto'
+
+import { LoginPage } from '../page-models/loginPage'
+import { LOGIN_PASSWORD } from '../utils/playwright-test-core'
+import { expect, test } from '../utils/workspace-test-base'
+
+function base32Decode(secret: string): Buffer {
+    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+    let bits = 0
+    let value = 0
+    const bytes: number[] = []
+    for (const char of secret.replace(/=+$/, '').toUpperCase()) {
+        value = (value << 5) | alphabet.indexOf(char)
+        bits += 5
+        if (bits >= 8) {
+            bytes.push((value >>> (bits - 8)) & 0xff)
+            bits -= 8
+        }
+    }
+    return Buffer.from(bytes)
+}
+
+function totp(secret: string, atMs: number): string {
+    const counter = Buffer.alloc(8)
+    counter.writeBigUInt64BE(BigInt(Math.floor(atMs / 1000 / 30)))
+    const hmac = createHmac('sha1', base32Decode(secret)).update(counter).digest()
+    const offset = hmac[hmac.length - 1] & 0xf
+    return String((hmac.readUInt32BE(offset) & 0x7fffffff) % 1_000_000).padStart(6, '0')
+}
+
+test.describe('Two-factor authentication', () => {
+    test('login requires a TOTP code once 2FA is enabled', async ({ page, playwrightSetup }) => {
+        const workspace = await playwrightSetup.createWorkspace({ skip_onboarding: true, no_demo_data: true })
+        await playwrightSetup.login(page, workspace)
+        let secret = ''
+
+        await test.step('enable TOTP from user settings', async () => {
+            await page.goto('/settings/user-profile')
+            await page.getByRole('button', { name: 'Setup', exact: true }).click()
+            const modal = page.locator('.LemonModal').filter({ hasText: 'authenticator' })
+            const secretText = modal.getByText(/^[A-Z2-7]{16,}$/)
+            await expect(secretText).toBeVisible()
+            secret = (await secretText.textContent()) ?? ''
+            await page.locator('[data-attr=token]').fill(totp(secret, Date.now()))
+            await page.locator('[data-attr="2fa-setup"]').click()
+            await expect(page.locator('[data-attr="2fa-setup"]')).not.toBeVisible({ timeout: 15000 })
+        })
+
+        await test.step('log out via the account menu', async () => {
+            await page.locator('[data-attr=new-account-menu-button]').click()
+            await page.locator('[data-attr=new-account-menu-logout-button]').click()
+            await page.waitForURL(/\/login/, { timeout: 15000 })
+        })
+
+        await test.step('password login lands on the 2FA challenge instead of the app', async () => {
+            const loginPage = new LoginPage(page)
+            await loginPage.enterUsername(workspace.user_email)
+            await loginPage.enterPassword(LOGIN_PASSWORD)
+            await loginPage.clickLogin()
+            await expect(page.locator('[data-attr=token]')).toBeVisible({ timeout: 15000 })
+        })
+
+        await test.step('a valid TOTP code completes the login', async () => {
+            // Use the next 30s window: the current window's code was consumed during
+            // setup, and django_otp rejects token reuse within the same window.
+            await page.locator('[data-attr=token]').fill(totp(secret, Date.now() + 30_000))
+            await page.locator('[data-attr="2fa-login"]').click()
+            await page.waitForURL(/\/project\//, { timeout: 30000 })
+        })
+    })
+})

--- a/tools/playwright_area_map.json
+++ b/tools/playwright_area_map.json
@@ -108,15 +108,27 @@
         "retention": ["playwright/e2e/product-analytics/retention.spec.ts"],
         "persons": ["playwright/e2e/persons/persons.spec.ts"],
         "persons-management": ["playwright/e2e/persons/persons.spec.ts"],
-        "authentication": ["playwright/e2e/auth.spec.ts", "playwright/e2e/auth-password-reset.spec.ts"],
+        "authentication": [
+            "playwright/e2e/auth.spec.ts",
+            "playwright/e2e/auth-password-reset.spec.ts",
+            "playwright/e2e/two-factor.spec.ts",
+            "playwright/e2e/invite-signup.spec.ts"
+        ],
         "onboarding": ["playwright/e2e/before-onboarding.spec.ts", "playwright/e2e/signup.spec.ts"],
         "data-management": ["playwright/e2e/event-definitions.spec.ts", "playwright/e2e/annotations.spec.ts"],
         "annotations": ["playwright/e2e/annotations.spec.ts"],
         "toolbar-launch": ["playwright/e2e/toolbar.spec.ts"],
-        "settings": ["playwright/e2e/before-onboarding.spec.ts"],
-        "feature-flags": ["products/surveys/frontend/e2e/quickcreate.spec.ts"]
+        "settings": [
+            "playwright/e2e/before-onboarding.spec.ts",
+            "playwright/e2e/api-keys.spec.ts",
+            "playwright/e2e/two-factor.spec.ts",
+            "playwright/e2e/invite-signup.spec.ts",
+            "playwright/e2e/settings-danger-zone.spec.ts"
+        ],
+        "feature-flags": ["playwright/e2e/feature-flags.spec.ts", "products/surveys/frontend/e2e/quickcreate.spec.ts"]
     },
     "explicit": {
+        "products/feature_flags/frontend/**": ["playwright/e2e/feature-flags.spec.ts"],
         "products/product_analytics/frontend/**": ["playwright/e2e/product-analytics/"],
         "products/dashboards/frontend/**": [
             "playwright/e2e/product-analytics/dashboards.spec.ts",
@@ -144,6 +156,7 @@
     "full_suite_only": [
         "playwright/e2e/oauth-mcp-consent.spec.ts",
         "playwright/e2e/preflight.spec.ts",
-        "playwright/e2e/system-status.spec.ts"
+        "playwright/e2e/system-status.spec.ts",
+        "playwright/e2e/ingestion-capture.spec.ts"
     ]
 }


### PR DESCRIPTION
## Problem

Stacked on [#71342](https://github.com/PostHog/posthog/pull/71342) (the Playwright suite prune). The audit behind that PR found that while the suite was heavy on product-UI CRUD, the flows with the highest blast radius had zero e2e coverage: 2FA login (lockout), invite acceptance (org entry), API key lifecycle (the credential agents authenticate with), project deletion guards (irreversible), feature flag creation (a flagship product with zero browser coverage), and real event ingestion (capture → Kafka → plugin-server → ClickHouse). This PR adds exactly those, and nothing else — no general product-UI specs, in line with the AI-first direction the prune executed.

## Changes

Six new specs under `playwright/e2e/`, each proving a cross-stack flow no lower layer can:

| Spec | What it proves |
| --- | --- |
| `two-factor.spec.ts` | Enabling TOTP from user settings (the test computes real RFC 6238 codes from the secret shown in the setup modal), then that password login is **gated by the 2FA challenge** and a valid code completes it. Uses the next 30s TOTP window at login since django_otp rejects token reuse within a window. |
| `invite-signup.spec.ts` | Sending an invite from org settings, then a brand-new user accepting it in a **fresh browser context** and landing in the inviting organization (verified via `/api/users/@me/`). Forces link-generation mode by patching `email_service_available` in both `POSTHOG_APP_CONTEXT` and the `/_preflight` response, so the flow is deterministic with or without SMTP. |
| `api-keys.spec.ts` | Creating a personal API key in the UI, capturing the one-time `phx_` value, proving it **authorizes a real API request**, deleting it via the row menu, and proving it returns 401 afterwards. A broken revoke leaves a compromised key active; a broken create blocks every agent integration. |
| `settings-danger-zone.spec.ts` | Project deletion requires typing the exact project name (confirm stays disabled on a wrong name), and confirming marks `is_pending_deletion` and hard-redirects to the lockout screen. |
| `feature-flags.spec.ts` | A 100% rollout flag created through the UI is persisted and shows enabled at 100% in the flags list — the browser-only creation path (template picker → form → save → persist), previously uncovered at any layer. |
| `ingestion-capture.spec.ts` | A real event POSTed to `/e/` becomes queryable via HogQL — the full capture → Kafka → plugin-server → ClickHouse pipeline. Every other spec seeds events through a backend shortcut; this is the only test of the pipeline itself. |

Also:

- `tools/playwright_area_map.json`: maps the new specs (`authentication`, new `settings` and `feature-flags` scene entries, `products/feature_flags/frontend/**` explicit rule). `ingestion-capture` is `full_suite_only` — no single frontend area owns the pipeline. Selection test passes.

> [!NOTE]
> **Flag evaluation via `/flags` was dropped after review.** A reviewer flagged that the `/flags` poll can never pass in CI, and verifying the claim confirmed the outcome (with a different mechanism): the flags container does start (it's a default-profile compose service), but the dev proxy's `extra_hosts` resolves `feature-flags` to `host-gateway:3001` — the slot for a natively-run flags service, which CI never starts and which the container doesn't publish a port into (unlike `capture`, which publishes `3307:3000`, and is why the capture spec works). Independently, the container reads the default `posthog` Postgres database while the CI backend writes to `posthog_e2e_test`. Django can't serve as a fallback: `/decide` no longer exists there. Wiring the flags service into the e2e environment (a host port that doesn't collide with native local dev, plus `POSTHOG_DB_NAME` substitution in its compose env) is follow-up infra work; until then the spec stops at persistence.

## How did you test this code?

- The four auth/settings specs (`two-factor`, `invite-signup`, `api-keys`, `settings-danger-zone`) pass a **40-run stability check** (`--repeat-each 10 --retries 0 --workers 3`, 40/40 in 1.7m) against the full local e2e stack.
- `feature-flags` (rewritten, see note above) passes 10/10 serially with `--repeat-each 10 --retries 0` locally. The rewrite also caught a latent bug in the original spec: its `randomString('e2e-flag-')` prefix produced a double-dash key that the flag key input silently sanitizes, invisible to the original URL-only assertion.
- `ingestion-capture` needs this PR's CI e2e environment: locally, compose env substitution doesn't reach my stack, so ingestion writes to a different ClickHouse database than the Django server queries. In CI the workflow sets `CLICKHOUSE_DATABASE=posthog_test` and `POSTHOG_DB_NAME=posthog_e2e_test` at workflow level and the consumers' compose env substitutes both, so the capture → ingest → query loop is coherent there. Validated by CI on this PR — if it fails there I'll iterate.
- `tools/test_playwright_spec_selection.py` passes (area-map invariants), `oxlint`/`oxfmt` clean, pre-push `ci:preflight --strict` clean.

Per-test regression justification (the `/writing-tests` bar): each spec catches a break that locks users out, strands invited teammates, leaves revoked credentials live, deletes a project without a guard, breaks flag creation, or silently drops events — none of which any existing test at any layer would catch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change; no docs needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georges-Antoine asked for tests covering the surfaces the prune audit flagged as uncovered, as a PR stacked on the prune branch. I (Claude) scoped it to the critical-path gaps rather than re-adding product-UI CRUD coverage the base PR just removed.

Skills invoked: `/writing-tests` (value gate per spec) and `/playwright-test` (explore → implement → run → `--repeat-each 10` stability loop).

Decisions worth flagging:

- Selector-only fixes found during the run loop: quoted `data-attr` values containing digits (`[data-attr="2fa-setup"]` — unquoted `2fa-setup` is an invalid CSS selector), `menuitem` role for LemonMenu options, logout via the account menu (matching `auth.spec.ts`) instead of `/logout` navigation.
- The danger-zone spec originally asserted a 404 after deletion; project deletion is actually async (`is_pending_deletion` + lockout redirect), so the assertion now matches the real contract.
- The branch carried the base PR's original, larger prune, which deleted ten specs that the landed version of #71342 kept after review. Merging master would have re-deleted them, so they're restored from master and `playwright_area_map.json` is rebuilt on master's version — the diff is now only the six new specs plus the map.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


