### PR TITLE
fix(experiments): Center vertical divider in recalculation status bar

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -68,7 +68,7 @@ export function RecalculationStatus({ experiment }: { experiment: Experiment }):
                     </span>
                     {currentRecalculation?.completed_at && (
                         <>
-                            <LemonDivider vertical className="h-3.5" />
+                            <LemonDivider vertical className="h-3.5 self-center" />
                             <span className="flex items-center gap-1 whitespace-nowrap text-muted text-xs [&_span]:align-baseline">
                                 <span>Results calculated </span>
                                 <ExperimentLastRefreshText lastRefresh={currentRecalculation.completed_at} />


### PR DESCRIPTION
## Problem

In the experiment metrics status bar ("16 metrics | Results calculated a day ago"), the vertical divider sits at the top of the bar instead of vertically centered.
`LemonDivider--vertical` sets `align-self: stretch`, and with the fixed `h-3.5` height flexbox stretch falls back to `flex-start`.

## Changes

Added `self-center` to the divider so it centers like its siblings.

## How did you test this code?

Verified the `self-center` utility overrides the divider's `align-self: stretch` the same way the existing `h-3.5` already overrides its `height: auto` (both live in the Tailwind utilities layer). No automated tests, it's a one-class CSS alignment fix.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Root-caused the misalignment to the flexbox spec behavior where `align-self: stretch` with a definite cross size behaves as `flex-start`, then picked `self-center` over removing the fixed height to keep the short divider design.
