### PR TITLE
fix(data-warehouse): clarify typeform partial-response resync guidance

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/typeform/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/typeform/source.py
@@ -108,10 +108,11 @@ You can generate a personal access token in your [Typeform account settings](htt
                             ),
                         ],
                         caption=(
-                            "Completed responses sync incrementally. Including partial & started responses "
-                            "syncs the whole responses table as a full refresh on every run, since Typeform "
-                            "has no cursor that covers partial responses. **After changing this, resync the "
-                            "responses table for the new setting to take effect.**"
+                            "Completed responses sync incrementally. Including partial and started responses "
+                            "syncs the whole responses table on every run, since Typeform has no cursor for "
+                            "partial responses. **To apply this change to an existing source, use 'Delete table "
+                            "and resync' on the responses table. 'Sync now' alone won't backfill the responses "
+                            "you're adding.**"
                         ),
                     ),
                 ],

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/typeform/tests/test_typeform_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/typeform/tests/test_typeform_source.py
@@ -23,10 +23,12 @@ class TestTypeformSource:
         assert field.defaultValue == "completed"
         assert [option.value for option in field.options] == ["completed", "completed,partial,started"]
 
-    def test_response_types_field_warns_about_full_refresh(self):
+    def test_response_types_field_points_to_delete_and_resync(self):
         field = self._response_types_field()
         assert field.caption is not None
-        assert "full refresh" in field.caption.lower()
+        # The caption must name the exact destructive action, since a plain "Sync now"
+        # won't backfill the newly included partial/started responses.
+        assert "delete table and resync" in field.caption.lower()
 
     def test_get_schemas_completed_only_uses_submitted_at(self):
         config = TypeformSourceConfig(auth_token="token", response_types="completed")


### PR DESCRIPTION
## Problem

PR #63636 added the "Responses to sync" setting to the Typeform source, letting you include partial and started responses. On an existing source, though, flipping that setting doesn't retroactively pull those responses in. The responses table has to be deleted and fully resynced, because partial and started responses have no cursor to backfill against.

The caption that shipped told users to "resync the responses table", which reads a lot like "Sync now". But "Sync now" only runs an incremental sync, so it silently won't backfill the responses you just enabled. Customers were hitting exactly this.

## Changes

Reworded the `response_types` field caption to name the exact action, "Delete table and resync", and to explicitly rule out "Sync now". Copy only, no behavior change, plus the test that guards the caption.

```diff
-Completed responses sync incrementally. Including partial & started responses syncs the whole
-responses table as a full refresh on every run, since Typeform has no cursor that covers partial
-responses. **After changing this, resync the responses table for the new setting to take effect.**
+Completed responses sync incrementally. Including partial and started responses syncs the whole
+responses table on every run, since Typeform has no cursor for partial responses. **To apply this
+change to an existing source, use 'Delete table and resync' on the responses table. 'Sync now'
+alone won't backfill the responses you're adding.**
```

The caption renders as markdown help text under the "Responses to sync" dropdown, in both the new-source wizard and the Configuration tab of an existing source. It's served at runtime via `api.externalDataSources.wizard()`, so no codegen.

## How did you test this code?

- Ran the Typeform source suite: `hogli test products/warehouse_sources/backend/temporal/data_imports/sources/typeform/` — 42 passed.
- The change realigns `test_response_types_field_...` to assert the caption names "Delete table and resync" (it previously asserted the vaguer "full refresh"). That guards the specific regression this PR is about: softening the copy back to a generic "resync"/"sync now" that doesn't name the destructive action.
- I (Claude, via PostHog Code) did not run the dev stack to eyeball the rendered markdown. The caption flows through the same `LemonMarkdown` select-field path #63636 added, so no new rendering surface.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Docs should make it clear a 'delete table and resync' is needed too.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Luke directed the work and is the DRI.

- Tool: PostHog Code (Claude Opus 4.8).
- I confirmed against the codebase that "Delete table and resync" is the verbatim UI action label (distinct from "Sync now"), and that the caption is served dynamically so a copy edit needs no `build:openapi` / `generate:source-configs` run.
- Scope decision: Luke asked to keep this simple and just fix the copy, so I rejected the heavier options I'd scoped (a confirmation dialog on config save, a persistent banner) in favor of the one-string change.
- I also corrected an over-optimistic "no test updates needed" assumption from planning: a grep for the verbatim caption missed `test_response_types_field_warns_about_full_refresh`, which asserted the caption contained "full refresh". Realigned it to the new, more specific action wording.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
