### PR TITLE
chore(replay): pin styleOMValue array handling in the anonymizer

### DIFF
--- a/rust/replay-anonymizer-node/tests/snapshot.rs
+++ b/rust/replay-anonymizer-node/tests/snapshot.rs
@@ -683,6 +683,52 @@ fn differential_cv_stream_vs_tree() {
 }
 
 #[test]
+fn mutation_style_om_value_array_scrubs_siblings_and_round_trips() {
+    // rrweb records `setProperty(prop, value, "important")` as a two-element `styleOMValue` array
+    // (`"display": ["block", "important"]`). A parser that models attribute values as a scalar-only
+    // union would fail the whole mutation and pass the line through unscrubbed — the scrub-bypass
+    // MLHog#93 fixed. The monorepo anonymizer parses generic JSON, so the array must (a) not fail the
+    // event, (b) leave the sibling text mutation scrubbed, and (c) round-trip the array byte-for-byte.
+    let allow = AllowLists::new(Vec::<String>::new(), Vec::<String>::new());
+    let inner = snapshot_message(json!([{
+        "type": 3,
+        "timestamp": TS0,
+        "data": {
+            "source": 0,
+            "texts": [{ "id": 5, "value": "SENSITIVE USER TEXT" }],
+            "attributes": [{
+                "id": 816,
+                "attributes": {
+                    "style": { "display": ["block", "important"] },
+                    "tabindex": "0",
+                    "aria-hidden": "false"
+                }
+            }],
+            "removes": [],
+            "adds": []
+        }
+    }]));
+    let inner_json = serde_json::to_string(&inner).unwrap();
+
+    // Both scrub engines and the tree path must agree — this pins the array shape across all three.
+    assert_stream_matches_tree(&allow, &inner_json, "styleOMValue array mutation");
+
+    let out = run(&allow, &payload_of(&inner)).expect("styleOMValue array must not fail the event");
+    let lines = parse_lines(&out.lines);
+    assert_eq!(lines.len(), 1, "the mutation event must survive scrubbing");
+    let data = &lines[0][1]["data"];
+    assert_eq!(
+        data["texts"][0]["value"], "********* **** ****",
+        "the sibling text mutation must still be scrubbed"
+    );
+    assert_eq!(
+        data["attributes"][0]["attributes"]["style"]["display"],
+        json!(["block", "important"]),
+        "the styleOMValue array must round-trip unchanged"
+    );
+}
+
+#[test]
 fn mutation_media_attr_past_the_prescan_budget_declines_to_the_parse() {
     // A media `src` positioned past the byte walk's 4 KB attribute prescan budget: the walk's
     // media probe hits its fallback there, which must decline to the tree (not silently classify


### PR DESCRIPTION
## Problem

A handover flagged a scrub-bypass in the rrweb replay anonymizer: rrweb records `el.style.setProperty(prop, value, "important")` as a two-element `styleOMValue` array (`"display": ["block", "important"]`). In the MLHog codebase, a parser that modeled attribute values as a scalar-only union (`string | number | bool | null | object`) failed to deserialize the whole mutation event, and the failed line was passed through to storage unscrubbed. That is a real PII risk because the rest of the failed batch (text mutations, adds, removes) skips scrubbing too. See [PostHog/MLHog#93](https://github.com/PostHog/MLHog/pull/93) for the reference fix.

The handover asked me to port that fix to this repo, but explicitly said to verify with the repro rather than assume the same bug exists here.

## Changes

I verified it against the actual code, and the monorepo anonymizer is not vulnerable. The production path for the ML training bucket is the Rust fused step (`rust/replay-anonymizer-node/`, wired into `ml-mirror/ml-mirror-pipeline.ts` via `createParseAndAnonymizeMessageStep`). It parses events as generic JSON (simd-json borrowed values) plus a parse-free byte walk, never a scalar-only union, so an array-valued style property cannot fail deserialization. It also fails closed at the whole-message level: any unscrubbable event drops or DLQs the entire message, never a per-line raw passthrough (already pinned by `scrub_errors_fail_closed_for_the_whole_message`).

So no production code change is warranted. What was missing was a test pinning the safe behavior against a future refactor (someone swapping generic parsing for a typed schema, or relaxing the fail-closed policy). This PR adds that one regression test.

Mapping the three-part MLHog fix onto this repo:

| MLHog#93 part | This repo |
| --- | --- |
| Add array variant to the attribute-value union | N/A — generic JSON already accepts it |
| Scrub coverage for the new variant | Already correct — style arrays copy verbatim (CSS keywords, low-PII, allowlisted); no bypass was ever gated on parseability |
| DOM-mirror reconstruction of `[v, "important"]` | MLHog-only, skipped |

## How did you test this code?

Added `mutation_style_om_value_array_scrubs_siblings_and_round_trips` in `rust/replay-anonymizer-node/tests/snapshot.rs`. It runs the handover's exact repro line through the real entry point and asserts, across both scrub engines and the tree path (via `assert_stream_matches_tree`):

- the event deserializes (no error, no passthrough)
- the sibling text mutation is still scrubbed (`"SENSITIVE USER TEXT"` → `"********* **** ****"`)
- `"display":["block","important"]` round-trips byte-for-byte

Regression it catches that no existing test did: a future change that reintroduces a scalar-only attribute-value model (or relaxes fail-closed) would reopen the exact MLHog-class scrub-bypass, and this test fails on it. I ran the full crate suite locally (`cargo test` in `rust/replay-anonymizer-node`) — 13 snapshot tests plus the rest pass.

> [!NOTE]
> The bucket line cited in the handover as evidence predates the current fail-closed Rust anonymizer, so the current ingestion path won't reproduce it. Re-scrubbing existing data at rest, if wanted, is a separate cleanup task, not an ingestion code change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Opus 4.8, via PostHog Code) was handed a port request and asked to verify rather than assume. I traced the parse and scrub paths in `snapshot.rs`, `bytewalk.rs`, `dom.rs`, and `parse-and-anonymize-step.ts`, confirmed the ML-mirror pipeline uses the fail-closed Rust step, wrote the repro as a test, and ran it green. The decision was to ship a test-only PR rather than the three-part MLHog fix, because parts 1 and 3 are N/A here and part 2 is already satisfied — the value is guarding the invariant, not changing behavior. No skills were invoked. Human (robbie-c) directed the work and is the DRI.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
