### PR TITLE
chore(web-analytics): clean up share nudge experiment

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -3,7 +3,7 @@ import { Form } from 'kea-forms'
 import posthog from 'posthog-js'
 import { useMemo, useState } from 'react'
 
-import { IconFilter, IconGlobe, IconPhone, IconPlus, IconShare } from '@posthog/icons'
+import { IconFilter, IconGlobe, IconPhone, IconPlus } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonDivider, LemonInput, LemonSelect, Popover, Tooltip } from '@posthog/lemon-ui'
 
 import { AuthorizedUrlListType, authorizedUrlListLogic } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
@@ -29,7 +29,6 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { COUNTRY_CODE_TO_LONG_NAME, countryCodeToFlag } from 'lib/utils/country'
 import MaxTool from 'scenes/max/MaxTool'
 import { Scene } from 'scenes/sceneTypes'
-import { shareNudgeLogic } from 'scenes/web-analytics/shareNudgeLogic'
 
 import { ReloadAll } from '~/queries/nodes/DataNode/Reload'
 import { PropertyFilterType, PropertyMathType } from '~/types'
@@ -480,7 +479,6 @@ export const WebAnalyticsCompareFilter = (): JSX.Element | null => {
 
 const ShareButton = (): JSX.Element => {
     const { activePreset } = useValues(webAnalyticsFilterPresetsLogic)
-    const { emphasizeShareButton } = useValues(shareNudgeLogic)
 
     const handleShare = (): void => {
         const url = new URL(window.location.href)
@@ -498,14 +496,12 @@ const ShareButton = (): JSX.Element => {
         <LemonButton
             type="secondary"
             size="small"
-            icon={emphasizeShareButton ? <IconShare /> : <IconLink />}
-            tooltip={emphasizeShareButton ? undefined : 'Share'}
+            icon={<IconLink />}
+            tooltip="Share"
             tooltipPlacement="top"
             onClick={handleShare}
             data-attr="web-analytics-share-button"
-        >
-            {emphasizeShareButton ? 'Share' : undefined}
-        </LemonButton>
+        />
     )
 }
 

--- a/frontend/src/scenes/web-analytics/WebAnalyticsHeaderButtons.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHeaderButtons.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useState } from 'react'
 
-import { IconBolt, IconPerson, IconShare } from '@posthog/icons'
+import { IconBolt, IconPerson } from '@posthog/icons'
 
 import { LiveUserCount } from 'lib/components/LiveUserCount'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -13,7 +13,6 @@ import { Popover } from 'lib/lemon-ui/Popover'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { teamLogic } from 'scenes/teamLogic'
-import { shareNudgeLogic } from 'scenes/web-analytics/shareNudgeLogic'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 import { WebAnalyticsMenu } from 'scenes/web-analytics/WebAnalyticsMenu'
 
@@ -23,7 +22,6 @@ export function WebAnalyticsHeaderButtons(): JSX.Element {
     const { updateCurrentTeam } = useActions(teamLogic)
     const { shouldFilterTestAccounts } = useValues(webAnalyticsLogic)
     const { setShouldFilterTestAccounts } = useActions(webAnalyticsLogic)
-    const { emphasizeShareButton } = useValues(shareNudgeLogic)
     const [showPopover, setShowPopover] = useState(false)
 
     const hasFeatureFlag = featureFlags[FEATURE_FLAGS.SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES]
@@ -59,14 +57,12 @@ export function WebAnalyticsHeaderButtons(): JSX.Element {
                 <LemonButton
                     type="secondary"
                     size="small"
-                    icon={emphasizeShareButton ? <IconShare fontSize="16" /> : <IconLink fontSize="16" />}
-                    tooltip={emphasizeShareButton ? undefined : 'Share'}
+                    icon={<IconLink fontSize="16" />}
+                    tooltip="Share"
                     tooltipPlacement="top"
                     onClick={handleShare}
                     data-attr="web-analytics-share-button"
-                >
-                    {emphasizeShareButton ? 'Share' : undefined}
-                </LemonButton>
+                />
             )}
             <LemonButton
                 type="secondary"

--- a/frontend/src/scenes/web-analytics/shareNudgeLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/shareNudgeLogic.test.ts
@@ -86,6 +86,17 @@ describe('shareNudgeLogic', () => {
         expect(logic.values.promptVisible).toBe(false)
     })
 
+    it.each([
+        { variant: 'control', expected: false },
+        { variant: 'control_b', expected: false },
+        { variant: 'banner', expected: true },
+        { variant: 'export', expected: false },
+    ])('shows the banner only for the "$variant" variant', ({ variant, expected }) => {
+        mount(variant)
+
+        expect(logic.values.showBanner).toBe(expected)
+    })
+
     it('does not show the prompt for a solo org even on the "export" variant', () => {
         randomSpy.mockReturnValue(0)
         setMemberCount(1)
@@ -129,13 +140,16 @@ describe('shareNudgeLogic', () => {
         }).toMatchValues({ promptVisible: false, sessionDismissed: true })
     })
 
-    it('captures the exposure event once for the "export" variant', () => {
-        setVariant('export')
-        logic = shareNudgeLogic()
-        logic.mount()
+    it.each(['control', 'control_b', 'banner', 'export'])(
+        'captures the exposure event once for the "%s" variant',
+        (variant) => {
+            setVariant(variant)
+            logic = shareNudgeLogic()
+            logic.mount()
 
-        expect(capturesOf('web analytics share nudge exposed')).toEqual([
-            ['web analytics share nudge exposed', { variant: 'export' }],
-        ])
-    })
+            expect(capturesOf('web analytics share nudge exposed')).toEqual([
+                ['web analytics share nudge exposed', { variant }],
+            ])
+        }
+    )
 })

--- a/frontend/src/scenes/web-analytics/shareNudgeLogic.ts
+++ b/frontend/src/scenes/web-analytics/shareNudgeLogic.ts
@@ -9,8 +9,6 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import type { shareNudgeLogicType } from './shareNudgeLogicType'
 
 const FLAG = FEATURE_FLAGS.WEB_ANALYTICS_SHARE_NUDGE_V2
-const DASHBOARD_SELECTOR = '[data-attr="web-analytics-dashboard"]'
-const HOVER_DWELL_MS = 2500
 const EXPORT_PROMPT_PROBABILITY = 0.25
 
 export const shareNudgeLogic = kea<shareNudgeLogicType>([
@@ -60,8 +58,6 @@ export const shareNudgeLogic = kea<shareNudgeLogicType>([
             (s) => [s.variant, s.sessionDismissed],
             (variant, sessionDismissed): boolean => variant === 'banner' && !sessionDismissed,
         ],
-        emphasizeShareButton: [(s) => [s.variant], (variant): boolean => variant === 'button'],
-        intentPromptEnabled: [(s) => [s.variant], (variant): boolean => variant === 'prompt'],
         exportPromptEnabled: [(s) => [s.variant], (variant): boolean => variant === 'export'],
     }),
     listeners(({ values, actions }) => ({
@@ -78,62 +74,12 @@ export const shareNudgeLogic = kea<shareNudgeLogicType>([
             actions.showPrompt('export_prompt')
         },
     })),
-    subscriptions(({ values, actions, cache }) => ({
+    subscriptions(({ cache }) => ({
         variant: (variant: string | null) => {
             if (variant && !cache.exposed) {
                 cache.exposed = true
                 posthog.capture('web analytics share nudge exposed', { variant })
             }
-
-            if (variant !== 'prompt') {
-                cache.disposables.dispose('shareNudgeIntentListeners')
-                return
-            }
-
-            cache.disposables.add(() => {
-                const shouldTrigger = (): boolean =>
-                    values.intentPromptEnabled && !values.sessionDismissed && !values.promptVisible
-
-                const onMouseUp = (): void => {
-                    if (!shouldTrigger()) {
-                        return
-                    }
-                    const selection = window.getSelection()
-                    const text = selection?.toString().trim()
-                    if (!text || text.length < 2 || !selection?.anchorNode) {
-                        return
-                    }
-                    const container = document.querySelector(DASHBOARD_SELECTOR)
-                    if (!container || !container.contains(selection.anchorNode)) {
-                        return
-                    }
-                    actions.showPrompt('intent_prompt')
-                }
-
-                const onMouseMove = (event: MouseEvent): void => {
-                    const target = event.target as HTMLElement | null
-                    if (!shouldTrigger() || !target?.closest?.(DASHBOARD_SELECTOR)) {
-                        cache.disposables.dispose('shareNudgeHoverDwell')
-                        return
-                    }
-                    cache.disposables.add(() => {
-                        const timer = setTimeout(() => {
-                            if (shouldTrigger()) {
-                                actions.showPrompt('intent_prompt')
-                            }
-                        }, HOVER_DWELL_MS)
-                        return () => clearTimeout(timer)
-                    }, 'shareNudgeHoverDwell')
-                }
-
-                document.addEventListener('mouseup', onMouseUp)
-                document.addEventListener('mousemove', onMouseMove)
-                return () => {
-                    document.removeEventListener('mouseup', onMouseUp)
-                    document.removeEventListener('mousemove', onMouseMove)
-                    cache.disposables.dispose('shareNudgeHoverDwell')
-                }
-            }, 'shareNudgeIntentListeners')
         },
     })),
 ])


### PR DESCRIPTION
## Problem

The completed web analytics share-nudge experiment left unreachable variant branches in the active V2 implementation.

**Why:** Keep the current experiment code aligned with its configured variants and remove obsolete behavior that can no longer run.

## Changes

- Remove the old button-emphasis and intent-triggered prompt paths.
- Preserve the active V2 banner and export-prompt behavior.
- Add regression coverage for every variant in the running V2 experiment.
- Retire the original experiment feature flag in PostHog.

## How did you test this code?

- `git diff --check`
- Added a parameterized V2 variant matrix that verifies banner visibility and exposure capture for `control`, `control_b`, `banner`, and `export`. This guards against cleanup accidentally removing a live experiment arm or its exposure event.
- The focused Jest test could not run locally because this cloud checkout has no frontend `node_modules`, `kea-typegen`, or `hogli` installation. CI runs the focused frontend validation on the pushed commit.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes are needed because this removes unreachable experiment code without changing the current V2 workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI made the code changes and used the PostHog MCP to audit the experiments and retire the original flag. It invoked `/auditing-experiments-flags`, `/writing-tests`, and `/using-kea-disposables`. The cleanup keeps the V2 `banner` and `export` variants while removing only branches that are absent from the V2 flag configuration.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*