### PR TITLE
feat(review_hog): scope custom review skills to their author

### DIFF
--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -2929,9 +2929,9 @@ Locked with the user (AskUserQuestion, 2026-07-16):
 
 - **Visibility rule:** a skill is visible to a user iff its name is canonical (`CANONICAL_*_SKILL_NAMES` — by name, so a team-edited canonical stays visible to everyone)
   OR the **earliest live version's `created_by`** is that user.
-  This refines the 2026-06-29 "`created_by` is audit-only" lock: still audit-only for identity and editing (edits mint new versions stamped with the *editor* and do NOT transfer visibility);
+  This refines the 2026-06-29 "`created_by` is audit-only" lock: still audit-only for identity and editing (edits mint new versions stamped with the _editor_ and do NOT transfer visibility);
   the first version's author now governs **menu visibility only**.
-  Earliest *live* version rather than literally `version=1`: deleted rows are excluded, so an archived name later recreated by another user belongs to the new author
+  Earliest _live_ version rather than literally `version=1`: deleted rows are excluded, so an archived name later recreated by another user belongs to the new author
   (deleted `(name, version)` pairs can duplicate — the unique constraints only cover `deleted=False`).
 - **Strict, no grandfathering** (decided while the feature had no external adopters): `partial_update` 404s on a non-visible skill exactly like a missing one
   (a distinct error would leak that the name exists), closing the enable-any-team-skill-by-name backdoor. No data migration; the loaders backstop instead.

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -2921,6 +2921,36 @@ file to prove a gap and another agent read it mid-experiment.
 API/MCP only for now); a partial unique index if a hard DB single-active guarantee is ever wanted (app-level matches
 perspectives today).
 
+##### ✅ BUILT 2026-07-16 — per-user VISIBILITY of custom review skills (menus show canonicals + your own)
+
+Custom review skills were team-visible: all three config menus (perspectives / validators / blind-spots) listed every team `LLMSkill` with the prefix,
+so one user's custom appeared in — and was enableable by exact name from — every teammate's Code review tab, with the clutter compounding as customs multiply.
+Locked with the user (AskUserQuestion, 2026-07-16):
+
+- **Visibility rule:** a skill is visible to a user iff its name is canonical (`CANONICAL_*_SKILL_NAMES` — by name, so a team-edited canonical stays visible to everyone)
+  OR the **earliest live version's `created_by`** is that user.
+  This refines the 2026-06-29 "`created_by` is audit-only" lock: still audit-only for identity and editing (edits mint new versions stamped with the *editor* and do NOT transfer visibility);
+  the first version's author now governs **menu visibility only**.
+  Earliest *live* version rather than literally `version=1`: deleted rows are excluded, so an archived name later recreated by another user belongs to the new author
+  (deleted `(name, version)` pairs can duplicate — the unique constraints only cover `deleted=False`).
+- **Strict, no grandfathering** (decided while the feature had no external adopters): `partial_update` 404s on a non-visible skill exactly like a missing one
+  (a distinct error would leak that the name exists), closing the enable-any-team-skill-by-name backdoor. No data migration; the loaders backstop instead.
+- **Loader backstop:** `load_perspectives_for_run` warn-and-skips an enabled name outside the acting user's visible set
+  (same posture and hole-preserving `pass_number` semantics as the dead-skill skip), and `_load_single_active_skill` falls back to the canonical on a foreign selection —
+  so a pre-fix foreign-enabled row stops running rather than running invisibly, self-healing with no migration.
+- **Scope:** all three review menus. The team-level Skills page (`/skills`) intentionally keeps showing all team skills —
+  this is a clutter fix, not confidentiality: bodies stay team-readable there, and teammates can still edit each other's customs (accepted risk).
+  Signals scouts share the identical all-team-menu pattern; same future problem, deliberately out of scope here.
+- **Consequences:** a custom whose author's account is deleted (`created_by` → NULL on SET_NULL) is visible to no one and stops running
+  (its config rows CASCADE with the account); cleanup is archiving from the Skills page.
+  A skill authored through an agent session is stamped with that session's user.
+  "Adopt a teammate's skill" is now duplicate-under-a-new-name (v1 `created_by` = the duplicator), not enable-by-name.
+
+Implementation: `visible_skill_names(team_id, user_id, prefix, canonical_names)` in `skill_loader.py` (one `DISTINCT ON (name) ORDER BY name, version` query over live rows),
+used by all three config viewsets (`list` + `partial_update`) and both loader paths.
+Tests: per surface, a teammate's custom is hidden from `list` and 404s on PATCH; the perspective loader skips a foreign-enabled row keeping pass-number holes;
+the single-active loader falls back to canonical on a foreign selection; existing custom-skill fixtures now stamp `created_by`.
+
 The fact that keeps all of this safe: **the output schema is fixed; only the skill (logic) is editable.** Every
 perspective validates against `IssuesReview`/`Issue`, the validator against `IssueValidation`, chunking against
 `ChunksList` — all **code, not skills** — so editing a skill cannot change the output format and the downstream

--- a/products/review_hog/backend/api/blind_spots.py
+++ b/products/review_hog/backend/api/blind_spots.py
@@ -16,8 +16,10 @@ from posthog.models.scoping.manager import resolve_effective_team_id
 from products.review_hog.backend.models import ReviewSkillConfig
 from products.review_hog.backend.reviewer.lazy_seed import seed_canonicals_tolerantly, sync_canonical_blind_spots
 from products.review_hog.backend.reviewer.skill_loader import (
+    CANONICAL_BLIND_SPOTS_SKILL_NAMES,
     REVIEW_HOG_BLIND_SPOTS_PREFIX,
     register_missing_blind_spots_config,
+    visible_skill_names,
 )
 from products.skills.backend.models.skills import LLMSkill
 
@@ -53,13 +55,16 @@ class ReviewBlindSpotsConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
     """Per-user selection of ReviewHog's single active blind-spots skill for a project.
 
     A blind-spots skill is any team `review-hog-blind-spots-*` `LLMSkill` (canonical or custom —
-    handled identically): the final per-chunk sweep that reads the perspective wave's findings and
-    hunts for what every perspective missed. The skill itself is team-level; this surface only
-    controls **which one** runs on the requesting user's PR reviews. Like validators (and unlike
-    perspectives), a review runs exactly one, so this is a single-active selection: `list` shows
-    every blind-spots skill with the user's active one flagged (the canonical auto-seeds active on
-    first read); `partial_update` selects one by skill name, flipping the user's others off in the
-    same call. There is always a default (the canonical), so no minimum floor is needed.
+    handled identically at run time): the final per-chunk sweep that reads the perspective wave's
+    findings and hunts for what every perspective missed. The skill itself is team-level; this
+    surface only controls **which one** runs on the requesting user's PR reviews. Visibility is
+    per-user: the menu shows the canonical plus the customs the requesting user authored — a
+    teammate's custom is neither listed nor selectable (`visible_skill_names`). Like validators
+    (and unlike perspectives), a review runs exactly one, so this is a single-active selection:
+    `list` shows the visible blind-spots skills with the user's active one flagged (the canonical
+    auto-seeds active on first read); `partial_update` selects one by skill name, flipping the
+    user's others off in the same call. There is always a default (the canonical), so no minimum
+    floor is needed.
     """
 
     # llm_skill, not INTERNAL: responses carry skill body/description, so the llm_analytics RBAC
@@ -80,9 +85,10 @@ class ReviewBlindSpotsConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
         },
         summary="List blind-spots skills and which one is active",
         description=(
-            "List every `review-hog-blind-spots-*` skill on this project, flagging the one active for "
-            "the requesting user. The canonical skill is auto-seeded active on the first read; a "
-            "custom skill the user has not selected shows as inactive."
+            "List the `review-hog-blind-spots-*` skills visible to the requesting user — the "
+            "canonical skill plus the customs they authored — flagging the one active for them. "
+            "The canonical skill is auto-seeded active on the first read; a custom skill the user "
+            "has not selected shows as inactive."
         ),
     )
     def list(self, request: Request, **kwargs) -> Response:
@@ -99,9 +105,14 @@ class ReviewBlindSpotsConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
             .filter(user_id=user_id, skill_name__startswith=REVIEW_HOG_BLIND_SPOTS_PREFIX)
             .values_list("skill_name", "enabled")
         )
-        skills = LLMSkill.objects.filter(
-            team_id=team_id, name__startswith=REVIEW_HOG_BLIND_SPOTS_PREFIX, is_latest=True, deleted=False
-        ).order_by("name")
+        # Per-user visibility: the menu advertises the canonical plus this user's own customs —
+        # never a teammate's.
+        visible = visible_skill_names(
+            team_id, user_id, prefix=REVIEW_HOG_BLIND_SPOTS_PREFIX, canonical_names=CANONICAL_BLIND_SPOTS_SKILL_NAMES
+        )
+        skills = LLMSkill.objects.filter(team_id=team_id, name__in=visible, is_latest=True, deleted=False).order_by(
+            "name"
+        )
         items = [
             {
                 "skill_name": s.name,
@@ -121,14 +132,15 @@ class ReviewBlindSpotsConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
                 description="The blind-spots skill now active for the user.",
             ),
             400: OpenApiResponse(description="Not a blind-spots skill, or `active` was not true."),
-            404: OpenApiResponse(description="No such blind-spots skill on this project."),
+            404: OpenApiResponse(description="No such blind-spots skill visible to the user on this project."),
         },
         summary="Select the active blind-spots skill",
         description=(
             "Make a `review-hog-blind-spots-*` skill the single sweep that runs on the requesting "
             "user's PR reviews, switching the user's other blind-spots skills off in the same call. "
-            "Upserts the per-user config row, so selecting a freshly authored custom skill works in "
-            "one call."
+            "Only skills visible to the user — the canonical plus the customs they authored — can "
+            "be selected; anything else 404s. Upserts the per-user config row, so selecting a "
+            "freshly authored custom skill works in one call."
         ),
     )
     def partial_update(self, request: Request, skill_name: str, **kwargs) -> Response:
@@ -143,7 +155,11 @@ class ReviewBlindSpotsConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
         # would 404 without it.
         seed_canonicals_tolerantly(team_id, sync_canonical_blind_spots)
         skill = LLMSkill.objects.filter(team_id=team_id, name=skill_name, is_latest=True, deleted=False).first()
-        if skill is None:
+        # A teammate's custom 404s exactly like a missing skill — visibility is author-only, and a
+        # distinct error would leak that the name exists.
+        if skill is None or skill_name not in visible_skill_names(
+            team_id, user_id, prefix=REVIEW_HOG_BLIND_SPOTS_PREFIX, canonical_names=CANONICAL_BLIND_SPOTS_SKILL_NAMES
+        ):
             raise NotFound(f"No blind-spots skill '{skill_name}' on this project")
 
         select = ReviewBlindSpotsConfigSelectSerializer(data=request.data)

--- a/products/review_hog/backend/api/perspectives.py
+++ b/products/review_hog/backend/api/perspectives.py
@@ -13,8 +13,10 @@ from posthog.models.scoping.manager import resolve_effective_team_id
 from products.review_hog.backend.models import ReviewSkillConfig
 from products.review_hog.backend.reviewer.lazy_seed import seed_canonicals_tolerantly, sync_canonical_perspectives
 from products.review_hog.backend.reviewer.skill_loader import (
+    CANONICAL_PERSPECTIVE_SKILL_NAMES,
     REVIEW_HOG_PERSPECTIVE_PREFIX,
     register_missing_perspective_configs,
+    visible_skill_names,
 )
 from products.skills.backend.models.skills import LLMSkill
 
@@ -46,11 +48,13 @@ class ReviewPerspectiveConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
     """Per-user enablement of ReviewHog's review perspectives for a project.
 
     A perspective is any team `review-hog-perspective-*` `LLMSkill` (canonical or custom — handled
-    identically). The skill itself is team-level; this surface only controls **which** perspectives
-    run on the requesting user's PR reviews. `list` shows the full perspective menu joined with the
-    user's enable state (the 3 canonicals auto-seed enabled on first read); `partial_update` toggles
-    one by skill name (upserting the config row, so a freshly authored custom perspective is enabled
-    by the same call). At least one perspective must stay enabled.
+    identically at run time). The skill itself is team-level; this surface only controls **which**
+    perspectives run on the requesting user's PR reviews. Visibility is per-user: the menu shows
+    the canonicals plus the customs the requesting user authored — a teammate's custom is neither
+    listed nor enableable (`visible_skill_names`). `list` joins that menu with the user's enable
+    state (the 3 canonicals auto-seed enabled on first read); `partial_update` toggles one by skill
+    name (upserting the config row, so a freshly authored custom perspective is enabled by the same
+    call). At least one perspective must stay enabled.
     """
 
     # llm_skill, not INTERNAL: responses carry skill body/description, so the llm_analytics RBAC
@@ -71,9 +75,10 @@ class ReviewPerspectiveConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
         },
         summary="List review perspectives and their enablement",
         description=(
-            "List every `review-hog-perspective-*` skill on this project joined with the requesting "
-            "user's enable state. The 3 canonical perspectives are auto-seeded enabled on the first "
-            "read; a custom perspective the user has not switched on shows as disabled."
+            "List the `review-hog-perspective-*` skills visible to the requesting user — the "
+            "canonical perspectives plus the customs they authored — joined with their enable "
+            "state. The 3 canonical perspectives are auto-seeded enabled on the first read; a "
+            "custom perspective the user has not switched on shows as disabled."
         ),
     )
     def list(self, request: Request, **kwargs) -> Response:
@@ -91,9 +96,14 @@ class ReviewPerspectiveConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
             .filter(user_id=user_id, skill_name__startswith=REVIEW_HOG_PERSPECTIVE_PREFIX)
             .values_list("skill_name", "enabled")
         )
-        skills = LLMSkill.objects.filter(
-            team_id=team_id, name__startswith=REVIEW_HOG_PERSPECTIVE_PREFIX, is_latest=True, deleted=False
-        ).order_by("name")
+        # Per-user visibility: the menu advertises the canonicals plus this user's own customs —
+        # never a teammate's.
+        visible = visible_skill_names(
+            team_id, user_id, prefix=REVIEW_HOG_PERSPECTIVE_PREFIX, canonical_names=CANONICAL_PERSPECTIVE_SKILL_NAMES
+        )
+        skills = LLMSkill.objects.filter(team_id=team_id, name__in=visible, is_latest=True, deleted=False).order_by(
+            "name"
+        )
         items = [
             {
                 "skill_name": s.name,
@@ -112,14 +122,15 @@ class ReviewPerspectiveConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
                 response=ReviewPerspectiveConfigSerializer, description="The perspective's updated enable state."
             ),
             400: OpenApiResponse(description="Not a perspective skill, or disabling the user's last enabled one."),
-            404: OpenApiResponse(description="No such perspective skill on this project."),
+            404: OpenApiResponse(description="No such perspective skill visible to the user on this project."),
         },
         summary="Enable or disable a review perspective",
         description=(
             "Toggle whether a `review-hog-perspective-*` skill runs on the requesting user's PR "
-            "reviews. Upserts the per-user config row, so enabling a freshly authored custom "
-            "perspective works in one call. Rejected if it would leave the user with no enabled "
-            "perspective."
+            "reviews. Only skills visible to the user — the canonicals plus the customs they "
+            "authored — can be toggled; anything else 404s. Upserts the per-user config row, so "
+            "enabling a freshly authored custom perspective works in one call. Rejected if it "
+            "would leave the user with no enabled perspective."
         ),
     )
     def partial_update(self, request: Request, skill_name: str, **kwargs) -> Response:
@@ -134,7 +145,11 @@ class ReviewPerspectiveConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
         # 404 without it.
         seed_canonicals_tolerantly(team_id, sync_canonical_perspectives)
         skill = LLMSkill.objects.filter(team_id=team_id, name=skill_name, is_latest=True, deleted=False).first()
-        if skill is None:
+        # A teammate's custom 404s exactly like a missing skill — visibility is author-only, and a
+        # distinct error would leak that the name exists.
+        if skill is None or skill_name not in visible_skill_names(
+            team_id, user_id, prefix=REVIEW_HOG_PERSPECTIVE_PREFIX, canonical_names=CANONICAL_PERSPECTIVE_SKILL_NAMES
+        ):
             raise NotFound(f"No perspective skill '{skill_name}' on this project")
 
         update = ReviewPerspectiveConfigUpdateSerializer(data=request.data)

--- a/products/review_hog/backend/api/validators.py
+++ b/products/review_hog/backend/api/validators.py
@@ -16,8 +16,10 @@ from posthog.models.scoping.manager import resolve_effective_team_id
 from products.review_hog.backend.models import ReviewSkillConfig
 from products.review_hog.backend.reviewer.lazy_seed import seed_canonicals_tolerantly, sync_canonical_validation
 from products.review_hog.backend.reviewer.skill_loader import (
+    CANONICAL_VALIDATION_SKILL_NAMES,
     REVIEW_HOG_VALIDATION_PREFIX,
     register_missing_validation_config,
+    visible_skill_names,
 )
 from products.skills.backend.models.skills import LLMSkill
 
@@ -53,12 +55,14 @@ class ReviewValidatorConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
     """Per-user selection of ReviewHog's single active review validator for a project.
 
     A validator is any team `review-hog-validation-*` `LLMSkill` (canonical or custom — handled
-    identically). The skill itself is team-level; this surface only controls **which one** validates
-    the requesting user's PR reviews. Unlike perspectives (multi-enable), a review runs exactly one
-    validator, so this is a single-active selection: `list` shows every validator with the user's
-    active one flagged (the canonical auto-seeds active on first read); `partial_update` selects one
-    by skill name, flipping the user's other validators off in the same call. There is always a
-    default (the canonical), so no minimum floor is needed.
+    identically at run time). The skill itself is team-level; this surface only controls **which
+    one** validates the requesting user's PR reviews. Visibility is per-user: the menu shows the
+    canonical plus the customs the requesting user authored — a teammate's custom is neither listed
+    nor selectable (`visible_skill_names`). Unlike perspectives (multi-enable), a review runs
+    exactly one validator, so this is a single-active selection: `list` shows the visible
+    validators with the user's active one flagged (the canonical auto-seeds active on first read);
+    `partial_update` selects one by skill name, flipping the user's other validators off in the
+    same call. There is always a default (the canonical), so no minimum floor is needed.
     """
 
     # llm_skill, not INTERNAL: responses carry skill body/description, so the llm_analytics RBAC
@@ -79,9 +83,10 @@ class ReviewValidatorConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         },
         summary="List review validators and which one is active",
         description=(
-            "List every `review-hog-validation-*` skill on this project, flagging the one active for "
-            "the requesting user. The canonical validator is auto-seeded active on the first read; a "
-            "custom validator the user has not selected shows as inactive."
+            "List the `review-hog-validation-*` skills visible to the requesting user — the "
+            "canonical validator plus the customs they authored — flagging the one active for "
+            "them. The canonical validator is auto-seeded active on the first read; a custom "
+            "validator the user has not selected shows as inactive."
         ),
     )
     def list(self, request: Request, **kwargs) -> Response:
@@ -98,9 +103,14 @@ class ReviewValidatorConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
             .filter(user_id=user_id, skill_name__startswith=REVIEW_HOG_VALIDATION_PREFIX)
             .values_list("skill_name", "enabled")
         )
-        skills = LLMSkill.objects.filter(
-            team_id=team_id, name__startswith=REVIEW_HOG_VALIDATION_PREFIX, is_latest=True, deleted=False
-        ).order_by("name")
+        # Per-user visibility: the menu advertises the canonical plus this user's own customs —
+        # never a teammate's.
+        visible = visible_skill_names(
+            team_id, user_id, prefix=REVIEW_HOG_VALIDATION_PREFIX, canonical_names=CANONICAL_VALIDATION_SKILL_NAMES
+        )
+        skills = LLMSkill.objects.filter(team_id=team_id, name__in=visible, is_latest=True, deleted=False).order_by(
+            "name"
+        )
         items = [
             {
                 "skill_name": s.name,
@@ -119,13 +129,15 @@ class ReviewValidatorConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
                 response=ReviewValidatorConfigSerializer, description="The validator now active for the user."
             ),
             400: OpenApiResponse(description="Not a validator skill, or `active` was not true."),
-            404: OpenApiResponse(description="No such validator skill on this project."),
+            404: OpenApiResponse(description="No such validator skill visible to the user on this project."),
         },
         summary="Select the active review validator",
         description=(
             "Make a `review-hog-validation-*` skill the single validator that runs on the requesting "
-            "user's PR reviews, switching the user's other validators off in the same call. Upserts the "
-            "per-user config row, so selecting a freshly authored custom validator works in one call."
+            "user's PR reviews, switching the user's other validators off in the same call. Only "
+            "skills visible to the user — the canonical plus the customs they authored — can be "
+            "selected; anything else 404s. Upserts the per-user config row, so selecting a freshly "
+            "authored custom validator works in one call."
         ),
     )
     def partial_update(self, request: Request, skill_name: str, **kwargs) -> Response:
@@ -140,7 +152,11 @@ class ReviewValidatorConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         # would 404 without it.
         seed_canonicals_tolerantly(team_id, sync_canonical_validation)
         skill = LLMSkill.objects.filter(team_id=team_id, name=skill_name, is_latest=True, deleted=False).first()
-        if skill is None:
+        # A teammate's custom 404s exactly like a missing skill — visibility is author-only, and a
+        # distinct error would leak that the name exists.
+        if skill is None or skill_name not in visible_skill_names(
+            team_id, user_id, prefix=REVIEW_HOG_VALIDATION_PREFIX, canonical_names=CANONICAL_VALIDATION_SKILL_NAMES
+        ):
             raise NotFound(f"No validator skill '{skill_name}' on this project")
 
         select = ReviewValidatorConfigSelectSerializer(data=request.data)

--- a/products/review_hog/backend/reviewer/skill_loader.py
+++ b/products/review_hog/backend/reviewer/skill_loader.py
@@ -41,6 +41,29 @@ class NoEnabledPerspectivesError(LookupError):
     """No enabled review perspective resolves to a live skill — there is nothing to review with."""
 
 
+def visible_skill_names(team_id: int, user_id: int, *, prefix: str, canonical_names: tuple[str, ...]) -> set[str]:
+    """Names of `<prefix>*` skills this user may see: the canonicals plus the customs they authored.
+
+    Skills are team-level rows with no owner dimension, so authorship is derived from the earliest
+    live version's `created_by` — every edit mints a new version stamped with the *editor*, so only
+    the first version identifies the author. Canonicals are visible to everyone by name, even when
+    team-edited (the edit doesn't change what they are; their seeded rows carry no `created_by`
+    anyway). A custom whose author is gone (`created_by` nulls on account deletion) is visible to
+    no one — archiving it from the team-level Skills page is the cleanup path. Only live rows count:
+    a name whose every version is archived and then recreated by someone else belongs to the new
+    author, not the old one.
+    """
+    authored = {
+        name
+        for name, author_id in LLMSkill.objects.filter(team_id=team_id, name__startswith=prefix, deleted=False)
+        .order_by("name", "version")
+        .distinct("name")
+        .values_list("name", "created_by_id")
+        if author_id == user_id
+    }
+    return set(canonical_names) | authored
+
+
 @dataclass(frozen=True)
 class LoadedPerspective:
     """A perspective resolved for one run: its per-run index, skill name, and pinned version."""
@@ -90,8 +113,11 @@ def load_perspectives_for_run(team_id: int, acting_user_id: int) -> list[LoadedP
     perspective on its `(pass_number, chunk_id)` resume key across same-`head_sha` runs; a shifted
     index would silently reuse another perspective's persisted review on resume. An enabled
     perspective with no live skill row (e.g. an archived custom) is skipped with a warning rather
-    than failing the run; restoring the skill resumes it. Raises `NoEnabledPerspectivesError` when
-    nothing resolves — zero enabled (min-1 floor) or every enabled name is dead.
+    than failing the run; restoring the skill resumes it. An enabled custom the acting user did not
+    author is skipped the same way — customs are visible/enableable only to their author (the
+    config API enforces it), so such a row can only be a leftover from before that rule; running it
+    invisibly would be undebuggable. Raises `NoEnabledPerspectivesError` when nothing resolves —
+    zero enabled (min-1 floor) or every enabled name is dead.
     """
     register_missing_perspective_configs(team_id, acting_user_id)
     # Prefix-scope: perspectives and validators share this table — read only perspective rows here.
@@ -113,6 +139,9 @@ def load_perspectives_for_run(team_id: int, acting_user_id: int) -> list[LoadedP
             is_latest=True,
         ).values_list("name", "version", "description")
     }
+    visible = visible_skill_names(
+        team_id, acting_user_id, prefix=REVIEW_HOG_PERSPECTIVE_PREFIX, canonical_names=CANONICAL_PERSPECTIVE_SKILL_NAMES
+    )
     loaded: list[LoadedPerspective] = []
     for slot, skill_name in enumerate(enabled_names, start=1):
         resolved = latest_by_name.get(skill_name)
@@ -122,6 +151,16 @@ def load_perspectives_for_run(team_id: int, acting_user_id: int) -> list[LoadedP
             logger.warning(
                 "review_hog: enabled perspective '%s' has no live skill on team %s; skipping it this run",
                 skill_name,
+                team_id,
+            )
+            continue
+        if skill_name not in visible:
+            # A leftover config for a custom the acting user did not author (enabled before
+            # visibility became author-only): skip it rather than run an invisible perspective.
+            logger.warning(
+                "review_hog: enabled perspective '%s' was not authored by user %s on team %s; skipping it this run",
+                skill_name,
+                acting_user_id,
                 team_id,
             )
             continue
@@ -179,9 +218,11 @@ def _load_single_active_skill(
     Reads the user's one enabled row for the prefix, falling back to the canonical when none is
     enabled — there is always a default, so no min-1 floor. A selected custom whose skill row is
     dead (e.g. archived from the Skills UI) also falls back to the canonical rather than failing
-    the run. Raises `error` only when the canonical itself has no live row (the sync recreates
-    archived canonicals, so this is a genuine seeding failure). The enabled set is single-active in
-    app code; `sorted(...)[0]` is only a deterministic tiebreak.
+    the run, as does a selected custom the acting user did not author (a leftover from before
+    visibility became author-only — the config API no longer allows such a selection). Raises
+    `error` only when the canonical itself has no live row (the sync recreates archived canonicals,
+    so this is a genuine seeding failure). The enabled set is single-active in app code;
+    `sorted(...)[0]` is only a deterministic tiebreak.
     """
     enabled_names = sorted(
         ReviewSkillConfig.objects.for_team(team_id)
@@ -189,6 +230,17 @@ def _load_single_active_skill(
         .values_list("skill_name", flat=True)
     )
     skill_name = enabled_names[0] if enabled_names else canonical_name
+    if skill_name != canonical_name and skill_name not in visible_skill_names(
+        team_id, acting_user_id, prefix=prefix, canonical_names=(canonical_name,)
+    ):
+        logger.warning(
+            "review_hog: selected skill '%s' was not authored by user %s on team %s; falling back to canonical '%s'",
+            skill_name,
+            acting_user_id,
+            team_id,
+            canonical_name,
+        )
+        skill_name = canonical_name
 
     def _live_version(name: str) -> int | None:
         return (

--- a/products/review_hog/backend/tests/test_blind_spots_config_api.py
+++ b/products/review_hog/backend/tests/test_blind_spots_config_api.py
@@ -2,7 +2,7 @@ from posthog.test.base import APIBaseTest
 
 from parameterized import parameterized
 
-from posthog.models import Team
+from posthog.models import Team, User
 
 from products.review_hog.backend.models import ReviewSkillConfig
 from products.review_hog.backend.reviewer.lazy_seed import sync_canonical_blind_spots
@@ -23,8 +23,16 @@ class TestReviewBlindSpotsConfigAPI(APIBaseTest):
         sync_canonical_blind_spots(self.team)
         self.base = f"/api/projects/{self.team.id}/review_hog/blind_spots"
 
-    def _author_custom(self, name: str = _CUSTOM) -> None:
-        LLMSkill.objects.create(team=self.team, name=name, description="d", body="x" * 250, version=1, is_latest=True)
+    def _author_custom(self, name: str = _CUSTOM, created_by: User | None = None) -> None:
+        LLMSkill.objects.create(
+            team=self.team,
+            name=name,
+            description="d",
+            body="x" * 250,
+            version=1,
+            is_latest=True,
+            created_by=created_by or self.user,
+        )
 
     def test_list_shows_canonical_active_and_custom_inactive(self) -> None:
         # The menu flags the user's active sweep; the canonical seeds active on first read.
@@ -90,6 +98,19 @@ class TestReviewBlindSpotsConfigAPI(APIBaseTest):
             f"{self.base}/{REVIEW_HOG_BLIND_SPOTS_PREFIX}does-not-exist/", {"active": True}, format="json"
         )
         assert res.status_code == 404
+
+    def test_a_teammates_custom_sweep_is_hidden_and_not_selectable(self) -> None:
+        # Visibility is author-only: a custom another user authored must not appear in this user's
+        # menu, and selecting it by exact name must 404 as if it didn't exist.
+        teammate = User.objects.create(email="teammate-blind-spots@example.com")
+        self._author_custom(created_by=teammate)
+
+        listing = self.client.get(f"{self.base}/")
+        selected = self.client.patch(f"{self.base}/{_CUSTOM}/", {"active": True}, format="json")
+
+        assert listing.status_code == 200
+        assert _CUSTOM not in {item["skill_name"] for item in listing.json()}
+        assert selected.status_code == 404
 
     def test_environment_url_resolves_to_the_canonical_team(self) -> None:
         # Same failure mode as the settings/perspectives viewsets: an environment (child team) id in

--- a/products/review_hog/backend/tests/test_blind_spots_skill.py
+++ b/products/review_hog/backend/tests/test_blind_spots_skill.py
@@ -30,7 +30,13 @@ def test_discover_finds_the_blind_spots_skill() -> None:
 class TestLoadBlindSpotsSkillForRun(BaseTest):
     def _author_custom(self) -> None:
         LLMSkill.objects.create(
-            team=self.team, name=_CUSTOM, description="custom sweep", body="x" * 250, version=1, is_latest=True
+            team=self.team,
+            name=_CUSTOM,
+            description="custom sweep",
+            body="x" * 250,
+            version=1,
+            is_latest=True,
+            created_by=self.user,
         )
 
     def test_cold_user_gets_the_canonical_pinned(self) -> None:

--- a/products/review_hog/backend/tests/test_perspective_config_api.py
+++ b/products/review_hog/backend/tests/test_perspective_config_api.py
@@ -2,7 +2,7 @@ from posthog.test.base import APIBaseTest
 
 from parameterized import parameterized
 
-from posthog.models import Team
+from posthog.models import Team, User
 
 from products.review_hog.backend.models import ReviewSkillConfig
 from products.review_hog.backend.reviewer.lazy_seed import sync_canonical_perspectives
@@ -23,9 +23,15 @@ class TestReviewPerspectiveConfigAPI(APIBaseTest):
         sync_canonical_perspectives(self.team)
         self.base = f"/api/projects/{self.team.id}/review_hog/perspectives"
 
-    def _author_custom(self) -> None:
+    def _author_custom(self, created_by: User | None = None) -> None:
         LLMSkill.objects.create(
-            team=self.team, name=_CUSTOM, description="d", body="x" * 250, version=1, is_latest=True
+            team=self.team,
+            name=_CUSTOM,
+            description="d",
+            body="x" * 250,
+            version=1,
+            is_latest=True,
+            created_by=created_by or self.user,
         )
 
     def test_list_shows_canonicals_enabled_and_custom_disabled(self) -> None:
@@ -89,6 +95,20 @@ class TestReviewPerspectiveConfigAPI(APIBaseTest):
     def test_patch_rejects_bad_skill(self, _name: str, skill_name: str, expected_status: int) -> None:
         res = self.client.patch(f"{self.base}/{skill_name}/", {"enabled": True}, format="json")
         assert res.status_code == expected_status
+
+    def test_a_teammates_custom_perspective_is_hidden_and_not_enableable(self) -> None:
+        # Visibility is author-only: a custom another user authored must not appear in this user's
+        # menu, and PATCHing it by exact name (the old backdoor) must 404 as if it didn't exist.
+        teammate = User.objects.create(email="teammate-perspectives@example.com")
+        self._author_custom(created_by=teammate)
+
+        listing = self.client.get(f"{self.base}/")
+        patched = self.client.patch(f"{self.base}/{_CUSTOM}/", {"enabled": True}, format="json")
+
+        assert listing.status_code == 200
+        assert _CUSTOM not in {item["skill_name"] for item in listing.json()}
+        assert patched.status_code == 404
+        assert not ReviewSkillConfig.objects.for_team(self.team.id).filter(skill_name=_CUSTOM).exists()
 
     def test_environment_url_resolves_to_the_canonical_team(self) -> None:
         # With an environment (child team) id in the URL, the canonicalized `for_team` filter and a

--- a/products/review_hog/backend/tests/test_perspectives.py
+++ b/products/review_hog/backend/tests/test_perspectives.py
@@ -28,9 +28,9 @@ _LOGIC = f"{REVIEW_HOG_PERSPECTIVE_PREFIX}logic-correctness"
 _CUSTOM = f"{REVIEW_HOG_PERSPECTIVE_PREFIX}custom-x"
 
 
-def _author_perspective_skill(team, name: str) -> LLMSkill:
+def _author_perspective_skill(team, name: str, created_by: User | None = None) -> LLMSkill:
     return LLMSkill.objects.create(
-        team=team, name=name, description="custom", body="x" * 250, version=1, is_latest=True
+        team=team, name=name, description="custom", body="x" * 250, version=1, is_latest=True, created_by=created_by
     )
 
 
@@ -209,7 +209,7 @@ class TestLoadPerspectivesForRun(BaseTest):
         # The core "author a custom perspective and run it" path: an enabled custom prefixed skill is
         # loaded alongside the canonicals, with its own pass_number.
         sync_canonical_perspectives(self.team)
-        _author_perspective_skill(self.team, _CUSTOM)
+        _author_perspective_skill(self.team, _CUSTOM, created_by=self.user)
         register_missing_perspective_configs(self.team.id, self.user.id)
         ReviewSkillConfig.objects.for_team(self.team.id).create(
             team_id=self.team.id, user_id=self.user.id, skill_name=_CUSTOM, enabled=True
@@ -253,6 +253,24 @@ class TestLoadPerspectivesForRun(BaseTest):
         # make a surviving perspective silently reuse the dead one's persisted review on resume.
         # Sorted enabled set: contracts(1), custom-x(2, dead), logic(3), performance(4).
         sync_canonical_perspectives(self.team)
+        register_missing_perspective_configs(self.team.id, self.user.id)
+        ReviewSkillConfig.objects.for_team(self.team.id).create(
+            team_id=self.team.id, user_id=self.user.id, skill_name=_CUSTOM, enabled=True
+        )
+
+        loaded = load_perspectives_for_run(self.team.id, self.user.id)
+
+        assert [lp.skill_name for lp in loaded] == sorted(CANONICAL_PERSPECTIVE_SKILL_NAMES)
+        assert [lp.pass_number for lp in loaded] == [1, 3, 4]
+
+    def test_skips_an_enabled_perspective_authored_by_another_user(self) -> None:
+        # A leftover enabled config for a teammate's custom (from before visibility became
+        # author-only) must be skipped, not silently run as an invisible perspective — and like a
+        # dead skill it leaves its pass_number slot as a hole so resume keys stay stable.
+        # Sorted enabled set: contracts(1), custom-x(2, foreign), logic(3), performance(4).
+        sync_canonical_perspectives(self.team)
+        teammate = User.objects.create(email="teammate-loader@example.com")
+        _author_perspective_skill(self.team, _CUSTOM, created_by=teammate)
         register_missing_perspective_configs(self.team.id, self.user.id)
         ReviewSkillConfig.objects.for_team(self.team.id).create(
             team_id=self.team.id, user_id=self.user.id, skill_name=_CUSTOM, enabled=True

--- a/products/review_hog/backend/tests/test_validation_skill.py
+++ b/products/review_hog/backend/tests/test_validation_skill.py
@@ -24,9 +24,9 @@ from products.skills.backend.models.skills import LLMSkill
 _CUSTOM_VALIDATOR = f"{REVIEW_HOG_VALIDATION_PREFIX}strict"
 
 
-def _author_validator_skill(team, name: str) -> LLMSkill:
+def _author_validator_skill(team, name: str, created_by: User | None = None) -> LLMSkill:
     return LLMSkill.objects.create(
-        team=team, name=name, description="custom", body="x" * 250, version=1, is_latest=True
+        team=team, name=name, description="custom", body="x" * 250, version=1, is_latest=True, created_by=created_by
     )
 
 
@@ -127,7 +127,7 @@ class TestLoadValidationSkillForRun(BaseTest):
         # The core "author a custom validator and run it" path: with the custom selected (canonical
         # off), the run resolves the custom validator, not the canonical default.
         sync_canonical_validation(self.team)
-        _author_validator_skill(self.team, _CUSTOM_VALIDATOR)
+        _author_validator_skill(self.team, _CUSTOM_VALIDATOR, created_by=self.user)
         register_missing_validation_config(self.team.id, self.user.id)
         configs = ReviewSkillConfig.objects.for_team(self.team.id)
         configs.filter(user_id=self.user.id, skill_name=REVIEW_HOG_VALIDATION_SKILL_NAME).update(enabled=False)
@@ -136,6 +136,21 @@ class TestLoadValidationSkillForRun(BaseTest):
         loaded = load_validation_skill_for_run(self.team.id, self.user.id)
 
         assert loaded.skill_name == _CUSTOM_VALIDATOR
+
+    def test_falls_back_to_canonical_when_the_selected_skill_was_authored_by_another_user(self) -> None:
+        # A leftover selection of a teammate's custom validator (from before visibility became
+        # author-only) must fall back to the canonical, not silently validate with an invisible bar.
+        sync_canonical_validation(self.team)
+        teammate = User.objects.create(email="teammate-validation-loader@example.com")
+        _author_validator_skill(self.team, _CUSTOM_VALIDATOR, created_by=teammate)
+        register_missing_validation_config(self.team.id, self.user.id)
+        configs = ReviewSkillConfig.objects.for_team(self.team.id)
+        configs.filter(user_id=self.user.id, skill_name=REVIEW_HOG_VALIDATION_SKILL_NAME).update(enabled=False)
+        configs.create(team_id=self.team.id, user_id=self.user.id, skill_name=_CUSTOM_VALIDATOR, enabled=True)
+
+        loaded = load_validation_skill_for_run(self.team.id, self.user.id)
+
+        assert loaded.skill_name == REVIEW_HOG_VALIDATION_SKILL_NAME
 
     def test_falls_back_to_canonical_when_none_enabled(self) -> None:
         # No min-1 floor: if the user has no enabled validator row at all, the loader resolves the
@@ -171,7 +186,7 @@ class TestLoadValidationSkillForRun(BaseTest):
     def test_selection_is_per_user(self) -> None:
         # Selecting a custom validator for one user must not affect another user's run.
         sync_canonical_validation(self.team)
-        _author_validator_skill(self.team, _CUSTOM_VALIDATOR)
+        _author_validator_skill(self.team, _CUSTOM_VALIDATOR, created_by=self.user)
         other = User.objects.create(email="other-validator@example.com")
         configs = ReviewSkillConfig.objects.for_team(self.team.id)
         register_missing_validation_config(self.team.id, self.user.id)

--- a/products/review_hog/backend/tests/test_validator_config_api.py
+++ b/products/review_hog/backend/tests/test_validator_config_api.py
@@ -2,7 +2,7 @@ from posthog.test.base import APIBaseTest
 
 from parameterized import parameterized
 
-from posthog.models import Team
+from posthog.models import Team, User
 
 from products.review_hog.backend.models import ReviewSkillConfig
 from products.review_hog.backend.reviewer.lazy_seed import sync_canonical_validation
@@ -22,9 +22,15 @@ class TestReviewValidatorConfigAPI(APIBaseTest):
         sync_canonical_validation(self.team)
         self.base = f"/api/projects/{self.team.id}/review_hog/validators"
 
-    def _author_custom(self) -> None:
+    def _author_custom(self, created_by: User | None = None) -> None:
         LLMSkill.objects.create(
-            team=self.team, name=_CUSTOM, description="d", body="x" * 250, version=1, is_latest=True
+            team=self.team,
+            name=_CUSTOM,
+            description="d",
+            body="x" * 250,
+            version=1,
+            is_latest=True,
+            created_by=created_by or self.user,
         )
 
     def test_list_shows_canonical_active_and_custom_inactive(self) -> None:
@@ -58,7 +64,13 @@ class TestReviewValidatorConfigAPI(APIBaseTest):
         c1, c2 = f"{REVIEW_HOG_VALIDATION_PREFIX}c1", f"{REVIEW_HOG_VALIDATION_PREFIX}c2"
         for name in (c1, c2):
             LLMSkill.objects.create(
-                team=self.team, name=name, description="d", body="x" * 250, version=1, is_latest=True
+                team=self.team,
+                name=name,
+                description="d",
+                body="x" * 250,
+                version=1,
+                is_latest=True,
+                created_by=self.user,
             )
         configs = ReviewSkillConfig.objects.for_team(self.team.id).filter(user_id=self.user.id)
 
@@ -122,6 +134,19 @@ class TestReviewValidatorConfigAPI(APIBaseTest):
             f"{self.base}/{REVIEW_HOG_VALIDATION_PREFIX}does-not-exist/", {"active": True}, format="json"
         )
         assert res.status_code == 404
+
+    def test_a_teammates_custom_validator_is_hidden_and_not_selectable(self) -> None:
+        # Visibility is author-only: a custom another user authored must not appear in this user's
+        # menu, and selecting it by exact name must 404 as if it didn't exist.
+        teammate = User.objects.create(email="teammate-validators@example.com")
+        self._author_custom(created_by=teammate)
+
+        listing = self.client.get(f"{self.base}/")
+        selected = self.client.patch(f"{self.base}/{_CUSTOM}/", {"active": True}, format="json")
+
+        assert listing.status_code == 200
+        assert _CUSTOM not in {item["skill_name"] for item in listing.json()}
+        assert selected.status_code == 404
 
     def test_environment_url_resolves_to_the_canonical_team(self) -> None:
         # Same failure mode as the settings/perspectives viewsets: an environment (child team) id in

--- a/products/review_hog/frontend/generated/api.ts
+++ b/products/review_hog/frontend/generated/api.ts
@@ -28,7 +28,7 @@ export const getReviewHogBlindSpotsListUrl = (projectId: string) => {
 }
 
 /**
- * List every `review-hog-blind-spots-*` skill on this project, flagging the one active for the requesting user. The canonical skill is auto-seeded active on the first read; a custom skill the user has not selected shows as inactive.
+ * List the `review-hog-blind-spots-*` skills visible to the requesting user — the canonical skill plus the customs they authored — flagging the one active for them. The canonical skill is auto-seeded active on the first read; a custom skill the user has not selected shows as inactive.
  * @summary List blind-spots skills and which one is active
  */
 export const reviewHogBlindSpotsList = async (
@@ -46,7 +46,7 @@ export const getReviewHogBlindSpotsPartialUpdateUrl = (projectId: string, skillN
 }
 
 /**
- * Make a `review-hog-blind-spots-*` skill the single sweep that runs on the requesting user's PR reviews, switching the user's other blind-spots skills off in the same call. Upserts the per-user config row, so selecting a freshly authored custom skill works in one call.
+ * Make a `review-hog-blind-spots-*` skill the single sweep that runs on the requesting user's PR reviews, switching the user's other blind-spots skills off in the same call. Only skills visible to the user — the canonical plus the customs they authored — can be selected; anything else 404s. Upserts the per-user config row, so selecting a freshly authored custom skill works in one call.
  * @summary Select the active blind-spots skill
  */
 export const reviewHogBlindSpotsPartialUpdate = async (
@@ -68,7 +68,7 @@ export const getReviewHogPerspectivesListUrl = (projectId: string) => {
 }
 
 /**
- * List every `review-hog-perspective-*` skill on this project joined with the requesting user's enable state. The 3 canonical perspectives are auto-seeded enabled on the first read; a custom perspective the user has not switched on shows as disabled.
+ * List the `review-hog-perspective-*` skills visible to the requesting user — the canonical perspectives plus the customs they authored — joined with their enable state. The 3 canonical perspectives are auto-seeded enabled on the first read; a custom perspective the user has not switched on shows as disabled.
  * @summary List review perspectives and their enablement
  */
 export const reviewHogPerspectivesList = async (
@@ -86,7 +86,7 @@ export const getReviewHogPerspectivesPartialUpdateUrl = (projectId: string, skil
 }
 
 /**
- * Toggle whether a `review-hog-perspective-*` skill runs on the requesting user's PR reviews. Upserts the per-user config row, so enabling a freshly authored custom perspective works in one call. Rejected if it would leave the user with no enabled perspective.
+ * Toggle whether a `review-hog-perspective-*` skill runs on the requesting user's PR reviews. Only skills visible to the user — the canonicals plus the customs they authored — can be toggled; anything else 404s. Upserts the per-user config row, so enabling a freshly authored custom perspective works in one call. Rejected if it would leave the user with no enabled perspective.
  * @summary Enable or disable a review perspective
  */
 export const reviewHogPerspectivesPartialUpdate = async (
@@ -215,7 +215,7 @@ export const getReviewHogValidatorsListUrl = (projectId: string) => {
 }
 
 /**
- * List every `review-hog-validation-*` skill on this project, flagging the one active for the requesting user. The canonical validator is auto-seeded active on the first read; a custom validator the user has not selected shows as inactive.
+ * List the `review-hog-validation-*` skills visible to the requesting user — the canonical validator plus the customs they authored — flagging the one active for them. The canonical validator is auto-seeded active on the first read; a custom validator the user has not selected shows as inactive.
  * @summary List review validators and which one is active
  */
 export const reviewHogValidatorsList = async (
@@ -233,7 +233,7 @@ export const getReviewHogValidatorsPartialUpdateUrl = (projectId: string, skillN
 }
 
 /**
- * Make a `review-hog-validation-*` skill the single validator that runs on the requesting user's PR reviews, switching the user's other validators off in the same call. Upserts the per-user config row, so selecting a freshly authored custom validator works in one call.
+ * Make a `review-hog-validation-*` skill the single validator that runs on the requesting user's PR reviews, switching the user's other validators off in the same call. Only skills visible to the user — the canonical plus the customs they authored — can be selected; anything else 404s. Upserts the per-user config row, so selecting a freshly authored custom validator works in one call.
  * @summary Select the active review validator
  */
 export const reviewHogValidatorsPartialUpdate = async (

--- a/products/review_hog/frontend/generated/api.zod.ts
+++ b/products/review_hog/frontend/generated/api.zod.ts
@@ -10,7 +10,7 @@
 import * as zod from 'zod'
 
 /**
- * Make a `review-hog-blind-spots-*` skill the single sweep that runs on the requesting user's PR reviews, switching the user's other blind-spots skills off in the same call. Upserts the per-user config row, so selecting a freshly authored custom skill works in one call.
+ * Make a `review-hog-blind-spots-*` skill the single sweep that runs on the requesting user's PR reviews, switching the user's other blind-spots skills off in the same call. Only skills visible to the user — the canonical plus the customs they authored — can be selected; anything else 404s. Upserts the per-user config row, so selecting a freshly authored custom skill works in one call.
  * @summary Select the active blind-spots skill
  */
 export const ReviewHogBlindSpotsPartialUpdateBody = /* @__PURE__ */ zod.object({
@@ -23,7 +23,7 @@ export const ReviewHogBlindSpotsPartialUpdateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Toggle whether a `review-hog-perspective-*` skill runs on the requesting user's PR reviews. Upserts the per-user config row, so enabling a freshly authored custom perspective works in one call. Rejected if it would leave the user with no enabled perspective.
+ * Toggle whether a `review-hog-perspective-*` skill runs on the requesting user's PR reviews. Only skills visible to the user — the canonicals plus the customs they authored — can be toggled; anything else 404s. Upserts the per-user config row, so enabling a freshly authored custom perspective works in one call. Rejected if it would leave the user with no enabled perspective.
  * @summary Enable or disable a review perspective
  */
 export const ReviewHogPerspectivesPartialUpdateBody = /* @__PURE__ */ zod.object({
@@ -60,7 +60,7 @@ export const ReviewHogSettingsPartialUpdateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Make a `review-hog-validation-*` skill the single validator that runs on the requesting user's PR reviews, switching the user's other validators off in the same call. Upserts the per-user config row, so selecting a freshly authored custom validator works in one call.
+ * Make a `review-hog-validation-*` skill the single validator that runs on the requesting user's PR reviews, switching the user's other validators off in the same call. Only skills visible to the user — the canonical plus the customs they authored — can be selected; anything else 404s. Upserts the per-user config row, so selecting a freshly authored custom validator works in one call.
  * @summary Select the active review validator
  */
 export const ReviewHogValidatorsPartialUpdateBody = /* @__PURE__ */ zod.object({


### PR DESCRIPTION
## Problem

Custom review skills (perspectives, validators, blind-spots checks) are team-level `LLMSkill` rows, and all three Code review config menus listed every prefixed team skill. A custom perspective one user authored showed up in every teammate's menu, with its body readable and enableable by exact name. As more people author custom skills, everyone's menu fills up with everyone else's customs.

**Why:** users should only see the canonical skills plus the customs they created themselves, so the review menus stay theirs.

## Changes

- New `visible_skill_names()` in `skill_loader.py`: a skill is visible to a user iff it's canonical (by name, so team-edited canonicals stay visible to everyone) or the earliest live version's `created_by` is that user. Every edit mints a new version stamped with the editor, so only the first version identifies the author.
- All three config viewsets (perspectives, validators, blind-spots) filter `list` by visibility, and `partial_update` 404s on a non-visible skill exactly like a missing one, closing the enable-any-team-skill-by-name backdoor.
- Loader backstop instead of a data migration: `load_perspectives_for_run` warn-and-skips enabled names outside the acting user's visible set (hole-preserving `pass_number` slots, same as the dead-skill skip), and the single-active loaders fall back to the canonical on a foreign selection. Leftover foreign-enabled configs stop running instead of running invisibly.
- Decision and rationale recorded in `products/review_hog/ARCHITECTURE.md` (dated entry under "Customizable perspectives").

> [!NOTE]
> The team-level Skills page (`/skills`) intentionally still shows all team skills. This is a menu-scoping fix, not a confidentiality boundary. Signals scouts share the same all-team-menu pattern and are deliberately out of scope.

## How did you test this code?

Automated tests added/updated (each guards a regression no existing test caught):

- Per surface: a teammate's custom is hidden from `list` and PATCHing it by name 404s (previously the exact reported behavior).
- Perspective loader skips a foreign-enabled config while keeping `pass_number` holes stable (resume-key safety).
- Single-active validator loader falls back to the canonical on a foreign selection.
- Existing custom-skill fixtures now stamp `created_by`, so the whole existing suite runs under the new visibility rule.

I (Claude via PostHog Code) could not execute the test suite in the cloud sandbox (no service stack for pytest), so these tests are authored but not yet run. Please run locally before marking ready:

```
hogli test products/review_hog/backend/tests/
```

`ruff check` and `ruff format` pass. `hogli ci:preflight` flags OpenAPI type drift (endpoint description text changed); run `hogli build:openapi` locally and commit any regenerated files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No `docs/` pages cover the review-hog config menus yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog Code session directed by the assignee. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`. Design was settled interactively before implementation: chose earliest-live-version `created_by` as the authorship signal (no schema change) over adding an owner field to `LLMSkill` or a config-row-subscription model; chose strict enforcement with no grandfathering (feature just released) with loader-level soft-skip as the backstop instead of a data migration.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
