### PR TITLE
fix(signals): use web URL for inbox report link in autostart PR footer

### DIFF
--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -117,7 +117,7 @@ def _build_autostart_task_description(
         "social faux pas in someone else's project.\n\n"
         "When opening the PR, include this report link in the description footer, "
         "making the footer '*Created with [PostHog Code](https://posthog.com/code?ref=pr) "
-        f"from [an inbox report]({report_link}).' - "
+        f"from [this inbox report]({report_link}).' - "
         "so the human reviewer can jump straight to it."
     )
 

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import TypedDict, TypeVar
 
+from django.conf import settings
 from django.db import transaction
 
 import structlog
@@ -36,7 +37,6 @@ from products.signals.backend.report_generation.research import (
 from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
 from products.signals.backend.report_generation.select_repo import RepoSelectionResult
 from products.signals.backend.signal_metadata import fetch_source_products_for_reports
-from products.signals.backend.slack_inbox_notifications import POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME
 from products.signals.backend.task_run_artefacts import (
     SIGNALS_PRODUCT,
     TASK_RUN_TYPE_IMPLEMENTATION,
@@ -85,10 +85,13 @@ def _report_meets_team_autostart_threshold(report_priority: Priority, team_defau
 
 
 def _build_autostart_task_description(
-    *, report_id: str, summary: str, repository: str, priority: PriorityAssessment | None
+    *, report_id: str, team_id: int, summary: str, repository: str, priority: PriorityAssessment | None
 ) -> str:
     priority_line = f"Priority: {priority.priority.value}\nReason: {priority.explanation}\n\n" if priority else ""
-    report_deep_link = f"{POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME}://inbox/{report_id}"
+    # Web URL to the report (same shape as the Slack "Open in PostHog" button), not the
+    # `posthog-code://` desktop deep link — GitHub markdown strips custom URL schemes, so a
+    # deep-link footer renders as dead plain text in the PR description.
+    report_link = f"{settings.SITE_URL}/project/{team_id}/inbox/reports/{report_id}"
     return (
         f"{summary}\n\n"
         f"{priority_line}"
@@ -112,9 +115,9 @@ def _build_autostart_task_description(
         "the user to that branch so they can review the changes and decide how to proceed, and explain in your "
         "turn summary why you didn't open the PR directly. Err on the side of caution to avoid committing a "
         "social faux pas in someone else's project.\n\n"
-        "When opening the PR, include this report deep link in the description footer, "
+        "When opening the PR, include this report link in the description footer, "
         "making the footer '*Created with [PostHog Code](https://posthog.com/code?ref=pr) "
-        f"from [an inbox report]({report_deep_link}).' - "
+        f"from [an inbox report]({report_link}).' - "
         "so the human reviewer can jump straight to it."
     )
 
@@ -491,7 +494,7 @@ async def maybe_autostart_implementation_task(
         report_id=report_id,
         title=title,
         description=_build_autostart_task_description(
-            report_id=report_id, summary=summary, repository=repository, priority=priority
+            report_id=report_id, team_id=team_id, summary=summary, repository=repository, priority=priority
         ),
         user_id=task_user.id,
         repository=repository,

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -88,9 +88,6 @@ def _build_autostart_task_description(
     *, report_id: str, team_id: int, summary: str, repository: str, priority: PriorityAssessment | None
 ) -> str:
     priority_line = f"Priority: {priority.priority.value}\nReason: {priority.explanation}\n\n" if priority else ""
-    # Web URL to the report (same shape as the Slack "Open in PostHog" button), not the
-    # `posthog-code://` desktop deep link — GitHub markdown strips custom URL schemes, so a
-    # deep-link footer renders as dead plain text in the PR description.
     report_link = f"{settings.SITE_URL}/project/{team_id}/inbox/reports/{report_id}"
     return (
         f"{summary}\n\n"


### PR DESCRIPTION
Vibed description:

## Problem

Auto-started inbox PRs footer a backlink to the report that spawned them, but the link isn't clickable — it renders as dead plain text. The autostart task prompt instructed the agent to use a `posthog-code://inbox/<id>` desktop deep link, and GitHub markdown only linkifies `http`/`https`/`mailto`, silently stripping custom URL schemes. This affected every autostarted inbox PR, not just older ones.

## Changes

Swap the deep link for the same web URL the Slack "Open in PostHog" button already uses: `{SITE_URL}/project/{team_id}/inbox/reports/{report_id}`. Threads `team_id` (already in scope at the call site) into the description builder and drops the now-unused deep-link-scheme import.

## Why

Reviewers on auto-generated inbox PRs couldn't click through to the originating report — the footer link was inert plain text. This restores the intended one-click jump back to the report.

## How did you test this code?

`auto_start.py` parses cleanly; the change is a string-construction swap mirroring the verified working URL shape in `slack_inbox_notifications.py`. No existing test exercised `_build_autostart_task_description`, so there was no test to update. I (the agent) did not run the Django test suite or boot the app in this environment.

## Docs update

No user-facing docs affected.

## 🤖 Agent context

Fully autonomous

Authored by the PostHog Slack app from a Slack thread reporting that the inbox-report backlink in an auto-generated PR wasn't working.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1784137445605899?thread_ts=1784137445.605899&cid=C09SK2PAGKF)*
