### PR TITLE
fix(workflows): variable-scan metric cardinality, timing, and bytecode skip

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-variable-usage.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-variable-usage.test.ts
@@ -74,6 +74,22 @@ describe('findMissingVariableReferences', () => {
             expected: [],
         },
         {
+            name: 'bytecode is not scanned even when a constant embeds matching text',
+            config: {
+                inputs: {
+                    subject: {
+                        value: 'plain text',
+                        // A template string carried verbatim as a bytecode constant: the executor
+                        // renders from `value`, so this must not be reported
+                        bytecode: ['_H', 1, 32, 'Your code: {{ variables.ghost }}'],
+                        transpiled: 'return `${variables.spectre}`',
+                    },
+                },
+            },
+            variables: {},
+            expected: [],
+        },
+        {
             name: 'multiple missing references come back sorted and unique',
             config: {
                 inputs: {

--- a/nodejs/src/cdp/services/hogflows/hogflow-variable-usage.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-variable-usage.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { Counter } from 'prom-client'
+import { Counter, Histogram } from 'prom-client'
 
 import { HogFlowAction } from '~/cdp/schema/hogflow'
 import { CyclotronJobInvocationHogFlow, CyclotronJobInvocationResult } from '~/cdp/types'
@@ -7,20 +7,34 @@ import { logger } from '~/common/utils/logger'
 
 import { actionIdForLogging } from './hogflow-utils'
 
+// Deliberately unlabelled: the metric answers "how common are variable misses fleet-wide" (it
+// sizes the publish-time lint work); which flow/step/variable missed is in the warn log, where
+// unbounded cardinality belongs.
 const counterMissingVariableReference = new Counter({
     name: 'cdp_hogflow_missing_variable_reference',
     help: 'A workflow step referenced a variable that is not set for the run, so it renders empty',
-    labelNames: ['hog_flow_id'],
+})
+
+// The scan runs on every fresh entry into a function step, so its cost has to stay observable.
+const histogramVariableScanDuration = new Histogram({
+    name: 'cdp_hogflow_variable_scan_duration_seconds',
+    help: 'Time spent scanning a step config for workflow variable references',
+    buckets: [0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5],
 })
 
 // Both templating modes reference workflow variables textually: `{variables.foo}` (hog) and
-// `{{ variables.foo }}` (liquid), plus the bracket form `variables['my-var']`. A regex scan over
-// the raw template strings covers both without parsing either language. Compiled hog bytecode
-// never matches (it stores 'variables' and the key as separate string constants), so scanning a
-// whole config is safe.
+// `{{ variables.foo }}` (liquid), plus the bracket form `variables['my-var']`.  A regex scan over
+// the raw template strings covers both without parsing either language.
 const DOT_REFERENCE_REGEX = /\bvariables\.([A-Za-z_$][A-Za-z0-9_$]*)/g
 // Whitespace allowed around the brackets and quotes - liquid accepts `variables[ 'x' ]`
 const BRACKET_REFERENCE_REGEX = /\bvariables\s*\[\s*['"]([^'"\]]+)['"]\s*\]/g
+
+// Compiled hog output carried alongside the template strings. Never scanned: it's by far the
+// bulkiest part of a config (hundreds of elements per input), references in it are stored as
+// separate string constants that can't match the regexes, and a liquid/template string embedded
+// verbatim as a bytecode constant would be a false positive - the executor renders from the
+// template, not from that constant.
+const SKIPPED_KEYS = new Set(['bytecode', 'transpiled'])
 
 const collectReferences = (value: unknown, into: Set<string>): void => {
     if (typeof value === 'string') {
@@ -36,7 +50,11 @@ const collectReferences = (value: unknown, into: Set<string>): void => {
         return
     }
     if (value && typeof value === 'object') {
-        Object.values(value).forEach((item) => collectReferences(item, into))
+        Object.entries(value).forEach(([key, item]) => {
+            if (!SKIPPED_KEYS.has(key)) {
+                collectReferences(item, into)
+            }
+        })
     }
 }
 
@@ -68,10 +86,12 @@ export function observeMissingVariableReferences(
     action: HogFlowAction,
     result: CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow>
 ): void {
+    const stopTimer = histogramVariableScanDuration.startTimer()
     const missing = findMissingVariableReferences(
         action.config as { inputs?: unknown; mappings?: unknown },
         invocation.state.variables
     )
+    stopTimer()
     if (missing.length === 0) {
         return
     }
@@ -87,5 +107,5 @@ export function observeMissingVariableReferences(
         actionId: action.id,
         missing,
     })
-    counterMissingVariableReference.labels({ hog_flow_id: invocation.hogFlow.id }).inc()
+    counterMissingVariableReference.inc()
 }


### PR DESCRIPTION
## Problem

Review follow-ups on #71060 (variable-miss tracing), raised in the [team Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1784197503274559) after it auto-merged:

1. The miss counter is labelled `hog_flow_id` - one Prometheus series per workflow UUID that ever misses a variable, unbounded cardinality for a metric whose job is fleet-wide ("are misses common enough to justify the publish-time lint?").
2. The regex scan runs on every fresh entry into a function step with no timing instrumentation, so its cost is assumed rather than observed.
3. The scan traverses compiled `bytecode` arrays. The in-code comment claimed that's safe because compiled references store `variables` and the key as separate constants - true for compiled references, but a template string embedded **verbatim as a bytecode constant** (or the `transpiled` JS form) does match the regex while the executor never renders from it: wasted work on the bulkiest part of the config, plus a latent false-positive warning.

## Changes

- `cdp_hogflow_missing_variable_reference` is now unlabelled. The per-flow drill-down lives in the structured warn log, which already carries team, flow, action, and the missing names - strictly richer than the label was. The metric is a day old, so nothing charts by the old label yet.
- New `cdp_hogflow_variable_scan_duration_seconds` histogram around the scan (fixed buckets, 0.5ms-500ms). If it flatlines sub-millisecond we can delete it later with evidence in hand.
- The traversal skips `bytecode` and `transpiled` keys, with the comment corrected to explain the false-positive case rather than asserting safety.

## How did you test this code?

Extended the existing parameterized suite with a row where a matching-looking template string sits inside a bytecode constant and a `transpiled` string - it must not be reported (catches anyone removing the skip and reintroducing the false positive; the pre-existing bytecode row only covered the compiled-reference shape that can't match). Full `hogflow-variable-usage` + `hog_function` suites pass (28 tests), lint and tsc clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - internal observability only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), addressing colleague review feedback relayed from Slack. Skills invoked: `/writing-tests`. The bytecode-skip finding turned out to be a correctness fix, not just perf - the original safety comment held for compiled references but not for template strings carried verbatim as constants.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*