### PR TITLE
fix(tracing): duration histogram counts the population the active view shows

### DIFF
--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -624,6 +624,9 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
                             serviceNames:
                                 values.filters.serviceNames.length > 0 ? values.filters.serviceNames : undefined,
                             filterGroup: values.queryFilterGroup as PropertyGroupFilter,
+                            // Match the population the list shows (and the sparkline counts):
+                            // root spans in Traces view, every matching span in Spans view.
+                            rootSpans: values.filters.viewMode === 'traces',
                         },
                         controller.signal
                     )


### PR DESCRIPTION
## Problem

The trace list's duration histogram always buckets root spans. In Spans view the list shows every matching span (often child spans), so the histogram above it describes a different population, and the visible-row highlight snaps child durations onto a root-only axis — clamping to the wrong range.

## Changes

Pass `rootSpans` by view mode, matching what the sparkline and the list already do: root spans in Traces view, every matching span in Spans view.

## How did you test this code?

`tracingDataLogic.test.ts` passes locally (26 tests). Three-line change reusing the endpoint's existing `rootSpans` parameter.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Part of a set of small PRs split from the too-broad #71484 (now closed); this was a code-review finding on the histogram/list population mismatch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*