### PR TITLE
feat(prompts): Fetch prompts by label

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -270,7 +270,7 @@ class LLMPromptViewSet(
         if prompt is None:
             if label is not None:
                 return Response(
-                    {"detail": f"Prompt '{prompt_name}' has no label '{label}'."},
+                    {"detail": f"Prompt '{prompt_name}' not found or has no label '{label}'."},
                     status=status.HTTP_404_NOT_FOUND,
                 )
             return self._prompt_not_found_response(prompt_name)

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -175,6 +175,16 @@ class LLMPromptViewSet(
         return prompt
 
     def _track_prompt_fetch(self, prompt: dict[str, Any]) -> None:
+        # prompt_label + prompt_version together answer "what was the production label
+        # actually serving at time X" from the event stream alone.
+        properties = {
+            "prompt_id": prompt["id"],
+            "prompt_name": prompt["name"],
+            "prompt_version": prompt["version"],
+            "prompt_label": prompt.get("label"),
+            "prompt_is_latest": prompt["is_latest"],
+            "prompt_first_version_created_at": prompt["first_version_created_at"],
+        }
         if not settings.TEST:
             try:
                 capture_internal(
@@ -183,28 +193,12 @@ class LLMPromptViewSet(
                     event_source=PROMPT_FETCHED_EVENT_SOURCE,
                     distinct_id=str(self.team.uuid),
                     timestamp=None,
-                    properties={
-                        "prompt_id": prompt["id"],
-                        "prompt_name": prompt["name"],
-                        "prompt_version": prompt["version"],
-                        "prompt_is_latest": prompt["is_latest"],
-                        "prompt_first_version_created_at": prompt["first_version_created_at"],
-                    },
+                    properties=properties,
                 )
             except Exception as err:
                 capture_exception(err)
 
-        report_team_action(
-            self.team,
-            "llma prompt fetched",
-            {
-                "prompt_id": prompt["id"],
-                "prompt_name": prompt["name"],
-                "prompt_version": prompt["version"],
-                "prompt_is_latest": prompt["is_latest"],
-                "prompt_first_version_created_at": prompt["first_version_created_at"],
-            },
-        )
+        report_team_action(self.team, "llma prompt fetched", properties)
 
     def _get_list_params(self, request: Request) -> dict[str, Any]:
         serializer = LLMPromptListQuerySerializer(data=request.query_params)
@@ -270,9 +264,15 @@ class LLMPromptViewSet(
     def get_by_name(self, request: Request, prompt_name: str = "", **kwargs) -> Response:
         query_params = self._get_get_by_name_params(request)
         version = cast(int | None, query_params.get("version"))
+        label = cast(str | None, query_params.get("label"))
         content_mode = cast(str, query_params.get("content", "full"))
-        prompt = get_prompt_by_name_from_cache(self.team, prompt_name, version)
+        prompt = get_prompt_by_name_from_cache(self.team, prompt_name, version, label=label)
         if prompt is None:
+            if label is not None:
+                return Response(
+                    {"detail": f"Prompt '{prompt_name}' has no label '{label}'."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
             return self._prompt_not_found_response(prompt_name)
 
         self._track_prompt_fetch(prompt)

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -112,6 +112,12 @@ class LLMPromptGetByNameQuerySerializer(LLMPromptFetchQuerySerializer):
         help_text=CONTENT_MODE_HELP,
     )
 
+    def validate_label(self, value: str) -> str:
+        # Fetching also writes to the cache (miss sentinels under caller-controlled keys),
+        # so impossible label names are rejected before any cache touch — and a caller
+        # sending 'Production' gets the naming rules instead of a confusing 404.
+        return validate_prompt_label_name_value(value)
+
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         if attrs.get("version") is not None and attrs.get("label") is not None:
             raise serializers.ValidationError("Use either version or label, not both.")

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -101,8 +101,10 @@ class LLMPromptFetchQuerySerializer(serializers.Serializer):
 class LLMPromptGetByNameQuerySerializer(LLMPromptFetchQuerySerializer):
     label = serializers.CharField(  # type: ignore[assignment]
         required=False,
+        max_length=PROMPT_LABEL_NAME_MAX_LENGTH,
         help_text=(
-            "Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version."
+            "Fetch the version this label currently points to, e.g. 'production'. "
+            "Lowercase letters, numbers, dots, hyphens and underscores. Mutually exclusive with version."
         ),
     )
     content = serializers.ChoiceField(

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -99,12 +99,23 @@ class LLMPromptFetchQuerySerializer(serializers.Serializer):
 
 
 class LLMPromptGetByNameQuerySerializer(LLMPromptFetchQuerySerializer):
+    label = serializers.CharField(  # type: ignore[assignment]
+        required=False,
+        help_text=(
+            "Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version."
+        ),
+    )
     content = serializers.ChoiceField(
         choices=CONTENT_MODE_CHOICES,
         required=False,
         default="full",
         help_text=CONTENT_MODE_HELP,
     )
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs.get("version") is not None and attrs.get("label") is not None:
+            raise serializers.ValidationError("Use either version or label, not both.")
+        return attrs
 
 
 class LLMPromptListQuerySerializer(serializers.Serializer):
@@ -415,6 +426,10 @@ class LLMPromptPublicSerializer(serializers.Serializer):
         help_text="Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents.",
     )
     version = serializers.IntegerField()
+    label = serializers.CharField(  # type: ignore[assignment]
+        required=False,
+        help_text="The label this prompt was fetched by. Only present when fetching with the label parameter.",
+    )
     created_at = serializers.DateTimeField()
     updated_at = serializers.DateTimeField()
     deleted = serializers.BooleanField()

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -1116,15 +1116,19 @@ class TestLLMPromptLabelsAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["version"] == 1
 
-    def test_fetch_rejects_label_and_version_together(self):
+    def test_fetch_rejects_invalid_label_params(self):
         self.create_prompt_version(version=1)
         self._set_label("my-prompt", "production", 1)
 
-        response = self.client.get(
+        both_params = self.client.get(
             f"/api/environments/{self.team.id}/llm_prompts/name/my-prompt/?label=production&version=1"
         )
+        # Invalid names must be rejected before any cache touch — an unvalidated fetch
+        # writes a miss sentinel under a caller-controlled key and silently 404s.
+        bad_name = self._fetch_by_label("my-prompt", "Production")
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert both_params.status_code == status.HTTP_400_BAD_REQUEST
+        assert bad_name.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_fetch_by_label_404s_after_label_delete_and_prompt_archive(self):
         self.create_prompt_version(version=1)

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -1074,6 +1074,76 @@ class TestLLMPromptLabelsAPI(APIBaseTest):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert LLMPromptLabel.objects.filter(team=self.team).count() == 0
 
+    def _fetch_by_label(self, prompt_name: str, label_name: str):
+        return self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/{prompt_name}/?label={label_name}")
+
+    def _set_label_committed(self, prompt_name: str, label_name: str, version: int):
+        # Cache invalidation rides on transaction.on_commit, which TestCase never fires
+        # on its own — execute the callbacks so these tests exercise the invalidation
+        # exactly as a committed request would.
+        with self.captureOnCommitCallbacks(execute=True):
+            return self._set_label(prompt_name, label_name, version)
+
+    def test_fetch_by_label_returns_resolved_version_and_survives_label_move(self):
+        self.create_prompt_version(version=1, is_latest=False, prompt="v1 content")
+        self.create_prompt_version(version=2, prompt="v2 content")
+        self._set_label_committed("my-prompt", "production", 1)
+
+        first_fetch = self._fetch_by_label("my-prompt", "production")
+        assert first_fetch.status_code == status.HTTP_200_OK
+        assert first_fetch.json()["version"] == 1
+        assert first_fetch.json()["prompt"] == "v1 content"
+        assert first_fetch.json()["label"] == "production"
+
+        # The move must invalidate the cached label entry the first fetch created —
+        # a stale entry here means the promote button silently doesn't promote.
+        self._set_label_committed("my-prompt", "production", 2)
+
+        second_fetch = self._fetch_by_label("my-prompt", "production")
+        assert second_fetch.status_code == status.HTTP_200_OK
+        assert second_fetch.json()["version"] == 2
+        assert second_fetch.json()["prompt"] == "v2 content"
+
+    def test_fetch_by_label_after_cached_miss_sees_newly_created_label(self):
+        self.create_prompt_version(version=1)
+
+        # This 404 caches a miss sentinel; creating the label must clear it.
+        assert self._fetch_by_label("my-prompt", "production").status_code == status.HTTP_404_NOT_FOUND
+
+        self._set_label_committed("my-prompt", "production", 1)
+
+        response = self._fetch_by_label("my-prompt", "production")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["version"] == 1
+
+    def test_fetch_rejects_label_and_version_together(self):
+        self.create_prompt_version(version=1)
+        self._set_label("my-prompt", "production", 1)
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/name/my-prompt/?label=production&version=1"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_fetch_by_label_404s_after_label_delete_and_prompt_archive(self):
+        self.create_prompt_version(version=1)
+        self._set_label_committed("my-prompt", "production", 1)
+        assert self._fetch_by_label("my-prompt", "production").status_code == status.HTTP_200_OK
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.delete(self._label_url("my-prompt", "production"))
+        assert self._fetch_by_label("my-prompt", "production").status_code == status.HTTP_404_NOT_FOUND
+
+        self._set_label_committed("my-prompt", "production", 1)
+        assert self._fetch_by_label("my-prompt", "production").status_code == status.HTTP_200_OK
+
+        # Archive removes labels via a queryset delete — its post_delete signals must
+        # clear the label cache entries too, not just the explicit delete endpoint path.
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(f"/api/environments/{self.team.id}/llm_prompts/name/my-prompt/archive/")
+        assert self._fetch_by_label("my-prompt", "production").status_code == status.HTTP_404_NOT_FOUND
+
     def test_label_writes_forbidden_for_read_only_personal_api_key(self):
         self.create_prompt_version(version=1)
         api_key = self.create_personal_api_key_with_scopes(["llm_prompt:read"])

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -580,6 +580,9 @@ FLAGS_CACHE_TTL = int(os.getenv("FLAGS_CACHE_TTL", str(60 * 60 * 24 * 7)))  # 7 
 FLAGS_CACHE_MISS_TTL = int(os.getenv("FLAGS_CACHE_MISS_TTL", str(60 * 60 * 24)))  # 1 day
 LLM_PROMPTS_CACHE_TTL = int(os.getenv("LLM_PROMPTS_CACHE_TTL", str(60 * 60 * 24)))  # 1 day
 LLM_PROMPTS_CACHE_MISS_TTL = int(os.getenv("LLM_PROMPTS_CACHE_MISS_TTL", str(60 * 5)))  # 5 minutes
+# Label entries resolve a mutable pointer, so they get a short TTL as a hard bound on
+# staleness when a cache fill races an invalidation (signals stay the fast path).
+LLM_PROMPTS_LABEL_CACHE_TTL = int(os.getenv("LLM_PROMPTS_LABEL_CACHE_TTL", str(60)))  # 1 minute
 
 CACHES = {
     "default": {

--- a/posthog/storage/llm_prompt_cache.py
+++ b/posthog/storage/llm_prompt_cache.py
@@ -123,6 +123,21 @@ llm_prompts_hypercache = HyperCache(
     cache_miss_ttl=settings.LLM_PROMPTS_CACHE_MISS_TTL,
 )
 
+# Label entries go through their own instance (same key space) with a short TTL. Latest
+# and version entries hold immutable content, but a label entry is a resolved pointer:
+# a cache fill racing an invalidation can store an already-stale resolution that the
+# generation marker cannot detect. The short TTL bounds that staleness to a minute;
+# signal invalidation still makes the common path near-instant. Label entries are also
+# kept out of S3 (redis-only writes) — an S3 copy has no TTL, so a stale fill there
+# would keep restoring itself past every redis expiry.
+llm_prompts_label_hypercache = HyperCache(
+    namespace="llm_prompts",
+    value="prompt.json",
+    load_fn=_load_prompt_cache,
+    cache_ttl=settings.LLM_PROMPTS_LABEL_CACHE_TTL,
+    cache_miss_ttl=settings.LLM_PROMPTS_LABEL_CACHE_TTL,
+)
+
 
 def get_prompt_by_name_from_cache(
     team: Team,
@@ -146,7 +161,7 @@ def get_prompt_by_name_from_cache(
 
     if label is not None:
         label_key = prompt_label_cache_key(team.id, prompt_name, label)
-        labeled_prompt = llm_prompts_hypercache.get_from_cache(label_key)
+        labeled_prompt = llm_prompts_label_hypercache.get_from_cache(label_key)
         if not isinstance(labeled_prompt, dict):
             return None
 
@@ -163,7 +178,7 @@ def get_prompt_by_name_from_cache(
                 return None
             labeled_prompt = _serialize_labeled_prompt(db_labeled, label)
             try:
-                llm_prompts_hypercache.set_cache_value(label_key, labeled_prompt)
+                llm_prompts_label_hypercache.set_cache_value_redis_only(label_key, labeled_prompt)
             except Exception as err:
                 capture_exception(err)
 
@@ -204,7 +219,7 @@ def invalidate_prompt_version_cache(team: Team | str | int, prompt_name: str, ve
 
 
 def invalidate_prompt_label_cache(team: Team | str | int, prompt_name: str, label_name: str) -> None:
-    llm_prompts_hypercache.clear_cache(prompt_label_cache_key(team, prompt_name, label_name))
+    llm_prompts_label_hypercache.clear_cache(prompt_label_cache_key(team, prompt_name, label_name))
 
 
 def invalidate_prompt_version_caches(team: Team | str | int, prompt_name: str, versions: Iterable[int]) -> None:

--- a/posthog/storage/llm_prompt_cache.py
+++ b/posthog/storage/llm_prompt_cache.py
@@ -9,6 +9,7 @@ from posthog.models.team.team import Team
 from posthog.storage.hypercache import HyperCache, HyperCacheStoreMissing, KeyType
 from posthog.storage.llm_prompt_cache_keys import (
     parse_prompt_cache_key,
+    prompt_label_cache_key,
     prompt_latest_cache_key,
     prompt_version_cache_key,
 )
@@ -21,7 +22,11 @@ from posthog.storage.llm_prompt_cache_payloads import (
     strip_internal_metadata,
 )
 
-from products.ai_observability.backend.models.llm_prompt import LLMPrompt, annotate_llm_prompt_version_history_metadata
+from products.ai_observability.backend.models.llm_prompt import (
+    LLMPrompt,
+    LLMPromptLabel,
+    annotate_llm_prompt_version_history_metadata,
+)
 
 # Used in tests; keep as module export.
 _serialize_prompt = serialize_prompt
@@ -69,12 +74,33 @@ def _get_prompt_version_from_db(team_id: int, prompt_name: str, version: int) ->
     return _attach_first_version_id(prompt, team_id, prompt_name)
 
 
+def _get_labeled_prompt_from_db(team_id: int, prompt_name: str, label_name: str) -> LLMPrompt | None:
+    label = (
+        LLMPromptLabel.objects.filter(team_id=team_id, prompt_name=prompt_name, name=label_name)
+        .select_related("prompt")
+        .first()
+    )
+    if label is None or label.prompt.deleted:
+        return None
+    return _attach_first_version_id(label.prompt, team_id, prompt_name)
+
+
+def _serialize_labeled_prompt(prompt: LLMPrompt, label_name: str) -> dict[str, Any]:
+    return {**serialize_prompt_version(prompt, include_internal=True), "label": label_name}
+
+
 def _load_prompt_cache(cache_key: KeyType) -> dict[str, Any] | HyperCacheStoreMissing:
     parsed_key = parse_prompt_cache_key(cache_key)
     if parsed_key is None:
         return HyperCacheStoreMissing()
 
-    team_id, prompt_name, version = parsed_key
+    team_id, prompt_name, version, label_name = parsed_key
+
+    if label_name is not None:
+        labeled_prompt = _get_labeled_prompt_from_db(team_id, prompt_name, label_name)
+        if labeled_prompt is None:
+            return HyperCacheStoreMissing()
+        return _serialize_labeled_prompt(labeled_prompt, label_name)
 
     if version is None:
         prompt = _get_latest_prompt_from_db(team_id, prompt_name)
@@ -98,7 +124,12 @@ llm_prompts_hypercache = HyperCache(
 )
 
 
-def get_prompt_by_name_from_cache(team: Team, prompt_name: str, version: int | None = None) -> dict[str, Any] | None:
+def get_prompt_by_name_from_cache(
+    team: Team,
+    prompt_name: str,
+    version: int | None = None,
+    label: str | None = None,
+) -> dict[str, Any] | None:
     latest_key = prompt_latest_cache_key(team.id, prompt_name)
     latest_prompt = llm_prompts_hypercache.get_from_cache(latest_key)
 
@@ -112,6 +143,31 @@ def get_prompt_by_name_from_cache(team: Team, prompt_name: str, version: int | N
             llm_prompts_hypercache.set_cache_value(latest_key, latest_prompt)
         except Exception as err:
             capture_exception(err)
+
+    if label is not None:
+        label_key = prompt_label_cache_key(team.id, prompt_name, label)
+        labeled_prompt = llm_prompts_hypercache.get_from_cache(label_key)
+        if not isinstance(labeled_prompt, dict):
+            return None
+
+        # The generation marker guards against a stale entry surviving an archive + recreate
+        # of the whole prompt; label moves are covered by the model-signal invalidation.
+        if is_stale_exact_version_entry(labeled_prompt, latest_prompt):
+            try:
+                invalidate_prompt_label_cache(team.id, prompt_name, label)
+            except Exception as err:
+                capture_exception(err)
+
+            db_labeled = _get_labeled_prompt_from_db(team.id, prompt_name, label)
+            if db_labeled is None:
+                return None
+            labeled_prompt = _serialize_labeled_prompt(db_labeled, label)
+            try:
+                llm_prompts_hypercache.set_cache_value(label_key, labeled_prompt)
+            except Exception as err:
+                capture_exception(err)
+
+        return strip_internal_metadata(merge_prompt_version_history_metadata(labeled_prompt, latest_prompt))
 
     if version is None or version == latest_prompt["latest_version"]:
         return strip_internal_metadata(latest_prompt)
@@ -145,6 +201,10 @@ def invalidate_prompt_latest_cache(team: Team | str | int, prompt_name: str) -> 
 
 def invalidate_prompt_version_cache(team: Team | str | int, prompt_name: str, version: int) -> None:
     llm_prompts_hypercache.clear_cache(prompt_version_cache_key(team, prompt_name, version))
+
+
+def invalidate_prompt_label_cache(team: Team | str | int, prompt_name: str, label_name: str) -> None:
+    llm_prompts_hypercache.clear_cache(prompt_label_cache_key(team, prompt_name, label_name))
 
 
 def invalidate_prompt_version_caches(team: Team | str | int, prompt_name: str, versions: Iterable[int]) -> None:

--- a/posthog/storage/llm_prompt_cache_keys.py
+++ b/posthog/storage/llm_prompt_cache_keys.py
@@ -15,7 +15,17 @@ def prompt_version_cache_key(team: Team | str | int, prompt_name: str, version: 
     return f"{_prompt_cache_key_prefix(team, prompt_name)}:v:{version}"
 
 
-def parse_prompt_cache_key(cache_key: KeyType) -> tuple[int, str, int | None] | None:
+def prompt_label_cache_key(team: Team | str | int, prompt_name: str, label_name: str) -> str:
+    # Prompt names and label names both forbid ":", so splitting on it stays unambiguous.
+    return f"{_prompt_cache_key_prefix(team, prompt_name)}:label:{label_name}"
+
+
+def parse_prompt_cache_key(cache_key: KeyType) -> tuple[int, str, int | None, str | None] | None:
+    """Parse a prompt cache key into (team_id, prompt_name, version, label).
+
+    Latest keys have version=None and label=None; version and label keys carry
+    exactly one of the two.
+    """
     if not isinstance(cache_key, str):
         return None
 
@@ -33,7 +43,7 @@ def parse_prompt_cache_key(cache_key: KeyType) -> tuple[int, str, int | None] | 
         return None
 
     if len(parts) == 3 and parts[2] == "latest":
-        return team_id, prompt_name, None
+        return team_id, prompt_name, None, None
 
     if len(parts) == 4 and parts[2] == "v":
         try:
@@ -42,6 +52,9 @@ def parse_prompt_cache_key(cache_key: KeyType) -> tuple[int, str, int | None] | 
             return None
         if version < 1:
             return None
-        return team_id, prompt_name, version
+        return team_id, prompt_name, version, None
+
+    if len(parts) == 4 and parts[2] == "label" and parts[3]:
+        return team_id, prompt_name, None, parts[3]
 
     return None

--- a/products/ai_observability/backend/models/llm_prompt.py
+++ b/products/ai_observability/backend/models/llm_prompt.py
@@ -160,3 +160,25 @@ def invalidate_llm_prompt_cache(sender: type[LLMPrompt], instance: LLMPrompt, **
             capture_exception(err)
 
     transaction.on_commit(clear_cache)
+
+
+@receiver(post_save, sender=LLMPromptLabel)
+@receiver(post_delete, sender=LLMPromptLabel)
+def invalidate_llm_prompt_label_cache(sender: type[LLMPromptLabel], instance: LLMPromptLabel, **kwargs) -> None:
+    # Label pointer changes never touch LLMPrompt rows, so the receiver above can't cover
+    # them — without this, a moved label would keep serving the old version from cache.
+    # post_save covers create (clears a cached 404 miss) and move; post_delete covers
+    # removal, including archive's queryset delete.
+    team_id = instance.team_id
+    prompt_name = instance.prompt_name
+    label_name = instance.name
+
+    def clear_cache() -> None:
+        from posthog.storage.llm_prompt_cache import invalidate_prompt_label_cache
+
+        try:
+            invalidate_prompt_label_cache(team_id, prompt_name, label_name)
+        except Exception as err:
+            capture_exception(err)
+
+    transaction.on_commit(clear_cache)

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -2213,6 +2213,8 @@ export interface LLMPromptPublicApi {
     /** Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents. */
     outline: LLMPromptOutlineEntryApi[]
     version: number
+    /** The label this prompt was fetched by. Only present when fetching with the label parameter. */
+    label?: string
     created_at: string
     updated_at: string
     deleted: boolean
@@ -2971,6 +2973,11 @@ export type LlmPromptsNameRetrieveParams = {
      * @minLength 1
      */
     content?: LlmPromptsNameRetrieveContent
+    /**
+     * Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.
+     * @minLength 1
+     */
+    label?: string
     /**
      * Specific prompt version to fetch. If omitted, the latest version is returned.
      * @minimum 1

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -2974,8 +2974,9 @@ export type LlmPromptsNameRetrieveParams = {
      */
     content?: LlmPromptsNameRetrieveContent
     /**
-     * Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.
+     * Fetch the version this label currently points to, e.g. 'production'. Lowercase letters, numbers, dots, hyphens and underscores. Mutually exclusive with version.
      * @minLength 1
+     * @maxLength 128
      */
     label?: string
     /**

--- a/products/ai_observability/mcp/tools.yaml
+++ b/products/ai_observability/mcp/tools.yaml
@@ -518,6 +518,8 @@ tools:
         title: Get prompt
         description: |
             Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.
+            Pass `label` (e.g. 'production') to fetch the version that label currently points to, or `version` for an
+            exact version number — not both. With neither, the latest version is returned.
             The response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful
             as a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,
             or `content=preview` for a short `prompt_preview` snippet instead of the full prompt.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5021,7 +5021,7 @@
         }
     },
     "llma-prompt-get": {
-        "description": "Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.\nThe response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful\nas a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,\nor `content=preview` for a short `prompt_preview` snippet instead of the full prompt.",
+        "description": "Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.\nPass `label` (e.g. 'production') to fetch the version that label currently points to, or `version` for an\nexact version number — not both. With neither, the latest version is returned.\nThe response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful\nas a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,\nor `content=preview` for a short `prompt_preview` snippet instead of the full prompt.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get prompt",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5316,7 +5316,7 @@
         }
     },
     "llma-prompt-get": {
-        "description": "Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.\nThe response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful\nas a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,\nor `content=preview` for a short `prompt_preview` snippet instead of the full prompt.",
+        "description": "Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.\nPass `label` (e.g. 'production') to fetch the version that label currently points to, or `version` for an\nexact version number — not both. With neither, the latest version is returned.\nThe response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful\nas a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,\nor `content=preview` for a short `prompt_preview` snippet instead of the full prompt.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get prompt",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33013,6 +33013,8 @@ export namespace Schemas {
       /** Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents. */
       outline: LLMPromptOutlineEntry[];
       version: number;
+      /** The label this prompt was fetched by. Only present when fetching with the label parameter. */
+      label?: string;
       created_at: string;
       updated_at: string;
       deleted: boolean;
@@ -67686,6 +67688,11 @@ export namespace Schemas {
      */
     content?: EnvironmentsLlmPromptsNameRetrieveContent;
     /**
+     * Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.
+     * @minLength 1
+     */
+    label?: string;
+    /**
      * Specific prompt version to fetch. If omitted, the latest version is returned.
      * @minimum 1
      */
@@ -75222,6 +75229,11 @@ export namespace Schemas {
      * @minLength 1
      */
     content?: LlmPromptsNameRetrieveContent;
+    /**
+     * Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.
+     * @minLength 1
+     */
+    label?: string;
     /**
      * Specific prompt version to fetch. If omitted, the latest version is returned.
      * @minimum 1

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -67688,8 +67688,9 @@ export namespace Schemas {
      */
     content?: EnvironmentsLlmPromptsNameRetrieveContent;
     /**
-     * Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.
+     * Fetch the version this label currently points to, e.g. 'production'. Lowercase letters, numbers, dots, hyphens and underscores. Mutually exclusive with version.
      * @minLength 1
+     * @maxLength 128
      */
     label?: string;
     /**
@@ -75230,8 +75231,9 @@ export namespace Schemas {
      */
     content?: LlmPromptsNameRetrieveContent;
     /**
-     * Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.
+     * Fetch the version this label currently points to, e.g. 'production'. Lowercase letters, numbers, dots, hyphens and underscores. Mutually exclusive with version.
      * @minLength 1
+     * @maxLength 128
      */
     label?: string;
     /**

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -1622,6 +1622,13 @@ export const LlmPromptsNameRetrieveQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.\n\n* `full` - full\n* `preview` - preview\n* `none` - none"
         ),
+    label: zod
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+            "Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version."
+        ),
     version: zod
         .number()
         .min(1)

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -1614,6 +1614,7 @@ export const LlmPromptsNameRetrieveParams = /* @__PURE__ */ zod.object({
 })
 
 export const llmPromptsNameRetrieveQueryContentDefault = `full`
+export const llmPromptsNameRetrieveQueryLabelMax = 128
 
 export const LlmPromptsNameRetrieveQueryParams = /* @__PURE__ */ zod.object({
     content: zod
@@ -1625,9 +1626,10 @@ export const LlmPromptsNameRetrieveQueryParams = /* @__PURE__ */ zod.object({
     label: zod
         .string()
         .min(1)
+        .max(llmPromptsNameRetrieveQueryLabelMax)
         .optional()
         .describe(
-            "Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version."
+            "Fetch the version this label currently points to, e.g. 'production'. Lowercase letters, numbers, dots, hyphens and underscores. Mutually exclusive with version."
         ),
     version: zod
         .number()

--- a/services/mcp/src/tools/generated/ai_observability.ts
+++ b/services/mcp/src/tools/generated/ai_observability.ts
@@ -798,6 +798,7 @@ const llmaPromptGet = (): ToolBase<typeof LlmaPromptGetSchema, Schemas.LLMPrompt
             path: `/api/projects/${encodeURIComponent(String(projectId))}/llm_prompts/name/${encodeURIComponent(String(params.prompt_name))}/`,
             query: {
                 content: params.content,
+                label: params.label,
                 version: params.version,
             },
         })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-prompt-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-prompt-get.json
@@ -7,6 +7,11 @@
             "enum": ["full", "preview", "none"],
             "type": "string"
         },
+        "label": {
+            "description": "Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.",
+            "minLength": 1,
+            "type": "string"
+        },
         "prompt_name": {
             "pattern": "^[^/]+$",
             "type": "string"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-prompt-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-prompt-get.json
@@ -8,7 +8,8 @@
             "type": "string"
         },
         "label": {
-            "description": "Fetch the version this label currently points to, e.g. 'production'. Mutually exclusive with version.",
+            "description": "Fetch the version this label currently points to, e.g. 'production'. Lowercase letters, numbers, dots, hyphens and underscores. Mutually exclusive with version.",
+            "maxLength": 128,
             "minLength": 1,
             "type": "string"
         },


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/70862 added prompt labels (movable pointers to versions) and the endpoints to manage them, but there is no way to fetch a prompt through a label yet. Until that exists, moving a label has no effect on the apps that consume prompts.

## Changes

Adds `?label=production` to the prompt fetch endpoint. The response is the version the label points to, plus a `label` field showing what was resolved. Stacked on #70862.

- `?label=` on `GET .../llm_prompts/name/{name}/`, mutually exclusive with `?version=` (400 if both are passed)
- Label results get their own HyperCache entry (`{team}:{name}:label:{label}`). We cache the resolved prompt content, so a warm fetch is two Redis reads (the latest entry for metadata, then the label entry) with no Postgres lookup
- Signals on `LLMPromptLabel` clear that cache entry whenever a label is created, moved, or deleted
- New `prompt_label` property on the `$llm_prompt_fetched` event
- The get-prompt MCP tool description now explains the `label` parameter
- Fetching without a label or version still returns the latest version, same as before

Design notes:

- **Why signals for cache invalidation:** the existing invalidation runs when a prompt version row is saved, and a label move doesn't save any version row — without its own trigger, a moved label would serve the old version until the cache expires (up to a day). A signal on the label model covers every path that changes labels (set, delete, archive's cleanup) in one place.
- **Creating a label also needs invalidation:** fetching a missing label caches a short-lived "not found", and the create signal clears it so a new label works right away.

## How did you test this code?

New tests in `test_llm_prompt.py`, all through the public API with the cache in the loop: fetching by label after a move returns the new version (this test fails if the invalidation breaks, and it caught a real gap during development), a label created after a cached 404 works immediately, label+version together returns 400, and fetches 404 after label delete and after prompt archive. Full prompt API + cache suites pass locally (119 tests), mypy clean on changed files.
