### PR TITLE
fix(conversations): keep To recipients on email tickets

### DIFF
--- a/products/conversations/backend/api/email_events.py
+++ b/products/conversations/backend/api/email_events.py
@@ -248,6 +248,34 @@ def _sender_authenticated(request: HttpRequest, sender_email: str) -> bool:
     return bool(envelope_domain and from_domain and envelope_domain == from_domain)
 
 
+def _collect_participants(
+    to_header: str,
+    cc_header: str,
+    inbound_token: str,
+    channel_email: str,
+    sender_email: str,
+) -> list[str]:
+    """Collect the other people on the thread from the To + Cc headers.
+
+    Excludes the support inbox itself (the Mailgun team-<token>@ inbound address
+    and the channel's own from_email) and the sender, since none of those are
+    "other participants" — they're the mailbox we received on, or the person we
+    reply back to. The result is what we keep CC'd on outbound replies, so a
+    direct recipient (someone in To with the support address only CC'd) stays on
+    the thread instead of being dropped.
+    """
+    team_inbound_address = f"team-{inbound_token}@"
+    excluded = {channel_email.lower(), sender_email.lower()}
+    participants: list[str] = []
+    for _name, addr in getaddresses([to_header, cc_header]):
+        low = addr.lower()
+        if not low or low in excluded or low.startswith(team_inbound_address):
+            continue
+        if low not in participants:
+            participants.append(low)
+    return participants
+
+
 def _resolve_team_member(email: str, team: Team) -> User | None:
     """Match a sender email to a PostHog user within the team's organization."""
     if not email:
@@ -329,16 +357,16 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
     # senders whose domain has p=quarantine or p=reject).
     sender_email, sender_name = _recover_dmarc_rewritten_sender(request, config, sender_email, sender_name)
 
-    # 6b. Parse CC recipients
-    cc_header = request.POST.get("Cc", "")
-    cc_list: list[str] = []
-    if cc_header:
-        team_inbound_address = f"team-{inbound_token}@"
-        cc_list = [
-            addr.lower()
-            for _name, addr in getaddresses([cc_header])
-            if addr and not addr.lower().startswith(team_inbound_address)
-        ]
+    # 6b. Parse other thread participants from To + Cc. We fold both into a single
+    # list (dropping the support inbox itself and the sender) so a direct recipient
+    # who only CC'd the support address still shows up and stays on replies.
+    cc_list = _collect_participants(
+        to_header=request.POST.get("To", ""),
+        cc_header=request.POST.get("Cc", ""),
+        inbound_token=inbound_token,
+        channel_email=config.from_email,
+        sender_email=sender_email,
+    )
 
     # 7. Get content (stripped by Mailgun to remove quotes/signatures)
     content = (request.POST.get("stripped-text", "") or request.POST.get("body-plain", ""))[:MAX_EMAIL_BODY_LENGTH]
@@ -417,6 +445,11 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
             )
 
             if existing_ticket:
+                # The requester is already the reply target (to=email_from); when another
+                # participant reply-alls, the requester shows up in their To/Cc and must not
+                # be folded into cc_participants or replies would deliver to them twice.
+                ticket_from = (ticket.email_from or "").lower()
+                cc_list = [addr for addr in cc_list if addr != ticket_from]
                 qs = Ticket.objects.filter(id=ticket.id, team=team)
                 if not is_team_member and cc_list:
                     qs.update(

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -1540,14 +1540,33 @@ class TestEmailInboundCcParticipants(BaseTest):
 
     @parameterized.expand(
         [
-            ("with_display_names", "Dev <dev@company.com>, pm@company.com", ["dev@company.com", "pm@company.com"]),
-            ("self_cc_filtered", "dev@company.com, team-cc00ee11ff22@mg.posthog.com", ["dev@company.com"]),
-            ("no_cc_header", None, []),
+            # (_name, to_header, cc_header, expected)
+            (
+                "cc_with_display_names",
+                None,
+                "Dev <dev@company.com>, pm@company.com",
+                ["dev@company.com", "pm@company.com"],
+            ),
+            ("self_cc_filtered", None, "dev@company.com, team-cc00ee11ff22@mg.posthog.com", ["dev@company.com"]),
+            ("no_recipients", None, None, []),
+            # Direct recipient in To, support address only CC'd — the recipient must survive.
+            (
+                "to_recipient_kept_channel_dropped",
+                "auser@example.com",
+                "support@example.com",
+                ["auser@example.com"],
+            ),
+            # Channel's own address and the sender are never participants.
+            ("channel_and_sender_excluded", "sender@test.com, support@example.com", None, []),
+            # To + Cc merge and dedupe.
+            ("to_and_cc_merged", "auser@example.com", "dev@company.com", ["auser@example.com", "dev@company.com"]),
         ]
     )
     @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
-    def test_new_ticket_cc_participants(self, _name, cc_header, expected, _mock_sig):
+    def test_new_ticket_participants(self, _name, to_header, cc_header, expected, _mock_sig):
         data = self._base_data(f"<cc-{_name}@test.com>")
+        if to_header:
+            data["To"] = to_header
         if cc_header:
             data["Cc"] = cc_header
         response = self.client.post("/api/conversations/v1/email/inbound", data)
@@ -1568,6 +1587,18 @@ class TestEmailInboundCcParticipants(BaseTest):
         data2["In-Reply-To"] = "<cc2@test.com>"
         data2["Cc"] = "dev@company.com, new@company.com"
         self.client.post("/api/conversations/v1/email/inbound", data2)
+
+        ticket.refresh_from_db()
+        assert ticket.cc_participants == ["dev@company.com", "new@company.com"]
+
+        # A participant reply-alls: the requester lands in To but is already the
+        # reply target, so they must not be merged into cc_participants.
+        data3 = self._base_data("<cc4@test.com>")
+        data3["from"] = "dev@company.com"
+        data3["In-Reply-To"] = "<cc2@test.com>"
+        data3["To"] = "sender@test.com, support@example.com"
+        data3["Cc"] = "new@company.com"
+        self.client.post("/api/conversations/v1/email/inbound", data3)
 
         ticket.refresh_from_db()
         assert ticket.cc_participants == ["dev@company.com", "new@company.com"]

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -897,7 +897,9 @@ class TestSendEmailReplyMultiConfig(BaseTest):
         config1 = self._create_config("support@example.com", "aaa111")
         self._create_config("billing@example.com", "bbb222")
         ticket = self._create_ticket(config1)
-        ticket.cc_participants = ["cc1@example.com", "cc2@example.com"]
+        # Legacy tickets may carry the requester in cc_participants; they must not
+        # be delivered to twice (they're already the To recipient).
+        ticket.cc_participants = ["cc1@example.com", "customer@test.com", "cc2@example.com"]
         ticket.save(update_fields=["cc_participants"])
 
         _, outbox = self._run_reply(ticket)
@@ -908,7 +910,7 @@ class TestSendEmailReplyMultiConfig(BaseTest):
         # Regression guard: must use the ticket's domain, not a shared/global one.
         assert args[0] == "example.com"
 
-        # Recipients include the customer and every CC participant.
+        # Recipients include the customer and every CC participant, minus the requester.
         assert kwargs["recipients"] == ["customer@test.com", "cc1@example.com", "cc2@example.com"]
 
         # MIME body carries the From header with the config's from_email.

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -743,17 +743,21 @@ def _process_outbox_row(outbox: EmailOutboxMessage) -> None:
 
     from_email = formataddr((config.from_name or author_name, config.from_email))
 
+    # Tickets created before To/Cc participant filtering may still have the requester
+    # persisted in cc_participants; drop them here so they aren't delivered to twice.
+    cc = [addr for addr in (ticket.cc_participants or []) if addr.lower() != ticket.email_from.lower()]
+
     email_message = mail.EmailMultiAlternatives(
         subject=subject,
         body=txt_body,
         from_email=from_email,
         to=[ticket.email_from],
-        cc=ticket.cc_participants or [],
+        cc=cc,
         headers=headers,
     )
     email_message.attach_alternative(html_body, "text/html")
 
-    recipients = [ticket.email_from, *(ticket.cc_participants or [])]
+    recipients = [ticket.email_from, *cc]
     mime_bytes = email_message.message().as_bytes(linesep="\r\n")
 
     try:


### PR DESCRIPTION
## Problem

Inbound email tickets only stored participants from the `Cc` header. Anyone listed only in `To` was dropped, so they never showed in the ticket UI and were not CC'd on replies.

Separately, the channel's own `from_email` could leak into `cc_participants` when it appeared on the original message (the filter only stripped the Mailgun `team-<token>@` inbound address).

## Changes

- Parse both `To` and `Cc` into `cc_participants`, excluding the support inbox (`team-<token>@` and channel `from_email`) and the current sender
- On threaded replies, also exclude the ticket requester (`email_from`) so they are not double-delivered when a participant reply-alls (outbound already uses them as `To`)


## How did you test this code?

Extended `TestEmailInboundCcParticipants` in `test_email_endpoints.py`:

- Direct `To` recipient kept while channel address in `Cc` is dropped
- Channel + sender excluded from participants
- `To` + `Cc` merge/dedupe
- Reply-all path: requester in `To` must not land in `cc_participants`
