### PR TITLE
feat(data-warehouse): show non-billable syncs in source sync history

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6429,6 +6429,11 @@ export interface ExternalDataJob {
      * (cdc-only history table). `null` for non-CDC syncs.
      */
     cdc_write_mode?: 'incremental_merge' | 'scd2_append' | null
+    /**
+     * Whether the rows synced by this job count toward billing. `false` for system-initiated
+     * runs the customer isn't charged for. `null` on legacy rows and means billable.
+     */
+    billable?: boolean | null
 }
 
 export interface SimpleDataWarehouseTable {

--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -721,6 +721,15 @@ class ExternalDataJobSerializers(serializers.ModelSerializer):
             "(cdc-only history table). `null` for non-CDC syncs. Read from `schema_snapshot`."
         ),
     )
+    billable = serializers.BooleanField(
+        read_only=True,
+        allow_null=True,
+        help_text=(
+            "Whether the rows synced by this job count toward billing. `false` for system-initiated "
+            "runs the customer isn't charged for (e.g. rebuilding a table after an internal issue). "
+            "`null` on legacy rows and means billable."
+        ),
+    )
 
     class Meta:
         model = ExternalDataJob
@@ -735,6 +744,7 @@ class ExternalDataJobSerializers(serializers.ModelSerializer):
             "latest_error",
             "workflow_run_id",
             "cdc_write_mode",
+            "billable",
         ]
         read_only_fields = [
             "id",
@@ -747,6 +757,7 @@ class ExternalDataJobSerializers(serializers.ModelSerializer):
             "latest_error",
             "workflow_run_id",
             "cdc_write_mode",
+            "billable",
         ]
 
     def get_cdc_write_mode(self, instance: ExternalDataJob) -> str | None:
@@ -4252,9 +4263,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         # select_related joins the full ExternalDataSchema row; defer its large JSON/text
         # columns so the serializer only pulls the fields SimpleExternalDataSchemaSerializer
         # actually reads (sync_type_config + latest_error can each be sizeable).
+        # Non-billable jobs are included on purpose: the UI shows them tagged so a sync the
+        # customer wasn't charged for is still visible in the history.
         jobs = (
-            instance.jobs.filter(billable=True)
-            .select_related("schema")
+            instance.jobs.select_related("schema")
             .defer("schema__sync_type_config", "schema__latest_error")
             .order_by("-created_at")
         )

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -4735,18 +4735,21 @@ class TestExternalDataSource(APIBaseTest):
 
         data = response.json()
 
-        assert response.status_code, status.HTTP_200_OK
+        assert response.status_code == status.HTTP_200_OK
         assert len(data) == 1
         assert data[0]["id"] == str(job.pk)
         assert data[0]["status"] == "Completed"
         assert data[0]["rows_synced"] == 100
         assert data[0]["schema"]["id"] == str(schema.pk)
         assert data[0]["workflow_run_id"] is not None
+        assert data[0]["billable"] is True
 
-    def test_source_jobs_billable_job(self):
+    def test_source_jobs_includes_non_billable(self):
+        # Non-billable jobs (system-initiated runs the customer isn't charged for) must show up
+        # in the sync history, flagged so the UI can tag them.
         source = self._create_external_data_source()
         schema = self._create_external_data_schema(source.pk)
-        ExternalDataJob.objects.create(
+        job = ExternalDataJob.objects.create(
             team=self.team,
             pipeline=source,
             schema=schema,
@@ -4763,8 +4766,10 @@ class TestExternalDataSource(APIBaseTest):
 
         data = response.json()
 
-        assert response.status_code, status.HTTP_200_OK
-        assert len(data) == 0
+        assert response.status_code == status.HTTP_200_OK
+        assert len(data) == 1
+        assert data[0]["id"] == str(job.pk)
+        assert data[0]["billable"] is False
 
     def test_source_jobs_pagination(self):
         source = self._create_external_data_source()

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SyncsTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SyncsTab.tsx
@@ -127,12 +127,23 @@ export const SyncsTab = ({ id }: SyncsTabProps): JSX.Element => {
                             const tagContent = (
                                 <LemonTag type={StatusTagSetting[job.status] || 'default'}>{job.status}</LemonTag>
                             )
-                            return job.latest_error && job.status === ExternalDataJobStatus.Failed ? (
-                                <Tooltip title={job.latest_error} interactive>
-                                    {tagContent}
-                                </Tooltip>
-                            ) : (
-                                tagContent
+                            return (
+                                <span className="flex items-center gap-1">
+                                    {job.latest_error && job.status === ExternalDataJobStatus.Failed ? (
+                                        <Tooltip title={job.latest_error} interactive>
+                                            {tagContent}
+                                        </Tooltip>
+                                    ) : (
+                                        tagContent
+                                    )}
+                                    {job.billable === false && (
+                                        <Tooltip title="You're not charged for this sync. These are usually system-initiated runs, like rebuilding a table after an issue on our side.">
+                                            <LemonTag type="muted" size="small">
+                                                Non-billable
+                                            </LemonTag>
+                                        </Tooltip>
+                                    )}
+                                </span>
                             )
                         },
                     },


### PR DESCRIPTION
## Problem

Non-billable `ExternalDataJob` rows are filtered out of the source sync history (`jobs` endpoint hardcodes `billable=True`), so a sync the customer isn't charged for is completely invisible in the UI.
That makes it look like nothing ran at all, e.g. when the system rebuilds a table from source after recovering from internal Delta table corruption (the kind of run #71531 stops from looping).
Customers and support both benefit from seeing those runs with an explanation instead of a gap in the history.

## Changes

- The `jobs` endpoint no longer filters out non-billable jobs.
- `ExternalDataJobSerializers` now exposes the `billable` field (read-only, nullable — `null` on legacy rows means billable).
- The syncs tab tags non-billable runs with a `Non-billable` tag next to the status, with a tooltip: "You're not charged for this sync. These are usually system-initiated runs, like rebuilding a table after an issue on our side."

The tag only renders on `billable === false`, so legacy `null` rows show unchanged.

## How did you test this code?

Inverted the existing `test_source_jobs_billable_job` endpoint test (which locked in the old hide-non-billable behavior) into `test_source_jobs_includes_non_billable`, asserting a non-billable job is returned with `billable: false` — this catches the filter being reintroduced or the field being dropped from the serializer.
Also extended `test_source_jobs` to assert `billable: true` on a default job.
Ran the six `test_source_jobs*` endpoint tests locally, all passing.
I (well, Claude) couldn't run the full frontend typecheck locally (pre-existing environment breakage unrelated to this change) and didn't manually test the rendered tag; the frontend change is a small conditional tag in the existing status column.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe the sync history's billable filtering; nothing to update.
