### PR TITLE
fix(insights): make shared query throttle cost aware

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -57,6 +57,7 @@ def process_query_dict(
     dashboard_id: Optional[int] = None,
     is_query_service: bool = False,
     cache_age_seconds: Optional[int] = None,
+    cost_aware_cache_age: bool = False,
     pagination_cursor: Optional[str] = None,
     analytics_props: Optional[AnalyticsProps] = None,
 ) -> dict | BaseModel:
@@ -109,6 +110,7 @@ def process_query_dict(
         dashboard_id=dashboard_id,
         is_query_service=is_query_service,
         cache_age_seconds=cache_age_seconds,
+        cost_aware_cache_age=cost_aware_cache_age,
         pagination_cursor=pagination_cursor,
         analytics_props=analytics_props,
     )
@@ -129,6 +131,7 @@ def process_query_model(
     dashboard_id: Optional[int] = None,
     is_query_service: bool = False,
     cache_age_seconds: Optional[int] = None,
+    cost_aware_cache_age: bool = False,
     pagination_cursor: Optional[str] = None,
     analytics_props: Optional[AnalyticsProps] = None,
 ) -> dict | BaseModel:
@@ -240,6 +243,7 @@ def process_query_model(
             insight_id=insight_id,
             dashboard_id=dashboard_id,
             cache_age_seconds=cache_age_seconds,
+            cost_aware_cache_age=cost_aware_cache_age,
             analytics_props=analytics_props,
         )
 

--- a/posthog/hogql_queries/query_cache_base.py
+++ b/posthog/hogql_queries/query_cache_base.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from typing import Optional
 
 from posthog import redis
+from posthog.settings.schedules import CACHED_RESULTS_TTL
 
 
 class QueryCacheManagerBase(ABC):
@@ -95,6 +96,22 @@ class QueryCacheManagerBase(ABC):
 
         redis_key = f"{self._redis_key_prefix()}:{self.team_id}"
         self.redis_client.zrem(redis_key, self.identifier)
+
+    def set_query_duration_ms(self, query_duration_ms: float) -> None:
+        self.redis_client.setex(
+            f"query_cost_proxy:{self.team_id}:{self.cache_key}",
+            CACHED_RESULTS_TTL,
+            str(query_duration_ms),
+        )
+
+    def get_query_duration_ms(self) -> float | None:
+        value = self.redis_client.get(f"query_cost_proxy:{self.team_id}:{self.cache_key}")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     @abstractmethod
     def set_cache_data(self, *, response: dict, target_age: Optional[datetime]) -> None:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -300,6 +300,7 @@ class SharedExecutionSettings(NamedTuple):
 
     execution_mode: ExecutionMode
     cache_age_seconds: int | None
+    cost_aware_cache_age: bool
 
 
 def shared_insights_execution_mode(execution_mode: ExecutionMode) -> SharedExecutionSettings:
@@ -315,10 +316,21 @@ def shared_insights_execution_mode(execution_mode: ExecutionMode) -> SharedExecu
         return SharedExecutionSettings(
             ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
             int(SHARED_FORCE_BLOCKING_STALENESS_WINDOW.total_seconds()),
+            True,
         )
     return SharedExecutionSettings(
-        _SHARED_MODE_WHITELIST.get(execution_mode, ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE), None
+        _SHARED_MODE_WHITELIST.get(execution_mode, ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE), None, False
     )
+
+
+def cost_aware_shared_cache_age_seconds(base_cache_age_seconds: int, query_duration_ms: float | None) -> int:
+    if query_duration_ms is None:
+        return base_cache_age_seconds
+
+    for minimum_duration_ms, cache_age_seconds in sorted(settings.SHARED_QUERY_COST_AWARE_THROTTLE_TIERS, reverse=True):
+        if query_duration_ms >= minimum_duration_ms:
+            return max(base_cache_age_seconds, cache_age_seconds)
+    return base_cache_age_seconds
 
 
 RunnableQueryNode = Union[
@@ -1626,6 +1638,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         insight_id: Optional[int] = None,
         dashboard_id: Optional[int] = None,
         cache_age_seconds: Optional[int] = None,
+        cost_aware_cache_age: bool = False,
         analytics_props: Optional[AnalyticsProps] = None,
     ) -> CR | CacheMissResponse | QueryStatusResponse:
         # Set user for access control during query execution. Some subclasses
@@ -1737,6 +1750,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                         insight_id=insight_id,
                         dashboard_id=dashboard_id,
                     )
+                    if cost_aware_cache_age and cache_age_seconds is not None:
+                        self._cache_age_override = cost_aware_shared_cache_age_seconds(
+                            cache_age_seconds, cache_manager.get_query_duration_ms()
+                        )
 
                     if execution_mode == ExecutionMode.CALCULATE_ASYNC_ALWAYS:
                         # We should always kick off async calculation and disregard the cache.
@@ -1963,6 +1980,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     # Set target_age to None in that case
                     target_age=target_age,
                 )
+                cache_manager.set_query_duration_ms(query_duration_ms)
 
             query_executed_props = {
                 "insight_id": insight_id,

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from django.core.cache import cache
 from django.db import connection
+from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
@@ -55,6 +56,7 @@ from posthog.hogql_queries.query_runner import (
     ExecutionMode,
     QueryRunner,
     QueryRunnerWithHogQLContext,
+    cost_aware_shared_cache_age_seconds,
     get_query_runner,
     shared_insights_execution_mode,
 )
@@ -1279,27 +1281,30 @@ class TestApplySeriesCustomNames(BaseTest):
         self.assertEqual(was_modified, expect_modified)
 
 
-class TestSharedInsightsExecutionMode(BaseTest):
+class TestSharedInsightsExecutionMode(SimpleTestCase):
     @parameterized.expand(
         [
-            # name, execution_mode, expected_mode, expected_cache_age_seconds
+            # name, execution_mode, expected_mode, expected_cache_age_seconds, expected_cost_aware
             (
                 "force_blocking_downgrades_with_staleness_window_threshold",
                 ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
                 ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                 int(SHARED_FORCE_BLOCKING_STALENESS_WINDOW.total_seconds()),
+                True,
             ),
             (
                 "cache_only_remaps_to_extended_async",
                 ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                 ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
                 None,
+                False,
             ),
             (
                 "recent_cache_async_passes_through",
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
                 None,
+                False,
             ),
             (
                 "blocking_if_stale_passes_through",
@@ -1310,6 +1315,7 @@ class TestSharedInsightsExecutionMode(BaseTest):
                 ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                 ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                 None,
+                False,
             ),
         ]
     )
@@ -1319,10 +1325,27 @@ class TestSharedInsightsExecutionMode(BaseTest):
         execution_mode: ExecutionMode,
         expected_mode: ExecutionMode,
         expected_cache_age_seconds: int | None,
+        expected_cost_aware: bool,
     ) -> None:
-        result_mode, cache_age_seconds = shared_insights_execution_mode(execution_mode)
+        result_mode, cache_age_seconds, cost_aware = shared_insights_execution_mode(execution_mode)
         self.assertEqual(result_mode, expected_mode)
         self.assertEqual(cache_age_seconds, expected_cache_age_seconds)
+        self.assertEqual(cost_aware, expected_cost_aware)
+
+    @parameterized.expand(
+        [
+            (None, 1800),
+            (9999, 1800),
+            (10_000, 3600),
+            (60_000, 21_600),
+        ]
+    )
+    def test_cost_aware_shared_cache_age_seconds(self, query_duration_ms: float | None, expected: int) -> None:
+        with mock.patch(
+            "posthog.hogql_queries.query_runner.settings.SHARED_QUERY_COST_AWARE_THROTTLE_TIERS",
+            [(10_000, 3600), (60_000, 21_600)],
+        ):
+            self.assertEqual(cost_aware_shared_cache_age_seconds(1800, query_duration_ms), expected)
 
 
 @pytest.mark.ee

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -955,6 +955,11 @@ API_ENVIRONMENTS_SUNSET_DATE = get_from_env("API_ENVIRONMENTS_SUNSET_DATE", "202
 # var without redeploy. 1.0 = emit every operation, 0.01 = 1% sample.
 # Defaults to 1.0 under TEST so assertions on emitted SLO events are deterministic.
 QUERY_SERVICE_SLO_SAMPLE_RATE = get_from_env("QUERY_SERVICE_SLO_SAMPLE_RATE", 1.0 if TEST else 0.01, type_cast=float)
+SHARED_QUERY_COST_AWARE_THROTTLE_TIERS: list[tuple[int, int]] = [
+    tuple(map(int, tier.split(":")))
+    for tier in os.getenv("SHARED_QUERY_COST_AWARE_THROTTLE_TIERS", "").split(",")
+    if tier
+]
 
 ####
 # Livestream

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1150,8 +1150,11 @@ class InsightSerializer(InsightBasicSerializer):
                 )
 
                 shared_cache_age_seconds: int | None = None
+                cost_aware_shared_cache_age = False
                 if is_shared:
-                    execution_mode, shared_cache_age_seconds = shared_insights_execution_mode(execution_mode)
+                    execution_mode, shared_cache_age_seconds, cost_aware_shared_cache_age = (
+                        shared_insights_execution_mode(execution_mode)
+                    )
 
                 # Shared rendering bypasses the FE scene-tag flow, so set product/feature
                 # tags here. No-op overwrite for authenticated paths (same values).
@@ -1180,6 +1183,7 @@ class InsightSerializer(InsightBasicSerializer):
                         variables_override=variables_override,
                         tile_filters_override=tile_filters_override,
                         cache_age_seconds=shared_cache_age_seconds,
+                        cost_aware_cache_age=cost_aware_shared_cache_age,
                         analytics_props=get_request_analytics_properties(self.context["request"]),
                     )
             except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:


### PR DESCRIPTION
## Problem

Public shared dashboards can repeatedly force expensive insight recomputations on a fixed schedule. The existing 30-minute cache-age throttle treats cheap and expensive queries the same.

**Why:** Shared refreshes need a stronger guard for costly queries without publishing deployment-specific cost thresholds.

## Changes

- Store the prior query execution duration as an internal cache-side cost proxy.
- Allow deployments to configure duration-to-cache-age tiers through `SHARED_QUERY_COST_AWARE_THROTTLE_TIERS`.
- Apply the dynamic window only to forced refreshes from shared resources, retaining the 30-minute fallback when no proxy or tiers exist.

## How did you test this code?

- Added focused cases for shared execution-mode policy and duration-tier selection. These guard the fallback and tier-boundary behavior that did not previously exist.
- Ran `./bin/hogli test posthog/hogql_queries/test/test_query_runner.py -k 'shared_insights_execution_mode or cost_aware_shared_cache_age_seconds'` (8 passed).
- Ran Ruff formatting and lint checks on all changed Python files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

This is an internal deployment setting. The PR keeps the configuration format beside the setting and does not change the public product workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code using the `/writing-tests` skill. I chose prior execution duration as the proxy because query scan-cost multipliers should remain deployment-private; the tier values are therefore supplied through the environment. The PR is intentionally draft so the policy and configuration shape can be reviewed before rollout.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
