### PR TITLE
fix(tasks): stop escalating already-resolved permission responses

### DIFF
--- a/products/tasks/backend/logic/services/agent_command.py
+++ b/products/tasks/backend/logic/services/agent_command.py
@@ -40,6 +40,18 @@ BLOCKED_IP_RANGES = [
 
 NO_ACTIVE_SESSION_ERROR = "No active session for this run"
 
+# The agent-server raises this (as a JSON-RPC error) when a permission_response
+# targets a request that is no longer pending — it was already resolved, most
+# often by a duplicate delivery of the same response through the Modal tunnel.
+# The message carries the request id as a suffix, so match on the stable prefix.
+# A response that gets this back has effectively landed: callers should treat it
+# as delivered rather than retry it or escalate the request to a human.
+NO_PENDING_PERMISSION_REQUEST_ERROR = "No pending permission request found"
+
+
+def is_permission_already_resolved_error(error: str | None) -> bool:
+    return error is not None and NO_PENDING_PERMISSION_REQUEST_ERROR in error
+
 
 @dataclass
 class CommandResult:

--- a/products/tasks/backend/logic/services/permission_broker.py
+++ b/products/tasks/backend/logic/services/permission_broker.py
@@ -27,7 +27,11 @@ from django.core.cache import cache
 
 import structlog
 
-from products.tasks.backend.logic.services.agent_command import CommandResult, send_agent_command
+from products.tasks.backend.logic.services.agent_command import (
+    CommandResult,
+    is_permission_already_resolved_error,
+    send_agent_command,
+)
 from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.logic.services.run_actor import get_actor_distinct_id, get_task_run_credential_user
 
@@ -458,6 +462,19 @@ def try_auto_respond_permission_request(task_run: "TaskRun", permission_request:
         auth_token=auth_token,
     )
     if not result.success:
+        if is_permission_already_resolved_error(result.error):
+            # A duplicate delivery of this response already resolved the request,
+            # so the decision has landed. Dedupe and treat it as answered rather
+            # than escalating an already-approved request to a human.
+            cache.set(dedupe_key, True, timeout=AUTO_RESPONSE_DEDUPE_SECONDS)
+            logger.info(
+                "permission_broker_request_already_resolved",
+                run_id=run_id,
+                request_id=request_id,
+                option_id=option_id,
+                actor_user_id=actor.id,
+            )
+            return True
         logger.warning(
             "permission_broker_auto_allow_failed",
             run_id=run_id,

--- a/products/tasks/backend/logic/services/tests/test_permission_broker.py
+++ b/products/tasks/backend/logic/services/tests/test_permission_broker.py
@@ -125,13 +125,15 @@ class TestTryAutoRespondPermissionRequest(APIBaseTest):
         assert parsed is not None
         return parsed
 
-    def _auto_respond(self, permission_request: dict, *, send_success: bool = True) -> tuple[bool, MagicMock]:
+    def _auto_respond(
+        self, permission_request: dict, *, send_success: bool = True, send_error: str | None = None
+    ) -> tuple[bool, MagicMock]:
         with (
             patch(f"{BROKER}.create_sandbox_connection_token", return_value="sandbox-token"),
             patch(
                 f"{BROKER}.send_agent_command",
                 return_value=SimpleNamespace(
-                    success=send_success, status_code=200 if send_success else 502, error=None
+                    success=send_success, status_code=200 if send_success else 502, error=send_error
                 ),
             ) as mock_send,
         ):
@@ -243,4 +245,21 @@ class TestTryAutoRespondPermissionRequest(APIBaseTest):
 
         assert first_handled is True
         assert second_handled is True
+        mock_send.assert_not_called()
+
+    def test_already_resolved_request_is_answered_not_escalated(self) -> None:
+        # A duplicate delivery already resolved the request; the agent-server
+        # reports it as gone. The broker must treat that as answered (and dedupe),
+        # never fall through to a human approval prompt.
+        request = self._permission_request(command="ls -la")
+
+        handled, _ = self._auto_respond(
+            request,
+            send_success=False,
+            send_error="No pending permission request found for id: perm-1",
+        )
+        assert handled is True
+
+        handled, mock_send = self._auto_respond(request)
+        assert handled is True
         mock_send.assert_not_called()

--- a/products/tasks/backend/temporal/process_task/activities/send_permission_response_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_permission_response_to_sandbox.py
@@ -7,7 +7,11 @@ from temporalio import activity
 from posthog.models.user import User
 from posthog.temporal.common.utils import close_db_connections
 
-from products.tasks.backend.logic.services.agent_command import send_agent_command, send_user_message
+from products.tasks.backend.logic.services.agent_command import (
+    is_permission_already_resolved_error,
+    send_agent_command,
+    send_user_message,
+)
 from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.temporal.process_task.utils import get_actor_distinct_id
@@ -122,7 +126,11 @@ def send_permission_response_to_sandbox(input: SendPermissionResponseToSandboxIn
         auth_token=auth_token,
         timeout=PERMISSION_RESPONSE_TIMEOUT_SECONDS,
     )
-    if not result.success:
+    # A duplicate delivery may have already resolved the request. The decision is
+    # final on the sandbox, so record it as delivered instead of retrying the
+    # activity and posting a spurious "couldn't deliver" notice to the thread.
+    already_resolved = not result.success and is_permission_already_resolved_error(result.error)
+    if not result.success and not already_resolved:
         logger.warning(
             "permission_response_delivery_failed",
             run_id=input.run_id,
@@ -160,6 +168,7 @@ def send_permission_response_to_sandbox(input: SendPermissionResponseToSandboxIn
         actor_slack_user_id=input.actor_slack_user_id,
         broker_reason=input.broker_reason,
         is_denial=input.is_denial,
+        already_resolved=already_resolved,
     )
 
 

--- a/products/tasks/backend/temporal/process_task/tests/test_send_permission_response_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_permission_response_to_sandbox.py
@@ -131,6 +131,34 @@ class TestSendPermissionResponseToSandbox:
 
         patches["task_run_cls"].update_state_atomic.assert_not_called()
 
+    def test_already_resolved_records_state_without_raising(self, patches):
+        # A duplicate delivery already resolved the request. The decision is final
+        # on the sandbox, so record it as delivered rather than retry the activity
+        # and post a spurious delivery-failure notice to the thread.
+        patches["send_agent_command"].return_value = CommandResult(
+            success=False,
+            status_code=200,
+            error="No pending permission request found for id: perm-1",
+        )
+
+        send_permission_response_to_sandbox(
+            SendPermissionResponseToSandboxInput(
+                run_id="run-1",
+                request_id="perm-1",
+                option_id="allow",
+                actor_user_id=42,
+            )
+        )
+
+        patches["task_run_cls"].update_state_atomic.assert_called_once_with(
+            "run-1",
+            updates={
+                "slack_actor_user_id": 42,
+                "slack_permission_response_last_request_id": "perm-1",
+                "slack_permission_response_last_option_id": "allow",
+            },
+        )
+
 
 class TestSendPermissionDenialGuidance:
     def test_sends_guidance_with_actor_token(self, patches):


### PR DESCRIPTION
## Problem

Slack `@PostHog` runs in `full_auto` were spamming threads with approval cards and "Approval recorded / No further action is needed" replies, even though the user never should have been asked.

Root cause: a `permission_response` sent to the sandbox agent can be delivered twice (the Modal tunnel retries the request on a stale upstream connection). The first delivery resolves the request. The second gets back the agent-server's `No pending permission request found for id: X` JSON-RPC error. The broker read that as a failed send and fell through to posting a Slack approval card for a request it had already auto-approved. Each card was dead on arrival, and every click swapped it for the "Approval recorded" notice, hence the flood.

Origin thread (behind PostHog auth): https://posthog.slack.com/archives/C09SK2PAGKF/p1784197051162259

## Changes

Treat the "already resolved" error as a delivered response on both paths:

- **Auto-responder** (`permission_broker.try_auto_respond_permission_request`): dedupes and returns handled instead of escalating to a human card.
- **Human-response activity** (`send_permission_response_to_sandbox`): records the decision without retrying or posting a delivery-failure notice.

Detection lives in one place, `is_permission_already_resolved_error()` in `agent_command.py`, mirroring the existing `NO_ACTIVE_SESSION_ERROR` handling.

> [!NOTE]
> This stops the Slack symptom but not the underlying duplicate delivery. The source-level fix (making the agent-server's `permission_response` idempotent so a duplicate returns success) belongs in the `posthog/code` repo and is a planned follow-up.

## How did you test this code?

Automated only (no manual Slack run). New regression tests, both run locally and passing:

- `test_permission_broker.py::test_already_resolved_request_is_answered_not_escalated` — the "already resolved" error is answered and deduped, never escalated to a human prompt. No existing test covered a non-success send that should still count as handled.
- `test_send_permission_response_to_sandbox.py::test_already_resolved_records_state_without_raising` — the human-response activity records state and returns instead of raising (which would retry the activity and post a delivery-failure notice).

Ran the two affected suites (49 tests) plus the relay permission tests, all green. Did not run mypy locally per repo convention (CI covers it).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Vojta) directed this; Claude did the investigation and the change. Diagnosis started from the Slack thread and used the PostHog MCP (`tasks-runs-retrieve`, `query-logs`, `tasks-runs-session-logs-retrieve`) to correlate the sandbox session log with the tasks-agent worker logs. That correlation is what pinned it to duplicate `permission_response` delivery rather than a bad permission mode: the run state was a clean `full_auto`, and every escalated request had a matching `permission_broker_auto_allow_failed` carrying the "No pending permission request found" error a few ms before the card was posted.

Considered fixing it in the agent-server (idempotent responses) but kept this PR to the Python side to stop the user-visible spam quickly; the agent-server hardening is noted above as a follow-up. No repo skills were invoked.
