### PR TITLE
feat(signals): open self-driving PRs ready for review

### DIFF
--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -895,6 +895,57 @@ class GitHubIntegrationBase:
             "updated_at": pr.get("updatedAt"),
         }
 
+    _PR_NODE_QUERY = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) { id isDraft }
+      }
+    }
+    """
+
+    _MARK_PR_READY_MUTATION = """
+    mutation($pullRequestId: ID!) {
+      markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
+        pullRequest { number isDraft }
+      }
+    }
+    """
+
+    def mark_pull_request_ready_for_review(self, pr_url: str) -> dict[str, Any]:
+        """Convert a draft PR to ready-for-review. No-op when the PR is already ready.
+
+        Resolves the PR node id via the installation token (rather than trusting a
+        caller-supplied id) and only mutates when the PR is still a draft — GitHub
+        errors if ``markPullRequestReadyForReview`` targets a non-draft PR.
+
+        Returns ``{"success": True, "converted": bool}`` on success, or
+        ``{"success": False, "error": ...}`` on a handled failure. Rate-limit and
+        unexpected errors raise ``GitHubIntegrationError`` so the caller can back off.
+        """
+        parsed = self.parse_pull_request_url(pr_url)
+        if parsed is None:
+            return {"success": False, "error": f"Invalid GitHub pull request URL: {pr_url}"}
+        owner, repo, pr_number = parsed
+
+        data = self._gh_graphql(
+            self._PR_NODE_QUERY,
+            {"owner": owner, "repo": repo, "number": pr_number},
+            endpoint="/graphql:pullRequestNode",
+        )
+        pr = ((data or {}).get("repository") or {}).get("pullRequest")
+        if not pr or not pr.get("id"):
+            return {"success": False, "error": f"Pull request not found: {pr_url}"}
+        if not pr.get("isDraft"):
+            return {"success": True, "converted": False}
+
+        result = self._gh_graphql(
+            self._MARK_PR_READY_MUTATION,
+            {"pullRequestId": pr["id"]},
+            endpoint="/graphql:markPullRequestReadyForReview",
+        )
+        converted = ((result or {}).get("markPullRequestReadyForReview") or {}).get("pullRequest")
+        return {"success": True, "converted": bool(converted) and converted.get("isDraft") is False}
+
     def list_repositories(self, *, page: int = 1, per_page: int = 100) -> tuple[list[dict], bool]:
         """List one page of installation repositories from the GitHub API.
 

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -139,7 +139,9 @@ def _create_implementation_task_if_absent(
             # Full scopes so the implementation agent can log its work on the report (notes,
             # code references) via the task:write artefact tools.
             posthog_mcp_scopes="full",
-            interaction_origin="signal_report",  # Makes the agent auto-push and open a draft PR
+            # Makes the agent auto-push and open a PR. The agent opens it as a draft; the
+            # `pull_request.opened` webhook then promotes signals PRs to ready-for-review.
+            interaction_origin="signal_report",
             ai_stage="implementation",
         )
         if created.latest_run is None:

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -474,6 +474,127 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(self.report.status, SignalReport.Status.READY)
 
 
+class TestGitHubPRWebhookPromotesSignalsPR(TestCase):
+    """A freshly opened signals-initiated draft PR is promoted to ready-for-review."""
+
+    organization: ClassVar[Organization]
+    team: ClassVar[Team]
+    user: ClassVar[User]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = Organization.objects.create(name="Test Org")
+        cls.team = Team.objects.create(organization=cls.organization, name="Test Team")
+        cls.user = User.objects.create(email="promote@example.com", distinct_id="user-promote")
+        cls.integration = Integration.objects.create(
+            team=cls.team,
+            kind="github",
+            integration_id="90210",
+            config={"account": {"name": "posthog"}},
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.webhook_secret = "test-webhook-secret"
+
+    def _make_task(self, origin_product: str) -> TaskRun:
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Task",
+            description="desc",
+            origin_product=origin_product,
+            repository="posthog/posthog",
+        )
+        return TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="feature/signals-fix",
+            output={},
+        )
+
+    def _post_opened(self, *, draft: bool, head_repo: str = "posthog/posthog", installation_id: int | None = 90210):
+        payload: dict = {
+            "action": "opened",
+            "repository": {"full_name": "posthog/posthog"},
+            "pull_request": {
+                "html_url": "https://github.com/posthog/posthog/pull/321",
+                "merged": False,
+                "draft": draft,
+                "head": {"ref": "feature/signals-fix", "repo": {"full_name": head_repo}},
+            },
+        }
+        if installation_id is not None:
+            payload["installation"] = {"id": installation_id}
+        payload_bytes = json.dumps(payload).encode("utf-8")
+        signature = generate_github_signature(payload_bytes, self.webhook_secret)
+        return self.client.post(
+            "/webhooks/github/pr/",
+            data=payload_bytes,
+            content_type="application/json",
+            headers={"x-hub-signature-256": signature, "x-github-event": "pull_request"},
+        )
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    @patch("products.tasks.backend.webhooks.GitHubIntegration")
+    def test_signals_draft_pr_is_promoted(self, mock_github, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self._make_task(Task.OriginProduct.SIGNAL_REPORT)
+
+        response = self._post_opened(draft=True)
+
+        self.assertEqual(response.status_code, 200)
+        mock_github.assert_called_once()
+        mock_github.return_value.mark_pull_request_ready_for_review.assert_called_once_with(
+            "https://github.com/posthog/posthog/pull/321"
+        )
+
+    @parameterized.expand(
+        [
+            ("not_draft", {"draft": False}),
+            ("fork_head", {"draft": True, "head_repo": "attacker/posthog"}),
+            ("no_installation", {"draft": True, "installation_id": None}),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    @patch("products.tasks.backend.webhooks.GitHubIntegration")
+    def test_signals_pr_not_promoted(self, _name, kwargs, mock_github, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self._make_task(Task.OriginProduct.SIGNAL_REPORT)
+
+        response = self._post_opened(**kwargs)
+
+        self.assertEqual(response.status_code, 200)
+        mock_github.return_value.mark_pull_request_ready_for_review.assert_not_called()
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    @patch("products.tasks.backend.webhooks.GitHubIntegration")
+    def test_non_signals_draft_pr_is_not_promoted(self, mock_github, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self._make_task(Task.OriginProduct.USER_CREATED)
+
+        response = self._post_opened(draft=True)
+
+        self.assertEqual(response.status_code, 200)
+        mock_github.return_value.mark_pull_request_ready_for_review.assert_not_called()
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    @patch("products.tasks.backend.webhooks.GitHubIntegration")
+    def test_promotion_failure_does_not_fail_webhook(self, mock_github, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self._make_task(Task.OriginProduct.SIGNAL_REPORT)
+        mock_github.return_value.mark_pull_request_ready_for_review.side_effect = Exception("boom")
+
+        response = self._post_opened(draft=True)
+
+        self.assertEqual(response.status_code, 200)
+
+
 class TestExternalPRWebhook(TestCase):
     """PRs with no matching TaskRun are emitted as external PR events."""
 

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -10,11 +10,11 @@ import posthoganalytics
 
 from posthog.event_usage import groups
 from posthog.models.instance_setting import get_instance_setting
-from posthog.models.integration import Integration
+from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.team.team import Team
 
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
-from products.tasks.backend.models import TaskRun
+from products.tasks.backend.models import Task, TaskRun
 
 logger = structlog.get_logger(__name__)
 
@@ -132,6 +132,8 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
     )
     if task_run is not None and is_internal_branch:
         _record_run_pr_url(task_run, pr_url)
+        if action == "opened":
+            _maybe_promote_signals_pr_to_ready(task_run, payload, pull_request)
 
     # Deterministic UUID dedupes duplicate webhook deliveries of the same PR action.
     event_uuid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{pr_url}:{analytics_event}"))
@@ -167,6 +169,33 @@ def _record_run_pr_url(task_run: TaskRun, pr_url: str) -> None:
         task_run.output = {**(task_run.output if isinstance(task_run.output, dict) else {}), "pr_url": pr_url}
     except Exception:
         logger.warning("github_pr_webhook_record_pr_url_failed", run_id=str(task_run.id), exc_info=True)
+
+
+def _maybe_promote_signals_pr_to_ready(task_run: TaskRun, payload: dict, pull_request: dict) -> None:
+    """Flip a freshly opened signals-initiated PR from draft to ready-for-review.
+
+    The agent opens signal-report PRs as drafts; the Inbox merge flow needs them
+    ready for review, so we promote them the moment GitHub reports the ``opened``
+    event. Guarded to the installation the webhook came from and skipped when the
+    PR is already non-draft. Tolerant: a failure here must not fail the webhook.
+    """
+    if task_run.task.origin_product != Task.OriginProduct.SIGNAL_REPORT:
+        return
+    if not pull_request.get("draft"):
+        return
+    pr_url = pull_request.get("html_url")
+    installation_id = (payload.get("installation") or {}).get("id")
+    if not pr_url or installation_id is None:
+        return
+    integration = Integration.objects.filter(
+        team_id=task_run.team_id, kind="github", integration_id=str(installation_id)
+    ).first()
+    if integration is None:
+        return
+    try:
+        GitHubIntegration(integration).mark_pull_request_ready_for_review(pr_url)
+    except Exception:
+        logger.warning("github_pr_webhook_mark_ready_failed", run_id=str(task_run.id), pr_url=pr_url, exc_info=True)
 
 
 # Nulled on external PRs so their schema matches task-originated PR events.


### PR DESCRIPTION
## Problem

Signals-initiated PRs (a.k.a. PostHog Self-Driving PRs — those associated with a signal report) are currently opened as **drafts** by the agent. As the in-Inbox merging experience takes shape, these PRs need to land **ready for review** so they can be acted on directly.

## Changes

The agent (in `@posthog/agent`, out of this repo) opens signal-report PRs as drafts because they carry `interaction_origin="signal_report"`. Rather than change that, we promote the PR the moment GitHub reports the `pull_request.opened` event:

- Added `mark_pull_request_ready_for_review(pr_url)` to the shared `GitHubIntegrationBase`. It resolves the PR node id via the installation token (not a caller-supplied id) and only fires the `markPullRequestReadyForReview` GraphQL mutation when the PR is still a draft — GitHub errors if you target a non-draft PR.
- Wired a best-effort promotion into the tasks PR webhook (`_maybe_promote_signals_pr_to_ready`), gated to `SIGNAL_REPORT`-origin tasks on internal branches (never forks) and to the installation the webhook came from. A failure here never fails the webhook.

The criterion for "initiated via signals" is the task's `origin_product == SIGNAL_REPORT`, which is the flag `auto_start` already sets — the simplest available signal.

## How did you test this code?

I'm an agent (PostHog Slack app). I added automated tests in `products/tasks/backend/tests/test_webhooks.py`:
- a signals draft PR is promoted (mutation called with the PR URL),
- it is *not* promoted when the PR is already non-draft, comes from a fork, or has no resolvable installation,
- non-signals draft PRs are left alone,
- a promotion failure doesn't fail the webhook.

I could **not** run the DB-backed suite in the sandbox (no Postgres/Docker available). I verified syntax, ruff lint, and ruff format on all changed files, and exercised the new integration method's branching in isolation (draft→convert, already-ready→no-op, bad URL→handled). CI will run the full suite.

These tests catch the regression that signals PRs silently revert to (or stay as) drafts, and that the promotion never escapes its guards to touch fork or non-signals PRs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Michael Matloka via Slack while building the in-Inbox merging experience: open PRs initiated via signals as ready to review, using whichever "signals PR" criterion is simplest to implement.

Key decisions:
- **Where to make the change.** The PR is opened by the external `@posthog/agent` binary, which decides draft-vs-ready from the `interaction_origin` env flag — not changeable from this repo. So instead of opening ready, we open-then-promote: flip the draft to ready via GitHub's GraphQL API from the webhook this repo already receives. This keeps the whole change self-contained and testable here.
- **Trigger point.** The `pull_request.opened` webhook was chosen over the agent's `set_output` callback because the webhook is the canonical "PR exists on GitHub" signal; the promotion resolves the node id itself via the installation token for defense in depth.
- **Criterion.** `origin_product == SIGNAL_REPORT` (what `auto_start` sets) over the deprecated `signal_report` FK.

No skills were required for this change (no migrations, DRF serializers, or generated-type surfaces touched).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782318800452949?thread_ts=1782318800.452949&cid=C09SK2PAGKF)*
