### PR TITLE
feat(replay): emit ingestion lag metrics after batch flush

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
@@ -225,21 +225,24 @@ describe('SessionRecordingIngester', () => {
         expect(await lagHistogramCount('0')).toBeUndefined()
     })
 
-    it('retains pending lag samples when a flush fails, reporting them on the next successful flush', async () => {
+    it('keeps pending lag samples across a failed flush so a later successful flush still reports them', async () => {
         ingestionLagHistogram.reset()
         createIngester({ SESSION_RECORDING_MAX_BATCH_AGE_MS: 0 })
 
-        // The first flush fails at the offset-store step, after the batch's capture timestamp was buffered.
+        // A flush that fails after the capture timestamp was buffered must not observe or drop the pending
+        // sample. Poll-batch flush failures crash the process; the retain-and-report path that matters is a
+        // swallowed revoke-hook flush, after which this still-running process flushes successfully and
+        // reports the samples it kept. The failure is simulated here at the offset-store step.
         jest.mocked(ingester.kafkaConsumer).offsetsStore.mockImplementationOnce(() => {
             throw new Error('offset store failed')
         })
         const firstMessage = kafkaMessage(0, 42, Date.now() - 5000)
         runPipelineMock.mockResolvedValue(progress(new Map([[0, 42]]), [firstMessage]))
         await expect(ingester.handleEachBatch([firstMessage])).rejects.toThrow('offset store failed')
-        // The flush threw, so nothing is observed and the sample stays pending for the next flush.
+        // The flush threw, so nothing is observed and the sample stays pending.
         expect(await lagHistogramCount('0')).toBeUndefined()
 
-        // The next batch flushes cleanly and reports both the retained and the new sample.
+        // A later successful flush reports the retained sample alongside the new one.
         const secondMessage = kafkaMessage(0, 43, Date.now() - 5000)
         runPipelineMock.mockResolvedValue(progress(new Map([[0, 43]]), [secondMessage]))
         await ingester.handleEachBatch([secondMessage])

--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
@@ -1,5 +1,6 @@
 import { Message } from 'node-rdkafka'
 
+import { ingestionLagGauge, ingestionLagHistogram } from '~/common/metrics'
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import { SessionReplayPipeline, runSessionReplayPipeline } from '~/ingestion/pipelines/sessionreplay'
 import { KeyStore, RecordingEncryptor } from '~/ingestion/pipelines/sessionreplay/shared/types'
@@ -37,7 +38,7 @@ function flushMicrotasks(): Promise<void> {
     return new Promise((resolve) => setImmediate(resolve))
 }
 
-function kafkaMessage(partition: number, offset: number): Message {
+function kafkaMessage(partition: number, offset: number, capturedAtMs?: number): Message {
     return {
         value: Buffer.from('data'),
         size: 4,
@@ -45,7 +46,15 @@ function kafkaMessage(partition: number, offset: number): Message {
         partition,
         offset,
         timestamp: Date.now(),
+        headers: capturedAtMs === undefined ? undefined : [{ now: Buffer.from(new Date(capturedAtMs).toISOString()) }],
     }
+}
+
+async function lagHistogramCount(partition: string): Promise<number | undefined> {
+    const metric = await ingestionLagHistogram.get()
+    return metric.values.find(
+        (v) => v.metricName === 'ingestion_lag_ms_histogram_count' && v.labels.partition === partition
+    )?.value
 }
 
 describe('SessionRecordingIngester', () => {
@@ -176,6 +185,23 @@ describe('SessionRecordingIngester', () => {
         expect(jest.mocked(ingester.kafkaConsumer).offsetsStore).toHaveBeenCalledWith([
             { topic: consumeTopic, partition: 0, offset: 43 },
         ])
+    })
+
+    it('reports ingestion lag only once the batch is flushed', async () => {
+        ingestionLagGauge.reset()
+        ingestionLagHistogram.reset()
+
+        // The default ingester keeps age/size out of reach, so recording a batch does not flush it —
+        // and lag must not be observed until the data is durably ingested.
+        runPipelineMock.mockResolvedValue(new Map([[0, 42]]))
+        await ingester.handleEachBatch([kafkaMessage(0, 42, Date.now() - 5000)])
+        expect(await lagHistogramCount('0')).toBeUndefined()
+
+        // With the age trigger the batch flushes immediately, so its capture lag is observed post-flush.
+        createIngester({ SESSION_RECORDING_MAX_BATCH_AGE_MS: 0 })
+        runPipelineMock.mockResolvedValue(new Map([[0, 43]]))
+        await ingester.handleEachBatch([kafkaMessage(0, 43, Date.now() - 5000)])
+        expect(await lagHistogramCount('0')).toBe(1)
     })
 
     it('start() wires the revoke hook, and the hook flushes the tracked offsets', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
@@ -2,7 +2,11 @@ import { Message } from 'node-rdkafka'
 
 import { ingestionLagGauge, ingestionLagHistogram } from '~/common/metrics'
 import { PostgresRouter } from '~/common/utils/db/postgres'
-import { SessionReplayPipeline, runSessionReplayPipeline } from '~/ingestion/pipelines/sessionreplay'
+import {
+    SessionReplayBatchProgress,
+    SessionReplayPipeline,
+    runSessionReplayPipeline,
+} from '~/ingestion/pipelines/sessionreplay'
 import { KeyStore, RecordingEncryptor } from '~/ingestion/pipelines/sessionreplay/shared/types'
 import { RedisPool } from '~/types'
 
@@ -48,6 +52,10 @@ function kafkaMessage(partition: number, offset: number, capturedAtMs?: number):
         timestamp: Date.now(),
         headers: capturedAtMs === undefined ? undefined : [{ now: Buffer.from(new Date(capturedAtMs).toISOString()) }],
     }
+}
+
+function progress(maxOffsets: Map<number, number>, okMessages: Message[] = []): SessionReplayBatchProgress {
+    return { maxOffsets, okMessages }
 }
 
 async function lagHistogramCount(partition: string): Promise<number | undefined> {
@@ -134,7 +142,7 @@ describe('SessionRecordingIngester', () => {
                     })
                 )
             )
-            return new Map([[0, 42]])
+            return progress(new Map([[0, 42]]))
         })
 
         const batchPromise = ingester.handleEachBatch([kafkaMessage(0, 42)])
@@ -174,7 +182,7 @@ describe('SessionRecordingIngester', () => {
                     })
                 )
             )
-            return Promise.resolve(new Map([[0, 42]]))
+            return Promise.resolve(progress(new Map([[0, 42]])))
         })
 
         await ingester.handleEachBatch([kafkaMessage(0, 42)])
@@ -193,15 +201,28 @@ describe('SessionRecordingIngester', () => {
 
         // The default ingester keeps age/size out of reach, so recording a batch does not flush it —
         // and lag must not be observed until the data is durably ingested.
-        runPipelineMock.mockResolvedValue(new Map([[0, 42]]))
-        await ingester.handleEachBatch([kafkaMessage(0, 42, Date.now() - 5000)])
+        const bufferedMessage = kafkaMessage(0, 42, Date.now() - 5000)
+        runPipelineMock.mockResolvedValue(progress(new Map([[0, 42]]), [bufferedMessage]))
+        await ingester.handleEachBatch([bufferedMessage])
         expect(await lagHistogramCount('0')).toBeUndefined()
 
         // With the age trigger the batch flushes immediately, so its capture lag is observed post-flush.
         createIngester({ SESSION_RECORDING_MAX_BATCH_AGE_MS: 0 })
-        runPipelineMock.mockResolvedValue(new Map([[0, 43]]))
-        await ingester.handleEachBatch([kafkaMessage(0, 43, Date.now() - 5000)])
+        const flushedMessage = kafkaMessage(0, 43, Date.now() - 5000)
+        runPipelineMock.mockResolvedValue(progress(new Map([[0, 43]]), [flushedMessage]))
+        await ingester.handleEachBatch([flushedMessage])
         expect(await lagHistogramCount('0')).toBe(1)
+    })
+
+    it('samples the pipeline OK-result messages, not the raw consumed batch', async () => {
+        ingestionLagHistogram.reset()
+        createIngester({ SESSION_RECORDING_MAX_BATCH_AGE_MS: 0 })
+
+        // The consumed message carries a capture header, but the pipeline dropped it (no OK results), so
+        // no lag is sampled even though the batch flushes.
+        runPipelineMock.mockResolvedValue(progress(new Map([[0, 42]]), []))
+        await ingester.handleEachBatch([kafkaMessage(0, 42, Date.now() - 5000)])
+        expect(await lagHistogramCount('0')).toBeUndefined()
     })
 
     it('retains pending lag samples when a flush fails, reporting them on the next successful flush', async () => {
@@ -212,16 +233,16 @@ describe('SessionRecordingIngester', () => {
         jest.mocked(ingester.kafkaConsumer).offsetsStore.mockImplementationOnce(() => {
             throw new Error('offset store failed')
         })
-        runPipelineMock.mockResolvedValue(new Map([[0, 42]]))
-        await expect(ingester.handleEachBatch([kafkaMessage(0, 42, Date.now() - 5000)])).rejects.toThrow(
-            'offset store failed'
-        )
+        const firstMessage = kafkaMessage(0, 42, Date.now() - 5000)
+        runPipelineMock.mockResolvedValue(progress(new Map([[0, 42]]), [firstMessage]))
+        await expect(ingester.handleEachBatch([firstMessage])).rejects.toThrow('offset store failed')
         // The flush threw, so nothing is observed and the sample stays pending for the next flush.
         expect(await lagHistogramCount('0')).toBeUndefined()
 
         // The next batch flushes cleanly and reports both the retained and the new sample.
-        runPipelineMock.mockResolvedValue(new Map([[0, 43]]))
-        await ingester.handleEachBatch([kafkaMessage(0, 43, Date.now() - 5000)])
+        const secondMessage = kafkaMessage(0, 43, Date.now() - 5000)
+        runPipelineMock.mockResolvedValue(progress(new Map([[0, 43]]), [secondMessage]))
+        await ingester.handleEachBatch([secondMessage])
         expect(await lagHistogramCount('0')).toBe(2)
     })
 
@@ -232,7 +253,7 @@ describe('SessionRecordingIngester', () => {
         const [eachBatch, onPartitionsRevoked] = connectMock.mock.calls[0]
         expect(onPartitionsRevoked).toBeDefined()
 
-        runPipelineMock.mockImplementation(() => Promise.resolve(new Map([[0, 7]])))
+        runPipelineMock.mockImplementation(() => Promise.resolve(progress(new Map([[0, 7]]))))
         await eachBatch([kafkaMessage(0, 7)])
         // Age/size are out of reach, so nothing has flushed yet.
         expect(events).toEqual([])

--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.test.ts
@@ -204,6 +204,27 @@ describe('SessionRecordingIngester', () => {
         expect(await lagHistogramCount('0')).toBe(1)
     })
 
+    it('retains pending lag samples when a flush fails, reporting them on the next successful flush', async () => {
+        ingestionLagHistogram.reset()
+        createIngester({ SESSION_RECORDING_MAX_BATCH_AGE_MS: 0 })
+
+        // The first flush fails at the offset-store step, after the batch's capture timestamp was buffered.
+        jest.mocked(ingester.kafkaConsumer).offsetsStore.mockImplementationOnce(() => {
+            throw new Error('offset store failed')
+        })
+        runPipelineMock.mockResolvedValue(new Map([[0, 42]]))
+        await expect(ingester.handleEachBatch([kafkaMessage(0, 42, Date.now() - 5000)])).rejects.toThrow(
+            'offset store failed'
+        )
+        // The flush threw, so nothing is observed and the sample stays pending for the next flush.
+        expect(await lagHistogramCount('0')).toBeUndefined()
+
+        // The next batch flushes cleanly and reports both the retained and the new sample.
+        runPipelineMock.mockResolvedValue(new Map([[0, 43]]))
+        await ingester.handleEachBatch([kafkaMessage(0, 43, Date.now() - 5000)])
+        expect(await lagHistogramCount('0')).toBe(2)
+    })
+
     it('start() wires the revoke hook, and the hook flushes the tracked offsets', async () => {
         await ingester.start()
         const connectMock = jest.mocked(ingester.kafkaConsumer).connect

--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.ts
@@ -289,14 +289,22 @@ export class SessionRecordingIngester {
         // Run messages through the pipeline (handles restrictions, parsing, team filtering, and recording)
         // and track the highest offset reached per partition — the single place Kafka progress is tracked.
         // Recording holds the batch lock so a concurrent revoke can't flush the batch mid-record.
-        const offsets = await instrumentFn(`recordingingesterv2.handleEachBatch.runPipeline`, async () =>
-            this.batchLock(() =>
-                runSessionReplayPipeline(this.sessionReplayPipeline, messages, this.currentBatch, this.promiseScheduler)
-            )
+        const { maxOffsets, okMessages } = await instrumentFn(
+            `recordingingesterv2.handleEachBatch.runPipeline`,
+            async () =>
+                this.batchLock(() =>
+                    runSessionReplayPipeline(
+                        this.sessionReplayPipeline,
+                        messages,
+                        this.currentBatch,
+                        this.promiseScheduler
+                    )
+                )
         )
-        this.sessionBatchManager.trackProcessedOffsets(offsets)
-        // Buffer capture timestamps now; lag is reported once the batch is durably flushed and committed.
-        this.lagReporter.record(messages)
+        this.sessionBatchManager.trackProcessedOffsets(maxOffsets)
+        // Buffer capture timestamps of the recorded (OK) messages; lag is reported once the batch is
+        // durably flushed and committed.
+        this.lagReporter.record(okMessages)
 
         if (this.sessionBatchManager.shouldFlush(this.currentBatch, this.lastFlushTime)) {
             await this.flushCurrentBatch()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.ts
@@ -39,6 +39,7 @@ import { HealthCheckResult, PluginServerService, RedisPool, ValueMatcher } from 
 import { SessionRecordingApiConfig, SessionRecordingConfig } from './config'
 import { KafkaOffsetManager } from './kafka/offset-manager'
 import { SessionRecordingIngesterMetrics } from './metrics'
+import { SessionReplayLagReporter } from './session-replay-lag-reporter'
 import { BlackholeSessionBatchFileStorage } from './sessions/blackhole-session-batch-writer'
 import { RetentionAwareStorage } from './sessions/retention-aware-batch-writer'
 import { SessionBatchFileStorage } from './sessions/session-batch-file-storage'
@@ -89,6 +90,8 @@ export class SessionRecordingIngester {
     private isDebugLoggingEnabled: ValueMatcher<number>
     private readonly promiseScheduler: PromiseScheduler
     private readonly sessionBatchManager: SessionBatchManager
+    /** Buffers capture timestamps of processed messages and reports ingestion lag after each flush. */
+    private readonly lagReporter: SessionReplayLagReporter
     /** The accumulator for the current flush cycle. Owned here, minted and flushed via the manager. */
     private currentBatch: SessionBatchRecorder
     /** When the current accumulation cycle started (last flush, or startup), for the age flush trigger. */
@@ -241,6 +244,8 @@ export class SessionRecordingIngester {
             encryptor: this.encryptor,
         })
 
+        this.lagReporter = new SessionReplayLagReporter(this.topic)
+
         this.currentBatch = this.sessionBatchManager.createBatch()
         this.lastFlushTime = Date.now()
     }
@@ -290,6 +295,8 @@ export class SessionRecordingIngester {
             )
         )
         this.sessionBatchManager.trackProcessedOffsets(offsets)
+        // Buffer capture timestamps now; lag is reported once the batch is durably flushed and committed.
+        this.lagReporter.record(messages)
 
         if (this.sessionBatchManager.shouldFlush(this.currentBatch, this.lastFlushTime)) {
             await this.flushCurrentBatch()
@@ -312,6 +319,9 @@ export class SessionRecordingIngester {
         await this.batchLock(async () => {
             logger.info('🔁', 'blob_ingester_consumer_v2 - flushing batch', { batchSize: this.currentBatch.size })
             await instrumentFn(`recordingingesterv2.handleEachBatch.flush`, async () => this.currentBatch.flush())
+            // The flush committed the batch's offsets, so its data is now durably ingested — report lag.
+            // Skipped if the flush above threw, so a failed flush records no premature lag sample.
+            this.lagReporter.flush()
             this.currentBatch = this.sessionBatchManager.createBatch()
             this.lastFlushTime = Date.now()
         })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/index.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/index.ts
@@ -1,6 +1,7 @@
 export {
     createSessionReplayPipeline,
     runSessionReplayPipeline,
+    type SessionReplayBatchProgress,
     type SessionReplayPipeline,
     type SessionReplayPipelineConfig,
     type SessionReplayPipelineInput,

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.test.ts
@@ -82,6 +82,21 @@ describe('SessionReplayLagReporter', () => {
         expect(await getHistogramCountAndSum('0')).toBeNull()
     })
 
+    it('uses the last valid now header when a message carries duplicates, matching parseEventHeaders', async () => {
+        // Kafka permits duplicate header keys and parseEventHeaders lets the last valid `now` win, so the
+        // lag sample must come from the same timestamp the message was processed with.
+        reporter.record([
+            message(0, [
+                { now: Buffer.from(new Date(FAKE_NOW_MS - 9000).toISOString()) },
+                { now: Buffer.from(new Date(FAKE_NOW_MS - 4000).toISOString()) },
+            ]),
+        ])
+        reporter.flush()
+
+        expect(await getGaugeValue('0')).toBe(4000)
+        expect(await getHistogramCountAndSum('0')).toEqual({ count: 1, sum: 4000 })
+    })
+
     it.each<{ name: string; headers?: MessageHeader[] }>([
         { name: 'no headers at all', headers: undefined },
         { name: 'no now header', headers: [{ token: Buffer.from('t') }] },

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.test.ts
@@ -1,0 +1,96 @@
+import { MessageHeader } from 'node-rdkafka'
+
+import { ingestionLagGauge, ingestionLagHistogram } from '~/common/metrics'
+
+import { LagReportableMessage, SessionReplayLagReporter } from './session-replay-lag-reporter'
+
+const FAKE_NOW_MS = 1702654321987 // 2023-12-15T14:32:01.987Z
+const TEST_TOPIC = 'test-topic'
+
+async function getGaugeValue(partition: string): Promise<number | undefined> {
+    const metric = await ingestionLagGauge.get()
+    return metric.values.find((v) => v.labels.topic === TEST_TOPIC && v.labels.partition === partition)?.value
+}
+
+async function getHistogramCountAndSum(partition: string): Promise<{ count: number; sum: number } | null> {
+    const metric = await ingestionLagHistogram.get()
+    const find = (suffix: string): number | undefined =>
+        metric.values.find(
+            (v) => v.metricName === `ingestion_lag_ms_histogram${suffix}` && v.labels.partition === partition
+        )?.value
+    const count = find('_count')
+    const sum = find('_sum')
+    return count === undefined || sum === undefined ? null : { count, sum }
+}
+
+function message(partition: number, headers?: MessageHeader[]): LagReportableMessage {
+    return { partition, headers }
+}
+
+function nowHeader(capturedAtMs: number): MessageHeader[] {
+    return [{ now: Buffer.from(new Date(capturedAtMs).toISOString()) }]
+}
+
+describe('SessionReplayLagReporter', () => {
+    let reporter: SessionReplayLagReporter
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.setSystemTime(FAKE_NOW_MS)
+        ingestionLagGauge.reset()
+        ingestionLagHistogram.reset()
+        reporter = new SessionReplayLagReporter(TEST_TOPIC)
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('observes lag from capture time to flush time and reports it per partition', async () => {
+        reporter.record([message(0, nowHeader(FAKE_NOW_MS - 5000)), message(0, nowHeader(FAKE_NOW_MS - 3000))])
+        reporter.record([message(1, nowHeader(FAKE_NOW_MS - 2000))])
+
+        // Nothing is observed until the batch is durably flushed.
+        expect(await getGaugeValue('0')).toBeUndefined()
+
+        // The flush happens two seconds after the last record — lag is measured against flush time.
+        jest.setSystemTime(FAKE_NOW_MS + 2000)
+        reporter.flush()
+
+        // Gauge keeps the last sample per partition; the histogram aggregates every sample.
+        expect(await getGaugeValue('0')).toBe(5000)
+        expect(await getHistogramCountAndSum('0')).toEqual({ count: 2, sum: 12000 })
+        expect(await getGaugeValue('1')).toBe(4000)
+        expect(await getHistogramCountAndSum('1')).toEqual({ count: 1, sum: 4000 })
+    })
+
+    it('clears pending timestamps after a flush so the next flush does not re-report them', async () => {
+        reporter.record([message(0, nowHeader(FAKE_NOW_MS - 5000))])
+        reporter.flush()
+        expect(await getHistogramCountAndSum('0')).toEqual({ count: 1, sum: 5000 })
+
+        reporter.flush()
+
+        // A second flush with nothing recorded since must not add another sample.
+        expect(await getHistogramCountAndSum('0')).toEqual({ count: 1, sum: 5000 })
+    })
+
+    it('is a no-op when flushing with nothing pending', async () => {
+        reporter.flush()
+
+        expect(await getGaugeValue('0')).toBeUndefined()
+        expect(await getHistogramCountAndSum('0')).toBeNull()
+    })
+
+    it.each<{ name: string; headers?: MessageHeader[] }>([
+        { name: 'no headers at all', headers: undefined },
+        { name: 'no now header', headers: [{ token: Buffer.from('t') }] },
+        { name: 'an unparseable now value', headers: [{ now: Buffer.from('not-a-date') }] },
+    ])('skips a message with $name', async ({ headers }) => {
+        reporter.record([message(0, headers)])
+        reporter.flush()
+
+        expect(await getGaugeValue('0')).toBeUndefined()
+        expect(await getHistogramCountAndSum('0')).toBeNull()
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
@@ -13,6 +13,13 @@ export type LagReportableMessage = Pick<Message, 'partition' | 'headers'>
  * The consumer records each poll batch's messages as they are processed and flushes the reporter after
  * the session batch flush succeeds. Only the capture timestamps (epoch ms) are retained per partition;
  * the messages themselves are never held.
+ *
+ * Unlike the per-event `record-ingestion-lag` step, which samples only events that were actually
+ * ingested, this samples every consumed message — including ones the pipeline dropped or DLQ'd — because
+ * it records the raw batch. That is intentional: dropped and DLQ'd messages still advance the committed
+ * offset, so the metric reads as committed-offset progress versus capture time for the replay consumer.
+ * On a flush failure with batch redelivery, retried messages can be sampled twice, consistent with the
+ * consumer's existing batch-retry behavior.
  */
 export class SessionReplayLagReporter {
     private pendingByPartition: Map<number, number[]> = new Map()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
@@ -15,9 +15,14 @@ export type LagReportableMessage = Pick<Message, 'partition' | 'headers'>
  * are retained per partition; the messages themselves are never held.
  *
  * Only OK results are sampled — dropped, DLQ'd, and redirected messages are excluded — matching the
- * per-event `record-ingestion-lag` step's ingested-only semantics. On a flush failure with batch
- * redelivery, retried messages can be sampled twice, consistent with the consumer's existing batch-retry
- * behavior.
+ * per-event `record-ingestion-lag` step's ingested-only semantics.
+ *
+ * A failed poll-batch flush crashes the process (eachBatch errors are uncaught), so its pending samples
+ * die unreported and are re-read from the uncommitted offsets on restart. The one path that retains and
+ * later reports is a failed or timed-out revoke-hook flush: it is swallowed and the partitions are given
+ * up without committed offsets, so this still-running process can report its retained samples while the
+ * new owner reprocesses the same messages — a bounded duplicate consistent with the at-least-once
+ * delivery both owners already provide for the data itself.
  */
 export class SessionReplayLagReporter {
     private pendingByPartition: Map<number, number[]> = new Map()
@@ -59,17 +64,24 @@ export class SessionReplayLagReporter {
  * Parses just the `now` header to epoch ms, mirroring the capture-time parse in `parseEventHeaders`.
  * The pipeline already ran the full header parse (and its header-status metrics) on these messages, so
  * re-running it here would double-count those metrics; reading the one header we need avoids that.
+ *
+ * Kafka allows duplicate header keys, so this iterates every header and keeps the last valid `now` —
+ * matching `parseEventHeaders`, so lag is reported from the same timestamp the message was processed
+ * with. An invalid value does not clear a valid one seen earlier.
  */
 function captureTimestampMs(headers: MessageHeader[] | undefined): number | undefined {
     if (headers === undefined) {
         return undefined
     }
+    let capturedAtMs: number | undefined
     for (const header of headers) {
         const value = header['now']
         if (value !== undefined) {
             const parsedMs = new Date(value.toString()).getTime()
-            return isNaN(parsedMs) ? undefined : parsedMs
+            if (!isNaN(parsedMs)) {
+                capturedAtMs = parsedMs
+            }
         }
     }
-    return undefined
+    return capturedAtMs
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
@@ -10,16 +10,14 @@ export type LagReportableMessage = Pick<Message, 'partition' | 'headers'>
  * capture) — but only once a batch is durably flushed and its offsets committed, because that is when
  * replay data is actually ingested.
  *
- * The consumer records each poll batch's messages as they are processed and flushes the reporter after
- * the session batch flush succeeds. Only the capture timestamps (epoch ms) are retained per partition;
- * the messages themselves are never held.
+ * The consumer records the recorded (OK-result) messages of each poll batch as they are processed and
+ * flushes the reporter after the session batch flush succeeds. Only the capture timestamps (epoch ms)
+ * are retained per partition; the messages themselves are never held.
  *
- * Unlike the per-event `record-ingestion-lag` step, which samples only events that were actually
- * ingested, this samples every consumed message — including ones the pipeline dropped or DLQ'd — because
- * it records the raw batch. That is intentional: dropped and DLQ'd messages still advance the committed
- * offset, so the metric reads as committed-offset progress versus capture time for the replay consumer.
- * On a flush failure with batch redelivery, retried messages can be sampled twice, consistent with the
- * consumer's existing batch-retry behavior.
+ * Only OK results are sampled — dropped, DLQ'd, and redirected messages are excluded — matching the
+ * per-event `record-ingestion-lag` step's ingested-only semantics. On a flush failure with batch
+ * redelivery, retried messages can be sampled twice, consistent with the consumer's existing batch-retry
+ * behavior.
  */
 export class SessionReplayLagReporter {
     private pendingByPartition: Map<number, number[]> = new Map()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.ts
@@ -1,0 +1,70 @@
+import { Message, MessageHeader } from 'node-rdkafka'
+
+import { ingestionLagGauge, ingestionLagHistogram } from '~/common/metrics'
+
+/** The message fields the reporter reads — a raw Kafka {@link Message} satisfies this structurally. */
+export type LagReportableMessage = Pick<Message, 'partition' | 'headers'>
+
+/**
+ * Reports session replay ingestion lag — wall-clock time minus capture time (the `now` header set by
+ * capture) — but only once a batch is durably flushed and its offsets committed, because that is when
+ * replay data is actually ingested.
+ *
+ * The consumer records each poll batch's messages as they are processed and flushes the reporter after
+ * the session batch flush succeeds. Only the capture timestamps (epoch ms) are retained per partition;
+ * the messages themselves are never held.
+ */
+export class SessionReplayLagReporter {
+    private pendingByPartition: Map<number, number[]> = new Map()
+
+    constructor(private readonly topic: string) {}
+
+    /** Extracts and stores the capture timestamp of each message that carries a valid `now` header. */
+    public record(messages: LagReportableMessage[]): void {
+        for (const message of messages) {
+            const capturedAtMs = captureTimestampMs(message.headers)
+            if (capturedAtMs === undefined) {
+                continue
+            }
+            let pending = this.pendingByPartition.get(message.partition)
+            if (pending === undefined) {
+                pending = []
+                this.pendingByPartition.set(message.partition, pending)
+            }
+            pending.push(capturedAtMs)
+        }
+    }
+
+    /** Observes lag for every pending capture timestamp against a single now, then clears the state. */
+    public flush(): void {
+        const nowMs = Date.now()
+        for (const [partition, timestamps] of this.pendingByPartition) {
+            const partitionLabel = String(partition)
+            for (const capturedAtMs of timestamps) {
+                const lag = nowMs - capturedAtMs
+                ingestionLagGauge.labels({ topic: this.topic, partition: partitionLabel }).set(lag)
+                ingestionLagHistogram.labels({ partition: partitionLabel }).observe(lag)
+            }
+        }
+        this.pendingByPartition.clear()
+    }
+}
+
+/**
+ * Parses just the `now` header to epoch ms, mirroring the capture-time parse in `parseEventHeaders`.
+ * The pipeline already ran the full header parse (and its header-status metrics) on these messages, so
+ * re-running it here would double-count those metrics; reading the one header we need avoids that.
+ */
+function captureTimestampMs(headers: MessageHeader[] | undefined): number | undefined {
+    if (headers === undefined) {
+        return undefined
+    }
+    for (const header of headers) {
+        const value = header['now']
+        if (value !== undefined) {
+            const parsedMs = new Date(value.toString()).getTime()
+            return isNaN(parsedMs) ? undefined : parsedMs
+        }
+    }
+    return undefined
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-pipeline.test.ts
@@ -296,11 +296,16 @@ describe('session-replay-pipeline', () => {
 
             const messages = [createMessage(0, 1, 'session-1'), createMessage(0, 2, 'session-2')]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(recordedSessionIds()).toEqual(['session-1', 'session-2'])
             // Highest offset reached on the partition is tracked.
-            expect(offsets).toEqual(new Map([[0, 2]]))
+            expect(maxOffsets).toEqual(new Map([[0, 2]]))
         })
 
         it('filters out dropped messages from restrictions', async () => {
@@ -334,12 +339,17 @@ describe('session-replay-pipeline', () => {
                 createMessage(0, 3, 'session-3'),
             ]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(recordedSessionIds()).toEqual(['session-1', 'session-3'])
             // The dropped message (offset 2) is not recorded, but its offset is still accounted for —
             // the partition's committed offset advances past it rather than replaying it forever.
-            expect(offsets).toEqual(new Map([[0, 3]]))
+            expect(maxOffsets).toEqual(new Map([[0, 3]]))
         })
 
         it('tracks the offset of a dropped message even when it is the highest in the partition', async () => {
@@ -373,12 +383,17 @@ describe('session-replay-pipeline', () => {
                 createMessage(0, 3, 'session-3'),
             ]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(recordedSessionIds()).toEqual(['session-1', 'session-2'])
             // The highest offset on the partition belongs to the dropped message; it must still be
             // tracked or that partition would never commit past offset 2.
-            expect(offsets).toEqual(new Map([[0, 3]]))
+            expect(maxOffsets).toEqual(new Map([[0, 3]]))
         })
 
         it('tracks the offset of a rate-limited session even when it is the highest in the partition', async () => {
@@ -418,12 +433,17 @@ describe('session-replay-pipeline', () => {
                 createMessage(0, 3, 'session-3'),
             ]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(recordedSessionIds()).toEqual(['session-1', 'session-2'])
             // The highest offset on the partition belongs to the blocked session; it must still be tracked
             // or that partition would never commit past offset 2.
-            expect(offsets).toEqual(new Map([[0, 3]]))
+            expect(maxOffsets).toEqual(new Map([[0, 3]]))
         })
 
         // Offsets are tracked per partition. Each case drops the highest-offset message on partition 0 via
@@ -492,10 +512,15 @@ describe('session-replay-pipeline', () => {
                 createMessage(1, 5, 'session-4'), // recorded on partition 1 at a higher offset
             ]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(recordedSessionIds().sort()).toEqual(['session-1', 'session-2', 'session-4'])
-            expect(offsets).toEqual(
+            expect(maxOffsets).toEqual(
                 new Map([
                     [0, 3],
                     [1, 5],
@@ -533,11 +558,16 @@ describe('session-replay-pipeline', () => {
 
             const messages = [createMessage(0, 1, 'session-1'), invalidMessage, createMessage(0, 3, 'session-3')]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(recordedSessionIds()).toEqual(['session-1', 'session-3'])
             // The unparseable message (offset 2) is DLQ'd, but its offset is still accounted for.
-            expect(offsets).toEqual(new Map([[0, 3]]))
+            expect(maxOffsets).toEqual(new Map([[0, 3]]))
         })
 
         it('sends messages that fail to parse to the DLQ topic', async () => {
@@ -615,20 +645,38 @@ describe('session-replay-pipeline', () => {
                 createMessage(0, 3, 'session-3'),
             ]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             // Wait for side effects to complete
             await promiseScheduler.waitForAll()
 
             expect(recordedSessionIds()).toEqual(['session-1', 'session-3'])
             // The redirected message (offset 2) is not recorded, but its offset is still accounted for.
-            expect(offsets).toEqual(new Map([[0, 3]]))
+            expect(maxOffsets).toEqual(new Map([[0, 3]]))
 
             // Verify the overflow message was produced
             expect(outputs.produce).toHaveBeenCalledWith(OVERFLOW_OUTPUT, expect.anything())
         })
 
-        it('returns empty offsets for empty input', async () => {
+        it('collects only OK-result messages, excluding dropped, redirected, and DLQ dispositions', async () => {
+            // offset 2 dropped, offset 3 redirected to overflow; offset 4 fails to parse (DLQ); 1 and 5 are OK.
+            mockCreateApplyEventRestrictionsStep.mockReturnValue(
+                (input: { message: Message; headers: Record<string, string> }) => {
+                    if (input.message.offset === 2) {
+                        return Promise.resolve(drop('blocked'))
+                    }
+                    if (input.message.offset === 3) {
+                        return Promise.resolve(redirect('overflow', OVERFLOW_OUTPUT, true, false))
+                    }
+                    return Promise.resolve(ok(input))
+                }
+            )
+
             const pipeline = createSessionReplayPipeline({
                 outputs,
                 eventIngestionRestrictionManager: mockRestrictionManager,
@@ -644,9 +692,63 @@ describe('session-replay-pipeline', () => {
                 isDebugLoggingEnabled,
             })
 
-            const offsets = await runSessionReplayPipeline(pipeline, [], mockBatchRecorder, promiseScheduler)
+            const invalidMessage: Message = {
+                partition: 0,
+                offset: 4,
+                topic: 'test-topic',
+                value: Buffer.from('invalid json'),
+                key: Buffer.from('test-key'),
+                timestamp: Date.now(),
+                headers: [],
+                size: 12,
+            }
+            const messages = [
+                createMessage(0, 1, 'session-1'),
+                createMessage(0, 2, 'session-2'),
+                createMessage(0, 3, 'session-3'),
+                invalidMessage,
+                createMessage(0, 5, 'session-5'),
+            ]
 
-            expect(offsets.size).toBe(0)
+            const { maxOffsets, okMessages } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
+            await promiseScheduler.waitForAll()
+
+            // Only the recorded (OK) messages are collected for lag sampling.
+            expect(okMessages.map((m) => m.offset).sort((a, b) => a - b)).toEqual([1, 5])
+            // Every disposition still advances the committed offset.
+            expect(maxOffsets).toEqual(new Map([[0, 5]]))
+        })
+
+        it('returns empty progress for empty input', async () => {
+            const pipeline = createSessionReplayPipeline({
+                outputs,
+                eventIngestionRestrictionManager: mockRestrictionManager,
+                overflowMode: 'redirect',
+                promiseScheduler,
+                teamService: mockTeamService,
+                retentionService,
+                sessionTracker,
+                sessionFilter,
+                keyStore,
+                sessionKeyResolutionMaxConcurrency: 20,
+                topHog,
+                isDebugLoggingEnabled,
+            })
+
+            const { maxOffsets, okMessages } = await runSessionReplayPipeline(
+                pipeline,
+                [],
+                mockBatchRecorder,
+                promiseScheduler
+            )
+
+            expect(maxOffsets.size).toBe(0)
+            expect(okMessages).toEqual([])
         })
 
         it('processes large batch with mixed dropped and passed messages correctly', async () => {
@@ -681,7 +783,12 @@ describe('session-replay-pipeline', () => {
                 messages.push(createMessage(0, i))
             }
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             // 100 messages dropped (10, 20, ..., 1000), 900 recorded
             const recorded = recordedSessionIds()
@@ -694,7 +801,7 @@ describe('session-replay-pipeline', () => {
                 }
             }
             // Every message's offset is accounted for regardless of disposition.
-            expect(offsets).toEqual(new Map([[0, 1000]]))
+            expect(maxOffsets).toEqual(new Map([[0, 1000]]))
         })
 
         it('correctly parses and passes headers to the restrictions step', async () => {
@@ -767,14 +874,19 @@ describe('session-replay-pipeline', () => {
                 messages.push(createMessage(0, i))
             }
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             const recorded = recordedSessionIds()
             expect(recorded).toHaveLength(500)
             for (let i = 0; i < 500; i++) {
                 expect(recorded[i]).toBe(`session-${i + 1}`)
             }
-            expect(offsets).toEqual(new Map([[0, 500]]))
+            expect(maxOffsets).toEqual(new Map([[0, 500]]))
         })
 
         it('filters out messages with invalid team', async () => {
@@ -809,11 +921,16 @@ describe('session-replay-pipeline', () => {
                 createMessage(0, 3, 'session-3', { token: 'valid-token' }),
             ]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(recordedSessionIds()).toEqual(['session-1', 'session-3'])
             // The invalid-team message (offset 2) isn't recorded, but its offset is still tracked.
-            expect(offsets).toEqual(new Map([[0, 3]]))
+            expect(maxOffsets).toEqual(new Map([[0, 3]]))
         })
 
         it('sends messages with no token header to DLQ', async () => {
@@ -835,11 +952,16 @@ describe('session-replay-pipeline', () => {
             // Explicitly pass empty headers (no token)
             const messages = [createMessage(0, 1, 'session-1', {})]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             // Message is dropped by team filter due to missing token — not recorded, offset still tracked.
             expect(recordedSessionIds()).toEqual([])
-            expect(offsets).toEqual(new Map([[0, 1]]))
+            expect(maxOffsets).toEqual(new Map([[0, 1]]))
         })
 
         it('sends ingestion warning for old lib version', async () => {
@@ -952,11 +1074,16 @@ describe('session-replay-pipeline', () => {
             // Create a message with timestamps 10 days old (threshold is 7 days)
             const messages = [createMessageWithOldTimestamps(0, 1, 'session-1', 10, { token: 'test-token' })]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             // Message is dropped (not recorded) but its offset is tracked and a warning is sent.
             expect(recordedSessionIds()).toEqual([])
-            expect(offsets).toEqual(new Map([[0, 1]]))
+            expect(maxOffsets).toEqual(new Map([[0, 1]]))
             expect(outputs.queueMessages).toHaveBeenCalledTimes(1)
 
             expect(outputs.queueMessages).toHaveBeenCalledWith(
@@ -1053,11 +1180,16 @@ describe('session-replay-pipeline', () => {
 
             const messages = [createMessage(0, 1, 'session-1')]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(mockBatchRecorder.record).not.toHaveBeenCalled()
             // Dropped, but its offset is still tracked so the partition commits past it.
-            expect(offsets).toEqual(new Map([[0, 1]]))
+            expect(maxOffsets).toEqual(new Map([[0, 1]]))
         })
 
         it('does not record messages with invalid team to session batch', async () => {
@@ -1082,11 +1214,16 @@ describe('session-replay-pipeline', () => {
 
             const messages = [createMessage(0, 1, 'session-1', { token: 'invalid-token' })]
 
-            const offsets = await runSessionReplayPipeline(pipeline, messages, mockBatchRecorder, promiseScheduler)
+            const { maxOffsets } = await runSessionReplayPipeline(
+                pipeline,
+                messages,
+                mockBatchRecorder,
+                promiseScheduler
+            )
 
             expect(mockBatchRecorder.record).not.toHaveBeenCalled()
             // Dropped, but its offset is still tracked so the partition commits past it.
-            expect(offsets).toEqual(new Map([[0, 1]]))
+            expect(maxOffsets).toEqual(new Map([[0, 1]]))
         })
 
         it('records parse time metric via TopHog', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/session-replay-pipeline.ts
@@ -11,7 +11,7 @@ import { newBatchingPipeline } from '~/ingestion/framework/builders'
 import { TopHogRegistry, createTopHogWrapper, sum, timer } from '~/ingestion/framework/extensions/tophog'
 import { createBatch } from '~/ingestion/framework/helpers'
 import { PipelineConfig } from '~/ingestion/framework/result-handling-pipeline'
-import { ok } from '~/ingestion/framework/results'
+import { isOkResult, ok } from '~/ingestion/framework/results'
 import { ParsedMessageData } from '~/ingestion/pipelines/sessionreplay/kafka/types'
 import { SessionBatchRecorder } from '~/ingestion/pipelines/sessionreplay/sessions/session-batch-recorder'
 import { SessionFilter } from '~/ingestion/pipelines/sessionreplay/sessions/session-filter'
@@ -245,15 +245,25 @@ export function createSessionReplayPipeline(config: SessionReplayPipelineConfig)
     )
 }
 
+/** The Kafka progress and lag inputs a processed batch yields for the caller to act on after it drains. */
+export interface SessionReplayBatchProgress {
+    /** Highest Kafka offset reached per partition, across every terminal result — advances the commit. */
+    maxOffsets: Map<number, number>
+    /** Source messages of the OK (recorded) results only, for ingestion-lag sampling after the flush. */
+    okMessages: Message[]
+}
+
 /**
- * Runs a batch of messages through the session replay pipeline and returns the highest Kafka offset
- * reached per partition.
+ * Runs a batch of messages through the session replay pipeline and returns the Kafka progress it made:
+ * the highest offset reached per partition, plus the source messages of the OK results.
  *
  * Every message ends the pipeline with a terminal result — OK (recorded), DROP, DLQ, or REDIRECT —
  * and each result still carries its source message in the context. Draining them here and taking the
  * max offset per partition is the single place Kafka progress is tracked: the recorder no longer
  * tracks offsets while recording, and drop/dlq steps no longer have to remember to. The caller feeds
- * the returned offsets to the offset manager, which commits them on the next flush.
+ * the returned offsets to the offset manager, which commits them on the next flush. Every disposition
+ * advances the offset, but only OK results are collected for lag sampling — those are the messages
+ * actually recorded, matching the per-event `record-ingestion-lag` step's ingested-only semantics.
  *
  * Relies on the pipeline draining the whole fed batch before it returns null, so every fed message
  * yields exactly one terminal result here.
@@ -268,10 +278,11 @@ export async function runSessionReplayPipeline(
     messages: Message[],
     sessionBatchRecorder: SessionBatchRecorder,
     promiseScheduler: PromiseScheduler
-): Promise<Map<number, number>> {
-    const maxOffsetByPartition = new Map<number, number>()
+): Promise<SessionReplayBatchProgress> {
+    const maxOffsets = new Map<number, number>()
+    const okMessages: Message[] = []
     if (messages.length === 0) {
-        return maxOffsetByPartition
+        return { maxOffsets, okMessages }
     }
 
     // Stamp the caller's current recorder onto every message, so the record step folds into the batch
@@ -289,15 +300,18 @@ export async function runSessionReplayPipeline(
         for (const sideEffect of batchResult.sideEffects ?? []) {
             void promiseScheduler.schedule(sideEffect)
         }
-        for (const { context } of batchResult.elements) {
+        for (const { result, context } of batchResult.elements) {
             const { partition, offset } = context.message
-            const current = maxOffsetByPartition.get(partition)
+            const current = maxOffsets.get(partition)
             if (current === undefined || offset > current) {
-                maxOffsetByPartition.set(partition, offset)
+                maxOffsets.set(partition, offset)
+            }
+            if (isOkResult(result)) {
+                okMessages.push(context.message)
             }
         }
         batchResult = await pipeline.next()
     }
 
-    return maxOffsetByPartition
+    return { maxOffsets, okMessages }
 }


### PR DESCRIPTION
## Problem

The session replay v2 consumer was the only ingestion path not emitting the shared ingestion-lag metrics (`ingestion_lag_ms` gauge and `ingestion_lag_ms_histogram`). That left a blind spot: we could not see, per topic and partition, how far behind real time replay ingestion was running.

## Changes

Replay now emits the same `ingestion_lag_ms` / `ingestion_lag_ms_histogram` metrics every other pipeline emits (reusing the exact metric objects from `common/metrics.ts` — no new names). Lag is wall-clock time minus capture time, where capture time is the `now` Kafka header set by rust capture.

The one difference from other pipelines is *when* the sample is taken. Other pipelines observe lag at processing time via `createRecordIngestionLagStep`. Replay observes it **after the session batch flush succeeds** — the flush is what durably writes the data and commits offsets, so that is the moment replay data is actually ingested. Observing at processing time would understate lag, since a message can sit buffered across several poll batches before its batch flushes.

Only OK (recorded) results are sampled, matching `record-ingestion-lag.ts` semantics — dropped, DLQ'd, and redirected messages are excluded. `runSessionReplayPipeline` already drains every terminal result, so it now returns both the per-partition max offsets (every disposition still advances the commit, unchanged) and the source messages of the OK results, as a `SessionReplayBatchProgress` object. The consumer records only those OK messages for lag.

A small dedicated `SessionReplayLagReporter` holds the pending state:

- `record(okMessages)` runs after each poll batch is processed. It extracts only the `now` capture timestamp (epoch ms) per partition and never retains the messages. Kafka permits duplicate header keys, so it reads the last valid `now`, matching `parseEventHeaders` exactly — lag is reported from the same timestamp the message was processed with. Messages without a valid `now` header are skipped. It reads only the one header it needs rather than re-running the full header parse the pipeline already ran, so it doesn't double-count the header-status metrics.
- `flush()` runs after `currentBatch.flush()` resolves. It takes `Date.now()` once, observes every pending timestamp on the shared gauge/histogram (same call shape as `record-ingestion-lag.ts`), then clears. If the flush throws, the reporter flush is skipped, so a failed flush records no premature sample and the pending timestamps survive for the next flush.

> [!NOTE]
> Sampling parity with `record-ingestion-lag.ts`: only OK results are sampled. A failed poll-batch flush crashes the process (eachBatch errors are uncaught), so its pending samples die unreported and are re-read from the uncommitted offsets on restart. The one path that retains and later reports is a failed or timed-out revoke-hook flush: it is swallowed and the partitions are given up without committed offsets, so this still-running process can report its retained samples while the new owner reprocesses the same messages — a bounded duplicate consistent with the at-least-once delivery both owners already provide for the data itself.

The revoke path already drains through `flushCurrentBatch`, so pending timestamps get observed and cleared there naturally. There is no code path that drops a partition's offsets without flushing, so no partition-discard method was needed.

## How did you test this code?

All automated, run locally in `nodejs/`:

- `pnpm test -- src/ingestion/pipelines/sessionreplay/session-replay-lag-reporter.test.ts` — covers: lag measured from capture to flush time and reported per partition (gauge keeps last, histogram aggregates); pending state cleared after flush so a second flush doesn't re-report; flush with nothing pending is a no-op; messages with no headers / no `now` / an unparseable `now` are skipped; and a message with duplicate `now` headers samples from the last valid one.
- `pnpm test -- src/ingestion/pipelines/sessionreplay/session-replay-pipeline.test.ts` — includes a case proving the runner collects only OK-result messages (a dropped, a redirected, and a DLQ'd message in the same batch are excluded) while every disposition still advances the max offset.
- `pnpm test -- src/ingestion/pipelines/sessionreplay/consumer.test.ts` — guards the consumer wiring: lag is observed only after a flush and never before; only the pipeline's OK messages are sampled, not the raw consumed batch; and a failed flush observes nothing and keeps the pending sample so a later successful flush still reports it.
- `pnpm build` (full `tsc -b`) green, `eslint` and `prettier --check` clean on the changed files, `check:boundaries` clean, `hogli ci:preflight --fix` reports no failure classes.

Each test targets a distinct regression (wrong lag math, stale/leaked samples, garbage samples from bad headers, wrong timestamp on duplicate headers, sampling non-OK dispositions, sampling before durable ingest).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by Claude (Claude Code) driven by @pl. Invoked the `/writing-tests` skill before writing tests to keep each case tied to a named regression and push the matrix down to the cheapest level.

Design evolved during the session. An earlier plan threaded per-partition capture timestamps back through the pipeline's return value and into `KafkaOffsetManager.commit()`; we rejected that to avoid overloading the offset manager, and settled on a self-contained `SessionReplayLagReporter` owned by the consumer. A first cut recorded the whole raw batch; on review that was reversed to restore strict parity with `record-ingestion-lag.ts` — the pipeline now returns the OK-result messages alongside the offsets (as `SessionReplayBatchProgress`) and the consumer samples only those. Review also caught a duplicate-`now`-header case where a first-wins parse would disagree with `parseEventHeaders`' last-wins, now fixed, and corrected the failed-flush note to reflect the real crash-vs-revoke semantics. The reporter takes messages through a minimal `Pick<Message, 'partition' | 'headers'>` structural type so it never couples to the wider message shape.
