### PR TITLE
feat(tracing): carry the date range through the operation scene URL

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1315,8 +1315,19 @@ export const productUrls = {
     slackTaskContext: (): string => '/slack-task-context',
     toolbarLaunch: (): string => '/toolbar',
     tracing: (): string => '/tracing',
-    tracingOperation: (serviceName: string, spanName: string): string =>
-        combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
+    tracingOperation: (
+        serviceName: string,
+        spanName: string,
+        dateRange?: {
+            date_from?: string | null
+            date_to?: string | null
+        }
+    ): string =>
+        combineUrl('/tracing/operation', {
+            service: serviceName,
+            name: spanName,
+            ...(dateRange ? { dateRange: JSON.stringify(dateRange) } : {}),
+        }).url,
     userInterviews: (): string => '/user_research',
     userInterview: (id: string): string => `/user_research/${id}`,
     userInterviewResponse: (topicId: string, responseId: string): string =>

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -229,7 +229,9 @@ function TracingSceneContents(): JSX.Element {
                                 loading={aggregationLoading}
                                 windowMs={operationsWindowMs}
                                 onRowClick={(row) =>
-                                    router.actions.push(urls.tracingOperation(row.service_name, row.name))
+                                    router.actions.push(
+                                        urls.tracingOperation(row.service_name, row.name, filters.dateRange)
+                                    )
                                 }
                             />
                         ) : compareActive ? (

--- a/products/tracing/frontend/tracingOperationSceneLogic.test.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.test.ts
@@ -4,8 +4,8 @@ import api from 'lib/api'
 
 import { initKeaTests } from '~/test/init'
 
-import { tracingOperationSceneLogic } from './tracingOperationSceneLogic'
 import { DEFAULT_DATE_RANGE } from './tracingFiltersLogic'
+import { tracingOperationSceneLogic } from './tracingOperationSceneLogic'
 import type { Span } from './types'
 
 const createMockSample = (n: number): Span => ({

--- a/products/tracing/frontend/tracingOperationSceneLogic.test.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.test.ts
@@ -5,6 +5,7 @@ import api from 'lib/api'
 import { initKeaTests } from '~/test/init'
 
 import { tracingOperationSceneLogic } from './tracingOperationSceneLogic'
+import { DEFAULT_DATE_RANGE } from './tracingFiltersLogic'
 import type { Span } from './types'
 
 const createMockSample = (n: number): Span => ({
@@ -198,5 +199,29 @@ describe('tracingOperationSceneLogic', () => {
 
         await logic.asyncActions.fetchSampleTrace({ sample: logic.values.currentSample! })
         expect(getTraceSpy).toHaveBeenCalledWith('trace-1', expect.anything(), expect.anything())
+    })
+
+    it('restores a non-default date range from the URL', () => {
+        const dateRange = { date_from: '-7d', date_to: null }
+        router.actions.push('/tracing/operation', { service: 'web', name: 'db query', dateRange })
+        expect(logic.values.dateRange).toEqual(dateRange)
+    })
+
+    it('resets to the default range when navigating to a URL without one', () => {
+        logic.actions.setDateRange({ date_from: '-7d', date_to: null })
+        router.actions.push('/tracing/operation', { service: 'web', name: 'db query' })
+        expect(logic.values.dateRange).toEqual(DEFAULT_DATE_RANGE)
+    })
+
+    // A syntactically valid param of the wrong shape must not reach setDateRange and corrupt the query.
+    it.each([
+        ['a number', 42],
+        ['an array', []],
+        ['a wrong-typed field', { date_from: 5 }],
+    ])('keeps the current range when the URL date range is %s', (_label, dateRange) => {
+        const current = { date_from: '-7d', date_to: null }
+        logic.actions.setDateRange(current)
+        router.actions.push('/tracing/operation', { service: 'web', name: 'db query', dateRange })
+        expect(logic.values.dateRange).toEqual(current)
     })
 })

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -8,6 +8,7 @@ import api from 'lib/api'
 import { dataColorVars } from 'lib/colors'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic, type FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+import { objectsEqual } from 'lib/utils/objects'
 
 import { AggregatedSpanRow, DateRange } from '~/queries/schema/schema-general'
 
@@ -539,8 +540,11 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
 
     actionToUrl(({ values }) => {
         const withSelectionParams = (): [string, Record<string, any>, Record<string, any>, { replace: boolean }] => {
-            const { min, max, sample, chart, ...rest } = router.values.searchParams
+            const { min, max, sample, chart, dateRange, ...rest } = router.values.searchParams
             const params: Record<string, any> = { ...rest }
+            if (!objectsEqual(values.dateRange, DEFAULT_DATE_RANGE)) {
+                params.dateRange = JSON.stringify(values.dateRange)
+            }
             if (values.durationSelection) {
                 params.min = values.durationSelection.minNs
                 params.max = values.durationSelection.maxNs
@@ -554,6 +558,7 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             return [router.values.location.pathname, params, router.values.hashParams, { replace: true }]
         }
         return {
+            setDateRange: withSelectionParams,
             setDurationSelection: withSelectionParams,
             setSampleIndex: withSelectionParams,
             setChartType: withSelectionParams,
@@ -565,10 +570,24 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             if (method === 'REPLACE') {
                 return // our own actionToUrl writes
             }
+            // Restore the date range first: setDateRange resets sampleIndex.
+            if (searchParams.dateRange) {
+                try {
+                    const dateRange =
+                        typeof searchParams.dateRange === 'string'
+                            ? JSON.parse(searchParams.dateRange)
+                            : searchParams.dateRange
+                    if (!objectsEqual(dateRange, values.dateRange)) {
+                        actions.setDateRange(dateRange)
+                    }
+                } catch {
+                    // Malformed param — keep the current range.
+                }
+            }
             const minNs = parseInt(String(searchParams.min), 10)
             const maxNs = parseInt(String(searchParams.max), 10)
             const selection = !isNaN(minNs) && !isNaN(maxNs) ? { minNs, maxNs } : null
-            if (JSON.stringify(selection) !== JSON.stringify(values.durationSelection)) {
+            if (!objectsEqual(selection, values.durationSelection)) {
                 actions.setDurationSelection(selection)
             }
             const sample = parseInt(String(searchParams.sample), 10)

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -234,6 +234,31 @@ function trackedSignal(cache: Record<string, any>, key: string): AbortSignal {
     return controller.signal
 }
 
+function isDateRange(value: unknown): value is DateRange {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return false
+    }
+    const { date_from, date_to } = value as Record<string, unknown>
+    return (
+        (date_from === undefined || date_from === null || typeof date_from === 'string') &&
+        (date_to === undefined || date_to === null || typeof date_to === 'string')
+    )
+}
+
+// Returns a valid DateRange from the URL param, or null when it is missing,
+// malformed JSON, or a syntactically valid value of the wrong shape.
+function parseDateRangeParam(raw: unknown): DateRange | null {
+    let value = raw
+    if (typeof raw === 'string') {
+        try {
+            value = JSON.parse(raw)
+        } catch {
+            return null
+        }
+    }
+    return isDateRange(value) ? value : null
+}
+
 export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
     props({} as TracingOperationSceneLogicProps),
     key(({ serviceName, spanName }) => `${serviceName}//${spanName}`),
@@ -566,23 +591,22 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
     }),
 
     urlToAction(({ actions, values }) => ({
-        '/tracing/operation': (_, searchParams, __, { method }) => {
-            if (method === 'REPLACE') {
-                return // our own actionToUrl writes
-            }
+        '/tracing/operation': (_, searchParams) => {
+            // Don't gate on the navigation method: the equality guards below make
+            // re-processing our own (REPLACE) actionToUrl writes a no-op, while still
+            // restoring state when the scene is entered via a router replacement.
+            //
             // Restore the date range first: setDateRange resets sampleIndex.
             if (searchParams.dateRange) {
-                try {
-                    const dateRange =
-                        typeof searchParams.dateRange === 'string'
-                            ? JSON.parse(searchParams.dateRange)
-                            : searchParams.dateRange
-                    if (!objectsEqual(dateRange, values.dateRange)) {
-                        actions.setDateRange(dateRange)
-                    }
-                } catch {
-                    // Malformed param — keep the current range.
+                const dateRange = parseDateRangeParam(searchParams.dateRange)
+                // A malformed or wrong-shaped param yields null — keep the current range.
+                if (dateRange && !objectsEqual(dateRange, values.dateRange)) {
+                    actions.setDateRange(dateRange)
                 }
+            } else if (!objectsEqual(values.dateRange, DEFAULT_DATE_RANGE)) {
+                // No range in the URL — fall back to the default so a back/forward
+                // navigation off a non-default URL doesn't keep a stale range.
+                actions.setDateRange(DEFAULT_DATE_RANGE)
             }
             const minNs = parseInt(String(searchParams.min), 10)
             const maxNs = parseInt(String(searchParams.max), 10)

--- a/products/tracing/manifest.tsx
+++ b/products/tracing/manifest.tsx
@@ -37,8 +37,16 @@ export const manifest: ProductManifest = {
         tracing: (): string => '/tracing',
         // Query params rather than path segments: span names ("GET /api/stats") contain slashes
         // and arbitrary characters that break path routing.
-        tracingOperation: (serviceName: string, spanName: string): string =>
-            combineUrl('/tracing/operation', { service: serviceName, name: spanName }).url,
+        tracingOperation: (
+            serviceName: string,
+            spanName: string,
+            dateRange?: { date_from?: string | null; date_to?: string | null }
+        ): string =>
+            combineUrl('/tracing/operation', {
+                service: serviceName,
+                name: spanName,
+                ...(dateRange ? { dateRange: JSON.stringify(dateRange) } : {}),
+            }).url,
     },
     fileSystemTypes: {},
     treeItemsNew: [],


### PR DESCRIPTION
## Problem

Clicking a row on the Operations tab computed over, say, the last 7 days opens the operation detail scene on the default last hour — the stats describe a different window than the row the user clicked. The scene's date range also doesn't survive reloads or shared links, though the duration selection and sample index already do.

## Changes

`urls.tracingOperation` takes an optional `dateRange`, the Operations tab passes its active range, and the scene logic persists non-default ranges to the URL and restores them on load (restored before the selection params, since `setDateRange` resets the pager). Also swaps a `JSON.stringify` comparison for `objectsEqual`.

## How did you test this code?

`tracingOperationSceneLogic.test.ts` passes locally. `products.tsx` regenerated via `pnpm build:products`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude); `/writing-kea-logics` conventions followed for the router bindings. Part of a set of small PRs split from the too-broad #71484 (now closed).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*