### PR TITLE
chore(capture): pin $snapshot_host serializing before $snapshot_items

### DIFF
--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -781,6 +781,25 @@ mod tests {
                 expected.map(|h| json!(h)).as_ref(),
                 "stamp={stamp:?}"
             );
+            if expected.is_some() {
+                // Byte order in the serialized message is a contract: the anonymizer reads the
+                // stamp from the envelope prefix and stops at `$snapshot_items` without
+                // traversing it, so a stamp serialized after the items is silently ignored
+                // (collapse-all). serde_json's sorted map ordering provides this today; the
+                // assertion turns it into a requirement.
+                // Key form (with colon) — the bare string also occurs as the `event` name value.
+                let raw = &captured[0].event.data;
+                let host_at = raw
+                    .find("\"$snapshot_host\":")
+                    .expect("stamp key in output");
+                let items_at = raw
+                    .find("\"$snapshot_items\":")
+                    .expect("items key in output");
+                assert!(
+                    host_at < items_at,
+                    "$snapshot_host must serialize before $snapshot_items"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The ml-mirror anonymizer ([#70528](https://github.com/PostHog/posthog/pull/70528)) reads the `$snapshot_host` stamp from the serialized message's envelope prefix and stops at `$snapshot_items` without traversing the multi-MB array - that keeps the per-message pre-scan at a few hundred bytes instead of a full buffer pass. The trade is an ordering contract: a stamp serialized *after* the items is silently ignored (the message uniformly collapses every hostname, fail-closed, and is counted as a `stamp_late` outcome).

Capture currently satisfies the order by accident: `serialize_snapshot_data_sync` builds a `serde_json` map, whose default sorted key ordering places `$snapshot_host` before `$snapshot_items`. Nothing pinned that, so enabling `preserve_order`, restructuring the serializer, or renaming a property could break the contract without any test noticing - the downstream failure mode is silent signal loss, not an error.

## Changes

Extends the existing `$snapshot_host` pass-through test ([#71048](https://github.com/PostHog/posthog/pull/71048)) to assert byte order in the serialized output: the `"$snapshot_host":` key must appear before `"$snapshot_items":`. Matching on the key form (with colon) because the bare string `"$snapshot_items"` also occurs earlier as the message's `event` name value.

## How did you test this code?

- `cargo test -p capture --lib events::recordings`: 21 tests pass. The regression this catches: any serializer change that moves the stamp behind the items array, which would silently disable host classification fleet-wide with collapse-all as the only symptom. First version of the assertion matched the bare string and failed on the event-name occurrence - fixed to key-form matching, which is also why the assertion needs to exist as code rather than as an assumption.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal message-shape contract, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), companion to the anonymizer's prefix-scan simplification on [#70528](https://github.com/PostHog/posthog/pull/70528). Robbie (AI research, which owns the ml-mirror pipeline) directed the work.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*