### PR TITLE
fix(surveys): respect position setting for embedded tab feedback button

### DIFF
--- a/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
+++ b/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
@@ -53,9 +53,10 @@ export function SurveyWidgetCustomization(): JSX.Element {
                             <LemonSelect
                                 value={appearance.widgetType}
                                 onChange={(widgetType) => {
-                                    // NextToTrigger is only available for Selector widget type
+                                    // NextToTrigger is available for both Selector and Tab widget types
                                     const newPosition =
                                         widgetType !== SurveyWidgetType.Selector &&
+                                        widgetType !== SurveyWidgetType.Tab &&
                                         appearance?.position === SurveyPosition.NextToTrigger
                                             ? SurveyPosition.Right
                                             : appearance?.position

--- a/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
+++ b/frontend/src/scenes/surveys/survey-appearance/SurveyAppearanceSections.tsx
@@ -173,8 +173,10 @@ export function SurveyContainerAppearance({
             <LemonField.Pure
                 label="Position"
                 info={
-                    surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector
-                        ? 'The "next to feedback button" option requires posthog.js version 1.235.2 or higher.'
+                    surveyType === SurveyType.Widget &&
+                    (appearance.widgetType === SurveyWidgetType.Selector ||
+                        appearance.widgetType === SurveyWidgetType.Tab)
+                        ? 'The "next to button" option requires posthog.js version 1.235.2 or higher.'
                         : undefined
                 }
                 className="gap-1"
@@ -196,27 +198,31 @@ export function SurveyContainerAppearance({
                         disabledReason={disabledReason || undefined}
                     />
                 </div>
-                {surveyType === SurveyType.Widget && appearance.widgetType === SurveyWidgetType.Selector && (
-                    <div className="flex flex-col gap-1 items-start w-60">
-                        <LemonButton
-                            key={SurveyPosition.NextToTrigger}
-                            type="tertiary"
-                            size="small"
-                            fullWidth
-                            onClick={() =>
-                                onAppearanceChange({ ...appearance, position: SurveyPosition.NextToTrigger })
-                            }
-                            active={appearance.position === SurveyPosition.NextToTrigger}
-                            disabled={disabled}
-                            disabledReason={disabledReason || undefined}
-                        >
-                            {positionDisplayNames[SurveyPosition.NextToTrigger]}
-                            {appearance.position === SurveyPosition.NextToTrigger && (
-                                <IconCheck className="ml-2 size-4" />
-                            )}
-                        </LemonButton>
-                    </div>
-                )}
+                {surveyType === SurveyType.Widget &&
+                    (appearance.widgetType === SurveyWidgetType.Selector ||
+                        appearance.widgetType === SurveyWidgetType.Tab) && (
+                        <div className="flex flex-col gap-1 items-start w-60">
+                            <LemonButton
+                                key={SurveyPosition.NextToTrigger}
+                                type="tertiary"
+                                size="small"
+                                fullWidth
+                                onClick={() =>
+                                    onAppearanceChange({ ...appearance, position: SurveyPosition.NextToTrigger })
+                                }
+                                active={appearance.position === SurveyPosition.NextToTrigger}
+                                disabled={disabled}
+                                disabledReason={disabledReason || undefined}
+                            >
+                                {appearance.widgetType === SurveyWidgetType.Tab
+                                    ? 'Next to tab'
+                                    : positionDisplayNames[SurveyPosition.NextToTrigger]}
+                                {appearance.position === SurveyPosition.NextToTrigger && (
+                                    <IconCheck className="ml-2 size-4" />
+                                )}
+                            </LemonButton>
+                        </div>
+                    )}
             </LemonField.Pure>
         </div>
     )


### PR DESCRIPTION
## Problem

Closes #31267

For embedded tab (Widget survey with `widgetType = Tab`) feedback button surveys, the survey popup always rendered next to the tab regardless of the configured position. Users who selected a position like "Left" or "Center" saw the survey popup still appear next to the tab button.

This is the same class of bug fixed for the Selector widget type in #31034.

## Changes

- `SurveyAppearanceSections.tsx`: Extended the "Next to trigger" position button to also appear when `widgetType === Tab` (previously only shown for `widgetType === Selector`). Button label reads "Next to tab" for Tab widget type and "Next to feedback button" for Selector widget type. Updated the version info tooltip to cover both widget types.
- `SurveyWidgetCustomization.tsx`: Updated the widget type change handler so switching to Tab no longer resets a `NextToTrigger` position (it was only preserved when switching to Selector). Both Selector and Tab now support this position.

## How did you test this code?

Agent-authored. Verified the conditional logic and TypeScript types manually. Could not run the local dev server to test visually.

Automated: Ran `pnpm oxlint --fix` (no errors) and checked TypeScript types compile cleanly.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Claude Code (claude-sonnet-4-6) identified the issue and made the fix by tracing the pattern from the previous Selector fix (#31034) and applying it to the Tab widget type. Two files changed — the appearance section UI and the widget type change handler. No skills invoked.