### PR TITLE
fix(data-warehouse): stop delta revive marker resurrecting after removal

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -470,8 +470,10 @@ async def handle_corrupted_delta_log(
                 )
 
                 # The completed swap copied the full temp table over live, so any hollow-table
-                # marker is stale now.
-                await database_sync_to_async_pool(update_sync_type_config_keys)(
+                # marker is stale now. Refresh the in-memory config from the persisted result —
+                # this schema object keeps saving `sync_type_config` for the rest of the run, and
+                # a stale copy would write the marker back, re-arming the revive every sync.
+                schema.sync_type_config = await database_sync_to_async_pool(update_sync_type_config_keys)(
                     schema.id, schema.team_id, removes=["delta_revive_required"]
                 )
                 await logger.ainfo(
@@ -491,7 +493,10 @@ async def handle_corrupted_delta_log(
 
     await delta_table_helper.reset_table()
     await database_sync_to_async_pool(schema.update_sync_type_config_for_reset_pipeline)()
-    await database_sync_to_async_pool(update_sync_type_config_keys)(
+    # Refresh the in-memory config from the persisted result — this schema object keeps saving
+    # `sync_type_config` for the rest of the run (incremental staging, partition bookkeeping), and
+    # a stale copy would write the marker back, re-arming a non-billable revive on every sync.
+    schema.sync_type_config = await database_sync_to_async_pool(update_sync_type_config_keys)(
         schema.id, schema.team_id, removes=["repartition_pending", "repartition_swap", "delta_revive_required"]
     )
     was_billable = bool(job.billable)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -287,6 +287,11 @@ class TestHandleCorruptedDeltaLog:
         helper.reset_table.assert_awaited_once()
         job.refresh_from_db()
         assert job.billable is False
+        # The in-memory copy must be refreshed too: the pipeline keeps saving this same schema
+        # object for the rest of the run (incremental staging, partition bookkeeping), and a stale
+        # copy writes the marker back — re-arming a non-billable full rebuild on every sync.
+        assert "delta_revive_required" not in schema.sync_type_config
+        schema.stage_incremental_field_value("run-1", 5)
         schema.refresh_from_db()
         assert "delta_revive_required" not in schema.sync_type_config
         assert ph.capture.call_args.kwargs["properties"]["outcome"] == "reset_rebuild"
@@ -296,8 +301,11 @@ class TestHandleCorruptedDeltaLog:
         # rather than reset — the customer's data is recovered without a rebuild, so reset_table never runs
         # and the job stays billable. Guards the salvage-from-temp branch against regressing to a reset.
         schema, job = self._schema_and_job(team)
+        # A hollow-table marker can coexist with the interrupted swap (the repartition scan set it
+        # before the swap crashed) — the salvage must clear it in memory as well as in the DB.
         schema.sync_type_config = {
-            "repartition_swap": {"state": "ready", "temp_uri": "s3://bucket/temp", "live_uri": "s3://bucket/live"}
+            "repartition_swap": {"state": "ready", "temp_uri": "s3://bucket/temp", "live_uri": "s3://bucket/live"},
+            "delta_revive_required": {"reason": "repartition_scan_missing_data_file", "missing_path": "x/p.parquet"},
         }
         schema.save(update_fields=["sync_type_config"])
         helper = MagicMock(
@@ -323,6 +331,12 @@ class TestHandleCorruptedDeltaLog:
         helper.reset_table.assert_not_awaited()
         job.refresh_from_db()
         assert job.billable is True
+        # Same stale-copy guard as the reset path: a later full-config save off this schema object
+        # must not write the cleared marker back.
+        assert "delta_revive_required" not in schema.sync_type_config
+        schema.stage_incremental_field_value("run-1", 5)
+        schema.refresh_from_db()
+        assert "delta_revive_required" not in schema.sync_type_config
         # A salvage must be observable too, tagged as recovered-from-temp with the rebuild left billable.
         assert ph.capture.call_args.kwargs["event"] == "warehouse_delta_revived"
         assert ph.capture.call_args.kwargs["properties"]["outcome"] == "salvaged"


### PR DESCRIPTION
## Problem

`handle_corrupted_delta_log` revives a corrupt Delta table when the schema carries a `delta_revive_required` marker in `sync_type_config`:
it resets the table, marks the job non-billable (the corruption is our fault, not the customer's), and removes the marker from the DB via `update_sync_type_config_keys`.

That helper removes the key by re-fetching the row under a lock and returns the persisted config, and its contract says callers must refresh their in-memory copy from the returned dict.
`handle_corrupted_delta_log` ignored the return value, so the long-lived in-memory `schema.sync_type_config` still contained the marker.
Any later full-config save in the same run (incremental staging, partition bookkeeping) wrote the stale JSON back and resurrected the marker.

The result is a permanent loop: every subsequent sync sees the marker, resets the table, re-pulls the entire table from the customer's source, wipes incremental state, and creates another non-billable job.
This shows up as a step increase in non-billable `ExternalDataJob` rows and repeated `warehouse_delta_revived` telemetry events for the same schemas.

## Changes

- Assign the persisted config returned by `update_sync_type_config_keys` back onto the in-memory schema in both revive paths (salvage and reset + rebuild), matching the helper's documented contract and the existing pattern in the CDC activities.

Affected schemas in production still carry a stale marker and need it cleared once (the table itself is healthy, since each loop iteration rebuilt it from source):

```sql
update posthog_externaldataschema
set sync_type_config = sync_type_config - 'delta_revive_required'
where sync_type_config ? 'delta_revive_required';
```

## How did you test this code?

Extended the two existing revive tests in `test_extract.py` to simulate the pipeline's follow-up `sync_type_config` save after a revive (`stage_incremental_field_value`) and assert the marker does not reappear in the DB.
No existing test caught this regression because they refreshed the schema from the DB before asserting, which masked the stale in-memory copy.
Verified both tests fail on the resurrection assertion against the unfixed code, and the full `test_extract.py` suite (23 tests) passes with the fix.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal pipeline behavior only, no user-facing docs affected.
