### PR TITLE
chore(tracing): dedupe duration-axis config, error-rate formatting, and duration-range type

### DIFF
--- a/products/tracing/frontend/OperationHistogram.tsx
+++ b/products/tracing/frontend/OperationHistogram.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 
-import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
+import { Sparkline } from 'lib/components/Sparkline'
 
 import {
     formatBucketLabel,
@@ -11,6 +11,7 @@ import {
     type TracingDurationHistogramData,
 } from './durationBuckets'
 import type { DurationRange } from './operationFilters'
+import { categoryDurationXScale } from './TracingSparkline'
 
 interface OperationHistogramProps {
     data: TracingDurationHistogramData
@@ -18,24 +19,6 @@ interface OperationHistogramProps {
     selection: DurationRange | null
     onSelect: (selection: DurationRange) => void
     onClear: () => void
-}
-
-// Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is already
-// log-spaced, so a plain category axis renders it evenly (mirrors TracingSparkline).
-function withCategoryXScale(scale: AnyScaleOptions): AnyScaleOptions {
-    return {
-        ...scale,
-        type: 'category',
-        ticks: {
-            display: true,
-            maxRotation: 0,
-            maxTicksLimit: 8,
-            font: {
-                size: 10,
-                lineHeight: 1,
-            },
-        },
-    } as AnyScaleOptions
 }
 
 export function OperationHistogram({
@@ -97,7 +80,7 @@ export function OperationHistogram({
                         data={data.data}
                         className="w-full h-full"
                         onSelectionChange={onSelectionChange}
-                        withXScale={withCategoryXScale}
+                        withXScale={categoryDurationXScale}
                         renderLabel={(label) => label}
                         tooltipRowCutoff={100}
                         hideZerosInTooltip

--- a/products/tracing/frontend/OperationsTable.tsx
+++ b/products/tracing/frontend/OperationsTable.tsx
@@ -24,8 +24,13 @@ function formatRate(count: number, windowMs: number): string {
     return `${humanFriendlyNumber(perSec * 3600, 1)}/hr`
 }
 
-function errorRate(row: AggregatedSpanRow): number {
+export function errorRate(row: AggregatedSpanRow): number {
     return row.count > 0 ? row.error_count / row.count : 0
+}
+
+// Sub-1% rates get an extra decimal so small-but-nonzero rates don't render as 0.0%.
+export function formatErrorRate(rate: number): string {
+    return `${(rate * 100).toFixed(rate > 0 && rate < 0.01 ? 2 : 1)}%`
 }
 
 const durationCell =
@@ -68,11 +73,7 @@ function buildColumns(windowMs: number): VirtualizedTableColumn<AggregatedSpanRo
             sorter: (a, b) => errorRate(a) - errorRate(b),
             render: (row) => {
                 const rate = errorRate(row)
-                return (
-                    <span className={rate > 0 ? 'text-danger' : 'text-muted'}>
-                        {`${(rate * 100).toFixed(rate > 0 && rate < 0.01 ? 2 : 1)}%`}
-                    </span>
-                )
+                return <span className={rate > 0 ? 'text-danger' : 'text-muted'}>{formatErrorRate(rate)}</span>
             },
         },
         {

--- a/products/tracing/frontend/TracingOperationScene.tsx
+++ b/products/tracing/frontend/TracingOperationScene.tsx
@@ -15,6 +15,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { OperationHistogram } from './OperationHistogram'
+import { errorRate, formatErrorRate } from './OperationsTable'
 import { formatDuration, TraceWaterfallView } from './TraceWaterfallView'
 import { tracingOperationSceneLogic, type TracingOperationSceneLogicProps } from './tracingOperationSceneLogic'
 
@@ -68,8 +69,6 @@ export function TracingOperationScene(): JSX.Element {
         )
     }
 
-    const errorRate = operationStats && operationStats.count > 0 ? operationStats.error_count / operationStats.count : 0
-
     return (
         <SceneContent>
             <SceneTitleSection
@@ -94,10 +93,7 @@ export function TracingOperationScene(): JSX.Element {
             {operationStats && (
                 <div className="flex gap-8">
                     <StatBlock label="Requests" value={humanFriendlyNumber(operationStats.count)} />
-                    <StatBlock
-                        label="Error rate"
-                        value={`${(errorRate * 100).toFixed(errorRate > 0 && errorRate < 0.01 ? 2 : 1)}%`}
-                    />
+                    <StatBlock label="Error rate" value={formatErrorRate(errorRate(operationStats))} />
                     <StatBlock label="p50" value={formatDuration(operationStats.p50_duration_nano)} />
                     <StatBlock label="p95" value={formatDuration(operationStats.p95_duration_nano)} />
                     <StatBlock label="p99" value={formatDuration(operationStats.p99_duration_nano)} />
@@ -128,7 +124,7 @@ export function TracingOperationScene(): JSX.Element {
                             }
                         />
                         <span className="text-sm whitespace-nowrap">
-                            {samples.length > 0 ? sampleIndex + 1 : 0} of {samples.length}
+                            {sampleIndex + 1} of {samples.length}
                             {samplesHaveMore ? '+' : ''}
                         </span>
                         <LemonButton

--- a/products/tracing/frontend/TracingSparkline.tsx
+++ b/products/tracing/frontend/TracingSparkline.tsx
@@ -14,6 +14,25 @@ import { type TracingDurationHistogramData, type VisibleDurationRange, snapDurat
 import { SparklineCompareOverlay } from './SparklineCompareOverlay'
 import type { TracingSparklineData, VisibleSpanTimeRange } from './tracingDataLogic'
 
+// Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is already
+// log-spaced, so a plain category axis renders it evenly. Shared with OperationHistogram
+// so the two duration histograms render identically.
+export function categoryDurationXScale(scale: AnyScaleOptions): AnyScaleOptions {
+    return {
+        ...scale,
+        type: 'category',
+        ticks: {
+            display: true,
+            maxRotation: 0,
+            maxTicksLimit: 8,
+            font: {
+                size: 10,
+                lineHeight: 1,
+            },
+        },
+    } as AnyScaleOptions
+}
+
 interface CompareConfig {
     fullStartMs: number
     fullEndMs: number
@@ -68,21 +87,7 @@ export function TracingSparkline({
     const withXScale = useCallback(
         (scale: AnyScaleOptions): AnyScaleOptions => {
             if (durationMode) {
-                // Duration buckets are categorical (1ms, 2ms, 5ms, ...) — the 1-2-5 series is
-                // already log-spaced, so a plain category axis renders it evenly.
-                return {
-                    ...scale,
-                    type: 'category',
-                    ticks: {
-                        display: true,
-                        maxRotation: 0,
-                        maxTicksLimit: 8,
-                        font: {
-                            size: 10,
-                            lineHeight: 1,
-                        },
-                    },
-                } as AnyScaleOptions
+                return categoryDurationXScale(scale)
             }
             return {
                 ...scale,

--- a/products/tracing/frontend/durationBuckets.ts
+++ b/products/tracing/frontend/durationBuckets.ts
@@ -1,4 +1,4 @@
-// Pure helpers for the duration-histogram sparkline (JON-36). The list sorted by duration pairs
+// Pure helpers for the duration-histogram sparkline. The list sorted by duration pairs
 // with a histogram of trace counts per logarithmic duration bucket; everything here is pure so it
 // can be unit-tested without the kea logic's import graph.
 
@@ -15,10 +15,13 @@ export interface TracingDurationHistogramData {
     labels: string[]
 }
 
-export interface VisibleDurationRange {
+/** A `[minNs, maxNs)` duration range in nanoseconds — the shared currency of selection and filtering. */
+export interface DurationRange {
     minNs: number
     maxNs: number
 }
+
+export type VisibleDurationRange = DurationRange
 
 const BUCKET_MANTISSAS = [1, 2, 5]
 
@@ -114,9 +117,7 @@ export function pivotDurationHistogram(
 
 /** Exclusive upper edge of a 1-2-5 bucket — the next bucket on the series (1→2, 2→5, 5→10). */
 export function bucketUpperBound(bucketNs: number): number {
-    const decade = Math.pow(10, Math.floor(Math.log10(Math.max(bucketNs, 1))))
-    const mantissa = bucketNs / decade
-    return Math.round(mantissa < 2 ? 2 * decade : mantissa < 5 ? 5 * decade : 10 * decade)
+    return fillBucketSeries(bucketNs, bucketNs * 10)[1]
 }
 
 /**
@@ -128,7 +129,7 @@ export function selectionToDurationRange(
     bucketsNs: number[],
     startIndex: number,
     endIndex: number
-): { minNs: number; maxNs: number } | null {
+): DurationRange | null {
     if (bucketsNs.length === 0) {
         return null
     }

--- a/products/tracing/frontend/operationFilters.ts
+++ b/products/tracing/frontend/operationFilters.ts
@@ -6,10 +6,9 @@ import {
     SpanPropertyFilter,
 } from '~/types'
 
-export interface DurationRange {
-    minNs: number
-    maxNs: number
-}
+import type { DurationRange } from './durationBuckets'
+
+export type { DurationRange } from './durationBuckets'
 
 const NS_PER_MS = 1_000_000
 


### PR DESCRIPTION
## Problem

Three helpers exist as near-verbatim copies that can silently drift: the category duration axis config (`TracingSparkline` + `OperationHistogram`, character-for-character identical), the error-rate computation and its sub-1% formatting rule (`OperationsTable` + the operation scene), and the `{minNs, maxNs}` range shape (`durationBuckets` + `operationFilters`). The 1-2-5 bucket series math is also hand-rolled three times in one file.

## Changes

Each helper now lives in one place: `categoryDurationXScale` exported from `TracingSparkline`, `errorRate`/`formatErrorRate` exported from `OperationsTable`, `DurationRange` declared in `durationBuckets` and re-exported from `operationFilters`. `bucketUpperBound` derives from `fillBucketSeries` so the series is encoded once. Also drops a dead pager ternary. Refactor only, no behavior change.

## How did you test this code?

`durationBuckets.test.ts` passes locally (27 tests), covering `bucketUpperBound`'s reimplementation. Component changes are import/reference swaps of identical code.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Part of a set of small PRs split from the too-broad #71484 (now closed); these are the reuse findings from a multi-angle review pass.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*