### PR TITLE
refactor(experiments): remove eligible-flags endpoint (superseded by flag list API)

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
-from django.db.models import BooleanField, Case, CharField, Count, F, Prefetch, Q, QuerySet, Value, When
+from django.db.models import BooleanField, Case, CharField, F, Q, QuerySet, Value, When
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce, Now, NullIf
 from django.utils import timezone
@@ -48,8 +48,6 @@ from posthog.models.person.util import get_person_ids_and_uuids_by_uuids
 from posthog.models.signals import mute_selected_signals
 from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.models.team.team import Team
-from posthog.models.user import User
-from posthog.rbac.user_access_control import UserAccessControl
 from posthog.utils import str_to_bool
 
 from products.actions.backend.models.action import Action
@@ -98,7 +96,6 @@ from products.feature_flags.backend.facade.filters import (
     strip_group_cohort_restriction,
 )
 from products.feature_flags.backend.facade.rules import experiment_rule_from_filters
-from products.feature_flags.backend.models.evaluation_context import FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag, experiment_eligibility_error
 from products.notifications.backend.facade.api import (
     NotificationData,
@@ -596,15 +593,6 @@ class ExperimentService:
         "-duration",
         "status",
         "-status",
-    }
-
-    ELIGIBLE_FLAGS_ORDER_ALLOWLIST = {
-        "created_at",
-        "-created_at",
-        "key",
-        "-key",
-        "name",
-        "-name",
     }
 
     @classmethod
@@ -3721,115 +3709,6 @@ class ExperimentService:
             queryset = queryset.order_by("-created_at")
 
         return queryset
-
-    # ------------------------------------------------------------------
-    # Eligible feature flags
-    # ------------------------------------------------------------------
-
-    def get_eligible_feature_flags(
-        self,
-        *,
-        limit: int = 20,
-        offset: int = 0,
-        excluded_flag_ids: list[int] | set[int] | None = None,
-        search: str | None = None,
-        active: str | bool | None = None,
-        created_by_id: str | int | None = None,
-        order: str | None = None,
-        evaluation_runtime: str | None = None,
-        has_evaluation_contexts: str | bool | None = None,
-    ) -> dict[str, Any]:
-        """Get feature flags eligible for use in experiments."""
-        queryset = self._get_eligible_feature_flags_queryset(
-            excluded_flag_ids=excluded_flag_ids,
-            search=search,
-            active=active,
-            created_by_id=created_by_id,
-            order=order,
-            evaluation_runtime=evaluation_runtime,
-            has_evaluation_contexts=has_evaluation_contexts,
-        )
-
-        return {
-            "results": queryset[offset : offset + limit],
-            "count": queryset.count(),
-        }
-
-    def _get_eligible_feature_flags_queryset(
-        self,
-        *,
-        excluded_flag_ids: list[int] | set[int] | None,
-        search: str | None,
-        active: str | bool | None,
-        created_by_id: str | int | None,
-        order: str | None,
-        evaluation_runtime: str | None,
-        has_evaluation_contexts: str | bool | None,
-    ) -> QuerySet[FeatureFlag]:
-        queryset = FeatureFlag.objects.filter(team__project_id=self.team.project_id).eligible_for_experiment()
-
-        # This action is experiment-scoped, so the flag resource's object-level access
-        # controls are not applied by the viewset — filter here like the flag list
-        # endpoint does, so private flags don't leak through the eligible-flags listing.
-        if isinstance(self.user, User):
-            queryset = UserAccessControl(user=self.user, team=self.team).filter_queryset_by_access_level(
-                queryset, include_all_if_admin=True
-            )
-        else:
-            queryset = queryset.none()
-
-        if excluded_flag_ids:
-            queryset = queryset.exclude(id__in=excluded_flag_ids)
-
-        if search:
-            queryset = queryset.filter(Q(key__icontains=search) | Q(name__icontains=search))
-
-        if active is not None:
-            active_bool = active if isinstance(active, bool) else str(active).lower() == "true"
-            queryset = queryset.filter(active=active_bool)
-
-        if created_by_id:
-            user_ids = parse_created_by_ids(created_by_id)
-            if user_ids:
-                queryset = queryset.filter(created_by_id__in=user_ids)
-
-        if evaluation_runtime:
-            queryset = queryset.filter(evaluation_runtime=evaluation_runtime)
-
-        if has_evaluation_contexts is not None:
-            filter_value = (
-                has_evaluation_contexts
-                if isinstance(has_evaluation_contexts, bool)
-                else str(has_evaluation_contexts).lower() in ("true", "1", "yes")
-            )
-            queryset = queryset.annotate(eval_context_count=Count("flag_evaluation_contexts"))
-            if filter_value:
-                queryset = queryset.filter(eval_context_count__gt=0)
-            else:
-                queryset = queryset.filter(eval_context_count=0)
-
-        if order and order not in self.ELIGIBLE_FLAGS_ORDER_ALLOWLIST:
-            raise ValidationError(f"Invalid order field: '{order}'")
-
-        queryset = queryset.order_by(order or "-created_at")
-
-        return queryset.prefetch_related(
-            Prefetch(
-                "experiment_set", queryset=Experiment.objects.filter(deleted=False), to_attr="_active_experiments"
-            ),
-            "features",
-            "analytics_dashboards",
-            "surveys_linked_flag",
-            Prefetch(
-                "flag_evaluation_contexts",
-                queryset=FeatureFlagEvaluationContext.objects.select_related("evaluation_context"),
-            ),
-            Prefetch(
-                "team__cohort_set",
-                queryset=Cohort.objects.filter(deleted=False).only("id", "name"),
-                to_attr="available_cohorts",
-            ),
-        ).select_related("created_by", "last_modified_by")
 
     # ------------------------------------------------------------------
     # Timeseries

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -88,11 +88,8 @@ from products.experiments.backend.session_context import get_session_experiment_
 from products.experiments.backend.temporal.models import (
     ExperimentMetricsRecalculationWorkflowInputs as MetricsRecalcInputs,
 )
-from products.feature_flags.backend.facade.api import serialize_flags
 from products.feature_flags.backend.models.evaluation_context import FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
-from products.product_tours.backend.models import ProductTour
-from products.surveys.backend.models import Survey
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.access import has_tasks_access
 
@@ -912,63 +909,6 @@ class EnterpriseExperimentsViewSet(
         )
         cohort_data = CohortSerializer(cohort, context={"request": request, "team": self.team}).data
         return Response({"cohort": cohort_data}, status=201)
-
-    @action(methods=["GET"], detail=False, required_scopes=["feature_flag:read"])
-    def eligible_feature_flags(self, request: Request, **kwargs: Any) -> Response:
-        """
-        Returns a paginated list of feature flags eligible for use in experiments.
-
-        Eligible flags must:
-        - Be multivariate with 2 to 20 variants
-
-        Query parameters:
-        - search: Filter by flag key or name (case insensitive)
-        - limit: Number of results per page (default: 20)
-        - offset: Pagination offset (default: 0)
-        - active: Filter by active status ("true" or "false")
-        - created_by_id: Filter by creator user ID
-        - order: Sort order field
-        - evaluation_runtime: Filter by evaluation runtime
-        - has_evaluation_contexts: Filter by presence of evaluation contexts ("true" or "false")
-        """
-        # validate limit and offset
-        try:
-            limit = min(int(request.query_params.get("limit", 20)), 100)
-            offset = max(int(request.query_params.get("offset", 0)), 0)
-        except ValueError:
-            return Response({"error": "Invalid limit or offset"}, status=400)
-
-        survey_flag_ids = Survey.get_internal_flag_ids(project_id=self.project_id)
-        product_tour_internal_targeting_flags = ProductTour.all_objects.filter(
-            team__project_id=self.project_id, internal_targeting_flag__isnull=False
-        ).values_list("internal_targeting_flag_id", flat=True)
-        excluded_flag_ids = survey_flag_ids | set(product_tour_internal_targeting_flags)
-
-        service = ExperimentService(team=self.team, user=request.user)
-        eligible_feature_flags = service.get_eligible_feature_flags(
-            limit=limit,
-            offset=offset,
-            excluded_flag_ids=excluded_flag_ids,
-            search=request.query_params.get("search"),
-            active=request.query_params.get("active"),
-            created_by_id=request.query_params.get("created_by_id"),
-            order=request.query_params.get("order"),
-            evaluation_runtime=request.query_params.get("evaluation_runtime"),
-            has_evaluation_contexts=request.query_params.get("has_evaluation_contexts"),
-        )
-
-        # Serialize using the flag API's standard representation
-        results = serialize_flags(
-            eligible_feature_flags["results"],
-            context=self.get_serializer_context(),
-        )
-
-        return Response(
-            {
-                "results": results,
-                "count": eligible_feature_flags["count"],
-            }
-        )
 
     @extend_schema(
         parameters=[

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -52,7 +52,6 @@ from products.experiments.backend.models.experiment import (
 )
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 from products.feature_flags.backend.facade.api import set_flag_active, update_flag
-from products.feature_flags.backend.models.evaluation_context import EvaluationContext, FeatureFlagEvaluationContext
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.warehouse_sources.backend.facade.models import DataWarehouseCredential, DataWarehouseTable
 
@@ -4879,93 +4878,6 @@ class TestExperimentService(APIBaseTest):
         assert ExperimentMetricResult.objects.filter(experiment=experiment, metric_uuid="m1").count() == 0
 
     # ------------------------------------------------------------------
-    # Eligible feature flags
-    # ------------------------------------------------------------------
-
-    def test_get_eligible_feature_flags_only_returns_multivariate_flags_within_variant_bounds(self) -> None:
-        eligible_flag = self._create_flag(key="eligible-flag")
-        no_control_flag = self._create_flag(
-            key="no-control-flag",
-            variants=[
-                {"key": "test-1", "name": "Test 1", "rollout_percentage": 50},
-                {"key": "test-2", "name": "Test 2", "rollout_percentage": 50},
-            ],
-        )
-        self._create_flag(
-            key="single-variant-flag",
-            variants=[{"key": "control", "name": "Control", "rollout_percentage": 100}],
-        )
-
-        result = self._service().get_eligible_feature_flags(order="key")
-
-        assert result["count"] == 2
-        assert [flag.key for flag in result["results"]] == [eligible_flag.key, no_control_flag.key]
-
-    def test_get_eligible_feature_flags_applies_search_and_pagination(self) -> None:
-        self._create_flag(key="search-alpha")
-        self._create_flag(key="search-beta")
-        self._create_flag(key="other-flag")
-
-        result = self._service().get_eligible_feature_flags(
-            search="search",
-            order="key",
-            limit=1,
-            offset=1,
-        )
-
-        assert result["count"] == 2
-        assert [flag.key for flag in result["results"]] == ["search-beta"]
-
-    def test_get_eligible_feature_flags_filters_by_evaluation_contexts(self) -> None:
-        flag_with_tags = self._create_flag(key="flag-with-tags")
-        self._create_flag(key="flag-without-tags")
-        evaluation_context = EvaluationContext.objects.create(name="app", team=self.team)
-        FeatureFlagEvaluationContext.objects.create(feature_flag=flag_with_tags, evaluation_context=evaluation_context)
-
-        service = self._service()
-
-        flags_with_tags = service.get_eligible_feature_flags(has_evaluation_contexts="true", order="key")
-        flags_without_tags = service.get_eligible_feature_flags(has_evaluation_contexts="false", order="key")
-
-        assert [flag.key for flag in flags_with_tags["results"]] == ["flag-with-tags"]
-        assert [flag.key for flag in flags_without_tags["results"]] == ["flag-without-tags"]
-
-    def test_get_eligible_feature_flags_excludes_flags_blocked_by_access_controls(self) -> None:
-        self.organization.available_product_features = [
-            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
-            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
-        ]
-        self.organization.save()
-        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
-        membership.level = OrganizationMembership.Level.MEMBER
-        membership.save()
-
-        self._create_flag(key="accessible-flag")
-        other_user = User.objects.create_and_join(self.organization, "flag-owner@posthog.com", None)
-        private_flag = FeatureFlag.objects.create(
-            team=self.team,
-            created_by=other_user,
-            key="private-flag",
-            filters={
-                "groups": [{"properties": [], "rollout_percentage": 100}],
-                "multivariate": {
-                    "variants": [
-                        {"key": "control", "rollout_percentage": 50},
-                        {"key": "test", "rollout_percentage": 50},
-                    ]
-                },
-            },
-        )
-        AccessControl.objects.create(
-            team=self.team, resource="feature_flag", resource_id=str(private_flag.id), access_level="none"
-        )
-
-        result = self._service().get_eligible_feature_flags(order="key")
-
-        assert result["count"] == 1
-        assert [flag.key for flag in result["results"]] == ["accessible-flag"]
-
-    # ------------------------------------------------------------------
     # Experiment list/querying
     # ------------------------------------------------------------------
 
@@ -5927,12 +5839,6 @@ class TestExperimentService(APIBaseTest):
         service = self._service()
         qs = service.filter_experiments_queryset(self._base_queryset(), action="list", query_params={"order": order})
         assert qs is not None
-
-    def test_eligible_flags_order_by_invalid_field_raises(self):
-        """Ordering eligible flags by a non-allowlisted field should be rejected."""
-        service = self._service()
-        with self.assertRaises(ValidationError):
-            service.get_eligible_feature_flags(order="team__organization__name")
 
     def test_launch_with_deleted_flag_raises(self):
         """Launching an experiment whose flag is soft-deleted should fail."""

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -162,55 +162,6 @@ class TestExperimentCRUD(_HoistFlagConfigClientMixin, APILicensedTest):
         response = self.client.get(f"/api/projects/{self.team.id}/experiments/{experiment.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_can_list_eligible_feature_flags(self) -> None:
-        FeatureFlag.objects.create(
-            team=self.team,
-            created_by=self.user,
-            key="eligible-flag",
-            filters={
-                "groups": [{"properties": [], "rollout_percentage": 100}],
-                "multivariate": {
-                    "variants": [
-                        {"key": "control", "name": "Control", "rollout_percentage": 50},
-                        {"key": "test", "name": "Test", "rollout_percentage": 50},
-                    ]
-                },
-            },
-        )
-        FeatureFlag.objects.create(
-            team=self.team,
-            created_by=self.user,
-            key="wrong-order-flag",
-            filters={
-                "groups": [{"properties": [], "rollout_percentage": 100}],
-                "multivariate": {
-                    "variants": [
-                        {"key": "test", "name": "Test", "rollout_percentage": 50},
-                        {"key": "control", "name": "Control", "rollout_percentage": 50},
-                    ]
-                },
-            },
-        )
-        FeatureFlag.objects.create(
-            team=self.team,
-            created_by=self.user,
-            key="single-variant-flag",
-            filters={
-                "groups": [{"properties": [], "rollout_percentage": 100}],
-                "multivariate": {
-                    "variants": [
-                        {"key": "control", "name": "Control", "rollout_percentage": 100},
-                    ]
-                },
-            },
-        )
-
-        response = self.client.get(f"/api/projects/{self.team.id}/experiments/eligible_feature_flags/?order=key")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 2)
-        self.assertEqual([flag["key"] for flag in response.json()["results"]], ["eligible-flag", "wrong-order-flag"])
-
     @parameterized.expand(
         [
             ("draft", "draft"),

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -972,36 +972,6 @@ export const experimentsCreateFromPromptCreate = async (
     })
 }
 
-export const getExperimentsEligibleFeatureFlagsRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/experiments/eligible_feature_flags/`
-}
-
-/**
- * Returns a paginated list of feature flags eligible for use in experiments.
- *
- * Eligible flags must:
- * - Be multivariate with 2 to 20 variants
- *
- * Query parameters:
- * - search: Filter by flag key or name (case insensitive)
- * - limit: Number of results per page (default: 20)
- * - offset: Pagination offset (default: 0)
- * - active: Filter by active status ("true" or "false")
- * - created_by_id: Filter by creator user ID
- * - order: Sort order field
- * - evaluation_runtime: Filter by evaluation runtime
- * - has_evaluation_contexts: Filter by presence of evaluation contexts ("true" or "false")
- */
-export const experimentsEligibleFeatureFlagsRetrieve = async (
-    projectId: string,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getExperimentsEligibleFeatureFlagsRetrieveUrl(projectId), {
-        ...options,
-        method: 'GET',
-    })
-}
-
 export const getExperimentsPromptTemplatesRetrieveUrl = (projectId: string) => {
     return `/api/projects/${projectId}/experiments/prompt_templates/`
 }

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -1033,9 +1033,6 @@ tools:
     experiments-create-from-prompt-create:
         operation: experiments_create_from_prompt_create
         enabled: false
-    experiments-eligible-feature-flags:
-        operation: experiments_eligible_feature_flags_retrieve
-        enabled: false
     experiments-flag-cleanup-task-retrieve:
         operation: experiments_flag_cleanup_task_retrieve
         enabled: false


### PR DESCRIPTION
## Problem

Follow-up "contract" half split out from #70127. That PR added an `eligible_for_experiment` filter to the flag list API and migrated the experiment pickers onto it, but the endpoint removal was pulled out of it to avoid breaking clients still calling the old endpoint before the migration deploys.

## Changes

−358 across 6 files. Deletes the now-superseded experiments eligible-flags path:

- `EnterpriseExperimentsViewSet.eligible_feature_flags` viewset action.
- `ExperimentService.get_eligible_feature_flags` / `_get_eligible_feature_flags_queryset` and the `ELIGIBLE_FLAGS_ORDER_ALLOWLIST` (plus the imports they alone used).
- The generated experiments client operation `experimentsEligibleFeatureFlagsRetrieve` and the disabled MCP tool stub.
- The associated backend tests in `test_experiment_service.py` and `test_presentation_api.py`.

The eligible-flags listing is now served by the flag list API's `eligible_for_experiment` filter (added in #70127).

## How did you test this code?

This is a pure deletion of the endpoint restored in #70127 — it reinstates the exact removal that was originally validated as part of that PR (backend suites and Jest were green there before the split). No code references to the removed symbols remain on `master` (only stale `.test_durations` timing entries, which regenerate).

## 🤖 Agent context

Split out from #70127 by Claude Code at the author's request, to ship the additive change first and defer the breaking removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
