### PR TITLE
feat(signals): add anomaly investigation to inbox source config UI

### DIFF
--- a/frontend/src/scenes/inbox/SourcesList.tsx
+++ b/frontend/src/scenes/inbox/SourcesList.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconArrowRight, IconBell, IconGithub, IconHeartPlus, IconLinear } from '@posthog/icons'
+import { IconArrowRight, IconBell, IconGithub, IconGraph, IconHeartPlus, IconLinear } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { RecordingsUniversalFiltersDisplay } from 'lib/components/Cards/InsightCard/RecordingsUniversalFiltersDisplay'
@@ -148,6 +148,7 @@ export function SourcesList(): JSX.Element {
         pgAnalyzeIssuesConfig,
         errorTrackingIsFullyEnabled,
         healthChecksConfig,
+        anomalyInvestigationConfig,
         isSessionAnalysisToggling,
         isGithubIssuesToggling,
         isLinearIssuesToggling,
@@ -155,6 +156,7 @@ export function SourcesList(): JSX.Element {
         isPgAnalyzeIssuesToggling,
         isErrorTrackingToggling,
         isHealthChecksToggling,
+        isAnomalyInvestigationToggling,
     } = useValues(signalSourcesLogic)
     const {
         toggleSessionAnalysis,
@@ -163,6 +165,7 @@ export function SourcesList(): JSX.Element {
         initiateDataWarehouseSourceToggle,
         toggleErrorTracking,
         toggleHealthChecks,
+        toggleAnomalyInvestigation,
     } = useActions(signalSourcesLogic)
 
     const recordingFilters = sessionAnalysisConfig?.config?.recording_filters
@@ -219,6 +222,16 @@ export function SourcesList(): JSX.Element {
                 checked={!!healthChecksConfig?.enabled}
                 loading={isHealthChecksToggling}
                 onToggle={() => toggleHealthChecks()}
+            />
+
+            <Source
+                icon={<IconGraph className="size-5 text-accent" />}
+                title="PostHog Product Analytics"
+                description="Anomalies in your tracked metrics, investigated automatically → Signals"
+                variant="available"
+                checked={!!anomalyInvestigationConfig?.enabled}
+                loading={isAnomalyInvestigationToggling}
+                onToggle={() => toggleAnomalyInvestigation()}
             />
 
             <Source

--- a/frontend/src/scenes/inbox/filterOptions.tsx
+++ b/frontend/src/scenes/inbox/filterOptions.tsx
@@ -8,6 +8,7 @@ import {
     IconCompass,
     IconDatabase,
     IconGithub,
+    IconGraph,
     IconList,
     IconReceipt,
     IconRefresh,
@@ -85,6 +86,7 @@ export const INBOX_SOURCE_OPTIONS: { value: string; label: string; icon: JSX.Ele
     { value: 'zendesk', label: 'Zendesk', icon: <IconReceipt /> },
     { value: 'conversations', label: 'Conversations', icon: <IconSupport /> },
     { value: 'pganalyze', label: 'pganalyze', icon: <IconDatabase /> },
+    { value: 'analytics', label: 'Product analytics', icon: <IconGraph /> },
     { value: 'signals_scout', label: 'Scout', icon: <IconCompass /> },
 ]
 

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -146,6 +146,7 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
         toggleHealthChecks: true,
         toggleEvalReports: true,
         toggleConversations: true,
+        toggleAnomalyInvestigation: true,
         saveSessionAnalysisFilters: (filters: RecordingUniversalFilters) => ({ filters }),
         clearSessionAnalysisFilters: true,
     }),
@@ -203,6 +204,8 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                 toggleSourceConfigState(state, SignalSourceProduct.LlmAnalytics, SignalSourceType.EvaluationReport),
             toggleConversations: (state: SignalSourceConfig[] | null) =>
                 toggleSourceConfigState(state, SignalSourceProduct.Conversations, SignalSourceType.Ticket),
+            toggleAnomalyInvestigation: (state: SignalSourceConfig[] | null) =>
+                toggleSourceConfigState(state, SignalSourceProduct.Analytics, SignalSourceType.AnomalyInvestigation),
         },
         togglingSourceKeys: [
             new Set<string>(),
@@ -340,6 +343,20 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
             (s) => [s.togglingSourceKeys],
             (keys: Set<string>): boolean =>
                 keys.has(`${SignalSourceProduct.LlmAnalytics}_${SignalSourceType.EvaluationReport}`),
+        ],
+        anomalyInvestigationConfig: [
+            (s) => [s.sourceConfigs],
+            (sourceConfigs: SignalSourceConfig[] | null): SignalSourceConfig | null =>
+                sourceConfigs?.find(
+                    (c) =>
+                        c.source_product === SignalSourceProduct.Analytics &&
+                        c.source_type === SignalSourceType.AnomalyInvestigation
+                ) ?? null,
+        ],
+        isAnomalyInvestigationToggling: [
+            (s) => [s.togglingSourceKeys],
+            (keys: Set<string>): boolean =>
+                keys.has(`${SignalSourceProduct.Analytics}_${SignalSourceType.AnomalyInvestigation}`),
         ],
         errorTrackingIsFullyEnabled: [
             (s) => [s.sourceConfigs],
@@ -564,6 +581,17 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                 actions.toggleSignalSource({
                     sourceProduct: SignalSourceProduct.Conversations,
                     sourceType: SignalSourceType.Ticket,
+                    enabled: desiredEnabled,
+                })
+            },
+            toggleAnomalyInvestigation: () => {
+                // The optimistic reducer flips the config before this listener runs,
+                // so config.enabled already reflects the desired state.
+                const config = values.anomalyInvestigationConfig
+                const desiredEnabled = config?.enabled ?? true
+                actions.toggleSignalSource({
+                    sourceProduct: SignalSourceProduct.Analytics,
+                    sourceType: SignalSourceType.AnomalyInvestigation,
                     enabled: desiredEnabled,
                 })
             },


### PR DESCRIPTION
## Problem

Anomaly investigations run and emit signals with `source_product = analytics` / `source_type = anomaly_investigation`, but there was no way to configure that source: no `SignalSourceConfig` row could be created from the product because the Inbox source-config UI had no entry for it. So the signals never flowed into the inbox even when investigations happened.

## Changes

- Add a "PostHog Product Analytics" toggle to the Inbox source config UI (`SourcesList.tsx`), wired through `signalSourcesLogic` exactly like the existing health-checks source (action, optimistic reducer, config + toggling selectors, and a listener that creates/updates the `SignalSourceConfig` row).
- Add `analytics` as a filterable source in the report list source dropdown (`filterOptions.tsx`).

No backend changes: the model choice, enum, migration (`0062_add_analytics_anomaly_investigation_source`), and generated frontend types already accept this source — the only gap was the UI.

## How did you test this code?

Ran `pnpm --filter=@posthog/frontend format` (oxfmt left all three changed files untouched — already conformant) and `typescript:check`: no errors reference the changed files or the new symbols (`toggleAnomalyInvestigation`, `anomalyInvestigationConfig`, `isAnomalyInvestigationToggling`). kea typegen for `signalSourcesLogic` regenerates cleanly with the new action/selectors. No automated tests were added — this follows the established per-source toggle pattern, which has no unit coverage today. Not manually exercised in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app after a thread noticed an anomaly investigation had run but produced no inbox signals, because the `SignalSourceConfig` for it could not be created from the UI. Skills invoked: `/signals` and `/inbox-exploration` (to confirm no `analytics`/`anomaly_investigation` source config existed for the project and that signals were otherwise flowing). Used the Explore agent to map the source-config UI, then mirrored the health-checks source pattern across `signalSourcesLogic.ts`, `SourcesList.tsx`, and `filterOptions.tsx`. Chose the health-checks pattern over the session-replay one because anomaly investigation is a plain single `(source_product, source_type)` on/off toggle with no extra config.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784206606547139?thread_ts=1784206606.547139&cid=C087XQ7K9K7)*

