### PR TITLE
feat(workflows): clearer multi-channel metrics tab (split tables, channel-aware tile, step deep-linking)

### DIFF
--- a/frontend/src/lib/components/AppMetrics/AppMetricSummary.tsx
+++ b/frontend/src/lib/components/AppMetrics/AppMetricSummary.tsx
@@ -12,6 +12,9 @@ export type AppMetricSummaryProps = {
     name: string
     description: string
     color?: string
+    /** Per-series colors keyed by series name, for tiles whose sparkline breaks down into named series
+     *  (e.g. a channel split). Takes precedence over `color` so the tile matches the full trends chart. */
+    seriesColors?: Record<string, string>
     colorIfZero?: string
     timeSeries: AppMetricsTimeSeriesResponse | null
     previousPeriodTimeSeries?: AppMetricsTimeSeriesResponse | null
@@ -31,6 +34,7 @@ export function AppMetricSummary({
     previousPeriodTimeSeries,
     description,
     color,
+    seriesColors,
     colorIfZero,
     loading,
     hideIfZero = false,
@@ -58,15 +62,32 @@ export function AppMetricSummary({
     const diffForDisplay = formatPercentageDiff(total, totalPreviousPeriod)
 
     const chartColor = total === 0 ? colorIfZero : color
-    const seriesOverrides = useMemo(
-        () =>
-            timeSeries && chartColor
-                ? Object.fromEntries(
-                      timeSeries.series.map((x): [string, AppMetricsSeriesOverride] => [x.name, { color: chartColor }])
-                  )
-                : undefined,
-        [timeSeries, chartColor]
-    )
+    const seriesOverrides = useMemo(() => {
+        if (!timeSeries) {
+            return undefined
+        }
+        // With per-series colors, color each named series so the tile matches the full trends chart —
+        // this is what keeps a channel-breakdown sparkline consistent with the big chart below it.
+        if (seriesColors && total !== 0) {
+            return Object.fromEntries(
+                timeSeries.series
+                    .filter((x) => seriesColors[x.name])
+                    .map((x): [string, AppMetricsSeriesOverride] => [x.name, { color: seriesColors[x.name] }])
+            )
+        }
+        if (!chartColor) {
+            return undefined
+        }
+        // A single-series tile takes its metric's brand color. With more than one series (e.g. a
+        // channel breakdown) forcing them all to that one color makes the lines indistinguishable,
+        // so let each fall back to the theme palette — matching how the full trends chart colors them.
+        if (timeSeries.series.length > 1 && total !== 0) {
+            return undefined
+        }
+        return Object.fromEntries(
+            timeSeries.series.map((x): [string, AppMetricsSeriesOverride] => [x.name, { color: chartColor }])
+        )
+    }, [timeSeries, chartColor, total, seriesColors])
 
     // Hide component if hideIfZero is true and there's no data
     if (hideIfZero && !loading && total === 0 && totalPreviousPeriod === 0) {

--- a/frontend/src/lib/components/AppMetrics/AppMetricsTrends.tsx
+++ b/frontend/src/lib/components/AppMetrics/AppMetricsTrends.tsx
@@ -9,24 +9,32 @@ export function AppMetricsTrends({
     appMetricsTrends,
     loading,
     metricLabels,
+    seriesColors,
 }: {
     appMetricsTrends: AppMetricsTimeSeriesResponse | null
     loading: boolean
     /** Optional display labels keyed by series name (e.g. `{ rows_synced: 'Rows synced' }`). */
     metricLabels?: Record<string, string>
+    /** Optional colors keyed by series name, so a metric reads the same color here as in its tile. */
+    seriesColors?: Record<string, string>
 }): JSX.Element {
-    const seriesOverrides = useMemo(
-        () =>
-            metricLabels
-                ? Object.fromEntries(
-                      Object.entries(metricLabels).map(([name, label]): [string, AppMetricsSeriesOverride] => [
-                          name,
-                          { label },
-                      ])
-                  )
-                : undefined,
-        [metricLabels]
-    )
+    const seriesOverrides = useMemo(() => {
+        // Identical to the previous label-only behavior when `seriesColors` is unset, so callers that
+        // don't pass colors (data pipelines, batch exports, event filtering, etc.) are unaffected.
+        if (!metricLabels && !seriesColors) {
+            return undefined
+        }
+        const names = new Set([...Object.keys(metricLabels ?? {}), ...Object.keys(seriesColors ?? {})])
+        return Object.fromEntries(
+            [...names].map((name): [string, AppMetricsSeriesOverride] => [
+                name,
+                {
+                    ...(metricLabels && name in metricLabels ? { label: metricLabels[name] } : {}),
+                    ...(seriesColors && name in seriesColors ? { color: seriesColors[name] } : {}),
+                },
+            ])
+        )
+    }, [metricLabels, seriesColors])
 
     return (
         <div className="relative border rounded min-h-[20rem] h-[70vh] bg-surface-primary">

--- a/products/workflows/frontend/Workflows/EmailMetricsSummary.tsx
+++ b/products/workflows/frontend/Workflows/EmailMetricsSummary.tsx
@@ -6,7 +6,12 @@ import { appMetricsLogic } from 'lib/components/AppMetrics/appMetricsLogic'
 import { AppMetricsTrends } from 'lib/components/AppMetrics/AppMetricsTrends'
 import { AppMetricSummary } from 'lib/components/AppMetrics/AppMetricSummary'
 
-import { EMAIL_METRIC_INVOCATION_FILTERS, EmailMetric, WORKFLOW_EMAIL_METRICS } from './workflowMetricsSummaryLogic'
+import {
+    EMAIL_METRIC_INVOCATION_FILTERS,
+    EmailMetric,
+    METRIC_COLORS,
+    WORKFLOW_EMAIL_METRICS,
+} from './workflowMetricsSummaryLogic'
 
 const EMAIL_METRIC_KEYS = Object.keys(WORKFLOW_EMAIL_METRICS) as (keyof typeof WORKFLOW_EMAIL_METRICS)[]
 
@@ -31,7 +36,6 @@ export function EmailMetricsSummary({
                               name:
                                   WORKFLOW_EMAIL_METRICS[series.name as keyof typeof WORKFLOW_EMAIL_METRICS]?.name ??
                                   series.name,
-                              color: WORKFLOW_EMAIL_METRICS[series.name as keyof typeof WORKFLOW_EMAIL_METRICS]?.color,
                           })),
                   }
                 : null,
@@ -60,7 +64,11 @@ export function EmailMetricsSummary({
                     )
                 })}
             </div>
-            <AppMetricsTrends appMetricsTrends={emailTrends} loading={appMetricsTrendsLoading} />
+            <AppMetricsTrends
+                appMetricsTrends={emailTrends}
+                loading={appMetricsTrendsLoading}
+                seriesColors={METRIC_COLORS}
+            />
         </>
     )
 }

--- a/products/workflows/frontend/Workflows/PushMetricsSummary.tsx
+++ b/products/workflows/frontend/Workflows/PushMetricsSummary.tsx
@@ -6,7 +6,7 @@ import { appMetricsLogic } from 'lib/components/AppMetrics/appMetricsLogic'
 import { AppMetricsTrends } from 'lib/components/AppMetrics/AppMetricsTrends'
 import { AppMetricSummary } from 'lib/components/AppMetrics/AppMetricSummary'
 
-import { WORKFLOW_PUSH_METRICS } from './workflowMetricsSummaryLogic'
+import { METRIC_COLORS, WORKFLOW_PUSH_METRICS } from './workflowMetricsSummaryLogic'
 
 const PUSH_METRIC_KEYS = Object.keys(WORKFLOW_PUSH_METRICS) as (keyof typeof WORKFLOW_PUSH_METRICS)[]
 
@@ -25,7 +25,6 @@ export function PushMetricsSummary({ logicKey }: { logicKey: string }): JSX.Elem
                               name:
                                   WORKFLOW_PUSH_METRICS[series.name as keyof typeof WORKFLOW_PUSH_METRICS]?.name ??
                                   series.name,
-                              color: WORKFLOW_PUSH_METRICS[series.name as keyof typeof WORKFLOW_PUSH_METRICS]?.color,
                           })),
                   }
                 : null,
@@ -51,7 +50,11 @@ export function PushMetricsSummary({ logicKey }: { logicKey: string }): JSX.Elem
                     )
                 })}
             </div>
-            <AppMetricsTrends appMetricsTrends={pushTrends} loading={appMetricsTrendsLoading} />
+            <AppMetricsTrends
+                appMetricsTrends={pushTrends}
+                loading={appMetricsTrendsLoading}
+                seriesColors={METRIC_COLORS}
+            />
         </>
     )
 }

--- a/products/workflows/frontend/Workflows/WorkflowMetrics.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetrics.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 
 import * as greekPng from '@posthog/brand/hoggies/png/greek'
 import { IconLetter } from '@posthog/icons'
-import { LemonButton, LemonCollapse, LemonSelect, ProfilePicture, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonCollapse, LemonSelect, LemonSelectOptions, ProfilePicture, Spinner } from '@posthog/lemon-ui'
 
 import { pngHoggie } from 'lib/brand/hoggies'
 import { getColorVar } from 'lib/colors'
@@ -23,7 +23,7 @@ import { HogFlowBatchJob } from './hogflows/types'
 import { PushMetricsSummary } from './PushMetricsSummary'
 import { WorkflowLogicProps, workflowLogic } from './workflowLogic'
 import { WorkflowMetricsSummary } from './WorkflowMetricsSummary'
-import { type EmailMetric, buildEmailMetricInvocationSearchParams } from './workflowMetricsSummaryLogic'
+import { type EmailMetric, METRIC_COLORS, buildEmailMetricInvocationSearchParams } from './workflowMetricsSummaryLogic'
 
 const HedgehogGreek = pngHoggie(greekPng)
 
@@ -33,27 +33,28 @@ export const WORKFLOW_METRICS_INFO: Record<string, { name: string; description: 
     succeeded: {
         name: 'Success',
         description: 'Total number of events processed successfully',
-        color: getColorVar('success'),
+        color: METRIC_COLORS['Success'],
     },
     failed: {
         name: 'Failure',
         description: 'Total number of events that had errors during processing',
-        color: getColorVar('danger'),
+        color: METRIC_COLORS['Failure'],
     },
     rate_limited: {
         name: 'Rate Limited',
         description: 'Total number of events that were rate limited',
-        color: getColorVar('danger'),
+        color: METRIC_COLORS['Rate Limited'],
     },
     triggered: {
         name: 'Triggered',
         description: 'Total number of events that were triggered',
-        color: getColorVar('success'),
+        color: METRIC_COLORS['Triggered'],
     },
 }
 
 function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
     const logicKey = `hog-flow-metrics-${props.id}`
+    const { searchParams } = useValues(router)
 
     const logic = appMetricsLogic({
         logicKey,
@@ -63,6 +64,9 @@ function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
             appSource: 'hog_flow',
             appSourceId: props.id,
             breakdownBy: 'metric_name',
+            // Seed the drilled-in step from ?action= so a refreshed or shared metrics link restores it.
+            // Subsequent changes (clicks, back/forward) are synced by workflowSceneLogic's urlToAction.
+            instanceId: (searchParams.action as string) || undefined,
         },
     })
 
@@ -70,7 +74,6 @@ function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
 
     const { appMetricsTrendsLoading, appMetricsTrends, getSingleTrendSeries, params, getDateRangeAbsolute } =
         useValues(logic)
-    const { setParams } = useActions(logic)
 
     const selectedAction = workflow.actions.find((action) => action.id === params.instanceId)
 
@@ -81,27 +84,34 @@ function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
                       ...appMetricsTrends,
                       series: appMetricsTrends.series.map((series) => ({
                           ...series,
-                          color: WORKFLOW_METRICS_INFO[series.name as keyof typeof WORKFLOW_METRICS_INFO]?.color,
+                          name:
+                              WORKFLOW_METRICS_INFO[series.name as keyof typeof WORKFLOW_METRICS_INFO]?.name ??
+                              series.name,
                       })),
                   }
                 : null,
         [appMetricsTrends]
     )
 
-    const workflowStepOptions = useMemo(
+    const workflowStepOptions: LemonSelectOptions<string> = useMemo(
         () => [
             {
-                label: 'Overview',
-                value: OVERVIEW_OPTION_VALUE,
+                options: [{ label: 'Whole workflow', value: OVERVIEW_OPTION_VALUE }],
             },
-            ...workflow.actions.map((action) => {
-                const Step = getHogFlowStep(action, hogFunctionTemplatesById)
-                return {
-                    label: action.name,
-                    icon: Step?.icon,
-                    value: action.id,
-                }
-            }),
+            {
+                // A titled section makes it obvious you can drill into a single step's metrics.
+                title: 'Per step',
+                options: workflow.actions
+                    .filter((action) => action.id !== 'trigger_node')
+                    .map((action) => {
+                        const Step = getHogFlowStep(action, hogFunctionTemplatesById)
+                        return {
+                            label: action.name,
+                            icon: Step?.icon,
+                            value: action.id,
+                        }
+                    }),
+            },
         ],
         [workflow.actions, hogFunctionTemplatesById]
     )
@@ -112,30 +122,36 @@ function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
             return
         }
         const { dateFrom, dateTo } = getDateRangeAbsolute()
-        const searchParams = buildEmailMetricInvocationSearchParams(
+        const invocationSearchParams = buildEmailMetricInvocationSearchParams(
             metricKey,
             dateFrom.toISOString(),
             dateTo.toISOString()
         )
-        if (searchParams) {
-            router.actions.push(urls.workflow(props.id, 'invocations'), searchParams)
+        if (invocationSearchParams) {
+            router.actions.push(urls.workflow(props.id, 'invocations'), invocationSearchParams)
         }
+    }
+
+    // Reflect the selected step in the URL (?action=) so it survives refresh/share/back-forward. The
+    // actual params.instanceId update is applied by workflowSceneLogic's urlToAction watching this.
+    const selectMetricsAction = (actionId?: string): void => {
+        if (!props.id) {
+            return
+        }
+        const { action: _prev, ...rest } = searchParams
+        router.actions.push(urls.workflow(props.id, 'metrics'), actionId ? { ...rest, action: actionId } : rest)
     }
 
     return (
         <div className="flex flex-col gap-2" data-attr="workflow-metrics">
-            <div className="flex flex-row gap-2 flex-wrap justify-between">
+            <div className="flex flex-row gap-2 flex-wrap justify-end items-center">
                 <div className="flex flex-row gap-2 items-center flex-wrap">
+                    <span className="text-muted text-xs whitespace-nowrap">Metrics for</span>
                     <LemonSelect
                         size="small"
-                        options={workflowStepOptions.filter((option) => option.value !== 'trigger_node')}
+                        options={workflowStepOptions}
                         value={params.instanceId ?? OVERVIEW_OPTION_VALUE}
-                        onChange={(value) =>
-                            setParams({
-                                ...params,
-                                instanceId: value === OVERVIEW_OPTION_VALUE ? undefined : value,
-                            })
-                        }
+                        onChange={(value) => selectMetricsAction(value === OVERVIEW_OPTION_VALUE ? undefined : value)}
                     />
                     {selectedAction?.type === 'function_email' && props.id ? (
                         <LemonButton
@@ -155,7 +171,7 @@ function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
                 <WorkflowMetricsSummary
                     logicKey={logicKey}
                     id={props.id ?? ''}
-                    onSelectAction={(actionId) => setParams({ ...params, instanceId: actionId })}
+                    onSelectAction={(actionId) => selectMetricsAction(actionId)}
                     onMetricClick={onEmailMetricClick}
                 />
             ) : selectedAction?.type === 'function_email' ? (
@@ -178,7 +194,11 @@ function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
                             />
                         ))}
                     </div>
-                    <AppMetricsTrends appMetricsTrends={modifiedAppMetricsTrends} loading={appMetricsTrendsLoading} />
+                    <AppMetricsTrends
+                        appMetricsTrends={modifiedAppMetricsTrends}
+                        loading={appMetricsTrendsLoading}
+                        seriesColors={METRIC_COLORS}
+                    />
                 </>
             )}
         </div>
@@ -237,38 +257,46 @@ function BatchJobMetrics({ job }: { job: HogFlowBatchJob }): JSX.Element {
                       ...appMetricsTrends,
                       series: appMetricsTrends.series.map((series) => ({
                           ...series,
-                          color: WORKFLOW_METRICS_INFO[series.name as keyof typeof WORKFLOW_METRICS_INFO]?.color,
+                          name:
+                              WORKFLOW_METRICS_INFO[series.name as keyof typeof WORKFLOW_METRICS_INFO]?.name ??
+                              series.name,
                       })),
                   }
                 : null,
         [appMetricsTrends]
     )
 
-    const workflowStepOptions = useMemo(
+    const workflowStepOptions: LemonSelectOptions<string> = useMemo(
         () => [
             {
-                label: 'Overview',
-                value: OVERVIEW_OPTION_VALUE,
+                options: [{ label: 'Whole workflow', value: OVERVIEW_OPTION_VALUE }],
             },
-            ...workflow.actions.map((action) => {
-                const Step = getHogFlowStep(action, hogFunctionTemplatesById)
-                return {
-                    label: action.name,
-                    icon: Step?.icon,
-                    value: action.id,
-                }
-            }),
+            {
+                // A titled section makes it obvious you can drill into a single step's metrics.
+                title: 'Per step',
+                options: workflow.actions
+                    .filter((action) => action.id !== 'trigger_node')
+                    .map((action) => {
+                        const Step = getHogFlowStep(action, hogFunctionTemplatesById)
+                        return {
+                            label: action.name,
+                            icon: Step?.icon,
+                            value: action.id,
+                        }
+                    }),
+            },
         ],
         [workflow.actions, hogFunctionTemplatesById]
     )
 
     return (
         <div className="flex flex-col gap-2">
-            <div className="flex flex-row gap-2 flex-wrap justify-between">
+            <div className="flex flex-row gap-2 flex-wrap justify-end items-center">
                 <div className="flex flex-row gap-2 items-center flex-wrap">
+                    <span className="text-muted text-xs whitespace-nowrap">Metrics for</span>
                     <LemonSelect
                         size="small"
-                        options={workflowStepOptions.filter((option) => option.value !== 'trigger_node')}
+                        options={workflowStepOptions}
                         value={params.instanceId ?? OVERVIEW_OPTION_VALUE}
                         onChange={(value) =>
                             setParams({
@@ -318,7 +346,11 @@ function BatchJobMetrics({ job }: { job: HogFlowBatchJob }): JSX.Element {
                             />
                         ))}
                     </div>
-                    <AppMetricsTrends appMetricsTrends={modifiedAppMetricsTrends} loading={appMetricsTrendsLoading} />
+                    <AppMetricsTrends
+                        appMetricsTrends={modifiedAppMetricsTrends}
+                        loading={appMetricsTrendsLoading}
+                        seriesColors={METRIC_COLORS}
+                    />
                 </>
             )}
         </div>

--- a/products/workflows/frontend/Workflows/WorkflowMetrics.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetrics.tsx
@@ -55,6 +55,19 @@ export const WORKFLOW_METRICS_INFO: Record<string, { name: string; description: 
 function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
     const logicKey = `hog-flow-metrics-${props.id}`
     const { searchParams } = useValues(router)
+    const { workflow, hogFunctionTemplatesById } = useValues(workflowLogic)
+
+    // Seed the drilled-in step from ?action= so a refreshed or shared metrics link restores it, but
+    // only honor a value that points at a real step — a stale/deleted/mistyped id would otherwise
+    // select a nonexistent instance and get stuck in the generic step view. While the workflow is
+    // still loading (no actions yet) we honor it optimistically so a shared link doesn't flash the
+    // overview first. Later changes (clicks, back/forward) are synced by workflowSceneLogic's urlToAction.
+    const requestedAction = (searchParams.action as string) || undefined
+    const instanceId =
+        requestedAction &&
+        (!workflow.actions.length || workflow.actions.some((action) => action.id === requestedAction))
+            ? requestedAction
+            : undefined
 
     const logic = appMetricsLogic({
         logicKey,
@@ -64,13 +77,9 @@ function WorkflowRunMetrics(props: WorkflowLogicProps): JSX.Element {
             appSource: 'hog_flow',
             appSourceId: props.id,
             breakdownBy: 'metric_name',
-            // Seed the drilled-in step from ?action= so a refreshed or shared metrics link restores it.
-            // Subsequent changes (clicks, back/forward) are synced by workflowSceneLogic's urlToAction.
-            instanceId: (searchParams.action as string) || undefined,
+            instanceId,
         },
     })
-
-    const { workflow, hogFunctionTemplatesById } = useValues(workflowLogic)
 
     const { appMetricsTrendsLoading, appMetricsTrends, getSingleTrendSeries, params, getDateRangeAbsolute } =
         useValues(logic)

--- a/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
@@ -1,18 +1,21 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import { LemonLabel, LemonTable, LemonTableColumns, Link, SpinnerOverlay } from '@posthog/lemon-ui'
+import { IconArrowRight, IconLetter, IconNotification } from '@posthog/icons'
+import { LemonLabel, LemonTable, LemonTableColumns, LemonTag, Link, SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { getColorVar } from 'lib/colors'
+import { type AppMetricsTimeSeriesResponse } from 'lib/components/AppMetrics/appMetricsLogic'
 import { AppMetricsTrends } from 'lib/components/AppMetrics/AppMetricsTrends'
 import { AppMetricSummary } from 'lib/components/AppMetrics/AppMetricSummary'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import {
     type EmailMetric,
-    WORKFLOW_SUMMARY_METRICS,
     type EmailMetricRow,
+    METRIC_COLORS,
     type PushMetricRow,
+    WORKFLOW_SUMMARY_METRICS,
     withDisplayName,
     workflowMetricsSummaryLogic,
     type WorkflowMetricsSummaryLogicProps,
@@ -47,139 +50,116 @@ export function WorkflowMetricsSummary({
         conversionStatsLoading,
         convertedUsersUrl,
         hasConversionGoal,
+        messagingChannels,
+        sentSummaryLabel,
     } = useValues(workflowMetricsSummaryLogic(props))
 
-    const emailMetricsColumns: LemonTableColumns<EmailMetricRow> = useMemo(
-        () => [
+    // Email and push don't share a funnel, so each channel gets its own table with the columns that
+    // actually apply — email keeps the delivery→open→click funnel, push surfaces skipped/failed as
+    // first-class columns. A workflow with a single channel just shows that one table.
+    const viewMetricsColumn = useCallback(
+        (id: string): JSX.Element => (
+            <Link onClick={() => onSelectAction?.(id)} className="whitespace-nowrap inline-flex items-center gap-1">
+                View metrics <IconArrowRight />
+            </Link>
+        ),
+        [onSelectAction]
+    )
+
+    const emailColumns: LemonTableColumns<EmailMetricRow> = useMemo(() => {
+        return [
             {
-                title: 'Email',
-                dataIndex: 'email',
-                key: 'email',
-                render: (_, row) =>
-                    onSelectAction ? (
-                        <span className="cursor-pointer text-link" onClick={() => onSelectAction(row.id)}>
-                            {row.email}
-                        </span>
-                    ) : (
-                        row.email
-                    ),
+                title: 'Step',
+                key: 'step',
+                render: (_, row) => <span className="font-medium">{row.email}</span>,
             },
-            {
-                title: 'Sent',
-                dataIndex: 'sent',
-                key: 'sent',
-                align: 'right',
-                render: (_, row) => row.sent.toLocaleString(),
-            },
+            { title: 'Sent', key: 'sent', align: 'right', render: (_, row) => row.sent.toLocaleString() },
             {
                 title: 'Delivered',
-                dataIndex: 'delivered',
                 key: 'delivered',
                 align: 'right',
                 render: (_, row) => row.delivered.toLocaleString(),
             },
+            { title: 'Opened', key: 'opened', align: 'right', render: (_, row) => row.opened.toLocaleString() },
+            { title: 'Clicked', key: 'clicked', align: 'right', render: (_, row) => row.linkClicked.toLocaleString() },
             {
-                title: 'Bounced',
-                dataIndex: 'bounced',
-                key: 'bounced',
-                align: 'right',
-                render: (_, row) =>
-                    onMetricClick && row.bounced > 0 ? (
-                        <span className="cursor-pointer text-link" onClick={() => onMetricClick('email_bounced')}>
-                            {row.bounced.toLocaleString()}
-                        </span>
-                    ) : (
-                        row.bounced.toLocaleString()
-                    ),
+                title: 'Issues',
+                key: 'issues',
+                render: (_, row) => {
+                    const issues = [
+                        {
+                            label: 'bounced',
+                            value: row.bounced,
+                            type: 'danger' as const,
+                            metric: 'email_bounced' as EmailMetric,
+                        },
+                        {
+                            label: 'blocked',
+                            value: row.blocked,
+                            type: 'danger' as const,
+                            metric: 'email_blocked' as EmailMetric,
+                        },
+                        {
+                            label: 'bounce prevented',
+                            value: row.bouncePrevented,
+                            type: 'warning' as const,
+                            metric: 'email_bounce_prevented' as EmailMetric,
+                        },
+                    ].filter((issue) => issue.value > 0)
+                    if (issues.length === 0) {
+                        return <span className="text-muted">—</span>
+                    }
+                    return (
+                        <div className="flex flex-wrap gap-1">
+                            {issues.map((issue) => (
+                                <LemonTag
+                                    key={issue.label}
+                                    type={issue.type}
+                                    onClick={onMetricClick ? () => onMetricClick(issue.metric) : undefined}
+                                    forceClickable={!!onMetricClick}
+                                >
+                                    {issue.value.toLocaleString()} {issue.label}
+                                </LemonTag>
+                            ))}
+                        </div>
+                    )
+                },
             },
-            {
-                title: 'Bounce prevented',
-                dataIndex: 'bouncePrevented',
-                key: 'bouncePrevented',
-                align: 'right',
-                render: (_, row) =>
-                    onMetricClick && row.bouncePrevented > 0 ? (
-                        <span
-                            className="cursor-pointer text-link"
-                            onClick={() => onMetricClick('email_bounce_prevented')}
-                        >
-                            {row.bouncePrevented.toLocaleString()}
-                        </span>
-                    ) : (
-                        row.bouncePrevented.toLocaleString()
-                    ),
-            },
-            {
-                title: 'Blocked',
-                dataIndex: 'blocked',
-                key: 'blocked',
-                align: 'right',
-                render: (_, row) =>
-                    onMetricClick && row.blocked > 0 ? (
-                        <span className="cursor-pointer text-link" onClick={() => onMetricClick('email_blocked')}>
-                            {row.blocked.toLocaleString()}
-                        </span>
-                    ) : (
-                        row.blocked.toLocaleString()
-                    ),
-            },
-            {
-                title: 'Opened',
-                dataIndex: 'opened',
-                key: 'opened',
-                align: 'right',
-                render: (_, row) => row.opened.toLocaleString(),
-            },
-            {
-                title: 'Clicked',
-                dataIndex: 'linkClicked',
-                key: 'linkClicked',
-                align: 'right',
-                render: (_, row) => row.linkClicked.toLocaleString(),
-            },
-        ],
-        [onSelectAction, onMetricClick]
-    )
+            ...(onSelectAction
+                ? [
+                      {
+                          title: '',
+                          key: 'view',
+                          align: 'right' as const,
+                          render: (_: unknown, row: EmailMetricRow) => viewMetricsColumn(row.id),
+                      },
+                  ]
+                : []),
+        ]
+    }, [onSelectAction, onMetricClick, viewMetricsColumn])
 
-    const pushMetricsColumns: LemonTableColumns<PushMetricRow> = useMemo(
-        () => [
+    const pushColumns: LemonTableColumns<PushMetricRow> = useMemo(() => {
+        return [
             {
-                title: 'Push',
-                dataIndex: 'push',
-                key: 'push',
-                render: (_, row) =>
-                    onSelectAction ? (
-                        <span className="cursor-pointer text-link" onClick={() => onSelectAction(row.id)}>
-                            {row.push}
-                        </span>
-                    ) : (
-                        row.push
-                    ),
+                title: 'Step',
+                key: 'step',
+                render: (_, row) => <span className="font-medium">{row.push}</span>,
             },
-            {
-                title: 'Sent',
-                dataIndex: 'sent',
-                key: 'sent',
-                align: 'right',
-                render: (_, row) => row.sent.toLocaleString(),
-            },
-            {
-                title: 'Skipped',
-                dataIndex: 'skipped',
-                key: 'skipped',
-                align: 'right',
-                render: (_, row) => row.skipped.toLocaleString(),
-            },
-            {
-                title: 'Failed',
-                dataIndex: 'failed',
-                key: 'failed',
-                align: 'right',
-                render: (_, row) => row.failed.toLocaleString(),
-            },
-        ],
-        [onSelectAction]
-    )
+            { title: 'Sent', key: 'sent', align: 'right', render: (_, row) => row.sent.toLocaleString() },
+            { title: 'Skipped', key: 'skipped', align: 'right', render: (_, row) => row.skipped.toLocaleString() },
+            { title: 'Failed', key: 'failed', align: 'right', render: (_, row) => row.failed.toLocaleString() },
+            ...(onSelectAction
+                ? [
+                      {
+                          title: '',
+                          key: 'view',
+                          align: 'right' as const,
+                          render: (_: unknown, row: PushMetricRow) => viewMetricsColumn(row.id),
+                      },
+                  ]
+                : []),
+        ]
+    }, [onSelectAction, viewMetricsColumn])
 
     return (
         <>
@@ -208,25 +188,62 @@ export function WorkflowMetricsSummary({
                     }
                     const metric = WORKFLOW_SUMMARY_METRICS[summaryMetric]
                     const metricName = metricNameBySummaryMetric[summaryMetric]
-                    const timeSeries =
-                        summaryMetric === 'completed'
-                            ? withDisplayName(getCompletedSingleTrendSeries('succeeded'), metric.name)
-                            : withDisplayName(getSingleTrendSeries(metricName), metric.name)
 
-                    const previousPeriodTimeSeries =
-                        summaryMetric === 'completed'
-                            ? withDisplayName(getCompletedSingleTrendSeries('succeeded', true), metric.name)
-                            : withDisplayName(getSingleTrendSeries(metricName, true), metric.name)
+                    // The "sent" tile is channel-aware: email-only and push-only get their own label,
+                    // and a flow that sends both sums the two channels into one "Messages" total.
+                    const isSent = summaryMetric === 'persons_messaged'
+                    const { hasEmail, hasPush } = messagingChannels
+                    const name = isSent ? sentSummaryLabel : metric.name
+                    const description =
+                        isSent && hasEmail && hasPush
+                            ? 'Total number of messages (emails and push notifications) attempted to be sent by this workflow'
+                            : isSent && hasPush
+                              ? 'Total number of push notifications attempted to be sent by this workflow'
+                              : metric.description
+                    const sentSeries = (previous?: boolean): AppMetricsTimeSeriesResponse | null => {
+                        if (hasEmail && hasPush) {
+                            // Split the combined "Messages" tile into Emails + Push lines. The headline
+                            // number stays their sum (AppMetricSummary totals across series); the sparkline
+                            // and its tooltip break the total down by channel.
+                            const emailSeries = getSingleTrendSeries('email_sent', previous)
+                            const pushSeries = getSingleTrendSeries('push_sent', previous)
+                            const labels = emailSeries?.labels ?? pushSeries?.labels ?? []
+                            return {
+                                labels,
+                                series: [
+                                    { name: 'Emails', values: emailSeries?.series[0]?.values ?? [] },
+                                    { name: 'Push notifications', values: pushSeries?.series[0]?.values ?? [] },
+                                ],
+                            }
+                        }
+                        return withDisplayName(
+                            getSingleTrendSeries(hasPush ? 'push_sent' : 'email_sent', previous),
+                            name
+                        )
+                    }
+
+                    const timeSeries = isSent
+                        ? sentSeries()
+                        : summaryMetric === 'completed'
+                          ? withDisplayName(getCompletedSingleTrendSeries('succeeded'), name)
+                          : withDisplayName(getSingleTrendSeries(metricName), name)
+
+                    const previousPeriodTimeSeries = isSent
+                        ? sentSeries(true)
+                        : summaryMetric === 'completed'
+                          ? withDisplayName(getCompletedSingleTrendSeries('succeeded', true), name)
+                          : withDisplayName(getSingleTrendSeries(metricName, true), name)
 
                     return (
                         <AppMetricSummary
                             key={summaryMetric}
-                            name={metric.name}
-                            description={metric.description}
+                            name={name}
+                            description={description}
                             loading={loading}
                             timeSeries={timeSeries}
                             previousPeriodTimeSeries={previousPeriodTimeSeries}
-                            color={metric.color}
+                            color={METRIC_COLORS[name] ?? metric.color}
+                            seriesColors={METRIC_COLORS}
                             colorIfZero={getColorVar('muted')}
                             footer={
                                 summaryMetric === 'converted' &&
@@ -265,28 +282,43 @@ export function WorkflowMetricsSummary({
                 )}
             </div>
 
-            <LemonTable
-                columns={emailMetricsColumns}
-                dataSource={emailMetricsRows}
-                loading={emailTotalsByActionIdLoading}
-                rowKey="id"
-                size="small"
-                emptyState="No email actions in this workflow"
-            />
+            {/* A table per channel, since email and push report different metrics. */}
+            {emailMetricsRows.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                    <LemonLabel className="flex items-center gap-1.5">
+                        <span className="flex text-lg text-secondary">
+                            <IconLetter />
+                        </span>
+                        Email steps
+                    </LemonLabel>
+                    <LemonTable
+                        columns={emailColumns}
+                        dataSource={emailMetricsRows}
+                        loading={emailTotalsByActionIdLoading}
+                        rowKey="id"
+                        size="small"
+                    />
+                </div>
+            ) : null}
+            {pushMetricsRows.length > 0 ? (
+                <div className="flex flex-col gap-1">
+                    <LemonLabel className="flex items-center gap-1.5">
+                        <span className="flex text-lg text-secondary">
+                            <IconNotification />
+                        </span>
+                        Push steps
+                    </LemonLabel>
+                    <LemonTable
+                        columns={pushColumns}
+                        dataSource={pushMetricsRows}
+                        loading={pushTotalsByActionIdLoading}
+                        rowKey="id"
+                        size="small"
+                    />
+                </div>
+            ) : null}
 
-            {/* Push has no delivery/open/click receipts like email — only the three send-time outcomes. */}
-            {pushMetricsRows.length > 0 && (
-                <LemonTable
-                    columns={pushMetricsColumns}
-                    dataSource={pushMetricsRows}
-                    loading={pushTotalsByActionIdLoading}
-                    rowKey="id"
-                    size="small"
-                    emptyState="No push actions in this workflow"
-                />
-            )}
-
-            <AppMetricsTrends appMetricsTrends={workflowSummaryTrends} loading={loading} />
+            <AppMetricsTrends appMetricsTrends={workflowSummaryTrends} loading={loading} seriesColors={METRIC_COLORS} />
         </>
     )
 }

--- a/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
@@ -202,7 +202,7 @@ export function WorkflowMetricsSummary({
                               : metric.description
                     const sentSeries = (previous?: boolean): AppMetricsTimeSeriesResponse | null => {
                         if (hasEmail && hasPush) {
-                            // Split the combined "Messages" tile into Emails + Push lines. The headline
+                            // Split the combined "Messages sent" tile into Emails + Push lines. The headline
                             // number stays their sum (AppMetricSummary totals across series); the sparkline
                             // and its tooltip break the total down by channel.
                             const emailSeries = getSingleTrendSeries('email_sent', previous)
@@ -211,8 +211,8 @@ export function WorkflowMetricsSummary({
                             return {
                                 labels,
                                 series: [
-                                    { name: 'Emails', values: emailSeries?.series[0]?.values ?? [] },
-                                    { name: 'Push notifications', values: pushSeries?.series[0]?.values ?? [] },
+                                    { name: 'Emails sent', values: emailSeries?.series[0]?.values ?? [] },
+                                    { name: 'Push notifications sent', values: pushSeries?.series[0]?.values ?? [] },
                                 ],
                             }
                         }

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.test.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.test.ts
@@ -142,10 +142,10 @@ describe('detectMessagingChannels', () => {
 
 describe('channelSentLabel', () => {
     it.each([
-        [{ hasEmail: true, hasPush: true }, 'Messages'],
-        [{ hasEmail: false, hasPush: true }, 'Push notifications'],
-        [{ hasEmail: true, hasPush: false }, 'Emails'],
-        [{ hasEmail: false, hasPush: false }, 'Emails'],
+        [{ hasEmail: true, hasPush: true }, 'Messages sent'],
+        [{ hasEmail: false, hasPush: true }, 'Push notifications sent'],
+        [{ hasEmail: true, hasPush: false }, 'Emails sent'],
+        [{ hasEmail: false, hasPush: false }, 'Emails sent'],
     ])('%o -> %s', (channels, expected) => {
         expect(channelSentLabel(channels)).toBe(expected)
     })

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.test.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.test.ts
@@ -3,6 +3,10 @@ import { AppMetricsTimeSeriesResponse } from 'lib/components/AppMetrics/appMetri
 import {
     type EmailMetric,
     buildEmailMetricInvocationSearchParams,
+    buildEmailMetricRows,
+    buildPushMetricRows,
+    channelSentLabel,
+    detectMessagingChannels,
     subtractSeries,
     withDisplayName,
 } from './workflowMetricsSummaryLogic'
@@ -109,4 +113,94 @@ describe('buildEmailMetricInvocationSearchParams', () => {
             expect(buildEmailMetricInvocationSearchParams(metricKey, dateFrom, dateTo)).toBeNull()
         }
     )
+})
+
+describe('detectMessagingChannels', () => {
+    // Only the `*_sent` series flip a channel on — this guards the exact metric names the tile keys off.
+    it.each([
+        { name: 'no trends', input: null, expected: { hasEmail: false, hasPush: false } },
+        {
+            name: 'email only',
+            input: series(['d1'], ['email_sent', [3]]),
+            expected: { hasEmail: true, hasPush: false },
+        },
+        { name: 'push only', input: series(['d1'], ['push_sent', [2]]), expected: { hasEmail: false, hasPush: true } },
+        {
+            name: 'both channels',
+            input: series(['d1'], ['email_sent', [3]], ['push_sent', [2]]),
+            expected: { hasEmail: true, hasPush: true },
+        },
+        {
+            name: 'ignores non-sent series',
+            input: series(['d1'], ['email_delivered', [3]], ['push_skipped', [1]]),
+            expected: { hasEmail: false, hasPush: false },
+        },
+    ])('$name', ({ input, expected }) => {
+        expect(detectMessagingChannels(input)).toEqual(expected)
+    })
+})
+
+describe('channelSentLabel', () => {
+    it.each([
+        [{ hasEmail: true, hasPush: true }, 'Messages'],
+        [{ hasEmail: false, hasPush: true }, 'Push notifications'],
+        [{ hasEmail: true, hasPush: false }, 'Emails'],
+        [{ hasEmail: false, hasPush: false }, 'Emails'],
+    ])('%o -> %s', (channels, expected) => {
+        expect(channelSentLabel(channels)).toBe(expected)
+    })
+})
+
+describe('buildEmailMetricRows', () => {
+    it('maps each metric key onto the row, preferring the reported email_delivered', () => {
+        const rows = buildEmailMetricRows([{ id: 'a1', name: 'Welcome email' }], {
+            a1: {
+                email_sent: 100,
+                email_delivered: 85, // reported value wins over the derived sent - bounced - blocked (= 90)
+                email_opened: 40,
+                email_link_clicked: 12,
+                email_bounced: 6,
+                email_bounce_prevented: 2,
+                email_blocked: 4,
+            },
+        })
+        expect(rows).toEqual([
+            {
+                id: 'a1',
+                email: 'Welcome email',
+                sent: 100,
+                delivered: 85,
+                opened: 40,
+                linkClicked: 12,
+                bounced: 6,
+                bouncePrevented: 2,
+                blocked: 4,
+            },
+        ])
+    })
+
+    // delivered falls back to sent - bounced - blocked (clamped at 0) when it wasn't collected.
+    it.each<{ totals: Partial<Record<EmailMetric, number>>; delivered: number }>([
+        { totals: { email_sent: 10, email_bounced: 3, email_blocked: 2 }, delivered: 5 },
+        { totals: { email_sent: 1, email_bounced: 5 }, delivered: 0 },
+        { totals: {}, delivered: 0 },
+    ])('derives delivered=$delivered when email_delivered is absent', ({ totals, delivered }) => {
+        expect(buildEmailMetricRows([{ id: 'a1', name: 'E' }], { a1: totals })[0].delivered).toBe(delivered)
+    })
+})
+
+describe('buildPushMetricRows', () => {
+    it('maps sent/skipped/failed per action and defaults missing totals to 0', () => {
+        const rows = buildPushMetricRows(
+            [
+                { id: 'p1', name: 'Reminder' },
+                { id: 'p2', name: 'Promo' },
+            ],
+            { p1: { push_sent: 50, push_skipped: 20, push_failed: 3 } }
+        )
+        expect(rows).toEqual([
+            { id: 'p1', push: 'Reminder', sent: 50, skipped: 20, failed: 3 },
+            { id: 'p2', push: 'Promo', sent: 0, skipped: 0, failed: 0 },
+        ])
+    })
 })

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -82,12 +82,12 @@ export type EmailMetricRow = {
 // which is built for it — except Failed, which always uses `danger` so a failure reads as an error.
 export const METRIC_COLORS: Record<string, string> = {
     // Whole-workflow summary
-    'In progress': getColorVar('warning'),
-    Started: getColorVar('success'),
+    'Workflows in progress': getColorVar('warning'),
+    'Workflows started': getColorVar('success'),
     Emails: getColorVar('blue'),
     'Push notifications': getColorVar('data-color-3'),
     Messages: getColorVar('blue'),
-    Completed: getColorVar('warning'),
+    'Workflows completed': getColorVar('warning'),
     Converted: getColorVar('purple'),
     // Email + push step funnels
     Sent: getColorVar('data-color-1'),
@@ -117,15 +117,15 @@ export const WORKFLOW_SUMMARY_METRICS: Record<
     }
 > = {
     in_progress: {
-        name: 'In progress',
+        name: 'Workflows in progress',
         description: 'Total number of workflow runs currently in progress',
-        color: METRIC_COLORS['In progress'],
+        color: METRIC_COLORS['Workflows in progress'],
         metricNames: ['in_progress'],
     },
     started: {
-        name: 'Started',
+        name: 'Workflows started',
         description: 'Total number of workflow runs started',
-        color: METRIC_COLORS['Started'],
+        color: METRIC_COLORS['Workflows started'],
         metricNames: ['triggered'],
     },
     persons_messaged: {
@@ -135,10 +135,10 @@ export const WORKFLOW_SUMMARY_METRICS: Record<
         metricNames: ['email_sent'],
     },
     completed: {
-        name: 'Completed',
+        name: 'Workflows completed',
         description:
             'Total number of workflow runs that finished — whether they reached the end of the workflow or exited early (for example, by meeting the conversion goal on an exit-on-conversion workflow). This may include runs that began before the selected date range but finished within it.',
-        color: METRIC_COLORS['Completed'],
+        color: METRIC_COLORS['Workflows completed'],
         metricNames: ['succeeded'],
     },
     converted: {

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -629,7 +629,10 @@ export interface workflowMetricsSummaryLogicMeta {
             type: 'function_push'
             updated_at?: number | undefined
         } & Record<string, unknown>)[]
-        messagingChannels: (appMetricsTrends: AppMetricsTimeSeriesResponse | null) => {
+        messagingChannels: (
+            workflow: HogFlow,
+            appMetricsTrends: AppMetricsTimeSeriesResponse | null
+        ) => {
             hasEmail: boolean
             hasPush: boolean
         }
@@ -936,12 +939,22 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
             (workflow: import('./hogflows/types').HogFlow) => workflow.actions.filter(isPushAction),
         ],
 
-        // Which messaging channels actually produced "sent" metrics in the fetched window. Drives the
-        // channel-aware "sent" summary tile + chart, so a push-only flow says "Push notifications".
+        // Which messaging channels the workflow uses, driving the channel-aware "sent" summary tile +
+        // chart. Keyed off the workflow's configured actions so the tile's identity stays stable across
+        // date ranges (matching the step tables, which also key off configured actions), unioned with any
+        // channel that actually sent in the window so historical data from a since-deleted action still shows.
         messagingChannels: [
-            (s) => [s.appMetricsTrends],
-            (appMetricsTrends: AppMetricsTimeSeriesResponse | null): { hasEmail: boolean; hasPush: boolean } =>
-                detectMessagingChannels(appMetricsTrends),
+            (s) => [s.workflow, s.appMetricsTrends],
+            (
+                workflow: import('./hogflows/types').HogFlow,
+                appMetricsTrends: AppMetricsTimeSeriesResponse | null
+            ): { hasEmail: boolean; hasPush: boolean } => {
+                const observed = detectMessagingChannels(appMetricsTrends)
+                return {
+                    hasEmail: workflow.actions.some(isEmailAction) || observed.hasEmail,
+                    hasPush: workflow.actions.some(isPushAction) || observed.hasPush,
+                }
+            },
         ],
 
         // "Emails sent" for email-only, "Push notifications sent" for push-only, "Messages sent" for both.

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -69,6 +69,44 @@ export type EmailMetricRow = {
     blocked: number
 }
 
+// Single source of truth for metric colors across the workflow metric views. Keyed by the metric's
+// display name so the same label reads the same color everywhere — in the summary tiles and in the
+// trends chart below them. Pass this to `AppMetricsTrends` as `seriesColors` and to `AppMetricSummary`
+// so tiles and charts never drift apart.
+//
+// Only `success`/`blue`/`purple`/`warning`/`danger` exist as themed color vars; the rest (`orange`,
+// `indigo`, `red`, `primary`) resolve to white in dark mode. The whole-workflow summary mostly uses
+// those themed colors, but Push notifications takes a neutral data-visualization color instead of
+// `danger` so a normal channel does not read as an error. The email and push funnels have more series
+// than there are distinct semantic colors, so they use the data-visualization palette (`data-color-*`),
+// which is built for it — except Failed, which always uses `danger` so a failure reads as an error.
+export const METRIC_COLORS: Record<string, string> = {
+    // Whole-workflow summary
+    'In progress': getColorVar('warning'),
+    Started: getColorVar('success'),
+    Emails: getColorVar('blue'),
+    'Push notifications': getColorVar('data-color-3'),
+    Messages: getColorVar('blue'),
+    Completed: getColorVar('warning'),
+    Converted: getColorVar('purple'),
+    // Email + push step funnels
+    Sent: getColorVar('data-color-1'),
+    Delivered: getColorVar('data-color-2'),
+    Failed: getColorVar('danger'),
+    Opened: getColorVar('data-color-4'),
+    'Link clicked': getColorVar('data-color-5'),
+    Bounced: getColorVar('data-color-6'),
+    'Bounce prevented': getColorVar('data-color-7'),
+    Blocked: getColorVar('data-color-8'),
+    'Marked as spam': getColorVar('data-color-9'),
+    Skipped: getColorVar('data-color-2'),
+    // Workflow run + batch-job metrics
+    Success: getColorVar('success'),
+    Failure: getColorVar('danger'),
+    'Rate Limited': getColorVar('warning'),
+    Triggered: getColorVar('blue'),
+}
+
 export const WORKFLOW_SUMMARY_METRICS: Record<
     WorkflowSummaryMetric,
     {
@@ -81,33 +119,33 @@ export const WORKFLOW_SUMMARY_METRICS: Record<
     in_progress: {
         name: 'In progress',
         description: 'Total number of workflow runs currently in progress',
-        color: getColorVar('warning'),
+        color: METRIC_COLORS['In progress'],
         metricNames: ['in_progress'],
     },
     started: {
         name: 'Started',
         description: 'Total number of workflow runs started',
-        color: getColorVar('success'),
+        color: METRIC_COLORS['Started'],
         metricNames: ['triggered'],
     },
     persons_messaged: {
-        name: 'Emails sent',
+        name: 'Emails',
         description: 'Total number of emails attempted to be sent by this workflow',
-        color: '#00F',
+        color: METRIC_COLORS['Emails'],
         metricNames: ['email_sent'],
     },
     completed: {
         name: 'Completed',
         description:
             'Total number of workflow runs that finished — whether they reached the end of the workflow or exited early (for example, by meeting the conversion goal on an exit-on-conversion workflow). This may include runs that began before the selected date range but finished within it.',
-        color: getColorVar('success'),
+        color: METRIC_COLORS['Completed'],
         metricNames: ['succeeded'],
     },
     converted: {
         name: 'Converted',
         description:
             'Total number of conversions recorded for this workflow. A conversion is counted when a person matches the workflow’s conversion goal (property- or event-based), regardless of whether the workflow is set to exit on conversion.',
-        color: getColorVar('purple'),
+        color: METRIC_COLORS['Converted'],
         metricNames: ['conversion'],
     },
 }
@@ -119,58 +157,58 @@ export const WORKFLOW_EMAIL_METRICS: Record<
     email_sent: {
         name: 'Sent',
         description: 'Total number of emails sent to recipients',
-        color: getColorVar('primary'),
+        color: METRIC_COLORS['Sent'],
         metricNames: ['email_sent'],
     },
     email_delivered: {
         name: 'Delivered',
         description:
             "Total number of emails that were successfully delivered to the recipient's inbox. This is confirmed by the recipient's mail server accepting the email.",
-        color: getColorVar('success'),
+        color: METRIC_COLORS['Delivered'],
         metricNames: ['email_delivered'],
     },
     email_failed: {
         name: 'Failed',
         description:
             'Total number of emails that were not attempted to be sent. This typically indicates the PostHog email service determined the email contained a virus.',
-        color: getColorVar('danger'),
+        color: METRIC_COLORS['Failed'],
         metricNames: ['email_failed'],
     },
     email_opened: {
         name: 'Opened',
         description: 'Total number of emails opened',
-        color: getColorVar('blue'),
+        color: METRIC_COLORS['Opened'],
         metricNames: ['email_opened'],
     },
     email_link_clicked: {
         name: 'Link clicked',
         description: 'Total number of times links in emails were clicked',
-        color: getColorVar('indigo'),
+        color: METRIC_COLORS['Link clicked'],
         metricNames: ['email_link_clicked'],
     },
     email_bounced: {
         name: 'Bounced',
         description: 'Total number of emails that bounced',
-        color: getColorVar('orange'),
+        color: METRIC_COLORS['Bounced'],
         metricNames: ['email_bounced'],
     },
     email_bounce_prevented: {
         name: 'Bounce prevented',
         description:
             'Total number of emails that were not sent because pre-send validation predicted a hard bounce: the address was malformed or its domain has no mail servers. These sends are skipped before they can hurt deliverability and are not billed.',
-        color: getColorVar('purple'),
+        color: METRIC_COLORS['Bounce prevented'],
         metricNames: ['email_bounce_prevented'],
     },
     email_blocked: {
         name: 'Blocked',
         description: 'Total number of emails that were blocked by the recipient server',
-        color: getColorVar('red'),
+        color: METRIC_COLORS['Blocked'],
         metricNames: ['email_blocked'],
     },
     email_spam: {
         name: 'Marked as spam',
         description: 'Total number of emails that were marked as spam by recipient server or recipient email client',
-        color: getColorVar('danger'),
+        color: METRIC_COLORS['Marked as spam'],
         metricNames: ['email_spam'],
     },
 }
@@ -186,21 +224,21 @@ export const WORKFLOW_PUSH_METRICS: Record<
         name: 'Sent',
         description:
             'Total number of push notifications accepted by the provider (FCM or APNs) for delivery. The provider accepting a notification does not guarantee the device displayed it.',
-        color: getColorVar('primary'),
+        color: METRIC_COLORS['Sent'],
         metricNames: ['push_sent'],
     },
     push_skipped: {
         name: 'Skipped',
         description:
             'Total number of recipients skipped because they had no registered device token, or their token was reported dead by the provider (for example, the app was uninstalled) and removed.',
-        color: getColorVar('warning'),
+        color: METRIC_COLORS['Skipped'],
         metricNames: ['push_skipped'],
     },
     push_failed: {
         name: 'Failed',
         description:
             'Total number of push notifications that could not be sent — for example invalid credentials, a rejected payload, or a provider outage after retries.',
-        color: getColorVar('danger'),
+        color: METRIC_COLORS['Failed'],
         metricNames: ['push_failed'],
     },
 }
@@ -343,6 +381,10 @@ export interface workflowMetricsSummaryLogicValues {
     inProgressTotal: number
     inProgressTotalLoading: boolean
     loading: boolean
+    messagingChannels: {
+        hasEmail: boolean
+        hasPush: boolean
+    }
     metricNameBySummaryMetric: Record<WorkflowSummaryMetric, string>
     pushActions: ({
         config: {
@@ -395,6 +437,7 @@ export interface workflowMetricsSummaryLogicValues {
     pushMetricsRows: PushMetricRow[]
     pushTotalsByActionId: Record<string, Partial<Record<PushMetric, number>>>
     pushTotalsByActionIdLoading: boolean
+    sentSummaryLabel: string
     summaryMetricKeys: WorkflowSummaryMetric[]
     workflowSummaryTrends: AppMetricsTimeSeriesResponse | null
 }
@@ -586,6 +629,11 @@ export interface workflowMetricsSummaryLogicMeta {
             type: 'function_push'
             updated_at?: number | undefined
         } & Record<string, unknown>)[]
+        messagingChannels: (appMetricsTrends: AppMetricsTimeSeriesResponse | null) => {
+            hasEmail: boolean
+            hasPush: boolean
+        }
+        sentSummaryLabel: (messagingChannels: { hasEmail: boolean; hasPush: boolean }) => string
         metricNameBySummaryMetric: (
             appMetricsTrends: AppMetricsTimeSeriesResponse | null
         ) => Record<WorkflowSummaryMetric, string>
@@ -596,7 +644,7 @@ export interface workflowMetricsSummaryLogicMeta {
                 dateFrom: Dayjs
                 dateTo: Dayjs
                 diffMs: number
-            },
+            }, // appMetricsLogic
             arg: string
         ) => string
         workflowSummaryTrends: (
@@ -606,7 +654,12 @@ export interface workflowMetricsSummaryLogicMeta {
             getCompletedSingleTrendSeries: (
                 name: string,
                 previousPeriod?: boolean
-            ) => AppMetricsTimeSeriesResponse | null
+            ) => AppMetricsTimeSeriesResponse | null, // appMetricsLogic
+            messagingChannels: {
+                hasEmail: boolean
+                hasPush: boolean
+            },
+            sentSummaryLabel: string
         ) => AppMetricsTimeSeriesResponse | null
         emailMetricsRows: (
             emailActions: ({
@@ -883,6 +936,20 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
             (workflow: import('./hogflows/types').HogFlow) => workflow.actions.filter(isPushAction),
         ],
 
+        // Which messaging channels actually produced "sent" metrics in the fetched window. Drives the
+        // channel-aware "sent" summary tile + chart, so a push-only flow says "Push notifications".
+        messagingChannels: [
+            (s) => [s.appMetricsTrends],
+            (appMetricsTrends: AppMetricsTimeSeriesResponse | null): { hasEmail: boolean; hasPush: boolean } =>
+                detectMessagingChannels(appMetricsTrends),
+        ],
+
+        // "Emails" for email-only, "Push notifications" for push-only, "Messages" for both.
+        sentSummaryLabel: [
+            (s) => [s.messagingChannels],
+            (messagingChannels: { hasEmail: boolean; hasPush: boolean }): string => channelSentLabel(messagingChannels),
+        ],
+
         metricNameBySummaryMetric: [
             (s) => [s.appMetricsTrends],
             (appMetricsTrends: AppMetricsTimeSeriesResponse | null): Record<WorkflowSummaryMetric, string> =>
@@ -966,6 +1033,8 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
                 s.completedTrends,
                 s.metricNameBySummaryMetric,
                 s.getCompletedSingleTrendSeries,
+                s.messagingChannels,
+                s.sentSummaryLabel,
             ],
             (
                 appMetricsTrends: AppMetricsTimeSeriesResponse | null,
@@ -974,36 +1043,46 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
                 getCompletedSingleTrendSeries: (
                     name: string,
                     previousPeriod?: boolean
-                ) => AppMetricsTimeSeriesResponse | null
+                ) => AppMetricsTimeSeriesResponse | null,
+                messagingChannels: { hasEmail: boolean; hasPush: boolean },
+                sentSummaryLabel: string
             ): AppMetricsTimeSeriesResponse | null => {
                 if (!appMetricsTrends && !completedTrends) {
                     return null
                 }
 
                 const labels = appMetricsTrends?.labels ?? completedTrends?.labels ?? []
-                const completedValues =
-                    getCompletedSingleTrendSeries('succeeded')?.series[0]?.values ??
-                    Array.from({ length: labels.length }, () => 0)
+                const zero = (): number[] => Array.from({ length: labels.length }, () => 0)
+                const seriesFor = (metricName: string): number[] =>
+                    appMetricsTrends?.series.find((x: { name: string }) => x.name === metricName)?.values ?? zero()
+                const completedValues = getCompletedSingleTrendSeries('succeeded')?.series[0]?.values ?? zero()
 
                 return {
                     labels,
-                    series: SUMMARY_METRIC_KEYS.map((summaryMetric) => {
+                    series: SUMMARY_METRIC_KEYS.flatMap((summaryMetric) => {
                         if (summaryMetric === 'completed') {
-                            return {
-                                name: WORKFLOW_SUMMARY_METRICS.completed.name,
-                                values: completedValues,
+                            return [{ name: WORKFLOW_SUMMARY_METRICS.completed.name, values: completedValues }]
+                        }
+
+                        // Channel-aware "sent": split into separate Emails + Push notifications lines when
+                        // both channels sent, otherwise a single line labelled for whichever channel did.
+                        if (summaryMetric === 'persons_messaged') {
+                            const { hasEmail, hasPush } = messagingChannels
+                            if (hasEmail && hasPush) {
+                                return [
+                                    { name: 'Emails', values: seriesFor('email_sent') },
+                                    { name: 'Push notifications', values: seriesFor('push_sent') },
+                                ]
                             }
+                            return [{ name: sentSummaryLabel, values: seriesFor(hasPush ? 'push_sent' : 'email_sent') }]
                         }
 
-                        const selectedMetricName = metricNameBySummaryMetric[summaryMetric]
-                        const matchedSeries = appMetricsTrends?.series.find(
-                            (series: { name: string }) => series.name === selectedMetricName
-                        )
-
-                        return {
-                            name: WORKFLOW_SUMMARY_METRICS[summaryMetric].name,
-                            values: matchedSeries?.values ?? Array.from({ length: labels.length }, () => 0),
-                        }
+                        return [
+                            {
+                                name: WORKFLOW_SUMMARY_METRICS[summaryMetric].name,
+                                values: seriesFor(metricNameBySummaryMetric[summaryMetric]),
+                            },
+                        ]
                     }),
                 }
             },
@@ -1061,25 +1140,7 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
                     updated_at?: number | undefined
                 } & Record<string, unknown>)[],
                 emailTotalsByActionId: Record<string, Partial<Record<EmailMetric, number>>>
-            ): EmailMetricRow[] =>
-                emailActions.map((action: { id: string; name: string }) => {
-                    const totals = emailTotalsByActionId[action.id] || {}
-                    const sent = totals.email_sent ?? 0
-                    const bounced = totals.email_bounced ?? 0
-                    const blocked = totals.email_blocked ?? 0
-                    return {
-                        id: action.id,
-                        email: action.name,
-                        // Fallback to calculating delivered as sent - bounced - blocked if email_delivered metric is not available, since we were not always collecting this metric
-                        delivered: totals.email_delivered ?? Math.max(0, sent - bounced - blocked),
-                        sent: totals.email_sent ?? 0,
-                        opened: totals.email_opened ?? 0,
-                        linkClicked: totals.email_link_clicked ?? 0,
-                        bounced,
-                        bouncePrevented: totals.email_bounce_prevented ?? 0,
-                        blocked,
-                    }
-                }),
+            ): EmailMetricRow[] => buildEmailMetricRows(emailActions, emailTotalsByActionId),
         ],
 
         pushMetricsRows: [
@@ -1134,17 +1195,7 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
                     updated_at?: number | undefined
                 } & Record<string, unknown>)[],
                 pushTotalsByActionId: Record<string, Partial<Record<PushMetric, number>>>
-            ): PushMetricRow[] =>
-                pushActions.map((action: { id: string; name: string }) => {
-                    const totals = pushTotalsByActionId[action.id] || {}
-                    return {
-                        id: action.id,
-                        push: action.name,
-                        sent: totals.push_sent ?? 0,
-                        skipped: totals.push_skipped ?? 0,
-                        failed: totals.push_failed ?? 0,
-                    }
-                }),
+            ): PushMetricRow[] => buildPushMetricRows(pushActions, pushTotalsByActionId),
         ],
     }),
 
@@ -1218,6 +1269,62 @@ export function subtractSeries(
             },
         ],
     }
+}
+
+// Which messaging channels produced "sent" metrics in the fetched window, keyed off the trend series.
+export function detectMessagingChannels(appMetricsTrends: AppMetricsTimeSeriesResponse | null): {
+    hasEmail: boolean
+    hasPush: boolean
+} {
+    return {
+        hasEmail: !!appMetricsTrends?.series.some((x: { name: string }) => x.name === 'email_sent'),
+        hasPush: !!appMetricsTrends?.series.some((x: { name: string }) => x.name === 'push_sent'),
+    }
+}
+
+// "Emails" for email-only, "Push notifications" for push-only, "Messages" for both.
+export function channelSentLabel({ hasEmail, hasPush }: { hasEmail: boolean; hasPush: boolean }): string {
+    return hasEmail && hasPush ? 'Messages' : hasPush ? 'Push notifications' : 'Emails'
+}
+
+export function buildEmailMetricRows(
+    emailActions: { id: string; name: string }[],
+    emailTotalsByActionId: Record<string, Partial<Record<EmailMetric, number>>>
+): EmailMetricRow[] {
+    return emailActions.map((action) => {
+        const totals = emailTotalsByActionId[action.id] || {}
+        const sent = totals.email_sent ?? 0
+        const bounced = totals.email_bounced ?? 0
+        const blocked = totals.email_blocked ?? 0
+        return {
+            id: action.id,
+            email: action.name,
+            // Fallback to calculating delivered as sent - bounced - blocked if email_delivered metric is not available, since we were not always collecting this metric
+            delivered: totals.email_delivered ?? Math.max(0, sent - bounced - blocked),
+            sent,
+            opened: totals.email_opened ?? 0,
+            linkClicked: totals.email_link_clicked ?? 0,
+            bounced,
+            bouncePrevented: totals.email_bounce_prevented ?? 0,
+            blocked,
+        }
+    })
+}
+
+export function buildPushMetricRows(
+    pushActions: { id: string; name: string }[],
+    pushTotalsByActionId: Record<string, Partial<Record<PushMetric, number>>>
+): PushMetricRow[] {
+    return pushActions.map((action) => {
+        const totals = pushTotalsByActionId[action.id] || {}
+        return {
+            id: action.id,
+            push: action.name,
+            sent: totals.push_sent ?? 0,
+            skipped: totals.push_skipped ?? 0,
+            failed: totals.push_failed ?? 0,
+        }
+    })
 }
 
 function mapEmailMetricsToActions(

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -84,11 +84,11 @@ export const METRIC_COLORS: Record<string, string> = {
     // Whole-workflow summary
     'Workflows in progress': getColorVar('warning'),
     'Workflows started': getColorVar('success'),
-    Emails: getColorVar('blue'),
-    'Push notifications': getColorVar('data-color-3'),
-    Messages: getColorVar('blue'),
+    'Emails sent': getColorVar('blue'),
+    'Push notifications sent': getColorVar('data-color-3'),
+    'Messages sent': getColorVar('blue'),
     'Workflows completed': getColorVar('warning'),
-    Converted: getColorVar('purple'),
+    'Workflows converted': getColorVar('purple'),
     // Email + push step funnels
     Sent: getColorVar('data-color-1'),
     Delivered: getColorVar('data-color-2'),
@@ -129,9 +129,9 @@ export const WORKFLOW_SUMMARY_METRICS: Record<
         metricNames: ['triggered'],
     },
     persons_messaged: {
-        name: 'Emails',
+        name: 'Emails sent',
         description: 'Total number of emails attempted to be sent by this workflow',
-        color: METRIC_COLORS['Emails'],
+        color: METRIC_COLORS['Emails sent'],
         metricNames: ['email_sent'],
     },
     completed: {
@@ -142,10 +142,10 @@ export const WORKFLOW_SUMMARY_METRICS: Record<
         metricNames: ['succeeded'],
     },
     converted: {
-        name: 'Converted',
+        name: 'Workflows converted',
         description:
             'Total number of conversions recorded for this workflow. A conversion is counted when a person matches the workflow’s conversion goal (property- or event-based), regardless of whether the workflow is set to exit on conversion.',
-        color: METRIC_COLORS['Converted'],
+        color: METRIC_COLORS['Workflows converted'],
         metricNames: ['conversion'],
     },
 }
@@ -944,7 +944,7 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
                 detectMessagingChannels(appMetricsTrends),
         ],
 
-        // "Emails" for email-only, "Push notifications" for push-only, "Messages" for both.
+        // "Emails sent" for email-only, "Push notifications sent" for push-only, "Messages sent" for both.
         sentSummaryLabel: [
             (s) => [s.messagingChannels],
             (messagingChannels: { hasEmail: boolean; hasPush: boolean }): string => channelSentLabel(messagingChannels),
@@ -1070,8 +1070,8 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
                             const { hasEmail, hasPush } = messagingChannels
                             if (hasEmail && hasPush) {
                                 return [
-                                    { name: 'Emails', values: seriesFor('email_sent') },
-                                    { name: 'Push notifications', values: seriesFor('push_sent') },
+                                    { name: 'Emails sent', values: seriesFor('email_sent') },
+                                    { name: 'Push notifications sent', values: seriesFor('push_sent') },
                                 ]
                             }
                             return [{ name: sentSummaryLabel, values: seriesFor(hasPush ? 'push_sent' : 'email_sent') }]
@@ -1282,9 +1282,9 @@ export function detectMessagingChannels(appMetricsTrends: AppMetricsTimeSeriesRe
     }
 }
 
-// "Emails" for email-only, "Push notifications" for push-only, "Messages" for both.
+// "Emails sent" for email-only, "Push notifications sent" for push-only, "Messages sent" for both.
 export function channelSentLabel({ hasEmail, hasPush }: { hasEmail: boolean; hasPush: boolean }): string {
-    return hasEmail && hasPush ? 'Messages' : hasPush ? 'Push notifications' : 'Emails'
+    return hasEmail && hasPush ? 'Messages sent' : hasPush ? 'Push notifications sent' : 'Emails sent'
 }
 
 export function buildEmailMetricRows(

--- a/products/workflows/frontend/Workflows/workflowSceneLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowSceneLogic.ts
@@ -1,6 +1,7 @@
 import { MakeLogicType, actions, kea, key, path, props, reducers, selectors } from 'kea'
 import { router, urlToAction } from 'kea-router'
 
+import { appMetricsLogic } from 'lib/components/AppMetrics/appMetricsLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -106,6 +107,14 @@ export const workflowSceneLogic = kea<workflowSceneLogicType>([
             }
             if (tab !== values.currentTab) {
                 actions.setCurrentTab(tab as WorkflowTab)
+            }
+            // Keep the run-metrics step drilldown in sync with ?action= so refresh, shared links, and
+            // browser back/forward restore the selected step (its date range/interval stay untouched).
+            // Batch metrics render several per-job tables, so they keep their own local selection.
+            if (tab === 'metrics' && id && id !== 'new') {
+                appMetricsLogic
+                    .findMounted({ logicKey: `hog-flow-metrics-${id}` })
+                    ?.actions.setParams({ instanceId: (searchParams.action as string) || undefined })
             }
         },
     })),


### PR DESCRIPTION
## Problem

The Workflows Metrics tab was built for email. Once workflows started mixing email and push in one flow, the breakdown got cluttered, the drill-downs were unclear, and metric colors were inconsistent:

- The "Messages" tile and chart lumped email and push into one line, so you couldn't tell the channels apart (they even rendered the same color).
- A single email-shaped table forced push into columns it can't fill (delivered / opened / clicked showed "—"), and demoted push's real signals (skipped / failed) into tags.
- Selecting one step's metrics wasn't discoverable, and the selection lived only in local state, so it couldn't be shared, refreshed, or navigated with the back button.
- Every metric view colored its summary tiles from one source and its trends chart from another, so the same metric showed a different color in the tile and in the chart below it.
- The whole-workflow tile labels were terse enough to misread — "Started" could mean "started sending emails" rather than "workflow runs started", and "Converted" / "Emails" didn't say what they counted.

This is a UX exploration branch to make the Metrics tab clear for multi-channel workflows.

## Changes

The change has four parts:

| Area | What |
|---|---|
| Channel-aware "sent" metric | The "sent" tile reads "Emails sent" / "Push notifications sent" / "Messages sent" depending on which channels the workflow actually used. |
| Explicit tile labels | The whole-workflow tiles spell out what they count so customers don't have to guess: "Workflows started", "Workflows in progress", "Workflows completed", "Workflows converted", and the sent tiles carry "sent". |
| Per-step drill-down | Adds a "Metrics for" label, groups the step selector with the interval / date-range filters, and deep-links the selected step as `?action=` so refresh, shared links, and back/forward restore it (date range + interval preserved). |
| Split step tables | Two channel-specific tables: email keeps the delivery→open→click funnel with bounced / blocked issue tags; push gets Sent / Skipped / Failed as real columns. The channel icon shows once in the table heading. Each row has a "View metrics →" link. |
| Consistent metric colors | A single `METRIC_COLORS` map (keyed by metric display name) drives both the summary tiles and the trends chart across every workflow metric view (summary, email step, push step, run/batch step), so a metric reads the same color in both. `AppMetricsTrends` and `AppMetricSummary` gained additive optional `seriesColors` props — when unset the behavior is identical, so every other metric consumer (destinations, batch exports, pipeline nodes, event filtering, data warehouse) is unaffected. Colors use only CSS vars that actually resolve — `orange` / `indigo` / `red` / `primary` don't exist and fall back to white in dark mode. The summary uses resolving semantic colors (with a neutral palette color for push notifications, so a normal channel doesn't read as an error); the email/push funnels use the data-viz palette, since they have more series than there are distinct semantic colors; and `danger` is reserved for failures. |

Before:
<img width="2764" height="1370" alt="Screenshot 2026-07-16 at 21 07 03" src="https://github.com/user-attachments/assets/be46b2c6-fce4-4bcc-9318-11df0da77566"/>

After:

https://github.com/user-attachments/assets/96ff8e71-c8e9-4ba3-884a-6445feb19da6



> [!NOTE]
> The email Issues tags (bounced / blocked) are clickable and drill into the filtered Invocations tab. The push Skipped / Failed numbers are plain, since they aren't clickable.

## How did you test this code?

I (Claude, agent-assisted) drove a local dev instance in a real browser (Playwright MCP), and @dmarchuk reviewed the rendered result across email-only, push-only, and mixed workflows. Verified:

- Both channel-specific tables render with the right columns, and push shows no "—" placeholders.
- Clicking an email "bounced" / "blocked" tag navigates to the Invocations tab pre-filtered (search term + WARN/ERROR levels) over the current window. Checked against real SES bounce and complaint data generated locally via the mailbox simulator.
- The summary tiles and the trends chart show each metric in the same color, including the combined "Messages sent" tile's Emails + Push split lines matching the big chart.
- Step selection deep-links end to end: loading `?action=` restores the step, clicking a step writes the URL, browser back/forward live-syncs the selection, and the date range / interval are preserved across selection.

The run/batch-step view uses the same shared `seriesColors` mechanism, so its consistency was covered by typecheck + CI rather than driven separately in a browser.

Added Jest unit tests in `workflowMetricsSummaryLogic.test.ts` for the extracted pure logic — `detectMessagingChannels`, `channelSentLabel`, `buildEmailMetricRows`, `buildPushMetricRows` — alongside the existing `buildEmailMetricInvocationSearchParams` coverage. Frontend CI — typecheck, Jest, format, bundle, storybook, visual regression — is green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a - internal Metrics tab UX, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, driven by @dmarchuk across an interactive session. The arc: analyze the cluttered multi-channel Metrics tab, make the "sent" metric channel-aware, explore the breakdown layout (uniform cards → one unified table → two channel-specific tables, once it was clear email and push don't share a funnel), make metric colors consistent between tiles and charts, then make the whole-workflow tile labels explicit ("Workflows started/in progress/completed/converted", sent tiles carry "sent") so customers don't misread them.

The color work landed as one shared `METRIC_COLORS` constant (in `workflowMetricsSummaryLogic.ts`) plus additive `seriesColors` props on the shared `AppMetricsTrends` / `AppMetricSummary` (opt-in, so other metric consumers render byte-identically when they don't pass it). Destinations were explicitly kept out of scope: that metrics view is `HogFunctionMetrics`, shared with transformations and site apps, so an earlier attempt to wire it was reverted to avoid touching those surfaces. Along the way we found several color vars (`orange`, `indigo`, `red`, `primary`) aren't defined and resolve to white in dark mode — a latent bug in the original constants that only surfaced once charts read the shared map; the fix uses the resolving semantic vars where they suffice and the data-viz palette for the wider email/push funnels.

URL deep-linking was scoped to the run-metrics view via `workflowSceneLogic`'s `urlToAction`, kept out of the shared `appMetricsLogic` (12 callers) and driven so the date range / interval aren't reset.
