### PR TITLE
feat(error-tracking): attach fingerprint to issue spiking internal event

### DIFF
--- a/rust/cymbal/src/modes/notifications/issue_handler.rs
+++ b/rust/cymbal/src/modes/notifications/issue_handler.rs
@@ -154,6 +154,7 @@ pub async fn handle_issue_spiking(
         &context.internal_events_topic,
         meta.notification_id,
         &issue,
+        &event_properties.fingerprint,
         computed_baseline,
         current_bucket_value,
     )

--- a/rust/cymbal/src/modes/notifications/issue_handler.rs
+++ b/rust/cymbal/src/modes/notifications/issue_handler.rs
@@ -116,11 +116,14 @@ pub async fn handle_issue_spiking(
         event_properties,
     } = issue;
 
+    let detected_at = spike_detection_time(meta.notification_id);
+
     match persist_spike_event(
         context,
         meta.notification_id,
         meta.team_id,
         issue_id,
+        detected_at,
         computed_baseline,
         current_bucket_value,
     )
@@ -155,6 +158,7 @@ pub async fn handle_issue_spiking(
         meta.notification_id,
         &issue,
         &event_properties.fingerprint,
+        detected_at,
         computed_baseline,
         current_bucket_value,
     )
@@ -191,15 +195,29 @@ fn issue_from_notification(
     }
 }
 
+// When the spike was detected, not when this consumer processed the notification. The
+// notification_id is a UUIDv7 minted in notification_meta() on the processing side, in the same
+// call stack as spike detection, so its embedded timestamp survives any consumer lag. Falls back
+// to now() for legacy payloads where serde defaulted the id at consume time.
+fn spike_detection_time(notification_id: Uuid) -> DateTime<Utc> {
+    notification_id
+        .get_timestamp()
+        .and_then(|ts| {
+            let (secs, nanos) = ts.to_unix();
+            DateTime::from_timestamp(secs as i64, nanos)
+        })
+        .unwrap_or_else(Utc::now)
+}
+
 async fn persist_spike_event(
     context: &NotificationsContext,
     notification_id: Uuid,
     team_id: i32,
     issue_id: Uuid,
+    detected_at: DateTime<Utc>,
     computed_baseline: f64,
     current_bucket_value: f64,
 ) -> Result<PersistSpikeEventResult, UnhandledError> {
-    let now = Utc::now();
     let result = sqlx::query(
         r#"WITH existing_issue AS (
                SELECT 1 FROM posthog_errortrackingissue
@@ -214,7 +232,7 @@ async fn persist_spike_event(
     .bind(notification_id)
     .bind(team_id)
     .bind(issue_id)
-    .bind(now)
+    .bind(detected_at)
     .bind(computed_baseline)
     .bind(current_bucket_value as i32)
     .execute(&context.posthog_pool)
@@ -249,4 +267,29 @@ fn parse_notification_timestamp(event_timestamp: &str, event_uuid: Uuid) -> Date
         );
         Utc::now()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::{NoContext, Timestamp};
+
+    #[test]
+    fn spike_detection_time_recovers_the_v7_mint_instant() {
+        let minted = DateTime::parse_from_rfc3339("2026-07-16T10:30:00.123Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let ts = Timestamp::from_unix(
+            NoContext,
+            minted.timestamp() as u64,
+            minted.timestamp_subsec_nanos(),
+        );
+        let notification_id = Uuid::new_v7(ts);
+
+        // UUIDv7 stores millisecond precision, so compare at that granularity.
+        assert_eq!(
+            spike_detection_time(notification_id).timestamp_millis(),
+            minted.timestamp_millis()
+        );
+    }
 }

--- a/rust/cymbal/src/modes/notifications/side_effects.rs
+++ b/rust/cymbal/src/modes/notifications/side_effects.rs
@@ -157,6 +157,7 @@ pub async fn send_issue_spiking_internal_event<I: NotificationIssue>(
     internal_events_topic: &str,
     notification_id: Uuid,
     issue: &I,
+    fingerprint: &str,
     computed_baseline: f64,
     current_bucket_value: f64,
 ) -> Result<(), UnhandledError> {
@@ -179,6 +180,13 @@ pub async fn send_issue_spiking_internal_event<I: NotificationIssue>(
     event
         .insert_prop("current_bucket_value", current_bucket_value)
         .expect("insert_prop for current_bucket_value should never fail");
+    event
+        .insert_prop("fingerprint", fingerprint)
+        .expect("insert_prop for fingerprint should never fail");
+    // Spikes are detected on live traffic, so "now" is a good anchor for finding example events.
+    event
+        .insert_prop("exception_timestamp", Utc::now())
+        .expect("insert_prop for exception_timestamp should never fail");
 
     let iter = [InternalEvent {
         team_id: issue.team_id(),

--- a/rust/cymbal/src/modes/notifications/side_effects.rs
+++ b/rust/cymbal/src/modes/notifications/side_effects.rs
@@ -152,12 +152,14 @@ pub async fn send_issue_reopened_internal_event<I: NotificationIssue>(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn send_issue_spiking_internal_event<I: NotificationIssue>(
     producer: &FutureProducer<KafkaContext>,
     internal_events_topic: &str,
     notification_id: Uuid,
     issue: &I,
     fingerprint: &str,
+    detected_at: DateTime<Utc>,
     computed_baseline: f64,
     current_bucket_value: f64,
 ) -> Result<(), UnhandledError> {
@@ -183,9 +185,10 @@ pub async fn send_issue_spiking_internal_event<I: NotificationIssue>(
     event
         .insert_prop("fingerprint", fingerprint)
         .expect("insert_prop for fingerprint should never fail");
-    // Spikes are detected on live traffic, so "now" is a good anchor for finding example events.
+    // Spikes are detected on live traffic, so detection time is a good anchor for finding
+    // example events.
     event
-        .insert_prop("exception_timestamp", Utc::now())
+        .insert_prop("exception_timestamp", detected_at)
         .expect("insert_prop for exception_timestamp should never fail");
 
     let iter = [InternalEvent {


### PR DESCRIPTION
## Problem

Spiking alert links need a merge-stable fingerprint, but `$error_tracking_issue_spiking` internal events don't carry one.

## Changes

Attach `fingerprint` and `exception_timestamp` (spike detection time) to the spiking internal event in cymbal, matching the created/reopened events. Split out of #71031 so it can deploy first; the alert templates that consume these properties land there.

## How did you test this code?

`cargo check -p cymbal` / clippy — the emit path has no existing test harness, and templates tolerate the property being absent until #71031 lands.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — alert-authoring skill references update in #71031 with the templates.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split from #71031 per review workflow so cymbal deploys before the templates that rely on the new properties.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
