### PR TITLE
fix(tracing): harden operation scene request lifecycle

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2901,6 +2901,8 @@ const api = {
                 // false (default) groups by trace_id and returns root spans; true returns every
                 // matching span (root and child) flat. See products/tracing/backend logic.py.
                 flatSpans?: boolean
+                // true omits the per-span attribute maps — use when only scalar span fields are read.
+                excludeAttributes?: boolean
             },
             signal?: AbortSignal
         ): Promise<{
@@ -2918,12 +2920,14 @@ const api = {
                 statusCodes?: number[]
                 filterGroup?: PropertyGroupFilter
                 offset?: number
-            }
+            },
+            signal?: AbortSignal
         ): Promise<{ results: Record<string, any>[]; hasMore: boolean; nextOffset?: number | null }> {
             return new ApiRequest()
                 .tracingSpans()
                 .withAction(`trace/${traceId}`)
                 .create({
+                    signal,
                     data: {
                         ...query,
                         dateRange: query?.dateRange ?? { date_from: '-24h' },

--- a/products/tracing/frontend/OperationHistogram.tsx
+++ b/products/tracing/frontend/OperationHistogram.tsx
@@ -19,6 +19,8 @@ interface OperationHistogramProps {
     selection: DurationRange | null
     onSelect: (selection: DurationRange) => void
     onClear: () => void
+    /** Clearing the selection refetches samples — disable the button while that's in flight. */
+    samplesLoading?: boolean
 }
 
 export function OperationHistogram({
@@ -27,6 +29,7 @@ export function OperationHistogram({
     selection,
     onSelect,
     onClear,
+    samplesLoading = false,
 }: OperationHistogramProps): JSX.Element {
     const onSelectionChange = useCallback(
         ({ startIndex, endIndex }: { startIndex: number; endIndex: number }): void => {
@@ -65,7 +68,12 @@ export function OperationHistogram({
                         <span className="text-xs font-mono">
                             {formatBucketLabel(selection.minNs)} – {formatBucketLabel(selection.maxNs)}
                         </span>
-                        <LemonButton size="xsmall" type="tertiary" onClick={onClear}>
+                        <LemonButton
+                            size="xsmall"
+                            type="tertiary"
+                            onClick={onClear}
+                            disabledReason={samplesLoading ? 'Loading samples…' : undefined}
+                        >
                             Clear
                         </LemonButton>
                     </>

--- a/products/tracing/frontend/TracingOperationScene.tsx
+++ b/products/tracing/frontend/TracingOperationScene.tsx
@@ -58,11 +58,11 @@ export function TracingOperationScene(): JSX.Element {
     } = useValues(tracingOperationSceneLogic)
     const { setDateRange, setDurationSelection, setSampleIndex, selectSpan } = useActions(tracingOperationSceneLogic)
 
-    if (!spanName) {
+    if (!spanName || !serviceName) {
         return (
             <SceneContent>
                 <div className="flex flex-col items-center gap-1 py-16">
-                    <span>This link is missing an operation name.</span>
+                    <span>This link is missing an operation or service name.</span>
                     <Link to={urls.tracing()}>Back to tracing</Link>
                 </div>
             </SceneContent>
@@ -105,6 +105,7 @@ export function TracingOperationScene(): JSX.Element {
                 selection={durationSelection}
                 onSelect={setDurationSelection}
                 onClear={() => setDurationSelection(null)}
+                samplesLoading={samplesLoading}
             />
             <SceneDivider />
             {samples.length === 0 && samplesLoading ? (

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -68,9 +68,9 @@ export interface VisibleSpanTimeRange {
 
 const DEFAULT_PAGE_SIZE = 100
 export const PREFETCH_SPANS = 20
-const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
+export const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 
-function isUserInitiatedError(error: unknown): boolean {
+export function isUserInitiatedError(error: unknown): boolean {
     const errorStr = String(error).toLowerCase()
     return error === NEW_QUERY_STARTED_ERROR_MESSAGE || errorStr.includes('abort')
 }

--- a/products/tracing/frontend/tracingOperationSceneLogic.test.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.test.ts
@@ -80,7 +80,8 @@ describe('tracingOperationSceneLogic', () => {
                         },
                     ],
                 },
-            })
+            }),
+            expect.anything()
         )
     })
 
@@ -91,7 +92,7 @@ describe('tracingOperationSceneLogic', () => {
         expect(logic.values.sampleTraceSpansLoading).toBe(true)
 
         await logic.asyncActions.fetchSampleTrace({ sample: logic.values.currentSample! })
-        expect(getTraceSpy).toHaveBeenLastCalledWith('trace-2', expect.anything())
+        expect(getTraceSpy).toHaveBeenLastCalledWith('trace-2', expect.anything(), expect.anything())
         expect(logic.values.selectedSpanId).toBe('span-2')
     })
 

--- a/products/tracing/frontend/tracingOperationSceneLogic.test.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.test.ts
@@ -100,4 +100,43 @@ describe('tracingOperationSceneLogic', () => {
         router.actions.push('/tracing/operation', { sample: '-1' })
         expect(logic.values.sampleIndex).toBe(0)
     })
+
+    // A trace longer than the ±1h lookup window can share a trace_id with the loaded waterfall yet
+    // omit spans that fell outside it — reuse must be gated on the span actually being present.
+    it.each([
+        { desc: 'refetches when the loaded trace lacks the paged-to span', loaded: ['span-a'], expectLoading: true },
+        {
+            desc: 'reuses the loaded trace when it already contains the paged-to span',
+            loaded: ['span-a', 'span-b'],
+            expectLoading: false,
+        },
+    ])('paging within a shared trace $desc', async ({ loaded, expectLoading }) => {
+        const sameTrace = (spanId: string): Span => ({
+            ...createMockSample(1),
+            span_id: spanId,
+            trace_id: 'trace-long',
+        })
+        logic.actions.fetchSamplesSuccess([sameTrace('span-a'), sameTrace('span-b')])
+        logic.actions.fetchSampleTraceSuccess(loaded.map(sameTrace))
+
+        logic.actions.setSampleIndex(1)
+        expect(logic.values.sampleTraceSpansLoading).toBe(expectLoading)
+
+        // Settle any in-flight fetch so it can't resolve after the test ends.
+        await logic.asyncActions.fetchSampleTrace({ sample: logic.values.currentSample! })
+    })
+
+    it('recovers a retained sample when a failed refetch is left with a stale index', async () => {
+        logic.actions.fetchSamplesSuccess([1, 2].map(createMockSample))
+        // Browser navigation can move the index past the retained set while a refetch is in flight.
+        logic.actions.setSampleIndex(5)
+        getTraceSpy.mockClear()
+
+        logic.actions.fetchSamplesFailure('network down')
+        // The stale index clamps back into the retained set so the waterfall reloads, not stays blank.
+        expect(logic.values.sampleIndex).toBe(0)
+
+        await logic.asyncActions.fetchSampleTrace({ sample: logic.values.currentSample! })
+        expect(getTraceSpy).toHaveBeenCalledWith('trace-1', expect.anything(), expect.anything())
+    })
 })

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -316,8 +316,10 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
                 return
             }
             // Adjacent samples often share a trace (a child operation hit N times per request) —
-            // re-anchor on the already-loaded trace instead of refetching it.
-            if (values.sampleTraceSpans[0]?.trace_id === sample.trace_id) {
+            // re-anchor on the already-loaded trace instead of refetching it, but only when that
+            // trace actually contains this span: a trace longer than the ±1h lookup window can
+            // share a trace_id yet omit spans that fell outside the window of the earlier fetch.
+            if (values.sampleTraceSpans.some((span) => span.span_id === sample.span_id)) {
                 actions.selectSpan(sample.span_id)
                 return
             }
@@ -359,7 +361,13 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             }
             lemonToast.error(`Failed to load sample traces: ${error}`)
             // The failed refetch already blanked the waterfall (see the sampleTraceSpans reducer);
-            // reload the trace for the retained samples so the scene stays usable.
+            // reload the trace for the retained samples so the scene stays usable. A stale index
+            // (e.g. restored from the URL mid-load) can point past the retained set, resolving to
+            // no current sample — clamp it back to 0 first, mirroring fetchSamplesSuccess.
+            if (values.sampleIndex >= values.samples.length) {
+                actions.setSampleIndex(0)
+                return
+            }
             actions.loadCurrentSampleTrace()
         },
         fetchStatsFailure: ({ error }) => {

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -120,7 +120,9 @@ export interface tracingOperationSceneLogicActions {
         operationStats: AggregatedSpanRow | null
         payload?: void
     }
-    loadCurrentSampleTrace: (_: void) => void
+    loadCurrentSampleTrace: () => {
+        value: true
+    }
     selectSpan: (spanId: string | null) => {
         spanId: string | null
     }

--- a/products/tracing/frontend/tracingOperationSceneLogic.ts
+++ b/products/tracing/frontend/tracingOperationSceneLogic.ts
@@ -12,6 +12,7 @@ import { AggregatedSpanRow, DateRange } from '~/queries/schema/schema-general'
 import { type DurationHistogramRow, pivotDurationHistogram, type TracingDurationHistogramData } from './durationBuckets'
 import { type DurationRange, operationFilterGroup } from './operationFilters'
 import { traceLookupDateRange } from './traceLinks'
+import { isUserInitiatedError, NEW_QUERY_STARTED_ERROR_MESSAGE } from './tracingDataLogic'
 import { DEFAULT_DATE_RANGE } from './tracingFiltersLogic'
 import type { Span } from './types'
 
@@ -119,6 +120,7 @@ export interface tracingOperationSceneLogicActions {
         operationStats: AggregatedSpanRow | null
         payload?: void
     }
+    loadCurrentSampleTrace: (_: void) => void
     selectSpan: (spanId: string | null) => {
         spanId: string | null
     }
@@ -154,6 +156,22 @@ export type tracingOperationSceneLogicType = MakeLogicType<
     tracingOperationSceneLogicMeta
 >
 
+// One tracked AbortController per loader: re-issuing a fetch aborts the superseded request
+// (not just discards its result), and unmount aborts whatever is still in flight.
+function trackedSignal(cache: Record<string, any>, key: string): AbortSignal {
+    let controller!: AbortController
+    cache.disposables.add(
+        () => {
+            controller = new AbortController()
+            return () => controller.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
+        },
+        key,
+        // In-flight requests must survive tab switches — only supersession or unmount aborts.
+        { pauseOnPageHidden: false }
+    )
+    return controller.signal
+}
+
 export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
     props({} as TracingOperationSceneLogicProps),
     key(({ serviceName, spanName }) => `${serviceName}//${spanName}`),
@@ -165,22 +183,26 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
         setSampleIndex: (index: number) => ({ index }),
         selectSpan: (spanId: string | null) => ({ spanId }),
         setSamplesHaveMore: (hasMore: boolean) => ({ hasMore }),
+        loadCurrentSampleTrace: true,
     }),
 
-    loaders(({ props, values, actions }) => ({
+    loaders(({ props, values, actions, cache }) => ({
         rawHistogram: [
             [] as DurationHistogramRow[],
             {
                 fetchHistogram: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.durationHistogram({
-                        dateRange: values.dateRange,
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, null),
-                        // Span-level: operations are often child spans, and the samples query
-                        // below is span-level too — both must count the same population.
-                        rootSpans: false,
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.durationHistogram(
+                        {
+                            dateRange: values.dateRange,
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, null),
+                            // Span-level: operations are often child spans, and the samples query
+                            // below is span-level too — both must count the same population.
+                            rootSpans: false,
+                        },
+                        trackedSignal(cache, 'fetchHistogram')
+                    )
                     breakpoint()
                     return response.results
                 },
@@ -190,16 +212,22 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             [] as Span[],
             {
                 fetchSamples: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.listSpans({
-                        dateRange: values.dateRange,
-                        orderBy: 'timestamp',
-                        orderDirection: 'DESC',
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, values.durationSelection),
-                        flatSpans: true,
-                        limit: SAMPLE_LIMIT,
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.listSpans(
+                        {
+                            dateRange: values.dateRange,
+                            orderBy: 'timestamp',
+                            orderDirection: 'DESC',
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, values.durationSelection),
+                            flatSpans: true,
+                            limit: SAMPLE_LIMIT,
+                            // Samples only feed the pager header (5 scalar fields); the waterfall
+                            // loads the full trace separately, so skip the heavy attribute maps.
+                            excludeAttributes: true,
+                        },
+                        trackedSignal(cache, 'fetchSamples')
+                    )
                     breakpoint()
                     actions.setSamplesHaveMore(!!response.hasMore)
                     return response.results as Span[]
@@ -210,12 +238,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             null as AggregatedSpanRow | null,
             {
                 fetchStats: async (_: void, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.aggregate({
-                        dateRange: values.dateRange,
-                        serviceNames: [props.serviceName],
-                        filterGroup: operationFilterGroup(props.spanName, null),
-                    })
+                    await breakpoint(10) // coalesce same-tick dispatches (URL restore + afterMount)
+                    const response = await api.tracing.aggregate(
+                        {
+                            dateRange: values.dateRange,
+                            serviceNames: [props.serviceName],
+                            filterGroup: operationFilterGroup(props.spanName, null),
+                        },
+                        trackedSignal(cache, 'fetchStats')
+                    )
                     breakpoint()
                     return response.results.find((row) => row.name === props.spanName) ?? null
                 },
@@ -225,10 +256,14 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             [] as Span[],
             {
                 fetchSampleTrace: async ({ sample }: { sample: Span }, breakpoint) => {
-                    await breakpoint(100)
-                    const response = await api.tracing.getTrace(sample.trace_id, {
-                        dateRange: traceLookupDateRange(sample.timestamp),
-                    })
+                    await breakpoint(100) // debounce rapid pager clicks
+                    const response = await api.tracing.getTrace(
+                        sample.trace_id,
+                        {
+                            dateRange: traceLookupDateRange(sample.timestamp),
+                        },
+                        trackedSignal(cache, 'fetchSampleTrace')
+                    )
                     breakpoint()
                     return response.results as Span[]
                 },
@@ -275,6 +310,19 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             actions.fetchSamples()
             actions.fetchStats()
         },
+        loadCurrentSampleTrace: () => {
+            const sample = values.currentSample
+            if (!sample) {
+                return
+            }
+            // Adjacent samples often share a trace (a child operation hit N times per request) —
+            // re-anchor on the already-loaded trace instead of refetching it.
+            if (values.sampleTraceSpans[0]?.trace_id === sample.trace_id) {
+                actions.selectSpan(sample.span_id)
+                return
+            }
+            actions.fetchSampleTrace({ sample })
+        },
         fetchSamplesSuccess: ({ samples }) => {
             if (samples.length === 0) {
                 actions.selectSpan(null)
@@ -285,14 +333,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
                 actions.setSampleIndex(0)
                 return
             }
-            if (values.currentSample) {
-                actions.fetchSampleTrace({ sample: values.currentSample })
-            }
+            actions.loadCurrentSampleTrace()
         },
         setSampleIndex: () => {
-            if (values.currentSample) {
-                actions.fetchSampleTrace({ sample: values.currentSample })
+            // While samples are (re)loading, the index points into the outgoing result set;
+            // fetchSamplesSuccess (or fetchSamplesFailure) loads the trace for the resolved index.
+            if (values.samplesLoading) {
+                return
             }
+            actions.loadCurrentSampleTrace()
         },
         fetchSampleTraceSuccess: () => {
             // Anchor the waterfall on the operation's own span — for child operations the
@@ -300,16 +349,28 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
             actions.selectSpan(values.currentSample?.span_id ?? null)
         },
         fetchHistogramFailure: ({ error }) => {
-            lemonToast.error(`Failed to load latency distribution: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load latency distribution: ${error}`)
+            }
         },
         fetchSamplesFailure: ({ error }) => {
+            if (isUserInitiatedError(error)) {
+                return
+            }
             lemonToast.error(`Failed to load sample traces: ${error}`)
+            // The failed refetch already blanked the waterfall (see the sampleTraceSpans reducer);
+            // reload the trace for the retained samples so the scene stays usable.
+            actions.loadCurrentSampleTrace()
         },
         fetchStatsFailure: ({ error }) => {
-            lemonToast.error(`Failed to load operation stats: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load operation stats: ${error}`)
+            }
         },
         fetchSampleTraceFailure: ({ error }) => {
-            lemonToast.error(`Failed to load trace: ${error}`)
+            if (!isUserInitiatedError(error)) {
+                lemonToast.error(`Failed to load trace: ${error}`)
+            }
         },
     })),
 
@@ -350,13 +411,15 @@ export const tracingOperationSceneLogic = kea<tracingOperationSceneLogicType>([
         },
     })),
 
-    afterMount(({ actions, values }) => {
+    afterMount(({ actions, props }) => {
+        // A malformed link renders the scene's missing-params fallback; don't query for it.
+        if (!props.spanName || !props.serviceName) {
+            return
+        }
+        // URL restore may have dispatched these already in this same tick — the loaders'
+        // leading breakpoint coalesces the duplicates into one request each.
         actions.fetchHistogram()
         actions.fetchStats()
-        // A deep link restores the selection via urlToAction, whose listener already fetches
-        // samples — only fetch directly when mounting without one.
-        if (!values.durationSelection) {
-            actions.fetchSamples()
-        }
+        actions.fetchSamples()
     }),
 ])


### PR DESCRIPTION
## Problem

The operation detail scene relies only on kea breakpoints to discard stale results — superseded ClickHouse queries keep running server-side (unlike `tracingDataLogic`, which aborts them). It also transfers span attribute maps it never renders, refetches a trace the pager already has when adjacent samples share one, leaves a permanently blank waterfall when a samples refetch fails, fires queries for links missing the service param, and leaves clear-selection buttons clickable while the refetch they trigger is in flight.

## Changes

- Each loader carries a tracked `AbortController` (via the disposables plugin, with `pauseOnPageHidden: false`) that aborts the superseded request on re-issue and whatever is in flight on unmount; abort-driven failures are excluded from error toasts via the shared `isUserInitiatedError`.
- The samples query passes `excludeAttributes` — the scene reads only scalar span fields; the waterfall loads the full trace separately.
- A shared `loadCurrentSampleTrace` action reuses the loaded waterfall when the target sample lives in the same trace, and reloads it after a failed samples refetch so the scene stays usable.
- Links missing the service param render the missing-params fallback without firing the mount queries.
- Clear-selection buttons disable while a samples fetch is in flight, per the double-submission rule.
- `api.tracing.getTrace` accepts an `AbortSignal`; `listSpans` gains the (already backend-supported) `excludeAttributes` param.

## How did you test this code?

`tracingOperationSceneLogic.test.ts` and `tracingDataLogic.test.ts` pass locally (29 tests), including the drag-selection refetch and sample-paging regressions, with assertions updated for the new signal argument.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude); `/using-kea-disposables` invoked for the AbortController pattern, `/writing-tests` for the assertion updates. Part of a set of small PRs split from the too-broad #71484 (now closed). This is the largest of the set because the abort, reuse, and failure-recovery paths all rewrite the same loader/listener blocks and can't be separated without conflicts.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*