### PR TITLE
feat(mcp-analytics): tiered exact/contains/fuzzy tool search

### DIFF
--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
@@ -5,7 +5,14 @@ import api from 'lib/api'
 import { initKeaTests } from '~/test/init'
 
 import { formatMsAsSeconds } from './dashboard/formatters'
-import { type DailyToolStat, buildDailyChartData, mcpAnalyticsToolQualityLogic } from './mcpAnalyticsToolQualityLogic'
+import {
+    type DailyToolStat,
+    type SortState,
+    type ToolQualityRow,
+    buildDailyChartData,
+    mcpAnalyticsToolQualityLogic,
+    searchToolRows,
+} from './mcpAnalyticsToolQualityLogic'
 
 jest.mock('lib/api')
 jest.mock('~/queries/query', () => ({
@@ -70,6 +77,43 @@ describe('mcpAnalyticsToolQualityLogic', () => {
             [Infinity, '—'],
         ])('formats %s ms as %s', (input, expected) => {
             expect(formatMsAsSeconds(input)).toBe(expected)
+        })
+    })
+
+    describe('searchToolRows', () => {
+        const sort: SortState = { column: 'tool', direction: 'ASC' }
+        const row = (tool: string): ToolQualityRow => ({
+            tool,
+            total_calls: 0,
+            errors: 0,
+            error_rate_pct: 0,
+            p50_duration_ms: 0,
+            p95_duration_ms: 0,
+            p99_duration_ms: 0,
+            users: 0,
+            sessions: 0,
+            first_seen: '',
+            last_seen: '',
+        })
+        const names = (rows: ToolQualityRow[]): string[] => rows.map((r) => r.tool)
+        const rows = [row('query-run'), row('query'), row('insight-create'), row('dashboard-get')]
+
+        it('ranks an exact match above substring ("contains") matches', () => {
+            // Both contain "query", but the exact match must come first.
+            expect(names(searchToolRows(rows, 'query', sort))).toEqual(['query', 'query-run'])
+        })
+
+        it('returns every substring match when there is no exact match', () => {
+            expect(names(searchToolRows(rows, 'insight', sort))).toEqual(['insight-create'])
+        })
+
+        it('falls back to trigram similarity for a typo instead of returning nothing', () => {
+            // "querey" contains no tool as a substring; the fuzzy tier still surfaces the close names.
+            expect(names(searchToolRows(rows, 'querey', sort))).toContain('query')
+        })
+
+        it('returns no rows when nothing is even fuzzy-close', () => {
+            expect(searchToolRows(rows, 'zzzzzz', sort)).toEqual([])
         })
     })
 

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -175,17 +175,76 @@ export function buildDailyChartData(
     }
 }
 
-function sortToolRows(rows: ToolQualityRow[], sort: SortState): ToolQualityRow[] {
+function toolRowComparator(sort: SortState): (a: ToolQualityRow, b: ToolQualityRow) => number {
     const direction = sort.direction === 'ASC' ? 1 : -1
     const column = sort.column as keyof ToolQualityRow
-    return [...rows].sort((a, b) => {
+    return (a, b) => {
         const aValue = a[column]
         const bValue = b[column]
         if (typeof aValue === 'number' && typeof bValue === 'number') {
             return (aValue - bValue) * direction
         }
         return String(aValue).localeCompare(String(bValue)) * direction
-    })
+    }
+}
+
+function sortToolRows(rows: ToolQualityRow[], sort: SortState): ToolQualityRow[] {
+    return [...rows].sort(toolRowComparator(sort))
+}
+
+// Trigram (Jaccard) similarity between two strings, mirroring the exact/contains/fuzzy
+// fallback other search boxes use. Returns 1 for an exact match, 0 for no shared trigrams.
+function trigramSimilarity(a: string, b: string): number {
+    if (a === b) {
+        return 1
+    }
+    const trigrams = (value: string): Set<string> => {
+        const padded = `  ${value} `
+        const grams = new Set<string>()
+        for (let i = 0; i < padded.length - 2; i++) {
+            grams.add(padded.slice(i, i + 3))
+        }
+        return grams
+    }
+    const left = trigrams(a)
+    const right = trigrams(b)
+    if (left.size === 0 || right.size === 0) {
+        return 0
+    }
+    let shared = 0
+    for (const gram of left) {
+        if (right.has(gram)) {
+            shared += 1
+        }
+    }
+    return shared / (left.size + right.size - shared)
+}
+
+// Minimum trigram similarity for a tool to surface as a fuzzy fallback match.
+const TRIGRAM_MATCH_THRESHOLD = 0.3
+
+// Rank tools by relevance to the search term: exact matches first, then substring
+// ("contains") matches, then a trigram-similarity fallback so a typo or partial recall
+// still surfaces the closest tools instead of an empty table. Within each tier the
+// active column sort is preserved.
+export function searchToolRows(rows: ToolQualityRow[], term: string, sort: SortState): ToolQualityRow[] {
+    const comparator = toolRowComparator(sort)
+    return rows
+        .map((row) => {
+            const name = row.tool.toLowerCase()
+            let tier = 0
+            if (name === term) {
+                tier = 3
+            } else if (name.includes(term)) {
+                tier = 2
+            } else if (trigramSimilarity(name, term) >= TRIGRAM_MATCH_THRESHOLD) {
+                tier = 1
+            }
+            return { row, tier }
+        })
+        .filter((entry) => entry.tier > 0)
+        .sort((a, b) => b.tier - a.tier || comparator(a.row, b.row))
+        .map((entry) => entry.row)
 }
 
 export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType>([
@@ -398,8 +457,7 @@ ORDER BY day
             (s) => [s.toolRows, s.toolQualitySort, s.searchTerm],
             (toolRows: ToolQualityRow[], sort: SortState, searchTerm: string): ToolQualityRow[] => {
                 const term = searchTerm.trim().toLowerCase()
-                const filtered = term ? toolRows.filter((row) => row.tool.toLowerCase().includes(term)) : toolRows
-                return sortToolRows(filtered, sort)
+                return term ? searchToolRows(toolRows, term, sort) : sortToolRows(toolRows, sort)
             },
         ],
         dailyChartData: [


### PR DESCRIPTION
## Problem

The "All tools" box on the MCP analytics dashboard filters with a plain case-insensitive substring match.
If what you type isn't a substring of any tool name, the table just goes empty.
A typo or a half-remembered name gets you nothing, with no fallback.

## Changes

Search now ranks by relevance in tiers, matching how other search boxes behave:

1. exact match
2. substring ("contains") match
3. trigram-similarity fuzzy fallback, so a typo or partial recall still surfaces the closest tools

The active column sort is preserved within each tier, so sorting the table while searching still works.
There's no shared frontend trigram helper today (the repo's trigram similarity lives server-side in the dashboards list endpoint), so this adds a small self-contained `trigramSimilarity` in the tool-quality logic.

> [!NOTE]
> This is a client-side (UI-only) improvement. A follow-up is being scoped to move this search to the backend so MCP consumers and agents get it too, not just the web UI.

## How did you test this code?

Added a unit test for the pure `searchToolRows` function covering: exact ranks above contains, contains-only matches, the fuzzy fallback surfacing a typo ("querey" → "query"), and a no-match returning empty.
That's the regression this locks in: a revert to plain `.includes()` would make the typo case return nothing and stop exact matches ranking first, which no existing test caught (nothing exercised the search path before).

Ran the full Jest file locally: **22 passed** (the 4 new `searchToolRows` cases plus the existing suite, which still passes after refactoring the sort into a reusable comparator). TypeScript check of the changed file is clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Paul D'Ambra in Slack: confirm whether the "All tools" search fell back to trigram similarity when there were no exact matches, and if not, make it check exact, then contains, then fuzzy similarity like other scenes.

Findings while scoping: the current filter is a single `row.tool.toLowerCase().includes(term)` in the `filteredRows` selector of `mcpAnalyticsToolQualityLogic.ts` with no fuzzy tier. There's no shared *frontend* trigram helper to reuse (trigram word-similarity in this repo is Postgres-side via `posthog/helpers/trigram_search.py`). The Fuse-based `filterSearchItems` and a Levenshtein `similarityScore` exist but neither is a clean exact→contains→fuzzy tiering, so I implemented a small local trigram (Jaccard) similarity and a tiered `searchToolRows`, refactoring the existing sort into a reusable comparator so column sort survives inside each tier.

Skills invoked: `/writing-tests` (to gate the added test).

Tools: PostHog Slack app (Claude).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09KTRWD3HD/p1784198325206709?thread_ts=1784198325.206709&cid=C09KTRWD3HD)*
